### PR TITLE
fix: remove edit pencil from confirmed PO orders

### DIFF
--- a/apps/backoffice/src/app/(admin)/inventory/orders/page.tsx
+++ b/apps/backoffice/src/app/(admin)/inventory/orders/page.tsx
@@ -644,11 +644,6 @@ export default function OrdersPage() {
                             <Pencil className="h-3 w-3" />
                           </Link>
                         )}
-                        {["PENDING_APPROVAL", "SENT", "AWAITING_DELIVERY", "PARTIALLY_RECEIVED"].includes(order.status) && (
-                          <Link href={`/inventory/orders/${order.id}`} className="rounded-md px-2 py-1 text-[10px] font-medium text-gray-600 border border-gray-200 hover:bg-gray-50" title="Edit PO">
-                            <Pencil className="h-3 w-3" />
-                          </Link>
-                        )}
                         {["APPROVED", "SENT"].includes(order.status) && (
                           <button onClick={() => { if (confirm("Cancel this order?")) updateStatus(order.id, "CANCELLED"); }} disabled={updatingId === order.id} className="rounded-md px-2 py-1 text-[10px] font-medium text-red-600 border border-red-200 hover:bg-red-50 disabled:opacity-50" title="Cancel Order">
                             Cancel


### PR DESCRIPTION
## Summary
- Removed pencil edit button from SENT, AWAITING_DELIVERY, and PARTIALLY_RECEIVED orders
- Only DRAFT orders keep the edit button (goes to Smart Order page)
- Confirmed orders don't need editing

https://claude.ai/code/session_01UAgmzJrp4B8oKRPafjVPnW