### PR TITLE
feat: configurable stock count schedule

### DIFF
--- a/apps/backoffice/src/app/(admin)/layout.tsx
+++ b/apps/backoffice/src/app/(admin)/layout.tsx
@@ -200,6 +200,7 @@ const NAV_SECTIONS: NavSection[] = [
       { label: "Staff & Access", href: "/settings/staff", icon: <UserCog className={ICON_SIZE} />, moduleKey: "settings:staff" },
       { label: "Approval Rules", href: "/settings/rules", icon: <ShieldCheck className={ICON_SIZE} />, moduleKey: "settings:rules" },
       { label: "Integrations", href: "/settings/integrations", icon: <Plug className={ICON_SIZE} />, moduleKey: "settings:integrations" },
+      { label: "Stock Count", href: "/settings/stock-count", icon: <ClipboardCheck className={ICON_SIZE} />, moduleKey: "settings:stock-count" },
       { label: "System", href: "/settings/system", icon: <Wrench className={ICON_SIZE} />, moduleKey: "settings:system" },
     ],
   },

--- a/apps/backoffice/src/app/(admin)/settings/stock-count/page.tsx
+++ b/apps/backoffice/src/app/(admin)/settings/stock-count/page.tsx
@@ -1,0 +1,141 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { Button } from "@/components/ui/button";
+import { Card } from "@/components/ui/card";
+import { CalendarDays, Loader2, Check } from "lucide-react";
+
+const WEEKDAYS = [
+  { value: 0, label: "Sunday" },
+  { value: 1, label: "Monday" },
+  { value: 2, label: "Tuesday" },
+  { value: 3, label: "Wednesday" },
+  { value: 4, label: "Thursday" },
+  { value: 5, label: "Friday" },
+  { value: 6, label: "Saturday" },
+];
+
+const MONTH_DAYS = [28, 29, 30, 31];
+
+export default function StockCountSettingsPage() {
+  const [weeklyDays, setWeeklyDays] = useState<number[]>([0, 2, 4]);
+  const [endOfMonthDays, setEndOfMonthDays] = useState<number[]>([28, 29, 30, 31]);
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [saved, setSaved] = useState(false);
+
+  useEffect(() => {
+    fetch("/api/settings/stock-count")
+      .then((r) => r.json())
+      .then((data) => {
+        if (data.weeklyDays) setWeeklyDays(data.weeklyDays);
+        if (data.endOfMonthDays) setEndOfMonthDays(data.endOfMonthDays);
+      })
+      .finally(() => setLoading(false));
+  }, []);
+
+  const toggleDay = (day: number) => {
+    setWeeklyDays((prev) =>
+      prev.includes(day) ? prev.filter((d) => d !== day) : [...prev, day].sort()
+    );
+    setSaved(false);
+  };
+
+  const toggleMonthDay = (day: number) => {
+    setEndOfMonthDays((prev) =>
+      prev.includes(day) ? prev.filter((d) => d !== day) : [...prev, day].sort()
+    );
+    setSaved(false);
+  };
+
+  const handleSave = async () => {
+    setSaving(true);
+    try {
+      const res = await fetch("/api/settings/stock-count", {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ weeklyDays, endOfMonthDays }),
+      });
+      if (res.ok) setSaved(true);
+      else alert("Failed to save");
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center p-12">
+        <Loader2 className="h-5 w-5 animate-spin text-terracotta" />
+      </div>
+    );
+  }
+
+  return (
+    <div className="p-6 max-w-2xl">
+      <div className="mb-6">
+        <h2 className="text-xl font-semibold text-gray-900">Stock Count Schedule</h2>
+        <p className="mt-1 text-sm text-gray-500">
+          Set which days staff should do stock counts
+        </p>
+      </div>
+
+      {/* Weekly Days */}
+      <Card className="mb-4 p-5">
+        <div className="mb-3">
+          <h3 className="text-sm font-semibold text-gray-800 flex items-center gap-2">
+            <CalendarDays className="h-4 w-4 text-terracotta" />
+            Weekly Count Days
+          </h3>
+          <p className="mt-0.5 text-xs text-gray-500">Regular stock count on these days</p>
+        </div>
+        <div className="flex flex-wrap gap-2">
+          {WEEKDAYS.map((d) => (
+            <button
+              key={d.value}
+              onClick={() => toggleDay(d.value)}
+              className={`rounded-lg border px-4 py-2 text-sm font-medium transition-colors ${
+                weeklyDays.includes(d.value)
+                  ? "border-terracotta bg-terracotta text-white"
+                  : "border-gray-200 bg-white text-gray-600 hover:bg-gray-50"
+              }`}
+            >
+              {d.label}
+            </button>
+          ))}
+        </div>
+      </Card>
+
+      {/* End of Month Days */}
+      <Card className="mb-6 p-5">
+        <div className="mb-3">
+          <h3 className="text-sm font-semibold text-gray-800 flex items-center gap-2">
+            <CalendarDays className="h-4 w-4 text-blue-500" />
+            End of Month Full Count
+          </h3>
+          <p className="mt-0.5 text-xs text-gray-500">Full stock count on these dates each month</p>
+        </div>
+        <div className="flex flex-wrap gap-2">
+          {MONTH_DAYS.map((d) => (
+            <button
+              key={d}
+              onClick={() => toggleMonthDay(d)}
+              className={`rounded-lg border px-4 py-2 text-sm font-medium transition-colors ${
+                endOfMonthDays.includes(d)
+                  ? "border-blue-500 bg-blue-500 text-white"
+                  : "border-gray-200 bg-white text-gray-600 hover:bg-gray-50"
+              }`}
+            >
+              {d}
+            </button>
+          ))}
+        </div>
+      </Card>
+
+      <Button onClick={handleSave} disabled={saving} className="bg-terracotta hover:bg-terracotta-dark">
+        {saving ? <Loader2 className="mr-1.5 h-4 w-4 animate-spin" /> : saved ? <Check className="mr-1.5 h-4 w-4" /> : null}
+        {saved ? "Saved" : "Save Schedule"}
+      </Button>
+    </div>
+  );
+}

