### PR TITLE
fix(inventory): handle new { orders, summary } response shape

### DIFF
--- a/apps/backoffice/src/app/(admin)/inventory/orders/create/page.tsx
+++ b/apps/backoffice/src/app/(admin)/inventory/orders/create/page.tsx
@@ -366,7 +366,7 @@ export default function CreateOrderPage() {
         return aName.localeCompare(bName);
       });
       setOutlets(sorted);
-      setOrders(o);
+      setOrders(Array.isArray(o) ? o : (o?.orders ?? []));
       const defaultOutlet = sorted[0]?.id ?? "";
       setSelectedOutletId(defaultOutlet);
       if (defaultOutlet) {

--- a/apps/backoffice/src/app/(admin)/inventory/receivings/page.tsx
+++ b/apps/backoffice/src/app/(admin)/inventory/receivings/page.tsx
@@ -97,7 +97,11 @@ export default function ReceivingsPage() {
   const { data: receivings = [], isLoading: recLoading, mutate: reloadReceivings } = useFetch<Receiving[]>(receivingsUrl);
 
   type AwaitingOrder = { id: string; orderNumber: string; outlet: string; supplier: string; status: string; totalAmount: number; items: number; deliveryDate: string | null; createdAt: string; isTransfer?: boolean; transferId?: string };
-  const { data: rawActiveOrders = [], isLoading: ordLoading, mutate: reloadOrders } = useFetch<{ id: string; orderNumber: string; outlet: string; supplier: string; status: string; totalAmount: number; items: { id: string }[]; deliveryDate: string | null; createdAt: string }[]>("/api/inventory/orders?tab=active");
+  type ActiveOrderRaw = { id: string; orderNumber: string; outlet: string; supplier: string; status: string; totalAmount: number; items: { id: string }[]; deliveryDate: string | null; createdAt: string };
+  const { data: activeOrdersResponse, isLoading: ordLoading, mutate: reloadOrders } = useFetch<{ orders: ActiveOrderRaw[] } | ActiveOrderRaw[]>("/api/inventory/orders?tab=active");
+  const rawActiveOrders: ActiveOrderRaw[] = Array.isArray(activeOrdersResponse)
+    ? activeOrdersResponse
+    : activeOrdersResponse?.orders ?? [];
 
   // Also fetch transfers that are approved/in-transit — they need receiving too
   type TransferRaw = { id: string; fromOutlet: string; toOutlet: string; status: string; items: { id: string }[]; createdAt: string; approvedAt: string | null };
@@ -159,7 +163,8 @@ export default function ReceivingsPage() {
       fetch("/api/inventory/orders?tab=active"),
       fetch("/api/inventory/transfers"),
     ]);
-    const orders = ordersRes.ok ? await ordersRes.json() : [];
+    const ordersJson = ordersRes.ok ? await ordersRes.json() : [];
+    const orders = Array.isArray(ordersJson) ? ordersJson : ordersJson?.orders ?? [];
     const transfers = transfersRes.ok ? await transfersRes.json() : [];
 
     const pendingFromOrders: PendingOrder[] = orders


### PR DESCRIPTION
## Summary
- Commit 626d080 changed `GET /api/inventory/orders` to return `{ orders, summary }` instead of `Order[]`, but only updated the PO list page
- The Create Order page (`/inventory/orders/create`) and Receivings page (`/inventory/receivings`) still read the response as an array, so both pages crashed on load — Chrome shows "This page couldn't load" when the React render throws
- Tolerate both shapes in the two stragglers (3 call sites total), with `Array.isArray()` fallback so pages keep working across rollouts / cached bundles

## Test plan
- [ ] Visit `/inventory/orders/create` — page loads and recent orders list renders
- [ ] Visit `/inventory/receivings` — awaiting-delivery list renders
- [ ] Click "Receive" on receivings page — dialog opens with pending orders populated
- [ ] Regression: `/inventory/orders` still loads with correct summary card counts

https://claude.ai/code/session_01Rv5uwfaSudQDB5P83559cY