### PR TITLE
Populate invoice.depositAmount from all creation paths (fixes deposit POP detection)

### DIFF
--- a/apps/backoffice/src/app/api/inventory/orders/[id]/route.ts
+++ b/apps/backoffice/src/app/api/inventory/orders/[id]/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse, NextRequest } from "next/server";
 import { prisma } from "@/lib/prisma";
 import { getUserFromHeaders } from "@/lib/auth";
+import { computeDepositAmount } from "@/lib/inventory/deposit";
 
 export async function GET(_req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   try {
@@ -104,6 +105,7 @@ export async function PATCH(req: NextRequest, { params }: { params: Promise<{ id
         const existingInvoice = await prisma.invoice.findFirst({ where: { orderId: id } });
         if (!existingInvoice) {
           const invCount = await prisma.invoice.count();
+          const depositAmount = await computeDepositAmount(order.supplierId, Number(order.totalAmount));
           await prisma.invoice.create({
             data: {
               invoiceNumber: `INV-${String(invCount + 1).padStart(4, "0")}`,
@@ -113,6 +115,7 @@ export async function PATCH(req: NextRequest, { params }: { params: Promise<{ id
               amount: order.totalAmount,
               status: "PENDING",
               photos: invoicePhotos || [],
+              ...(depositAmount ? { depositAmount } : {}),
             },
           });
         }

--- a/apps/backoffice/src/app/api/inventory/receivings/route.ts
+++ b/apps/backoffice/src/app/api/inventory/receivings/route.ts
@@ -2,6 +2,7 @@ import { NextResponse, NextRequest } from "next/server";
 import { prisma } from "@/lib/prisma";
 import { adjustStockBalance } from "@/lib/stock";
 import { getUserFromHeaders } from "@/lib/auth";
+import { computeDepositAmount } from "@/lib/inventory/deposit";
 
 export async function GET(req: NextRequest) {
   // Auto-reconcile: fix PO statuses where receivings exist but order is still "awaiting"
@@ -214,6 +215,8 @@ export async function POST(req: NextRequest) {
           ? (await prisma.order.findUnique({ where: { id: orderId }, select: { totalAmount: true } }))?.totalAmount ?? 0
           : items.reduce((s: number, i: { receivedQty: number; unitPrice?: number }) => s + (i.receivedQty * (i.unitPrice ?? 0)), 0);
 
+        const depositAmount = await computeDepositAmount(supplierId, Number(totalAmount));
+
         await prisma.invoice.create({
           data: {
             invoiceNumber,
@@ -224,6 +227,7 @@ export async function POST(req: NextRequest) {
             status: "PENDING",
             photos: invoicePhotos || [],
             notes: notes ? `From receiving: ${notes}` : null,
+            ...(depositAmount ? { depositAmount } : {}),
           },
         });
       }

--- a/apps/backoffice/src/app/api/inventory/telegram/webhook/route.ts
+++ b/apps/backoffice/src/app/api/inventory/telegram/webhook/route.ts
@@ -5,6 +5,7 @@ import Anthropic from "@anthropic-ai/sdk";
 import { prisma } from "@/lib/prisma";
 import { createShortLink } from "@/lib/shortlink";
 import { detectPaymentFlags, appendInvoiceFlags } from "@/lib/inventory/flag-detector";
+import { computeDepositAmount } from "@/lib/inventory/deposit";
 import {
   sendMessage,
   sendPhoto,
@@ -750,7 +751,7 @@ async function handleInvoice(chatId: number, msgId: number, photoUrl: string, in
     include: {
       supplier: { select: { name: true } },
       outlet: { select: { id: true, name: true } },
-      invoices: { select: { id: true, photos: true, amount: true, status: true } },
+      invoices: { select: { id: true, photos: true, amount: true, status: true, depositAmount: true } },
     },
     orderBy: { createdAt: "desc" },
     take: 5,
@@ -815,38 +816,58 @@ async function handleInvoice(chatId: number, msgId: number, photoUrl: string, in
   }).catch((e) => console.error("[telegram] Failed to attach invoice photo to order:", e));
 
   if (existingInvoice) {
-    // Update existing invoice — add photo, and correct the amount if the
-    // AI-extracted grand total is materially higher than what's stored
-    // (typically because the receiving flow created the invoice with
-    // order.totalAmount = subtotal and missed the delivery charge). Only
-    // touch amount on unpaid invoices so we don't rewrite settled records.
+    // Update existing invoice — add photo, and correct amount + backfill
+    // depositAmount when the row needs it. Both corrections apply only to
+    // unpaid invoices so we don't rewrite settled records.
+    //
+    // Amount correction: receiving flow creates invoices with
+    // order.totalAmount = subtotal; the AI-extracted grand total may be
+    // higher (delivery/service fees). Bump the stored amount if so.
+    //
+    // Deposit backfill: receivings/orders paths used to skip the deposit
+    // calc, so invoices from those paths have depositAmount = null even
+    // when the supplier requires one — POP matcher can never hit
+    // DEPOSIT_PAID in that state. Fill it in using the current effective
+    // amount as the base.
     const storedAmount = Number(existingInvoice.amount);
-    const shouldCorrectAmount =
-      effectiveAmount > storedAmount + 0.5 &&
-      ["PENDING", "INITIATED", "OVERDUE", "DRAFT"].includes(existingInvoice.status);
+    const isUnpaid = ["PENDING", "INITIATED", "OVERDUE", "DRAFT"].includes(existingInvoice.status);
+    const shouldCorrectAmount = effectiveAmount > storedAmount + 0.5 && isUnpaid;
 
-    const updateData: Record<string, unknown> = {
-      photos: { push: renamedUrl },
-      ...(inv.invoiceNumber ? { invoiceNumber: inv.invoiceNumber } : {}),
-      ...(shouldCorrectAmount ? { amount: effectiveAmount } : {}),
-    };
+    const existingDepositAmount = (existingInvoice as { depositAmount: unknown }).depositAmount;
+    const shouldBackfillDeposit = isUnpaid && existingDepositAmount == null;
+    const backfilledDeposit = shouldBackfillDeposit
+      ? await computeDepositAmount(order.supplierId, effectiveAmount)
+      : null;
+
     await prisma.invoice.update({
       where: { id: existingInvoice.id },
-      data: updateData,
+      data: {
+        photos: { push: renamedUrl },
+        ...(inv.invoiceNumber ? { invoiceNumber: inv.invoiceNumber } : {}),
+        ...(shouldCorrectAmount ? { amount: effectiveAmount } : {}),
+        ...(backfilledDeposit ? { depositAmount: backfilledDeposit } : {}),
+      },
     });
 
     const correctionLine = shouldCorrectAmount
       ? `\n💡 Amount corrected: RM ${storedAmount.toFixed(2)} → RM ${effectiveAmount.toFixed(2)} (delivery ${deliveryCharge ? `+RM ${deliveryCharge.toFixed(2)}` : "included"})`
       : "";
+    const depositLine = backfilledDeposit
+      ? `\n💡 Deposit required: RM ${backfilledDeposit.toFixed(2)}`
+      : "";
     await sendMessage(
       chatId,
-      `✅ <b>Invoice photo added</b>\n\nPO: ${order.orderNumber}\nSupplier: ${order.supplier?.name ?? "?"}\nAmount: RM ${effectiveAmount.toFixed(2)}\nInvoice #: ${inv.invoiceNumber ?? existingInvoice.id.slice(0, 8)}${correctionLine}\n\n📎 Uploaded to PO + Invoice`,
+      `✅ <b>Invoice photo added</b>\n\nPO: ${order.orderNumber}\nSupplier: ${order.supplier?.name ?? "?"}\nAmount: RM ${effectiveAmount.toFixed(2)}\nInvoice #: ${inv.invoiceNumber ?? existingInvoice.id.slice(0, 8)}${correctionLine}${depositLine}\n\n📎 Uploaded to PO + Invoice`,
       msgId,
     );
   } else {
-    // Create new invoice linked to PO
+    // Create new invoice linked to PO. effectiveAmount = grand total incl.
+    // delivery; deposit is computed off that so a supplier charging 10%
+    // deposit on RM 105 (RM 100 items + RM 5 delivery) gets RM 10.50, not
+    // RM 10.00.
     const invCount = await prisma.invoice.count();
     const invoiceNumber = inv.invoiceNumber || `INV-${String(invCount + 1).padStart(4, "0")}`;
+    const depositAmount = await computeDepositAmount(order.supplierId, effectiveAmount);
 
     await prisma.invoice.create({
       data: {
@@ -859,13 +880,15 @@ async function handleInvoice(chatId: number, msgId: number, photoUrl: string, in
         paymentType: "SUPPLIER",
         photos: [renamedUrl],
         issueDate: inv.date ? new Date(inv.date) : new Date(),
+        ...(depositAmount ? { depositAmount } : {}),
       },
     });
 
     const deliveryLine = deliveryCharge > 0 ? `\nDelivery: RM ${deliveryCharge.toFixed(2)}` : "";
+    const depositLine = depositAmount ? `\nDeposit: RM ${depositAmount.toFixed(2)}` : "";
     await sendMessage(
       chatId,
-      `✅ <b>Invoice created</b>\n\nPO: ${order.orderNumber}\nSupplier: ${order.supplier?.name ?? "?"}\nInvoice: ${invoiceNumber}\nAmount: RM ${effectiveAmount.toFixed(2)}${deliveryLine}\n\n📎 Uploaded to PO + Invoice`,
+      `✅ <b>Invoice created</b>\n\nPO: ${order.orderNumber}\nSupplier: ${order.supplier?.name ?? "?"}\nInvoice: ${invoiceNumber}\nAmount: RM ${effectiveAmount.toFixed(2)}${deliveryLine}${depositLine}\n\n📎 Uploaded to PO + Invoice`,
       msgId,
     );
   }

--- a/apps/backoffice/src/lib/inventory/deposit.ts
+++ b/apps/backoffice/src/lib/inventory/deposit.ts
@@ -1,0 +1,24 @@
+import { prisma } from "@/lib/prisma";
+
+/**
+ * If the supplier requires an upfront deposit, return the depositAmount
+ * rounded to 2 decimals. Returns null when there's no supplier, no percent
+ * configured, or the computed amount is zero.
+ *
+ * Kept in one place so every invoice-creation path (manual POST, receivings,
+ * telegram webhook, order PATCH) populates invoice.depositAmount consistently
+ * — the POP matcher's DEPOSIT_PAID branch only triggers when this field is set.
+ */
+export async function computeDepositAmount(
+  supplierId: string | null | undefined,
+  amount: number | null | undefined,
+): Promise<number | null> {
+  if (!supplierId || !amount || amount <= 0) return null;
+  const supplier = await prisma.supplier.findUnique({
+    where: { id: supplierId },
+    select: { depositPercent: true },
+  });
+  const pct = supplier?.depositPercent ?? 0;
+  if (pct <= 0) return null;
+  return Math.round((Number(amount) * pct / 100) * 100) / 100;
+}


### PR DESCRIPTION
Supersedes #98 (rebased on main after #97 landed). Resolves the conflict in \`telegram/webhook/route.ts\` between #97's delivery-charge handling and this PR's deposit initialization — both corrections now run on the same invoice update: existing rows can be amount-corrected AND deposit-backfilled in one shot, new invoices use \`effectiveAmount\` (delivery-aware) as the deposit base.

## Summary

POP matcher's \`DEPOSIT_PAID\` branch only triggers when \`invoice.depositAmount\` is set, but only one of four invoice-creation paths was computing it from \`supplier.depositPercent\`:

| Path | Before | After |
|---|---|---|
| \`POST /api/inventory/invoices\` | ✅ | ✅ |
| Receivings auto-create | ❌ | ✅ |
| Telegram webhook invoice handler | ❌ | ✅ |
| Order PATCH auto-create (Confirm Order) | ❌ | ✅ |

For suppliers with \`depositPercent > 0\` (currently Collective Project @ 10% / 21-day balance terms), an invoice created via anything other than the manual POST had \`depositAmount = NULL\`. Supplier's deposit POP then either missed or mis-matched.

### Changes
- New \`lib/inventory/deposit.ts#computeDepositAmount(supplierId, amount)\` centralises the calc.
- All 4 create paths call it before \`prisma.invoice.create\`.
- Telegram webhook's *existing-invoice* branch backfills \`depositAmount\` on unpaid rows whose stored value is null, using \`effectiveAmount\` (grand total incl. delivery) as the base — so a deposit charged on "items + delivery" computes correctly.
- Merged with #97: the same existing-invoice update now both corrects under-stored \`amount\` AND backfills \`depositAmount\` in one call.

### Not in this PR
- Retrospective fix for historical settled short-pays. That's a Finance reconciliation step.
- DB backfill — dry-run found zero unpaid invoices matching \`depositAmount IS NULL AND supplier.depositPercent > 0\`.

## Test plan

- [ ] Confirm an order from Collective Project at RM 100 → invoice auto-created with amount=100, depositAmount=10
- [ ] Telegram webhook: supplier sends invoice photo showing RM 100 items + RM 5 delivery → new invoice amount=105, depositAmount=10.50
- [ ] Existing unpaid invoice with no depositAmount receives a photo via Telegram → depositAmount backfilled, reply shows "💡 Deposit required: RM X"
- [ ] Supplier sends deposit POP → invoice becomes DEPOSIT_PAID, dueDate auto-set to +21 days
- [ ] Supplier sends balance POP → invoice becomes PAID
- [ ] Non-deposit supplier → depositAmount stays null, normal POP flow unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)