### PR TITLE
Prevent duplicate suppliers when creating products

### DIFF
--- a/apps/backoffice/src/app/api/inventory/products/[id]/route.ts
+++ b/apps/backoffice/src/app/api/inventory/products/[id]/route.ts
@@ -122,14 +122,21 @@ export async function PATCH(req: NextRequest, { params }: { params: Promise<{ id
       for (const entry of suppliers) {
         let supplierId = entry.supplierId;
 
-        // Create new supplier if needed
+        // Create new supplier if needed (check existing first to avoid duplicates)
         if (!supplierId && entry.supplierName) {
-          const count = await prisma.supplier.count();
-          const supplierCode = `SUP-${String(count + 1).padStart(4, "0")}`;
-          const newSupplier = await prisma.supplier.create({
-            data: { name: entry.supplierName, supplierCode, phone: entry.phone || null, status: "ACTIVE" },
+          const existing = await prisma.supplier.findFirst({
+            where: { name: { equals: entry.supplierName, mode: "insensitive" } },
           });
-          supplierId = newSupplier.id;
+          if (existing) {
+            supplierId = existing.id;
+          } else {
+            const count = await prisma.supplier.count();
+            const supplierCode = `SUP-${String(count + 1).padStart(4, "0")}`;
+            const newSupplier = await prisma.supplier.create({
+              data: { name: entry.supplierName, supplierCode, phone: entry.phone || null, status: "ACTIVE" },
+            });
+            supplierId = newSupplier.id;
+          }
         }
 
         // Resolve packageIndex to actual package ID

--- a/apps/backoffice/src/app/api/inventory/products/route.ts
+++ b/apps/backoffice/src/app/api/inventory/products/route.ts
@@ -145,17 +145,25 @@ export async function POST(req: NextRequest) {
       let supplierId = entry.supplierId;
 
       if (!supplierId && entry.supplierName) {
-        const count = await prisma.supplier.count();
-        const supplierCode = `SUP-${String(count + 1).padStart(4, "0")}`;
-        const newSupplier = await prisma.supplier.create({
-          data: {
-            name: entry.supplierName,
-            supplierCode,
-            phone: entry.phone || null,
-            status: "ACTIVE",
-          },
+        // Check if supplier already exists to avoid duplicates
+        const existing = await prisma.supplier.findFirst({
+          where: { name: { equals: entry.supplierName, mode: "insensitive" } },
         });
-        supplierId = newSupplier.id;
+        if (existing) {
+          supplierId = existing.id;
+        } else {
+          const count = await prisma.supplier.count();
+          const supplierCode = `SUP-${String(count + 1).padStart(4, "0")}`;
+          const newSupplier = await prisma.supplier.create({
+            data: {
+              name: entry.supplierName,
+              supplierCode,
+              phone: entry.phone || null,
+              status: "ACTIVE",
+            },
+          });
+          supplierId = newSupplier.id;
+        }
       }
 
       // Resolve packageIndex to actual package ID for newly created packages


### PR DESCRIPTION
## Summary

- When typing a new supplier name in the product form, the API now checks if a supplier with that name already exists (case-insensitive) before creating a new one
- Fixed in both POST (create product) and PATCH (edit product) handlers
- Cleaned up existing duplicate "Multiways Packaging (M) Sdn Bhd" in the database

## Test plan
- [ ] Create two products with the same typed-in supplier name → verify only one supplier is created
- [ ] Verify suppliers page shows no duplicates

https://claude.ai/code/session_01Nr6vJrEsZfWn2cN6yHPji6