### PR TITLE
fix: loyalty alarm — 60 min threshold, 15 min repeat

### DIFF
--- a/apps/loyalty/src/app/staff/page.tsx
+++ b/apps/loyalty/src/app/staff/page.tsx
@@ -79,8 +79,8 @@ export default function PortalPage() {
   const currentOutlet = outlets.find((o) => o.id === outletId) || outlets[0];
   const [notifPermission, setNotifPermission] = useState<NotificationPermission>("default");
   const inactivityRef = useRef<NodeJS.Timeout | null>(null);
-  const INACTIVITY_MINUTES = 1; // TESTING: 1 min (change back to 60)
-  const REPEAT_INTERVAL_MS = 10 * 60 * 1000; // repeat every 10 mins until activity resumes
+  const INACTIVITY_MINUTES = 60; // remind after 60 mins of no loyalty activity
+  const REPEAT_INTERVAL_MS = 15 * 60 * 1000; // repeat every 15 mins until activity resumes
 
   // ─── Push notification for loyalty inactivity ───────────
   useEffect(() => {


### PR DESCRIPTION
## Summary
Production settings for loyalty inactivity alarm:
- 60 mins of no activity → first reminder fires
- Repeats every 15 mins with loud sound until staff awards points
- Resets when points are awarded

https://claude.ai/code/session_01UAgmzJrp4B8oKRPafjVPnW