### PR TITLE
fix: PO flow cleanup — remove Mark as Sent, fix draft collision

### DIFF
--- a/apps/backoffice/src/app/(admin)/inventory/orders/page.tsx
+++ b/apps/backoffice/src/app/(admin)/inventory/orders/page.tsx
@@ -101,16 +101,9 @@ const STATUS_CONFIG: Record<string, { label: string; color: string; icon: typeof
 };
 
 const NEXT_ACTIONS: Record<string, { status: string; label: string; icon: typeof Clock; color: string }[]> = {
-  DRAFT: [
-    { status: "APPROVED", label: "Confirm Request", icon: CheckCircle2, color: "bg-blue-500 hover:bg-blue-600" },
-  ],
-  PENDING_APPROVAL: [
-    { status: "APPROVED", label: "Confirm", icon: CheckCircle2, color: "bg-blue-500 hover:bg-blue-600" },
-    { status: "CANCELLED", label: "Reject", icon: Ban, color: "bg-red-500 hover:bg-red-600" },
-  ],
-  APPROVED: [
-    { status: "SENT", label: "Mark as Sent", icon: Send, color: "bg-green-500 hover:bg-green-600" },
-  ],
+  DRAFT: [],
+  PENDING_APPROVAL: [],
+  APPROVED: [],
   SENT: [],
   AWAITING_DELIVERY: [],
   PARTIALLY_RECEIVED: [],
@@ -641,7 +634,7 @@ export default function OrdersPage() {
                             {updatingId === order.id ? <Loader2 className="h-3 w-3 animate-spin" /> : a.label}
                           </button>
                         ))}
