### PR TITLE
fix: turbopack build error in backoffice

### DIFF
--- a/apps/backoffice/next.config.ts
+++ b/apps/backoffice/next.config.ts
@@ -6,7 +6,9 @@ const nextConfig: NextConfig = {
       { protocol: "https", hostname: "res.cloudinary.com" },
     ],
   },
-  // Force rebuild
+  turbopack: {
+    root: "../..",
+  },
 };
 
 export default nextConfig;


### PR DESCRIPTION
## Summary
- Fix Turbopack build error: "couldn't find Next.js package from project directory"
- Added `turbopack.root` config pointing to monorepo root

https://claude.ai/code/session_01UAgmzJrp4B8oKRPafjVPnW