### PR TITLE
fix(ai-agent): surface telegram delivery errors to dashboard

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,3 +13,10 @@ NEXT_PUBLIC_SUPABASE_ANON_KEY="eyJ..."
 # ── StoreHub (inventory only) ────────────────────
 STOREHUB_ACCOUNT_ID=""
 STOREHUB_API_KEY=""
+
+# ── AI Agent (Celsius overview → Telegram) ───────
+ANTHROPIC_API_KEY=""
+TELEGRAM_BOT_TOKEN=""             # e.g. 8490404757:AAHb4Lk3GlfaGfTXVT50qA0EF6cy3zCXbY0
+TELEGRAM_OWNER_CHAT_ID=""         # owner's Telegram chat id (numeric). DM the bot then call getUpdates to find it.
+TELEGRAM_WEBHOOK_SECRET=""        # only needed if using inventory telegram webhook
+CRON_SECRET=""                    # vercel cron bearer token

--- a/apps/backoffice/src/app/(admin)/dashboard/page.tsx
+++ b/apps/backoffice/src/app/(admin)/dashboard/page.tsx
@@ -51,12 +51,16 @@ function AiAgentButton() {
         setMsg(data.error || "Failed to run agent");
         return;
       }
-      setState("done");
+      setState(data.deliveryError ? "error" : "done");
       const count = data.recommendationCount ?? 0;
       const sent = data.delivered?.messages ?? 0;
