### PR TITLE
fix(shortlink): strip periods from Cloudinary fl_attachment value

### DIFF
--- a/apps/backoffice/src/app/r/[id]/route.ts
+++ b/apps/backoffice/src/app/r/[id]/route.ts
@@ -55,12 +55,16 @@ export async function GET(
   }
 
   // Image fast path: 302 to Cloudinary with fl_attachment so the download
-  // filename is set by Cloudinary itself (no proxy overhead).
+  // filename is set by Cloudinary itself (no proxy overhead). Cloudinary
+  // rejects fl_attachment values containing `.` (it interprets them as a
+  // file-extension separator), so strip the extension then swap any remaining
+  // periods for hyphens — e.g. `RM21.20` → `RM21-20`.
   if (!isRaw && hasImageExt) {
-    const name = buildName("jpg");
+    const raw = buildName("jpg").replace(/\.[^.]+$/, "");
+    const attachmentName = raw.replace(/\./g, "-");
     const target = link.url.replace(
       /\/image\/upload\//,
-      `/image/upload/fl_attachment:${encodeURIComponent(name.replace(/\.[^.]+$/, ""))}/`,
+      `/image/upload/fl_attachment:${encodeURIComponent(attachmentName)}/`,
     );
     return NextResponse.redirect(target, 302);
   }


### PR DESCRIPTION
## Summary
- Cloudinary rejects `fl_attachment:foo.bar` with HTTP 400 — it interprets the `.` as a filename-extension separator. Two image POP shortlinks (`10c96362`, `95155446`) whose generated filenames contained an amount with cents (e.g. `RM77.85`) were therefore broken after PR #89.
- Fix: strip the trailing ext, then replace remaining periods with hyphens before encoding. `RM21.20` → `RM21-20`.
- PDFs on Supabase set Content-Disposition directly and are unaffected.

## Test plan
- [ ] Deploy; curl both previously-broken shortlinks → expect 200 + `content-disposition: attachment; filename="POP_..._RM21-20.jpg"` at the Cloudinary redirect target
- [ ] Spot-check a previously-working image shortlink (no periods in amount) still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)