### PR TITLE
fix: Quick Upload Receipt submit/save + drag & drop

### DIFF
--- a/apps/backoffice/src/app/(admin)/inventory/pay-and-claim/page.tsx
+++ b/apps/backoffice/src/app/(admin)/inventory/pay-and-claim/page.tsx
@@ -398,6 +398,7 @@ export default function PayAndClaimPage() {
           photos: quPhotos,
           notes: quNotes,
           draft: asDraft,
+          quickUpload: true,
           aiExtracted: quAiData,
           purchaseDate: (quAiData as Record<string, string>).issueDate || undefined,
         }),
@@ -405,8 +406,13 @@ export default function PayAndClaimPage() {
       if (res.ok) {
         setQuickUploadOpen(false);
         mutate();
+      } else {
+        const data = await res.json().catch(() => null);
+        alert(data?.error || "Failed to save receipt. Please try again.");
       }
-    } catch { /* ignore */ }
+    } catch {
+      alert("Network error. Please check your connection and try again.");
+    }
     setQuSubmitting(false);
   };
 

--- a/apps/backoffice/src/app/(admin)/inventory/pay-and-claim/page.tsx
+++ b/apps/backoffice/src/app/(admin)/inventory/pay-and-claim/page.tsx
@@ -156,6 +156,7 @@ export default function PayAndClaimPage() {
   const [quStaffId, setQuStaffId] = useState("");
   const [quNotes, setQuNotes] = useState("");
   const [quUploading, setQuUploading] = useState(false);
+  const [quDragging, setQuDragging] = useState(false);
   const [quExtracting, setQuExtracting] = useState(false);
   const [quSubmitting, setQuSubmitting] = useState(false);
   const [quAiData, setQuAiData] = useState<Record<string, unknown>>({});
@@ -347,13 +348,13 @@ export default function PayAndClaimPage() {
     setQuickUploadOpen(true);
   };
 
-  const handleQuickPhotoUpload = async (e: React.ChangeEvent<HTMLInputElement>) => {
-    const files = e.target.files;
-    if (!files?.length) return;
+  const processQuickUploadFiles = async (files: File[]) => {
+    const valid = files.filter((f) => f.type.startsWith("image/") || f.type === "application/pdf");
+    if (!valid.length) return;
     setQuUploading(true);
     const newUrls: string[] = [];
     try {
-      for (const file of Array.from(files)) {
+      for (const file of valid) {
         const formData = new FormData();
         formData.append("file", file);
         const res = await fetch("/api/inventory/upload", { method: "POST", body: formData });
@@ -365,7 +366,6 @@ export default function PayAndClaimPage() {
       }
     } catch { /* ignore */ }
     setQuUploading(false);
-    e.target.value = "";
 
     // AI extraction
     if (newUrls.length > 0) {
@@ -383,6 +383,20 @@ export default function PayAndClaimPage() {
       } catch { /* ignore */ }
       setQuExtracting(false);
     }
+  };
+
+  const handleQuickPhotoUpload = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const files = e.target.files;
+    if (!files?.length) return;
+    await processQuickUploadFiles(Array.from(files));
+    e.target.value = "";
+  };
+
+  const handleQuickDrop = async (e: React.DragEvent) => {
+    e.preventDefault();
+    setQuDragging(false);
+    const files = Array.from(e.dataTransfer.files);
+    if (files.length) await processQuickUploadFiles(files);
   };
 
   const handleQuickSubmit = async (asDraft: boolean) => {
@@ -1054,9 +1068,25 @@ export default function PayAndClaimPage() {
           </DialogHeader>
 
           <div className="space-y-4">
-            {/* Photo upload */}
-            <div className="rounded-lg border-2 border-dashed border-gray-200 p-4">
+            {/* Photo upload with drag & drop */}
+            <div
+              className={`rounded-lg border-2 border-dashed p-4 transition-colors ${
+                quDragging ? "border-[#C2714F] bg-orange-50" : "border-gray-200"
+              }`}
+              onDragOver={(e) => { e.preventDefault(); setQuDragging(true); }}
+              onDragEnter={(e) => { e.preventDefault(); setQuDragging(true); }}
+              onDragLeave={(e) => { e.preventDefault(); if (!e.currentTarget.contains(e.relatedTarget as Node)) setQuDragging(false); }}
+              onDrop={handleQuickDrop}
+            >
               <p className="text-xs font-medium text-gray-600 mb-2">Upload receipt photo(s)</p>
+              {quPhotos.length === 0 && !quUploading ? (
+                <label className="flex flex-col items-center justify-center py-8 cursor-pointer">
+                  <Upload className="h-8 w-8 text-gray-300 mb-2" />
+                  <span className="text-sm text-gray-400">{quDragging ? "Drop files here" : "Drag & drop or click to upload"}</span>
+                  <span className="text-[10px] text-gray-300 mt-1">Images or PDFs</span>
+                  <input type="file" accept="image/*,.pdf" multiple onChange={handleQuickPhotoUpload} className="hidden" />
+                </label>
+              ) : (
               <div className="flex flex-wrap gap-2">
                 {quPhotos.map((url, i) => (
                   <div key={i} className="relative w-20 h-20 rounded-lg border overflow-hidden group">
@@ -1082,6 +1112,7 @@ export default function PayAndClaimPage() {
                   <input type="file" accept="image/*,.pdf" multiple onChange={handleQuickPhotoUpload} className="hidden" />
                 </label>
               </div>
+              )}
 
               {quExtracting && (
                 <div className="mt-3 flex items-center gap-2 rounded-lg border border-purple-200 bg-purple-50 px-3 py-2">

--- a/apps/backoffice/src/app/api/inventory/pay-and-claim/route.ts
+++ b/apps/backoffice/src/app/api/inventory/pay-and-claim/route.ts
@@ -107,20 +107,21 @@ export async function GET(req: NextRequest) {
 
 export async function POST(req: NextRequest) {
   const body = await req.json();
-  const { outletId, supplierId, claimedById, items, notes, photos, purchaseDate, draft, aiExtracted } = body;
+  const { outletId, supplierId, claimedById, items, notes, photos, purchaseDate, draft, quickUpload, aiExtracted } = body;
 
   const isDraft = draft === true;
+  const isQuickUpload = quickUpload === true;
 
-  // For non-draft: require supplier, staff, items
-  if (!isDraft && (!outletId || !supplierId || !claimedById || !items?.length)) {
+  // For non-draft non-quick-upload: require supplier, staff, items
+  if (!isDraft && !isQuickUpload && (!outletId || !supplierId || !claimedById || !items?.length)) {
     return NextResponse.json(
       { error: "outletId, supplierId, claimedById, and items are required" },
       { status: 400 },
     );
   }
 
-  // For draft: at minimum need outletId
-  if (isDraft && !outletId) {
+  // For draft or quick upload: at minimum need outletId
+  if ((isDraft || isQuickUpload) && !outletId) {
     return NextResponse.json({ error: "outletId is required" }, { status: 400 });
   }
 
@@ -139,20 +140,23 @@ export async function POST(req: NextRequest) {
       )
     : 0;
 
-  // Store AI-extracted data in notes for draft review
-  const orderNotes = isDraft && aiExtracted
+  // Store AI-extracted data in notes for draft/quick-upload review
+  const orderNotes = (isDraft || isQuickUpload) && aiExtracted
     ? JSON.stringify({ userNotes: notes || null, aiExtracted })
     : notes || null;
 
-  if (isDraft) {
-    // ── Draft mode: no receiving, no stock adjustment ──
+  if (isDraft || isQuickUpload) {
+    // ── Draft / Quick Upload mode: no receiving, no stock adjustment ──
+    const orderStatus = isQuickUpload && !isDraft ? "COMPLETED" : "DRAFT";
+    const invoiceStatus = isQuickUpload && !isDraft ? "PENDING" : "DRAFT";
+
     const order = await prisma.order.create({
       data: {
         orderNumber,
         orderType: "PAY_AND_CLAIM",
         outletId,
         supplierId: supplierId || null,
-        status: "DRAFT",
+        status: orderStatus,
         totalAmount,
         notes: orderNotes,
         deliveryDate: purchaseDate ? new Date(purchaseDate) : new Date(),
@@ -174,7 +178,7 @@ export async function POST(req: NextRequest) {
       },
     });
 
-    // Create draft invoice
+    // Create invoice
     const invCount = await prisma.invoice.count();
     const invoiceNumber = `INV-${String(invCount + 1).padStart(4, "0")}`;
     const invoice = await prisma.invoice.create({
@@ -184,11 +188,13 @@ export async function POST(req: NextRequest) {
         outletId,
         supplierId: supplierId || null,
         amount: totalAmount,
-        status: "DRAFT",
+        status: invoiceStatus,
         paymentType: "STAFF_CLAIM",
         claimedById: claimedById || caller.id,
         photos: photos || [],
-        notes: notes ? `Draft claim: ${notes}` : "Draft claim",
+        notes: isDraft
+          ? (notes ? `Draft claim: ${notes}` : "Draft claim")
+          : (notes ? `Quick upload claim: ${notes}` : "Quick upload claim"),
       },
     });
 


### PR DESCRIPTION
## Summary
- **Fix submit/save not working** — "Submit Approved" always failed silently because the API required `supplierId`, `claimedById`, and `items` which the Quick Upload form doesn't collect. "Save as Draft" errors were also silently swallowed. Added `quickUpload` flag so the API accepts submissions without items/supplier, and added error alerts so failures are visible.
- **Add drag & drop** — The upload zone now supports drag & drop for images and PDFs. Empty state shows a large centered drop target. Highlights with brand color on drag-over.

## Test plan
- [ ] Open Quick Upload Receipt dialog
- [ ] Drag & drop an image or PDF onto the upload zone — should upload and trigger AI extraction
- [ ] Click "Save as Draft" — should save and close the dialog
- [ ] Click "Submit Approved" — should submit and close the dialog
- [ ] Verify both saved records appear in the Pay & Claim list with correct statuses (DRAFT vs COMPLETED)

https://claude.ai/code/session_018enaLqn9qvzDgY22pgArdp