### PR TITLE
fix: PO edit page + duplicate invoice fix

### DIFF
--- a/apps/backoffice/src/app/(admin)/inventory/orders/[id]/page.tsx
+++ b/apps/backoffice/src/app/(admin)/inventory/orders/[id]/page.tsx
@@ -188,7 +188,7 @@ export default function EditOrderPage({ params }: { params: Promise<{ id: string
           </Button>
           <Button onClick={() => saveOrder(false)} disabled={saving} className="bg-terracotta hover:bg-terracotta-dark">
             {saving ? <Loader2 className="mr-1.5 h-4 w-4 animate-spin" /> : <Save className="mr-1.5 h-4 w-4" />}
-            Save Draft
+            Save Changes
           </Button>
           {isDraft && (
             <Button onClick={() => saveOrder(true)} disabled={saving} className="bg-blue-500 hover:bg-blue-600">

--- a/apps/backoffice/src/app/(admin)/inventory/orders/page.tsx
+++ b/apps/backoffice/src/app/(admin)/inventory/orders/page.tsx
@@ -629,15 +629,10 @@ export default function OrdersPage() {
                             {updatingId === order.id ? <Loader2 className="h-3 w-3 animate-spin" /> : "Confirm Order"}
                           </button>
                         )}
-                        {order.status === "DRAFT" && (
+                        {["DRAFT", "PENDING_APPROVAL", "SENT", "AWAITING_DELIVERY", "PARTIALLY_RECEIVED"].includes(order.status) && (
                           <Link href={`/inventory/orders/${order.id}`} className="rounded-md px-2 py-1 text-[10px] font-medium text-gray-600 border border-gray-200 hover:bg-gray-50" title="Edit PO">
                             <Pencil className="h-3 w-3" />
                           </Link>
-                        )}
-                        {["PENDING_APPROVAL", "SENT", "AWAITING_DELIVERY", "PARTIALLY_RECEIVED"].includes(order.status) && (
-                          <button onClick={() => openEditDialog(order)} className="rounded-md px-2 py-1 text-[10px] font-medium text-gray-600 border border-gray-200 hover:bg-gray-50" title="Edit Order">
-                            <Pencil className="h-3 w-3" />
-                          </button>
                         )}
                         {order.status === "APPROVED" && (
                           <button onClick={() => { if (confirm("Cancel this order?")) updateStatus(order.id, "CANCELLED"); }} disabled={updatingId === order.id} className="rounded-md px-2 py-1 text-[10px] font-medium text-red-600 border border-red-200 hover:bg-red-50 disabled:opacity-50" title="Cancel Order">

--- a/apps/backoffice/src/app/api/inventory/orders/[id]/route.ts
+++ b/apps/backoffice/src/app/api/inventory/orders/[id]/route.ts
@@ -25,7 +25,7 @@ export async function PATCH(req: NextRequest, { params }: { params: Promise<{ id
   try {
     const { id } = await params;
     const body = await req.json();
-    const { status, totalAmount, deliveryDate, items, invoiceNumber: bodyInvoiceNumber, invoiceDueDate, invoicePhotos } = body;
+    const { status, totalAmount, deliveryDate, items, invoicePhotos } = body;
 
     const data: Record<string, unknown> = {};
 
@@ -95,32 +95,9 @@ export async function PATCH(req: NextRequest, { params }: { params: Promise<{ id
       },
     });
 
-    // Auto-create invoice + receiving when order is confirmed (AWAITING_DELIVERY)
+    // Auto-create receiving when order is confirmed (AWAITING_DELIVERY)
     if (status === "AWAITING_DELIVERY") {
       const caller = await getUserFromHeaders(req.headers);
-
-      try {
-        // Check if invoice already exists for this order
-        const existingInvoice = await prisma.invoice.findFirst({ where: { orderId: id } });
-        if (!existingInvoice) {
-          const invCount = await prisma.invoice.count();
-          const invoiceNumber = bodyInvoiceNumber || `INV-${String(invCount + 1).padStart(4, "0")}`;
-          await prisma.invoice.create({
-            data: {
-              invoiceNumber,
-              orderId: id,
-              outletId: order.outletId,
-              supplierId: order.supplierId,
-              amount: order.totalAmount,
-              status: "PENDING",
-              dueDate: invoiceDueDate ? new Date(invoiceDueDate) : null,
-              photos: invoicePhotos || [],
-            },
-          });
-        }
-      } catch (e) {
-        console.error("[orders/[id] PATCH] Invoice auto-create failed:", e);
-      }
 
       try {
         // Check if receiving already exists for this order


### PR DESCRIPTION
## Summary
- Edit button on all PO statuses now navigates to `/inventory/orders/[id]` full page instead of opening inline modal
- Remove auto-create invoice from AWAITING_DELIVERY PATCH handler — was creating duplicate invoices (e.g. INV-0008 + 26040498 for the same PO)
- Rename "Save Draft" to "Save Changes" on PO edit page

## Test plan
- [ ] Click edit on a DRAFT PO → should navigate to full PO page
- [ ] Click edit on a SENT PO → should navigate to full PO page
- [ ] "Confirm Order" on SENT PO (from list) → should still open modal with invoice matching
- [ ] Confirm a SENT order with invoice → verify only ONE invoice is created

https://claude.ai/code/session_01P4aS9Nfq7eK2wUQFjvqibv