### PR TITLE
fix: perishables auto-SKU + invoice delete + conversion bug

### DIFF
--- a/apps/backoffice/src/app/(admin)/inventory/invoices/page.tsx
+++ b/apps/backoffice/src/app/(admin)/inventory/invoices/page.tsx
@@ -538,6 +538,26 @@ export default function InvoicesPage() {
                       >
                         <Pencil className="h-3.5 w-3.5" />
                       </button>
+                      {["DRAFT", "PENDING"].includes(inv.status) && (
+                        <button
+                          onClick={async () => {
+                            if (!confirm(`Delete invoice ${inv.invoiceNumber}?`)) return;
+                            setUpdatingId(inv.id);
+                            try {
+                              const res = await fetch(`/api/inventory/invoices/${inv.id}`, { method: "DELETE" });
+                              if (res.ok) loadInvoices(undefined, { revalidate: true });
+                              else alert("Failed to delete invoice");
+                            } finally {
+                              setUpdatingId(null);
+                            }
+                          }}
+                          disabled={updatingId === inv.id}
+                          className="rounded-md p-1 text-red-400 hover:bg-red-50 hover:text-red-600 disabled:opacity-50"
+                          title="Delete invoice"
+                        >
+                          <Trash2 className="h-3.5 w-3.5" />
+                        </button>
+                      )}
                       {actions.map((a) => (
                         <button
                           key={a.status}

--- a/apps/backoffice/src/app/(admin)/inventory/orders/[id]/page.tsx
+++ b/apps/backoffice/src/app/(admin)/inventory/orders/[id]/page.tsx
@@ -188,7 +188,7 @@ export default function EditOrderPage({ params }: { params: Promise<{ id: string
           </Button>
           <Button onClick={() => saveOrder(false)} disabled={saving} className="bg-terracotta hover:bg-terracotta-dark">
             {saving ? <Loader2 className="mr-1.5 h-4 w-4 animate-spin" /> : <Save className="mr-1.5 h-4 w-4" />}
-            Save Draft
+            Save Changes
           </Button>
           {isDraft && (
             <Button onClick={() => saveOrder(true)} disabled={saving} className="bg-blue-500 hover:bg-blue-600">

--- a/apps/backoffice/src/app/(admin)/inventory/orders/page.tsx
+++ b/apps/backoffice/src/app/(admin)/inventory/orders/page.tsx
@@ -629,15 +629,10 @@ export default function OrdersPage() {
                             {updatingId === order.id ? <Loader2 className="h-3 w-3 animate-spin" /> : "Confirm Order"}
                           </button>
                         )}
-                        {order.status === "DRAFT" && (
+                        {["DRAFT", "PENDING_APPROVAL", "SENT", "AWAITING_DELIVERY", "PARTIALLY_RECEIVED"].includes(order.status) && (
                           <Link href={`/inventory/orders/${order.id}`} className="rounded-md px-2 py-1 text-[10px] font-medium text-gray-600 border border-gray-200 hover:bg-gray-50" title="Edit PO">
                             <Pencil className="h-3 w-3" />
                           </Link>
-                        )}
-                        {["PENDING_APPROVAL", "SENT", "AWAITING_DELIVERY", "PARTIALLY_RECEIVED"].includes(order.status) && (
-                          <button onClick={() => openEditDialog(order)} className="rounded-md px-2 py-1 text-[10px] font-medium text-gray-600 border border-gray-200 hover:bg-gray-50" title="Edit Order">
-                            <Pencil className="h-3 w-3" />
-                          </button>
                         )}
                         {order.status === "APPROVED" && (
                           <button onClick={() => { if (confirm("Cancel this order?")) updateStatus(order.id, "CANCELLED"); }} disabled={updatingId === order.id} className="rounded-md px-2 py-1 text-[10px] font-medium text-red-600 border border-red-200 hover:bg-red-50 disabled:opacity-50" title="Cancel Order">

--- a/apps/backoffice/src/app/api/inventory/invoices/[id]/route.ts
+++ b/apps/backoffice/src/app/api/inventory/invoices/[id]/route.ts
@@ -50,3 +50,24 @@ export async function PATCH(req: NextRequest, { params }: { params: Promise<{ id
     return NextResponse.json({ error: message }, { status: 500 });
   }
 }
+
+export async function DELETE(req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  const caller = await getUserFromHeaders(req.headers);
+  if (!caller) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+
+  try {
+    const { id } = await params;
+    const invoice = await prisma.invoice.findUnique({ where: { id }, select: { id: true, status: true } });
+    if (!invoice) return NextResponse.json({ error: "Not found" }, { status: 404 });
+
+    if (!["DRAFT", "PENDING"].includes(invoice.status)) {
+      return NextResponse.json({ error: "Only draft or pending invoices can be deleted" }, { status: 400 });
+    }
+
+    await prisma.invoice.delete({ where: { id } });
+    return NextResponse.json({ ok: true });
+  } catch (err) {
+    console.error("[invoices/[id] DELETE]", err);
+    return NextResponse.json({ error: "Failed to delete invoice" }, { status: 500 });
+  }
+}

--- a/apps/backoffice/src/app/api/inventory/orders/[id]/route.ts
+++ b/apps/backoffice/src/app/api/inventory/orders/[id]/route.ts
@@ -25,7 +25,7 @@ export async function PATCH(req: NextRequest, { params }: { params: Promise<{ id
   try {
     const { id } = await params;
     const body = await req.json();
-    const { status, totalAmount, deliveryDate, items, invoiceNumber: bodyInvoiceNumber, invoiceDueDate, invoicePhotos } = body;
+    const { status, totalAmount, deliveryDate, items, invoicePhotos } = body;
 
     const data: Record<string, unknown> = {};
 
@@ -95,32 +95,9 @@ export async function PATCH(req: NextRequest, { params }: { params: Promise<{ id
       },
     });
 
-    // Auto-create invoice + receiving when order is confirmed (AWAITING_DELIVERY)
+    // Auto-create receiving when order is confirmed (AWAITING_DELIVERY)
     if (status === "AWAITING_DELIVERY") {
       const caller = await getUserFromHeaders(req.headers);
-
-      try {
-        // Check if invoice already exists for this order
-        const existingInvoice = await prisma.invoice.findFirst({ where: { orderId: id } });
-        if (!existingInvoice) {
-          const invCount = await prisma.invoice.count();
-          const invoiceNumber = bodyInvoiceNumber || `INV-${String(invCount + 1).padStart(4, "0")}`;
-          await prisma.invoice.create({
-            data: {
-              invoiceNumber,
-              orderId: id,
-              outletId: order.outletId,
-              supplierId: order.supplierId,
-              amount: order.totalAmount,
-              status: "PENDING",
-              dueDate: invoiceDueDate ? new Date(invoiceDueDate) : null,
-              photos: invoicePhotos || [],
-            },
-          });
-        }
-      } catch (e) {
-        console.error("[orders/[id] PATCH] Invoice auto-create failed:", e);
-      }
 
       try {
         // Check if receiving already exists for this order


### PR DESCRIPTION
## Summary
- **Perishables auto-SKU**: Package presets now have code mappings (CTN, BTL, etc.) and SKU auto-generates when adding a package, matching ingredients behavior
- **Conversion factor bug**: Replaced uncontrolled DOM inputs with React controlled state — previously any re-render would reset the value to 0
- **Invoice delete**: Added DELETE endpoint + trash button for DRAFT/PENDING invoices to clean up duplicates from the previous bug

## Test plan
- [ ] Edit a perishable → add a package → SKU should auto-fill (e.g. PER001-CTN)
- [ ] Enter conversion factor → interact with other fields → value should persist
- [ ] On invoices page, click trash on INV-0008 and INV-0006 to remove duplicates

https://claude.ai/code/session_01P4aS9Nfq7eK2wUQFjvqibv