### PR TITLE
Fix perishable dialog width

### DIFF
--- a/apps/backoffice/src/app/(admin)/inventory/perishables/page.tsx
+++ b/apps/backoffice/src/app/(admin)/inventory/perishables/page.tsx
@@ -584,7 +584,7 @@ export default function PerishablesPage() {
 
       {/* Add/Edit Dialog */}
       <Dialog open={dialogOpen} onOpenChange={(open) => { setDialogOpen(open); if (!open) { setEditingId(null); setForm(emptyForm); resetSupplierForm(); } }}>
-        <DialogContent className="max-w-4xl max-h-[90vh] overflow-y-auto">
+        <DialogContent className="sm:max-w-4xl max-h-[90vh] overflow-y-auto">
           <DialogHeader>
             <DialogTitle className="text-lg">{editingId ? "Edit Perishable" : "Add Perishable"}</DialogTitle>
           </DialogHeader>


### PR DESCRIPTION
## Summary
- DialogContent base styles have `sm:max-w-sm` which overrode `max-w-4xl`
- Changed to `sm:max-w-4xl` to properly override at the same breakpoint

https://claude.ai/code/session_01Nr6vJrEsZfWn2cN6yHPji6