### PR TITLE
fix: Save as Draft collision + clickable cards + perishables label

### DIFF
--- a/apps/backoffice/src/app/(admin)/inventory/orders/page.tsx
+++ b/apps/backoffice/src/app/(admin)/inventory/orders/page.tsx
@@ -131,6 +131,7 @@ export default function OrdersPage() {
   }, [search]);
   const url = `/api/inventory/orders?tab=${tab}${debouncedSearch ? `&search=${debouncedSearch}` : ""}`;
   const { data: orders = [], isLoading: loading, mutate: loadOrders } = useFetch<Order[]>(url);
+  const [cardFilter, setCardFilter] = useState<string | null>(null);
   const [expandedId, setExpandedId] = useState<string | null>(null);
   const [updatingId, setUpdatingId] = useState<string | null>(null);
 
@@ -526,19 +527,19 @@ export default function OrdersPage() {
 
       {/* Summary cards */}
       <div className="mt-4 grid grid-cols-2 lg:grid-cols-5 gap-4">
-        <Card className="px-4 py-3">
+        <Card className={`px-4 py-3 cursor-pointer transition-colors ${cardFilter === null ? "ring-2 ring-terracotta" : "hover:bg-gray-50"}`} onClick={() => setCardFilter(null)}>
           <p className="text-xs text-gray-500">Total Orders</p>
           <p className="text-xl font-bold text-gray-900">{orders.length}</p>
         </Card>
-        <Card className="px-4 py-3">
+        <Card className={`px-4 py-3 cursor-pointer transition-colors ${cardFilter === "DRAFT" ? "ring-2 ring-terracotta" : "hover:bg-gray-50"}`} onClick={() => setCardFilter(cardFilter === "DRAFT" ? null : "DRAFT")}>
           <p className="text-xs text-gray-500">Draft</p>
           <p className="text-xl font-bold text-gray-500">{orders.filter((o) => o.status === "DRAFT").length}</p>
         </Card>
-        <Card className="px-4 py-3">
+        <Card className={`px-4 py-3 cursor-pointer transition-colors ${cardFilter === "active" ? "ring-2 ring-terracotta" : "hover:bg-gray-50"}`} onClick={() => setCardFilter(cardFilter === "active" ? null : "active")}>
           <p className="text-xs text-gray-500">Active / In Progress</p>
           <p className="text-xl font-bold text-terracotta">{pendingCount}</p>
         </Card>
-        <Card className="px-4 py-3">
+        <Card className={`px-4 py-3 cursor-pointer transition-colors ${cardFilter === "COMPLETED" ? "ring-2 ring-terracotta" : "hover:bg-gray-50"}`} onClick={() => setCardFilter(cardFilter === "COMPLETED" ? null : "COMPLETED")}>
           <p className="text-xs text-gray-500">Completed</p>
           <p className="text-xl font-bold text-green-600">{orders.filter((o) => o.status === "COMPLETED").length}</p>
         </Card>
@@ -594,7 +595,13 @@ export default function OrdersPage() {
                 </td>
               </tr>
             )}
