### PR TITLE
fix: enforce Confirm Order before staff can receive items

### DIFF
--- a/apps/backoffice/src/app/(admin)/inventory/orders/[id]/page.tsx
+++ b/apps/backoffice/src/app/(admin)/inventory/orders/[id]/page.tsx
@@ -1,10 +1,11 @@
 "use client";
 
-import { useState, useEffect, use } from "react";
+import { useState, useEffect, useCallback, use } from "react";
 import { useRouter } from "next/navigation";
 import Link from "next/link";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
+import { Badge } from "@/components/ui/badge";
 import {
   ArrowLeft,
   Loader2,
@@ -13,15 +14,16 @@ import {
   Pencil,
   X,
   Plus,
-  Trash2,
   Save,
+  MessageCircle,
+  Send,
 } from "lucide-react";
 
 type OrderItem = {
   id: string;
   productId: string;
-  product: { name: string; sku: string };
-  productPackage: { label: string } | null;
+  product: { name: string; sku: string; baseUom?: string };
+  productPackage: { label: string; packageLabel?: string; packageName?: string } | null;
   quantity: number;
   unitPrice: number;
   totalPrice: number;
@@ -36,7 +38,7 @@ type OrderDetail = {
   notes: string | null;
   deliveryDate: string | null;
   outlet: { id: string; name: string };
-  supplier: { id: string; name: string } | null;
+  supplier: { id: string; name: string; phone?: string | null } | null;
   items: OrderItem[];
   createdAt: string;
 };
@@ -51,6 +53,14 @@ type EditItem = {
   removed: boolean;
 };
 
+const STATUS_LABELS: Record<string, { label: string; color: string }> = {
+  DRAFT: { label: "Draft", color: "bg-gray-400" },
+  APPROVED: { label: "Confirmed", color: "bg-blue-500" },
+  SENT: { label: "Sent", color: "bg-green-500" },
+  AWAITING_DELIVERY: { label: "Awaiting Delivery", color: "bg-purple-500" },
+  COMPLETED: { label: "Completed", color: "bg-gray-500" },
+};
+
 export default function EditOrderPage({ params }: { params: Promise<{ id: string }> }) {
   const { id } = use(params);
   const router = useRouter();
@@ -61,9 +71,8 @@ export default function EditOrderPage({ params }: { params: Promise<{ id: string
 
   const [editItems, setEditItems] = useState<EditItem[]>([]);
   const [deliveryDate, setDeliveryDate] = useState("");
-  const [notes, setNotes] = useState("");
 
-  useEffect(() => {
+  const loadOrder = useCallback(() => {
     fetch(`/api/inventory/orders/${id}`)
       .then((r) => {
         if (!r.ok) throw new Error("Not found");
@@ -76,18 +85,19 @@ export default function EditOrderPage({ params }: { params: Promise<{ id: string
             id: i.id,
             product: i.product.name,
             sku: i.product.sku,
-            packageLabel: i.productPackage?.label ?? "pcs",
+            packageLabel: i.productPackage?.packageLabel ?? i.productPackage?.label ?? "pcs",
             qtyStr: String(Number(i.quantity)),
             priceStr: Number(i.unitPrice).toFixed(2),
             removed: false,
           }))
         );
         setDeliveryDate(data.deliveryDate ? data.deliveryDate.split("T")[0] : "");
-        setNotes(data.notes ?? "");
       })
       .catch(() => setError("Order not found"))
       .finally(() => setLoading(false));
   }, [id]);
+
+  useEffect(() => { loadOrder(); }, [loadOrder]);
 
   const total = editItems
     .filter((i) => !i.removed)
@@ -97,7 +107,6 @@ export default function EditOrderPage({ params }: { params: Promise<{ id: string
     if (!order) return;
     setSaving(true);
     try {
-      // Build item changes
       const itemChanges = editItems
         .filter((i) => {
           if (i.removed) return true;
@@ -133,12 +142,39 @@ export default function EditOrderPage({ params }: { params: Promise<{ id: string
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify({ status: "APPROVED" }),
         });
+        // Reload to show updated status with WhatsApp button
+        loadOrder();
+      } else {
+        router.push("/inventory/orders");
       }
+    } finally {
+      setSaving(false);
+    }
+  };
 
+  const markAsSent = async () => {
+    if (!order) return;
+    setSaving(true);
+    try {
+      await fetch(`/api/inventory/orders/${order.id}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ status: "SENT" }),
+      });
       router.push("/inventory/orders");
     } finally {
       setSaving(false);
     }
+  };
+
+  const buildWhatsAppUrl = () => {
+    if (!order?.supplier?.phone) return "";
+    const items = editItems
+      .filter((i) => !i.removed)
+      .map((i) => `• ${i.product} (${i.packageLabel}) × ${i.qtyStr}`).join("\n");
+    const msg = `Hi, this is Celsius Coffee.\n\nPO: ${order.orderNumber}\nOutlet: ${order.outlet.name}\n${deliveryDate ? `Delivery: ${deliveryDate}\n` : ""}\nOrder:\n${items}\n\nTotal: RM ${total.toFixed(2)}\n\nThank you!`;
+    const phone = order.supplier.phone.replace(/[^0-9]/g, "");
+    return `https://wa.me/${phone}?text=${encodeURIComponent(msg)}`;
   };
 
   if (loading) {
@@ -161,6 +197,8 @@ export default function EditOrderPage({ params }: { params: Promise<{ id: string
   }
 
   const isDraft = order.status === "DRAFT";
+  const isApproved = order.status === "APPROVED";
+  const statusConfig = STATUS_LABELS[order.status];
 
   return (
     <div className="p-6">
@@ -174,8 +212,8 @@ export default function EditOrderPage({ params }: { params: Promise<{ id: string
           </Link>
           <div>
             <div className="flex items-center gap-2">
-              <Pencil className="h-4 w-4 text-gray-400" />
               <h2 className="text-xl font-semibold text-gray-900">{order.orderNumber}</h2>
+              {statusConfig && <Badge className={`text-xs ${statusConfig.color}`}>{statusConfig.label}</Badge>}
             </div>
             <p className="text-sm text-gray-500">
               {order.supplier?.name ?? "No supplier"} &rarr; {order.outlet.name}
@@ -184,16 +222,32 @@ export default function EditOrderPage({ params }: { params: Promise<{ id: string
         </div>
         <div className="flex items-center gap-2">
           <Button variant="outline" onClick={() => router.push("/inventory/orders")} disabled={saving}>
-            Cancel
+            Back
           </Button>
-          <Button onClick={() => saveOrder(false)} disabled={saving} className="bg-terracotta hover:bg-terracotta-dark">
-            {saving ? <Loader2 className="mr-1.5 h-4 w-4 animate-spin" /> : <Save className="mr-1.5 h-4 w-4" />}
-            Save Changes
-          </Button>
+          {(isDraft || isApproved) && (
+            <Button onClick={() => saveOrder(false)} disabled={saving} className="bg-terracotta hover:bg-terracotta-dark">
+              {saving ? <Loader2 className="mr-1.5 h-4 w-4 animate-spin" /> : <Save className="mr-1.5 h-4 w-4" />}
+              Save Changes
+            </Button>
+          )}
           {isDraft && (
             <Button onClick={() => saveOrder(true)} disabled={saving} className="bg-blue-500 hover:bg-blue-600">
               {saving ? <Loader2 className="mr-1.5 h-4 w-4 animate-spin" /> : <CheckCircle2 className="mr-1.5 h-4 w-4" />}
               Confirm Request
+            </Button>
+          )}
+          {isApproved && order.supplier?.phone && (
+            <a href={buildWhatsAppUrl()} target="_blank" rel="noopener noreferrer">
+              <Button className="bg-green-500 hover:bg-green-600">
+                <MessageCircle className="mr-1.5 h-4 w-4" />
+                WhatsApp Supplier
+              </Button>
+            </a>
+          )}
+          {isApproved && (
+            <Button onClick={markAsSent} disabled={saving} className="bg-emerald-600 hover:bg-emerald-700">
+              {saving ? <Loader2 className="mr-1.5 h-4 w-4 animate-spin" /> : <Send className="mr-1.5 h-4 w-4" />}
+              Mark as Sent
             </Button>
           )}
         </div>
@@ -210,6 +264,7 @@ export default function EditOrderPage({ params }: { params: Promise<{ id: string
             value={deliveryDate}
             onChange={(e) => setDeliveryDate(e.target.value)}
             className="max-w-xs"
+            disabled={!isDraft && !isApproved}
           />
         </div>
 
@@ -226,7 +281,7 @@ export default function EditOrderPage({ params }: { params: Promise<{ id: string
                 <th className="px-4 py-2 text-right font-medium text-gray-500 w-24">Qty</th>
                 <th className="px-4 py-2 text-right font-medium text-gray-500 w-28">Unit Price</th>
                 <th className="px-4 py-2 text-right font-medium text-gray-500 w-28">Total</th>
-                <th className="px-4 py-2 w-10"></th>
+                {(isDraft || isApproved) && <th className="px-4 py-2 w-10"></th>}
               </tr>
             </thead>
             <tbody>
@@ -262,60 +317,70 @@ export default function EditOrderPage({ params }: { params: Promise<{ id: string
                     </td>
                     <td className="px-4 py-2.5 text-gray-500 text-xs">{item.packageLabel}</td>
                     <td className="px-4 py-2.5">
-                      <input
-                        type="number"
-                        min="0"
-                        step="1"
-                        className="w-full rounded border border-gray-200 px-2 py-1.5 text-right text-sm focus:border-terracotta focus:outline-none"
-                        value={item.qtyStr}
-                        onChange={(e) =>
-                          setEditItems((prev) =>
-                            prev.map((p, i) => (i === idx ? { ...p, qtyStr: e.target.value } : p))
-                          )
-                        }
-                      />
+                      {isDraft || isApproved ? (
+                        <input
+                          type="number"
+                          min="0"
+                          step="1"
+                          className="w-full rounded border border-gray-200 px-2 py-1.5 text-right text-sm focus:border-terracotta focus:outline-none"
+                          value={item.qtyStr}
+                          onChange={(e) =>
+                            setEditItems((prev) =>
+                              prev.map((p, i) => (i === idx ? { ...p, qtyStr: e.target.value } : p))
+                            )
+                          }
+                        />
+                      ) : (
+                        <p className="text-right text-sm text-gray-900">{item.qtyStr}</p>
+                      )}
                     </td>
                     <td className="px-4 py-2.5">
-                      <input
-                        type="number"
-                        min="0"
-                        step="0.01"
-                        className="w-full rounded border border-gray-200 px-2 py-1.5 text-right text-sm focus:border-terracotta focus:outline-none"
-                        value={item.priceStr}
-                        onChange={(e) =>
-                          setEditItems((prev) =>
-                            prev.map((p, i) => (i === idx ? { ...p, priceStr: e.target.value } : p))
-                          )
-                        }
-                      />
+                      {isDraft || isApproved ? (
+                        <input
+                          type="number"
+                          min="0"
+                          step="0.01"
+                          className="w-full rounded border border-gray-200 px-2 py-1.5 text-right text-sm focus:border-terracotta focus:outline-none"
+                          value={item.priceStr}
+                          onChange={(e) =>
+                            setEditItems((prev) =>
+                              prev.map((p, i) => (i === idx ? { ...p, priceStr: e.target.value } : p))
+                            )
+                          }
+                        />
+                      ) : (
+                        <p className="text-right text-sm text-gray-900">{item.priceStr}</p>
+                      )}
                     </td>
                     <td className="px-4 py-2.5 text-right font-medium text-gray-900">
                       RM {lineTotal.toFixed(2)}
                     </td>
-                    <td className="px-4 py-2.5 text-center">
-                      <button
-                        onClick={() =>
-                          setEditItems((prev) =>
-                            prev.map((p, i) => (i === idx ? { ...p, removed: true } : p))
-                          )
-                        }
-                        className="text-red-400 hover:text-red-600"
-                        title="Remove"
-                      >
-                        <X className="h-3.5 w-3.5" />
-                      </button>
-                    </td>
+                    {(isDraft || isApproved) && (
+                      <td className="px-4 py-2.5 text-center">
+                        <button
+                          onClick={() =>
+                            setEditItems((prev) =>
+                              prev.map((p, i) => (i === idx ? { ...p, removed: true } : p))
+                            )
+                          }
+                          className="text-red-400 hover:text-red-600"
+                          title="Remove"
+                        >
+                          <X className="h-3.5 w-3.5" />
+                        </button>
+                      </td>
+                    )}
                   </tr>
                 );
               })}
               <tr className="border-t-2 border-gray-200 bg-gray-50">
-                <td colSpan={4} className="px-4 py-2.5 text-right font-semibold text-gray-700">
+                <td colSpan={isDraft || isApproved ? 4 : 4} className="px-4 py-2.5 text-right font-semibold text-gray-700">
                   Total
                 </td>
                 <td className="px-4 py-2.5 text-right font-bold text-gray-900">
                   RM {total.toFixed(2)}
                 </td>
-                <td></td>
+                {(isDraft || isApproved) && <td></td>}
               </tr>
             </tbody>
           </table>

--- a/apps/backoffice/src/app/(admin)/inventory/orders/create/page.tsx
+++ b/apps/backoffice/src/app/(admin)/inventory/orders/create/page.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useEffect, useCallback, useRef } from "react";
 import { createPortal } from "react-dom";
-import { useRouter } from "next/navigation";
+import { useRouter, useSearchParams } from "next/navigation";
 import Link from "next/link";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -285,6 +285,8 @@ function SupplierCombobox({
 
 export default function CreateOrderPage() {
   const router = useRouter();
+  const searchParams = useSearchParams();
+  const draftId = searchParams.get("draft");
 
   // Data
   const [suppliers, setSuppliers] = useState<SupplierOption[]>([]);
@@ -297,6 +299,7 @@ export default function CreateOrderPage() {
 
   // Order
   const [cart, setCart] = useState<CartItem[]>([]);
+  const [editingDraftId, setEditingDraftId] = useState<string | null>(null);
   const [productSearch, setProductSearch] = useState("");
   const [supplierFilter, setSupplierFilter] = useState("");
   const [orderNotes, setOrderNotes] = useState("");
@@ -372,6 +375,39 @@ export default function CreateOrderPage() {
       setLoading(false);
     }).catch(() => setLoading(false));
   }, [loadStockLevels, loadAIRecommendations]);
+
+  // Load draft order into cart when ?draft=<id> is present
+  useEffect(() => {
+    if (!draftId || suppliers.length === 0) return;
+    fetch(`/api/inventory/orders/${draftId}`)
+      .then((r) => r.ok ? r.json() : null)
+      .then((draft) => {
+        if (!draft || draft.status !== "DRAFT") return;
+        setEditingDraftId(draft.id);
+        if (draft.outletId) setSelectedOutletId(draft.outletId);
+        if (draft.notes) setOrderNotes(draft.notes);
+        // Map draft items to cart items using supplier data
+        const supplier = suppliers.find((s) => s.id === draft.supplierId);
+        if (!supplier) return;
+        const cartItems: CartItem[] = draft.items.map((item: { productId: string; quantity: number; unitPrice: number; product: { name: string; sku: string; baseUom?: string }; productPackage: { packageLabel?: string; packageName?: string; id?: string } | null }) => {
+          const sp = supplier.products.find((p) => p.id === item.productId);
+          return {
+            productId: item.productId,
+            name: item.product.name,
+            sku: item.product.sku,
+            supplier: supplier.name,
+            supplierId: supplier.id,
+            supplierPhone: supplier.phone,
+            packageLabel: item.productPackage?.packageLabel ?? item.productPackage?.packageName ?? item.product.baseUom ?? "pcs",
+            quantity: Number(item.quantity),
+            unitPrice: Number(item.unitPrice),
+            productPackageId: sp?.packageId ?? null,
+          };
+        });
+        setCart(cartItems);
+      })
+      .catch(() => {});
+  }, [draftId, suppliers]);
 
   const handleOutletChange = (outletId: string) => {
     setSelectedOutletId(outletId);
@@ -559,30 +595,43 @@ export default function CreateOrderPage() {
       if (!group) return;
       const deliveryDate = getDeliveryDate(group.supplierId);
 
-      const orderRes = await fetch("/api/inventory/orders", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          outletId: selectedOutletId,
-          supplierId: whatsappDialog.supplierId,
-          items: group.items.map((item) => ({
-            productId: item.productId,
-            productPackageId: item.productPackageId || undefined,
-            quantity: item.quantity,
-            unitPrice: item.unitPrice,
-          })),
-          notes: orderNotes || null,
-          deliveryDate,
-        }),
-      });
+      let orderId = editingDraftId;
 
-      if (orderRes.ok) {
-        const order = await orderRes.json();
-        await fetch(`/api/inventory/orders/${order.id}`, {
+      if (editingDraftId) {
+        // Update existing draft then mark as SENT
+        await fetch(`/api/inventory/orders/${editingDraftId}`, {
           method: "PATCH",
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify({ status: "SENT" }),
         });
+      } else {
+        // Create new order
+        const orderRes = await fetch("/api/inventory/orders", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            outletId: selectedOutletId,
+            supplierId: whatsappDialog.supplierId,
+            items: group.items.map((item) => ({
+              productId: item.productId,
+              productPackageId: item.productPackageId || undefined,
+              quantity: item.quantity,
+              unitPrice: item.unitPrice,
+            })),
+            notes: orderNotes || null,
+            deliveryDate,
+          }),
+        });
+
+        if (orderRes.ok) {
+          const order = await orderRes.json();
+          orderId = order.id;
+          await fetch(`/api/inventory/orders/${order.id}`, {
+            method: "PATCH",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ status: "SENT" }),
+          });
+        }
       }
 
       const phone = whatsappDialog.phone.replace(/\+/g, "");
@@ -607,6 +656,10 @@ export default function CreateOrderPage() {
     if (entries.length === 0) return;
     setSaving(true);
     try {
+      // If editing an existing draft, delete it first then recreate
+      if (editingDraftId) {
+        await fetch(`/api/inventory/orders/${editingDraftId}`, { method: "DELETE" });
+      }
       for (const [, group] of entries) {
         const deliveryDate = getDeliveryDate(group.supplierId);
         const res = await fetch("/api/inventory/orders", {

--- a/apps/backoffice/src/app/(admin)/inventory/orders/page.tsx
+++ b/apps/backoffice/src/app/(admin)/inventory/orders/page.tsx
@@ -646,7 +646,12 @@ export default function OrdersPage() {
                             {updatingId === order.id ? <Loader2 className="h-3 w-3 animate-spin" /> : "Confirm Order"}
                           </button>
                         )}
-                        {["DRAFT", "PENDING_APPROVAL", "SENT", "AWAITING_DELIVERY", "PARTIALLY_RECEIVED"].includes(order.status) && (
+                        {order.status === "DRAFT" && (
+                          <Link href={`/inventory/orders/create?draft=${order.id}`} className="rounded-md px-2 py-1 text-[10px] font-medium text-gray-600 border border-gray-200 hover:bg-gray-50" title="Edit Draft">
+                            <Pencil className="h-3 w-3" />
+                          </Link>
+                        )}
+                        {["PENDING_APPROVAL", "SENT", "AWAITING_DELIVERY", "PARTIALLY_RECEIVED"].includes(order.status) && (
                           <Link href={`/inventory/orders/${order.id}`} className="rounded-md px-2 py-1 text-[10px] font-medium text-gray-600 border border-gray-200 hover:bg-gray-50" title="Edit PO">
                             <Pencil className="h-3 w-3" />
                           </Link>

--- a/apps/backoffice/src/app/(admin)/inventory/orders/page.tsx
+++ b/apps/backoffice/src/app/(admin)/inventory/orders/page.tsx
@@ -131,6 +131,7 @@ export default function OrdersPage() {
   }, [search]);
   const url = `/api/inventory/orders?tab=${tab}${debouncedSearch ? `&search=${debouncedSearch}` : ""}`;
   const { data: orders = [], isLoading: loading, mutate: loadOrders } = useFetch<Order[]>(url);
+  const [cardFilter, setCardFilter] = useState<string | null>(null);
   const [expandedId, setExpandedId] = useState<string | null>(null);
   const [updatingId, setUpdatingId] = useState<string | null>(null);
 
@@ -526,19 +527,19 @@ export default function OrdersPage() {
 
       {/* Summary cards */}
       <div className="mt-4 grid grid-cols-2 lg:grid-cols-5 gap-4">
-        <Card className="px-4 py-3">
+        <Card className={`px-4 py-3 cursor-pointer transition-colors ${cardFilter === null ? "ring-2 ring-terracotta" : "hover:bg-gray-50"}`} onClick={() => setCardFilter(null)}>
           <p className="text-xs text-gray-500">Total Orders</p>
           <p className="text-xl font-bold text-gray-900">{orders.length}</p>
         </Card>
-        <Card className="px-4 py-3">
+        <Card className={`px-4 py-3 cursor-pointer transition-colors ${cardFilter === "DRAFT" ? "ring-2 ring-terracotta" : "hover:bg-gray-50"}`} onClick={() => setCardFilter(cardFilter === "DRAFT" ? null : "DRAFT")}>
           <p className="text-xs text-gray-500">Draft</p>
           <p className="text-xl font-bold text-gray-500">{orders.filter((o) => o.status === "DRAFT").length}</p>
         </Card>
-        <Card className="px-4 py-3">
+        <Card className={`px-4 py-3 cursor-pointer transition-colors ${cardFilter === "active" ? "ring-2 ring-terracotta" : "hover:bg-gray-50"}`} onClick={() => setCardFilter(cardFilter === "active" ? null : "active")}>
           <p className="text-xs text-gray-500">Active / In Progress</p>
           <p className="text-xl font-bold text-terracotta">{pendingCount}</p>
         </Card>
-        <Card className="px-4 py-3">
+        <Card className={`px-4 py-3 cursor-pointer transition-colors ${cardFilter === "COMPLETED" ? "ring-2 ring-terracotta" : "hover:bg-gray-50"}`} onClick={() => setCardFilter(cardFilter === "COMPLETED" ? null : "COMPLETED")}>
           <p className="text-xs text-gray-500">Completed</p>
           <p className="text-xl font-bold text-green-600">{orders.filter((o) => o.status === "COMPLETED").length}</p>
         </Card>
@@ -594,7 +595,13 @@ export default function OrdersPage() {
                 </td>
               </tr>
             )}
-            {orders.map((order) => {
+            {orders.filter((o) => {
+              if (!cardFilter) return true;
+              if (cardFilter === "DRAFT") return o.status === "DRAFT";
+              if (cardFilter === "COMPLETED") return o.status === "COMPLETED";
+              if (cardFilter === "active") return !["DRAFT", "COMPLETED", "CANCELLED"].includes(o.status);
+              return true;
+            }).map((order) => {
               const config = STATUS_CONFIG[order.status] ?? { label: order.status, color: "bg-gray-400", icon: Clock };
               const actions = NEXT_ACTIONS[order.status] ?? [];
               return (

--- a/apps/backoffice/src/app/(admin)/inventory/perishables/page.tsx
+++ b/apps/backoffice/src/app/(admin)/inventory/perishables/page.tsx
@@ -746,7 +746,7 @@ export default function PerishablesPage() {
                     {/* Add UOM */}
                     <div className="mb-4 flex flex-wrap items-end gap-3">
                       <div className="w-36">
-                        <label className="text-xs text-gray-500">Type</label>
+                        <label className="text-xs text-gray-500">Package Type</label>
                         <select
                           value={newPkgType}
                           onChange={(e) => setNewPkgType(e.target.value)}
@@ -757,7 +757,7 @@ export default function PerishablesPage() {
                         </select>
                       </div>
                       <div className="w-24">
-                        <label className="text-xs text-gray-500">Size</label>
+                        <label className="text-xs text-gray-500">= {form.baseUom || "pcs"}</label>
                         <Input
                           type="number"
                           placeholder="e.g. 50"
@@ -766,7 +766,6 @@ export default function PerishablesPage() {
                           onChange={(e) => setNewPkgConv(e.target.value)}
                         />
                       </div>
-                      <span className="pb-2 text-sm text-gray-400">{form.baseUom || "pcs"}</span>
                       <Button
                         type="button"
                         variant="outline"
@@ -778,7 +777,6 @@ export default function PerishablesPage() {
                           const preset = PACKAGE_PRESETS.find((p) => p.name === newPkgType);
                           const code = preset?.code || newPkgType.slice(0, 3).toUpperCase();
                           setForm((prev) => {
-                            const label = `${size.toLocaleString()}${form.baseUom || ""} ${newPkgType}`;
                             const count = prev.packages.filter((p) => p.packageName.toLowerCase().includes(newPkgType.toLowerCase())).length;
                             const autoSku = form.sku ? `${form.sku}-${code}${count > 0 ? count + 1 : ""}` : "";
                             return {
@@ -786,7 +784,7 @@ export default function PerishablesPage() {
                               packages: [...prev.packages, {
                                 sku: autoSku,
                                 packageName: newPkgType,
-                                packageLabel: label,
+                                packageLabel: newPkgType,
                                 conversionFactor: String(size),
                                 isDefault: prev.packages.length === 0,
                                 containsPackageId: null,

--- a/apps/backoffice/src/app/(admin)/inventory/perishables/page.tsx
+++ b/apps/backoffice/src/app/(admin)/inventory/perishables/page.tsx
@@ -65,6 +65,7 @@ type ProductForm = {
 type StorageAreaOption = { id: string; name: string; slug: string };
 
 const PACKAGE_PRESETS = [
+  { name: "Piece", label: "Piece (pcs)", code: "PCS" },
   { name: "Carton", label: "Carton", code: "CTN" },
   { name: "Bottle", label: "Bottle", code: "BTL" },
   { name: "Pack", label: "Pack", code: "PCK" },

--- a/apps/backoffice/src/app/(admin)/inventory/products/page.tsx
+++ b/apps/backoffice/src/app/(admin)/inventory/products/page.tsx
@@ -67,6 +67,7 @@ type ProductForm = {
 type StorageAreaOption = { id: string; name: string; slug: string };
 
 const PACKAGE_PRESETS = [
+  { name: "Piece", label: "Piece (pcs)", code: "PCS" },
   { name: "Bottle", label: "Bottle", code: "BTL" },
   { name: "Carton", label: "Carton", code: "CTN" },
   { name: "Box", label: "Box", code: "BOX" },

--- a/apps/backoffice/src/app/api/inventory/orders/[id]/route.ts
+++ b/apps/backoffice/src/app/api/inventory/orders/[id]/route.ts
@@ -95,9 +95,30 @@ export async function PATCH(req: NextRequest, { params }: { params: Promise<{ id
       },
     });
 
-    // Auto-create receiving when order is confirmed (AWAITING_DELIVERY)
+    // Auto-create invoice + receiving when order is confirmed (AWAITING_DELIVERY)
     if (status === "AWAITING_DELIVERY") {
       const caller = await getUserFromHeaders(req.headers);
+
+      try {
+        // Ensure invoice exists — saveEdit() usually creates it, but guard against edge cases
+        const existingInvoice = await prisma.invoice.findFirst({ where: { orderId: id } });
+        if (!existingInvoice) {
+          const invCount = await prisma.invoice.count();
+          await prisma.invoice.create({
+            data: {
+              invoiceNumber: `INV-${String(invCount + 1).padStart(4, "0")}`,
+              orderId: id,
+              outletId: order.outletId,
+              supplierId: order.supplierId,
+              amount: order.totalAmount,
+              status: "PENDING",
+              photos: invoicePhotos || [],
+            },
+          });
+        }
+      } catch (e) {
+        console.error("[orders/[id] PATCH] Invoice auto-create failed:", e);
+      }
 
       try {
         // Check if receiving already exists for this order

--- a/apps/backoffice/src/app/api/inventory/orders/route.ts
+++ b/apps/backoffice/src/app/api/inventory/orders/route.ts
@@ -113,60 +113,73 @@ export async function GET(req: NextRequest) {
 }
 
 export async function POST(req: NextRequest) {
-  const body = await req.json();
-  const { outletId, supplierId, items, notes, deliveryDate } = body;
-
-  const outlet = await prisma.outlet.findUniqueOrThrow({ where: { id: outletId } });
-  const count = await prisma.order.count({ where: { outletId } });
-  const orderNumber = `CC-${outlet.code}-${String(count + 1).padStart(4, "0")}`;
-
   const caller = await getUserFromHeaders(req.headers);
   if (!caller) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
 
-  const totalAmount = items.reduce(
-    (sum: number, i: { quantity: number; unitPrice: number }) => sum + i.quantity * i.unitPrice,
-    0,
-  );
+  try {
+    const body = await req.json();
+    const { outletId, supplierId, items, notes, deliveryDate } = body;
 
-  const order = await prisma.order.create({
-    data: {
-      orderNumber,
-      outletId,
-      supplierId,
-      status: "DRAFT",
-      totalAmount,
-      notes: notes || null,
-      deliveryDate: deliveryDate ? new Date(deliveryDate) : null,
-      createdById: caller.id,
-      items: {
-        create: items.map((i: { productId: string; productPackageId?: string; quantity: number; unitPrice: number; notes?: string }) => ({
-          productId: i.productId,
-          productPackageId: i.productPackageId || null,
-          quantity: i.quantity,
-          unitPrice: i.unitPrice,
-          totalPrice: i.quantity * i.unitPrice,
-          notes: i.notes || null,
-        })),
-      },
-    },
-    select: {
-      id: true,
-      orderNumber: true,
-      status: true,
-      totalAmount: true,
-      outlet: { select: { name: true } },
-      supplier: { select: { name: true } },
-      items: {
-        select: {
-          product: { select: { name: true } },
-          productPackage: { select: { packageLabel: true } },
-          quantity: true,
-          unitPrice: true,
-          totalPrice: true,
+    const outlet = await prisma.outlet.findUniqueOrThrow({ where: { id: outletId } });
+
+    // Use max order number to avoid collisions from deleted orders
+    const lastOrder = await prisma.order.findFirst({
+      where: { outletId },
+      orderBy: { orderNumber: "desc" },
+      select: { orderNumber: true },
+    });
+    const lastNum = lastOrder ? parseInt(lastOrder.orderNumber.split("-").pop() || "0") : 0;
+    const orderNumber = `CC-${outlet.code}-${String(lastNum + 1).padStart(4, "0")}`;
+
+    const totalAmount = items.reduce(
+      (sum: number, i: { quantity: number; unitPrice: number }) => sum + i.quantity * i.unitPrice,
+      0,
+    );
+
+    const order = await prisma.order.create({
+      data: {
+        orderNumber,
+        outletId,
+        supplierId,
+        status: "DRAFT",
+        totalAmount,
+        notes: notes || null,
+        deliveryDate: deliveryDate ? new Date(deliveryDate) : null,
+        createdById: caller.id,
+        items: {
+          create: items.map((i: { productId: string; productPackageId?: string; quantity: number; unitPrice: number; notes?: string }) => ({
+            productId: i.productId,
+            productPackageId: i.productPackageId || null,
+            quantity: i.quantity,
+            unitPrice: i.unitPrice,
+            totalPrice: i.quantity * i.unitPrice,
+            notes: i.notes || null,
+          })),
         },
       },
-    },
-  });
+      select: {
+        id: true,
+        orderNumber: true,
+        status: true,
+        totalAmount: true,
+        outlet: { select: { name: true } },
+        supplier: { select: { name: true } },
+        items: {
+          select: {
+            product: { select: { name: true } },
+            productPackage: { select: { packageLabel: true } },
+            quantity: true,
+            unitPrice: true,
+            totalPrice: true,
+          },
+        },
+      },
+    });
 
-  return NextResponse.json(order, { status: 201 });
+    return NextResponse.json(order, { status: 201 });
+  } catch (err) {
+    console.error("[orders POST]", err);
+    const message = err instanceof Error ? err.message : "Failed to create order";
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
 }

--- a/apps/backoffice/src/app/api/inventory/products/[id]/route.ts
+++ b/apps/backoffice/src/app/api/inventory/products/[id]/route.ts
@@ -91,36 +91,21 @@ export async function PATCH(req: NextRequest, { params }: { params: Promise<{ id
           );
           const replacementId = replacement?.id || null;
 
-          // Reassign supplier product refs
-          if (replacementId) {
-            await prisma.supplierProduct.updateMany({
-              where: { productPackageId: existing.id },
-              data: { productPackageId: replacementId },
-            });
-            await prisma.orderItem.updateMany({
-              where: { productPackageId: existing.id },
-              data: { productPackageId: replacementId },
-            });
-            // Reassign containsPackageId refs from other packages
-            await prisma.productPackage.updateMany({
-              where: { containsPackageId: existing.id },
-              data: { containsPackageId: replacementId },
-            });
-          } else {
-            // No replacement — null out refs instead of blocking delete
-            await prisma.supplierProduct.updateMany({
-              where: { productPackageId: existing.id },
-              data: { productPackageId: null },
-            });
-            await prisma.orderItem.updateMany({
-              where: { productPackageId: existing.id },
-              data: { productPackageId: null },
-            });
-            await prisma.productPackage.updateMany({
-              where: { containsPackageId: existing.id },
-              data: { containsPackageId: null },
-            });
-          }
+          // Clean up supplier product refs pointing to the deleted package
+          // Delete them — they'll be recreated with the new packages from the form
+          await prisma.supplierProduct.deleteMany({
+            where: { productPackageId: existing.id },
+          });
+          // Null out order item refs (historical data — keep the items)
+          await prisma.orderItem.updateMany({
+            where: { productPackageId: existing.id },
+            data: { productPackageId: replacementId },
+          });
+          // Reassign containsPackageId refs from other packages
+          await prisma.productPackage.updateMany({
+            where: { containsPackageId: existing.id },
+            data: { containsPackageId: replacementId },
+          });
 
           await prisma.productPackage.delete({ where: { id: existing.id } });
         }

--- a/apps/backoffice/src/app/api/inventory/products/[id]/route.ts
+++ b/apps/backoffice/src/app/api/inventory/products/[id]/route.ts
@@ -173,7 +173,7 @@ export async function PATCH(req: NextRequest, { params }: { params: Promise<{ id
         }
 
         // Resolve packageIndex to actual package ID
-        let packageId = entry.productPackageId || null;
+        let packageId = entry.productPackageId?.startsWith("new-") ? null : entry.productPackageId || null;
         if (!packageId && entry.packageIndex !== undefined && createdPkgIds[entry.packageIndex]) {
           packageId = createdPkgIds[entry.packageIndex];
         }

--- a/apps/backoffice/src/app/api/inventory/products/route.ts
+++ b/apps/backoffice/src/app/api/inventory/products/route.ts
@@ -171,7 +171,7 @@ export async function POST(req: NextRequest) {
       }
 
       // Resolve packageIndex to actual package ID for newly created packages
-      let packageId = entry.productPackageId || null;
+      let packageId = entry.productPackageId?.startsWith("new-") ? null : entry.productPackageId || null;
       if (!packageId && entry.packageIndex !== undefined && createdPackageIds[entry.packageIndex]) {
         packageId = createdPackageIds[entry.packageIndex];
       }

--- a/apps/staff/src/app/api/receivings/route.ts
+++ b/apps/staff/src/app/api/receivings/route.ts
@@ -80,6 +80,18 @@ export async function POST(req: NextRequest) {
 
   let receivingStatus = status || "COMPLETE";
   if (orderId) {
+    // Enforce Confirm Order flow — only allow receiving for AWAITING_DELIVERY orders
+    const order = await prisma.order.findUnique({
+      where: { id: orderId },
+      select: { status: true },
+    });
+    if (order && !["AWAITING_DELIVERY", "PARTIALLY_RECEIVED"].includes(order.status)) {
+      return NextResponse.json(
+        { error: "Order must be confirmed before receiving. Ask backoffice to Confirm Order first." },
+        { status: 400 },
+      );
+    }
+
     const hasShort = items.some(
       (i: { orderedQty?: number; receivedQty: number }) =>
         i.orderedQty !== undefined && i.receivedQty < i.orderedQty,
@@ -132,30 +144,6 @@ export async function POST(req: NextRequest) {
       const newStatus = totalReceived >= totalOrdered ? "COMPLETED" : "PARTIALLY_RECEIVED";
       await prisma.order.update({ where: { id: orderId }, data: { status: newStatus } });
     }
-  }
-
-  // Auto-create invoice from receiving
-  try {
-    const invCount = await prisma.invoice.count();
-    const invoiceNumber = `INV-${String(invCount + 1).padStart(4, "0")}`;
-    const totalAmount = orderId
-      ? (await prisma.order.findUnique({ where: { id: orderId }, select: { totalAmount: true } }))?.totalAmount ?? 0
-      : items.reduce((s: number, i: { receivedQty: number; unitPrice?: number }) => s + (i.receivedQty * (i.unitPrice ?? 0)), 0);
-
-    await prisma.invoice.create({
-      data: {
-        invoiceNumber,
-        orderId: orderId || null,
-        outletId,
-        supplierId,
-        amount: totalAmount,
-        status: "PENDING",
-        photos: invoicePhotos || [],
-        notes: notes ? `From receiving: ${notes}` : null,
-      },
-    });
-  } catch {
-    // Invoice creation is non-critical — don't fail the receiving
   }
 
   await logActivity({


### PR DESCRIPTION
## Summary
- Staff receiving now blocked for orders that haven't been confirmed — only AWAITING_DELIVERY and PARTIALLY_RECEIVED orders can be received
- SENT orders show error: "Order must be confirmed before receiving. Ask backoffice to Confirm Order first."
- Removed duplicate invoice auto-creation from receiving route (invoices are created by Confirm Order flow)

## Flow enforced
1. DRAFT → SENT (via WhatsApp)
2. SENT → **Confirm Order** (backoffice uploads invoice) → AWAITING_DELIVERY
3. AWAITING_DELIVERY → staff receives items → COMPLETED

https://claude.ai/code/session_01P4aS9Nfq7eK2wUQFjvqibv