### PR TITLE
Invoice summary cards use full-DB aggregates (fixes Payable RM 0 with 17 due today)

### DIFF
--- a/apps/backoffice/src/app/(admin)/inventory/invoices/page.tsx
+++ b/apps/backoffice/src/app/(admin)/inventory/invoices/page.tsx
@@ -99,7 +99,21 @@ const FLAG_TITLE: Record<InvoiceFlagCode, string> = {
 const activeFlags = (inv: Pick<Invoice, "flags">) => (inv.flags ?? []).filter((f) => !f.dismissed);
 
 type OutletOption = { id: string; name: string };
-type InvoicesResponse = { invoices: Invoice[]; outlets: OutletOption[]; dueTodayCount: number; dueTodayAmount: number };
+type SummaryBucket = { count: number; amount: number };
+type InvoicesSummary = {
+  total: SummaryBucket;
+  payable: SummaryBucket;
+  overdue: SummaryBucket;
+  paid: SummaryBucket;
+  dueToday: SummaryBucket;
+};
+type InvoicesResponse = {
+  invoices: Invoice[];
+  outlets: OutletOption[];
+  dueTodayCount: number;
+  dueTodayAmount: number;
+  summary?: InvoicesSummary;
+};
 
 export default function InvoicesPage() {
   const [tab, setTab] = useState("all");
@@ -393,11 +407,21 @@ export default function InvoicesPage() {
     }
   };
 
-  const totalOverdue = allInvoices.filter((i) => i.status === "OVERDUE").reduce((a, i) => a + i.amount, 0);
-  const totalPaid = allInvoices.filter((i) => i.status === "PAID").reduce((a, i) => a + i.amount, 0);
-  const totalAll = allInvoices.reduce((a, i) => a + i.amount, 0);
-  const totalPayable = allInvoices.filter((i) => i.status !== "PAID").reduce((a, i) => a + i.amount, 0);
-  const payableCount = allInvoices.filter((i) => i.status !== "PAID").length;
+  // Summary cards come from a server-side aggregate over the full invoice
+  // table. Computing from `allInvoices` here would silently understate
+  // anything when the API truncates at the 200-row pagination limit
+  // (e.g. once PAID grows past 200, Payable/Overdue collapsed to zero
+  // even when work was outstanding). Falls back to the loaded subset
+  // only when the API hasn't been redeployed yet.
+  const summary = data?.summary;
+  const totalAll = summary?.total.amount ?? allInvoices.reduce((a, i) => a + i.amount, 0);
+  const totalAllCount = summary?.total.count ?? allInvoices.length;
+  const totalPayable = summary?.payable.amount ?? allInvoices.filter((i) => i.status !== "PAID").reduce((a, i) => a + i.amount, 0);
+  const payableCount = summary?.payable.count ?? allInvoices.filter((i) => i.status !== "PAID").length;
+  const totalOverdue = summary?.overdue.amount ?? allInvoices.filter((i) => i.status === "OVERDUE").reduce((a, i) => a + i.amount, 0);
+  const overdueCount = summary?.overdue.count ?? allInvoices.filter((i) => i.status === "OVERDUE").length;
+  const totalPaid = summary?.paid.amount ?? allInvoices.filter((i) => i.status === "PAID").reduce((a, i) => a + i.amount, 0);
+  const paidCount = summary?.paid.count ?? allInvoices.filter((i) => i.status === "PAID").length;
 
   const statusLabel = (status: string, paymentType: string) => {
     // Staff claims used to show "approved"/"reimbursed" — unified with supplier
@@ -479,11 +503,11 @@ export default function InvoicesPage() {
       {/* Summary cards — clickable to filter */}
       <div className="mt-4 grid grid-cols-2 sm:grid-cols-5 gap-2 sm:gap-3">
         {([
-          { key: "all" as const, label: "Total", amount: totalAll, count: allInvoices.length, color: "text-gray-900", border: "border-gray-300", ring: "ring-gray-200" },
+          { key: "all" as const, label: "Total", amount: totalAll, count: totalAllCount, color: "text-gray-900", border: "border-gray-300", ring: "ring-gray-200" },
           { key: "payable" as const, label: "Payable", amount: totalPayable, count: payableCount, color: payableCount > 0 ? "text-orange-600" : "text-gray-400", border: "border-orange-400", ring: "ring-orange-100" },
           { key: "due_today" as const, label: "Due Today", amount: dueTodayAmount, count: dueTodayCount, color: dueTodayCount > 0 ? "text-blue-600" : "text-gray-400", border: "border-blue-400", ring: "ring-blue-100" },
-          { key: "overdue" as const, label: "Overdue", amount: totalOverdue, count: allInvoices.filter((i) => i.status === "OVERDUE").length, color: "text-red-600", border: "border-red-400", ring: "ring-red-100" },
-          { key: "paid" as const, label: "Paid", amount: totalPaid, count: allInvoices.filter((i) => i.status === "PAID").length, color: "text-green-600", border: "border-green-400", ring: "ring-green-100" },
+          { key: "overdue" as const, label: "Overdue", amount: totalOverdue, count: overdueCount, color: "text-red-600", border: "border-red-400", ring: "ring-red-100" },
+          { key: "paid" as const, label: "Paid", amount: totalPaid, count: paidCount, color: "text-green-600", border: "border-green-400", ring: "ring-green-100" },
         ]).map((card) => (
           <button
             key={card.key}

--- a/apps/backoffice/src/app/api/inventory/invoices/route.ts
+++ b/apps/backoffice/src/app/api/inventory/invoices/route.ts
@@ -132,19 +132,56 @@ export async function GET(req: NextRequest) {
     orderBy: { name: "asc" },
   });
 
-  // Count due-today invoices (unpaid, due date = today)
+  // Summary cards aggregate over the FULL invoice table — not the paginated
+  // 200-row response. Previously the client computed Total / Payable / Overdue
+  // / Paid by filtering `invoices` (capped at 200), so once you had >200
+  // PAID invoices the older unpaid ones fell off the page and Payable
+  // collapsed to RM 0.00 even though Due Today (server-side) correctly
+  // showed 17 outstanding. Compute everything server-side on the same
+  // snapshot so the cards stay consistent. INITIATED counts as Payable —
+  // it stays INITIATED rather than rolling to OVERDUE on its own (per the
+  // updateMany above) but it's still owed, not paid.
   const today = new Date();
   const todayStart = new Date(today.getFullYear(), today.getMonth(), today.getDate());
   const todayEnd = new Date(todayStart.getTime() + 86400000);
-  const dueTodayInvoices = await prisma.invoice.findMany({
-    where: {
-      status: { in: UNPAID_STATUSES as ("DRAFT" | "INITIATED" | "PENDING" | "OVERDUE")[] },
-      dueDate: { gte: todayStart, lt: todayEnd },
-    },
-    select: { id: true, amount: true },
-  });
+
+  const [allAgg, paidAgg, overdueAgg, payableInvoices, dueTodayInvoices] = await Promise.all([
+    prisma.invoice.aggregate({ _sum: { amount: true }, _count: { _all: true } }),
+    prisma.invoice.aggregate({ where: { status: "PAID" }, _sum: { amount: true }, _count: { _all: true } }),
+    prisma.invoice.aggregate({ where: { status: "OVERDUE" }, _sum: { amount: true }, _count: { _all: true } }),
+    prisma.invoice.findMany({
+      where: { status: { in: UNPAID_STATUSES as ("DRAFT" | "INITIATED" | "PENDING" | "DEPOSIT_PAID" | "OVERDUE")[] } },
+      select: { id: true, amount: true, status: true, depositAmount: true },
+    }),
+    prisma.invoice.findMany({
+      where: {
+        status: { in: UNPAID_STATUSES as ("DRAFT" | "INITIATED" | "PENDING" | "DEPOSIT_PAID" | "OVERDUE")[] },
+        dueDate: { gte: todayStart, lt: todayEnd },
+      },
+      select: { id: true, amount: true, status: true, depositAmount: true },
+    }),
+  ]);
+
+  // Outstanding balance = full amount, minus deposit already paid for
+  // DEPOSIT_PAID rows (only the balance is still owed). All other unpaid
+  // statuses owe the full amount.
+  const outstanding = (i: { amount: { toNumber?: () => number } | number; status: string; depositAmount: { toNumber?: () => number } | number | null }) => {
+    const amt = typeof i.amount === "number" ? i.amount : i.amount.toNumber?.() ?? 0;
+    const dep = i.depositAmount == null ? 0 : (typeof i.depositAmount === "number" ? i.depositAmount : i.depositAmount.toNumber?.() ?? 0);
+    return i.status === "DEPOSIT_PAID" ? Math.max(0, amt - dep) : amt;
+  };
+  const payableAmount = payableInvoices.reduce((s, i) => s + outstanding(i), 0);
+  const payableCount = payableInvoices.length;
   const dueTodayCount = dueTodayInvoices.length;
-  const dueTodayAmount = dueTodayInvoices.reduce((s, i) => s + Number(i.amount), 0);
+  const dueTodayAmount = dueTodayInvoices.reduce((s, i) => s + outstanding(i), 0);
+
+  const summary = {
+    total: { count: allAgg._count._all, amount: Number(allAgg._sum.amount ?? 0) },
+    payable: { count: payableCount, amount: payableAmount },
+    overdue: { count: overdueAgg._count._all, amount: Number(overdueAgg._sum.amount ?? 0) },
+    paid: { count: paidAgg._count._all, amount: Number(paidAgg._sum.amount ?? 0) },
+    dueToday: { count: dueTodayCount, amount: dueTodayAmount },
+  };
 
   const mapped = invoices.map((inv) => ({
     id: inv.id,
@@ -195,7 +232,7 @@ export async function GET(req: NextRequest) {
     flags: Array.isArray(inv.flags) ? inv.flags : [],
   }));
 
-  return NextResponse.json({ invoices: mapped, outlets, dueTodayCount, dueTodayAmount });
+  return NextResponse.json({ invoices: mapped, outlets, dueTodayCount, dueTodayAmount, summary });
 }
 
 export async function POST(req: NextRequest) {


### PR DESCRIPTION
## Summary

Reported: Invoices page showed **Payable: RM 0.00** while **Due Today: 17 invoices / RM 1,966.80** at the same time. Sanity-impossible — if 17 invoices are due today, they're payable.

### Root cause

Two different scopes:
- **Total / Payable / Overdue / Paid** were computed on the client by filtering \`allInvoices\`, which the API caps at \`take: 200\` ordered by createdAt desc. Once PAID grew past 200 (currently 202), all unpaid invoices fell off the loaded page. \`allInvoices.filter(i => i.status !== "PAID")\` matched zero rows.
- **Due Today** was already computed server-side over the full table, so it correctly counted the 17 outstanding rows that the client never saw.

### Fix

\`/api/inventory/invoices\` now returns a \`summary\` block with full-DB aggregates for total, payable, overdue, paid, and dueToday — same snapshot as the auto-mark-overdue pass at the start of the request. Page reads \`summary.{bucket}.{count,amount}\` for card values with a fallback to the old filter math for the redeploy window.

DEPOSIT_PAID rows now contribute only the remaining balance (\`amount - depositAmount\`) to Payable / Due Today, since the deposit portion is already settled.

### Sanity check on current dataset

| Card | Before | After |
|---|---|---|
| Total | 200 / RM 52,555.30 | **256 / RM 68,037.34** |
| Payable | 0 / RM 0.00 | **54 / RM 14,530.28** |
| Overdue | 0 / RM 0.00 | 0 / RM 0.00 |
| Paid | 200 / RM 52,555.30 | **202 / RM 53,507.06** |
| Due Today | 17 / RM 1,966.80 | 17 / RM 1,966.80 |

The 54 newly-visible Payable = 29 PENDING + 25 INITIATED.

### Behaviour preserved

INITIATED stays out of OVERDUE per the existing auto-rollover rule (\`status: "PENDING", dueDate < today → OVERDUE\`). The reasoning in the existing comment ("INITIATED stays INITIATED — payment is already in progress") still holds. INITIATED *is* now correctly counted as Payable, which it always should have been.

## Test plan

- [ ] Open Invoices page → cards show real numbers matching the SQL above
- [ ] Tab=All / Unpaid / Paid → cards stay constant (always full-DB), only the table changes
- [ ] Initiate a PENDING invoice → moves from Pending count to Initiated, still in Payable
- [ ] Mark a payment Paid → drops from Payable, increments Paid
- [ ] Refresh after creating a new DEPOSIT_PAID row → Payable amount reflects balance owed, not full invoice

🤖 Generated with [Claude Code](https://claude.com/claude-code)