### PR TITLE
Add Perishables checkbox to Staff module-access picker

### DIFF
--- a/apps/backoffice/src/app/(admin)/settings/staff/page.tsx
+++ b/apps/backoffice/src/app/(admin)/settings/staff/page.tsx
@@ -49,6 +49,7 @@ const APP_MODULES: Record<string, { label: string; key: string }[]> = {
   ],
   inventory: [
     { label: "Products", key: "products" },
+    { label: "Perishables", key: "perishables" },
     { label: "Suppliers", key: "suppliers" },
     { label: "Categories", key: "categories" },
     { label: "Menu & BOM", key: "menus" },


### PR DESCRIPTION
## Summary

Same pattern as #96. Sidebar gates \`/inventory/perishables\` on \`moduleKey: "inventory:perishables"\`, but \`APP_MODULES.inventory\` in \`settings/staff/page.tsx\` didn't list it — so there was no checkbox to grant MANAGERs access. Ariff flagged that his Perishables tab was missing.

One-line addition.

## Test plan

- [ ] Edit a MANAGER in Settings → Staff & Access, confirm "Perishables" checkbox appears under Inventory
- [ ] Toggle it on, reload → Perishables link appears in sidebar
- [ ] Toggle it off, reload → link disappears, direct URL access blocked

🤖 Generated with [Claude Code](https://claude.com/claude-code)