### PR TITLE
Android keyboard not appearing for staff OTP entry

### DIFF
--- a/apps/loyalty/src/app/staff/page.tsx
+++ b/apps/loyalty/src/app/staff/page.tsx
@@ -1104,13 +1104,29 @@ export default function PortalPage() {
                   </div>
 
                   {/* OTP Input Boxes */}
-                  <div className="mb-4 flex justify-center gap-2">
+                  {/* Tap anywhere on the row to focus the first empty box —
+                      Android Chrome refuses to show the soft keyboard for
+                      programmatic focus (autoFocus); we need a real user
+                      gesture. The blur+focus dance forces the IME to re-open
+                      even when the input is already focused from autoFocus. */}
+                  <div
+                    className="mb-2 flex cursor-text justify-center gap-2"
+                    onClick={() => {
+                      const firstEmpty = redeemOtp.findIndex((c) => !c);
+                      const target = otpInputRefs.current[firstEmpty === -1 ? 0 : firstEmpty];
+                      if (!target) return;
+                      target.blur();
+                      requestAnimationFrame(() => target.focus());
+                    }}
+                  >
                     {[0, 1, 2, 3, 4, 5].map((i) => (
                       <input
                         key={i}
                         ref={(el) => { otpInputRefs.current[i] = el; }}
-                        type="text"
+                        type="tel"
                         inputMode="numeric"
+                        autoComplete="one-time-code"
+                        pattern="[0-9]*"
                         maxLength={1}
                         value={redeemOtp[i]}
                         onChange={(e) => handleOtpChange(i, e.target.value)}
@@ -1124,6 +1140,9 @@ export default function PortalPage() {
                       />
                     ))}
                   </div>
+                  <p className="mb-4 text-center text-xs text-neutral-500">
+                    Tap a box if the keyboard doesn&apos;t appear
+                  </p>
 
                   {redeemOtpError && (
                     <p className="mb-4 text-center text-sm text-red-400 font-medium">{redeemOtpError}</p>


### PR DESCRIPTION
## Summary

Staff at Putrajaya reported the soft keyboard doesn't open on the OTP verification screen on their Android tablet. Works fine on iPhone (with iOS SMS autofill — see screenshot). The first OTP box shows the red focus ring, confirming \`autoFocus\` IS taking effect — Android Chrome just refuses to bring up the IME for focus that came from JavaScript without an active user gesture. iOS Safari is more permissive.

## Fix

Three changes in [apps/loyalty/src/app/staff/page.tsx](apps/loyalty/src/app/staff/page.tsx) that together get the keyboard back:

1. \`type="text"\` → \`type="tel"\` with \`pattern="[0-9]*"\` — more reliable numeric keypad on Android and a configuration Chrome treats as keyboard-eligible.
2. \`autoComplete="one-time-code"\` — signals OTP context to Chrome, surfaces the IME, connects to Android SMS autofill where supported.
3. \`onClick\` on the wrapping row that does \`blur\` → \`requestAnimationFrame\` → \`focus\` on the first empty box. Even when \`autoFocus\` has already focused box 0, Android won't reopen the keyboard from a tap that doesn't change focus — the blur+refocus forces a fresh focus event from the user gesture, which IS keyboard-eligible.

Plus a one-line hint below the boxes: *"Tap a box if the keyboard doesn't appear"* — covers staff who don't realise they can tap to recover.

iOS behaviour preserved: \`autoFocus\` still fires, keyboard still appears automatically, SMS one-time-code autofill still works.

## Test plan

- [ ] Android tablet at Putrajaya — open redeem flow, enter phone, tap Send OTP → keyboard appears on the OTP step automatically (or after one tap if not)
- [ ] iPhone — same flow, keyboard appears instantly with SMS autofill suggestion
- [ ] Tap a non-input area of the OTP row → first empty box gets focus and keyboard opens
- [ ] Backspace navigation between boxes still works
- [ ] Auto-submit on 6th digit still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)