### PR TITLE
Fix invoice dates, smart order cart, and purchase order UX

### DIFF
--- a/apps/backoffice/src/app/(admin)/inventory/invoices/page.tsx
+++ b/apps/backoffice/src/app/(admin)/inventory/invoices/page.tsx
@@ -60,7 +60,7 @@ export default function InvoicesPage() {
 
   // Edit invoice dialog
   const [editingInvoice, setEditingInvoice] = useState<Invoice | null>(null);
-  const [editForm, setEditForm] = useState({ invoiceNumber: "", dueDate: "", notes: "", amount: "" });
+  const [editForm, setEditForm] = useState({ invoiceNumber: "", issueDate: "", dueDate: "", notes: "", amount: "" });
   const [editPhotos, setEditPhotos] = useState<string[]>([]);
   const [editSaving, setEditSaving] = useState(false);
   const [editUploading, setEditUploading] = useState(false);
@@ -190,6 +190,7 @@ export default function InvoicesPage() {
     setEditingInvoice(inv);
     setEditForm({
       invoiceNumber: inv.invoiceNumber,
+      issueDate: inv.issueDate,
       dueDate: inv.dueDate ?? "",
       notes: inv.notes ?? "",
       amount: inv.amount.toFixed(2),
@@ -226,6 +227,7 @@ export default function InvoicesPage() {
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
           invoiceNumber: editForm.invoiceNumber,
+          issueDate: editForm.issueDate || null,
           dueDate: editForm.dueDate || null,
           notes: editForm.notes || null,
           amount: parseFloat(editForm.amount) || editingInvoice.amount,
@@ -589,14 +591,25 @@ export default function InvoicesPage() {
                 </div>
               </div>
 
-              <div>
-                <label className="mb-1 block text-xs font-medium text-gray-600">Due Date</label>
-                <input
-                  type="date"
-                  value={editForm.dueDate}
-                  onChange={(e) => setEditForm({ ...editForm, dueDate: e.target.value })}
-                  className="w-full rounded-md border border-gray-200 bg-white px-3 py-2 text-sm focus:border-blue-400 focus:outline-none focus:ring-1 focus:ring-blue-400"
-                />
+              <div className="grid grid-cols-2 gap-3">
+                <div>
+                  <label className="mb-1 block text-xs font-medium text-gray-600">Invoice Date</label>
+                  <input
+                    type="date"
+                    value={editForm.issueDate}
+                    onChange={(e) => setEditForm({ ...editForm, issueDate: e.target.value })}
+                    className="w-full rounded-md border border-gray-200 bg-white px-3 py-2 text-sm focus:border-blue-400 focus:outline-none focus:ring-1 focus:ring-blue-400"
+                  />
+                </div>
+                <div>
+                  <label className="mb-1 block text-xs font-medium text-gray-600">Due Date</label>
+                  <input
+                    type="date"
+                    value={editForm.dueDate}
+                    onChange={(e) => setEditForm({ ...editForm, dueDate: e.target.value })}
+                    className="w-full rounded-md border border-gray-200 bg-white px-3 py-2 text-sm focus:border-blue-400 focus:outline-none focus:ring-1 focus:ring-blue-400"
+                  />
+                </div>
               </div>
 
               <div>

--- a/apps/backoffice/src/app/(admin)/inventory/orders/create/page.tsx
+++ b/apps/backoffice/src/app/(admin)/inventory/orders/create/page.tsx
@@ -459,19 +459,22 @@ export default function CreateOrderPage() {
 
   // ── Cart helpers ────────────────────────────────────────────────────────
 
-  const isInCart = (productId: string, supplierId: string) =>
-    cart.some((c) => c.productId === productId && c.supplierId === supplierId);
+  const cartMatch = (c: CartItem, productId: string, supplierId: string, packageId?: string | null) =>
+    c.productId === productId && c.supplierId === supplierId && c.productPackageId === (packageId ?? null);
+
+  const isInCart = (productId: string, supplierId: string, packageId?: string | null) =>
+    cart.some((c) => cartMatch(c, productId, supplierId, packageId));
 
   const addToCart = (item: CartItem) => {
-    if (isInCart(item.productId, item.supplierId)) return;
+    if (isInCart(item.productId, item.supplierId, item.productPackageId)) return;
     setCart((prev) => [...prev, item]);
   };
 
-  const updateCartQty = (productId: string, supplierId: string, delta: number) => {
+  const updateCartQty = (productId: string, supplierId: string, packageId: string | null, delta: number) => {
     setCart((prev) =>
       prev
         .map((c) =>
-          c.productId === productId && c.supplierId === supplierId
+          cartMatch(c, productId, supplierId, packageId)
             ? { ...c, quantity: Math.max(0, c.quantity + delta) }
             : c
         )
@@ -479,8 +482,8 @@ export default function CreateOrderPage() {
     );
   };
 
-  const removeFromCart = (productId: string, supplierId: string) => {
-    setCart((prev) => prev.filter((c) => !(c.productId === productId && c.supplierId === supplierId)));
+  const removeFromCart = (productId: string, supplierId: string, packageId: string | null) => {
+    setCart((prev) => prev.filter((c) => !cartMatch(c, productId, supplierId, packageId)));
   };
 
   const cartTotal = cart.reduce((s, c) => s + c.quantity * c.unitPrice, 0);
@@ -525,8 +528,8 @@ export default function CreateOrderPage() {
       })
       .filter((x): x is CartItem => x !== null);
     setCart((prev) => {
-      const existing = new Set(prev.map((c) => `${c.productId}-${c.supplierId}`));
-      return [...prev, ...newItems.filter((n) => !existing.has(`${n.productId}-${n.supplierId}`))];
+      const existing = new Set(prev.map((c) => `${c.productId}-${c.supplierId}-${c.productPackageId}`));
+      return [...prev, ...newItems.filter((n) => !existing.has(`${n.productId}-${n.supplierId}-${n.productPackageId}`))];
     });
   };
 
@@ -783,7 +786,7 @@ export default function CreateOrderPage() {
                               const newItems: CartItem[] = [];
                               for (const item of needsOrdering) {
                                 if (!item.supplier || !item.supplierProduct) continue;
-                                if (isInCart(item.productId, item.supplier.id)) continue;
+                                if (isInCart(item.productId, item.supplier.id, item.supplierProduct.packageId)) continue;
                                 const pkgQty = Math.max(1, Math.ceil((item.suggestedOrderQty || 1) / (item.supplierProduct.conversionFactor || 1)));
                                 newItems.push({
                                   productId: item.productId,
@@ -859,8 +862,8 @@ export default function CreateOrderPage() {
                         {needsOrdering.map((item) => {
                           const pct = item.parLevel > 0 ? Math.min(100, Math.round((item.currentQty / item.parLevel) * 100)) : 0;
                           const barColor = item.status === "critical" ? "bg-red-500" : "bg-amber-500";
-                          const inCartAlready = item.supplier && isInCart(item.productId, item.supplier.id);
-                          const cartItem = item.supplier ? cart.find((c) => c.productId === item.productId && c.supplierId === item.supplier!.id) : null;
+                          const inCartAlready = item.supplier && item.supplierProduct && isInCart(item.productId, item.supplier.id, item.supplierProduct.packageId);
+                          const cartItem = item.supplier && item.supplierProduct ? cart.find((c) => cartMatch(c, item.productId, item.supplier!.id, item.supplierProduct!.packageId)) : null;
                           const pkgQty = item.supplierProduct ? Math.max(1, Math.ceil((item.suggestedOrderQty || 1) / (item.supplierProduct.conversionFactor || 1))) : 1;
                           const tf = item.transferOption;
 
@@ -902,9 +905,9 @@ export default function CreateOrderPage() {
                                   {/* Cart controls */}
                                   {inCartAlready && cartItem ? (
                                     <div className="flex items-center gap-2">
-                                      <button onClick={() => updateCartQty(item.productId, item.supplier!.id, -1)} className="flex h-7 w-7 items-center justify-center rounded-md bg-gray-100 text-gray-600 hover:bg-gray-200"><Minus className="h-3.5 w-3.5" /></button>
+                                      <button onClick={() => updateCartQty(item.productId, item.supplier!.id, item.supplierProduct!.packageId, -1)} className="flex h-7 w-7 items-center justify-center rounded-md bg-gray-100 text-gray-600 hover:bg-gray-200"><Minus className="h-3.5 w-3.5" /></button>
                                       <span className="min-w-[2rem] text-center text-sm font-bold">{cartItem.quantity}</span>
-                                      <button onClick={() => updateCartQty(item.productId, item.supplier!.id, 1)} className="flex h-7 w-7 items-center justify-center rounded-md bg-terracotta/10 text-terracotta-dark hover:bg-terracotta/20"><Plus className="h-3.5 w-3.5" /></button>
+                                      <button onClick={() => updateCartQty(item.productId, item.supplier!.id, item.supplierProduct!.packageId, 1)} className="flex h-7 w-7 items-center justify-center rounded-md bg-terracotta/10 text-terracotta-dark hover:bg-terracotta/20"><Plus className="h-3.5 w-3.5" /></button>
                                     </div>
                                   ) : item.supplier && item.supplierProduct ? (
                                     <Button size="sm" className={`h-8 text-xs ${item.status === "critical" ? "bg-red-600 hover:bg-red-700" : "bg-amber-600 hover:bg-amber-700"}`}
@@ -980,19 +983,19 @@ export default function CreateOrderPage() {
                     </div>
                     <div className="space-y-1.5">
                       {supplier.products.map((product) => {
-                        const inCart = isInCart(product.id, supplier.id);
-                        const cartItem = cart.find((c) => c.productId === product.id && c.supplierId === supplier.id);
+                        const inCart = isInCart(product.id, supplier.id, product.packageId);
+                        const cartItem = cart.find((c) => cartMatch(c, product.id, supplier.id, product.packageId));
                         return (
-                          <Card key={`${supplier.id}-${product.id}`} className="flex items-center justify-between px-4 py-3">
+                          <Card key={`${supplier.id}-${product.id}-${product.packageId}`} className="flex items-center justify-between px-4 py-3">
                             <div className="min-w-0 flex-1">
                               <p className="text-sm font-medium text-gray-900">{product.name}</p>
                               <p className="text-xs text-gray-500">{product.sku} &middot; {product.packageLabel} &middot; RM {product.price.toFixed(2)}</p>
                             </div>
                             {inCart ? (
                               <div className="flex items-center gap-2">
-                                <button onClick={() => updateCartQty(product.id, supplier.id, -1)} className="flex h-7 w-7 items-center justify-center rounded-md bg-gray-100 text-gray-600 hover:bg-gray-200"><Minus className="h-3.5 w-3.5" /></button>
+                                <button onClick={() => updateCartQty(product.id, supplier.id, product.packageId, -1)} className="flex h-7 w-7 items-center justify-center rounded-md bg-gray-100 text-gray-600 hover:bg-gray-200"><Minus className="h-3.5 w-3.5" /></button>
                                 <span className="min-w-[2rem] text-center text-sm font-bold">{cartItem?.quantity}</span>
-                                <button onClick={() => updateCartQty(product.id, supplier.id, 1)} className="flex h-7 w-7 items-center justify-center rounded-md bg-terracotta/10 text-terracotta-dark hover:bg-terracotta/20"><Plus className="h-3.5 w-3.5" /></button>
+                                <button onClick={() => updateCartQty(product.id, supplier.id, product.packageId, 1)} className="flex h-7 w-7 items-center justify-center rounded-md bg-terracotta/10 text-terracotta-dark hover:bg-terracotta/20"><Plus className="h-3.5 w-3.5" /></button>
                               </div>
                             ) : (
                               <Button size="sm" variant="outline" className="h-8 text-xs"
@@ -1095,14 +1098,14 @@ export default function CreateOrderPage() {
 
                           <div className="space-y-1.5">
                             {group.items.map((item) => (
-                              <div key={`${item.productId}-${item.supplierId}`} className="text-xs">
+                              <div key={`${item.productId}-${item.supplierId}-${item.productPackageId}`} className="text-xs">
                                 <div className="flex items-center justify-between">
                                   <p className="truncate text-gray-700 font-medium flex-1 min-w-0">{item.name}</p>
-                                  <button onClick={() => removeFromCart(item.productId, item.supplierId)} className="text-red-400 hover:text-red-600 ml-1"><Trash2 className="h-3 w-3" /></button>
+                                  <button onClick={() => removeFromCart(item.productId, item.supplierId, item.productPackageId)} className="text-red-400 hover:text-red-600 ml-1"><Trash2 className="h-3 w-3" /></button>
                                 </div>
                                 <div className="flex items-center justify-between mt-1">
                                   <div className="flex items-center gap-1.5">
-                                    <button onClick={() => updateCartQty(item.productId, item.supplierId, -1)} className="flex h-6 w-6 items-center justify-center rounded bg-gray-100 text-gray-600 hover:bg-gray-200"><Minus className="h-3 w-3" /></button>
+                                    <button onClick={() => updateCartQty(item.productId, item.supplierId, item.productPackageId, -1)} className="flex h-6 w-6 items-center justify-center rounded bg-gray-100 text-gray-600 hover:bg-gray-200"><Minus className="h-3 w-3" /></button>
                                     <input
                                       type="number"
                                       min="1"
@@ -1111,10 +1114,10 @@ export default function CreateOrderPage() {
                                       onChange={(e) => {
                                         const val = parseInt(e.target.value) || 0;
                                         const delta = val - item.quantity;
-                                        if (delta !== 0) updateCartQty(item.productId, item.supplierId, delta);
+                                        if (delta !== 0) updateCartQty(item.productId, item.supplierId, item.productPackageId, delta);
                                       }}
                                     />
-                                    <button onClick={() => updateCartQty(item.productId, item.supplierId, 1)} className="flex h-6 w-6 items-center justify-center rounded bg-terracotta/10 text-terracotta-dark hover:bg-terracotta/20"><Plus className="h-3 w-3" /></button>
+                                    <button onClick={() => updateCartQty(item.productId, item.supplierId, item.productPackageId, 1)} className="flex h-6 w-6 items-center justify-center rounded bg-terracotta/10 text-terracotta-dark hover:bg-terracotta/20"><Plus className="h-3 w-3" /></button>
                                     <span className="text-[10px] text-gray-400">{item.packageLabel}</span>
                                   </div>
                                   <span className="font-medium text-gray-900">RM {(item.quantity * item.unitPrice).toFixed(2)}</span>

--- a/apps/backoffice/src/app/(admin)/inventory/orders/page.tsx
+++ b/apps/backoffice/src/app/(admin)/inventory/orders/page.tsx
@@ -182,8 +182,31 @@ export default function OrdersPage() {
         fetch("/api/inventory/products"),
         fetch("/api/inventory/suppliers"),
       ]);
-      const allProducts: { name: string; sku: string }[] = productsRes.ok ? await productsRes.json() : [];
+      const allProducts: { name: string; sku: string; packages: { label: string; conversion: number }[]; suppliers: { name: string; price: number; uom: string }[] }[] = productsRes.ok ? await productsRes.json() : [];
       const allSuppliers: { name: string }[] = suppliersRes.ok ? await suppliersRes.json() : [];
+
+      // Build rich product names including packaging and supplier pricing context
+      const productNames = allProducts.map((p) => {
+        let desc = `${p.name} (${p.sku})`;
+        if (p.packages?.length > 0) {
+          const pkgInfo = p.packages.map((pkg) => `${pkg.label} [×${pkg.conversion}]`).join(", ");
+          desc += ` — packages: ${pkgInfo}`;
+        }
+        // Include supplier pricing for the current supplier
+        const relevantPrices = supplierName
+          ? p.suppliers?.filter((s) => s.name.toLowerCase().includes(supplierName.toLowerCase()))
+          : p.suppliers;
+        if (relevantPrices?.length > 0) {
+          const priceInfo = relevantPrices.map((s) => `RM${s.price}/${s.uom}`).join(", ");
+          desc += ` — prices: ${priceInfo}`;
+        }
+        return desc;
+      });
+
+      // Include current order items for context
+      const orderItemsContext = editItems
+        .filter((i) => !i.removed)
+        .map((i) => `${i.product} | package: ${i.uom || i.package || "pcs"} | ordered qty: ${i.quantity} | unit price: RM${i.unitPrice}`);
 
       const res = await fetch("/api/inventory/extract", {
         method: "POST",
@@ -191,8 +214,9 @@ export default function OrdersPage() {
         body: JSON.stringify({
           urls,
           context: supplierName ? `Supplier: ${supplierName}` : undefined,
-          productNames: allProducts.map((p) => `${p.name} (${p.sku})`),
+          productNames,
           supplierNames: allSuppliers.map((s) => s.name),
+          orderItems: orderItemsContext,
         }),
       });
       if (!res.ok) {
@@ -282,7 +306,7 @@ export default function OrdersPage() {
     } finally {
       setExtracting(false);
     }
-  }, [editDeliveryDate]);
+  }, [editDeliveryDate, editItems]);
 
   const uploadFile = useCallback(async (file: File) => {
     setUploading(true);

--- a/apps/backoffice/src/app/(admin)/inventory/orders/page.tsx
+++ b/apps/backoffice/src/app/(admin)/inventory/orders/page.tsx
@@ -108,9 +108,7 @@ const NEXT_ACTIONS: Record<string, { status: string; label: string; icon: typeof
     { status: "APPROVED", label: "Confirm", icon: CheckCircle2, color: "bg-blue-500 hover:bg-blue-600" },
     { status: "CANCELLED", label: "Reject", icon: Ban, color: "bg-red-500 hover:bg-red-600" },
   ],
-  APPROVED: [
-    { status: "SENT", label: "Mark as Sent", icon: Send, color: "bg-green-500 hover:bg-green-600" },
-  ],
+  APPROVED: [],
   SENT: [],
   AWAITING_DELIVERY: [],
   PARTIALLY_RECEIVED: [],

--- a/apps/backoffice/src/app/(admin)/inventory/orders/page.tsx
+++ b/apps/backoffice/src/app/(admin)/inventory/orders/page.tsx
@@ -60,6 +60,7 @@ type OrderInvoice = {
   invoiceNumber: string;
   amount: number;
   status: string;
+  issueDate: string;
   dueDate: string | null;
   photoCount: number;
 };
@@ -139,6 +140,7 @@ export default function OrdersPage() {
   const [editItems, setEditItems] = useState<EditItem[]>([]);
   const [editDeliveryDate, setEditDeliveryDate] = useState("");
   const [editInvoiceNumber, setEditInvoiceNumber] = useState("");
+  const [editInvoiceIssueDate, setEditInvoiceIssueDate] = useState("");
   const [editInvoiceDueDate, setEditInvoiceDueDate] = useState("");
   type InvoiceFile = { url: string; type: "image" | "pdf"; name: string };
   const [editInvoiceFiles, setEditInvoiceFiles] = useState<InvoiceFile[]>([]);
@@ -162,6 +164,7 @@ export default function OrdersPage() {
     setEditItems(order.items.map((i) => ({ ...i, removed: false, qtyStr: String(i.quantity), priceStr: i.unitPrice.toFixed(2) })));
     setEditDeliveryDate(order.deliveryDate ?? "");
     setEditInvoiceNumber(order.invoice?.invoiceNumber ?? "");
+    setEditInvoiceIssueDate(order.invoice?.issueDate ?? "");
     setEditInvoiceDueDate(order.invoice?.dueDate ?? "");
     setEditInvoiceFiles([]);
     setAiExtracted({});
@@ -213,6 +216,12 @@ export default function OrdersPage() {
       if (data.invoiceNumber) {
         setEditInvoiceNumber(data.invoiceNumber);
         filled.invoiceNumber = true;
+      }
+
+      // Issue date — always override with AI data
+      if (data.issueDate) {
+        setEditInvoiceIssueDate(data.issueDate);
+        filled.issueDate = true;
       }
 
       // Due date — always override with AI data
@@ -369,6 +378,9 @@ export default function OrdersPage() {
         if (editInvoiceNumber !== (editOrder.invoice.invoiceNumber ?? "")) {
           invoicePayload.invoiceNumber = editInvoiceNumber || null;
         }
+        if (editInvoiceIssueDate !== (editOrder.invoice.issueDate ?? "")) {
+          invoicePayload.issueDate = editInvoiceIssueDate || null;
+        }
         if (editInvoiceDueDate !== (editOrder.invoice.dueDate ?? "")) {
           invoicePayload.dueDate = editInvoiceDueDate || null;
         }
@@ -388,7 +400,7 @@ export default function OrdersPage() {
             body: JSON.stringify(invoicePayload),
           });
         }
-      } else if (editInvoiceNumber || editInvoiceDueDate || editInvoiceFiles.length > 0) {
+      } else if (editInvoiceNumber || editInvoiceIssueDate || editInvoiceDueDate || editInvoiceFiles.length > 0) {
         const detailRes = await fetch(`/api/inventory/orders/${editOrder.id}`);
         if (detailRes.ok) {
           const detail = await detailRes.json();
@@ -401,6 +413,7 @@ export default function OrdersPage() {
               supplierId: detail.supplierId,
               amount: invoiceAmount,
               invoiceNumber: editInvoiceNumber || null,
+              issueDate: editInvoiceIssueDate || null,
               dueDate: editInvoiceDueDate || null,
               photos: editInvoiceFiles.map((f) => f.url),
             }),
@@ -812,6 +825,20 @@ export default function OrdersPage() {
                       className={aiExtracted.invoiceNumber ? "border-purple-300 bg-purple-50/30" : ""}
                     />
                   </div>
+                  <div>
+                    <label className="mb-1 flex items-center gap-1.5 text-xs font-medium text-gray-600">
+                      <CalendarDays className="h-3.5 w-3.5" /> Invoice Date
+                      {aiExtracted.issueDate && <span className="ml-1 rounded bg-purple-100 px-1.5 py-0.5 text-[9px] font-medium text-purple-600">AI</span>}
+                    </label>
+                    <Input
+                      type="date"
+                      value={editInvoiceIssueDate}
+                      onChange={(e) => { setEditInvoiceIssueDate(e.target.value); setAiExtracted((p) => { const n = { ...p }; delete n.issueDate; return n; }); }}
+                      className={aiExtracted.issueDate ? "border-purple-300 bg-purple-50/30" : ""}
+                    />
+                  </div>
+                </div>
+                <div className="grid grid-cols-2 gap-3">
                   <div>
                     <label className="mb-1 flex items-center gap-1.5 text-xs font-medium text-gray-600">
                       <CalendarDays className="h-3.5 w-3.5" /> Invoice Due Date

--- a/apps/backoffice/src/app/(admin)/inventory/orders/page.tsx
+++ b/apps/backoffice/src/app/(admin)/inventory/orders/page.tsx
@@ -650,7 +650,7 @@ export default function OrdersPage() {
                             <Pencil className="h-3 w-3" />
                           </button>
                         )}
-                        {["DRAFT", "CANCELLED"].includes(order.status) && (
+                        {["DRAFT", "APPROVED", "CANCELLED"].includes(order.status) && (
                           <button onClick={() => deleteOrder(order.id)} disabled={updatingId === order.id} className="rounded-md px-2 py-1 text-[10px] font-medium text-red-600 border border-red-200 hover:bg-red-50 disabled:opacity-50" title="Delete">
                             <Trash2 className="h-3 w-3" />
                           </button>

--- a/apps/backoffice/src/app/(admin)/inventory/orders/page.tsx
+++ b/apps/backoffice/src/app/(admin)/inventory/orders/page.tsx
@@ -650,7 +650,12 @@ export default function OrdersPage() {
                             <Pencil className="h-3 w-3" />
                           </button>
                         )}
-                        {["DRAFT", "APPROVED", "CANCELLED"].includes(order.status) && (
+                        {order.status === "APPROVED" && (
+                          <button onClick={() => { if (confirm("Cancel this order?")) updateStatus(order.id, "CANCELLED"); }} disabled={updatingId === order.id} className="rounded-md px-2 py-1 text-[10px] font-medium text-red-600 border border-red-200 hover:bg-red-50 disabled:opacity-50" title="Cancel Order">
+                            Cancel
+                          </button>
+                        )}
+                        {["DRAFT", "CANCELLED"].includes(order.status) && (
                           <button onClick={() => deleteOrder(order.id)} disabled={updatingId === order.id} className="rounded-md px-2 py-1 text-[10px] font-medium text-red-600 border border-red-200 hover:bg-red-50 disabled:opacity-50" title="Delete">
                             <Trash2 className="h-3 w-3" />
                           </button>

--- a/apps/backoffice/src/app/(admin)/inventory/pay-and-claim/page.tsx
+++ b/apps/backoffice/src/app/(admin)/inventory/pay-and-claim/page.tsx
@@ -190,9 +190,9 @@ export default function PayAndClaimPage() {
   const pendingAmount = pendingClaims.reduce((s, c) => s + c.totalAmount, 0);
   const reimbursedAmount = reimbursedClaims.reduce((s, c) => s + c.totalAmount, 0);
 
-  // Load options
-  const loadOptions = async () => {
-    if (optionsLoaded || loadingOptions) return;
+  // Load options — returns suppliers list for immediate use
+  const loadOptions = async (): Promise<SupplierOption[]> => {
+    if (optionsLoaded || loadingOptions) return suppliers;
     setLoadingOptions(true);
     try {
       const [o, s, st] = await Promise.all([
@@ -204,14 +204,17 @@ export default function PayAndClaimPage() {
       setSuppliers(s);
       setStaff(Array.isArray(st) ? st : st.staff ?? []);
       setOptionsLoaded(true);
+      setLoadingOptions(false);
+      return s;
     } catch { /* ignore */ }
     setLoadingOptions(false);
+    return suppliers;
   };
 
   // ── Review Dialog ───────────────────────────────────────────────────────
 
   const openReview = async (claim: Claim) => {
-    await loadOptions();
+    const loadedSuppliers = await loadOptions();
     setReviewClaim(claim);
 
     // Parse AI hints from notes if JSON
@@ -237,7 +240,9 @@ export default function PayAndClaimPage() {
 
     setRvAiHints(aiHints);
     setRvAiFields(aiFields);
-    setRvSupplierId(claim.supplierId ?? "");
+    // Default to ADHOC supplier for pay & claim
+    const adhocSupplier = loadedSuppliers.find((s) => s.name === "Ad-hoc Purchase");
+    setRvSupplierId(claim.supplierId || adhocSupplier?.id || "");
     setRvStaffId("");
     setRvAmount(claim.totalAmount > 0 ? claim.totalAmount.toString() : (aiHints.totalAmount || ""));
     setRvDate(aiHints.issueDate || new Date(claim.createdAt).toISOString().split("T")[0]);
@@ -877,7 +882,7 @@ export default function PayAndClaimPage() {
                           <option value="">Select supplier</option>
                           {suppliers.map((s) => <option key={s.id} value={s.id}>{s.name}</option>)}
                         </select>
-                        {rvAiHints.supplierName && !rvSupplierId && (
+                        {rvAiHints.supplierName && rvAiHints.supplierName !== "Ad-hoc Purchase" && (
                           <p className="text-[10px] text-purple-500 mt-1">
                             <Sparkles className="h-2.5 w-2.5 inline mr-0.5" />
                             Detected: &quot;{rvAiHints.supplierName}&quot;
@@ -1040,8 +1045,6 @@ export default function PayAndClaimPage() {
                             <span className="font-mono">RM {rvCartTotal.toFixed(2)}</span>
                           </div>
                         </div>
-                      ) : !rvSupplierId ? (
-                        <p className="text-xs text-gray-400 italic">Select a supplier first to add products</p>
                       ) : null}
                     </div>
                   </>

--- a/apps/backoffice/src/app/api/inventory/extract/route.ts
+++ b/apps/backoffice/src/app/api/inventory/extract/route.ts
@@ -28,7 +28,7 @@ type ExtractedInvoice = {
 export async function POST(req: NextRequest) {
   try {
     const body = await req.json();
-    const { urls, context, productNames, supplierNames } = body as { urls: string[]; context?: string; productNames?: string[]; supplierNames?: string[] };
+    const { urls, context, productNames, supplierNames, orderItems } = body as { urls: string[]; context?: string; productNames?: string[]; supplierNames?: string[]; orderItems?: string[] };
 
     if (!urls?.length) {
       return NextResponse.json({ error: "No URLs provided" }, { status: 400 });
@@ -81,6 +81,17 @@ ${productNames?.length ? `\nKNOWN PRODUCT CATALOG (use these exact names when ma
 2. Use the EXACT catalog name (without the SKU in brackets) in the "name" field.
 3. ONLY include items that match a product in the catalog. Do NOT include items that have no catalog match.
 4. Delivery charges, shipping fees, service charges, discounts, and similar non-product charges should NOT be in the items array — put them in "deliveryCharge" or "notes" instead.` : ""}
+${orderItems?.length ? `\nCURRENT ORDER ITEMS (these are what was ordered — use this to understand the expected packaging and pricing):
+${orderItems.join("\n")}
+
+PACKAGING & PRICING LOGIC:
+- Suppliers may invoice using different packaging units than what the order uses (e.g. invoice says "carton" but order tracks per "bottle").
+- The product catalog above shows available packages with conversion factors [×N] and known prices per package.
+- Use the ORDER ITEMS above to determine the correct unit price and quantity to return.
+- If the invoice unit price matches a DIFFERENT package than what the order uses, convert accordingly:
+  Example: Order is per "bottle" at RM14.08. Invoice shows 6x at RM84.46/carton. Carton [×6] means 6 bottles per carton. Return: quantity=36 (6 cartons × 6 bottles), unitPrice=14.08 (per bottle).
+- If the invoice unit price matches the order's unit price, use it directly without conversion.
+- Always return quantity and unitPrice in the SAME unit as the order item's package.` : ""}
 
 Return a JSON object with these fields:
 - invoiceNumber: the invoice/receipt number (string or null)

--- a/apps/backoffice/src/app/api/inventory/invoices/[id]/route.ts
+++ b/apps/backoffice/src/app/api/inventory/invoices/[id]/route.ts
@@ -24,11 +24,12 @@ export async function PATCH(req: NextRequest, { params }: { params: Promise<{ id
   try {
     const { id } = await params;
     const body = await req.json();
-    const { status, invoiceNumber, dueDate, notes, amount, photos, paidVia, paymentRef } = body;
+    const { status, invoiceNumber, issueDate, dueDate, notes, amount, photos, paidVia, paymentRef } = body;
 
     const data: Record<string, unknown> = {};
     if (status !== undefined) data.status = status;
     if (invoiceNumber !== undefined) data.invoiceNumber = invoiceNumber;
+    if (issueDate !== undefined) data.issueDate = issueDate ? new Date(issueDate) : new Date();
     if (dueDate !== undefined) data.dueDate = dueDate ? new Date(dueDate) : null;
     if (notes !== undefined) data.notes = notes;
     if (amount !== undefined) data.amount = amount;

--- a/apps/backoffice/src/app/api/inventory/invoices/route.ts
+++ b/apps/backoffice/src/app/api/inventory/invoices/route.ts
@@ -121,7 +121,7 @@ export async function POST(req: NextRequest) {
 
   try {
     const body = await req.json();
-    const { orderId, outletId, supplierId, amount, invoiceNumber, dueDate, photos } = body;
+    const { orderId, outletId, supplierId, amount, invoiceNumber, issueDate, dueDate, photos } = body;
 
     if (!outletId || !supplierId) {
       return NextResponse.json({ error: "outletId and supplierId are required" }, { status: 400 });
@@ -142,6 +142,7 @@ export async function POST(req: NextRequest) {
         supplierId,
         amount: amount ?? 0,
         status: "PENDING",
+        issueDate: issueDate ? new Date(issueDate) : new Date(),
         dueDate: dueDate ? new Date(dueDate) : null,
         photos: photos || [],
       },

--- a/apps/backoffice/src/app/api/inventory/orders/[id]/route.ts
+++ b/apps/backoffice/src/app/api/inventory/orders/[id]/route.ts
@@ -164,8 +164,8 @@ export async function DELETE(_req: NextRequest, { params }: { params: Promise<{ 
     const order = await prisma.order.findUnique({ where: { id }, select: { status: true } });
     if (!order) return NextResponse.json({ error: "Not found" }, { status: 404 });
 
-    if (!["DRAFT", "APPROVED", "CANCELLED"].includes(order.status)) {
-      return NextResponse.json({ error: "Only draft, confirmed, or cancelled orders can be deleted" }, { status: 400 });
+    if (!["DRAFT", "CANCELLED"].includes(order.status)) {
+      return NextResponse.json({ error: "Only draft or cancelled orders can be deleted" }, { status: 400 });
     }
 
     // Wrap delete operations in a transaction

--- a/apps/backoffice/src/app/api/inventory/orders/[id]/route.ts
+++ b/apps/backoffice/src/app/api/inventory/orders/[id]/route.ts
@@ -164,12 +164,14 @@ export async function DELETE(_req: NextRequest, { params }: { params: Promise<{ 
     const order = await prisma.order.findUnique({ where: { id }, select: { status: true } });
     if (!order) return NextResponse.json({ error: "Not found" }, { status: 404 });
 
-    if (!["DRAFT", "CANCELLED"].includes(order.status)) {
-      return NextResponse.json({ error: "Only draft or cancelled orders can be deleted" }, { status: 400 });
+    if (!["DRAFT", "APPROVED", "CANCELLED"].includes(order.status)) {
+      return NextResponse.json({ error: "Only draft, confirmed, or cancelled orders can be deleted" }, { status: 400 });
     }
 
     // Wrap delete operations in a transaction
     await prisma.$transaction(async (tx) => {
+      // Delete linked invoices (only unpaid ones)
+      await tx.invoice.deleteMany({ where: { orderId: id, status: { in: ["DRAFT", "PENDING"] } } });
       await tx.orderItem.deleteMany({ where: { orderId: id } });
       await tx.order.delete({ where: { id } });
     });

--- a/apps/backoffice/src/app/api/inventory/orders/route.ts
+++ b/apps/backoffice/src/app/api/inventory/orders/route.ts
@@ -55,7 +55,7 @@ export async function GET(req: NextRequest) {
         },
       },
       invoices: {
-        select: { id: true, invoiceNumber: true, amount: true, status: true, dueDate: true, photos: true },
+        select: { id: true, invoiceNumber: true, amount: true, status: true, issueDate: true, dueDate: true, photos: true },
         orderBy: { createdAt: "desc" as const },
         take: 1,
       },
@@ -102,6 +102,7 @@ export async function GET(req: NextRequest) {
           invoiceNumber: o.invoices[0].invoiceNumber,
           amount: Number(o.invoices[0].amount),
           status: o.invoices[0].status,
+          issueDate: o.invoices[0].issueDate.toISOString().split("T")[0],
           dueDate: o.invoices[0].dueDate?.toISOString().split("T")[0] ?? null,
           photoCount: o.invoices[0].photos.length,
         }

--- a/apps/backoffice/src/app/api/inventory/products/[id]/route.ts
+++ b/apps/backoffice/src/app/api/inventory/products/[id]/route.ts
@@ -9,11 +9,12 @@ export async function PATCH(req: NextRequest, { params }: { params: Promise<{ id
   try {
     const { id } = await params;
     const body = await req.json();
-    const { name, sku, groupId, baseUom, storageArea, shelfLifeDays, description, checkFrequency, itemType, packages } = body as {
+    const { name, sku, groupId, baseUom, storageArea, shelfLifeDays, description, checkFrequency, itemType, packages, suppliers } = body as {
       name?: string; sku?: string; groupId?: string; baseUom?: string;
       storageArea?: string; shelfLifeDays?: string; description?: string;
       checkFrequency?: string; itemType?: string;
       packages?: { id?: string; sku?: string; packageName: string; packageLabel: string; conversionFactor: number; isDefault?: boolean; containsPackageId?: string | null; containsPackageIndex?: number }[];
+      suppliers?: { supplierId?: string; supplierName?: string; phone?: string; price: number; productPackageId?: string; packageIndex?: number }[];
     };
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -89,6 +90,68 @@ export async function PATCH(req: NextRequest, { params }: { params: Promise<{ id
             where: { id: createdPkgIds[i] },
             data: { containsPackageId: createdPkgIds[pkg.containsPackageIndex] },
           });
+        }
+      }
+    }
+
+    // Handle suppliers: sync supplier-product links
+    if (suppliers && Array.isArray(suppliers)) {
+      // Get existing supplier links (exclude ADHOC — managed separately)
+      const adhocSupplier = await prisma.supplier.findFirst({ where: { supplierCode: "ADHOC" } });
+      const existing = await prisma.supplierProduct.findMany({
+        where: { productId: id, ...(adhocSupplier ? { supplierId: { not: adhocSupplier.id } } : {}) },
+      });
+
+      // Delete removed supplier links
+      const incomingSupplierIds = new Set(
+        suppliers.filter((s) => s.supplierId).map((s) => `${s.supplierId}-${s.productPackageId || ""}`)
+      );
+      for (const ex of existing) {
+        if (!incomingSupplierIds.has(`${ex.supplierId}-${ex.productPackageId || ""}`)) {
+          await prisma.supplierProduct.delete({ where: { id: ex.id } });
+        }
+      }
+
+      // Resolve package IDs created in packages step above
+      const createdPkgIds = packages ? await prisma.productPackage.findMany({
+        where: { productId: id },
+        select: { id: true },
+      }).then((pkgs) => pkgs.map((p) => p.id)) : [];
+
+      // Upsert supplier links
+      for (const entry of suppliers) {
+        let supplierId = entry.supplierId;
+
+        // Create new supplier if needed
+        if (!supplierId && entry.supplierName) {
+          const count = await prisma.supplier.count();
+          const supplierCode = `SUP-${String(count + 1).padStart(4, "0")}`;
+          const newSupplier = await prisma.supplier.create({
+            data: { name: entry.supplierName, supplierCode, phone: entry.phone || null, status: "ACTIVE" },
+          });
+          supplierId = newSupplier.id;
+        }
+
+        // Resolve packageIndex to actual package ID
+        let packageId = entry.productPackageId || null;
+        if (!packageId && entry.packageIndex !== undefined && createdPkgIds[entry.packageIndex]) {
+          packageId = createdPkgIds[entry.packageIndex];
+        }
+
+        if (supplierId) {
+          const existingLink = await prisma.supplierProduct.findFirst({
+            where: { supplierId, productId: id, productPackageId: packageId },
+          });
+          if (existingLink) {
+            await prisma.supplierProduct.update({
+              where: { id: existingLink.id },
+              data: { price: entry.price },
+            });
+          } else {
+            await prisma.supplierProduct.create({
+              data: { supplierId, productId: id, productPackageId: packageId, price: entry.price },
+            });
+          }
         }
       }
     }

--- a/apps/backoffice/src/app/api/inventory/products/route.ts
+++ b/apps/backoffice/src/app/api/inventory/products/route.ts
@@ -177,5 +177,17 @@ export async function POST(req: NextRequest) {
     }
   }
 
+  // Auto-link to ADHOC supplier so product is available for pay & claim
+  const adhocSupplier = await prisma.supplier.findFirst({ where: { supplierCode: "ADHOC" } });
+  if (adhocSupplier) {
+    await prisma.supplierProduct.create({
+      data: {
+        supplierId: adhocSupplier.id,
+        productId: product.id,
+        price: 0,
+      },
+    }).catch(() => { /* already linked */ });
+  }
+
   return NextResponse.json(product, { status: 201 });
 }


### PR DESCRIPTION
## Summary

- **Fix invoice date display**: Invoice date (`issueDate`) from AI extraction was defaulting to today instead of the actual invoice date. Now properly saved and editable.
- **AI packaging/pricing intelligence**: AI extraction now receives product packaging info and supplier pricing context to correctly match invoice prices (e.g. carton vs bottle pricing).
- **ADHOC supplier for pay & claim**: Review dialog auto-selects "Ad-hoc Purchase" supplier. New products auto-linked to ADHOC on creation.
- **Fix smart order cart**: Products with multiple packages (e.g. Fresh Milk 2000ml vs 1000ml) were treated as the same cart item. Now each package variant is independent.
- **Fix product edit not saving suppliers**: PATCH API was ignoring supplier links — only POST worked. Now properly syncs supplier-product links on edit.
- **Remove "Mark as Sent" button**: Redundant step since orders go directly from Confirmed to Receiving.
- **Cancel button for confirmed orders**: APPROVED orders can be cancelled (with audit trail) instead of deleted. Delete restricted to DRAFT/CANCELLED only.

## Test plan
- [ ] Upload invoice → verify detected date shows correctly (not today's date)
- [ ] Edit invoice → verify Invoice Date field is editable
- [ ] Smart Order → add two package variants of same product → verify they appear as separate cart items
- [ ] Edit a product, add/change supplier → verify supplier link is saved
- [ ] Pay & Claim → open review → verify ADHOC supplier is pre-selected
- [ ] Confirmed order → verify no "Mark as Sent" button, Cancel button appears instead
- [ ] Confirmed order → Cancel → verify order moves to Cancelled status
- [ ] Completed/Received order → verify no delete or cancel options

https://claude.ai/code/session_01Nr6vJrEsZfWn2cN6yHPji6