### PR TITLE
fix(pop): serve POP PDFs with correct content-type

### DIFF
--- a/apps/backoffice/src/app/api/inventory/telegram/webhook/route.ts
+++ b/apps/backoffice/src/app/api/inventory/telegram/webhook/route.ts
@@ -92,6 +92,11 @@ async function processMessage(message: TelegramMessage) {
   const upload = await cloudinary.uploader.upload(base64, {
     folder: "celsius-coffee/telegram-inbox",
     resource_type: isPdf ? "raw" : "image",
+    // PDFs uploaded as `raw` need a .pdf public_id so Cloudinary serves them
+    // with `application/pdf` (not `application/octet-stream`). Otherwise
+    // browsers render the raw bytes as text. Shortlink route also guards
+    // against this, but fixing it at the source avoids the proxy hop.
+    ...(isPdf ? { public_id: `pop-${Date.now()}.pdf` } : {}),
     ...(isPdf ? {} : { transformation: [{ quality: "auto", fetch_format: "auto" }] }),
   });
   const cloudinaryUrl = upload.secure_url;

--- a/apps/backoffice/src/app/r/[id]/route.ts
+++ b/apps/backoffice/src/app/r/[id]/route.ts
@@ -1,6 +1,16 @@
 import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
 
+/**
+ * GET /r/[id]
+ *
+ * Short-link resolver. Redirects to the underlying Cloudinary URL,
+ * but PROXIES PDFs so we can force the correct `application/pdf`
+ * content-type. Cloudinary serves `raw` uploads (which is how our
+ * Telegram webhook stores PDFs) with `application/octet-stream`, and
+ * some browsers then render them as garbled text instead of opening
+ * the PDF viewer.
+ */
 export async function GET(
   _req: NextRequest,
   { params }: { params: Promise<{ id: string }> },
@@ -12,5 +22,44 @@ export async function GET(
     return new NextResponse("Not found", { status: 404 });
   }
 
-  return NextResponse.redirect(link.url, 302);
+  // Fast path: images and obvious non-PDFs → 302 to Cloudinary directly.
+  // Anything served from the `/raw/` namespace or without a recognised
+  // image extension gets proxied with sniffed content-type.
+  const isRaw = /\/raw\/upload\//i.test(link.url);
+  const hasImageExt = /\.(jpe?g|png|webp|gif|heic|avif)(\?|$)/i.test(link.url);
+  if (!isRaw && hasImageExt) {
+    return NextResponse.redirect(link.url, 302);
+  }
+
+  let upstream: Response;
+  try {
+    upstream = await fetch(link.url);
+  } catch (err) {
+    console.error("[shortlink] upstream fetch failed:", err);
+    return new NextResponse("Upstream unavailable", { status: 502 });
+  }
+
+  if (!upstream.ok || !upstream.body) {
+    return new NextResponse("Upstream error", { status: upstream.status || 502 });
+  }
+
+  // Sniff the first bytes to detect PDFs regardless of upstream content-type.
+  const buf = new Uint8Array(await upstream.arrayBuffer());
+  const isPdf = buf[0] === 0x25 && buf[1] === 0x50 && buf[2] === 0x44 && buf[3] === 0x46; // %PDF
+
+  const upstreamType = upstream.headers.get("content-type") || "";
+  const contentType = isPdf
+    ? "application/pdf"
+    : upstreamType || "application/octet-stream";
+
+  return new NextResponse(buf, {
+    status: 200,
+    headers: {
+      "Content-Type": contentType,
+      "Content-Length": String(buf.byteLength),
+      // Inline so browsers render the PDF instead of downloading it
+      "Content-Disposition": `inline; filename="${id}${isPdf ? ".pdf" : ""}"`,
+      "Cache-Control": "public, max-age=3600",
+    },
+  });
 }


### PR DESCRIPTION
## Summary
Staff were reporting that they "downloaded a different POP" than what the bot confirmed. Root cause: Cloudinary serves our raw-resource PDF uploads (from the Telegram webhook) with `application/octet-stream`, so Safari/Chrome render the raw `%PDF-1.4\n%...` bytes as garbled text on first click. A manual "Save As" + reopen eventually works, which is why owner + staff could see *different* things depending on how they opened the link.

## Changes
- **`apps/backoffice/src/app/r/[id]/route.ts`** — the `/r/<id>` shortlink now:
  - 302-redirects for obvious image URLs (unchanged hot path).
  - Proxies anything served from `/raw/upload/` or without an image extension, sniffs the first 4 bytes for `%PDF`, and forces `Content-Type: application/pdf` with `Content-Disposition: inline`.
  - Fixes every existing POP without needing re-uploads.
- **`apps/backoffice/src/app/api/inventory/telegram/webhook/route.ts`** — new POPs upload with `public_id: pop-<ts>.pdf`. Cloudinary then serves them with `application/pdf` directly, so future links skip the proxy hop entirely.

## Test plan
- [ ] Open an existing POP shortlink (e.g. `/r/0ed765a3`) → Safari renders the PDF inline, no garbled text.
- [ ] Curl `-I` the same URL → `Content-Type: application/pdf`.
- [ ] Send a new POP image via `@celsiuspulsebot` → confirm JPEG/PNG path still 302-redirects (fast path).
- [ ] Send a new POP as a PDF → confirm the returned shortlink opens directly, and the underlying Cloudinary URL ends in `.pdf`.

https://claude.ai/code/session_01E4czqgMQTQUPnU3ykxnMfA