### PR TITLE
Bank statement InterCo offsets — accurate cash generation

### DIFF
--- a/apps/backoffice/src/app/(admin)/finance/bank-statements/page.tsx
+++ b/apps/backoffice/src/app/(admin)/finance/bank-statements/page.tsx
@@ -3,7 +3,7 @@
 import { useState } from "react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
-import { Loader2, Plus, Trash2, X, Upload, FileDown, FileSpreadsheet, AlertTriangle } from "lucide-react";
+import { Loader2, Plus, Trash2, X, Upload, FileDown, FileSpreadsheet, AlertTriangle, Pencil } from "lucide-react";
 import { useFetch } from "@/lib/use-fetch";
 
 type BankStatement = {
@@ -15,6 +15,8 @@ type BankStatement = {
   periodEnd: string | null;
   totalInflows: number | null;
   totalOutflows: number | null;
+  interCoInflows: number | null;
+  interCoOutflows: number | null;
   fileUrl: string | null;
   notes: string | null;
   uploadedBy: { id: string; name: string };
@@ -35,6 +37,7 @@ type ParseResult = {
 export default function BankStatementsPage() {
   const { data, isLoading, mutate } = useFetch<BankStatement[]>("/api/finance/bank-statements");
   const [adding, setAdding] = useState(false);
+  const [editingId, setEditingId] = useState<string | null>(null);
 
   const [accountName, setAccountName] = useState("Maybank Operating");
   const [statementDate, setStatementDate] = useState(new Date().toISOString().split("T")[0]);
@@ -43,6 +46,8 @@ export default function BankStatementsPage() {
   const [periodEnd, setPeriodEnd] = useState("");
   const [totalInflows, setTotalInflows] = useState("");
   const [totalOutflows, setTotalOutflows] = useState("");
+  const [interCoInflows, setInterCoInflows] = useState("");
+  const [interCoOutflows, setInterCoOutflows] = useState("");
   const [notes, setNotes] = useState("");
   const [fileUrl, setFileUrl] = useState<string | null>(null);
 
@@ -56,15 +61,35 @@ export default function BankStatementsPage() {
 
   const reset = () => {
     setAdding(false);
+    setEditingId(null);
     setAccountName("Maybank Operating");
     setStatementDate(new Date().toISOString().split("T")[0]);
     setClosingBalance("");
     setPeriodStart(""); setPeriodEnd("");
     setTotalInflows(""); setTotalOutflows("");
+    setInterCoInflows(""); setInterCoOutflows("");
     setNotes("");
     setFileUrl(null);
     setParseResult(null);
     setError("");
+  };
+
+  const openEdit = (s: BankStatement) => {
+    setEditingId(s.id);
+    setAccountName(s.accountName ?? "");
+    setStatementDate(s.statementDate.slice(0, 10));
+    setClosingBalance(String(s.closingBalance));
+    setPeriodStart(s.periodStart?.slice(0, 10) ?? "");
+    setPeriodEnd(s.periodEnd?.slice(0, 10) ?? "");
+    setTotalInflows(s.totalInflows == null ? "" : String(s.totalInflows));
+    setTotalOutflows(s.totalOutflows == null ? "" : String(s.totalOutflows));
+    setInterCoInflows(s.interCoInflows == null ? "" : String(s.interCoInflows));
+    setInterCoOutflows(s.interCoOutflows == null ? "" : String(s.interCoOutflows));
+    setNotes(s.notes ?? "");
+    setFileUrl(s.fileUrl);
+    setParseResult(null);
+    setError("");
+    setAdding(true);
   };
 
   // Single combined drop-and-parse handler. CSV/XLSX → parse + extract +
@@ -120,20 +145,29 @@ export default function BankStatementsPage() {
   const save = async () => {
     if (!statementDate || !closingBalance) { setError("Statement date and closing balance required"); return; }
     setSaving(true); setError("");
-    const res = await fetch("/api/finance/bank-statements", {
-      method: "POST",
+    const url = editingId ? `/api/finance/bank-statements/${editingId}` : "/api/finance/bank-statements";
+    const method = editingId ? "PATCH" : "POST";
+    const payload: Record<string, unknown> = {
+      closingBalance: parseFloat(closingBalance),
+      periodStart: periodStart || null,
+      periodEnd: periodEnd || null,
+      totalInflows: totalInflows === "" ? null : parseFloat(totalInflows),
+      totalOutflows: totalOutflows === "" ? null : parseFloat(totalOutflows),
+      interCoInflows: interCoInflows === "" ? null : parseFloat(interCoInflows),
+      interCoOutflows: interCoOutflows === "" ? null : parseFloat(interCoOutflows),
+      notes: notes || null,
+    };
+    // POST also accepts accountName + statementDate + fileUrl; PATCH ignores
+    // those (statement date / account are immutable for audit).
+    if (!editingId) {
+      payload.accountName = accountName || null;
+      payload.statementDate = statementDate;
+      payload.fileUrl = fileUrl;
+    }
+    const res = await fetch(url, {
+      method,
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({
-        accountName: accountName || null,
-        statementDate,
-        closingBalance: parseFloat(closingBalance),
-        periodStart: periodStart || null,
-        periodEnd: periodEnd || null,
-        totalInflows: totalInflows === "" ? null : parseFloat(totalInflows),
-        totalOutflows: totalOutflows === "" ? null : parseFloat(totalOutflows),
-        fileUrl,
-        notes: notes || null,
-      }),
+      body: JSON.stringify(payload),
     });
     setSaving(false);
     if (!res.ok) {
@@ -184,7 +218,7 @@ export default function BankStatementsPage() {
         </div>
       ) : (
         <div className="mt-4 rounded-xl border border-gray-200 bg-white overflow-x-auto">
-          <table className="w-full min-w-[860px] text-sm">
+          <table className="w-full min-w-[960px] text-sm">
             <thead>
               <tr className="border-b bg-gray-50/50 text-left text-gray-500">
                 <th className="px-4 py-3 font-medium">Statement Date</th>
@@ -193,6 +227,7 @@ export default function BankStatementsPage() {
                 <th className="px-4 py-3 text-right font-medium">Closing (RM)</th>
                 <th className="px-4 py-3 text-right font-medium text-green-700">Inflows</th>
                 <th className="px-4 py-3 text-right font-medium text-red-700">Outflows</th>
+                <th className="px-4 py-3 text-right font-medium text-blue-700">InterCo</th>
                 <th className="px-4 py-3 font-medium">Uploaded By</th>
                 <th className="px-4 py-3 font-medium">File</th>
                 <th className="px-4 py-3 text-right font-medium"></th>
@@ -209,6 +244,15 @@ export default function BankStatementsPage() {
                   <td className="px-4 py-3 text-right font-mono">RM {s.closingBalance.toFixed(2)}</td>
                   <td className="px-4 py-3 text-right font-mono text-xs text-green-700">{s.totalInflows == null ? "—" : `+${s.totalInflows.toFixed(2)}`}</td>
                   <td className="px-4 py-3 text-right font-mono text-xs text-red-700">{s.totalOutflows == null ? "—" : `−${s.totalOutflows.toFixed(2)}`}</td>
+                  <td className="px-4 py-3 text-right font-mono text-[11px] text-blue-700">
+                    {(s.interCoInflows ?? 0) === 0 && (s.interCoOutflows ?? 0) === 0
+                      ? <span className="text-gray-300">—</span>
+                      : <>
+                          {(s.interCoInflows ?? 0) > 0 && <div>+{(s.interCoInflows ?? 0).toFixed(2)}</div>}
+                          {(s.interCoOutflows ?? 0) > 0 && <div>−{(s.interCoOutflows ?? 0).toFixed(2)}</div>}
+                        </>
+                    }
+                  </td>
                   <td className="px-4 py-3 text-xs text-gray-500">{s.uploadedBy.name}</td>
                   <td className="px-4 py-3">
                     {s.fileUrl
@@ -217,6 +261,9 @@ export default function BankStatementsPage() {
                   </td>
                   <td className="px-4 py-3">
                     <div className="flex justify-end gap-1">
+                      <button onClick={() => openEdit(s)} className="rounded-md p-1 text-gray-400 hover:bg-gray-100 hover:text-gray-600" title="Edit">
+                        <Pencil className="h-3.5 w-3.5" />
+                      </button>
                       <button onClick={() => remove(s.id)} className="rounded-md p-1 text-gray-400 hover:bg-red-50 hover:text-red-600" title="Delete">
                         <Trash2 className="h-3.5 w-3.5" />
                       </button>
@@ -234,7 +281,7 @@ export default function BankStatementsPage() {
         <div className="fixed inset-0 z-50 flex items-end sm:items-center justify-center bg-black/60 p-0 sm:p-4" onClick={reset}>
           <div className="relative w-full max-w-md max-h-[92vh] overflow-y-auto rounded-t-xl sm:rounded-xl bg-white p-4 sm:p-5" onClick={(e) => e.stopPropagation()}>
             <div className="flex items-center justify-between mb-4">
-              <h3 className="text-base font-semibold text-gray-900">New Bank Statement</h3>
+              <h3 className="text-base font-semibold text-gray-900">{editingId ? "Edit Bank Statement" : "New Bank Statement"}</h3>
               <button onClick={reset} className="rounded-md p-1 text-gray-400 hover:bg-gray-100 hover:text-gray-600">
                 <X className="h-5 w-5" />
               </button>
@@ -311,6 +358,23 @@ export default function BankStatementsPage() {
                   </div>
                 </div>
                 <p className="text-[10px] text-gray-400">Auto-filled when you upload a CSV/Excel; you can edit before saving.</p>
+              </div>
+
+              {/* InterCo offsets — let finance carve out internal transfers
+                  so the cash-generation KPI excludes them. */}
+              <div className="rounded-lg border border-blue-100 bg-blue-50/40 p-3 space-y-3">
+                <p className="text-[11px] font-medium uppercase tracking-wide text-blue-700">InterCo offset (optional)</p>
+                <p className="text-[10px] text-blue-700/80">Portion of the totals above that was a transfer between Celsius accounts (CCSB ↔ CCT ↔ CCC ↔ any 4th internal account). Subtracted from gross flows so cash generation reflects external movement only.</p>
+                <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+                  <div>
+                    <label className="mb-1 block text-xs font-medium text-gray-600">InterCo Inflows (RM)</label>
+                    <Input type="number" step="0.01" value={interCoInflows} onChange={(e) => setInterCoInflows(e.target.value)} placeholder="Internal transfer received" />
+                  </div>
+                  <div>
+                    <label className="mb-1 block text-xs font-medium text-gray-600">InterCo Outflows (RM)</label>
+                    <Input type="number" step="0.01" value={interCoOutflows} onChange={(e) => setInterCoOutflows(e.target.value)} placeholder="Internal transfer sent" />
+                  </div>
+                </div>
               </div>
 
               <div>

--- a/apps/backoffice/src/app/api/finance/bank-statements/[id]/route.ts
+++ b/apps/backoffice/src/app/api/finance/bank-statements/[id]/route.ts
@@ -2,6 +2,52 @@ import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
 import { requireRole, AuthError } from "@/lib/auth";
 
+export async function PATCH(req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  try { await requireRole(req.headers, "ADMIN"); }
+  catch (e) {
+    if (e instanceof AuthError) return NextResponse.json({ error: e.message }, { status: e.status });
+    return NextResponse.json({ error: "Auth error" }, { status: 500 });
+  }
+  const { id } = await params;
+  let body: unknown;
+  try { body = await req.json(); } catch { return NextResponse.json({ error: "Invalid body" }, { status: 400 }); }
+  const b = (body ?? {}) as Record<string, unknown>;
+
+  // Only allow editing the fields that finance commonly needs to fix —
+  // closing balance, period totals, InterCo offsets, notes. Statement
+  // date / account name are immutable to keep audit trail.
+  const data: Record<string, unknown> = {};
+  const numericOrNull = (v: unknown) => v == null || v === "" ? null : Number(v);
+  const dateOrNull = (v: unknown) => typeof v === "string" && v ? new Date(v) : null;
+
+  if ("closingBalance" in b) data.closingBalance = numericOrNull(b.closingBalance) ?? 0;
+  if ("totalInflows" in b)    data.totalInflows = numericOrNull(b.totalInflows);
+  if ("totalOutflows" in b)   data.totalOutflows = numericOrNull(b.totalOutflows);
+  if ("interCoInflows" in b)  data.interCoInflows = numericOrNull(b.interCoInflows);
+  if ("interCoOutflows" in b) data.interCoOutflows = numericOrNull(b.interCoOutflows);
+  if ("periodStart" in b)     data.periodStart = dateOrNull(b.periodStart);
+  if ("periodEnd" in b)       data.periodEnd = dateOrNull(b.periodEnd);
+  if (typeof b.notes === "string" || b.notes === null) data.notes = (b.notes as string | null) || null;
+
+  try {
+    const updated = await prisma.bankStatement.update({
+      where: { id },
+      data,
+      include: { uploadedBy: { select: { id: true, name: true } } },
+    });
+    return NextResponse.json({
+      ...updated,
+      closingBalance: Number(updated.closingBalance),
+      totalInflows: updated.totalInflows == null ? null : Number(updated.totalInflows),
+      totalOutflows: updated.totalOutflows == null ? null : Number(updated.totalOutflows),
+      interCoInflows: updated.interCoInflows == null ? null : Number(updated.interCoInflows),
+      interCoOutflows: updated.interCoOutflows == null ? null : Number(updated.interCoOutflows),
+    });
+  } catch {
+    return NextResponse.json({ error: "Not found" }, { status: 404 });
+  }
+}
+
 export async function DELETE(req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   try { await requireRole(req.headers, "ADMIN"); }
   catch (e) {

--- a/apps/backoffice/src/app/api/finance/bank-statements/route.ts
+++ b/apps/backoffice/src/app/api/finance/bank-statements/route.ts
@@ -23,6 +23,8 @@ export async function GET(req: NextRequest) {
       closingBalance: Number(s.closingBalance),
       totalInflows: s.totalInflows == null ? null : Number(s.totalInflows),
       totalOutflows: s.totalOutflows == null ? null : Number(s.totalOutflows),
+      interCoInflows: s.interCoInflows == null ? null : Number(s.interCoInflows),
+      interCoOutflows: s.interCoOutflows == null ? null : Number(s.interCoOutflows),
     })),
   );
 }
@@ -40,11 +42,13 @@ export async function POST(req: NextRequest) {
   const {
     accountName, statementDate, closingBalance, fileUrl, notes,
     periodStart, periodEnd, totalInflows, totalOutflows,
+    interCoInflows, interCoOutflows,
   } = (body ?? {}) as {
     accountName?: string | null; statementDate?: string;
     closingBalance?: number | string; fileUrl?: string | null; notes?: string | null;
     periodStart?: string | null; periodEnd?: string | null;
     totalInflows?: number | string | null; totalOutflows?: number | string | null;
+    interCoInflows?: number | string | null; interCoOutflows?: number | string | null;
   };
 
   if (!statementDate || closingBalance == null) {
@@ -61,6 +65,8 @@ export async function POST(req: NextRequest) {
       closingBalance: Number(closingBalance),
       periodStart: periodStart ? new Date(periodStart) : null,
       periodEnd: periodEnd ? new Date(periodEnd) : null,
+      interCoInflows: interCoInflows == null || interCoInflows === "" ? null : Number(interCoInflows),
+      interCoOutflows: interCoOutflows == null || interCoOutflows === "" ? null : Number(interCoOutflows),
       totalInflows: totalInflows == null || totalInflows === "" ? null : Number(totalInflows),
       totalOutflows: totalOutflows == null || totalOutflows === "" ? null : Number(totalOutflows),
       fileUrl: fileUrl || null,
@@ -76,6 +82,8 @@ export async function POST(req: NextRequest) {
       closingBalance: Number(created.closingBalance),
       totalInflows: created.totalInflows == null ? null : Number(created.totalInflows),
       totalOutflows: created.totalOutflows == null ? null : Number(created.totalOutflows),
+      interCoInflows: created.interCoInflows == null ? null : Number(created.interCoInflows),
+      interCoOutflows: created.interCoOutflows == null ? null : Number(created.interCoOutflows),
     },
     { status: 201 },
   );

--- a/apps/backoffice/src/lib/finance/cashflow.ts
+++ b/apps/backoffice/src/lib/finance/cashflow.ts
@@ -55,13 +55,17 @@ export type CashflowResult = {
   // what "Other (bank)" represents.
   bankFlowsPerDay: { inflow: number; outflow: number; sampleDays: number } | null;
   // Historical "cash generated per month" — straight from BankStatement
-  // period totals, consolidated across accounts. The user's primary
-  // KPI: did we generate cash or burn it last month?
+  // period totals, consolidated across accounts. cashIn/cashOut are
+  // gross; netGenerated subtracts any InterCo offset Finance has marked
+  // so internal transfers don't distort the KPI. The user's primary
+  // question: did we generate cash or burn it last month?
   monthlyHistory: Array<{
     month: string;            // YYYY-MM
-    cashIn: number;           // sum of totalInflows across accounts
-    cashOut: number;          // sum of totalOutflows
-    netGenerated: number;     // cashIn - cashOut
+    cashIn: number;           // gross totalInflows across accounts
+    cashOut: number;          // gross totalOutflows
+    interCoInflows: number;   // marked InterCo portion of cashIn
+    interCoOutflows: number;  // marked InterCo portion of cashOut
+    netGenerated: number;     // (cashIn - interCoIn) - (cashOut - interCoOut)
     accountsReporting: number; // 3 = full coverage; less = data gap
   }>;
   // Rolled-up averages for the headline cards. burnPerMonth is positive
@@ -233,7 +237,11 @@ async function bankFlowsPerDay(): Promise<{ inflow: number; outflow: number; sam
       OR: [{ totalInflows: { not: null } }, { totalOutflows: { not: null } }],
     },
     orderBy: { statementDate: "desc" },
-    select: { accountName: true, periodStart: true, periodEnd: true, totalInflows: true, totalOutflows: true },
+    select: {
+      accountName: true, periodStart: true, periodEnd: true,
+      totalInflows: true, totalOutflows: true,
+      interCoInflows: true, interCoOutflows: true,
+    },
   });
   if (rows.length === 0) return null;
 
@@ -259,8 +267,13 @@ async function bankFlowsPerDay(): Promise<{ inflow: number; outflow: number; sam
       if (!r.periodStart || !r.periodEnd) continue;
       const days = Math.max(1, Math.round((r.periodEnd.getTime() - r.periodStart.getTime()) / DAY_MS) + 1);
       acctDays += days;
-      if (r.totalInflows != null) acctIn += Number(r.totalInflows);
-      if (r.totalOutflows != null) acctOut += Number(r.totalOutflows);
+      // Subtract InterCo flows so the bank-residual rate reflects only
+      // external cash movement (sales receipts, supplier payments, etc),
+      // not internal transfers between Celsius entities.
+      const ico_in = r.interCoInflows == null ? 0 : Number(r.interCoInflows);
+      const ico_out = r.interCoOutflows == null ? 0 : Number(r.interCoOutflows);
+      if (r.totalInflows != null)  acctIn  += Math.max(0, Number(r.totalInflows)  - ico_in);
+      if (r.totalOutflows != null) acctOut += Math.max(0, Number(r.totalOutflows) - ico_out);
     }
     if (acctDays === 0) continue;
     perDayIn += acctIn / acctDays;
@@ -477,17 +490,18 @@ export async function computeCashflow(opts: {
 
   // Historical "cash generated per month" — primary KPI Finance asks
   // about. Pulled straight from BankStatement period totals, summed
-  // across accounts. Caveat surfaced in the warnings: gross bank flows
-  // can include InterCo transfers between Celsius entities (CCSB / CCT
-  // / CCC + any 4th internal account) which inflate both sides without
-  // representing real cash generation. Outliers like Jan 2026 (CCC RM
-  // 233k outflow with no matching inflow on the other accounts) suggest
-  // a 4th internal account exists.
+  // across accounts. When BankStatement.interCoInflows/Outflows are set
+  // we subtract them from gross flows so the net excludes internal
+  // transfers between Celsius entities — without that, a transfer to
+  // an internal account we don't track shows as "cash burned" when
+  // it isn't.
   const monthlyHistory = await loadMonthlyHistory();
   const cashGeneration = summariseCashGeneration(monthlyHistory, opening.amount);
-  const hasOutlier = monthlyHistory.some((m) => Math.abs(m.netGenerated) > 100000 && m.accountsReporting < 3 || (m.accountsReporting === 3 && Math.abs(m.netGenerated) > 100000));
-  if (hasOutlier && !isFiltered) {
-    warnings.push("One or more historical months show a net swing > RM 100k — typically an InterCo transfer to an internal account we don't yet track. Cash generation figures include these gross flows; treat outlier months with caution.");
+  const unflaggedOutlier = monthlyHistory.find(
+    (m) => Math.abs(m.netGenerated) > 100000 && (m.interCoInflows ?? 0) === 0 && (m.interCoOutflows ?? 0) === 0,
+  );
+  if (unflaggedOutlier && !isFiltered) {
+    warnings.push(`${unflaggedOutlier.month} net was ${unflaggedOutlier.netGenerated >= 0 ? "+" : ""}RM ${Math.round(unflaggedOutlier.netGenerated).toLocaleString()} — likely an InterCo transfer. Edit that month's statement and fill in the InterCo offset to exclude it from cash generation.`);
   }
   if (monthlyHistory.some((m) => m.accountsReporting < 3) && !isFiltered) {
     warnings.push("Some months have fewer than 3 reporting accounts — uploaded statement set is incomplete for those months.");
@@ -524,31 +538,43 @@ async function loadMonthlyHistory(): Promise<CashflowResult["monthlyHistory"]> {
       totalInflows: { not: null },
       totalOutflows: { not: null },
     },
-    select: { accountName: true, periodStart: true, totalInflows: true, totalOutflows: true },
+    select: {
+      accountName: true, periodStart: true,
+      totalInflows: true, totalOutflows: true,
+      interCoInflows: true, interCoOutflows: true,
+    },
     orderBy: { periodStart: "asc" },
   });
 
-  type Bucket = { cashIn: number; cashOut: number; accounts: Set<string> };
+  type Bucket = { cashIn: number; cashOut: number; icoIn: number; icoOut: number; accounts: Set<string> };
   const byMonth = new Map<string, Bucket>();
   for (const r of rows) {
     if (!r.periodStart) continue;
     const key = `${r.periodStart.getFullYear()}-${String(r.periodStart.getMonth() + 1).padStart(2, "0")}`;
-    const b = byMonth.get(key) ?? { cashIn: 0, cashOut: 0, accounts: new Set<string>() };
+    const b = byMonth.get(key) ?? { cashIn: 0, cashOut: 0, icoIn: 0, icoOut: 0, accounts: new Set<string>() };
     b.cashIn += Number(r.totalInflows ?? 0);
     b.cashOut += Number(r.totalOutflows ?? 0);
+    if (r.interCoInflows  != null) b.icoIn  += Number(r.interCoInflows);
+    if (r.interCoOutflows != null) b.icoOut += Number(r.interCoOutflows);
     b.accounts.add(r.accountName ?? "__default__");
     byMonth.set(key, b);
   }
 
   return Array.from(byMonth.entries())
     .sort(([a], [b]) => a.localeCompare(b))
-    .map(([month, b]) => ({
-      month,
-      cashIn: round2(b.cashIn),
-      cashOut: round2(b.cashOut),
-      netGenerated: round2(b.cashIn - b.cashOut),
-      accountsReporting: b.accounts.size,
-    }));
+    .map(([month, b]) => {
+      const adjustedIn  = Math.max(0, b.cashIn  - b.icoIn);
+      const adjustedOut = Math.max(0, b.cashOut - b.icoOut);
+      return {
+        month,
+        cashIn: round2(b.cashIn),
+        cashOut: round2(b.cashOut),
+        interCoInflows: round2(b.icoIn),
+        interCoOutflows: round2(b.icoOut),
+        netGenerated: round2(adjustedIn - adjustedOut),
+        accountsReporting: b.accounts.size,
+      };
+    });
 }
 
 // Last-month / 3-month-avg / runway. Excludes incomplete months (fewer

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -1362,6 +1362,14 @@ model BankStatement {
   periodEnd      DateTime?
   totalInflows   Decimal?  @db.Decimal(12, 2)
   totalOutflows  Decimal?  @db.Decimal(12, 2)
+  // Portion of totalInflows / totalOutflows that represents InterCo
+  // transfers between Celsius entities (CCSB / CCT / CCC / any 4th
+  // internal account). When finance fills these in, the cash-generation
+  // KPI subtracts them from both sides so internal movement doesn't
+  // distort the net. Without these, a transfer to an account we don't
+  // track shows as "cash burned" when it isn't.
+  interCoInflows  Decimal? @db.Decimal(12, 2)
+  interCoOutflows Decimal? @db.Decimal(12, 2)
   fileUrl        String?  // optional source file (CSV / Excel / PDF)
   notes          String?
   uploadedById   String


### PR DESCRIPTION
## Summary

Follow-up to #107. While loading 4 months × 3 accounts of Maybank statements, **Jan 2026 showed −RM 161k net cash generated** — but CCC's RM 233k outflow had no matching inflow on CCSB or CCT. Strong signal that a 4th internal account (Investments / holdings) exists and the RM 100k+ "missing" outflow is an InterCo transfer, not real cash burn.

Without a way to flag those, the cash-generation KPI shows **runway: 0.66 months** when reality is much longer.

## What this PR adds

### Schema
- \`BankStatement.interCoInflows\` / \`interCoOutflows\` — Decimal(12,2), nullable. Portion of totalInflows / totalOutflows on that statement that was a transfer between Celsius entities. Migration applied to Supabase.

### Compute
- \`loadMonthlyHistory()\` returns the InterCo split per month and computes \`netGenerated = (cashIn − icoIn) − (cashOut − icoOut)\`. Flagged InterCo nets out of the KPI.
- \`bankFlowsPerDay()\` subtracts InterCo before averaging so the weekly Other-bank residual stays clean.
- "Outlier" warning now only fires for months where >RM 100k swing has ZERO InterCo flagged. Once finance fills the offset, the warning disappears.

### API
- \`POST /api/finance/bank-statements\` accepts \`interCoInflows\` / \`Outflows\`.
- New \`PATCH /api/finance/bank-statements/:id\` for editing existing rows (closing, period totals, InterCo, notes). Account name + statement date stay immutable for audit.
- GET response includes the new fields.

### UI
- New "InterCo offset (optional)" panel in the bank-statement form with a clear note about which transfers count.
- Edit pencil button on each row → reopens the form pre-filled with that statement's data.
- New InterCo column on the list showing +inflows / −outflows.
- Form dialog title swaps "New Bank Statement" → "Edit Bank Statement" in edit mode.

## Test plan

- [ ] Load /finance/bank-statements → InterCo column shows "—" for all 11 existing rows
- [ ] Click pencil on the Jan 2026 CCC statement → form opens with totals + period pre-filled, account name + statement date locked, InterCo fields empty
- [ ] Type \`233000\` in InterCo Outflows for that row, save → row reloads with the offset visible
- [ ] /finance/cashflow → Jan 2026 row shows reduced net (closer to zero), 3-month avg shifts up, runway becomes more realistic, the "Jan 2026 net was..." warning disappears
- [ ] Cashflow forward projection's Other-bank residual recomputes lower since InterCo is no longer counted as bank outflow
- [ ] Try to PATCH \`accountName\` or \`statementDate\` via API → those fields are silently ignored (only the editable fields apply)

## Follow-up (not in this PR)

- **4th account upload** — once the missing internal account's statements come in, the InterCo flow is captured automatically by consolidation across accounts and these manual offset fields become a fallback for legacy rows.
- **GastroHub & other RecurringIncome** — separate PR (table + UI for predictable inflows like GastroHub RM 3.3k/week, Meetings & Events, InterCo, Management fee).

🤖 Generated with [Claude Code](https://claude.com/claude-code)