### PR TITLE
fix: invoice photos showing as PDF instead of images

### DIFF
--- a/apps/backoffice/src/app/(admin)/inventory/invoices/page.tsx
+++ b/apps/backoffice/src/app/(admin)/inventory/invoices/page.tsx
@@ -7,7 +7,7 @@ import { Badge } from "@/components/ui/badge";
 import { useFetch } from "@/lib/use-fetch";
 import { FileText, Search, Download, Eye, Image as ImageIcon, Loader2, CheckCircle2, Clock, AlertTriangle, Filter, X, CalendarDays, Building2, ZoomIn, Pencil, Upload, Trash2, FileDown, DollarSign, Landmark, Copy, Check } from "lucide-react";
 
-const isPdf = (url: string) => /\.pdf($|\?)/i.test(url) || url.includes("/raw/");
+const isPdf = (url: string) => /\.pdf($|\?)/i.test(url);
 
 type Invoice = {
   id: string;


### PR DESCRIPTION
## Summary
- Cloudinary `/raw/upload/` URLs were incorrectly detected as PDFs, causing invoice images to render in an iframe instead of as `<img>` tags
- Fixed `isPdf` to only match actual `.pdf` file extensions

https://claude.ai/code/session_01UAgmzJrp4B8oKRPafjVPnW