### PR TITLE
feat(telegram): auto-pick oldest STAFF_CLAIM on identical-amount collisions

### DIFF
--- a/apps/backoffice/src/app/api/inventory/telegram/webhook/route.ts
+++ b/apps/backoffice/src/app/api/inventory/telegram/webhook/route.ts
@@ -466,16 +466,30 @@ async function resolvePop(
   }
 
   if (candidates.length > 1) {
-    const list = candidates
-      .map((inv: any) => {
-        const payee = inv.paymentType === "STAFF_CLAIM"
-          ? `Staff: ${inv.order?.claimedBy?.name ?? "?"}`
-          : inv.supplier?.name ?? "?";
-        return `• ${inv.invoiceNumber} — ${payee} [${inv.outlet?.code ?? "?"}] — RM ${Number(inv.amount).toFixed(2)}`;
-      })
-      .join("\n");
-    await sendMessage(chatId, `💳 POP received — RM ${amount.toFixed(2)}\n\n⚠️ Multiple matching invoices:\n${list}\n\nPlease specify which invoice.`, msgId);
-    return;
+    // Finance pays identical-amount staff claims individually (e.g. Ariff has
+    // two RM 10 claims at MT2, receives two separate RM 10 transfers). When
+    // all candidates are the same claimant's STAFF_CLAIM at the same outlet,
+    // consume the oldest one instead of asking to disambiguate — next POP
+    // picks up the next one.
+    const allStaffClaim = candidates.every((c: any) => c.paymentType === "STAFF_CLAIM");
+    const claimantIds = new Set(candidates.map((c: any) => c.order?.claimedBy?.id));
+    const outletIds = new Set(candidates.map((c: any) => c.outletId));
+    if (allStaffClaim && claimantIds.size === 1 && !claimantIds.has(undefined) && outletIds.size === 1) {
+      candidates = [...candidates].sort(
+        (a: any, b: any) => new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime(),
+      ).slice(0, 1);
+    } else {
+      const list = candidates
+        .map((inv: any) => {
+          const payee = inv.paymentType === "STAFF_CLAIM"
+            ? `Staff: ${inv.order?.claimedBy?.name ?? "?"}`
+            : inv.supplier?.name ?? "?";
+          return `• ${inv.invoiceNumber} — ${payee} [${inv.outlet?.code ?? "?"}] — RM ${Number(inv.amount).toFixed(2)}`;
+        })
+        .join("\n");
+      await sendMessage(chatId, `💳 POP received — RM ${amount.toFixed(2)}\n\n⚠️ Multiple matching invoices:\n${list}\n\nPlease specify which invoice.`, msgId);
+      return;
+    }
   }
 
   // Single match — figure out if the POP matches the full amount or just the


### PR DESCRIPTION
## Summary

When multiple pending `STAFF_CLAIM` invoices match a Telegram POP for the **same claimant at the same outlet**, the webhook now auto-picks the oldest one (FIFO) instead of replying "Multiple matching invoices — please specify".

Real-world example: Ariff has two RM 10 claims at MT2 and gets two separate RM 10 transfers. First POP clears the older claim, second POP clears the newer one — no manual disambiguation.

Scope is strict — all three must hold:
- every candidate is `paymentType: STAFF_CLAIM`
- single distinct `claimedBy.id`
- single distinct `outletId`

Mixed payees, mixed outlets, or supplier invoices still trigger the clarification message.

## Test plan

- [ ] Seed two identical-amount pending STAFF_CLAIM invoices for one staff at one outlet; send two POPs → both clear FIFO.
- [ ] Seed two identical-amount STAFF_CLAIM invoices for the same staff at **different** outlets; send one POP → still replies "Multiple matching" (unchanged).
- [ ] Seed one STAFF_CLAIM + one SUPPLIER invoice at the same amount/outlet → still replies "Multiple matching" (unchanged).
- [ ] Single-match POP → still PAID as before.

https://claude.ai/code/session_016dRapEPUxaKNz3S6VBXwgr