-      setMsg(count === 0
-        ? "Nothing urgent — no Telegram sent."
-        : `${count} item${count === 1 ? "" : "s"} sent to Telegram (${sent} message${sent === 1 ? "" : "s"}).`);
+      if (data.deliveryError) {
+        setMsg(`Delivery failed: ${data.deliveryError}`);
+      } else {
+        setMsg(count === 0
+          ? "Nothing urgent — no Telegram sent."
+          : `${count} item${count === 1 ? "" : "s"} found, ${sent} Telegram message${sent === 1 ? "" : "s"} delivered.`);
+      }
     } catch (e) {
       setState("error");
       setMsg(e instanceof Error ? e.message : "Network error");

--- a/apps/backoffice/src/app/(admin)/dashboard/page.tsx
+++ b/apps/backoffice/src/app/(admin)/dashboard/page.tsx
@@ -6,7 +6,7 @@ import {
   ShoppingBag, Boxes, Gift, ArrowRight,
   ShoppingCart, ArrowRightLeft, FileText, AlertTriangle, Loader2,
   Warehouse, Receipt, Target, UserCheck, Repeat, DollarSign, Store,
-  ClipboardCheck, CheckCircle2, Clock,
+  ClipboardCheck, CheckCircle2, Clock, Sparkles,
 } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
 import { useFetch } from "@/lib/use-fetch";
@@ -35,6 +35,49 @@ type ShiftKpi = { shift: string; data: KpiData } | null;
 type OpsPerformance = {
   summary: { totalChecklists: number; completedChecklists: number; completionRate: number; photoRate: number };
 };
+
+function AiAgentButton() {
+  const [state, setState] = useState<"idle" | "running" | "done" | "error">("idle");
+  const [msg, setMsg] = useState<string>("");
+
+  async function run() {
+    setState("running");
+    setMsg("");
+    try {
+      const res = await fetch("/api/ai-agent/celsius-overview", { method: "POST", credentials: "include" });
+      const data = await res.json();
+      if (!res.ok || !data.ok) {
+        setState("error");
+        setMsg(data.error || "Failed to run agent");
+        return;
+      }
+      setState("done");
+      const count = data.recommendationCount ?? 0;
+      const sent = data.delivered?.messages ?? 0;
+      setMsg(count === 0
+        ? "Nothing urgent — no Telegram sent."
+        : `${count} item${count === 1 ? "" : "s"} sent to Telegram (${sent} message${sent === 1 ? "" : "s"}).`);
+    } catch (e) {
+      setState("error");
+      setMsg(e instanceof Error ? e.message : "Network error");
+    }
+  }
+
+  return (
+    <div className="flex flex-col items-end gap-1">
+      <button
+        type="button"
+        onClick={run}
+        disabled={state === "running"}
+        className="inline-flex items-center gap-1.5 rounded-lg border border-purple-200 bg-purple-50 px-3 py-1.5 text-xs font-medium text-purple-700 hover:bg-purple-100 disabled:opacity-50"
+      >
+        {state === "running" ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <Sparkles className="h-3.5 w-3.5" />}
+        {state === "running" ? "Scanning…" : "Run AI agent"}
+      </button>
+      {msg && <span className={`text-[10px] ${state === "error" ? "text-red-600" : "text-gray-500"}`}>{msg}</span>}
+    </div>
+  );
+}
 
 const STATUS_COLORS: Record<string, string> = {
   DRAFT: "bg-gray-400", PENDING_APPROVAL: "bg-amber-500", APPROVED: "bg-blue-500",
@@ -72,13 +115,16 @@ export default function DashboardPage() {
   return (
     <div className="p-4 sm:p-6 lg:p-8 overflow-x-hidden">
       {/* Header */}
-      <div className="mb-6">
-        <h1 className="font-heading text-xl sm:text-2xl font-bold text-foreground">
-          {greeting}{user?.name ? `, ${user.name}` : ""}
-        </h1>
-        <p className="mt-0.5 text-sm text-muted-foreground">
-          {now.toLocaleDateString("en-MY", { weekday: "long", day: "numeric", month: "long", year: "numeric" })}
-        </p>
+      <div className="mb-6 flex items-start justify-between gap-3">
+        <div>
+          <h1 className="font-heading text-xl sm:text-2xl font-bold text-foreground">
+            {greeting}{user?.name ? `, ${user.name}` : ""}
+          </h1>
+          <p className="mt-0.5 text-sm text-muted-foreground">
+            {now.toLocaleDateString("en-MY", { weekday: "long", day: "numeric", month: "long", year: "numeric" })}
+          </p>
+        </div>
+        <AiAgentButton />
       </div>
 
       {/* Top row — Key metrics across all modules */}

--- a/apps/backoffice/src/app/api/ai-agent/celsius-overview/route.ts
+++ b/apps/backoffice/src/app/api/ai-agent/celsius-overview/route.ts
@@ -1,0 +1,45 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getSession } from "@/lib/auth";
+import { runCelsiusOverviewAgent } from "@/lib/ai-agent/celsius-overview";
+
+export const dynamic = "force-dynamic";
+export const maxDuration = 60;
+
+/**
+ * POST /api/ai-agent/celsius-overview
+ *
+ * Runs the Celsius Coffee AI agent. Either authenticated as OWNER/ADMIN
+ * (manual trigger) or invoked by Vercel Cron with the CRON_SECRET bearer.
+ *
+ * The agent decides what to send and when — if nothing is urgent enough
+ * for owner attention, no Telegram message is delivered.
+ */
+async function handle(req: NextRequest) {
+  const cronSecret = req.headers.get("authorization")?.replace("Bearer ", "");
+  const isCron = !!process.env.CRON_SECRET && cronSecret === process.env.CRON_SECRET;
+
+  if (!isCron) {
+    const session = await getSession();
+    if (!session || !["OWNER", "ADMIN"].includes(session.role)) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+  }
+
+  try {
+    const result = await runCelsiusOverviewAgent();
+    return NextResponse.json({
+      ok: true,
+      generatedAt: result.generatedAt,
+      recommendationCount: result.recommendations.length,
+      delivered: result.delivered,
+      recommendations: result.recommendations,
+    });
+  } catch (err) {
+    console.error("[ai-agent] run failed:", err);
+    const message = err instanceof Error ? err.message : "Unknown error";
+    return NextResponse.json({ ok: false, error: message }, { status: 500 });
+  }
+}
+
+export const GET = handle;
+export const POST = handle;

--- a/apps/backoffice/src/app/api/ai-agent/celsius-overview/route.ts
+++ b/apps/backoffice/src/app/api/ai-agent/celsius-overview/route.ts
@@ -32,6 +32,7 @@ async function handle(req: NextRequest) {
       generatedAt: result.generatedAt,
       recommendationCount: result.recommendations.length,
       delivered: result.delivered,
+      deliveryError: result.deliveryError,
       recommendations: result.recommendations,
     });
   } catch (err) {

--- a/apps/backoffice/src/lib/ai-agent/celsius-overview.ts
+++ b/apps/backoffice/src/lib/ai-agent/celsius-overview.ts
@@ -27,6 +27,7 @@ export type AgentResult = {
   snapshot: OverviewSnapshot;
   recommendations: AgentRecommendation[];
   delivered: { chatId: number; messages: number } | null;
+  deliveryError: string | null;
 };
 
 type OverviewSnapshot = {
@@ -377,28 +378,56 @@ function escapeHtml(s: string): string {
   return s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
 }
 
-async function deliver(recommendations: AgentRecommendation[]): Promise<{ chatId: number; messages: number } | null> {
+type DeliveryOutcome = {
+  delivered: { chatId: number; messages: number } | null;
+  error: string | null;
+};
+
+async function sendAndCheck(chatId: number, text: string): Promise<void> {
+  const token = process.env.TELEGRAM_BOT_TOKEN;
+  if (!token) throw new Error("TELEGRAM_BOT_TOKEN not set");
+  const res = await fetch(`https://api.telegram.org/bot${token}/sendMessage`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ chat_id: chatId, text, parse_mode: "HTML" }),
+  });
+  if (!res.ok) {
+    const body = await res.text().catch(() => "");
+    throw new Error(`Telegram ${res.status}: ${body.slice(0, 200)}`);
+  }
+}
+
+async function deliver(recommendations: AgentRecommendation[]): Promise<DeliveryOutcome> {
+  if (!process.env.TELEGRAM_BOT_TOKEN) {
+    return { delivered: null, error: "TELEGRAM_BOT_TOKEN not set in this deployment" };
+  }
   const chatRaw = process.env.TELEGRAM_OWNER_CHAT_ID;
   if (!chatRaw) {
-    console.warn("[ai-agent] TELEGRAM_OWNER_CHAT_ID not configured — skipping delivery");
-    return null;
+    return { delivered: null, error: "TELEGRAM_OWNER_CHAT_ID not set in this deployment" };
   }
   const chatId = parseInt(chatRaw, 10);
-  if (Number.isNaN(chatId)) return null;
+  if (Number.isNaN(chatId)) {
+    return { delivered: null, error: `TELEGRAM_OWNER_CHAT_ID is not numeric: "${chatRaw}"` };
+  }
 
   if (recommendations.length === 0) {
-    // Stay silent — agent decided nothing is worth interrupting the owner.
-    return { chatId, messages: 0 };
+    return { delivered: { chatId, messages: 0 }, error: null };
   }
 
   const header = `🤖 <b>Celsius AI Agent — ${recommendations.length} item${recommendations.length === 1 ? "" : "s"} need your attention</b>\n<i>${new Date().toLocaleString("en-MY", { timeZone: "Asia/Kuala_Lumpur" })}</i>`;
-  await sendMessage(chatId, header);
 
-  for (let i = 0; i < recommendations.length; i++) {
-    await sendMessage(chatId, formatRecommendation(recommendations[i], i, recommendations.length));
+  try {
+    await sendAndCheck(chatId, header);
+    for (let i = 0; i < recommendations.length; i++) {
+      await sendAndCheck(chatId, formatRecommendation(recommendations[i], i, recommendations.length));
+    }
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    console.error("[ai-agent] telegram delivery failed:", msg);
+    return { delivered: { chatId, messages: 0 }, error: msg };
   }
 
-  return { chatId, messages: recommendations.length + 1 };
+  return { delivered: { chatId, messages: recommendations.length + 1 }, error: null };
 }
 
 // ────────────────────────────────────────────────────────────
@@ -408,12 +437,13 @@ async function deliver(recommendations: AgentRecommendation[]): Promise<{ chatId
 export async function runCelsiusOverviewAgent(): Promise<AgentResult> {
   const snapshot = await buildSnapshot();
   const recommendations = await analyse(snapshot);
-  const delivered = await deliver(recommendations);
+  const { delivered, error } = await deliver(recommendations);
 
   return {
     generatedAt: new Date().toISOString(),
     snapshot,
     recommendations,
     delivered,
+    deliveryError: error,
   };
 }

--- a/apps/backoffice/src/lib/ai-agent/celsius-overview.ts
+++ b/apps/backoffice/src/lib/ai-agent/celsius-overview.ts
@@ -1,0 +1,419 @@
+/**
+ * Celsius Coffee AI Agent — Overview Scanner.
+ *
+ * Pulls a 7-day snapshot of the business (ops checklists, inventory,
+ * wastage, cash/invoices), asks Claude to identify the decisions and
+ * improvements the owner needs to act on, and pushes each one as a
+ * Telegram message to the owner chat. Claude itself decides what is
+ * worth interrupting the owner with — silent runs are normal.
+ */
+
+import Anthropic from "@anthropic-ai/sdk";
+import { prisma } from "@/lib/prisma";
+import { sendMessage } from "@/lib/telegram";
+
+const anthropic = new Anthropic({ apiKey: process.env.ANTHROPIC_API_KEY });
+
+export type AgentRecommendation = {
+  area: "loyalty" | "ops" | "inventory" | "wastage" | "cash" | "people" | "other";
+  priority: "critical" | "high" | "medium" | "low";
+  title: string;
+  why: string;
+  action: string;
+};
+
+export type AgentResult = {
+  generatedAt: string;
+  snapshot: OverviewSnapshot;
+  recommendations: AgentRecommendation[];
+  delivered: { chatId: number; messages: number } | null;
+};
+
+type OverviewSnapshot = {
+  windowDays: number;
+  outlets: { id: string; name: string; code: string }[];
+  ops: {
+    totalChecklists: number;
+    completedChecklists: number;
+    completionRate: number;
+    photoRate: number;
+    staffLagging: { name: string; role: string; completionRate: number; itemsCompleted: number }[];
+    outletLagging: { name: string; completionRate: number }[];
+    incompleteCount: number;
+  };
+  inventory: {
+    pendingPoApprovals: number;
+    criticalReorders: number;
+    transfersRecommended: number;
+    weeklySpending: number;
+    inventoryValue: number;
+    cogsThisMonth: number;
+    invoicesPendingAmount: number;
+    invoicesOverdueAmount: number;
+    topReorders: { outlet: string; supplier: string; total: number; urgency: string }[];
+  };
+  wastage: {
+    weeklyCost: number;
+    topOffenders: { product: string; outlet: string; cost: number; type: string }[];
+  };
+};
+
+// ────────────────────────────────────────────────────────────
+// Snapshot collection (DB-driven, no HTTP loops)
+// ────────────────────────────────────────────────────────────
+
+async function buildSnapshot(): Promise<OverviewSnapshot> {
+  const now = new Date();
+  const weekAgo = new Date(now.getTime() - 7 * 24 * 60 * 60 * 1000);
+  const monthAgo = new Date(now.getTime() - 30 * 24 * 60 * 60 * 1000);
+
+  const [outlets, checklists, orders, parLevels, stockBalances, wastage, invoices] =
+    await Promise.all([
+      prisma.outlet.findMany({
+        where: { status: "ACTIVE" },
+        select: { id: true, name: true, code: true },
+      }),
+      prisma.checklist.findMany({
+        where: { date: { gte: weekAgo, lte: now } },
+        include: {
+          outlet: { select: { id: true, name: true, code: true } },
+          assignedTo: { select: { id: true, name: true, role: true } },
+          items: {
+            select: {
+              isCompleted: true,
+              photoUrl: true,
+              completedBy: { select: { id: true, name: true, role: true } },
+            },
+          },
+        },
+      }),
+      prisma.order.findMany({
+        where: { createdAt: { gte: weekAgo } },
+        select: {
+          id: true,
+          status: true,
+          totalAmount: true,
+          createdAt: true,
+          orderType: true,
+          outlet: { select: { name: true } },
+          supplier: { select: { name: true } },
+        },
+      }),
+      prisma.parLevel.findMany({
+        select: {
+          productId: true,
+          outletId: true,
+          parLevel: true,
+          reorderPoint: true,
+          avgDailyUsage: true,
+        },
+      }),
+      prisma.stockBalance.findMany({
+        select: { productId: true, outletId: true, quantity: true },
+      }),
+      prisma.stockAdjustment.findMany({
+        where: {
+          createdAt: { gte: weekAgo },
+          adjustmentType: { in: ["WASTAGE", "BREAKAGE", "EXPIRED", "SPILLAGE"] },
+        },
+        include: {
+          product: { select: { name: true } },
+          outlet: { select: { name: true } },
+        },
+      }),
+      prisma.invoice.findMany({
+        where: { status: { in: ["PENDING", "INITIATED", "OVERDUE"] } },
+        select: { amount: true, status: true, dueDate: true },
+      }),
+    ]);
+
+  // Ops — completion + photo rate + laggards
+  const totalChecklists = checklists.length;
+  const completedChecklists = checklists.filter((c) => c.status === "COMPLETED").length;
+  const totalItems = checklists.reduce((s, c) => s + c.items.length, 0);
+  const itemsWithPhotos = checklists.reduce(
+    (s, c) => s + c.items.filter((i) => i.photoUrl).length,
+    0,
+  );
+
+  const staffMap = new Map<string, {
+    name: string; role: string;
+    claimed: number; completed: number; itemsCompleted: number;
+  }>();
+  const outletStatsMap = new Map<string, { name: string; total: number; completed: number }>();
+
+  for (const cl of checklists) {
+    if (cl.assignedTo) {
+      const ex = staffMap.get(cl.assignedTo.id) ?? {
+        name: cl.assignedTo.name, role: cl.assignedTo.role,
+        claimed: 0, completed: 0, itemsCompleted: 0,
+      };
+      ex.claimed++;
+      if (cl.status === "COMPLETED") ex.completed++;
+      staffMap.set(cl.assignedTo.id, ex);
+    }
+    for (const item of cl.items) {
+      if (item.isCompleted && item.completedBy) {
+        const ex = staffMap.get(item.completedBy.id) ?? {
+          name: item.completedBy.name,
+          role: (item.completedBy as { role?: string }).role ?? "STAFF",
+          claimed: 0, completed: 0, itemsCompleted: 0,
+        };
+        ex.itemsCompleted++;
+        staffMap.set(item.completedBy.id, ex);
+      }
+    }
+    const oEx = outletStatsMap.get(cl.outlet.id) ?? {
+      name: cl.outlet.name, total: 0, completed: 0,
+    };
+    oEx.total++;
+    if (cl.status === "COMPLETED") oEx.completed++;
+    outletStatsMap.set(cl.outlet.id, oEx);
+  }
+
+  const staffLagging = [...staffMap.values()]
+    .filter((s) => s.claimed >= 3)
+    .map((s) => ({
+      name: s.name,
+      role: s.role,
+      completionRate: s.claimed > 0 ? Math.round((s.completed / s.claimed) * 100) : 0,
+      itemsCompleted: s.itemsCompleted,
+    }))
+    .filter((s) => s.completionRate < 80)
+    .sort((a, b) => a.completionRate - b.completionRate)
+    .slice(0, 5);
+
+  const outletLagging = [...outletStatsMap.values()]
+    .map((o) => ({
+      name: o.name,
+      completionRate: o.total > 0 ? Math.round((o.completed / o.total) * 100) : 0,
+    }))
+    .filter((o) => o.completionRate < 80)
+    .sort((a, b) => a.completionRate - b.completionRate);
+
+  // Inventory — pending POs + reorder + spending + COGS approximation
+  const pendingPoApprovals = orders.filter(
+    (o) => o.orderType === "PURCHASE_ORDER" && o.status === "PENDING_APPROVAL",
+  ).length;
+  const weeklySpending = orders
+    .filter((o) => o.orderType === "PURCHASE_ORDER" && o.status !== "CANCELLED" && o.status !== "DRAFT")
+    .reduce((s, o) => s + Number(o.totalAmount ?? 0), 0);
+
+  const stockMap = new Map(
+    stockBalances.map((s) => [`${s.productId}_${s.outletId}`, Number(s.quantity)]),
+  );
+  let criticalReorders = 0;
+  for (const par of parLevels) {
+    const qty = stockMap.get(`${par.productId}_${par.outletId}`) ?? 0;
+    if (qty <= 0 && Number(par.parLevel) > 0) criticalReorders++;
+  }
+
+  const inventoryValue = stockBalances.reduce((s, b) => s + Number(b.quantity ?? 0), 0);
+  const cogsThisMonth = orders
+    .filter((o) => o.orderType === "PURCHASE_ORDER" && new Date(o.createdAt) >= monthAgo)
+    .reduce((s, o) => s + Number(o.totalAmount ?? 0), 0);
+
+  const invoicesPendingAmount = invoices
+    .filter((i) => i.status === "PENDING" || i.status === "INITIATED")
+    .reduce((s, i) => s + Number(i.amount ?? 0), 0);
+  const invoicesOverdueAmount = invoices
+    .filter((i) => i.status === "OVERDUE" || (i.dueDate && new Date(i.dueDate) < now))
+    .reduce((s, i) => s + Number(i.amount ?? 0), 0);
+
+  // Wastage — top offenders by cost
+  type WasteAgg = { product: string; outlet: string; cost: number; type: string };
+  const wasteAggMap = new Map<string, WasteAgg>();
+  for (const w of wastage) {
+    if (!w.product || !w.outlet) continue;
+    const key = `${w.product.name}__${w.outlet.name}`;
+    const ex = wasteAggMap.get(key) ?? {
+      product: w.product.name,
+      outlet: w.outlet.name,
+      cost: 0,
+      type: w.adjustmentType,
+    };
+    ex.cost += Math.abs(Number(w.costAmount ?? 0));
+    wasteAggMap.set(key, ex);
+  }
+  const topOffenders = [...wasteAggMap.values()]
+    .sort((a, b) => b.cost - a.cost)
+    .slice(0, 5);
+  const weeklyWasteCost = [...wasteAggMap.values()].reduce((s, w) => s + w.cost, 0);
+
+  // Pull in AI-generated reorder summary (top 5)
+  const topReorders: { outlet: string; supplier: string; total: number; urgency: string }[] = [];
+  // Reuse the rules-based decisions endpoint logic inline would duplicate code;
+  // instead derive a simple urgency view from orders pending/draft.
+  const draftOrSent = orders
+    .filter((o) => o.orderType === "PURCHASE_ORDER" && (o.status === "DRAFT" || o.status === "PENDING_APPROVAL"))
+    .sort((a, b) => Number(b.totalAmount ?? 0) - Number(a.totalAmount ?? 0))
+    .slice(0, 5);
+  for (const o of draftOrSent) {
+    topReorders.push({
+      outlet: o.outlet?.name ?? "—",
+      supplier: o.supplier?.name ?? "—",
+      total: Number(o.totalAmount ?? 0),
+      urgency: o.status === "PENDING_APPROVAL" ? "needs approval" : "draft",
+    });
+  }
+
+  return {
+    windowDays: 7,
+    outlets: outlets.map((o) => ({ id: o.id, name: o.name, code: o.code })),
+    ops: {
+      totalChecklists,
+      completedChecklists,
+      completionRate: totalChecklists > 0 ? Math.round((completedChecklists / totalChecklists) * 100) : 0,
+      photoRate: totalItems > 0 ? Math.round((itemsWithPhotos / totalItems) * 100) : 0,
+      staffLagging,
+      outletLagging,
+      incompleteCount: totalChecklists - completedChecklists,
+    },
+    inventory: {
+      pendingPoApprovals,
+      criticalReorders,
+      transfersRecommended: 0,
+      weeklySpending: Math.round(weeklySpending),
+      inventoryValue: Math.round(inventoryValue),
+      cogsThisMonth: Math.round(cogsThisMonth),
+      invoicesPendingAmount: Math.round(invoicesPendingAmount),
+      invoicesOverdueAmount: Math.round(invoicesOverdueAmount),
+      topReorders,
+    },
+    wastage: {
+      weeklyCost: Math.round(weeklyWasteCost),
+      topOffenders,
+    },
+  };
+}
+
+// ────────────────────────────────────────────────────────────
+// Claude analysis — return structured recommendations
+// ────────────────────────────────────────────────────────────
+
+async function analyse(snapshot: OverviewSnapshot): Promise<AgentRecommendation[]> {
+  const mytNow = new Date().toLocaleString("en-MY", { timeZone: "Asia/Kuala_Lumpur" });
+
+  const prompt = `You are the AI operations advisor for Celsius Coffee, a multi-outlet specialty coffee
+business in Malaysia. The current time in Kuala Lumpur is ${mytNow}.
+
+Below is a live 7-day snapshot of the business. Your job is to decide:
+  (1) WHICH decisions or improvements the owner genuinely needs to know right now, and
+  (2) WHETHER they are urgent enough to interrupt the owner with a Telegram alert at this hour.
+
+Rules:
+- Only surface items that materially affect revenue, cost, compliance, or customer experience.
+- Skip anything already healthy or trending in the right direction.
+- Do NOT raise the same routine alert every cycle — only escalate if it has gotten worse.
+- If nothing is worth interrupting the owner with right now, return an empty list.
+- Outside Malaysian business hours (8am–11pm MYT), only "critical" items should be returned.
+- Hard ceiling: 6 items.
+
+Snapshot (JSON):
+${JSON.stringify(snapshot, null, 2)}
+
+Return STRICT JSON with this shape — no markdown, no commentary:
+{
+  "recommendations": [
+    {
+      "area": "loyalty" | "ops" | "inventory" | "wastage" | "cash" | "people" | "other",
+      "priority": "critical" | "high" | "medium" | "low",
+      "title": "short headline (<= 60 chars)",
+      "why": "1-2 sentences with the data point that triggered this",
+      "action": "1-2 sentences telling the owner what to do next"
+    }
+  ]
+}`;
+
+  const response = await anthropic.messages.create({
+    model: "claude-sonnet-4-6",
+    max_tokens: 2000,
+    messages: [{ role: "user", content: prompt }],
+  });
+
+  const text = response.content
+    .filter((b): b is Anthropic.TextBlock => b.type === "text")
+    .map((b) => b.text)
+    .join("");
+
+  const jsonMatch = text.match(/\{[\s\S]*\}/);
+  if (!jsonMatch) return [];
+  const parsed = JSON.parse(jsonMatch[0]) as { recommendations?: AgentRecommendation[] };
+  return (parsed.recommendations ?? []).slice(0, 8);
+}
+
+// ────────────────────────────────────────────────────────────
+// Telegram delivery
+// ────────────────────────────────────────────────────────────
+
+const PRIORITY_EMOJI: Record<AgentRecommendation["priority"], string> = {
+  critical: "🚨",
+  high: "🔴",
+  medium: "🟠",
+  low: "🟡",
+};
+
+const AREA_EMOJI: Record<AgentRecommendation["area"], string> = {
+  loyalty: "🎁",
+  ops: "📋",
+  inventory: "📦",
+  wastage: "🗑️",
+  cash: "💰",
+  people: "👥",
+  other: "📌",
+};
+
+function formatRecommendation(r: AgentRecommendation, idx: number, total: number): string {
+  return [
+    `${PRIORITY_EMOJI[r.priority]} <b>${escapeHtml(r.title)}</b>`,
+    `${AREA_EMOJI[r.area]} ${r.area} · ${r.priority} · ${idx + 1}/${total}`,
+    "",
+    `<b>Why:</b> ${escapeHtml(r.why)}`,
+    `<b>Action:</b> ${escapeHtml(r.action)}`,
+  ].join("\n");
+}
+
+function escapeHtml(s: string): string {
+  return s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+}
+
+async function deliver(recommendations: AgentRecommendation[]): Promise<{ chatId: number; messages: number } | null> {
+  const chatRaw = process.env.TELEGRAM_OWNER_CHAT_ID;
+  if (!chatRaw) {
+    console.warn("[ai-agent] TELEGRAM_OWNER_CHAT_ID not configured — skipping delivery");
+    return null;
+  }
+  const chatId = parseInt(chatRaw, 10);
+  if (Number.isNaN(chatId)) return null;
+
+  if (recommendations.length === 0) {
+    // Stay silent — agent decided nothing is worth interrupting the owner.
+    return { chatId, messages: 0 };
+  }
+
+  const header = `🤖 <b>Celsius AI Agent — ${recommendations.length} item${recommendations.length === 1 ? "" : "s"} need your attention</b>\n<i>${new Date().toLocaleString("en-MY", { timeZone: "Asia/Kuala_Lumpur" })}</i>`;
+  await sendMessage(chatId, header);
+
+  for (let i = 0; i < recommendations.length; i++) {
+    await sendMessage(chatId, formatRecommendation(recommendations[i], i, recommendations.length));
+  }
+
+  return { chatId, messages: recommendations.length + 1 };
+}
+
+// ────────────────────────────────────────────────────────────
+// Public entry point
+// ────────────────────────────────────────────────────────────
+
+export async function runCelsiusOverviewAgent(): Promise<AgentResult> {
+  const snapshot = await buildSnapshot();
+  const recommendations = await analyse(snapshot);
+  const delivered = await deliver(recommendations);
+
+  return {
+    generatedAt: new Date().toISOString(),
+    snapshot,
+    recommendations,
+    delivered,
+  };
+}

--- a/apps/backoffice/vercel.json
+++ b/apps/backoffice/vercel.json
@@ -1,4 +1,10 @@
 {
   "regions": ["sin1"],
-  "ignoreCommand": "git diff HEAD^ HEAD --quiet -- . ../../packages/"
+  "ignoreCommand": "git diff HEAD^ HEAD --quiet -- . ../../packages/",
+  "crons": [
+    {
+      "path": "/api/ai-agent/celsius-overview",
+      "schedule": "0 1,5,9,13 * * *"
+    }
+  ]
 }


### PR DESCRIPTION
## Summary
- Surface the real reason the AI agent's Telegram delivery fails, instead of silently showing `0 messages` on the dashboard.
- `deliver()` now checks the response from `api.telegram.org/sendMessage` and returns a concrete error string.
- Missing env vars, non-numeric chat ids, and 4xx responses from Telegram all bubble up to the dashboard "Run AI agent" button.

## Why
During testing against production, the button showed `2 items sent to Telegram (0 messages).` with no indication whether `TELEGRAM_OWNER_CHAT_ID` was unset, the bot token was invalid, or Telegram rejected the message. Diagnosing that required reading code. Now the UI tells you directly.

## Files
- `apps/backoffice/src/lib/ai-agent/celsius-overview.ts` — `deliver()` returns `{ delivered, error }`; uses local `sendAndCheck` that validates the Telegram response.
- `apps/backoffice/src/app/api/ai-agent/celsius-overview/route.ts` — passes `deliveryError` through in the JSON response.
- `apps/backoffice/src/app/(admin)/dashboard/page.tsx` — shows the error string inline under the button.

## Test plan
- [ ] Remove `TELEGRAM_OWNER_CHAT_ID` from Vercel, click Run AI agent → expect dashboard to show `Delivery failed: TELEGRAM_OWNER_CHAT_ID not set in this deployment`.
- [ ] Set `TELEGRAM_OWNER_CHAT_ID` to garbage like `notanumber` → expect `TELEGRAM_OWNER_CHAT_ID is not numeric`.
- [ ] Set correct env vars → expect `N items found, M Telegram messages delivered.` and messages in `@celsiuspulsebot`.

https://claude.ai/code/session_01E4czqgMQTQUPnU3ykxnMfA