### PR TITLE
Cashflow multi-account opening + correct per-day rate + multi-filter outlets

### DIFF
--- a/apps/backoffice/src/app/(admin)/finance/cashflow/page.tsx
+++ b/apps/backoffice/src/app/(admin)/finance/cashflow/page.tsx
@@ -3,7 +3,7 @@
 import { useState, useMemo } from "react";
 import Link from "next/link";
 import { useFetch } from "@/lib/use-fetch";
-import { Loader2, AlertTriangle, Banknote, Settings, ArrowRight, TrendingDown, TrendingUp } from "lucide-react";
+import { Loader2, AlertTriangle, Banknote, Settings, ArrowRight, TrendingDown, TrendingUp, ChevronDown, X } from "lucide-react";
 
 type Outlet = { id: string; name: string; code: string };
 
@@ -27,6 +27,7 @@ type CashflowResult = {
   asOf: string;
   weeks: number;
   outletId: string | null;
+  outletIds: string[];
   openingBalance: { amount: number; statementDate: string | null };
   bankFlowsPerDay: { inflow: number; outflow: number; sampleDays: number } | null;
   buckets: CashflowBucket[];
@@ -53,12 +54,21 @@ function shortRange(start: string, end: string): string {
 
 export default function CashflowPage() {
   const [weeks, setWeeks] = useState<number>(8);
-  const [outletId, setOutletId] = useState<string>("");
+  const [outletIds, setOutletIds] = useState<string[]>([]);
+  const [outletPickerOpen, setOutletPickerOpen] = useState(false);
 
   const params = new URLSearchParams({ weeks: String(weeks) });
-  if (outletId) params.set("outletId", outletId);
+  outletIds.forEach((id) => params.append("outlet", id));
   const { data, isLoading } = useFetch<CashflowResult>(`/api/finance/cashflow?${params.toString()}`);
   const { data: outlets } = useFetch<Outlet[]>("/api/settings/outlets");
+
+  const toggleOutlet = (id: string) =>
+    setOutletIds((prev) => (prev.includes(id) ? prev.filter((x) => x !== id) : [...prev, id]));
+  const clearOutlets = () => setOutletIds([]);
+  const outletButtonLabel =
+    outletIds.length === 0 ? "All outlets"
+    : outletIds.length === 1 ? (outlets?.find((o) => o.id === outletIds[0])?.name ?? "1 outlet")
+    : `${outletIds.length} outlets`;
 
   // Chart bounds — y-axis runs from min(closing, opening, 0) to max(closing).
   const chartData = useMemo(() => {
@@ -87,10 +97,52 @@ export default function CashflowPage() {
           </p>
         </div>
         <div className="flex flex-wrap items-center gap-2">
-          <select value={outletId} onChange={(e) => setOutletId(e.target.value)} className="rounded-md border border-gray-200 bg-white px-3 py-1.5 text-sm">
-            <option value="">All outlets</option>
-            {(outlets ?? []).map((o) => <option key={o.id} value={o.id}>{o.name}</option>)}
-          </select>
+          {/* Multi-filter outlet picker. Click to toggle the popover; tick
+              one or more outlets, click outside to dismiss. Empty selection
+              = consolidated "All outlets" view (same as the bank-residual
+              view that includes the Other-bank column). */}
+          <div className="relative">
+            <button
+              type="button"
+              onClick={() => setOutletPickerOpen((v) => !v)}
+              className={`flex items-center gap-1.5 rounded-md border bg-white px-3 py-1.5 text-sm transition-colors ${outletIds.length > 0 ? "border-terracotta text-terracotta-dark" : "border-gray-200 text-gray-700 hover:bg-gray-50"}`}
+            >
+              {outletButtonLabel}
+              {outletIds.length > 0 && (
+                <span
+                  role="button"
+                  onClick={(e) => { e.stopPropagation(); clearOutlets(); }}
+                  className="ml-1 rounded-full p-0.5 text-gray-400 hover:bg-gray-100 hover:text-gray-600"
+                  aria-label="Clear outlet filter"
+                >
+                  <X className="h-3 w-3" />
+                </span>
+              )}
+              <ChevronDown className="h-3.5 w-3.5 text-gray-400" />
+            </button>
+            {outletPickerOpen && (
+              <>
+                <div className="fixed inset-0 z-10" onClick={() => setOutletPickerOpen(false)} />
+                <div className="absolute right-0 z-20 mt-1 w-64 rounded-lg border border-gray-200 bg-white shadow-lg">
+                  <div className="flex items-center justify-between border-b border-gray-100 px-3 py-2">
+                    <span className="text-xs font-medium text-gray-500">Filter by outlet</span>
+                    <button onClick={clearOutlets} className="text-[11px] text-blue-600 hover:underline">Clear</button>
+                  </div>
+                  <div className="max-h-[280px] overflow-y-auto p-1">
+                    {(outlets ?? []).map((o) => {
+                      const checked = outletIds.includes(o.id);
+                      return (
+                        <label key={o.id} className="flex cursor-pointer items-center gap-2 rounded px-2 py-1.5 text-sm text-gray-700 hover:bg-gray-50">
+                          <input type="checkbox" checked={checked} onChange={() => toggleOutlet(o.id)} className="rounded border-gray-300 text-terracotta focus:ring-terracotta" />
+                          {o.name}
+                        </label>
+                      );
+                    })}
+                  </div>
+                </div>
+              </>
+            )}
+          </div>
           <div className="flex rounded-lg border border-gray-200 bg-white p-0.5">
             {HORIZONS.map((h) => (
               <button key={h} onClick={() => setWeeks(h)}
@@ -215,7 +267,7 @@ export default function CashflowPage() {
           </div>
 
           <p className="mt-3 text-[11px] text-gray-400">
-            Sales forecast: 12-week day-of-week average{outletId ? " for selected outlet" : ""}. Payroll: 4-month run-rate, projected on the 25th. Marketing: 4-month avg of Google Ads invoices, projected once per month{outletId ? " (HQ-level, excluded from per-outlet view)" : ""}.
+            Sales forecast: 12-week day-of-week average{outletIds.length > 0 ? ` for ${outletIds.length === 1 ? "selected outlet" : `${outletIds.length} selected outlets`}` : ""}. Payroll: 4-month run-rate, projected on the 25th. Marketing: 4-month avg of Google Ads invoices, projected once per month{outletIds.length > 0 ? " (HQ-level, excluded from filtered view)" : ""}.
             <strong className="text-gray-600"> Other (bank)</strong>: per-day residual from your bank statement period totals, minus everything the synthetic model already covers — captures pickup-app revenue, refunds, card-charged subscriptions, transfers and any other movement the projection isn&apos;t modelling yet.
             {data.bankFlowsPerDay
               ? ` Computed from the last ${data.bankFlowsPerDay.sampleDays} days of bank statements (avg in ${fmtMYR2(data.bankFlowsPerDay.inflow)}/day, out ${fmtMYR2(data.bankFlowsPerDay.outflow)}/day).`

--- a/apps/backoffice/src/app/(admin)/finance/cashflow/page.tsx
+++ b/apps/backoffice/src/app/(admin)/finance/cashflow/page.tsx
@@ -23,6 +23,21 @@ type CashflowBucket = {
   recurringExpenseIds: string[];
 };
 
+type MonthlyHistory = {
+  month: string;
+  cashIn: number;
+  cashOut: number;
+  netGenerated: number;
+  accountsReporting: number;
+};
+
+type CashGeneration = {
+  lastMonth: { month: string; net: number } | null;
+  avg3Month: number | null;
+  burnPerMonth: number | null;
+  runwayMonths: number | null;
+};
+
 type CashflowResult = {
   asOf: string;
   weeks: number;
@@ -30,6 +45,8 @@ type CashflowResult = {
   outletIds: string[];
   openingBalance: { amount: number; statementDate: string | null };
   bankFlowsPerDay: { inflow: number; outflow: number; sampleDays: number } | null;
+  monthlyHistory: MonthlyHistory[];
+  cashGeneration: CashGeneration;
   buckets: CashflowBucket[];
   warnings: string[];
 };
@@ -164,49 +181,104 @@ export default function CashflowPage() {
         <div className="mt-6 flex justify-center py-12"><Loader2 className="h-5 w-5 animate-spin text-gray-400" /></div>
       ) : (
         <>
-          {/* Headline cards */}
+          {/* Headline — Cash Generation. The primary KPI. */}
           <div className="mt-4 grid grid-cols-2 sm:grid-cols-4 gap-2 sm:gap-3">
             <div className="rounded-lg border border-gray-200 bg-white px-3 py-2.5">
-              <p className="text-xs text-gray-500">Opening balance</p>
+              <p className="text-xs text-gray-500">Last month generated</p>
+              {data.cashGeneration.lastMonth ? (
+                <>
+                  <p className={`mt-0.5 flex items-center gap-1 text-lg font-bold ${data.cashGeneration.lastMonth.net >= 0 ? "text-green-600" : "text-red-600"}`}>
+                    {data.cashGeneration.lastMonth.net >= 0 ? <TrendingUp className="h-4 w-4" /> : <TrendingDown className="h-4 w-4" />}
+                    {fmtMYR2(data.cashGeneration.lastMonth.net)}
+                  </p>
+                  <p className="text-[10px] text-gray-400">{data.cashGeneration.lastMonth.month}</p>
+                </>
+              ) : (
+                <>
+                  <p className="mt-0.5 text-lg font-bold text-gray-400">—</p>
+                  <p className="text-[10px] text-gray-400">No complete months yet</p>
+                </>
+              )}
+            </div>
+            <div className="rounded-lg border border-gray-200 bg-white px-3 py-2.5">
+              <p className="text-xs text-gray-500">3-month avg / month</p>
+              {data.cashGeneration.avg3Month != null ? (
+                <p className={`mt-0.5 text-lg font-bold ${data.cashGeneration.avg3Month >= 0 ? "text-green-600" : "text-red-600"}`}>
+                  {fmtMYR2(data.cashGeneration.avg3Month)}
+                </p>
+              ) : (
+                <p className="mt-0.5 text-lg font-bold text-gray-400">—</p>
+              )}
+              <p className="text-[10px] text-gray-400">From bank statements</p>
+            </div>
+            <div className="rounded-lg border border-gray-200 bg-white px-3 py-2.5">
+              <p className="text-xs text-gray-500">Cash on hand</p>
               <p className="mt-0.5 text-lg font-bold text-gray-900">{fmtMYR2(data.openingBalance.amount)}</p>
               <p className="text-[10px] text-gray-400">
-                {data.openingBalance.statementDate ? `Statement: ${data.openingBalance.statementDate}` : "No statement uploaded"}
+                {data.openingBalance.statementDate ? `As of ${data.openingBalance.statementDate}` : "No statement uploaded"}
               </p>
             </div>
             <div className="rounded-lg border border-gray-200 bg-white px-3 py-2.5">
-              <p className="text-xs text-gray-500">Projected end of {weeks}w</p>
-              <p className={`mt-0.5 text-lg font-bold ${data.buckets[data.buckets.length-1].closing < 0 ? "text-red-600" : "text-gray-900"}`}>
-                {fmtMYR2(data.buckets[data.buckets.length-1]?.closing ?? 0)}
-              </p>
-              <p className="text-[10px] text-gray-400">{data.buckets[data.buckets.length-1]?.weekEnd.slice(0,10)}</p>
-            </div>
-            <div className="rounded-lg border border-gray-200 bg-white px-3 py-2.5">
-              <p className="text-xs text-gray-500">Lowest week</p>
-              {lowestWeek ? (
+              <p className="text-xs text-gray-500">Runway</p>
+              {data.cashGeneration.runwayMonths != null ? (
                 <>
-                  <p className={`mt-0.5 text-lg font-bold ${lowestWeek.closing < 0 ? "text-red-600" : "text-amber-600"}`}>
-                    {fmtMYR2(lowestWeek.closing)}
+                  <p className={`mt-0.5 text-lg font-bold ${data.cashGeneration.runwayMonths < 3 ? "text-red-600" : data.cashGeneration.runwayMonths < 6 ? "text-amber-600" : "text-gray-900"}`}>
+                    {data.cashGeneration.runwayMonths.toFixed(1)} months
                   </p>
-                  <p className="text-[10px] text-gray-400">{shortRange(lowestWeek.weekStart, lowestWeek.weekEnd)}</p>
+                  <p className="text-[10px] text-gray-400">at current burn ({fmtMYR(data.cashGeneration.burnPerMonth ?? 0)}/mo)</p>
                 </>
-              ) : <p className="text-sm text-gray-400">—</p>}
-            </div>
-            <div className="rounded-lg border border-gray-200 bg-white px-3 py-2.5">
-              <p className="text-xs text-gray-500">Net change</p>
-              {(() => {
-                const last = data.buckets[data.buckets.length-1]?.closing ?? data.openingBalance.amount;
-                const delta = last - data.openingBalance.amount;
-                const Icon = delta >= 0 ? TrendingUp : TrendingDown;
-                return (
-                  <p className={`mt-0.5 flex items-center gap-1 text-lg font-bold ${delta >= 0 ? "text-green-600" : "text-red-600"}`}>
-                    <Icon className="h-4 w-4" />
-                    {fmtMYR2(delta)}
-                  </p>
-                );
-              })()}
-              <p className="text-[10px] text-gray-400">over {weeks} weeks</p>
+              ) : (
+                <>
+                  <p className="mt-0.5 text-lg font-bold text-green-600">∞</p>
+                  <p className="text-[10px] text-gray-400">3-month avg is positive</p>
+                </>
+              )}
             </div>
           </div>
+
+          {/* Monthly historical — actuals from bank statements */}
+          {data.monthlyHistory.length > 0 && (
+            <div className="mt-4 rounded-xl border border-gray-200 bg-white">
+              <div className="flex items-center justify-between border-b border-gray-100 px-4 py-2.5">
+                <p className="text-xs font-semibold uppercase tracking-wide text-gray-500">Cash generated per month (actual)</p>
+                <p className="text-[10px] text-gray-400">From {data.monthlyHistory.length} months of bank statements</p>
+              </div>
+              <div className="overflow-x-auto">
+                <table className="w-full min-w-[640px] text-sm">
+                  <thead>
+                    <tr className="border-b bg-gray-50/50 text-left text-gray-500">
+                      <th className="px-4 py-2 font-medium">Month</th>
+                      <th className="px-4 py-2 text-right font-medium text-green-600">Cash in</th>
+                      <th className="px-4 py-2 text-right font-medium text-red-600">Cash out</th>
+                      <th className="px-4 py-2 text-right font-medium">Net generated</th>
+                      <th className="px-4 py-2 font-medium">Coverage</th>
+                    </tr>
+                  </thead>
+                  <tbody className="divide-y">
+                    {data.monthlyHistory.map((m) => {
+                      const expectedAccounts = Math.max(...data.monthlyHistory.map((x) => x.accountsReporting));
+                      const incomplete = m.accountsReporting < expectedAccounts;
+                      return (
+                        <tr key={m.month} className={`hover:bg-gray-50 ${m.netGenerated < 0 ? "bg-red-50/30" : ""}`}>
+                          <td className="px-4 py-2 text-xs font-medium text-gray-700">{m.month}</td>
+                          <td className="px-4 py-2 text-right font-mono text-xs text-green-700">+{fmtMYR(m.cashIn)}</td>
+                          <td className="px-4 py-2 text-right font-mono text-xs text-red-700">−{fmtMYR(m.cashOut)}</td>
+                          <td className={`px-4 py-2 text-right font-mono text-xs font-bold ${m.netGenerated >= 0 ? "text-green-700" : "text-red-700"}`}>
+                            {m.netGenerated >= 0 ? "+" : ""}{fmtMYR(m.netGenerated)}
+                          </td>
+                          <td className="px-4 py-2 text-[11px]">
+                            {incomplete
+                              ? <span className="text-amber-600">{m.accountsReporting}/{expectedAccounts} accounts ⚠</span>
+                              : <span className="text-gray-500">{m.accountsReporting}/{expectedAccounts} accounts</span>}
+                          </td>
+                        </tr>
+                      );
+                    })}
+                  </tbody>
+                </table>
+              </div>
+            </div>
+          )}
 
           {/* Warnings */}
           {data.warnings.length > 0 && (
@@ -220,9 +292,35 @@ export default function CashflowPage() {
             </div>
           )}
 
+          {/* Forward weekly projection — sub-header */}
+          <div className="mt-6 mb-2 flex items-center justify-between gap-2 flex-wrap">
+            <div>
+              <p className="text-xs font-semibold uppercase tracking-wide text-gray-500">Forward projection · {weeks} weeks</p>
+              <p className="text-[11px] text-gray-400">Synthetic streams + bank-flow residual. Use the {weeks}w toggle above to change horizon.</p>
+            </div>
+            <div className="flex flex-wrap items-center gap-3 text-[11px] text-gray-500">
+              {lowestWeek && (
+                <span>
+                  Lowest week: <span className={`font-mono ${lowestWeek.closing < 0 ? "text-red-600" : "text-amber-600"}`}>{fmtMYR(lowestWeek.closing)}</span>{" "}
+                  ({shortRange(lowestWeek.weekStart, lowestWeek.weekEnd)})
+                </span>
+              )}
+              {(() => {
+                const last = data.buckets[data.buckets.length-1]?.closing ?? data.openingBalance.amount;
+                const delta = last - data.openingBalance.amount;
+                return (
+                  <span>
+                    Net change over {weeks}w:{" "}
+                    <span className={`font-mono ${delta >= 0 ? "text-green-600" : "text-red-600"}`}>{delta >= 0 ? "+" : ""}{fmtMYR(delta)}</span>
+                  </span>
+                );
+              })()}
+            </div>
+          </div>
+
           {/* Chart */}
           {chartData && (
-            <div className="mt-4 rounded-xl border border-gray-200 bg-white p-4">
+            <div className="rounded-xl border border-gray-200 bg-white p-4">
               <p className="mb-2 text-xs font-medium text-gray-500">Projected closing balance</p>
               <Sparkline points={chartData.points} max={chartData.max} min={chartData.min} />
             </div>

--- a/apps/backoffice/src/app/api/finance/cashflow/route.ts
+++ b/apps/backoffice/src/app/api/finance/cashflow/route.ts
@@ -10,11 +10,16 @@ export async function GET(req: NextRequest) {
   }
 
   const weeksParam = req.nextUrl.searchParams.get("weeks");
-  const outletId = req.nextUrl.searchParams.get("outletId");
+  // Accept either ?outletId=X (legacy single) or repeated ?outlet=X for
+  // multi-filter — same convention used by /api/inventory/invoices.
+  const outletIds = [
+    ...req.nextUrl.searchParams.getAll("outlet"),
+    ...req.nextUrl.searchParams.getAll("outletId"),
+  ].filter(Boolean);
   const weeks = weeksParam ? parseInt(weeksParam, 10) : 8;
 
   try {
-    const result = await computeCashflow({ weeks, outletId });
+    const result = await computeCashflow({ weeks, outletIds });
     return NextResponse.json(result);
   } catch (err) {
     console.error("[finance/cashflow]", err);

--- a/apps/backoffice/src/lib/finance/cashflow.ts
+++ b/apps/backoffice/src/lib/finance/cashflow.ts
@@ -54,6 +54,25 @@ export type CashflowResult = {
   // statements have period info yet. Echoed back so the UI can explain
   // what "Other (bank)" represents.
   bankFlowsPerDay: { inflow: number; outflow: number; sampleDays: number } | null;
+  // Historical "cash generated per month" — straight from BankStatement
+  // period totals, consolidated across accounts. The user's primary
+  // KPI: did we generate cash or burn it last month?
+  monthlyHistory: Array<{
+    month: string;            // YYYY-MM
+    cashIn: number;           // sum of totalInflows across accounts
+    cashOut: number;          // sum of totalOutflows
+    netGenerated: number;     // cashIn - cashOut
+    accountsReporting: number; // 3 = full coverage; less = data gap
+  }>;
+  // Rolled-up averages for the headline cards. burnPerMonth is positive
+  // when the business is losing cash; runwayMonths is openingBalance /
+  // burn (only meaningful when burn > 0).
+  cashGeneration: {
+    lastMonth: { month: string; net: number } | null;
+    avg3Month: number | null;     // average net generated across last 3 full months
+    burnPerMonth: number | null;  // -avg3Month when negative; else null
+    runwayMonths: number | null;  // openingBalance / burnPerMonth
+  };
   buckets: CashflowBucket[];
   warnings: string[];
 };
@@ -456,6 +475,24 @@ export async function computeCashflow(opts: {
     runningOpening = closing;
   }
 
+  // Historical "cash generated per month" — primary KPI Finance asks
+  // about. Pulled straight from BankStatement period totals, summed
+  // across accounts. Caveat surfaced in the warnings: gross bank flows
+  // can include InterCo transfers between Celsius entities (CCSB / CCT
+  // / CCC + any 4th internal account) which inflate both sides without
+  // representing real cash generation. Outliers like Jan 2026 (CCC RM
+  // 233k outflow with no matching inflow on the other accounts) suggest
+  // a 4th internal account exists.
+  const monthlyHistory = await loadMonthlyHistory();
+  const cashGeneration = summariseCashGeneration(monthlyHistory, opening.amount);
+  const hasOutlier = monthlyHistory.some((m) => Math.abs(m.netGenerated) > 100000 && m.accountsReporting < 3 || (m.accountsReporting === 3 && Math.abs(m.netGenerated) > 100000));
+  if (hasOutlier && !isFiltered) {
+    warnings.push("One or more historical months show a net swing > RM 100k — typically an InterCo transfer to an internal account we don't yet track. Cash generation figures include these gross flows; treat outlier months with caution.");
+  }
+  if (monthlyHistory.some((m) => m.accountsReporting < 3) && !isFiltered) {
+    warnings.push("Some months have fewer than 3 reporting accounts — uploaded statement set is incomplete for those months.");
+  }
+
   return {
     asOf: ymd(today),
     weeks,
@@ -467,9 +504,78 @@ export async function computeCashflow(opts: {
     bankFlowsPerDay: bankFlows
       ? { inflow: round2(bankFlows.inflow), outflow: round2(bankFlows.outflow), sampleDays: bankFlows.sampleDays }
       : null,
+    monthlyHistory,
+    cashGeneration,
     buckets,
     warnings,
   };
+}
+
+// Pull last 12 months of BankStatement period totals, group by calendar
+// month of periodStart, and consolidate across accounts. The unique
+// (accountName, month) pairs determine `accountsReporting` so the UI
+// can flag months with incomplete statement coverage.
+async function loadMonthlyHistory(): Promise<CashflowResult["monthlyHistory"]> {
+  const since = new Date();
+  since.setMonth(since.getMonth() - 12);
+  const rows = await prisma.bankStatement.findMany({
+    where: {
+      periodStart: { not: null, gte: since },
+      totalInflows: { not: null },
+      totalOutflows: { not: null },
+    },
+    select: { accountName: true, periodStart: true, totalInflows: true, totalOutflows: true },
+    orderBy: { periodStart: "asc" },
+  });
+
+  type Bucket = { cashIn: number; cashOut: number; accounts: Set<string> };
+  const byMonth = new Map<string, Bucket>();
+  for (const r of rows) {
+    if (!r.periodStart) continue;
+    const key = `${r.periodStart.getFullYear()}-${String(r.periodStart.getMonth() + 1).padStart(2, "0")}`;
+    const b = byMonth.get(key) ?? { cashIn: 0, cashOut: 0, accounts: new Set<string>() };
+    b.cashIn += Number(r.totalInflows ?? 0);
+    b.cashOut += Number(r.totalOutflows ?? 0);
+    b.accounts.add(r.accountName ?? "__default__");
+    byMonth.set(key, b);
+  }
+
+  return Array.from(byMonth.entries())
+    .sort(([a], [b]) => a.localeCompare(b))
+    .map(([month, b]) => ({
+      month,
+      cashIn: round2(b.cashIn),
+      cashOut: round2(b.cashOut),
+      netGenerated: round2(b.cashIn - b.cashOut),
+      accountsReporting: b.accounts.size,
+    }));
+}
+
+// Last-month / 3-month-avg / runway. Excludes incomplete months (fewer
+// than the max accountsReporting we have) and the in-progress current
+// month so the headline numbers don't get distorted by partial data.
+function summariseCashGeneration(
+  history: CashflowResult["monthlyHistory"],
+  openingBalance: number,
+): CashflowResult["cashGeneration"] {
+  if (history.length === 0) {
+    return { lastMonth: null, avg3Month: null, burnPerMonth: null, runwayMonths: null };
+  }
+  const maxAccounts = Math.max(...history.map((m) => m.accountsReporting));
+  const currentMonth = new Date().toISOString().slice(0, 7); // YYYY-MM
+  const complete = history.filter(
+    (m) => m.month !== currentMonth && m.accountsReporting === maxAccounts,
+  );
+  const lastMonth = complete.length > 0
+    ? { month: complete[complete.length - 1].month, net: complete[complete.length - 1].netGenerated }
+    : null;
+  const recent3 = complete.slice(-3);
+  const avg3 = recent3.length > 0
+    ? round2(recent3.reduce((s, m) => s + m.netGenerated, 0) / recent3.length)
+    : null;
+  const burn = avg3 != null && avg3 < 0 ? -avg3 : null;
+  const runway = burn != null && burn > 0 ? round2(openingBalance / burn) : null;
+  return { lastMonth, avg3Month: avg3, burnPerMonth: burn, runwayMonths: runway };
 }
 
 function round2(n: number): number {

--- a/apps/backoffice/src/lib/finance/cashflow.ts
+++ b/apps/backoffice/src/lib/finance/cashflow.ts
@@ -47,7 +47,8 @@ export type CashflowBucket = {
 export type CashflowResult = {
   asOf: string;
   weeks: number;
-  outletId: string | null;
+  outletId: string | null;       // legacy back-compat (set when exactly 1)
+  outletIds: string[];           // canonical: empty array = all outlets
   openingBalance: { amount: number; statementDate: string | null };
   // Per-day averages derived from BankStatement period totals; null if no
   // statements have period info yet. Echoed back so the UI can explain
@@ -86,13 +87,21 @@ function addCadence(d: Date, cadence: "MONTHLY" | "QUARTERLY" | "YEARLY"): Date 
   }
 }
 
+// Build a Prisma `outletId` filter clause from the array. Empty array =
+// no scoping (all outlets). Single id = exact match. Multi = `in`.
+function outletScope(outletIds: string[]) {
+  if (outletIds.length === 0) return {};
+  if (outletIds.length === 1) return { outletId: outletIds[0] };
+  return { outletId: { in: outletIds } };
+}
+
 // Avg daily sales by day-of-week (0=Sun..6=Sat) from the last 12 weeks.
-async function dayOfWeekSalesAverages(outletId: string | null): Promise<number[]> {
+async function dayOfWeekSalesAverages(outletIds: string[]): Promise<number[]> {
   const lookbackStart = new Date(Date.now() - 12 * 7 * DAY_MS);
   const rows = await prisma.salesTransaction.findMany({
     where: {
       transactedAt: { gte: lookbackStart },
-      ...(outletId ? { outletId } : {}),
+      ...outletScope(outletIds),
     },
     select: { transactedAt: true, grossAmount: true },
   });
@@ -115,15 +124,34 @@ async function dayOfWeekSalesAverages(outletId: string | null): Promise<number[]
   });
 }
 
+// Opening balance = sum of the most-recent closing balance per account.
+// Multiple bank accounts each contribute their own latest closing; the
+// projection runs against the consolidated cash position, not whichever
+// single statement happened to be uploaded last.
 async function fetchOpeningBalance(): Promise<{ amount: number; statementDate: string | null }> {
-  const latest = await prisma.bankStatement.findFirst({
-    orderBy: { statementDate: "desc" },
+  const rows = await prisma.bankStatement.findMany({
+    orderBy: [{ accountName: "asc" }, { statementDate: "desc" }],
+    select: { accountName: true, statementDate: true, closingBalance: true },
   });
-  if (!latest) return { amount: 0, statementDate: null };
-  return {
-    amount: Number(latest.closingBalance),
-    statementDate: ymd(latest.statementDate),
-  };
+  if (rows.length === 0) return { amount: 0, statementDate: null };
+
+  // Group by accountName (null = "default"), keep first row in each group
+  // since rows are already sorted statementDate desc within each group.
+  const seen = new Set<string>();
+  const latestPerAccount: typeof rows = [];
+  for (const r of rows) {
+    const key = r.accountName ?? "__default__";
+    if (seen.has(key)) continue;
+    seen.add(key);
+    latestPerAccount.push(r);
+  }
+
+  const amount = latestPerAccount.reduce((s, r) => s + Number(r.closingBalance), 0);
+  const newest = latestPerAccount.reduce(
+    (acc, r) => (acc == null || r.statementDate > acc ? r.statementDate : acc),
+    null as Date | null,
+  );
+  return { amount, statementDate: newest ? ymd(newest) : null };
 }
 
 // Last 3 paid monthly payroll runs → average net per month.
@@ -171,10 +199,13 @@ async function projectMarketing(start: Date, end: Date): Promise<{ date: Date; a
   return out;
 }
 
-// Hybrid model — derive a per-day inflow/outflow average from recent bank
-// statements that have period totals. The cashflow then ascribes whatever
-// the synthetic model can't explain to "other (bank)". Returns null if no
-// statement carries period info yet.
+// Hybrid model — derive a per-day inflow/outflow rate from recent bank
+// statements with period totals. With multiple bank accounts each posting
+// statements covering the same calendar dates, naive sum-then-divide
+// understates the per-day rate by the number of accounts (a calendar day
+// would be triple-counted in the divisor). Group by accountName, compute
+// a per-day rate per account from its own period coverage, then sum
+// across accounts — that's the consolidated daily flow.
 async function bankFlowsPerDay(): Promise<{ inflow: number; outflow: number; sampleDays: number } | null> {
   const rows = await prisma.bankStatement.findMany({
     where: {
@@ -183,38 +214,53 @@ async function bankFlowsPerDay(): Promise<{ inflow: number; outflow: number; sam
       OR: [{ totalInflows: { not: null } }, { totalOutflows: { not: null } }],
     },
     orderBy: { statementDate: "desc" },
-    take: 8, // last ~8 weeks of statements is plenty for a stable run-rate
-    select: { periodStart: true, periodEnd: true, totalInflows: true, totalOutflows: true },
+    select: { accountName: true, periodStart: true, periodEnd: true, totalInflows: true, totalOutflows: true },
   });
   if (rows.length === 0) return null;
 
-  let totalIn = 0;
-  let totalOut = 0;
-  let totalDays = 0;
+  // Bucket by account, keep at most the last 6 statements per account so a
+  // very stale row doesn't drag the rate.
+  const byAccount = new Map<string, typeof rows>();
   for (const r of rows) {
-    if (!r.periodStart || !r.periodEnd) continue;
-    const days = Math.max(1, Math.round((r.periodEnd.getTime() - r.periodStart.getTime()) / DAY_MS) + 1);
-    totalDays += days;
-    if (r.totalInflows != null) totalIn += Number(r.totalInflows);
-    if (r.totalOutflows != null) totalOut += Number(r.totalOutflows);
+    const key = r.accountName ?? "__default__";
+    const existing = byAccount.get(key) ?? [];
+    if (existing.length >= 6) continue;
+    existing.push(r);
+    byAccount.set(key, existing);
   }
-  if (totalDays === 0) return null;
-  return {
-    inflow: totalIn / totalDays,
-    outflow: totalOut / totalDays,
-    sampleDays: totalDays,
-  };
+
+  let perDayIn = 0;
+  let perDayOut = 0;
+  let maxSpanDays = 0;
+  for (const accountRows of byAccount.values()) {
+    let acctIn = 0;
+    let acctOut = 0;
+    let acctDays = 0;
+    for (const r of accountRows) {
+      if (!r.periodStart || !r.periodEnd) continue;
+      const days = Math.max(1, Math.round((r.periodEnd.getTime() - r.periodStart.getTime()) / DAY_MS) + 1);
+      acctDays += days;
+      if (r.totalInflows != null) acctIn += Number(r.totalInflows);
+      if (r.totalOutflows != null) acctOut += Number(r.totalOutflows);
+    }
+    if (acctDays === 0) continue;
+    perDayIn += acctIn / acctDays;
+    perDayOut += acctOut / acctDays;
+    maxSpanDays = Math.max(maxSpanDays, acctDays);
+  }
+  if (maxSpanDays === 0) return null;
+  return { inflow: perDayIn, outflow: perDayOut, sampleDays: maxSpanDays };
 }
 
 // Total invoice outflow paid out over the last 4 months / total days in the
 // window — feeds the synthetic-known per-day baseline for the residual calc.
-async function historicalInvoicePerDay(outletId: string | null): Promise<number> {
+async function historicalInvoicePerDay(outletIds: string[]): Promise<number> {
   const since = new Date(Date.now() - 120 * DAY_MS);
   const rows = await prisma.invoice.findMany({
     where: {
       status: "PAID",
       paidAt: { gte: since },
-      ...(outletId ? { outletId } : {}),
+      ...outletScope(outletIds),
     },
     select: { amount: true },
   });
@@ -243,10 +289,19 @@ function expandRecurring(
 
 export async function computeCashflow(opts: {
   weeks?: number;
+  // Either a single outletId (legacy) or an outletIds array (multi-filter).
+  // Empty / null / undefined = consolidated "all outlets" view.
   outletId?: string | null;
+  outletIds?: string[];
 }): Promise<CashflowResult> {
   const weeks = Math.max(1, Math.min(26, opts.weeks ?? 8));
-  const outletId = opts.outletId ?? null;
+  // Normalise to an array; deduplicate just in case.
+  const outletIds = Array.from(
+    new Set(
+      (opts.outletIds ?? []).concat(opts.outletId ? [opts.outletId] : []).filter(Boolean) as string[],
+    ),
+  );
+  const isFiltered = outletIds.length > 0;
   const warnings: string[] = [];
 
   // Today (local midnight). Buckets start at the next Monday.
@@ -255,12 +310,14 @@ export async function computeCashflow(opts: {
   const firstMonday = startOfWeek(today);
   const horizonEnd = new Date(firstMonday.getTime() + weeks * 7 * DAY_MS - 1);
 
-  // Opening balance
+  // Opening balance — always consolidated across all bank accounts; we
+  // don't have account → outlet mapping, so per-outlet views still see
+  // the company's full cash position.
   const opening = await fetchOpeningBalance();
   if (!opening.statementDate) warnings.push("No bank statement uploaded — opening balance is RM 0.00. Upload one to get a real projection.");
 
   // Sales forecast — day-of-week averages
-  const dowAvg = await dayOfWeekSalesAverages(outletId);
+  const dowAvg = await dayOfWeekSalesAverages(outletIds);
   const dowTotal = dowAvg.reduce((a, b) => a + b, 0);
   if (dowTotal === 0) warnings.push("No StoreHub sales in the last 12 weeks for the selected scope — sales forecast is RM 0.");
 
@@ -269,7 +326,7 @@ export async function computeCashflow(opts: {
     where: {
       status: { in: ["DRAFT", "PENDING", "INITIATED", "DEPOSIT_PAID", "OVERDUE"] },
       dueDate: { gte: today, lte: horizonEnd },
-      ...(outletId ? { outletId } : {}),
+      ...outletScope(outletIds),
     },
     select: { id: true, amount: true, depositAmount: true, status: true, dueDate: true },
   });
@@ -278,22 +335,24 @@ export async function computeCashflow(opts: {
   const recurring = await prisma.recurringExpense.findMany({
     where: {
       isActive: true,
-      ...(outletId ? { OR: [{ outletId }, { outletId: null }] } : {}),
+      ...(isFiltered
+        ? { OR: [{ outletId: outletIds.length === 1 ? outletIds[0] : { in: outletIds } }, { outletId: null }] }
+        : {}),
     },
   });
 
   // Outflows — payroll + marketing (HQ-level, not outlet-split for v1)
   const payrollProjected = await projectPayroll(today, horizonEnd);
-  const marketingProjected = outletId ? [] : await projectMarketing(today, horizonEnd);
-  if (outletId && !warnings.some((w) => w.includes("marketing"))) {
-    warnings.push("Marketing run-rate is HQ-only and not allocated to outlets — it's excluded from the per-outlet view.");
+  const marketingProjected = isFiltered ? [] : await projectMarketing(today, horizonEnd);
+  if (isFiltered) {
+    warnings.push("Marketing run-rate is HQ-only and not allocated to outlets — it's excluded from the filtered view.");
   }
 
   // Hybrid residual — bank flows per day minus what the synthetic streams
   // would already cover. Only applies in "all outlets" mode since
   // BankStatement isn't outlet-tagged.
-  const bankFlows = outletId ? null : await bankFlowsPerDay();
-  if (!outletId && !bankFlows) {
+  const bankFlows = isFiltered ? null : await bankFlowsPerDay();
+  if (!isFiltered && !bankFlows) {
     warnings.push("Bank statement period totals not yet uploaded — \"Other (bank)\" residual is RM 0. Upload a CSV/Excel statement to see the gap between bank actuals and the synthetic forecast.");
   }
   let otherInPerDay = 0;
@@ -310,7 +369,7 @@ export async function computeCashflow(opts: {
       const perYear = r.cadence === "MONTHLY" ? 12 : r.cadence === "QUARTERLY" ? 4 : 1;
       return s + Number(r.amount) * perYear / 365;
     }, 0);
-    const invoicePerDayHistory = await historicalInvoicePerDay(null);
+    const invoicePerDayHistory = await historicalInvoicePerDay([]);
     const dailySyntheticOut = monthlyPayrollAvg / 30 + monthlyMarketingAvg / 30 + recurringPerDay + invoicePerDayHistory;
     otherInPerDay = Math.max(0, bankFlows.inflow - dailySalesSynthetic);
     otherOutPerDay = Math.max(0, bankFlows.outflow - dailySyntheticOut);
@@ -400,7 +459,10 @@ export async function computeCashflow(opts: {
   return {
     asOf: ymd(today),
     weeks,
-    outletId,
+    // Echo back what the API was scoped to so the page can label the result.
+    // Still legacy outletId for back-compat; outletIds is the canonical field.
+    outletId: outletIds.length === 1 ? outletIds[0] : null,
+    outletIds,
     openingBalance: opening,
     bankFlowsPerDay: bankFlows
       ? { inflow: round2(bankFlows.inflow), outflow: round2(bankFlows.outflow), sampleDays: bankFlows.sampleDays }


### PR DESCRIPTION
## Summary

After importing 3 Maybank accounts × 4 months of bank statements (Jan–Apr 2026, ~3,000 transactions, RM 1.3M each side), two compute bugs surfaced that broke the weekly view:

1. **Opening balance picked one account at random.** \`fetchOpeningBalance()\` called \`findFirst()\` so the projection ran against RM 9k or RM 21k from a single account, not the combined RM 45,914 cash position across all three business entities (CCSB / CCT / CCC).

2. **Bank flows per day were 3× understated.** With three accounts each posting roughly concurrent monthly statements, \`bankFlowsPerDay()\` summed inflow/outflow across all rows and divided by sum of period lengths — each calendar day got triple-counted in the divisor. Pre-fix: RM 4,010/day in / RM 4,574/day out. Reality: ~RM 12.6k/day in / RM 14.2k/day out.

## Fixes

### Multi-account opening
\`fetchOpeningBalance()\` now sums the latest closing per \`accountName\`. Three accounts → three latest statements → consolidated opening.

### Per-day rate
\`bankFlowsPerDay()\` groups statements by account, computes each account's own per-day rate from its own period coverage, then sums across accounts. \`sampleDays\` is now the max calendar span (typically 1–4 months), not the summed account-days.

### Multi-filter outlets
- \`/api/finance/cashflow\` accepts repeated \`?outlet=X\` (matches \`/api/inventory/invoices\` convention).
- \`computeCashflow()\` takes \`outletIds: string[]\`; legacy \`outletId\` still works (normalised into the array).
- New \`outletScope()\` helper composes the Prisma where-clause once for sales / invoices / recurring lookups.
- Cashflow page swaps the single \`<select>\` for a checkbox popover (X-button to clear, ChevronDown affordance, click-outside to dismiss). 0 selected = "All outlets" (with Other-bank residual). 1+ selected = "N outlets" / outlet name (Other-bank disabled because \`BankStatement\` isn't outlet-tagged).

## Sanity check on current dataset

\`\`\`
Combined opening (latest closing × 3 accounts): RM 45,914.47  (was RM 9k or 21k)
                                          As of: 2026-04-28
Bank inflow per day:  RM 12,608.69                            (was RM 4,010)
Bank outflow per day: RM 14,164.04                            (was RM 4,574)
Sample days used:     118
\`\`\`

These numbers come from the 11 bank statements covering Jan 1 → Apr 28 across CCSB (4384), CCT (9345), CCC (2644).

## Test plan

- [ ] /finance/cashflow loads with **opening RM 45,914** (4 cards, all populated)
- [ ] Sparkline + table show 8 weekly buckets with sane numbers
- [ ] Footer text shows "Computed from the last 118 days of bank statements (avg in RM 12,608.69/day, out RM 14,164.04/day)"
- [ ] "Other (bank)" columns now show non-zero (positive in/out residuals)
- [ ] Click outlet pill → popover opens with checkbox per outlet
- [ ] Tick 2 outlets → table redraws with sales narrowed to those outlets, marketing warning appears, Other-bank columns clear
- [ ] X button on the pill clears the filter
- [ ] /finance/recurring-expenses shows the 4 seeded rows; their outflows hit the table correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)