-                        {order.status === "SENT" && (
+                        {["SENT", "APPROVED"].includes(order.status) && (
                           <button onClick={() => openEditDialog(order)} disabled={updatingId === order.id} className="rounded-md px-2 py-1 text-[10px] font-medium text-white bg-purple-500 hover:bg-purple-600 disabled:opacity-50" title="Confirm Order">
                             {updatingId === order.id ? <Loader2 className="h-3 w-3 animate-spin" /> : "Confirm Order"}
                           </button>
@@ -656,7 +649,7 @@ export default function OrdersPage() {
                             <Pencil className="h-3 w-3" />
                           </Link>
                         )}
-                        {order.status === "APPROVED" && (
+                        {["APPROVED", "SENT"].includes(order.status) && (
                           <button onClick={() => { if (confirm("Cancel this order?")) updateStatus(order.id, "CANCELLED"); }} disabled={updatingId === order.id} className="rounded-md px-2 py-1 text-[10px] font-medium text-red-600 border border-red-200 hover:bg-red-50 disabled:opacity-50" title="Cancel Order">
                             Cancel
                           </button>
@@ -1015,7 +1008,7 @@ export default function OrdersPage() {
               {editSaving ? <Loader2 className="mr-1.5 h-4 w-4 animate-spin" /> : <CheckCircle2 className="mr-1.5 h-4 w-4" />}
               {confirmOnSave ? "Confirm Order" : "Save Changes"}
             </Button>
-            {editOrder?.status === "SENT" && (
+            {editOrder && ["SENT", "APPROVED"].includes(editOrder.status) && (
               <Button
                 disabled={editSaving || uploading}
                 className="bg-purple-500 hover:bg-purple-600"

--- a/apps/backoffice/src/app/api/inventory/orders/route.ts
+++ b/apps/backoffice/src/app/api/inventory/orders/route.ts
@@ -122,59 +122,69 @@ export async function POST(req: NextRequest) {
 
     const outlet = await prisma.outlet.findUniqueOrThrow({ where: { id: outletId } });
 
-    // Use max order number to avoid collisions from deleted orders
-    const lastOrder = await prisma.order.findFirst({
-      where: { outletId },
-      orderBy: { orderNumber: "desc" },
-      select: { orderNumber: true },
-    });
-    const lastNum = lastOrder ? parseInt(lastOrder.orderNumber.split("-").pop() || "0") : 0;
-    const orderNumber = `CC-${outlet.code}-${String(lastNum + 1).padStart(4, "0")}`;
-
     const totalAmount = items.reduce(
       (sum: number, i: { quantity: number; unitPrice: number }) => sum + i.quantity * i.unitPrice,
       0,
     );
 
-    const order = await prisma.order.create({
-      data: {
-        orderNumber,
-        outletId,
-        supplierId,
-        status: "DRAFT",
-        totalAmount,
-        notes: notes || null,
-        deliveryDate: deliveryDate ? new Date(deliveryDate) : null,
-        createdById: caller.id,
-        items: {
-          create: items.map((i: { productId: string; productPackageId?: string; quantity: number; unitPrice: number; notes?: string }) => ({
-            productId: i.productId,
-            productPackageId: i.productPackageId || null,
-            quantity: i.quantity,
-            unitPrice: i.unitPrice,
-            totalPrice: i.quantity * i.unitPrice,
-            notes: i.notes || null,
-          })),
-        },
-      },
-      select: {
-        id: true,
-        orderNumber: true,
-        status: true,
-        totalAmount: true,
-        outlet: { select: { name: true } },
-        supplier: { select: { name: true } },
-        items: {
-          select: {
-            product: { select: { name: true } },
-            productPackage: { select: { packageLabel: true } },
-            quantity: true,
-            unitPrice: true,
-            totalPrice: true,
+    // Retry loop to handle orderNumber collisions
+    let order;
+    for (let attempt = 0; attempt < 5; attempt++) {
+      const maxResult = await prisma.order.aggregate({
+        where: { orderNumber: { startsWith: `CC-${outlet.code}-` } },
+        _max: { orderNumber: true },
+      });
+      const lastNum = maxResult._max.orderNumber
+        ? parseInt(maxResult._max.orderNumber.split("-").pop() || "0")
+        : 0;
+      const orderNumber = `CC-${outlet.code}-${String(lastNum + 1 + attempt).padStart(4, "0")}`;
+
+      try {
+        order = await prisma.order.create({
+          data: {
+            orderNumber,
+            outletId,
+            supplierId,
+            status: "DRAFT",
+            totalAmount,
+            notes: notes || null,
+            deliveryDate: deliveryDate ? new Date(deliveryDate) : null,
+            createdById: caller.id,
+            items: {
+              create: items.map((i: { productId: string; productPackageId?: string; quantity: number; unitPrice: number; notes?: string }) => ({
+                productId: i.productId,
+                productPackageId: i.productPackageId || null,
+                quantity: i.quantity,
+                unitPrice: i.unitPrice,
+                totalPrice: i.quantity * i.unitPrice,
+                notes: i.notes || null,
+              })),
+            },
           },
-        },
-      },
-    });
+          select: {
+            id: true,
+            orderNumber: true,
+            status: true,
+            totalAmount: true,
+            outlet: { select: { name: true } },
+            supplier: { select: { name: true } },
+            items: {
+              select: {
+                product: { select: { name: true } },
+                productPackage: { select: { packageLabel: true } },
+                quantity: true,
+                unitPrice: true,
+                totalPrice: true,
+              },
+            },
+          },
+        });
+        break;
+      } catch (e: unknown) {
+        const isUniqueViolation = e instanceof Error && e.message.includes("Unique constraint");
+        if (!isUniqueViolation || attempt === 4) throw e;
+      }
+    }
 
     return NextResponse.json(order, { status: 201 });
   } catch (err) {


### PR DESCRIPTION
## Summary
- Removed "Confirm Request" (DRAFT) and "Mark as Sent" (APPROVED) steps — flow is now Draft → Send via WhatsApp → SENT → Confirm Order → AWAITING_DELIVERY
- Fixed Save as Draft unique constraint collision on orderNumber — uses aggregate max + retry loop
- Confirm Order now works for both SENT and APPROVED orders (dialog button was only showing for SENT)
- Cancel button available for SENT orders too

https://claude.ai/code/session_01UAgmzJrp4B8oKRPafjVPnW