### PR TITLE
feat(shortlink): readable payment.celsiuscoffee.com URLs

### DIFF
--- a/apps/backoffice/src/app/api/inventory/invoices/[id]/shortlink/route.ts
+++ b/apps/backoffice/src/app/api/inventory/invoices/[id]/shortlink/route.ts
@@ -2,6 +2,7 @@ import { NextResponse, NextRequest } from "next/server";
 import { prisma } from "@/lib/prisma";
 import { getUserFromHeaders } from "@/lib/auth";
 import { createShortLink } from "@/lib/shortlink";
+import { popDownloadName } from "@/lib/inventory/file-naming";
 
 // POST /api/inventory/invoices/[id]/shortlink
 // Creates a shortlink for the invoice's last POP photo (if not already created)
@@ -16,7 +17,17 @@ export async function POST(
 
   const invoice = await prisma.invoice.findUnique({
     where: { id },
-    select: { id: true, popShortLink: true, photos: true },
+    select: {
+      id: true,
+      popShortLink: true,
+      photos: true,
+      invoiceNumber: true,
+      amount: true,
+      paidAt: true,
+      vendorName: true,
+      supplier: { select: { name: true } },
+      order: { select: { claimedBy: { select: { name: true } } } },
+    },
   });
 
   if (!invoice) {
@@ -35,7 +46,9 @@ export async function POST(
 
   // Create shortlink for the last photo (most recent POP)
   const popUrl = invoice.photos[invoice.photos.length - 1];
-  const shortLink = await createShortLink(popUrl);
+  const ext = /\.pdf(\?|$)/i.test(popUrl) ? "pdf" : "jpg";
+  const slug = popDownloadName(invoice, ext);
+  const shortLink = await createShortLink(popUrl, slug);
 
   // Save to invoice
   await prisma.invoice.update({

--- a/apps/backoffice/src/app/api/inventory/telegram/webhook/route.ts
+++ b/apps/backoffice/src/app/api/inventory/telegram/webhook/route.ts
@@ -580,21 +580,21 @@ async function resolvePop(
   // which invoice it belongs to. Falls back to the original URL if the file
   // lives outside Supabase (e.g. Cloudinary images) or if rename fails.
   let renamedUrl = photoUrl;
+  let popSlug: string | undefined;
   try {
-    const { popStoragePath } = await import("@/lib/inventory/file-naming");
+    const { popStoragePath, popDownloadName } = await import("@/lib/inventory/file-naming");
     const { moveInStorage } = await import("@/lib/inventory/pdf-splitter");
     const ext = /\.pdf(\?|$)/i.test(photoUrl) ? "pdf" : "jpg";
-    const newPath = popStoragePath(
-      { ...invoice, paidAt: new Date() } as any,
-      ext,
-    );
+    const invForNaming = { ...invoice, paidAt: new Date() } as any;
+    const newPath = popStoragePath(invForNaming, ext);
     const moved = await moveInStorage(photoUrl, newPath);
     if (moved) renamedUrl = moved;
+    popSlug = popDownloadName(invForNaming, ext);
   } catch (err) {
     console.error("[telegram] POP rename failed:", err);
   }
 
-  const shortLink = await createShortLink(renamedUrl).catch(() => null);
+  const shortLink = await createShortLink(renamedUrl, popSlug).catch(() => null);
 
   // DEPOSIT_PAID: stamp depositPaidAt + depositRef and compute balance due
   // from supplier.depositTermsDays (mirrors PATCH endpoint logic).

--- a/apps/backoffice/src/app/r/[...path]/route.ts
+++ b/apps/backoffice/src/app/r/[...path]/route.ts
@@ -3,18 +3,29 @@ import { prisma } from "@/lib/prisma";
 import { popDownloadName, invoiceDownloadName } from "@/lib/inventory/file-naming";
 
 /**
- * GET /r/[id]
+ * GET /r/[...path]
  *
- * Short-link resolver. Proxies PDFs so we can force `application/pdf`
- * and a human-readable Content-Disposition filename (`POP_26-0374_Blancoz_RM240.00.pdf`
- * instead of `f1bb4eff.pdf`). Images 302 to Cloudinary with an
- * `fl_attachment` transformation so they also download with a proper name.
+ * Short-link resolver. Accepts two path shapes:
+ *   /r/f1bb4eff                                    — legacy, still works
+ *   /r/f1bb4eff/POP_26-0374_Blancoz_RM240.00.pdf   — preferred, URL reads
+ *
+ * The first segment is the 8-char hex id (the actual resolution key). Any
+ * trailing segments are decorative — ignored server-side, so a stale slug
+ * still resolves to the current file (GitHub-gist pattern).
+ *
+ * Proxies PDFs so we can force `application/pdf` and a readable
+ * Content-Disposition. Images 302 to Cloudinary with `fl_attachment` so they
+ * also download with a proper name.
  */
 export async function GET(
   _req: NextRequest,
-  { params }: { params: Promise<{ id: string }> },
+  { params }: { params: Promise<{ path: string[] }> },
 ) {
-  const { id } = await params;
+  const { path } = await params;
+  const id = path?.[0] ?? "";
+  if (!id) {
+    return new NextResponse("Not found", { status: 404 });
+  }
 
   const link = await prisma.shortLink.findUnique({ where: { id } });
   if (!link) {
@@ -22,12 +33,14 @@ export async function GET(
   }
 
   // Look up the linked invoice for filename metadata. Either the shortlink is
-  // the POP (stored on Invoice.popShortLink) or it's an invoice photo.
-  const popHost = `/r/${id}`;
+  // the POP (stored on Invoice.popShortLink) or it's an invoice photo. The
+  // `contains` match on popShortLink tolerates both legacy (`/r/{id}`) and
+  // slug-suffixed (`/r/{id}/POP_...pdf`) URLs.
+  const popMarker = `/r/${id}`;
   const invoice = await prisma.invoice.findFirst({
     where: {
       OR: [
-        { popShortLink: { endsWith: popHost } },
+        { popShortLink: { contains: popMarker } },
         { photos: { has: link.url } },
       ],
     },
@@ -43,7 +56,7 @@ export async function GET(
     },
   });
 
-  const isPopLink = invoice?.popShortLink?.endsWith(popHost) ?? false;
+  const isPopLink = invoice?.popShortLink?.includes(popMarker) ?? false;
 
   const isRaw = /\/raw\/upload\//i.test(link.url);
   const hasImageExt = /\.(jpe?g|png|webp|gif|heic|avif)(\?|$)/i.test(link.url);

--- a/apps/backoffice/src/lib/shortlink.ts
+++ b/apps/backoffice/src/lib/shortlink.ts
@@ -3,8 +3,17 @@ import { randomBytes } from "crypto";
 
 const BASE_URL = process.env.SHORTLINK_BASE_URL || "https://payment.celsiuscoffee.com";
 
-export async function createShortLink(url: string): Promise<string> {
+/**
+ * Create a short link. The optional `slug` is appended as a decorative
+ * trailing segment so the shared URL reads like
+ * `payment.celsiuscoffee.com/r/f1bb4eff/POP_26-0374_Blancoz_RM240.00.pdf`
+ * instead of just `/r/f1bb4eff`. Resolution only uses the first segment (the
+ * 8-char hex id); the slug is ignored by the route handler, so stale slugs
+ * still resolve to the right file (GitHub-gist pattern).
+ */
+export async function createShortLink(url: string, slug?: string): Promise<string> {
   const id = randomBytes(4).toString("hex"); // 8-char hex
   await prisma.shortLink.create({ data: { id, url } });
-  return `${BASE_URL}/r/${id}`;
+  const suffix = slug ? `/${encodeURIComponent(slug)}` : "";
+  return `${BASE_URL}/r/${id}${suffix}`;
 }


### PR DESCRIPTION
## Summary
- Shortlink URLs now read: `payment.celsiuscoffee.com/r/f1bb4eff/POP_26-0374_Blancoz_RM240.00.pdf` instead of the opaque `/r/f1bb4eff`. Finance/suppliers who receive a link via WhatsApp or email can tell what it is before clicking.
- GitHub-gist pattern: the 8-char hex id is still the real resolution key; the trailing slug is decorative and ignored by the server. Stale slugs (invoice supplier rename, amount fix) still resolve to the current file.
- Legacy `/r/f1bb4eff` URLs keep working verbatim — no breakage of already-shared links.
- Existing `Invoice.popShortLink` values will be rewritten to include slugs via a one-off migration (not in this PR; runs after merge).

## Changes
- Route moved `/r/[id]/route.ts` → `/r/[...path]/route.ts` (catch-all; first segment = id).
- `createShortLink(url, slug?)` — optional slug is URL-encoded and appended to the returned URL.
- Telegram webhook + manual shortlink POST endpoint pass `popDownloadName(invoice, ext)` as the slug.

## Test plan
- [ ] Merge, wait for Vercel deploy
- [ ] `curl -I https://payment.celsiuscoffee.com/r/f1bb4eff` → still 200
- [ ] `curl -I https://payment.celsiuscoffee.com/r/f1bb4eff/wrong-slug.pdf` → still 200 (slug ignored)
- [ ] Send a new POP via Telegram → stored `Invoice.popShortLink` contains slug
- [ ] POST to manual shortlink endpoint for an invoice with no existing link → returned URL contains slug

🤖 Generated with [Claude Code](https://claude.com/claude-code)