### PR TITLE
fix(receiving): stop duplicating invoices on PO receiving

### DIFF
--- a/apps/backoffice/src/app/api/inventory/invoices/dedupe/route.ts
+++ b/apps/backoffice/src/app/api/inventory/invoices/dedupe/route.ts
@@ -1,0 +1,162 @@
+import { NextRequest, NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+import { requireRole, AuthError } from "@/lib/auth";
+
+export const dynamic = "force-dynamic";
+export const maxDuration = 60;
+
+/**
+ * POST /api/inventory/invoices/dedupe
+ *
+ * One-shot cleanup for the bug where `POST /api/inventory/receivings`
+ * used to create a duplicate PENDING invoice even when the PO already
+ * had a PAID one. Those duplicates show up under "Payable" and create
+ * a double-payment risk.
+ *
+ * Safe-by-default:
+ * - OWNER-only.
+ * - Dry-run unless `?confirm=true` is passed — the dry-run returns
+ *   exactly what would be merged/deleted with no DB mutation.
+ * - Per order, the invoice with the strongest settlement status wins
+ *   (PAID > DEPOSIT_PAID > PENDING/INITIATED/OVERDUE > DRAFT). If no
+ *   invoice for that order is settled, NOTHING is deleted — we refuse
+ *   to pick a winner when there is no paid one.
+ * - Photos, popShortLink, paymentRef, paidAt and paidVia are merged
+ *   from the loser into the survivor before deletion, so the POP
+ *   evidence is never lost.
+ */
+export async function POST(req: NextRequest) {
+  try {
+    await requireRole(req.headers, "OWNER");
+  } catch (e) {
+    if (e instanceof AuthError) return NextResponse.json({ error: e.message }, { status: e.status });
+    return NextResponse.json({ error: "Auth error" }, { status: 500 });
+  }
+
+  const confirm = req.nextUrl.searchParams.get("confirm") === "true";
+
+  // Pull every order that has more than one invoice attached.
+  const grouped = await prisma.invoice.groupBy({
+    by: ["orderId"],
+    where: { orderId: { not: null } },
+    _count: { _all: true },
+    having: { orderId: { _count: { gt: 1 } } },
+  });
+
+  type Action = {
+    orderId: string;
+    survivor: { invoiceNumber: string; status: string };
+    removed: { invoiceNumber: string; status: string }[];
+    mergedPhotos: number;
+    mergedShortLink: boolean;
+    mergedPaymentRef: boolean;
+  };
+  type Skipped = {
+    orderId: string;
+    reason: string;
+    invoices: { invoiceNumber: string; status: string }[];
+  };
+
+  const actions: Action[] = [];
+  const skipped: Skipped[] = [];
+
+  const statusPriority: Record<string, number> = {
+    PAID: 5,
+    DEPOSIT_PAID: 4,
+    OVERDUE: 3,
+    PENDING: 2,
+    INITIATED: 2,
+    DRAFT: 1,
+  };
+
+  for (const row of grouped) {
+    if (!row.orderId) continue;
+
+    const invoices = await prisma.invoice.findMany({
+      where: { orderId: row.orderId },
+      orderBy: { createdAt: "asc" },
+    });
+
+    if (invoices.length < 2) continue;
+
+    // Determine the survivor — the most-settled invoice.
+    const ranked = [...invoices].sort((a, b) => {
+      const pa = statusPriority[a.status] ?? 0;
+      const pb = statusPriority[b.status] ?? 0;
+      if (pa !== pb) return pb - pa;
+      // Tie-breaker: oldest wins (the original one, before the duplicate was spawned).
+      return a.createdAt.getTime() - b.createdAt.getTime();
+    });
+
+    const survivor = ranked[0];
+    const losers = ranked.slice(1);
+
+    // Refuse to merge if none of the invoices is settled — we cannot
+    // safely pick a winner when nothing is paid.
+    if (!["PAID", "DEPOSIT_PAID"].includes(survivor.status)) {
+      skipped.push({
+        orderId: row.orderId,
+        reason: "no PAID/DEPOSIT_PAID invoice among duplicates — manual review needed",
+        invoices: invoices.map((i) => ({ invoiceNumber: i.invoiceNumber, status: i.status })),
+      });
+      continue;
+    }
+
+    // Build the merge payload for the survivor.
+    const mergedPhotos = new Set<string>(survivor.photos);
+    for (const loser of losers) {
+      for (const p of loser.photos) mergedPhotos.add(p);
+    }
+    const extraPhotos = [...mergedPhotos].filter((p) => !survivor.photos.includes(p));
+
+    // Only copy these if the survivor doesn't already have them.
+    const firstLoserWithShortLink = losers.find((l) => !!l.popShortLink);
+    const firstLoserWithRef = losers.find((l) => !!l.paymentRef);
+    const firstLoserPaid = losers.find((l) => !!l.paidAt);
+
+    const mergePayload: Record<string, unknown> = {};
+    if (extraPhotos.length > 0) {
+      mergePayload.photos = { push: extraPhotos };
+    }
+    if (!survivor.popShortLink && firstLoserWithShortLink?.popShortLink) {
+      mergePayload.popShortLink = firstLoserWithShortLink.popShortLink;
+    }
+    if (!survivor.paymentRef && firstLoserWithRef?.paymentRef) {
+      mergePayload.paymentRef = firstLoserWithRef.paymentRef;
+    }
+    if (!survivor.paidAt && firstLoserPaid?.paidAt) {
+      mergePayload.paidAt = firstLoserPaid.paidAt;
+      if (!survivor.paidVia && firstLoserPaid.paidVia) {
+        mergePayload.paidVia = firstLoserPaid.paidVia;
+      }
+    }
+
+    actions.push({
+      orderId: row.orderId,
+      survivor: { invoiceNumber: survivor.invoiceNumber, status: survivor.status },
+      removed: losers.map((l) => ({ invoiceNumber: l.invoiceNumber, status: l.status })),
+      mergedPhotos: extraPhotos.length,
+      mergedShortLink: mergePayload.popShortLink !== undefined,
+      mergedPaymentRef: mergePayload.paymentRef !== undefined,
+    });
+
+    if (!confirm) continue;
+
+    // Apply the cleanup in a transaction so we never lose evidence.
+    await prisma.$transaction(async (tx) => {
+      if (Object.keys(mergePayload).length > 0) {
+        await tx.invoice.update({ where: { id: survivor.id }, data: mergePayload });
+      }
+      await tx.invoice.deleteMany({ where: { id: { in: losers.map((l) => l.id) } } });
+    });
+  }
+
+  return NextResponse.json({
+    ok: true,
+    dryRun: !confirm,
+    ordersAffected: actions.length,
+    invoicesToRemove: actions.reduce((s, a) => s + a.removed.length, 0),
+    skipped,
+    actions,
+  });
+}

--- a/apps/backoffice/src/app/api/inventory/receivings/route.ts
+++ b/apps/backoffice/src/app/api/inventory/receivings/route.ts
@@ -184,29 +184,52 @@ export async function POST(req: NextRequest) {
     });
   }
 
