### PR TITLE
Add Payment Requests checkbox to Staff module-access picker

### DIFF
--- a/apps/backoffice/src/app/(admin)/settings/staff/page.tsx
+++ b/apps/backoffice/src/app/(admin)/settings/staff/page.tsx
@@ -55,6 +55,7 @@ const APP_MODULES: Record<string, { label: string; key: string }[]> = {
     { label: "Purchase Orders", key: "orders" },
     { label: "Receivings", key: "receivings" },
     { label: "Invoices", key: "invoices" },
+    { label: "Payment Requests", key: "pay-and-claim" },
     { label: "Stock Count", key: "stock-count" },
     { label: "Wastage", key: "wastage" },
     { label: "Transfers", key: "transfers" },


### PR DESCRIPTION
## Summary

The sidebar at \`(admin)/layout.tsx\` gates \`/inventory/pay-and-claim\` on \`moduleKey: "inventory:pay-and-claim"\`, but \`APP_MODULES\` in \`settings/staff/page.tsx\` didn't list it — so there was no checkbox for OWNERs to grant MANAGERs access via the UI.

Effect: a manager either had no inventory restrictions set (full access, saw the link) or had their inventory list explicitly limited, which silently excluded Payment Requests with no way to re-enable it from the UI.

One-line fix — adds the entry under Inventory so the checkbox appears alongside Purchase Orders / Receivings / Invoices.

## Test plan

- [ ] Open Settings → Staff & Access, edit a MANAGER, confirm "Payment Requests" checkbox renders under Inventory
- [ ] Toggle it off → user loses sidebar link + direct-URL access to \`/inventory/pay-and-claim\`
- [ ] Toggle it on → link reappears after reload
- [ ] ADMIN/OWNER unchanged (they bypass module-access checks)

🤖 Generated with [Claude Code](https://claude.com/claude-code)