### PR TITLE
fix(loyalty): use bcrypt-aware PIN verification for staff login

### DIFF
--- a/apps/loyalty/src/app/api/staff/verify-pin/route.ts
+++ b/apps/loyalty/src/app/api/staff/verify-pin/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { centralDb } from '@/lib/central-db';
 import { createToken, setAuthCookie } from '@/lib/auth';
 import { checkRateLimit, RATE_LIMITS } from '@/lib/rate-limit';
+import { verifyPin, hashPin } from '@celsius/auth';
 
 // POST /api/staff/verify-pin — verify staff PIN against central DB
 export async function POST(request: NextRequest) {
@@ -83,8 +84,17 @@ export async function POST(request: NextRequest) {
 
       if (!hasOutletAccess) continue;
 
-      // PIN is stored as plaintext in central DB — direct comparison
-      if (user.pin === pin.trim()) {
+      // Verify PIN — supports both bcrypt hashes and legacy plaintext
+      const { match, needsRehash } = await verifyPin(pin, user.pin as string);
+      if (match) {
+        // Progressive rehash: upgrade plaintext PINs to bcrypt
+        if (needsRehash && centralDb) {
+          const hashed = await hashPin(pin);
+          await centralDb
+            .from('User')
+            .update({ pin: hashed })
+            .eq('id', user.id);
+        }
         matchedUser = user;
         break;
       }


### PR DESCRIPTION
## Summary
- Loyalty app staff PIN login was broken for all outlets — PINs that were progressively rehashed to bcrypt by the order/POS app could never match because the loyalty app was doing direct string comparison
- Now uses `verifyPin()` from `@celsius/auth` which handles both bcrypt hashes and legacy plaintext PINs
- Adds progressive rehashing on the loyalty side too, so plaintext PINs get upgraded to bcrypt on successful login

## Test plan
- [ ] Staff can log in with PIN at loyalty.celsiuscoffee.com/staff for Shah Alam and all other outlets
- [ ] PINs that were already hashed (via POS login) now work on the loyalty app
- [ ] New plaintext PINs still work and get auto-upgraded to bcrypt after first login

https://claude.ai/code/session_0148tJcSuPSvKwBeeAomZwNA