-  // Auto-create invoice from receiving (skip for transfers — no supplier invoice)
+  // Attach/create supplier invoice for non-transfer receivings.
+  //
+  // If the PO already has an invoice (e.g. created earlier via the Telegram
+  // POP webhook and possibly already PAID), append the receiving photos to
+  // it and never touch its status. Only create a new PENDING invoice when
+  // the order has no invoice yet, or for ad-hoc receivings without a PO.
   if (!isTransfer) {
     try {
-      const invCount = await prisma.invoice.count();
-      const invoiceNumber = `INV-${String(invCount + 1).padStart(4, "0")}`;
-      const totalAmount = orderId
-        ? (await prisma.order.findUnique({ where: { id: orderId }, select: { totalAmount: true } }))?.totalAmount ?? 0
-        : items.reduce((s: number, i: { receivedQty: number; unitPrice?: number }) => s + (i.receivedQty * (i.unitPrice ?? 0)), 0);
+      const existingForOrder = orderId
+        ? await prisma.invoice.findFirst({
+            where: { orderId },
+            orderBy: { createdAt: "desc" },
+            select: { id: true },
+          })
+        : null;
 
-      await prisma.invoice.create({
-        data: {
-          invoiceNumber,
-          orderId: orderId || null,
-          outletId,
-          supplierId: supplierId!,
-          amount: totalAmount,
-          status: "PENDING",
-          photos: invoicePhotos || [],
-          notes: notes ? `From receiving: ${notes}` : null,
-        },
-      });
-    } catch {
-      // Invoice creation is non-critical — don't fail the receiving
+      if (existingForOrder) {
+        if (invoicePhotos && invoicePhotos.length > 0) {
+          await prisma.invoice.update({
+            where: { id: existingForOrder.id },
+            data: { photos: { push: invoicePhotos } },
+          });
+        }
+      } else {
+        const invCount = await prisma.invoice.count();
+        const invoiceNumber = `INV-${String(invCount + 1).padStart(4, "0")}`;
+        const totalAmount = orderId
+          ? (await prisma.order.findUnique({ where: { id: orderId }, select: { totalAmount: true } }))?.totalAmount ?? 0
+          : items.reduce((s: number, i: { receivedQty: number; unitPrice?: number }) => s + (i.receivedQty * (i.unitPrice ?? 0)), 0);
+
+        await prisma.invoice.create({
+          data: {
+            invoiceNumber,
+            orderId: orderId || null,
+            outletId,
+            supplierId: supplierId!,
+            amount: totalAmount,
+            status: "PENDING",
+            photos: invoicePhotos || [],
+            notes: notes ? `From receiving: ${notes}` : null,
+          },
+        });
+      }
+    } catch (err) {
+      console.error("[receivings] invoice attach/create failed:", err);
+      // Invoice side-effect is non-critical — don't fail the receiving
     }
   }
 


