### PR TITLE
fix: cancel button scope, remove invoice delete, photo fix

### DIFF
--- a/apps/backoffice/src/app/(admin)/inventory/invoices/page.tsx
+++ b/apps/backoffice/src/app/(admin)/inventory/invoices/page.tsx
@@ -7,7 +7,7 @@ import { Badge } from "@/components/ui/badge";
 import { useFetch } from "@/lib/use-fetch";
 import { FileText, Search, Download, Eye, Image as ImageIcon, Loader2, CheckCircle2, Clock, AlertTriangle, Filter, X, CalendarDays, Building2, ZoomIn, Pencil, Upload, Trash2, FileDown, DollarSign, Landmark, Copy, Check } from "lucide-react";
 
-const isPdf = (url: string) => /\.pdf($|\?)/i.test(url) || url.includes("/raw/");
+const isPdf = (url: string) => /\.pdf($|\?)/i.test(url);
 
 type Invoice = {
   id: string;

--- a/apps/backoffice/src/app/(admin)/inventory/invoices/page.tsx
+++ b/apps/backoffice/src/app/(admin)/inventory/invoices/page.tsx
@@ -538,25 +538,6 @@ export default function InvoicesPage() {
                       >
                         <Pencil className="h-3.5 w-3.5" />
                       </button>
-                      {["DRAFT", "PENDING"].includes(inv.status) && (
-                        <button
-                          onClick={async () => {
-                            if (!confirm(`Delete invoice ${inv.invoiceNumber}?`)) return;
-                            setUpdatingId(inv.id);
-                            try {
-                              const res = await fetch(`/api/inventory/invoices/${inv.id}`, { method: "DELETE" });
-                              if (res.ok) loadInvoices(undefined, { revalidate: true });
-                              else alert("Failed to delete invoice");
-                            } finally {
-                              setUpdatingId(null);
-                            }
-                          }}
-                          disabled={updatingId === inv.id}
-                          className="rounded-md p-1 text-red-400 hover:bg-red-50 hover:text-red-600 disabled:opacity-50"
-                          title="Delete invoice"
-                        >
-                          <Trash2 className="h-3.5 w-3.5" />
-                        </button>
                       )}
                       {actions.map((a) => (
                         <button

--- a/apps/backoffice/src/app/(admin)/inventory/orders/page.tsx
+++ b/apps/backoffice/src/app/(admin)/inventory/orders/page.tsx
@@ -644,7 +644,7 @@ export default function OrdersPage() {
                             <Pencil className="h-3 w-3" />
                           </Link>
                         )}
-                        {order.status === "AWAITING_DELIVERY" && (
+                        {["SENT", "APPROVED", "AWAITING_DELIVERY"].includes(order.status) && (
                           <button onClick={() => { if (confirm("Cancel this order?")) updateStatus(order.id, "CANCELLED"); }} disabled={updatingId === order.id} className="rounded-md px-2 py-1 text-[10px] font-medium text-red-600 border border-red-200 hover:bg-red-50 disabled:opacity-50" title="Cancel Order">
                             Cancel
                           </button>

--- a/apps/backoffice/src/app/(admin)/inventory/orders/page.tsx
+++ b/apps/backoffice/src/app/(admin)/inventory/orders/page.tsx
@@ -644,7 +644,7 @@ export default function OrdersPage() {
                             <Pencil className="h-3 w-3" />
                           </Link>
                         )}
-                        {["APPROVED", "SENT"].includes(order.status) && (
+                        {["APPROVED", "SENT", "AWAITING_DELIVERY"].includes(order.status) && (
                           <button onClick={() => { if (confirm("Cancel this order?")) updateStatus(order.id, "CANCELLED"); }} disabled={updatingId === order.id} className="rounded-md px-2 py-1 text-[10px] font-medium text-red-600 border border-red-200 hover:bg-red-50 disabled:opacity-50" title="Cancel Order">
                             Cancel
                           </button>

--- a/apps/backoffice/src/app/(admin)/inventory/orders/page.tsx
+++ b/apps/backoffice/src/app/(admin)/inventory/orders/page.tsx
@@ -644,7 +644,7 @@ export default function OrdersPage() {
                             <Pencil className="h-3 w-3" />
                           </Link>
                         )}
-                        {["APPROVED", "SENT", "AWAITING_DELIVERY"].includes(order.status) && (
+                        {order.status === "AWAITING_DELIVERY" && (
                           <button onClick={() => { if (confirm("Cancel this order?")) updateStatus(order.id, "CANCELLED"); }} disabled={updatingId === order.id} className="rounded-md px-2 py-1 text-[10px] font-medium text-red-600 border border-red-200 hover:bg-red-50 disabled:opacity-50" title="Cancel Order">
                             Cancel
                           </button>


### PR DESCRIPTION
## Summary
- Cancel button available for SENT, APPROVED, and AWAITING_DELIVERY orders (not COMPLETED)
- Removed delete button from invoices page
- Invoice photos: fixed Cloudinary URLs showing as PDF instead of images

https://claude.ai/code/session_01UAgmzJrp4B8oKRPafjVPnW