-            {orders.map((order) => {
+            {orders.filter((o) => {
+              if (!cardFilter) return true;
+              if (cardFilter === "DRAFT") return o.status === "DRAFT";
+              if (cardFilter === "COMPLETED") return o.status === "COMPLETED";
+              if (cardFilter === "active") return !["DRAFT", "COMPLETED", "CANCELLED"].includes(o.status);
+              return true;
+            }).map((order) => {
               const config = STATUS_CONFIG[order.status] ?? { label: order.status, color: "bg-gray-400", icon: Clock };
               const actions = NEXT_ACTIONS[order.status] ?? [];
               return (

--- a/apps/backoffice/src/app/(admin)/inventory/perishables/page.tsx
+++ b/apps/backoffice/src/app/(admin)/inventory/perishables/page.tsx
@@ -746,7 +746,7 @@ export default function PerishablesPage() {
                     {/* Add UOM */}
                     <div className="mb-4 flex flex-wrap items-end gap-3">
                       <div className="w-36">
-                        <label className="text-xs text-gray-500">Type</label>
+                        <label className="text-xs text-gray-500">Package Type</label>
                         <select
                           value={newPkgType}
                           onChange={(e) => setNewPkgType(e.target.value)}
@@ -757,7 +757,7 @@ export default function PerishablesPage() {
                         </select>
                       </div>
                       <div className="w-24">
-                        <label className="text-xs text-gray-500">Size</label>
+                        <label className="text-xs text-gray-500">= {form.baseUom || "pcs"}</label>
                         <Input
                           type="number"
                           placeholder="e.g. 50"
@@ -766,7 +766,6 @@ export default function PerishablesPage() {
                           onChange={(e) => setNewPkgConv(e.target.value)}
                         />
                       </div>
-                      <span className="pb-2 text-sm text-gray-400">{form.baseUom || "pcs"}</span>
                       <Button
                         type="button"
                         variant="outline"
@@ -778,7 +777,6 @@ export default function PerishablesPage() {
                           const preset = PACKAGE_PRESETS.find((p) => p.name === newPkgType);
                           const code = preset?.code || newPkgType.slice(0, 3).toUpperCase();
                           setForm((prev) => {
-                            const label = `${size.toLocaleString()}${form.baseUom || ""} ${newPkgType}`;
                             const count = prev.packages.filter((p) => p.packageName.toLowerCase().includes(newPkgType.toLowerCase())).length;
                             const autoSku = form.sku ? `${form.sku}-${code}${count > 0 ? count + 1 : ""}` : "";
                             return {
@@ -786,7 +784,7 @@ export default function PerishablesPage() {
                               packages: [...prev.packages, {
                                 sku: autoSku,
                                 packageName: newPkgType,
-                                packageLabel: label,
+                                packageLabel: newPkgType,
                                 conversionFactor: String(size),
                                 isDefault: prev.packages.length === 0,
                                 containsPackageId: null,

--- a/apps/backoffice/src/app/api/inventory/orders/route.ts
+++ b/apps/backoffice/src/app/api/inventory/orders/route.ts
@@ -113,60 +113,73 @@ export async function GET(req: NextRequest) {
 }
 
 export async function POST(req: NextRequest) {
-  const body = await req.json();
-  const { outletId, supplierId, items, notes, deliveryDate } = body;
-
-  const outlet = await prisma.outlet.findUniqueOrThrow({ where: { id: outletId } });
-  const count = await prisma.order.count({ where: { outletId } });
-  const orderNumber = `CC-${outlet.code}-${String(count + 1).padStart(4, "0")}`;
-
   const caller = await getUserFromHeaders(req.headers);
   if (!caller) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
 
-  const totalAmount = items.reduce(
-    (sum: number, i: { quantity: number; unitPrice: number }) => sum + i.quantity * i.unitPrice,
-    0,
-  );
+  try {
+    const body = await req.json();
+    const { outletId, supplierId, items, notes, deliveryDate } = body;
 
-  const order = await prisma.order.create({
-    data: {
-      orderNumber,
-      outletId,
-      supplierId,
-      status: "DRAFT",
-      totalAmount,
-      notes: notes || null,
-      deliveryDate: deliveryDate ? new Date(deliveryDate) : null,
-      createdById: caller.id,
-      items: {
-        create: items.map((i: { productId: string; productPackageId?: string; quantity: number; unitPrice: number; notes?: string }) => ({
-          productId: i.productId,
-          productPackageId: i.productPackageId || null,
-          quantity: i.quantity,
-          unitPrice: i.unitPrice,
-          totalPrice: i.quantity * i.unitPrice,
-          notes: i.notes || null,
-        })),
-      },
-    },
-    select: {
-      id: true,
-      orderNumber: true,
-      status: true,
-      totalAmount: true,
-      outlet: { select: { name: true } },
-      supplier: { select: { name: true } },
-      items: {
-        select: {
-          product: { select: { name: true } },
-          productPackage: { select: { packageLabel: true } },
-          quantity: true,
-          unitPrice: true,
-          totalPrice: true,
+    const outlet = await prisma.outlet.findUniqueOrThrow({ where: { id: outletId } });
+
+    // Use max order number to avoid collisions from deleted orders
+    const lastOrder = await prisma.order.findFirst({
+      where: { outletId },
+      orderBy: { orderNumber: "desc" },
+      select: { orderNumber: true },
+    });
+    const lastNum = lastOrder ? parseInt(lastOrder.orderNumber.split("-").pop() || "0") : 0;
+    const orderNumber = `CC-${outlet.code}-${String(lastNum + 1).padStart(4, "0")}`;
+
+    const totalAmount = items.reduce(
+      (sum: number, i: { quantity: number; unitPrice: number }) => sum + i.quantity * i.unitPrice,
+      0,
+    );
+
+    const order = await prisma.order.create({
+      data: {
+        orderNumber,
+        outletId,
+        supplierId,
+        status: "DRAFT",
+        totalAmount,
+        notes: notes || null,
+        deliveryDate: deliveryDate ? new Date(deliveryDate) : null,
+        createdById: caller.id,
+        items: {
+          create: items.map((i: { productId: string; productPackageId?: string; quantity: number; unitPrice: number; notes?: string }) => ({
+            productId: i.productId,
+            productPackageId: i.productPackageId || null,
+            quantity: i.quantity,
+            unitPrice: i.unitPrice,
+            totalPrice: i.quantity * i.unitPrice,
+            notes: i.notes || null,
+          })),
         },
       },
-    },
-  });
+      select: {
+        id: true,
+        orderNumber: true,
+        status: true,
+        totalAmount: true,
+        outlet: { select: { name: true } },
+        supplier: { select: { name: true } },
+        items: {
+          select: {
+            product: { select: { name: true } },
+            productPackage: { select: { packageLabel: true } },
+            quantity: true,
+            unitPrice: true,
+            totalPrice: true,
+          },
+        },
+      },
+    });
 
-  return NextResponse.json(order, { status: 201 });
+    return NextResponse.json(order, { status: 201 });
+  } catch (err) {
+    console.error("[orders POST]", err);
+    const message = err instanceof Error ? err.message : "Failed to create order";
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
 }


### PR DESCRIPTION
## Summary
- **Save as Draft fix**: Order number was using `count()` which collides with deleted orders. Now uses max existing order number. Added try-catch so errors show properly.
- **Clickable filter cards**: Total, Draft, Active, Completed cards filter the PO list on click
- **Perishables label**: Package label uses name (e.g. "Pack") not ingredients-style "50pcs Pack"

https://claude.ai/code/session_01P4aS9Nfq7eK2wUQFjvqibv