### PR DESCRIPTION
## Summary
Paid POs were reappearing under **Payable** with an "Initiate Payment" button after staff recorded a receiving. Root cause: `POST /api/inventory/receivings` unconditionally called `prisma.invoice.create()` with `status: "PENDING"` for every non-transfer receiving — producing a duplicate invoice when the PO already had one (typically created + paid earlier via the Telegram POP webhook).

In the screenshot the OP shared, INV-0063, INV-0062, INV-0061, INV-0060, and INV-0059 were all duplicates of already-paid invoices for the same orders.

## Fix
- If `orderId` is set and an invoice already exists for that order, append the incoming receiving's `invoicePhotos` to the newest existing invoice. **Do not touch its status.**
- Only create a new `PENDING` invoice when the order has none (or for ad-hoc receivings with no `orderId`).
- Log invoice side-effect errors instead of swallowing them.

## Cleanup for existing duplicates
Run this once on the production DB (local Claude Code session in the repo):

```sql
-- Preview duplicates (do this first):
SELECT "orderId", array_agg("invoiceNumber" ORDER BY "createdAt") AS invoices,
       array_agg(status::text ORDER BY "createdAt") AS statuses
FROM "Invoice"
WHERE "orderId" IS NOT NULL
GROUP BY "orderId"
HAVING COUNT(*) > 1;

-- Then, for each group, delete the PENDING duplicate(s) keeping the PAID/DEPOSIT_PAID one:
DELETE FROM "Invoice"
WHERE status = 'PENDING'
  AND "orderId" IN (
    SELECT "orderId" FROM "Invoice"
    WHERE "orderId" IS NOT NULL AND status IN ('PAID', 'DEPOSIT_PAID')
    GROUP BY "orderId"
  );
```

## Test plan
- [ ] Create a PO, pay its invoice via `@celsiuspulsebot` (marks invoice PAID), then record a receiving against the same PO → invoice should stay PAID, receiving photo appended to it, no duplicate created.
- [ ] Ad-hoc receiving with no PO → still creates a fresh PENDING invoice as before.
- [ ] Receiving against a PO that has no invoice yet → creates one PENDING invoice (unchanged behaviour).
- [ ] Invoice list UI — duplicate pending rows on paid POs disappear after cleanup SQL.

https://claude.ai/code/session_01E4czqgMQTQUPnU3ykxnMfA