### PR TITLE
fix: make /api/outlets public for staff PIN login

### DIFF
--- a/apps/staff/src/app/api/outlets/route.ts
+++ b/apps/staff/src/app/api/outlets/route.ts
@@ -1,14 +1,10 @@
 import { NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
-import { getSession } from "@/lib/auth";
 
 export async function GET() {
-  const session = await getSession();
-  if (!session) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-
   const outlets = await prisma.outlet.findMany({
     where: { status: "ACTIVE" },
-    select: { id: true, code: true, name: true, type: true },
+    select: { id: true, name: true },
     orderBy: { name: "asc" },
   });
 


### PR DESCRIPTION
## Summary
- Staff PIN login is broken — the `/api/outlets` endpoint requires auth, but the login page needs the outlet list *before* the user is logged in
- Removed the `getSession()` guard so the outlet dropdown populates on the login page
- Narrowed the select to only `{ id, name }` to minimize data exposed on the public endpoint

## What changed
`apps/staff/src/app/api/outlets/route.ts` — 5 lines removed, 1 changed

## Risk
Low. Strictly subtractive change. No schema migration. Outlet names/IDs are not sensitive.

## Test plan
- [ ] Open staff.celsiuscoffee.com in incognito (no session)
- [ ] Verify outlet dropdown populates on PIN login screen
- [ ] Enter a valid 6-digit staff PIN → confirm login succeeds
- [ ] Verify manager/admin username login still works

https://claude.ai/code/session_01P4aS9Nfq7eK2wUQFjvqibv