--- a/apps/backoffice/src/app/api/settings/stock-count/route.ts
+++ b/apps/backoffice/src/app/api/settings/stock-count/route.ts
@@ -1,0 +1,32 @@
+import { NextRequest, NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+import { getUserFromHeaders } from "@/lib/auth";
+
+const KEY = "stock_count_schedule";
+const DEFAULT_SCHEDULE = { weeklyDays: [0, 2, 4], endOfMonthDays: [28, 29, 30, 31] };
+
+export async function GET() {
+  const config = await prisma.appConfig.findUnique({ where: { key: KEY } });
+  return NextResponse.json(config?.value ?? DEFAULT_SCHEDULE);
+}
+
+export async function PUT(req: NextRequest) {
+  const caller = await getUserFromHeaders(req.headers);
+  if (!caller) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+
+  const body = await req.json();
+  const { weeklyDays, endOfMonthDays } = body as { weeklyDays: number[]; endOfMonthDays: number[] };
+
+  const value = {
+    weeklyDays: weeklyDays ?? DEFAULT_SCHEDULE.weeklyDays,
+    endOfMonthDays: endOfMonthDays ?? DEFAULT_SCHEDULE.endOfMonthDays,
+  };
+
+  await prisma.appConfig.upsert({
+    where: { key: KEY },
+    update: { value },
+    create: { key: KEY, value },
+  });
+
+  return NextResponse.json(value);
+}

--- a/apps/staff/src/app/(ops)/home/home-client.tsx
+++ b/apps/staff/src/app/(ops)/home/home-client.tsx
@@ -97,6 +97,11 @@ export function HomeClient({
   const [dashboard, setDashboard] = useState(initialDashboard);
   const [showDone, setShowDone] = useState(false);
   const [refreshing, setRefreshing] = useState(false);
+  const [stockSchedule, setStockSchedule] = useState<{ weeklyDays: number[]; endOfMonthDays: number[] }>({ weeklyDays: [0, 2, 4], endOfMonthDays: [28, 29, 30, 31] });
+
+  useEffect(() => {
+    fetch("/api/settings/stock-count").then((r) => r.ok ? r.json() : null).then((s) => { if (s) setStockSchedule(s); }).catch(() => {});
+  }, []);
 
   // Pull-to-refresh state
   const scrollRef = useRef<HTMLDivElement>(null);
@@ -192,12 +197,11 @@ export function HomeClient({
     }
 
     if (dashboard) {
-      // Stock count schedule: Tue(2), Thu(4), Sun(0) = Regular Count, End of Month = Full Count
-      const dayOfWeek = now.getDay(); // 0=Sun, 2=Tue, 4=Thu
-      const isCountDay = [0, 2, 4].includes(dayOfWeek);
-      const daysInMonth = new Date(now.getFullYear(), now.getMonth() + 1, 0).getDate();
+      // Stock count schedule from settings
+      const dayOfWeek = now.getDay();
+      const isCountDay = stockSchedule.weeklyDays.includes(dayOfWeek);
       const dayOfMonth = now.getDate();
-      const isEndOfMonth = dayOfMonth >= daysInMonth - 2; // last 3 days
+      const isEndOfMonth = stockSchedule.endOfMonthDays.includes(dayOfMonth);
 
       const countLabel = isEndOfMonth
         ? "Full Stock Count (End of Month)"
@@ -235,7 +239,7 @@ export function HomeClient({
 
     list.sort((a, b) => PRIORITY_ORDER[a.priority] - PRIORITY_ORDER[b.priority]);
     return list;
-  }, [checklists, dashboard, now, hour]);
+  }, [checklists, dashboard, now, hour, stockSchedule]);
 
   const pendingTasks = tasks.filter((t) => t.priority !== "done");
   const doneTasks = tasks.filter((t) => t.priority === "done");

--- a/apps/staff/src/app/api/settings/stock-count/route.ts
+++ b/apps/staff/src/app/api/settings/stock-count/route.ts
@@ -1,0 +1,10 @@
+import { NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+
+const KEY = "stock_count_schedule";
+const DEFAULT_SCHEDULE = { weeklyDays: [0, 2, 4], endOfMonthDays: [28, 29, 30, 31] };
+
+export async function GET() {
+  const config = await prisma.appConfig.findUnique({ where: { key: KEY } });
+  return NextResponse.json(config?.value ?? DEFAULT_SCHEDULE);
+}

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -9,6 +9,13 @@ datasource db {
   directUrl = env("DIRECT_URL")
 }
 
+// ─── APP CONFIG ────────────────────────────────────────────
+model AppConfig {
+  key       String   @id
+  value     Json     @default("{}")
+  updatedAt DateTime @default(now()) @updatedAt
+}
+
 // ─── OUTLETS ────────────────────────────────────────────────
 
 model Outlet {


### PR DESCRIPTION
## Summary
- New AppConfig table for app-wide settings
- Backoffice: Settings > Stock Count page to configure weekly count days and end-of-month full count days
- Staff app: home page uses configured schedule instead of hardcoded Tue/Thu/Sun
- Default: Weekly on Tue/Thu/Sun, End of month on 28/29/30/31

https://claude.ai/code/session_01UAgmzJrp4B8oKRPafjVPnW