### PR TITLE
Add SWR caching for faster page loading

### DIFF
--- a/apps/inventory/package.json
+++ b/apps/inventory/package.json
@@ -21,6 +21,7 @@
     "react": "19.2.4",
     "react-dom": "19.2.4",
     "shadcn": "^4.1.2",
+    "swr": "^2.4.1",
     "tailwind-merge": "^3.5.0",
     "tw-animate-css": "^1.4.0"
   },

--- a/apps/inventory/src/app/admin/menus/page.tsx
+++ b/apps/inventory/src/app/admin/menus/page.tsx
@@ -1,11 +1,12 @@
 "use client";
 
-import { useState, useEffect, Fragment } from "react";
+import { useState, Fragment } from "react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Badge } from "@/components/ui/badge";
 import { Card } from "@/components/ui/card";
 import { Pencil, ChevronDown, Coffee, Search, Loader2, Trash2, X, Check } from "lucide-react";
+import { useFetch } from "@/lib/use-fetch";
 
 type Ingredient = { product: string; productId: string; sku: string; qty: number; uom: string; cost: number };
 
@@ -36,8 +37,8 @@ type EditIngredient = {
 };
 
 export default function MenusPage() {
-  const [menus, setMenus] = useState<MenuItem[]>([]);
-  const [loading, setLoading] = useState(true);
+  const { data: menus = [], isLoading: loading, mutate: loadMenus } = useFetch<MenuItem[]>("/api/menus");
+  const { data: products = [] } = useFetch<ProductOption[]>("/api/products");
   const [search, setSearch] = useState("");
   const [catFilter, setCatFilter] = useState("All");
   const [expandedId, setExpandedId] = useState<string | null>(null);
@@ -46,28 +47,7 @@ export default function MenusPage() {
   const [editingMenuId, setEditingMenuId] = useState<string | null>(null);
   const [editIngredients, setEditIngredients] = useState<EditIngredient[]>([]);
   const [saving, setSaving] = useState(false);
-
-  // Product search for adding ingredients
-  const [products, setProducts] = useState<ProductOption[]>([]);
   const [addSearch, setAddSearch] = useState("");
-
-  const loadMenus = () => {
-    fetch("/api/menus")
-      .then((res) => res.json())
-      .then((data) => { setMenus(data); setLoading(false); })
-      .catch(() => setLoading(false));
-  };
-
-  useEffect(() => {
-    loadMenus();
-    // Load products for ingredient picker
-    fetch("/api/products")
-      .then((r) => r.json())
-      .then((data) => setProducts(data.map((p: { id: string; name: string; sku: string; baseUom: string }) => ({
-        id: p.id, name: p.name, sku: p.sku, baseUom: p.baseUom,
-      }))))
-      .catch(() => {});
-  }, []);
 
   const categories = ["All", ...new Set(menus.map((m) => m.category).filter(Boolean))];
 

--- a/apps/inventory/src/app/admin/orders/page.tsx
+++ b/apps/inventory/src/app/admin/orders/page.tsx
@@ -1,10 +1,11 @@
 "use client";
 
-import { useState, useEffect, Fragment, useCallback } from "react";
+import { useState, Fragment } from "react";
 import Link from "next/link";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Badge } from "@/components/ui/badge";
+import { useFetch } from "@/lib/use-fetch";
 import { Card } from "@/components/ui/card";
 import {
   Search,
@@ -97,23 +98,11 @@ const NEXT_ACTIONS: Record<string, { status: string; label: string; icon: typeof
 
 export default function OrdersPage() {
   // Table state
-  const [orders, setOrders] = useState<Order[]>([]);
-  const [loading, setLoading] = useState(true);
+  const { data: orders = [], isLoading: loading, mutate: loadOrders } = useFetch<Order[]>("/api/orders");
   const [search, setSearch] = useState("");
   const [statusFilter, setStatusFilter] = useState("All");
   const [expandedId, setExpandedId] = useState<string | null>(null);
   const [updatingId, setUpdatingId] = useState<string | null>(null);
-
-  // ── Data loading ────────────────────────────────────────────────────────
-
-  const loadOrders = useCallback(() => {
-    fetch("/api/orders")
-      .then((res) => res.json())
-      .then((data) => { setOrders(data); setLoading(false); })
-      .catch(() => setLoading(false));
-  }, []);
-
-  useEffect(() => { loadOrders(); }, [loadOrders]);
 
   // ── Status update ───────────────────────────────────────────────────────
 

--- a/apps/inventory/src/app/admin/page.tsx
+++ b/apps/inventory/src/app/admin/page.tsx
@@ -1,21 +1,31 @@
 "use client";
 
-import { useState, useEffect } from "react";
 import Link from "next/link";
 import { Package, Truck, Tags, Building2, ShoppingCart, ArrowRightLeft, FileText, Users, TrendingUp, AlertTriangle, Clock, Loader2 } from "lucide-react";
-import { Card } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
+import { useFetch } from "@/lib/use-fetch";
 
-type DashboardData = {
+type Stats = {
   products: number;
   suppliers: number;
   categories: number;
   branches: number;
   staff: number;
   menus: number;
-  orders: { total: number; active: number; recent: { orderNumber: string; supplier: string; status: string; totalAmount: number; createdAt: string }[] };
-  receivings: { total: number; recentCount: number };
   invoices: { total: number; pendingAmount: number; overdueAmount: number };
+};
+
+type Dashboard = {
+  ordersPlaced: number;
+  pendingApprovals: number;
+  deliveriesExpected: number;
+  deliverySuppliers: string[];
+  weeklySpending: number;
+  wasteTotal: number;
+  receivingsThisWeek: number;
+  stockCheckDone: boolean;
+  lastCheckTime: string | null;
+  recentOrders: { id: string; orderNumber: string; supplier: string; status: string; totalAmount: number; createdAt: string }[];
 };
 
 const STATUS_COLORS: Record<string, string> = {
@@ -30,48 +40,12 @@ const STATUS_COLORS: Record<string, string> = {
 };
 
 export default function AdminDashboard() {
-  const [data, setData] = useState<DashboardData | null>(null);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState(false);
+  // 2 lightweight API calls instead of 8 full-data fetches
+  const { data: stats, isLoading: loadingStats, error: statsError } = useFetch<Stats>("/api/admin/stats");
+  const { data: dashboard, isLoading: loadingDash, error: dashError } = useFetch<Dashboard>("/api/dashboard");
 
-  useEffect(() => {
-    // Use the optimized dashboard endpoint for order/receiving stats,
-    // and lightweight count fetches for master data (small payloads).
-    Promise.all([
-      fetch("/api/dashboard").then((r) => r.json()),
-      fetch("/api/products").then((r) => r.json()),
-      fetch("/api/suppliers").then((r) => r.json()),
-      fetch("/api/categories").then((r) => r.json()),
-      fetch("/api/branches").then((r) => r.json()),
-      fetch("/api/staff").then((r) => r.json()),
-      fetch("/api/menus").then((r) => r.json()),
-      fetch("/api/invoices").then((r) => r.json()),
-    ]).then(([dashboard, products, suppliers, categories, branches, staff, menus, invoices]) => {
-      setData({
-        products: products.length,
-        suppliers: suppliers.length,
-        categories: categories.length,
-        branches: branches.length,
-        staff: staff.length,
-        menus: menus.length,
-        orders: {
-          total: dashboard.ordersPlaced,
-          active: dashboard.pendingApprovals + dashboard.deliveriesExpected,
-          recent: dashboard.recentOrders || [],
-        },
-        receivings: {
-          total: dashboard.receivingsThisWeek,
-          recentCount: dashboard.receivingsThisWeek,
-        },
-        invoices: {
-          total: invoices.length,
-          pendingAmount: invoices.filter((i: { status: string }) => i.status === "PENDING").reduce((a: number, i: { amount: number }) => a + i.amount, 0),
-          overdueAmount: invoices.filter((i: { status: string }) => i.status === "OVERDUE").reduce((a: number, i: { amount: number }) => a + i.amount, 0),
-        },
-      });
-      setLoading(false);
-    }).catch(() => { setError(true); setLoading(false); });
-  }, []);
+  const loading = loadingStats || loadingDash;
+  const error = statsError || dashError;
 
   if (loading) {
     return (
@@ -81,7 +55,7 @@ export default function AdminDashboard() {
     );
   }
 
-  if (error || !data) {
+  if (error || !stats || !dashboard) {
     return (
       <div className="flex flex-col items-center justify-center p-12 text-center">
         <AlertTriangle className="h-8 w-8 text-amber-500" />
@@ -90,6 +64,19 @@ export default function AdminDashboard() {
       </div>
     );
   }
+
+  const data = {
+    ...stats,
+    orders: {
+      total: dashboard.ordersPlaced,
+      active: dashboard.pendingApprovals + dashboard.deliveriesExpected,
+      recent: dashboard.recentOrders || [],
+    },
+    receivings: {
+      total: dashboard.receivingsThisWeek,
+      recentCount: dashboard.receivingsThisWeek,
+    },
+  };
 
   const stats = [
     { label: "Products", value: data.products, icon: Package, href: "/admin/products", color: "bg-blue-50 text-blue-600" },

--- a/apps/inventory/src/app/admin/products/page.tsx
+++ b/apps/inventory/src/app/admin/products/page.tsx
@@ -1,9 +1,10 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useState } from "react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Badge } from "@/components/ui/badge";
+import { useFetch } from "@/lib/use-fetch";
 import {
   Dialog,
   DialogContent,
@@ -43,28 +44,17 @@ type ProductForm = {
 const emptyForm: ProductForm = { name: "", sku: "", categoryId: "", baseUom: "", storageArea: "", shelfLifeDays: "", checkFrequency: "MONTHLY", description: "" };
 
 export default function ProductsPage() {
-  const [products, setProducts] = useState<Product[]>([]);
-  const [loading, setLoading] = useState(true);
+  const { data: products = [], isLoading: loading, mutate: reloadProducts } = useFetch<Product[]>("/api/products");
+  const { data: categoryOptions = [] } = useFetch<CategoryOption[]>("/api/categories");
   const [search, setSearch] = useState("");
   const [categoryFilter, setCategoryFilter] = useState("All");
   const [dialogOpen, setDialogOpen] = useState(false);
   const [editingId, setEditingId] = useState<string | null>(null);
   const [form, setForm] = useState<ProductForm>(emptyForm);
   const [expandedId, setExpandedId] = useState<string | null>(null);
-  const [categoryOptions, setCategoryOptions] = useState<CategoryOption[]>([]);
   const [saving, setSaving] = useState(false);
 
-  const loadProducts = () => {
-    fetch("/api/products")
-      .then((res) => res.json())
-      .then((data) => { setProducts(data); setLoading(false); })
-      .catch(() => setLoading(false));
-  };
-
-  useEffect(() => {
-    loadProducts();
-    fetch("/api/categories").then((r) => r.json()).then((data) => setCategoryOptions(data));
-  }, []);
+  const loadProducts = () => reloadProducts();
 
   const handleSubmit = async () => {
     if (!form.name || !form.sku || !form.categoryId) return;

--- a/apps/inventory/src/app/admin/suppliers/page.tsx
+++ b/apps/inventory/src/app/admin/suppliers/page.tsx
@@ -1,9 +1,10 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useState } from "react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Badge } from "@/components/ui/badge";
+import { useFetch } from "@/lib/use-fetch";
 import { Card } from "@/components/ui/card";
 import {
   Dialog,
@@ -55,8 +56,8 @@ type ProductOption = { id: string; name: string; sku: string; baseUom: string };
 const emptyForm: SupplierForm = { name: "", location: "", phone: "", supplierCode: "", leadTimeDays: "1", tags: "" };
 
 export default function SuppliersPage() {
-  const [suppliers, setSuppliers] = useState<Supplier[]>([]);
-  const [loading, setLoading] = useState(true);
+  const { data: suppliers = [], isLoading: loading, mutate: reloadSuppliers } = useFetch<Supplier[]>("/api/suppliers");
+  const { data: productOptions = [] } = useFetch<ProductOption[]>("/api/products");
   const [search, setSearch] = useState("");
   const [dialogOpen, setDialogOpen] = useState(false);
   const [editingId, setEditingId] = useState<string | null>(null);
@@ -70,19 +71,11 @@ export default function SuppliersPage() {
   const [editPrice, setEditPrice] = useState("");
   const [savingPrice, setSavingPrice] = useState(false);
   const [addingProduct, setAddingProduct] = useState(false);
-  const [productOptions, setProductOptions] = useState<ProductOption[]>([]);
   const [productSearch, setProductSearch] = useState("");
   const [newProductId, setNewProductId] = useState("");
   const [newPrice, setNewPrice] = useState("");
 
-  const loadSuppliers = () => {
-    fetch("/api/suppliers")
-      .then((res) => res.json())
-      .then((data) => { setSuppliers(data); setLoading(false); })
-      .catch(() => setLoading(false));
-  };
-
-  useEffect(() => { loadSuppliers(); }, []);
+  const loadSuppliers = () => reloadSuppliers();
 
   const filtered = suppliers.filter(
     (s) =>
@@ -128,19 +121,11 @@ export default function SuppliersPage() {
     }
   };
 
-  const openPriceList = async (supplier: Supplier) => {
+  const openPriceList = (supplier: Supplier) => {
     setSelectedSupplier(supplier);
     setEditingPriceId(null);
     setAddingProduct(false);
     setPriceDialogOpen(true);
-    // Load product options for add product dropdown
-    if (productOptions.length === 0) {
-      const res = await fetch("/api/products");
-      if (res.ok) {
-        const data = await res.json();
-        setProductOptions(data.map((p: ProductOption) => ({ id: p.id, name: p.name, sku: p.sku, baseUom: p.baseUom })));
-      }
-    }
   };
 
   const handleDelete = async (id: string) => {

--- a/apps/inventory/src/app/api/admin/stats/route.ts
+++ b/apps/inventory/src/app/api/admin/stats/route.ts
@@ -1,0 +1,51 @@
+import { NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+
+/**
+ * GET /api/admin/stats
+ * Returns all dashboard counts in a single query batch.
+ * Replaces 7 separate full-list API calls on the admin dashboard.
+ */
+export async function GET() {
+  const [
+    products,
+    suppliers,
+    categories,
+    branches,
+    staff,
+    menus,
+    invoices,
+    pendingInvoiceAgg,
+    overdueInvoiceAgg,
+  ] = await Promise.all([
+    prisma.product.count({ where: { isActive: true } }),
+    prisma.supplier.count({ where: { status: "ACTIVE" } }),
+    prisma.category.count(),
+    prisma.branch.count(),
+    prisma.staff.count({ where: { status: "ACTIVE" } }),
+    prisma.menu.count({ where: { isActive: true } }),
+    prisma.invoice.count(),
+    prisma.invoice.aggregate({
+      where: { status: "PENDING" },
+      _sum: { amount: true },
+    }),
+    prisma.invoice.aggregate({
+      where: { status: "OVERDUE" },
+      _sum: { amount: true },
+    }),
+  ]);
+
+  return NextResponse.json({
+    products,
+    suppliers,
+    categories,
+    branches,
+    staff,
+    menus,
+    invoices: {
+      total: invoices,
+      pendingAmount: Number(pendingInvoiceAgg._sum.amount ?? 0),
+      overdueAmount: Number(overdueInvoiceAgg._sum.amount ?? 0),
+    },
+  });
+}

--- a/apps/inventory/src/lib/use-fetch.ts
+++ b/apps/inventory/src/lib/use-fetch.ts
@@ -1,0 +1,21 @@
+import useSWR from "swr";
+
+const fetcher = (url: string) => fetch(url).then((res) => {
+  if (!res.ok) throw new Error(`Fetch failed: ${res.status}`);
+  return res.json();
+});
+
+/**
+ * Cached data fetcher using SWR.
+ * - Returns cached data instantly on re-render / page navigation
+ * - Revalidates in background (stale-while-revalidate)
+ * - Deduplicates concurrent requests to the same URL
+ */
+export function useFetch<T = unknown>(url: string | null) {
+  const { data, error, isLoading, mutate } = useSWR<T>(url, fetcher, {
+    revalidateOnFocus: false,
+    dedupingInterval: 10000, // don't re-fetch same URL within 10s
+  });
+
+  return { data: data as T | undefined, error, isLoading, mutate };
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,6 +33,7 @@
         "react": "19.2.4",
         "react-dom": "19.2.4",
         "shadcn": "^4.1.2",
+        "swr": "^2.4.1",
         "tailwind-merge": "^3.5.0",
         "tw-animate-css": "^1.4.0"
       },
@@ -5477,6 +5478,15 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/destr": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/destr/-/destr-2.0.5.tgz",
@@ -10827,6 +10837,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/swr": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/swr/-/swr-2.4.1.tgz",
+      "integrity": "sha512-2CC6CiKQtEwaEeNiqWTAw9PGykW8SR5zZX8MZk6TeAvEAnVS7Visz8WzphqgtQ8v2xz/4Q5K+j+SeMaKXeeQIA==",
+      "license": "MIT",
+      "dependencies": {
+        "dequal": "^2.0.3",
+        "use-sync-external-store": "^1.6.0"
+      },
+      "peerDependencies": {
+        "react": "^16.11.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/tabbable": {


### PR DESCRIPTION
## Summary
- Install SWR for client-side caching with stale-while-revalidate
- Create `/api/admin/stats` endpoint returning all counts in one DB query (replaces 7 full-list fetches)
- Dashboard: 2 API calls instead of 8
- Products, suppliers, orders, menus pages use SWR — navigating between pages returns cached data instantly

## Test plan
- [ ] Dashboard loads faster (2 calls vs 8)
- [ ] Navigate between Products → Suppliers → Menus — should feel instant after first load
- [ ] CRUD operations still work (create/edit/delete trigger revalidation)

https://claude.ai/code/session_015A7rRJLq7fHvxC4uvvRGAJ