### PR TITLE
fix: TypeScript build error in Smart Order transfer

### DIFF
--- a/apps/backoffice/src/app/(admin)/inventory/orders/create/page.tsx
+++ b/apps/backoffice/src/app/(admin)/inventory/orders/create/page.tsx
@@ -1013,7 +1013,7 @@ export default function CreateOrderPage() {
                                           data: {
                                             fromOutletId: tf.fromOutletId,
                                             toOutletId: selectedOutletId,
-                                            items: [{ productId: item.productId, productPackageId: tf.productPackageId || null, quantity: tf.transferQty }],
+                                            items: [{ productId: item.productId, quantity: tf.transferQty }],
                                           },
                                         }),
                                       });


### PR DESCRIPTION
## Summary
- Fix TypeScript build error: `productPackageId` doesn't exist on transfer option type

https://claude.ai/code/session_01UAgmzJrp4B8oKRPafjVPnW