### PR TITLE
fix: hide Cancel and Edit when invoice is paid

### DIFF
--- a/apps/backoffice/src/app/(admin)/inventory/orders/page.tsx
+++ b/apps/backoffice/src/app/(admin)/inventory/orders/page.tsx
@@ -644,7 +644,12 @@ export default function OrdersPage() {
                             <Pencil className="h-3 w-3" />
                           </Link>
                         )}
-                        {["SENT", "APPROVED", "AWAITING_DELIVERY"].includes(order.status) && (
+                        {["SENT", "APPROVED", "AWAITING_DELIVERY"].includes(order.status) && order.invoice?.status !== "PAID" && (
+                          <button onClick={() => openEditDialog(order)} disabled={updatingId === order.id} className="rounded-md px-2 py-1 text-[10px] font-medium text-gray-600 border border-gray-200 hover:bg-gray-50 disabled:opacity-50" title="Edit Order">
+                            <Pencil className="h-3 w-3" />
+                          </button>
+                        )}
+                        {["SENT", "APPROVED", "AWAITING_DELIVERY"].includes(order.status) && order.invoice?.status !== "PAID" && (
                           <button onClick={() => { if (confirm("Cancel this order?")) updateStatus(order.id, "CANCELLED"); }} disabled={updatingId === order.id} className="rounded-md px-2 py-1 text-[10px] font-medium text-red-600 border border-red-200 hover:bg-red-50 disabled:opacity-50" title="Cancel Order">
                             Cancel
                           </button>


### PR DESCRIPTION
## Summary
- Cancel and Edit buttons only show when invoice is not paid
- Paid orders cannot be cancelled or edited
- Applies to SENT, APPROVED, and AWAITING_DELIVERY statuses

https://claude.ai/code/session_01UAgmzJrp4B8oKRPafjVPnW