### PR TITLE
Populate invoice.depositAmount from all creation paths (fixes deposit POP detection)

### DIFF
--- a/apps/backoffice/src/app/api/inventory/orders/[id]/route.ts
+++ b/apps/backoffice/src/app/api/inventory/orders/[id]/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse, NextRequest } from "next/server";
 import { prisma } from "@/lib/prisma";
 import { getUserFromHeaders } from "@/lib/auth";
+import { computeDepositAmount } from "@/lib/inventory/deposit";
 
 export async function GET(_req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   try {
@@ -104,6 +105,7 @@ export async function PATCH(req: NextRequest, { params }: { params: Promise<{ id
         const existingInvoice = await prisma.invoice.findFirst({ where: { orderId: id } });
         if (!existingInvoice) {
           const invCount = await prisma.invoice.count();
+          const depositAmount = await computeDepositAmount(order.supplierId, Number(order.totalAmount));
           await prisma.invoice.create({
             data: {
               invoiceNumber: `INV-${String(invCount + 1).padStart(4, "0")}`,
@@ -113,6 +115,7 @@ export async function PATCH(req: NextRequest, { params }: { params: Promise<{ id
               amount: order.totalAmount,
               status: "PENDING",
               photos: invoicePhotos || [],
+              ...(depositAmount ? { depositAmount } : {}),
             },
           });
         }

--- a/apps/backoffice/src/app/api/inventory/receivings/route.ts
+++ b/apps/backoffice/src/app/api/inventory/receivings/route.ts
@@ -2,6 +2,7 @@ import { NextResponse, NextRequest } from "next/server";
 import { prisma } from "@/lib/prisma";
 import { adjustStockBalance } from "@/lib/stock";
 import { getUserFromHeaders } from "@/lib/auth";
+import { computeDepositAmount } from "@/lib/inventory/deposit";
 
 export async function GET(req: NextRequest) {
   // Auto-reconcile: fix PO statuses where receivings exist but order is still "awaiting"
@@ -214,6 +215,8 @@ export async function POST(req: NextRequest) {
           ? (await prisma.order.findUnique({ where: { id: orderId }, select: { totalAmount: true } }))?.totalAmount ?? 0
           : items.reduce((s: number, i: { receivedQty: number; unitPrice?: number }) => s + (i.receivedQty * (i.unitPrice ?? 0)), 0);
 
+        const depositAmount = await computeDepositAmount(supplierId, Number(totalAmount));
+
         await prisma.invoice.create({
           data: {
             invoiceNumber,
@@ -224,6 +227,7 @@ export async function POST(req: NextRequest) {
             status: "PENDING",
             photos: invoicePhotos || [],
             notes: notes ? `From receiving: ${notes}` : null,
+            ...(depositAmount ? { depositAmount } : {}),
           },
         });
       }

--- a/apps/backoffice/src/app/api/inventory/telegram/webhook/route.ts
+++ b/apps/backoffice/src/app/api/inventory/telegram/webhook/route.ts
@@ -5,6 +5,7 @@ import Anthropic from "@anthropic-ai/sdk";
 import { prisma } from "@/lib/prisma";
 import { createShortLink } from "@/lib/shortlink";
 import { detectPaymentFlags, appendInvoiceFlags } from "@/lib/inventory/flag-detector";
+import { computeDepositAmount } from "@/lib/inventory/deposit";
 import {
   sendMessage,
   sendPhoto,
@@ -740,7 +741,7 @@ async function handleInvoice(chatId: number, msgId: number, photoUrl: string, in
     include: {
       supplier: { select: { name: true } },
       outlet: { select: { id: true, name: true } },
-      invoices: { select: { id: true, photos: true } },
+      invoices: { select: { id: true, photos: true, depositAmount: true } },
     },
     orderBy: { createdAt: "desc" },
     take: 5,
@@ -799,24 +800,39 @@ async function handleInvoice(chatId: number, msgId: number, photoUrl: string, in
   }).catch((e) => console.error("[telegram] Failed to attach invoice photo to order:", e));
 
   if (existingInvoice) {
-    // Update existing invoice — add photo
+    // Update existing invoice — add photo. Also backfill depositAmount if the
+    // invoice was created by receivings/orders (which skip deposit calc) and
+    // the supplier requires a deposit — otherwise the POP matcher can never
+    // hit the DEPOSIT_PAID branch for this row.
+    const existingDepositAmount = (existingInvoice as { depositAmount: unknown }).depositAmount;
+    const shouldBackfillDeposit = existingDepositAmount == null;
+    const backfilledDeposit = shouldBackfillDeposit
+      ? await computeDepositAmount(order.supplierId, amount ?? Number(order.totalAmount))
+      : null;
+
     await prisma.invoice.update({
       where: { id: existingInvoice.id },
       data: {
         photos: { push: renamedUrl },
         ...(inv.invoiceNumber ? { invoiceNumber: inv.invoiceNumber } : {}),
+        ...(backfilledDeposit ? { depositAmount: backfilledDeposit } : {}),
       },
     });
 
+    const depositLine = backfilledDeposit
+      ? `\n💡 Deposit required: RM ${backfilledDeposit.toFixed(2)}`
+      : "";
     await sendMessage(
       chatId,
-      `✅ <b>Invoice photo added</b>\n\nPO: ${order.orderNumber}\nSupplier: ${order.supplier?.name ?? "?"}\nAmount: RM ${Number(order.totalAmount).toFixed(2)}\nInvoice #: ${inv.invoiceNumber ?? existingInvoice.id.slice(0, 8)}\n\n📎 Uploaded to PO + Invoice`,
+      `✅ <b>Invoice photo added</b>\n\nPO: ${order.orderNumber}\nSupplier: ${order.supplier?.name ?? "?"}\nAmount: RM ${Number(order.totalAmount).toFixed(2)}\nInvoice #: ${inv.invoiceNumber ?? existingInvoice.id.slice(0, 8)}${depositLine}\n\n📎 Uploaded to PO + Invoice`,
       msgId,
     );
   } else {
     // Create new invoice linked to PO
     const invCount = await prisma.invoice.count();
     const invoiceNumber = inv.invoiceNumber || `INV-${String(invCount + 1).padStart(4, "0")}`;
+    const invoiceAmount = amount ?? Number(order.totalAmount);
+    const depositAmount = await computeDepositAmount(order.supplierId, invoiceAmount);
 
     await prisma.invoice.create({
       data: {
@@ -824,17 +840,21 @@ async function handleInvoice(chatId: number, msgId: number, photoUrl: string, in
         orderId: order.id,
         outletId: order.outlet.id,
         supplierId: order.supplierId ?? undefined,
-        amount: amount ?? Number(order.totalAmount),
+        amount: invoiceAmount,
         status: "PENDING",
         paymentType: "SUPPLIER",
         photos: [renamedUrl],
         issueDate: inv.date ? new Date(inv.date) : new Date(),
+        ...(depositAmount ? { depositAmount } : {}),
       },
     });
 
+    const depositLine = depositAmount
+      ? `\nDeposit: RM ${depositAmount.toFixed(2)}`
+      : "";
     await sendMessage(
       chatId,
-      `✅ <b>Invoice created</b>\n\nPO: ${order.orderNumber}\nSupplier: ${order.supplier?.name ?? "?"}\nInvoice: ${invoiceNumber}\nAmount: RM ${(amount ?? Number(order.totalAmount)).toFixed(2)}\n\n📎 Uploaded to PO + Invoice`,
+      `✅ <b>Invoice created</b>\n\nPO: ${order.orderNumber}\nSupplier: ${order.supplier?.name ?? "?"}\nInvoice: ${invoiceNumber}\nAmount: RM ${invoiceAmount.toFixed(2)}${depositLine}\n\n📎 Uploaded to PO + Invoice`,
       msgId,
     );
   }

--- a/apps/backoffice/src/lib/inventory/deposit.ts
+++ b/apps/backoffice/src/lib/inventory/deposit.ts
@@ -1,0 +1,24 @@
+import { prisma } from "@/lib/prisma";
+
+/**
+ * If the supplier requires an upfront deposit, return the depositAmount
+ * rounded to 2 decimals. Returns null when there's no supplier, no percent
+ * configured, or the computed amount is zero.
+ *
+ * Kept in one place so every invoice-creation path (manual POST, receivings,
+ * telegram webhook, order PATCH) populates invoice.depositAmount consistently
+ * — the POP matcher's DEPOSIT_PAID branch only triggers when this field is set.
+ */
+export async function computeDepositAmount(
+  supplierId: string | null | undefined,
+  amount: number | null | undefined,
+): Promise<number | null> {
+  if (!supplierId || !amount || amount <= 0) return null;
+  const supplier = await prisma.supplier.findUnique({
+    where: { id: supplierId },
+    select: { depositPercent: true },
+  });
+  const pct = supplier?.depositPercent ?? 0;
+  if (pct <= 0) return null;
+  return Math.round((Number(amount) * pct / 100) * 100) / 100;
+}


### PR DESCRIPTION
## Summary

Addresses "POP not detected" for deposit payments. Root cause: the POP matcher's \`DEPOSIT_PAID\` branch only triggers when \`invoice.depositAmount\` is set, but only one of four invoice-creation paths computes it from \`supplier.depositPercent\`.

| Path | Before | After |
|---|---|---|
| \`POST /api/inventory/invoices\` | ✅ | ✅ |
| Receivings auto-create | ❌ | ✅ |
| Telegram webhook invoice handler | ❌ | ✅ |
| Order PATCH auto-create (on Confirm Order) | ❌ | ✅ |

### Consequence
For suppliers with \`depositPercent > 0\` (currently: Collective Project @ 10% / 21-day balance terms), an invoice created via any path other than the manual POST had \`depositAmount = NULL\`. When the supplier sent a deposit POP, the matcher fell through to full-amount match only, either missing entirely or matching wrong.

### Changes
- New \`lib/inventory/deposit.ts#computeDepositAmount(supplierId, amount)\` centralises the lookup + rounding. Every invoice-create path now calls this before \`prisma.invoice.create\` so they all initialise \`depositAmount\` the same way.
- Telegram webhook's *existing-invoice* branch also backfills \`depositAmount\` when the stored value is null and the supplier requires a deposit — catches rows created before this fix. Surfaced in the Telegram reply as a "💡 Deposit required: RM X" line.
- No DB backfill needed right now — dry-run found zero unpaid invoices matching \`depositAmount IS NULL AND supplier.depositPercent > 0\`.

### Not fixed by this PR
- Retrospective correction of historical invoices already settled as full-pay when they should have gone deposit → balance. That's a Finance reconciliation exercise, not code.

## Test plan

- [ ] Confirm an order from Collective Project at RM 100 → invoice auto-created with amount=100, depositAmount=10
- [ ] Receive without invoice photo first → same as above (receivings path)
- [ ] Telegram webhook receives invoice photo → new invoice has depositAmount populated; Telegram reply shows "Deposit: RM X"
- [ ] Existing invoice without depositAmount receives a photo via Telegram → invoice updated with depositAmount, reply shows "💡 Deposit required: RM X"
- [ ] Supplier sends deposit POP → invoice status becomes DEPOSIT_PAID, dueDate auto-set to +21 days
- [ ] Supplier sends balance POP → invoice status becomes PAID
- [ ] Regular (non-deposit) supplier → invoice.depositAmount stays null, normal POP flow unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)