### PR TITLE
Fix Vercel build: add 'use client' to useFetch hook

### DIFF
--- a/apps/inventory/src/lib/use-fetch.ts
+++ b/apps/inventory/src/lib/use-fetch.ts
@@ -1,3 +1,5 @@
+"use client";
+
 import useSWR from "swr";
 
 const fetcher = (url: string) => fetch(url).then((res) => {


### PR DESCRIPTION
## Summary
- Add missing `"use client"` directive to `useFetch` hook — required because it uses `useSWR` (a React hook) in Next.js App Router

Fixes the build failure from #3.

https://claude.ai/code/session_015A7rRJLq7fHvxC4uvvRGAJ