### PR TITLE
Checkout rewards hardening + reconcile-pending cron

### DIFF
--- a/apps/order/src/app/_components/home-content.tsx
+++ b/apps/order/src/app/_components/home-content.tsx
@@ -26,6 +26,12 @@ export function HomeContent({ featuredProducts, promoBanner, campaignBgUrl }: Ho
   const selectedStore = hasHydrated ? _selectedStore : null;
   const itemCount = hasHydrated ? _itemCount : 0;
 
+  // If the cart has items, the "Order Now" CTAs jump straight to checkout
+  // flow so a half-built order isn't abandoned by starting a new one.
+  const orderHref = itemCount > 0
+    ? "/cart"
+    : selectedStore ? `/menu?store=${selectedStore.id}` : "/store";
+
   return (
     <div className="flex flex-col min-h-dvh bg-[#f5f5f5]">
       {/* Header */}
@@ -99,7 +105,7 @@ export function HomeContent({ featuredProducts, promoBanner, campaignBgUrl }: Ho
               </div>
               <p className="text-sm text-white/60 mt-2">{promoBanner.description}</p>
               <Link
-                href={selectedStore ? `/menu?store=${selectedStore.id}` : "/store"}
+                href={orderHref}
                 className="inline-flex items-center gap-1.5 mt-4 bg-white text-primary rounded-full px-5 py-2.5 text-sm font-bold shadow-lg"
               >
                 Order Now <ChevronRight className="h-4 w-4" />
@@ -113,15 +119,15 @@ export function HomeContent({ featuredProducts, promoBanner, campaignBgUrl }: Ho
 
         {/* Quick Actions */}
         <div className="grid grid-cols-2 gap-3 px-4">
-          <Link href={selectedStore ? `/menu?store=${selectedStore.id}` : "/store"} className="block h-full">
+          <Link href={orderHref} className="block h-full">
             <Card className="p-4 flex flex-col gap-2.5 border border-border/60 shadow-sm bg-white hover:shadow-md hover:border-primary/20 transition-all active:scale-[0.98] h-full">
               <div className="w-10 h-10 rounded-xl bg-primary/8 flex items-center justify-center">
                 <Coffee className="h-5 w-5 text-primary" strokeWidth={1.5} />
               </div>
               <div>
-                <p className="font-bold text-sm">Order Now</p>
+                <p className="font-bold text-sm">{itemCount > 0 ? "Review Cart" : "Order Now"}</p>
                 <p className="text-xs text-muted-foreground leading-tight mt-0.5">
-                  Browse full menu
+                  {itemCount > 0 ? `${itemCount} item${itemCount === 1 ? "" : "s"} waiting` : "Browse full menu"}
                 </p>
               </div>
             </Card>

--- a/apps/order/src/app/api/checkout/initiate/route.ts
+++ b/apps/order/src/app/api/checkout/initiate/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { getSupabaseAdmin } from "@/lib/supabase/server";
 import { createPayment } from "@/lib/revenue-monster/client";
+import { earnLoyaltyPoints, deductLoyaltyPoints } from "@/lib/loyalty/points";
 import type { OrderRow } from "@/lib/supabase/types";
 
 // All active payment methods route through Stripe (live keys, MYR).
@@ -151,19 +152,26 @@ export async function POST(request: NextRequest) {
         .eq("reward_id", rewardId)
         .single();
 
-      if (rewardConfig) {
-        const { discount_type, discount_value } = rewardConfig;
-        if (discount_type === "flat" && discount_value != null) {
-          rewardDiscountSenAmt = Math.round(discount_value); // already in sen
-        } else if (discount_type === "percent" && discount_value != null) {
-          rewardDiscountSenAmt = Math.round(serverSubtotalSen * (discount_value / 100));
-        } else if (discount_type === "free_item" || discount_type === "bogo") {
-          // For free_item/bogo, the discount is the value of the free item(s)
-          // Trust the client value as it depends on which items were selected
-          rewardDiscountSenAmt = Math.round(rewardDiscountSen ?? 0);
-        }
+      // Reject unknown rewards up front — silently dropping the discount
+      // would cause the customer to be charged the pre-reward amount while
+      // the UI showed "free".
+      if (!rewardConfig) {
+        return NextResponse.json(
+          { error: "Reward is no longer valid" },
+          { status: 400 }
+        );
       }
-      // If no config found, discount stays 0 (don't trust client)
+
+      const { discount_type, discount_value } = rewardConfig;
+      if (discount_type === "flat" && discount_value != null) {
+        rewardDiscountSenAmt = Math.round(discount_value); // already in sen
+      } else if (discount_type === "percent" && discount_value != null) {
+        rewardDiscountSenAmt = Math.round(serverSubtotalSen * (discount_value / 100));
+      } else if (discount_type === "free_item" || discount_type === "bogo") {
+        // For free_item/bogo, the discount is the value of the free item(s)
+        // Trust the client value as it depends on which items were selected
+        rewardDiscountSenAmt = Math.round(rewardDiscountSen ?? 0);
+      }
     }
 
     // ── Server-side SST calculation ───────────────────────────────────────
@@ -257,6 +265,34 @@ export async function POST(request: NextRequest) {
 
     // Points deduction (reward) happens post-payment in webhook/confirm-stripe
     // to avoid deducting on abandoned payments.
+
+    // ── Zero-total bypass (fully-covered reward redemption) ────────────────
+    // Stripe rejects zero-amount PaymentIntents. If discounts fully cover the
+    // bill, skip the gateway and advance the order to "preparing" so it lands
+    // on KDS immediately. Loyalty earn/deduct runs here since there is no
+    // webhook / confirm-stripe callback to trigger it later.
+    if (totalSen === 0) {
+      await supabase
+        .from("orders")
+        .update({ status: "preparing" } as Record<string, unknown>)
+        .eq("id", order.id);
+
+      if (loyaltyId) {
+        if (pointsToEarn > 0) {
+          earnLoyaltyPoints(loyaltyId, order.id, pointsToEarn, order.store_id);
+        }
+        if (rewardId) {
+          deductLoyaltyPoints(loyaltyId, rewardId, order.store_id);
+        }
+      }
+
+      return NextResponse.json({
+        orderId:     order.id,
+        orderNumber: order.order_number,
+        totalSen:    0,
+        freeOrder:   true,
+      });
+    }
 
     // ── Stripe PaymentIntent ───────────────────────────────────────────────
     if (STRIPE_METHODS.has(paymentMethod)) {

--- a/apps/order/src/app/api/cron/reconcile-pending/route.ts
+++ b/apps/order/src/app/api/cron/reconcile-pending/route.ts
@@ -1,0 +1,115 @@
+export const dynamic = "force-dynamic";
+
+import { NextRequest, NextResponse } from "next/server";
+import Stripe from "stripe";
+import { getSupabaseAdmin } from "@/lib/supabase/server";
+import { earnLoyaltyPoints, deductLoyaltyPoints } from "@/lib/loyalty/points";
+
+// Runs every minute. Finds "pending" orders between 2 and 55 minutes old and
+// reconciles them against Stripe — covers wallet cancels where confirm-stripe
+// and the Stripe webhook both never fired. Older rows are left to
+// /api/cron/expire-orders, which fails them at the 60-minute mark.
+
+function getStripe() {
+  const key = process.env.STRIPE_SECRET_KEY?.trim();
+  if (!key) return null;
+  return new Stripe(key, { apiVersion: "2026-03-25.dahlia" });
+}
+
+type OrderLite = {
+  id: string;
+  order_number: string;
+  store_id: string;
+  loyalty_id: string | null;
+  loyalty_points_earned: number | null;
+  reward_id: string | null;
+};
+
+export async function GET(request: NextRequest) {
+  const authHeader = request.headers.get("authorization");
+  const secret = process.env.CRON_SECRET;
+  if (secret && authHeader !== `Bearer ${secret}`) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const stripe = getStripe();
+  if (!stripe) {
+    return NextResponse.json({ error: "Stripe not configured" }, { status: 500 });
+  }
+
+  const supabase = getSupabaseAdmin();
+  const now      = Date.now();
+  const olderThan  = new Date(now - 2  * 60 * 1000).toISOString();
+  const youngerThan = new Date(now - 55 * 60 * 1000).toISOString();
+
+  const { data: pending, error } = await supabase
+    .from("orders")
+    .select("id, order_number, store_id, loyalty_id, loyalty_points_earned, reward_id")
+    .eq("status", "pending")
+    .lt("created_at", olderThan)
+    .gt("created_at", youngerThan);
+
+  if (error) {
+    return NextResponse.json({ error: error.message }, { status: 500 });
+  }
+
+  const orders = (pending ?? []) as OrderLite[];
+  const result = { checked: orders.length, advanced: 0, failed: 0, unresolved: 0 };
+
+  for (const order of orders) {
+    try {
+      // Stripe indexes metadata for search within a few seconds of intent creation.
+      const search = await stripe.paymentIntents.search({
+        query: `metadata['orderId']:'${order.id}'`,
+        limit: 1,
+      });
+      const intent = search.data[0];
+
+      if (!intent) {
+        result.unresolved += 1;
+        continue;
+      }
+
+      if (intent.status === "succeeded") {
+        const { data: updated } = await supabase
+          .from("orders")
+          .update({
+            status: "preparing",
+            payment_provider_ref: intent.id,
+          } as Record<string, unknown>)
+          .eq("id", order.id)
+          .eq("status", "pending")
+          .select("id")
+          .maybeSingle();
+
+        if (updated) {
+          if (order.loyalty_id) {
+            if ((order.loyalty_points_earned ?? 0) > 0) {
+              earnLoyaltyPoints(order.loyalty_id, order.id, order.loyalty_points_earned ?? 0, order.store_id);
+            }
+            if (order.reward_id) {
+              deductLoyaltyPoints(order.loyalty_id, order.reward_id, order.store_id);
+            }
+          }
+          result.advanced += 1;
+        }
+      } else if (intent.status === "canceled" || intent.status === "requires_payment_method") {
+        // requires_payment_method after a failed attempt means the wallet /
+        // card rejected — treat as failed so the KDS stops seeing a ghost row.
+        await supabase
+          .from("orders")
+          .update({ status: "failed" } as Record<string, unknown>)
+          .eq("id", order.id)
+          .eq("status", "pending");
+        result.failed += 1;
+      } else {
+        result.unresolved += 1;
+      }
+    } catch (err) {
+      console.error("[reconcile-pending]", order.order_number, err);
+      result.unresolved += 1;
+    }
+  }
+
+  return NextResponse.json(result);
+}

--- a/apps/order/src/app/checkout/page.tsx
+++ b/apps/order/src/app/checkout/page.tsx
@@ -187,9 +187,17 @@ export default function CheckoutPage() {
       const data = await res.json() as {
         orderId: string; orderNumber: string; totalSen: number;
         clientSecret?: string;
+        freeOrder?: boolean;
         // Legacy redirect fallback (Revenue Monster)
         paymentType?: string; paymentUrl?: string;
       };
+
+      // Reward fully covers the bill — no gateway step, already "preparing".
+      if (data.freeOrder) {
+        saveOrderAndClearCart(data.orderId, data.orderNumber, data.totalSen);
+        router.push(`/order/${data.orderId}?payment=done`);
+        return;
+      }
 
       // New flow: Stripe PaymentIntent — open payment sheet.
       // Save order to recentOrders NOW (before any redirect) so FPX orders

--- a/apps/order/src/app/store/page.tsx
+++ b/apps/order/src/app/store/page.tsx
@@ -13,6 +13,7 @@ import { BottomNav } from "@/components/bottom-nav";
 export default function StoreSelector() {
   const router = useRouter();
   const { selectedStore, setSelectedStore } = useCartStore();
+  const itemCount = useCartStore((s) => s.getItemCount());
   const [stores, setStores] = useState<Store[]>([]);
   const [loading, setLoading] = useState(true);
 
@@ -28,7 +29,9 @@ export default function StoreSelector() {
 
   function handleSelectStore(store: Store) {
     setSelectedStore(store);
-    router.push(`/menu?store=${store.id}`);
+    // If they already have items, skip the menu and review the cart at the
+    // freshly-chosen outlet instead of starting a new browse session.
+    router.push(itemCount > 0 ? "/cart" : `/menu?store=${store.id}`);
   }
 
   return (

--- a/apps/order/vercel.json
+++ b/apps/order/vercel.json
@@ -13,6 +13,10 @@
     {
       "path": "/api/cron/expire-orders",
       "schedule": "*/10 * * * *"
+    },
+    {
+      "path": "/api/cron/reconcile-pending",
+      "schedule": "* * * * *"
     }
   ],
   "headers": [


### PR DESCRIPTION
## Summary

Two tightly-coupled changes for payment correctness on order.celsiuscoffee.com — shipped together because the reconcile cron catches the same race that the checkout zero-total bypass avoids creating.

### Checkout — reward validation (apps/order/src/app/api/checkout/initiate/route.ts)
- **Reject unknown rewards up front with 400.** Previously an unrecognised \`reward_id\` silently dropped the discount, so the customer was charged the pre-reward amount while the UI still showed "free".
- **Zero-total bypass** when a reward fully covers the bill. Stripe rejects 0-amount PaymentIntents, so skip the gateway, mark the order \`preparing\` directly, and run loyalty earn/deduct inline. Client reads the new \`freeOrder\` flag and jumps straight to \`/order/:id\`.

### Cart-aware Order Now CTAs (home-content, store selector)
- If cart has items, Order Now buttons route to \`/cart\` instead of starting a fresh menu browse.
- Store selector after picking an outlet goes to \`/cart\` when non-empty.

### New cron \`/api/cron/reconcile-pending\` (every minute)
- Scans \`pending\` orders aged 2-55 min and reconciles against Stripe via \`paymentIntents.search\` on \`metadata.orderId\`.
  - \`succeeded\` → \`preparing\` + loyalty earn/deduct
  - \`canceled\` / \`requires_payment_method\` → \`failed\`
  - no intent or inflight → unresolved, retry next run
- Covers the wallet-cancel race where neither \`confirm-stripe\` nor the Stripe webhook fire.
- Rows older than 60 min continue to be handled by the existing \`/api/cron/expire-orders\`.
- Gated by \`CRON_SECRET\`.

## Test plan

- [ ] Deploy to preview, hit \`GET /api/cron/reconcile-pending\` with \`Authorization: Bearer $CRON_SECRET\` → returns \`{checked, advanced, failed, unresolved}\`
- [ ] Unauthenticated request → 401
- [ ] Add reward to cart, set \`reward_id\` to a bogus value in the request body → 400 "Reward is no longer valid"
- [ ] Stack free-item rewards to reach total = 0 → checkout skips Stripe, order lands on KDS as \`preparing\`, \`freeOrder: true\` in response, loyalty points adjusted
- [ ] Regular paid order → unchanged Stripe flow
- [ ] Add items to cart, return to home → "Order Now" CTA becomes "Review Cart (N items waiting)" and routes to \`/cart\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)