### PR TITLE
fix: exclude Ad-hoc Purchase from purchase orders

### DIFF
--- a/apps/backoffice/src/app/(admin)/inventory/invoices/page.tsx
+++ b/apps/backoffice/src/app/(admin)/inventory/invoices/page.tsx
@@ -779,7 +779,8 @@ export default function InvoicesPage() {
               </div>
             )}
 
-            {/* Payment reference */}
+            {/* Payment reference — only for Mark Paid */}
+            {payingTargetStatus === "PAID" && (
             <div className="mt-3">
               <label className="mb-1 block text-xs font-medium text-gray-600">Payment Reference</label>
               <Input
@@ -788,8 +789,10 @@ export default function InvoicesPage() {
                 placeholder="e.g. Transfer ref, receipt no..."
               />
             </div>
+            )}
 
-            {/* Receipt upload */}
+            {/* Receipt upload — only for Mark Paid */}
+            {payingTargetStatus === "PAID" && (
             <div className="mt-3">
               <label className="mb-1 block text-xs font-medium text-gray-600">Receipt / Proof of Payment</label>
               {payReceipts.length > 0 && (
@@ -823,6 +826,7 @@ export default function InvoicesPage() {
                 <input type="file" accept="image/*,.pdf,application/pdf" multiple className="hidden" onChange={handlePayReceiptUpload} />
               </label>
             </div>
+            )}
 
             <div className="mt-4 flex gap-2">
               <button onClick={() => setPayingInvoice(null)} className="flex-1 rounded-md border border-gray-200 px-3 py-2 text-sm text-gray-600 hover:bg-gray-50">Cancel</button>

--- a/apps/backoffice/src/app/(admin)/inventory/invoices/page.tsx
+++ b/apps/backoffice/src/app/(admin)/inventory/invoices/page.tsx
@@ -538,6 +538,26 @@ export default function InvoicesPage() {
                       >
                         <Pencil className="h-3.5 w-3.5" />
                       </button>
+                      {["DRAFT", "PENDING"].includes(inv.status) && (
+                        <button
+                          onClick={async () => {
+                            if (!confirm(`Delete invoice ${inv.invoiceNumber}?`)) return;
+                            setUpdatingId(inv.id);
+                            try {
+                              const res = await fetch(`/api/inventory/invoices/${inv.id}`, { method: "DELETE" });
+                              if (res.ok) loadInvoices(undefined, { revalidate: true });
+                              else alert("Failed to delete invoice");
+                            } finally {
+                              setUpdatingId(null);
+                            }
+                          }}
+                          disabled={updatingId === inv.id}
+                          className="rounded-md p-1 text-red-400 hover:bg-red-50 hover:text-red-600 disabled:opacity-50"
+                          title="Delete invoice"
+                        >
+                          <Trash2 className="h-3.5 w-3.5" />
+                        </button>
+                      )}
                       {actions.map((a) => (
                         <button
                           key={a.status}

--- a/apps/backoffice/src/app/(admin)/inventory/orders/[id]/page.tsx
+++ b/apps/backoffice/src/app/(admin)/inventory/orders/[id]/page.tsx
@@ -188,7 +188,7 @@ export default function EditOrderPage({ params }: { params: Promise<{ id: string
           </Button>
           <Button onClick={() => saveOrder(false)} disabled={saving} className="bg-terracotta hover:bg-terracotta-dark">
             {saving ? <Loader2 className="mr-1.5 h-4 w-4 animate-spin" /> : <Save className="mr-1.5 h-4 w-4" />}
-            Save Draft
+            Save Changes
           </Button>
           {isDraft && (
             <Button onClick={() => saveOrder(true)} disabled={saving} className="bg-blue-500 hover:bg-blue-600">

--- a/apps/backoffice/src/app/(admin)/inventory/orders/create/page.tsx
+++ b/apps/backoffice/src/app/(admin)/inventory/orders/create/page.tsx
@@ -350,7 +350,7 @@ export default function CreateOrderPage() {
       fetch("/api/settings/outlets?status=ACTIVE").then((r) => r.json()),
       fetch("/api/inventory/orders").then((r) => r.json()),
     ]).then(([s, b, o]) => {
-      setSuppliers(s);
+      setSuppliers(s.filter((sup: SupplierOption) => sup.name !== "Ad-hoc Purchase"));
       // Sort outlets: Putrajaya first, Nilai last
       const sorted = [...b].sort((a: OutletOption, b: OutletOption) => {
         const aName = a.name.toLowerCase();

--- a/apps/backoffice/src/app/(admin)/inventory/orders/create/page.tsx
+++ b/apps/backoffice/src/app/(admin)/inventory/orders/create/page.tsx
@@ -603,11 +603,13 @@ export default function CreateOrderPage() {
   };
 
   const submitAsDraft = async () => {
+    const entries = Object.entries(cartBySupplier);
+    if (entries.length === 0) return;
     setSaving(true);
     try {
-      for (const [, group] of Object.entries(cartBySupplier)) {
+      for (const [, group] of entries) {
         const deliveryDate = getDeliveryDate(group.supplierId);
-        await fetch("/api/inventory/orders", {
+        const res = await fetch("/api/inventory/orders", {
           method: "POST",
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify({
@@ -623,6 +625,11 @@ export default function CreateOrderPage() {
             })),
           }),
         });
+        if (!res.ok) {
+          const err = await res.json().catch(() => ({}));
+          alert(`Failed to save draft: ${err.error || res.statusText}`);
+          return;
+        }
       }
       router.push("/inventory/orders");
     } finally {

--- a/apps/backoffice/src/app/(admin)/inventory/orders/page.tsx
+++ b/apps/backoffice/src/app/(admin)/inventory/orders/page.tsx
@@ -629,15 +629,10 @@ export default function OrdersPage() {
                             {updatingId === order.id ? <Loader2 className="h-3 w-3 animate-spin" /> : "Confirm Order"}
                           </button>
                         )}
-                        {order.status === "DRAFT" && (
+                        {["DRAFT", "PENDING_APPROVAL", "SENT", "AWAITING_DELIVERY", "PARTIALLY_RECEIVED"].includes(order.status) && (
                           <Link href={`/inventory/orders/${order.id}`} className="rounded-md px-2 py-1 text-[10px] font-medium text-gray-600 border border-gray-200 hover:bg-gray-50" title="Edit PO">
                             <Pencil className="h-3 w-3" />
                           </Link>
-                        )}
-                        {["PENDING_APPROVAL", "SENT", "AWAITING_DELIVERY", "PARTIALLY_RECEIVED"].includes(order.status) && (
-                          <button onClick={() => openEditDialog(order)} className="rounded-md px-2 py-1 text-[10px] font-medium text-gray-600 border border-gray-200 hover:bg-gray-50" title="Edit Order">
-                            <Pencil className="h-3 w-3" />
-                          </button>
                         )}
                         {order.status === "APPROVED" && (
                           <button onClick={() => { if (confirm("Cancel this order?")) updateStatus(order.id, "CANCELLED"); }} disabled={updatingId === order.id} className="rounded-md px-2 py-1 text-[10px] font-medium text-red-600 border border-red-200 hover:bg-red-50 disabled:opacity-50" title="Cancel Order">

--- a/apps/backoffice/src/app/(admin)/inventory/perishables/page.tsx
+++ b/apps/backoffice/src/app/(admin)/inventory/perishables/page.tsx
@@ -64,17 +64,17 @@ type ProductForm = {
 type StorageAreaOption = { id: string; name: string; slug: string };
 
 const PACKAGE_PRESETS = [
-  { name: "Carton", label: "Carton" },
-  { name: "Bottle", label: "Bottle" },
-  { name: "Pack", label: "Pack" },
-  { name: "Bag", label: "Bag" },
-  { name: "Box", label: "Box" },
-  { name: "Can", label: "Can" },
-  { name: "Tub", label: "Tub" },
-  { name: "Drum", label: "Drum" },
-  { name: "Roll", label: "Roll" },
-  { name: "Sleeve", label: "Sleeve" },
-  { name: "Slice", label: "Slice" },
+  { name: "Carton", label: "Carton", code: "CTN" },
+  { name: "Bottle", label: "Bottle", code: "BTL" },
+  { name: "Pack", label: "Pack", code: "PCK" },
+  { name: "Bag", label: "Bag", code: "BAG" },
+  { name: "Box", label: "Box", code: "BOX" },
+  { name: "Can", label: "Can", code: "CAN" },
+  { name: "Tub", label: "Tub", code: "TUB" },
+  { name: "Drum", label: "Drum", code: "DRM" },
+  { name: "Roll", label: "Roll", code: "ROL" },
+  { name: "Sleeve", label: "Sleeve", code: "SLV" },
+  { name: "Slice", label: "Slice", code: "SLC" },
 ];
 
 const emptyForm: ProductForm = { name: "", sku: "", groupId: "", baseUom: "", storageArea: "", shelfLifeDays: "", checkFrequency: "MONTHLY", description: "", packages: [], suppliers: [] };
@@ -91,6 +91,10 @@ export default function PerishablesPage() {
   const [form, setForm] = useState<ProductForm>(emptyForm);
   const [expandedId, setExpandedId] = useState<string | null>(null);
   const [saving, setSaving] = useState(false);
+
+  // Inline package form state
+  const [newPkgType, setNewPkgType] = useState("");
+  const [newPkgConv, setNewPkgConv] = useState("");
 
   // Inline supplier form state
   const [selectedSupplierId, setSelectedSupplierId] = useState("");
@@ -163,6 +167,8 @@ export default function PerishablesPage() {
     setForm(emptyForm);
     setEditingId(null);
     resetSupplierForm();
+    setNewPkgType("");
+    setNewPkgConv("");
     setDialogOpen(true);
   };
 
@@ -731,20 +737,12 @@ export default function PerishablesPage() {
 
               {/* Add new package row */}
               <div className="flex items-end gap-3">
-                <div className="w-28">
-                  <label className="text-xs text-gray-500">SKU</label>
-                  <Input
-                    id="perishable-new-pkg-sku"
-                    placeholder="e.g. PER001-CTN"
-                    className="mt-1 h-10"
-                  />
-                </div>
                 <div className="w-36">
                   <label className="text-xs text-gray-500">Package Type</label>
                   <select
-                    id="perishable-new-pkg-name"
+                    value={newPkgType}
+                    onChange={(e) => setNewPkgType(e.target.value)}
                     className="mt-1 h-10 w-full rounded-md border border-gray-200 px-3 text-sm"
-                    defaultValue=""
                   >
                     <option value="" disabled>Select...</option>
                     {PACKAGE_PRESETS.filter((p) => !form.packages.some((ep) => ep.packageName === p.name)).map((p) => (
@@ -753,12 +751,13 @@ export default function PerishablesPage() {
                   </select>
                 </div>
                 <div className="w-32">
-                  <label className="text-xs text-gray-500">= {form.baseUom || "units"}</label>
+                  <label className="text-xs text-gray-500">= {form.baseUom || "pcs"}</label>
                   <Input
-                    id="perishable-new-pkg-conv"
                     type="number"
                     placeholder="e.g. 50"
                     className="mt-1 h-10"
+                    value={newPkgConv}
+                    onChange={(e) => setNewPkgConv(e.target.value)}
                   />
                 </div>
                 <Button
@@ -766,23 +765,25 @@ export default function PerishablesPage() {
                   variant="outline"
                   className="h-10"
                   onClick={() => {
-                    const skuEl = document.getElementById("perishable-new-pkg-sku") as HTMLInputElement;
-                    const nameEl = document.getElementById("perishable-new-pkg-name") as HTMLSelectElement;
-                    const convEl = document.getElementById("perishable-new-pkg-conv") as HTMLInputElement;
-                    if (!nameEl.value || !convEl.value) return;
-                    setForm((prev) => ({
-                      ...prev,
-                      packages: [...prev.packages, {
-                        sku: skuEl.value || "",
-                        packageName: nameEl.value,
-                        packageLabel: nameEl.value,
-                        conversionFactor: convEl.value,
-                        isDefault: prev.packages.length === 0,
-                      }],
-                    }));
-                    skuEl.value = "";
-                    nameEl.value = "";
-                    convEl.value = "";
+                    if (!newPkgType || !newPkgConv) return;
+                    const preset = PACKAGE_PRESETS.find((p) => p.name === newPkgType);
+                    const code = preset?.code || newPkgType.slice(0, 3).toUpperCase();
+                    setForm((prev) => {
+                      const count = prev.packages.filter((p) => p.packageName.toLowerCase().includes(newPkgType.toLowerCase())).length;
+                      const autoSku = form.sku ? `${form.sku}-${code}${count > 0 ? count + 1 : ""}` : "";
+                      return {
+                        ...prev,
+                        packages: [...prev.packages, {
+                          sku: autoSku,
+                          packageName: newPkgType,
+                          packageLabel: newPkgType,
+                          conversionFactor: newPkgConv,
+                          isDefault: prev.packages.length === 0,
+                        }],
+                      };
+                    });
+                    setNewPkgType("");
+                    setNewPkgConv("");
                   }}
                 >
                   Add

--- a/apps/backoffice/src/app/(admin)/inventory/perishables/page.tsx
+++ b/apps/backoffice/src/app/(admin)/inventory/perishables/page.tsx
@@ -24,7 +24,7 @@ type Product = {
   shelfLifeDays: number | null;
   description: string;
   checkFrequency: string;
-  packages: { id: string; sku: string; name: string; uom: string; label: string; conversion: number; isDefault: boolean }[];
+  packages: { id: string; sku: string; name: string; uom: string; label: string; conversion: number; isDefault: boolean; containsPackageId: string | null }[];
   suppliers: { name: string; price: number; uom: string }[];
 };
 
@@ -38,6 +38,7 @@ type PackageEntry = {
   packageLabel: string;
   conversionFactor: string;
   isDefault: boolean;
+  containsPackageId?: string | null;
 };
 
 type SupplierEntry = {
@@ -95,6 +96,9 @@ export default function PerishablesPage() {
   // Inline package form state
   const [newPkgType, setNewPkgType] = useState("");
   const [newPkgConv, setNewPkgConv] = useState("");
+  const [newBulkType, setNewBulkType] = useState("");
+  const [newBulkQty, setNewBulkQty] = useState("");
+  const [newBulkContains, setNewBulkContains] = useState("");
 
   // Inline supplier form state
   const [selectedSupplierId, setSelectedSupplierId] = useState("");
@@ -129,13 +133,15 @@ export default function PerishablesPage() {
           description: form.description || null,
           checkFrequency: form.checkFrequency,
           itemType: "PERISHABLE",
-          packages: form.packages.filter((p) => p.packageName && p.conversionFactor).map((p) => ({
+          packages: form.packages.filter((p) => p.packageName && p.conversionFactor).map((p, idx) => ({
             id: p.id || undefined,
             sku: p.sku || undefined,
             packageName: p.packageName,
             packageLabel: p.packageLabel || p.packageName,
             conversionFactor: parseFloat(p.conversionFactor) || 1,
             isDefault: p.isDefault,
+            containsPackageId: p.containsPackageId && !p.containsPackageId.startsWith("new-") ? p.containsPackageId : undefined,
+            containsPackageIndex: p.containsPackageId?.startsWith("new-") ? parseInt(p.containsPackageId.replace("new-", "")) : undefined,
           })),
           suppliers: form.suppliers,
         }),
@@ -169,6 +175,9 @@ export default function PerishablesPage() {
     resetSupplierForm();
     setNewPkgType("");
     setNewPkgConv("");
+    setNewBulkType("");
+    setNewBulkQty("");
+    setNewBulkContains("");
     setDialogOpen(true);
   };
 
@@ -189,6 +198,7 @@ export default function PerishablesPage() {
         packageLabel: pkg.label,
         conversionFactor: pkg.conversion.toString(),
         isDefault: pkg.isDefault,
+        containsPackageId: pkg.containsPackageId ?? null,
       })),
       suppliers: [],
     });
@@ -706,89 +716,189 @@ export default function PerishablesPage() {
             {/* Packages */}
             <div className="rounded-lg border border-gray-200 bg-gray-50/30 p-4">
               <p className="mb-3 text-xs font-semibold uppercase tracking-wider text-gray-400">Packages</p>
-              <p className="mb-3 text-xs text-gray-400">
-                Define how this item is packaged when purchased. E.g. 1 Carton = 50 {form.baseUom || "units"}
-              </p>
 
-              {/* Existing package entries */}
-              {form.packages.length > 0 && (
-                <div className="mb-3 space-y-2">
-                  {form.packages.map((pkg, i) => (
-                    <div key={i} className="flex items-center gap-3 rounded-lg border border-gray-200 bg-white px-4 py-2.5">
-                      <code className="rounded bg-gray-100 px-1.5 py-0.5 text-xs text-gray-500">{pkg.sku || "—"}</code>
-                      <span className="text-sm font-medium text-gray-700">{pkg.packageName}</span>
-                      <span className="text-xs text-gray-400">=</span>
-                      <span className="text-sm text-gray-600">{Number(pkg.conversionFactor).toLocaleString()} {form.baseUom || "units"}</span>
-                      {pkg.isDefault && <Badge variant="outline" className="text-xs border-blue-200 bg-blue-50 text-blue-600">Default</Badge>}
-                      <div className="flex-1" />
-                      <button
+              {(() => {
+                const unitPkgs = form.packages.filter((p) => !p.containsPackageId);
+                const bulkPkgs = form.packages.filter((p) => !!p.containsPackageId);
+                return (
+                  <>
+                    {/* UOM — unit packages */}
+                    <p className="mb-2 text-xs font-medium text-gray-500">UOM <span className="font-normal text-gray-400">— countable unit (e.g. 1 Pack = 50 {form.baseUom || "pcs"})</span></p>
+                    {unitPkgs.length > 0 && (
+                      <div className="mb-3 space-y-2">
+                        {unitPkgs.map((pkg) => {
+                          const origIdx = form.packages.indexOf(pkg);
+                          return (
+                            <div key={origIdx} className="flex items-center gap-3 rounded-lg border border-gray-200 bg-white px-4 py-2.5">
+                              <code className="rounded bg-gray-100 px-1.5 py-0.5 text-xs text-gray-500">{pkg.sku || "—"}</code>
+                              <span className="text-sm font-medium text-gray-700">{pkg.packageLabel || pkg.packageName}</span>
+                              <span className="text-xs text-gray-400">=</span>
+                              <span className="text-sm text-gray-600">{Number(pkg.conversionFactor).toLocaleString()} {form.baseUom || "pcs"}</span>
+                              {pkg.isDefault && <Badge variant="outline" className="text-xs border-blue-200 bg-blue-50 text-blue-600">Default</Badge>}
+                              <div className="flex-1" />
+                              <button type="button" onClick={() => setForm((prev) => ({ ...prev, packages: prev.packages.filter((_, idx) => idx !== origIdx) }))} className="text-gray-400 hover:text-red-500"><X className="h-4 w-4" /></button>
+                            </div>
+                          );
+                        })}
+                      </div>
+                    )}
+
+                    {/* Add UOM */}
+                    <div className="mb-4 flex flex-wrap items-end gap-3">
+                      <div className="w-36">
+                        <label className="text-xs text-gray-500">Type</label>
+                        <select
+                          value={newPkgType}
+                          onChange={(e) => setNewPkgType(e.target.value)}
+                          className="mt-1 h-10 w-full rounded-md border border-gray-200 px-3 text-sm"
+                        >
+                          <option value="" disabled>Select...</option>
+                          {PACKAGE_PRESETS.map((p) => <option key={p.name} value={p.name}>{p.label}</option>)}
+                        </select>
+                      </div>
+                      <div className="w-24">
+                        <label className="text-xs text-gray-500">Size</label>
+                        <Input
+                          type="number"
+                          placeholder="e.g. 50"
+                          className="mt-1 h-10"
+                          value={newPkgConv}
+                          onChange={(e) => setNewPkgConv(e.target.value)}
+                        />
+                      </div>
+                      <span className="pb-2 text-sm text-gray-400">{form.baseUom || "pcs"}</span>
+                      <Button
                         type="button"
+                        variant="outline"
+                        className="h-10"
                         onClick={() => {
-                          setForm((prev) => ({ ...prev, packages: prev.packages.filter((_, idx) => idx !== i) }));
+                          if (!newPkgType || !newPkgConv) return;
+                          const size = Number(newPkgConv);
+                          if (!size || size <= 0) return;
+                          const preset = PACKAGE_PRESETS.find((p) => p.name === newPkgType);
+                          const code = preset?.code || newPkgType.slice(0, 3).toUpperCase();
+                          setForm((prev) => {
+                            const label = `${size.toLocaleString()}${form.baseUom || ""} ${newPkgType}`;
+                            const count = prev.packages.filter((p) => p.packageName.toLowerCase().includes(newPkgType.toLowerCase())).length;
+                            const autoSku = form.sku ? `${form.sku}-${code}${count > 0 ? count + 1 : ""}` : "";
+                            return {
+                              ...prev,
+                              packages: [...prev.packages, {
+                                sku: autoSku,
+                                packageName: newPkgType,
+                                packageLabel: label,
+                                conversionFactor: String(size),
+                                isDefault: prev.packages.length === 0,
+                                containsPackageId: null,
+                              }],
+                            };
+                          });
+                          setNewPkgType("");
+                          setNewPkgConv("");
                         }}
-                        className="text-gray-400 hover:text-red-500"
                       >
-                        <X className="h-4 w-4" />
-                      </button>
+                        Add
+                      </Button>
                     </div>
-                  ))}
-                </div>
-              )}
 
-              {/* Add new package row */}
-              <div className="flex items-end gap-3">
-                <div className="w-36">
-                  <label className="text-xs text-gray-500">Package Type</label>
-                  <select
-                    value={newPkgType}
-                    onChange={(e) => setNewPkgType(e.target.value)}
-                    className="mt-1 h-10 w-full rounded-md border border-gray-200 px-3 text-sm"
-                  >
-                    <option value="" disabled>Select...</option>
-                    {PACKAGE_PRESETS.filter((p) => !form.packages.some((ep) => ep.packageName === p.name)).map((p) => (
-                      <option key={p.name} value={p.name}>{p.label}</option>
-                    ))}
-                  </select>
-                </div>
-                <div className="w-32">
-                  <label className="text-xs text-gray-500">= {form.baseUom || "pcs"}</label>
-                  <Input
-                    type="number"
-                    placeholder="e.g. 50"
-                    className="mt-1 h-10"
-                    value={newPkgConv}
-                    onChange={(e) => setNewPkgConv(e.target.value)}
-                  />
-                </div>
-                <Button
-                  type="button"
-                  variant="outline"
-                  className="h-10"
-                  onClick={() => {
-                    if (!newPkgType || !newPkgConv) return;
-                    const preset = PACKAGE_PRESETS.find((p) => p.name === newPkgType);
-                    const code = preset?.code || newPkgType.slice(0, 3).toUpperCase();
-                    setForm((prev) => {
-                      const count = prev.packages.filter((p) => p.packageName.toLowerCase().includes(newPkgType.toLowerCase())).length;
-                      const autoSku = form.sku ? `${form.sku}-${code}${count > 0 ? count + 1 : ""}` : "";
-                      return {
-                        ...prev,
-                        packages: [...prev.packages, {
-                          sku: autoSku,
-                          packageName: newPkgType,
-                          packageLabel: newPkgType,
-                          conversionFactor: newPkgConv,
-                          isDefault: prev.packages.length === 0,
-                        }],
-                      };
-                    });
-                    setNewPkgType("");
-                    setNewPkgConv("");
-                  }}
-                >
-                  Add
-                </Button>
-              </div>
+                    {/* Bulk Packaging */}
+                    <p className="mb-2 text-xs font-medium text-gray-500">Bulk Packaging <span className="font-normal text-gray-400">— how it&apos;s purchased (e.g. Carton of 12× Pack)</span></p>
+                    {bulkPkgs.length > 0 && (
+                      <div className="mb-3 space-y-2">
+                        {bulkPkgs.map((pkg) => {
+                          const origIdx = form.packages.indexOf(pkg);
+                          const childPkg = form.packages.find((p, idx) => p.id === pkg.containsPackageId || `new-${idx}` === pkg.containsPackageId);
+                          const qty = childPkg ? Math.round(Number(pkg.conversionFactor) / Number(childPkg.conversionFactor)) : 0;
+                          return (
+                            <div key={origIdx} className="flex items-center gap-3 rounded-lg border border-gray-200 bg-white px-4 py-2.5">
+                              <code className="rounded bg-gray-100 px-1.5 py-0.5 text-xs text-gray-500">{pkg.sku || "—"}</code>
+                              <span className="text-sm font-medium text-gray-700">{pkg.packageLabel || pkg.packageName}</span>
+                              {childPkg && <span className="text-xs text-gray-400">({qty}× {childPkg.packageLabel || childPkg.packageName})</span>}
+                              <span className="text-xs text-gray-400">=</span>
+                              <span className="text-sm text-gray-600">{Number(pkg.conversionFactor).toLocaleString()} {form.baseUom || "pcs"}</span>
+                              <div className="flex-1" />
+                              <button type="button" onClick={() => setForm((prev) => ({ ...prev, packages: prev.packages.filter((_, idx) => idx !== origIdx) }))} className="text-gray-400 hover:text-red-500"><X className="h-4 w-4" /></button>
+                            </div>
+                          );
+                        })}
+                      </div>
+                    )}
+
+                    {/* Add Bulk Package */}
+                    {unitPkgs.length > 0 && (
+                      <div className="flex flex-wrap items-end gap-3">
+                        <div className="w-32">
+                          <label className="text-xs text-gray-500">Container</label>
+                          <select
+                            value={newBulkType}
+                            onChange={(e) => setNewBulkType(e.target.value)}
+                            className="mt-1 h-10 w-full rounded-md border border-gray-200 px-3 text-sm"
+                          >
+                            <option value="" disabled>Select...</option>
+                            {PACKAGE_PRESETS.map((p) => <option key={p.name} value={p.name}>{p.label}</option>)}
+                          </select>
+                        </div>
+                        <div className="w-20">
+                          <label className="text-xs text-gray-500">Qty</label>
+                          <Input type="number" placeholder="12" className="mt-1 h-10" value={newBulkQty} onChange={(e) => setNewBulkQty(e.target.value)} />
+                        </div>
+                        <span className="pb-2 text-sm text-gray-400">×</span>
+                        <div className="w-44">
+                          <label className="text-xs text-gray-500">Contains</label>
+                          <select
+                            value={newBulkContains}
+                            onChange={(e) => setNewBulkContains(e.target.value)}
+                            className="mt-1 h-10 w-full rounded-md border border-gray-200 px-3 text-sm"
+                          >
+                            <option value="" disabled>Select UOM...</option>
+                            {unitPkgs.map((pkg) => {
+                              const idx = form.packages.indexOf(pkg);
+                              return <option key={idx} value={pkg.id || `new-${idx}`}>{pkg.packageLabel || pkg.packageName}</option>;
+                            })}
+                          </select>
+                        </div>
+                        <Button
+                          type="button"
+                          variant="outline"
+                          className="h-10"
+                          onClick={() => {
+                            if (!newBulkType || !newBulkQty || !newBulkContains) return;
+                            const qty = Number(newBulkQty);
+                            if (!qty || qty <= 0) return;
+                            const preset = PACKAGE_PRESETS.find((p) => p.name === newBulkType);
+                            const code = preset?.code || newBulkType.slice(0, 3).toUpperCase();
+                            setForm((prev) => {
+                              const childPkg = prev.packages.find((p, idx) => p.id === newBulkContains || `new-${idx}` === newBulkContains);
+                              if (!childPkg) return prev;
+                              const childConv = Number(childPkg.conversionFactor);
+                              const totalConv = qty * childConv;
+                              const label = `${newBulkType} (${qty}× ${childPkg.packageLabel || childPkg.packageName})`;
+                              const count = prev.packages.filter((p) => p.packageName.toLowerCase().includes(newBulkType.toLowerCase())).length;
+                              const autoSku = form.sku ? `${form.sku}-${code}${count > 0 ? count + 1 : ""}` : "";
+                              return {
+                                ...prev,
+                                packages: [...prev.packages, {
+                                  sku: autoSku,
+                                  packageName: newBulkType,
+                                  packageLabel: label,
+                                  conversionFactor: String(totalConv),
+                                  isDefault: false,
+                                  containsPackageId: newBulkContains,
+                                }],
+                              };
+                            });
+                            setNewBulkType("");
+                            setNewBulkQty("");
+                            setNewBulkContains("");
+                          }}
+                        >
+                          Add
+                        </Button>
+                      </div>
+                    )}
+                  </>
+                );
+              })()}
             </div>
 
             {/* Suppliers & Pricing */}

--- a/apps/backoffice/src/app/(admin)/inventory/perishables/page.tsx
+++ b/apps/backoffice/src/app/(admin)/inventory/perishables/page.tsx
@@ -472,10 +472,10 @@ export default function PerishablesPage() {
                 </td>
                 <td className="px-4 py-3">
                   <div className="flex flex-wrap gap-1">
-                    {product.suppliers.map((s, i) => (
+                    {product.suppliers.filter((s) => s.name !== "Ad-hoc Purchase").map((s, i) => (
                       <span key={i} className="text-xs text-gray-500">{s.name} (RM{s.price.toFixed(2)})</span>
                     ))}
-                    {product.suppliers.length === 0 && <span className="text-xs text-gray-300">—</span>}
+                    {product.suppliers.filter((s) => s.name !== "Ad-hoc Purchase").length === 0 && <span className="text-xs text-gray-300">—</span>}
                   </div>
                 </td>
                 <td className="px-4 py-3">
@@ -940,7 +940,7 @@ export default function PerishablesPage() {
                       onChange={(e) => setSelectedSupplierId(e.target.value)}
                     >
                       <option value="">Select supplier...</option>
-                      {supplierOptions.map((s) => (
+                      {supplierOptions.filter((s) => s.name !== "Ad-hoc Purchase").map((s) => (
                         <option key={s.id} value={s.id}>{s.name}</option>
                       ))}
                     </select>

--- a/apps/backoffice/src/app/api/inventory/invoices/[id]/route.ts
+++ b/apps/backoffice/src/app/api/inventory/invoices/[id]/route.ts
@@ -50,3 +50,24 @@ export async function PATCH(req: NextRequest, { params }: { params: Promise<{ id
     return NextResponse.json({ error: message }, { status: 500 });
   }
 }
+
+export async function DELETE(req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  const caller = await getUserFromHeaders(req.headers);
+  if (!caller) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+
+  try {
+    const { id } = await params;
+    const invoice = await prisma.invoice.findUnique({ where: { id }, select: { id: true, status: true } });
+    if (!invoice) return NextResponse.json({ error: "Not found" }, { status: 404 });
+
+    if (!["DRAFT", "PENDING"].includes(invoice.status)) {
+      return NextResponse.json({ error: "Only draft or pending invoices can be deleted" }, { status: 400 });
+    }
+
+    await prisma.invoice.delete({ where: { id } });
+    return NextResponse.json({ ok: true });
+  } catch (err) {
+    console.error("[invoices/[id] DELETE]", err);
+    return NextResponse.json({ error: "Failed to delete invoice" }, { status: 500 });
+  }
+}

--- a/apps/backoffice/src/app/api/inventory/invoices/route.ts
+++ b/apps/backoffice/src/app/api/inventory/invoices/route.ts
@@ -68,7 +68,7 @@ export async function GET(req: NextRequest) {
       claimedById: true,
       order: { select: { orderNumber: true, claimedBy: { select: { name: true } } } },
       outlet: { select: { name: true } },
-      supplier: { select: { name: true } },
+      supplier: { select: { name: true, bankName: true, bankAccountNumber: true, bankAccountName: true } },
     },
     orderBy: { issueDate: "desc" },
   });
@@ -110,6 +110,11 @@ export async function GET(req: NextRequest) {
     paymentType: inv.paymentType ?? "SUPPLIER",
     claimedBy: inv.order?.claimedBy?.name ?? null,
     notes: inv.notes,
+    supplierBank: inv.supplier?.bankName ? {
+      bankName: inv.supplier.bankName,
+      accountNumber: inv.supplier.bankAccountNumber ?? null,
+      accountName: inv.supplier.bankAccountName ?? null,
+    } : null,
   }));
 
   return NextResponse.json({ invoices: mapped, outlets, dueTodayCount, dueTodayAmount });

--- a/apps/backoffice/src/app/api/inventory/orders/[id]/route.ts
+++ b/apps/backoffice/src/app/api/inventory/orders/[id]/route.ts
@@ -25,7 +25,7 @@ export async function PATCH(req: NextRequest, { params }: { params: Promise<{ id
   try {
     const { id } = await params;
     const body = await req.json();
-    const { status, totalAmount, deliveryDate, items, invoiceNumber: bodyInvoiceNumber, invoiceDueDate, invoicePhotos } = body;
+    const { status, totalAmount, deliveryDate, items, invoicePhotos } = body;
 
     const data: Record<string, unknown> = {};
 
@@ -95,32 +95,9 @@ export async function PATCH(req: NextRequest, { params }: { params: Promise<{ id
       },
     });
 
-    // Auto-create invoice + receiving when order is confirmed (AWAITING_DELIVERY)
+    // Auto-create receiving when order is confirmed (AWAITING_DELIVERY)
     if (status === "AWAITING_DELIVERY") {
       const caller = await getUserFromHeaders(req.headers);
-
-      try {
-        // Check if invoice already exists for this order
-        const existingInvoice = await prisma.invoice.findFirst({ where: { orderId: id } });
-        if (!existingInvoice) {
-          const invCount = await prisma.invoice.count();
-          const invoiceNumber = bodyInvoiceNumber || `INV-${String(invCount + 1).padStart(4, "0")}`;
-          await prisma.invoice.create({
-            data: {
-              invoiceNumber,
-              orderId: id,
-              outletId: order.outletId,
-              supplierId: order.supplierId,
-              amount: order.totalAmount,
-              status: "PENDING",
-              dueDate: invoiceDueDate ? new Date(invoiceDueDate) : null,
-              photos: invoicePhotos || [],
-            },
-          });
-        }
-      } catch (e) {
-        console.error("[orders/[id] PATCH] Invoice auto-create failed:", e);
-      }
 
       try {
         // Check if receiving already exists for this order

--- a/apps/staff/src/app/api/auth/pin/route.ts
+++ b/apps/staff/src/app/api/auth/pin/route.ts
@@ -20,12 +20,10 @@ export async function POST(req: NextRequest) {
     return NextResponse.json({ error: "PIN required (minimum 4 digits)" }, { status: 400 });
   }
 
-  // Scope to outlet if provided — prevents cross-outlet PIN collisions
-  const where: any = { pin: { not: null }, status: "ACTIVE" };
-  if (outletId) where.outletId = outletId;
-
+  // Find users with PINs — OWNER/ADMIN can log in to any outlet,
+  // STAFF are scoped to their assigned outlet to prevent collisions
   const users = await prisma.user.findMany({
-    where,
+    where: { pin: { not: null }, status: "ACTIVE" },
     include: { outlet: { select: { name: true } } },
   });
 
@@ -33,6 +31,8 @@ export async function POST(req: NextRequest) {
   const matches: (typeof users)[number][] = [];
   for (const u of users) {
     if (u.role !== "OWNER" && u.role !== "ADMIN" && !u.appAccess.includes("ops")) continue;
+    // Staff must belong to the selected outlet; owners/admins can access any
+    if (outletId && u.role !== "OWNER" && u.role !== "ADMIN" && u.outletId !== outletId) continue;
     const { match, needsRehash } = await verifyPin(pin, u.pin);
     if (match) {
       if (needsRehash) {
@@ -60,12 +60,17 @@ export async function POST(req: NextRequest) {
 
   const matchedUser = matches[0];
 
+  // Use the selected outlet for the session (allows owners to operate any outlet)
+  const selectedOutlet = outletId
+    ? await prisma.outlet.findUnique({ where: { id: outletId }, select: { name: true } })
+    : matchedUser.outlet;
+
   await createSession({
     id: matchedUser.id,
     name: matchedUser.name,
     role: matchedUser.role,
-    outletId: matchedUser.outletId,
-    outletName: matchedUser.outlet?.name ?? null,
+    outletId: outletId || matchedUser.outletId,
+    outletName: selectedOutlet?.name ?? matchedUser.outlet?.name ?? null,
   });
 
   return NextResponse.json({


### PR DESCRIPTION
## Summary
- Filter out Ad-hoc Purchase supplier from Smart Order create page
- Adhoc items (RM0.00) no longer appear in PO cart or supplier dropdown
- Ad-hoc Purchase is only for Pay & Claim flow

https://claude.ai/code/session_01P4aS9Nfq7eK2wUQFjvqibv