### PR TITLE
Cash tracking + bank-line projection (OWNER/ADMIN)

### DIFF
--- a/apps/backoffice/scripts/backfill-bank-lines-pdf.ts
+++ b/apps/backoffice/scripts/backfill-bank-lines-pdf.ts
@@ -1,0 +1,282 @@
+/* eslint-disable @typescript-eslint/no-require-imports */
+// Backfill BankStatementLine rows from Maybank PDF statements.
+//
+// Strategy: shell out to `pdftotext -layout`, then parse the columnar
+// output. Maybank PDF transaction blocks are typically 4 lines:
+//
+//   "    DD/MM    DESCRIPTION_LINE_1                ...   AMOUNT[+-]   BALANCE"
+//   "                                                vendor name      "
+//   "                                                reference no     "
+//   "                                                outlet hint      "
+//
+// Trailing "+" on the amount = credit (money in), "-" = debit (money out).
+// Some single-line types (e.g. "CMS - CR PYMT MARS") have no continuation.
+//
+// Year resolution: filename ends YYYY-MM-DD (period end). Most rows are
+// within the same calendar month, but a Jan statement may include
+// "31/12" rows from December — those get the previous year.
+//
+// Usage:
+//   cd apps/backoffice
+//   ../../node_modules/.bin/tsx scripts/backfill-bank-lines-pdf.ts
+
+import { PrismaClient } from "@prisma/client";
+import { execFileSync } from "node:child_process";
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+import { classifyBankLine } from "../src/lib/finance/bank-line-classifier";
+
+const prisma = new PrismaClient();
+
+// Maybank account number → BankStatement.accountName mapping
+const ACCOUNT_MAP: Record<string, string> = {
+  "562263574384": "Maybank CCSB (HQ - 4384)",
+  "562263659345": "Maybank CCT (Tamarind - 9345)",
+  "562263662644": "Maybank CCC (Conezion - 2644)",
+};
+
+// Roots to scan recursively for MBBcurrent_*_YYYY-MM-DD.pdf
+const PDF_ROOT = path.resolve(process.env.HOME!, "Desktop/Celsius Coffee/Claude Reports/Maybank Bank Statement");
+
+function findPdfs(root: string): string[] {
+  const out: string[] = [];
+  if (!fs.existsSync(root)) return out;
+  const stack = [root];
+  while (stack.length) {
+    const dir = stack.pop()!;
+    const entries = fs.readdirSync(dir, { withFileTypes: true });
+    for (const e of entries) {
+      const p = path.join(dir, e.name);
+      if (e.isDirectory()) stack.push(p);
+      else if (e.isFile() && /^MBBcurrent_\d+_\d{4}-\d{2}-\d{2}/.test(e.name)) out.push(p);
+    }
+  }
+  return out;
+}
+
+function parsePdfFilename(filename: string): { accountNo: string; periodEnd: Date } | null {
+  const m = filename.match(/MBBcurrent_(\d+)_(\d{4})-(\d{2})-(\d{2})/);
+  if (!m) return null;
+  return {
+    accountNo: m[1],
+    periodEnd: new Date(Date.UTC(parseInt(m[2], 10), parseInt(m[3], 10) - 1, parseInt(m[4], 10))),
+  };
+}
+
+type ParsedLine = {
+  txnDate: Date;
+  description: string;
+  reference: string | null;
+  amount: number;
+  direction: "CR" | "DR";
+};
+
+function parseAmount(s: string): number {
+  return parseFloat(s.replace(/,/g, ""));
+}
+
+function parsePdfText(text: string, statementYear: number, statementMonth: number): ParsedLine[] {
+  const lines = text.split(/\r?\n/);
+  // Match a transaction header row:
+  //    DD/MM    DESCRIPTION_TEXT (variable)   AMOUNT(+/-)   BALANCE
+  // The amount has trailing + (credit) or - (debit). Balance has no sign
+  // unless the account is overdrawn (rare).
+  const HEADER_RE = /^\s{2,}(\d{2})\/(\d{2})\s+(.+?)\s+([\d,]+\.\d{2})([+\-])\s+([\d,]+\.\d{2})\s*$/;
+  // Continuation rows: heavily-indented text, no leading date column.
+  const CONT_RE = /^\s{20,}(\S.*?)\s*$/;
+
+  const out: ParsedLine[] = [];
+  let pending: ParsedLine | null = null;
+  let pendingDescParts: string[] = [];
+
+  const flush = () => {
+    if (pending) {
+      pending.description = pendingDescParts.join(" ").replace(/\s+/g, " ").trim();
+      // Heuristic: the second-to-last continuation line (when present)
+      // is usually the reference number — pull it out.
+      const parts = pendingDescParts;
+      if (parts.length >= 2) {
+        // Try to detect a reference from parts[1] — alphanumeric refs
+        // like "INV-2509253", "144672", "365IN2512-0074".
+        const candidate = parts[1].trim();
+        if (/^[A-Z0-9][A-Z0-9_/\-.]+$/i.test(candidate) && candidate.length >= 4) {
+          pending.reference = candidate;
+        }
+      }
+      out.push(pending);
+    }
+    pending = null;
+    pendingDescParts = [];
+  };
+
+  for (let i = 0; i < lines.length; i++) {
+    const ln = lines[i];
+    const h = ln.match(HEADER_RE);
+    if (h) {
+      flush();
+      const day = parseInt(h[1], 10);
+      const month = parseInt(h[2], 10);
+      // Year handling: most rows match statementMonth/statementYear.
+      // When the row's month > statementMonth (e.g. Dec 31 row in a
+      // January statement), it's the previous year.
+      let year = statementYear;
+      if (month > statementMonth) year = statementYear - 1;
+      // Sanity: future-dated rows shouldn't appear; if month < statementMonth - 11
+      // we'd cross a year boundary the other way (rare, ignore for now).
+      const txnDate = new Date(Date.UTC(year, month - 1, day));
+      const amount = parseAmount(h[4]);
+      const sign = h[5];
+      const direction: "CR" | "DR" = sign === "+" ? "CR" : "DR";
+      pending = {
+        txnDate,
+        description: "",
+        reference: null,
+        amount,
+        direction,
+      };
+      pendingDescParts = [h[3].trim()];
+      continue;
+    }
+    const c = ln.match(CONT_RE);
+    if (c && pending) {
+      const t = c[1].trim();
+      // Skip footer/header noise that sometimes leaks through:
+      if (/^(BAKI|LEDGER|ENDING BALANCE|BEGINNING BALANCE|TOTAL DEBIT|TOTAL CREDIT|MUKA|TARIKH|NOMBOR|BUTIR|TRANSACTION|ENTRY|VALUE|JUMLAH|银碼|=|Wang|Overdrawn|PROTECTED|NOT|If|To)/i.test(t)) {
+        continue;
+      }
+      // Skip lines that are mostly punctuation/equals
+      if (/^[=\-_*\s]+$/.test(t)) continue;
+      pendingDescParts.push(t);
+      continue;
+    }
+    // Blank line — keep pending alive (continuations may resume after)
+  }
+  flush();
+
+  return out;
+}
+
+async function main() {
+  const pdfs = findPdfs(PDF_ROOT);
+  console.log(`Found ${pdfs.length} PDFs under ${PDF_ROOT}`);
+
+  // Build outlet code → id map once
+  const outlets = await prisma.outlet.findMany({ select: { id: true, code: true } });
+  const codeToId = new Map(outlets.map((o) => [o.code, o.id]));
+
+  let totalInserted = 0;
+  let totalSkippedNoStatement = 0;
+
+  for (const pdfPath of pdfs.sort()) {
+    const meta = parsePdfFilename(path.basename(pdfPath));
+    if (!meta) { console.warn(`[skip] unparseable filename ${pdfPath}`); continue; }
+    const accountName = ACCOUNT_MAP[meta.accountNo];
+    if (!accountName) { console.warn(`[skip] no account map for ${meta.accountNo}`); continue; }
+
+    // Find the matching BankStatement (use periodEnd from filename to
+    // map to the statement record — same period mapping the totals were
+    // ingested with).
+    const periodStart = new Date(Date.UTC(meta.periodEnd.getUTCFullYear(), meta.periodEnd.getUTCMonth(), 1));
+    const statement = await prisma.bankStatement.findFirst({
+      where: { accountName, periodStart },
+      select: { id: true, accountName: true, periodStart: true, periodEnd: true },
+    });
+    if (!statement) {
+      console.warn(`[skip] no BankStatement for ${accountName} ${periodStart.toISOString().slice(0,10)}`);
+      totalSkippedNoStatement++;
+      continue;
+    }
+
+    // Skip if this statement already has lines (preserves the April CSV
+    // ingest from the prior backfill). Use deleteMany only when the
+    // current line set is clearly stale or you want to re-classify.
+    const existing = await prisma.bankStatementLine.count({ where: { statementId: statement.id } });
+    if (existing > 0) {
+      console.log(`[skip] ${accountName} ${periodStart.toISOString().slice(0,10)} already has ${existing} lines — preserving`);
+      continue;
+    }
+
+    // pdftotext --layout for columnar preservation
+    const tmpFile = `/tmp/maybank-pdf-${Date.now()}.txt`;
+    try {
+      execFileSync("pdftotext", ["-layout", pdfPath, tmpFile], { stdio: "ignore" });
+    } catch (err) {
+      console.warn(`[skip] pdftotext failed for ${pdfPath}: ${err instanceof Error ? err.message : err}`);
+      continue;
+    }
+    const text = fs.readFileSync(tmpFile, "utf-8");
+    fs.unlinkSync(tmpFile);
+
+    const statementYear = meta.periodEnd.getUTCFullYear();
+    const statementMonth = meta.periodEnd.getUTCMonth() + 1;
+    const parsed = parsePdfText(text, statementYear, statementMonth);
+
+    if (parsed.length === 0) {
+      console.warn(`[empty] ${accountName} ${periodStart.toISOString().slice(0,10)} — no parseable transactions in PDF`);
+      continue;
+    }
+
+    type LineData = {
+      statementId: string;
+      txnDate: Date;
+      description: string;
+      reference: string | null;
+      amount: number;
+      direction: "CR" | "DR";
+      category: string | null;
+      outletId: string | null;
+      isInterCo: boolean;
+      classifiedBy: string;
+      ruleName: string;
+    };
+
+    const data: LineData[] = parsed.map((p) => {
+      const cls = classifyBankLine({
+        description: p.description,
+        reference: p.reference,
+        amount: p.amount,
+        direction: p.direction,
+        accountKey: accountName,
+      });
+      return {
+        statementId: statement.id,
+        txnDate: p.txnDate,
+        description: p.description,
+        reference: p.reference,
+        amount: p.amount,
+        direction: p.direction,
+        category: cls.category,
+        outletId: cls.outletCode ? codeToId.get(cls.outletCode) ?? null : null,
+        isInterCo: cls.isInterCo,
+        classifiedBy: "rule",
+        ruleName: cls.ruleName,
+      };
+    });
+
+    const result = await prisma.bankStatementLine.createMany({ data: data as never });
+    totalInserted += result.count;
+    console.log(`[ok] ${accountName} ${periodStart.toISOString().slice(0,10)}: parsed ${parsed.length} txns, inserted ${result.count}`);
+  }
+
+  // Summary by category × month
+  const summary = await prisma.bankStatementLine.groupBy({
+    by: ["category", "direction"],
+    _count: { _all: true },
+    _sum: { amount: true },
+  });
+  console.log("\n--- Category summary (all months) ---");
+  for (const s of summary.sort((a, b) => (a.category ?? "").localeCompare(b.category ?? ""))) {
+    const dir = s.direction === "CR" ? "in " : "out";
+    const amt = Number(s._sum.amount ?? 0);
+    console.log(`  ${dir} ${(s.category ?? "—").padEnd(28)} ${String(s._count._all).padStart(5)}  RM ${amt.toFixed(2)}`);
+  }
+
+  console.log(`\nTotal inserted: ${totalInserted}, statements without record: ${totalSkippedNoStatement}`);
+  await prisma.$disconnect();
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/apps/backoffice/scripts/backfill-bank-lines.ts
+++ b/apps/backoffice/scripts/backfill-bank-lines.ts
@@ -1,0 +1,181 @@
+/* eslint-disable @typescript-eslint/no-require-imports */
+// One-shot backfill — reads the 3 Maybank pipe-delimited CSV exports,
+// classifies each line, and inserts into BankStatementLine for the
+// matching April 2026 BankStatement records.
+//
+// Usage:
+//   cd apps/backoffice
+//   pnpm dlx tsx scripts/backfill-bank-lines.ts
+//
+// Maybank CSV format (pipe-delimited, 22 columns):
+//   BATCH DATE | ACCOUNT NO. | PROD TYPE | EFFECT DATE | EFFECT TIME |
+//   BRANCH | TELLER | CODE | SOURCE CODE | AMOUNT | AMOUNT IND |
+//   TRX DESCRIPTION | TRX REFERENCE | STD REF IND | STD REF1..3 | FILLER1..5
+//
+// Amount is sen, padded to 15 digits (000000000005201 = RM 52.01).
+
+import { PrismaClient } from "@prisma/client";
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+import { classifyBankLine } from "../src/lib/finance/bank-line-classifier";
+
+const prisma = new PrismaClient();
+
+// Account number → BankStatement period filter (account name)
+const ACCOUNT_MAP: Record<string, { accountName: string }> = {
+  "0000562263574384": { accountName: "Maybank CCSB (HQ - 4384)" },
+  "0000562263659345": { accountName: "Maybank CCT (Tamarind - 9345)" },
+  "0000562263662644": { accountName: "Maybank CCC (Conezion - 2644)" },
+};
+
+const CSV_FILES: Array<{ path: string; accountNo: string }> = [
+  { path: path.resolve(process.env.HOME!, "Downloads/ACCOUNTACTIVITYREPORT_562263574384 CCSB.csv"), accountNo: "0000562263574384" },
+  { path: path.resolve(process.env.HOME!, "Downloads/ACCOUNTACTIVITYREPORT_562263659345 CCT.csv"),  accountNo: "0000562263659345" },
+  { path: path.resolve(process.env.HOME!, "Downloads/ACCOUNTACTIVITYREPORT_562263662644 CCC.csv"),  accountNo: "0000562263662644" },
+];
+
+function parseDateYYYYMMDD(s: string): Date | null {
+  if (!/^\d{8}$/.test(s)) return null;
+  const y = parseInt(s.slice(0, 4), 10);
+  const m = parseInt(s.slice(4, 6), 10) - 1;
+  const d = parseInt(s.slice(6, 8), 10);
+  const dt = new Date(Date.UTC(y, m, d));
+  return isNaN(dt.getTime()) ? null : dt;
+}
+
+function parseSenAmount(s: string): number {
+  // Strip leading zeros, divide by 100 to get RM.
+  const n = parseInt(s.replace(/^0+/, "") || "0", 10);
+  return n / 100;
+}
+
+async function main() {
+  let totalInserted = 0;
+  let totalSkipped = 0;
+
+  for (const csv of CSV_FILES) {
+    if (!fs.existsSync(csv.path)) {
+      console.warn(`[skip] missing ${csv.path}`);
+      continue;
+    }
+    const accountInfo = ACCOUNT_MAP[csv.accountNo];
+    if (!accountInfo) {
+      console.warn(`[skip] no account map for ${csv.accountNo}`);
+      continue;
+    }
+
+    // Find the April 2026 BankStatement for this account.
+    const statement = await prisma.bankStatement.findFirst({
+      where: {
+        accountName: accountInfo.accountName,
+        periodStart: new Date("2026-04-01"),
+      },
+      select: { id: true, accountName: true },
+    });
+    if (!statement) {
+      console.warn(`[skip] no April 2026 BankStatement for ${accountInfo.accountName}`);
+      continue;
+    }
+
+    // Wipe any pre-existing lines for idempotency.
+    const wiped = await prisma.bankStatementLine.deleteMany({ where: { statementId: statement.id } });
+    if (wiped.count > 0) console.log(`[reset] dropped ${wiped.count} existing lines for ${statement.accountName}`);
+
+    const text = fs.readFileSync(csv.path, "utf-8");
+    const rows = text.split(/\r?\n/);
+
+    // Outlet code → id lookup (cache once).
+    const outlets = await prisma.outlet.findMany({ select: { id: true, code: true } });
+    const codeToId = new Map(outlets.map((o) => [o.code, o.id]));
+
+    type LineData = {
+      statementId: string;
+      txnDate: Date;
+      description: string;
+      reference: string | null;
+      amount: number;
+      direction: "CR" | "DR";
+      category: string | null;
+      outletId: string | null;
+      isInterCo: boolean;
+      classifiedBy: string;
+      ruleName: string;
+    };
+    const data: LineData[] = [];
+
+    for (let i = 0; i < rows.length; i++) {
+      const row = rows[i];
+      if (!row) continue;
+      // Skip header
+      if (row.startsWith("BATCH DATE")) continue;
+
+      const cols = row.split("|");
+      if (cols.length < 13) continue;
+
+      const effectDate = parseDateYYYYMMDD(cols[3]);
+      if (!effectDate) continue;
+      const amount = parseSenAmount(cols[9]);
+      if (amount <= 0) continue;
+      const ind = cols[10]?.trim();
+      const direction: "CR" | "DR" = ind === "CR" ? "CR" : ind === "DR" ? "DR" : (() => { throw new Error(`unknown ind ${ind}`); })();
+      const description = (cols[11] ?? "").trim();
+      const reference = (cols[12] ?? "").trim() || null;
+
+      const cls = classifyBankLine({
+        description,
+        reference,
+        amount,
+        direction,
+        accountKey: accountInfo.accountName,
+      });
+
+      data.push({
+        statementId: statement.id,
+        txnDate: effectDate,
+        description,
+        reference,
+        amount,
+        direction,
+        category: cls.category,
+        outletId: cls.outletCode ? (codeToId.get(cls.outletCode) ?? null) : null,
+        isInterCo: cls.isInterCo,
+        classifiedBy: "rule",
+        ruleName: cls.ruleName,
+      });
+    }
+
+    if (data.length === 0) {
+      console.log(`[empty] ${statement.accountName} — no parseable lines`);
+      continue;
+    }
+
+    // createMany doesn't accept enum strings without coercion — fine in this
+    // raw shape since Prisma will validate on insert.
+    const result = await prisma.bankStatementLine.createMany({ data: data as never });
+    totalInserted += result.count;
+    totalSkipped += (data.length - result.count);
+    console.log(`[ok] ${statement.accountName}: inserted ${result.count} lines (${data.length - result.count} skipped)`);
+  }
+
+  // Summary by category
+  const summary = await prisma.bankStatementLine.groupBy({
+    by: ["category", "direction"],
+    _count: { _all: true },
+    _sum: { amount: true },
+  });
+  console.log("\n--- Category summary ---");
+  for (const s of summary.sort((a, b) => (a.category ?? "").localeCompare(b.category ?? ""))) {
+    const dir = s.direction === "CR" ? "in " : "out";
+    const amt = Number(s._sum.amount ?? 0);
+    console.log(`  ${dir} ${(s.category ?? "—").padEnd(28)} ${String(s._count._all).padStart(5)}  RM ${amt.toFixed(2)}`);
+  }
+
+  console.log(`\nTotal inserted: ${totalInserted}, skipped: ${totalSkipped}`);
+  await prisma.$disconnect();
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/apps/backoffice/src/app/(admin)/finance/bank-statements/page.tsx
+++ b/apps/backoffice/src/app/(admin)/finance/bank-statements/page.tsx
@@ -23,6 +23,14 @@ type BankStatement = {
   createdAt: string;
 };
 
+type ParsedLine = {
+  txnDate: string;
+  description: string;
+  reference: string | null;
+  amount: number;
+  direction: "CR" | "DR";
+};
+
 type ParseResult = {
   totalInflows: number;
   totalOutflows: number;
@@ -32,6 +40,7 @@ type ParseResult = {
   warnings: string[];
   fileName: string;
   fileSize: number;
+  lines: ParsedLine[];
 };
 
 export default function BankStatementsPage() {
@@ -163,6 +172,9 @@ export default function BankStatementsPage() {
       payload.accountName = accountName || null;
       payload.statementDate = statementDate;
       payload.fileUrl = fileUrl;
+      // Forward parsed line items so the server can classify + persist
+      // BankStatementLine rows. Only present when a CSV/XLSX was parsed.
+      if (parseResult?.lines?.length) payload.lines = parseResult.lines;
     }
     const res = await fetch(url, {
       method,

--- a/apps/backoffice/src/app/(admin)/finance/cash-tracking/page.tsx
+++ b/apps/backoffice/src/app/(admin)/finance/cash-tracking/page.tsx
@@ -1,0 +1,312 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import Link from "next/link";
+import { useFetch } from "@/lib/use-fetch";
+import { Loader2, ChevronLeft } from "lucide-react";
+
+type Outlet = { id: string; code: string; name: string; isHQ: boolean };
+
+type CashMatrix = {
+  outlets: Outlet[];
+  months: string[];
+  cells: Record<string, number>;     // "category|outletId|YYYY-MM" → signed amount
+  monthTotals: Record<string, number>;
+  categoryMonthTotals: Record<string, Record<string, number>>;
+  categories: string[];
+};
+
+// Friendly category labels — matches Finance's spreadsheet exactly so the
+// page reads like the existing artefact.
+const CATEGORY_LABELS: Record<string, string> = {
+  CARD: "Card",
+  QR: "QR (DuitNow)",
+  STOREHUB: "StoreHub",
+  GRAB: "Grab",
+  GRAB_PUTRAJAYA: "Grab (Putrajaya)",
+  FOODPANDA: "Foodpanda",
+  MEETINGS_EVENTS: "Meetings & Events",
+  GASTROHUB: "GastroHub",
+  CAPITAL: "Capital injection",
+  MANAGEMENT_FEE: "Management fee",
+  ADTD: "AD/TD",
+  OTHER_INFLOW: "Other inflow",
+  RAW_MATERIALS: "Raw materials",
+  DELIVERY: "Delivery",
+  DIRECTORS_ALLOWANCE: "Directors' allowance",
+  EMPLOYEE_SALARY: "Employee salary",
+  PARTIMER: "Part-timers",
+  STATUTORY_PAYMENT: "Statutory (EPF/SOCSO)",
+  STAFF_CLAIM: "Staff claim",
+  PETTY_CASH: "Petty cash",
+  MARKETPLACE_FEE: "Marketplace fee",
+  DIGITAL_ADS: "Digital ads",
+  KOL: "KOL",
+  OTHER_MARKETING: "Other marketing",
+  RENT: "Rent",
+  UTILITIES: "Utilities",
+  SOFTWARE: "Software",
+  CFS_FEE: "CFS fee",
+  COMPLIANCE: "Compliance",
+  TAX: "Tax",
+  LICENSING_FEE: "Licensing fee",
+  ROYALTY_FEE: "Royalty fee",
+  LOAN: "Loan",
+  BANK_FEE: "Bank fee",
+  EQUIPMENTS: "Equipments",
+  MAINTENANCE: "Maintenance",
+  INVESTMENTS: "Investments",
+  INTERCO_PEOPLE: "InterCo (people)",
+  INTERCO_RAW_MATERIAL: "InterCo (raw mat)",
+  INTERCO_INVESTMENTS: "InterCo (investments)",
+  INTERCO_EXPENSES: "InterCo (expenses)",
+  TRANSFER_NOT_SUCCESSFUL: "Transfer not successful",
+  OTHER_OUTFLOW: "Other outflow",
+};
+
+// Category bands — used to group rows + insert subtotal rows so the
+// matrix reads in the same shape as Finance's spreadsheet.
+const BANDS: Array<{ label: string; categories: string[]; tone: "in" | "out" }> = [
+  { label: "Inflows", tone: "in", categories: [
+    "CARD", "QR", "STOREHUB", "GRAB", "GRAB_PUTRAJAYA", "FOODPANDA",
+    "MEETINGS_EVENTS", "GASTROHUB", "CAPITAL", "MANAGEMENT_FEE", "ADTD", "OTHER_INFLOW",
+  ]},
+  { label: "COGS", tone: "out", categories: ["RAW_MATERIALS", "DELIVERY"] },
+  { label: "Labour", tone: "out", categories: [
+    "DIRECTORS_ALLOWANCE", "EMPLOYEE_SALARY", "PARTIMER", "STATUTORY_PAYMENT", "STAFF_CLAIM", "PETTY_CASH",
+  ]},
+  { label: "Marketing", tone: "out", categories: ["MARKETPLACE_FEE", "DIGITAL_ADS", "KOL", "OTHER_MARKETING"] },
+  { label: "Property & Ops", tone: "out", categories: ["RENT", "UTILITIES", "SOFTWARE"] },
+  { label: "Compliance & Finance", tone: "out", categories: [
+    "CFS_FEE", "COMPLIANCE", "TAX", "LICENSING_FEE", "ROYALTY_FEE", "LOAN", "BANK_FEE",
+  ]},
+  { label: "Capex / Capital", tone: "out", categories: ["EQUIPMENTS", "MAINTENANCE", "INVESTMENTS"] },
+  { label: "InterCo", tone: "out", categories: [
+    "INTERCO_PEOPLE", "INTERCO_RAW_MATERIAL", "INTERCO_INVESTMENTS", "INTERCO_EXPENSES",
+  ]},
+  { label: "Catch-all", tone: "out", categories: ["TRANSFER_NOT_SUCCESSFUL", "OTHER_OUTFLOW"] },
+];
+
+function fmtMYR(n: number, opts?: { showZero?: boolean }): string {
+  if (n === 0 && !opts?.showZero) return "—";
+  return new Intl.NumberFormat("en-MY", { maximumFractionDigits: 0 }).format(n);
+}
+
+function monthLabel(m: string): string {
+  // m = YYYY-MM
+  const [y, mo] = m.split("-").map((s) => parseInt(s, 10));
+  const d = new Date(y, mo - 1, 1);
+  return d.toLocaleString("en-MY", { month: "short", year: "2-digit" });
+}
+
+export default function CashTrackingPage() {
+  const [monthsBack, setMonthsBack] = useState(6);
+  const [activeOutletId, setActiveOutletId] = useState<string | null>(null); // null = all
+  const [includeInterCo, setIncludeInterCo] = useState(true);
+
+  const params = new URLSearchParams({ months: String(monthsBack) });
+  if (activeOutletId) params.set("outlet", activeOutletId);
+  if (!includeInterCo) params.set("includeInterCo", "false");
+
+  const { data, isLoading } = useFetch<CashMatrix>(`/api/finance/cash-tracking?${params.toString()}`);
+
+  const visibleBands = useMemo(() => {
+    if (!data) return [];
+    const present = new Set(data.categories);
+    return BANDS
+      .map((b) => ({ ...b, categories: b.categories.filter((c) => present.has(c)) }))
+      .filter((b) => b.categories.length > 0);
+  }, [data]);
+
+  return (
+    <div className="p-3 sm:p-6">
+      <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+        <div>
+          <Link href="/finance/cashflow" className="inline-flex items-center gap-1 text-xs text-gray-500 hover:text-gray-700">
+            <ChevronLeft className="h-3 w-3" /> Cashflow
+          </Link>
+          <h2 className="mt-1 text-lg sm:text-xl font-semibold text-gray-900">Cash Tracking</h2>
+          <p className="mt-0.5 text-xs sm:text-sm text-gray-500">
+            Per-outlet × category × month breakdown. Sourced from classified bank statement lines — values mirror Finance&rsquo;s cash-tracking spreadsheet.
+          </p>
+        </div>
+        <div className="flex flex-wrap items-center gap-2">
+          <label className="flex items-center gap-1.5 rounded-md border border-gray-200 bg-white px-3 py-1.5 text-xs text-gray-700">
+            <input
+              type="checkbox"
+              checked={includeInterCo}
+              onChange={(e) => setIncludeInterCo(e.target.checked)}
+              className="rounded border-gray-300 text-terracotta focus:ring-terracotta"
+            />
+            Include InterCo
+          </label>
+          <div className="flex rounded-lg border border-gray-200 bg-white p-0.5">
+            {[3, 6, 12].map((m) => (
+              <button
+                key={m}
+                onClick={() => setMonthsBack(m)}
+                className={`rounded-md px-2.5 py-1 text-xs font-medium transition-colors ${monthsBack === m ? "bg-terracotta text-white" : "text-gray-600 hover:bg-gray-50"}`}
+              >
+                {m}m
+              </button>
+            ))}
+          </div>
+        </div>
+      </div>
+
+      {isLoading || !data ? (
+        <div className="mt-6 flex justify-center py-12"><Loader2 className="h-5 w-5 animate-spin text-gray-400" /></div>
+      ) : data.outlets.length === 0 || data.months.length === 0 ? (
+        <div className="mt-6 rounded-lg border border-dashed border-gray-300 bg-gray-50 px-4 py-8 text-center">
+          <p className="text-sm text-gray-500">No classified bank statement lines yet.</p>
+          <p className="mt-1 text-xs text-gray-400">
+            Upload a CSV/Excel statement on the <Link href="/finance/bank-statements" className="text-terracotta hover:underline">Bank Statements</Link> page — lines will be auto-classified and appear here.
+          </p>
+        </div>
+      ) : (
+        <>
+          {/* Outlet tabs — All + each outlet (incl. HQ pseudo) */}
+          <div className="mt-4 flex flex-wrap gap-1.5">
+            <button
+              onClick={() => setActiveOutletId(null)}
+              className={`rounded-md border px-3 py-1.5 text-xs font-medium transition-colors ${activeOutletId === null ? "border-terracotta bg-terracotta text-white" : "border-gray-200 bg-white text-gray-700 hover:bg-gray-50"}`}
+            >
+              All outlets
+            </button>
+            {data.outlets.map((o) => (
+              <button
+                key={o.id}
+                onClick={() => setActiveOutletId(o.id)}
+                className={`rounded-md border px-3 py-1.5 text-xs font-medium transition-colors ${activeOutletId === o.id ? "border-terracotta bg-terracotta text-white" : "border-gray-200 bg-white text-gray-700 hover:bg-gray-50"} ${o.isHQ ? "italic" : ""}`}
+              >
+                {o.name}
+              </button>
+            ))}
+          </div>
+
+          {/* Matrix table */}
+          <div className="mt-3 overflow-x-auto rounded-lg border border-gray-200 bg-white">
+            <table className="min-w-full text-xs">
+              <thead className="bg-gray-50 text-gray-600">
+                <tr>
+                  <th className="sticky left-0 z-10 bg-gray-50 px-3 py-2 text-left font-medium">Category</th>
+                  {data.months.map((m) => (
+                    <th key={m} className="px-3 py-2 text-right font-medium tabular-nums">{monthLabel(m)}</th>
+                  ))}
+                </tr>
+              </thead>
+              <tbody>
+                {visibleBands.map((band) => {
+                  const bandSubtotalByMonth: Record<string, number> = {};
+                  for (const m of data.months) {
+                    let sum = 0;
+                    for (const c of band.categories) {
+                      sum += getCellValue(data, c, activeOutletId, m);
+                    }
+                    bandSubtotalByMonth[m] = sum;
+                  }
+                  return (
+                    <BandSection
+                      key={band.label}
+                      band={band}
+                      months={data.months}
+                      cells={data.cells}
+                      activeOutletId={activeOutletId}
+                      outlets={data.outlets}
+                      subtotal={bandSubtotalByMonth}
+                    />
+                  );
+                })}
+                {/* Grand total */}
+                <tr className="border-t-2 border-gray-300 bg-gray-50 font-semibold">
+                  <td className="sticky left-0 z-10 bg-gray-50 px-3 py-2 text-gray-900">Net cash flow</td>
+                  {data.months.map((m) => {
+                    const total = activeOutletId
+                      ? totalForOutletMonth(data, activeOutletId, m)
+                      : (data.monthTotals[m] ?? 0);
+                    return (
+                      <td key={m} className={`px-3 py-2 text-right tabular-nums ${total >= 0 ? "text-green-700" : "text-red-700"}`}>
+                        {fmtMYR(total, { showZero: true })}
+                      </td>
+                    );
+                  })}
+                </tr>
+              </tbody>
+            </table>
+          </div>
+
+          <p className="mt-2 text-[11px] text-gray-400">
+            Inflows shown positive · outflows negative · empty cells dashed · &ldquo;HQ / unallocated&rdquo; holds payments paid centrally that aren&rsquo;t outlet-tagged.
+          </p>
+        </>
+      )}
+    </div>
+  );
+}
+
+function getCellValue(data: CashMatrix, category: string, activeOutletId: string | null, month: string): number {
+  if (activeOutletId) {
+    return data.cells[`${category}|${activeOutletId}|${month}`] ?? 0;
+  }
+  // Consolidated: sum across all outlets
+  let s = 0;
+  for (const o of data.outlets) {
+    s += data.cells[`${category}|${o.id}|${month}`] ?? 0;
+  }
+  return s;
+}
+
+function totalForOutletMonth(data: CashMatrix, outletId: string, month: string): number {
+  let s = 0;
+  for (const c of data.categories) {
+    s += data.cells[`${c}|${outletId}|${month}`] ?? 0;
+  }
+  return s;
+}
+
+function BandSection({
+  band, months, cells, activeOutletId, outlets, subtotal,
+}: {
+  band: { label: string; tone: "in" | "out"; categories: string[] };
+  months: string[];
+  cells: CashMatrix["cells"];
+  activeOutletId: string | null;
+  outlets: Outlet[];
+  subtotal: Record<string, number>;
+}) {
+  return (
+    <>
+      <tr className={`${band.tone === "in" ? "bg-green-50" : "bg-red-50"}`}>
+        <td className={`sticky left-0 z-10 ${band.tone === "in" ? "bg-green-50" : "bg-red-50"} px-3 py-1 text-[11px] font-semibold uppercase tracking-wide ${band.tone === "in" ? "text-green-800" : "text-red-800"}`}>
+          {band.label}
+        </td>
+        {months.map((m) => (
+          <td key={m} className={`px-3 py-1 text-right text-[11px] font-semibold tabular-nums ${band.tone === "in" ? "text-green-800" : "text-red-800"}`}>
+            {fmtMYR(subtotal[m] ?? 0)}
+          </td>
+        ))}
+      </tr>
+      {band.categories.map((c) => (
+        <tr key={c} className="border-t border-gray-100 hover:bg-gray-50">
+          <td className="sticky left-0 z-10 bg-white px-3 py-1.5 text-gray-700">
+            <span className="ml-2">{CATEGORY_LABELS[c] ?? c}</span>
+          </td>
+          {months.map((m) => {
+            let v: number;
+            if (activeOutletId) {
+              v = cells[`${c}|${activeOutletId}|${m}`] ?? 0;
+            } else {
+              v = 0;
+              for (const o of outlets) v += cells[`${c}|${o.id}|${m}`] ?? 0;
+            }
+            return (
+              <td key={m} className={`px-3 py-1.5 text-right tabular-nums ${v === 0 ? "text-gray-300" : v > 0 ? "text-green-700" : "text-red-700"}`}>
+                {fmtMYR(v)}
+              </td>
+            );
+          })}
+        </tr>
+      ))}
+    </>
+  );
+}

--- a/apps/backoffice/src/app/(admin)/layout.tsx
+++ b/apps/backoffice/src/app/(admin)/layout.tsx
@@ -60,6 +60,7 @@ import {
   CalendarOff,
   Flame,
   Banknote,
+  TableProperties,
   Bot,
   Sun,
   Moon,
@@ -210,6 +211,7 @@ const NAV_SECTIONS: NavSection[] = [
       // OWNER/ADMIN regardless of moduleAccess, so the section won't render
       // in the rail for managers/staff.
       { label: "Cashflow", href: "/finance/cashflow", icon: <LineChart className={ICON_SIZE} />, moduleKey: "finance:cashflow" },
+      { label: "Cash Tracking", href: "/finance/cash-tracking", icon: <TableProperties className={ICON_SIZE} />, moduleKey: "finance:cash-tracking" },
       { label: "Bank Statements", href: "/finance/bank-statements", icon: <Banknote className={ICON_SIZE} />, moduleKey: "finance:bank-statements" },
       { label: "Recurring Expenses", href: "/finance/recurring-expenses", icon: <CalendarClock className={ICON_SIZE} />, moduleKey: "finance:recurring-expenses" },
     ],

--- a/apps/backoffice/src/app/api/finance/bank-statements/route.ts
+++ b/apps/backoffice/src/app/api/finance/bank-statements/route.ts
@@ -1,9 +1,21 @@
 import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
 import { requireRole, AuthError } from "@/lib/auth";
+import { classifyBankLine } from "@/lib/finance/bank-line-classifier";
 
 // Bank statements are uploaded periodically by Finance — typically weekly.
 // The most recent row is the opening balance for the cashflow projection.
+// When CSV/XLSX lines are forwarded from the parser, each row is auto-
+// classified into a CashCategory and persisted as a BankStatementLine —
+// these power the cash-tracking matrix and the per-category projection.
+
+type IncomingLine = {
+  txnDate: string;
+  description: string;
+  reference: string | null;
+  amount: number;
+  direction: "CR" | "DR";
+};
 
 export async function GET(req: NextRequest) {
   try { await requireRole(req.headers, "ADMIN"); }
@@ -42,13 +54,14 @@ export async function POST(req: NextRequest) {
   const {
     accountName, statementDate, closingBalance, fileUrl, notes,
     periodStart, periodEnd, totalInflows, totalOutflows,
-    interCoInflows, interCoOutflows,
+    interCoInflows, interCoOutflows, lines,
   } = (body ?? {}) as {
     accountName?: string | null; statementDate?: string;
     closingBalance?: number | string; fileUrl?: string | null; notes?: string | null;
     periodStart?: string | null; periodEnd?: string | null;
     totalInflows?: number | string | null; totalOutflows?: number | string | null;
     interCoInflows?: number | string | null; interCoOutflows?: number | string | null;
+    lines?: IncomingLine[];
   };
 
   if (!statementDate || closingBalance == null) {
@@ -76,6 +89,46 @@ export async function POST(req: NextRequest) {
     include: { uploadedBy: { select: { id: true, name: true } } },
   });
 
+  // Classify + persist lines if the parser forwarded any. Best-effort —
+  // a failure here doesn't roll back the statement (Finance can re-upload
+  // or hand-classify in the cash-tracking edit UI).
+  let linesCreated = 0;
+  if (Array.isArray(lines) && lines.length > 0) {
+    // Map outlet codes once up front
+    const outlets = await prisma.outlet.findMany({ select: { id: true, code: true } });
+    const codeToId = new Map(outlets.map((o) => [o.code, o.id]));
+
+    const data = lines
+      .filter((l) => l && l.txnDate && l.amount > 0 && (l.direction === "CR" || l.direction === "DR"))
+      .map((l) => {
+        const cls = classifyBankLine({
+          description: l.description ?? "",
+          reference: l.reference ?? null,
+          amount: l.amount,
+          direction: l.direction,
+          accountKey: accountName ?? undefined,
+        });
+        return {
+          statementId: created.id,
+          txnDate: new Date(l.txnDate),
+          description: l.description ?? "",
+          reference: l.reference ?? null,
+          amount: Number(l.amount),
+          direction: l.direction,
+          category: cls.category,
+          outletId: cls.outletCode ? codeToId.get(cls.outletCode) ?? null : null,
+          isInterCo: cls.isInterCo,
+          classifiedBy: "rule",
+          ruleName: cls.ruleName,
+        };
+      });
+
+    if (data.length > 0) {
+      const result = await prisma.bankStatementLine.createMany({ data, skipDuplicates: true });
+      linesCreated = result.count;
+    }
+  }
+
   return NextResponse.json(
     {
       ...created,
@@ -84,6 +137,7 @@ export async function POST(req: NextRequest) {
       totalOutflows: created.totalOutflows == null ? null : Number(created.totalOutflows),
       interCoInflows: created.interCoInflows == null ? null : Number(created.interCoInflows),
       interCoOutflows: created.interCoOutflows == null ? null : Number(created.interCoOutflows),
+      linesCreated,
     },
     { status: 201 },
   );

--- a/apps/backoffice/src/app/api/finance/cash-tracking/route.ts
+++ b/apps/backoffice/src/app/api/finance/cash-tracking/route.ts
@@ -1,0 +1,34 @@
+import { NextRequest, NextResponse } from "next/server";
+import { requireRole, AuthError } from "@/lib/auth";
+import { loadCashTrackingMatrix } from "@/lib/finance/cash-tracking";
+
+// Returns the per-outlet × category × month matrix sourced from
+// classified BankStatementLine rows. OWNER/ADMIN only — finance:* is
+// gated at the role level upstream.
+
+export async function GET(req: NextRequest) {
+  try { await requireRole(req.headers, "ADMIN"); }
+  catch (e) {
+    if (e instanceof AuthError) return NextResponse.json({ error: e.message }, { status: e.status });
+    return NextResponse.json({ error: "Auth error" }, { status: 500 });
+  }
+
+  const sp = req.nextUrl.searchParams;
+  const monthsBack = sp.get("months") ? parseInt(sp.get("months")!, 10) : 6;
+  const outletIds = [
+    ...sp.getAll("outlet"),
+    ...sp.getAll("outletId"),
+  ].filter(Boolean);
+  const includeInterCo = sp.get("includeInterCo") !== "false";
+
+  try {
+    const matrix = await loadCashTrackingMatrix({ monthsBack, outletIds, includeInterCo });
+    return NextResponse.json(matrix);
+  } catch (err) {
+    console.error("[finance/cash-tracking]", err);
+    return NextResponse.json(
+      { error: err instanceof Error ? err.message : "Cash tracking compute failed" },
+      { status: 500 },
+    );
+  }
+}

--- a/apps/backoffice/src/lib/finance/bank-line-classifier.ts
+++ b/apps/backoffice/src/lib/finance/bank-line-classifier.ts
@@ -1,0 +1,199 @@
+// Auto-classifier for bank statement lines. Maps a transaction description
+// (and amount, direction, account) to one of the CashCategory buckets used
+// by the cash-tracking spreadsheet framework.
+//
+// Rules are ordered by specificity — first match wins. Each rule returns a
+// category, optional outlet hint, optional InterCo flag. Description is
+// pre-trimmed and uppercased before matching.
+//
+// Coverage target: ~80% of Maybank current-account transactions on the
+// first pass. The remaining 20% — usually one-off vendor payments — are
+// expected to be hand-classified via the cash-tracking edit UI.
+
+import type { CashCategory } from "@celsius/db";
+
+type Direction = "CR" | "DR";
+
+export type ClassifyInput = {
+  description: string;
+  reference?: string | null;
+  amount: number;
+  direction: Direction;
+  // Account this line came from. Used as a fallback for outlet inference
+  // when the description doesn't carry an outlet prefix (e.g. EPF Payment).
+  accountKey?: string;
+};
+
+export type ClassifyResult = {
+  category: CashCategory | null;
+  outletCode: string | null;   // resolved to outletId by the caller
+  isInterCo: boolean;
+  ruleName: string;
+};
+
+// Outlet-prefix conventions in Maybank descriptions:
+//   "CelsiusCoffee SA" / "CELSIUSCOFFEE SA"   → Shah Alam
+//   "CelsiusCoffee N"                          → Nilai
+//   "CelsiusCoffee P" / "CONEZION PUTRAJAYA"   → Conezion (Putrajaya)
+//   "CelsiusCoffee C" / "CELSIUSCOFFEE C"      → Conezion
+//   "CelsiusCoffee T" / "TAMARIND"             → Tamarind
+//   No prefix or "CelsiusCoffee" alone          → HQ-level / unattributed
+//
+// Outlet codes returned here match the Outlet.code values used elsewhere.
+function inferOutlet(desc: string): string | null {
+  if (/\bTAMARIND\b/i.test(desc) || /\bCELSIUSCOFFEE\s*T\b/i.test(desc)) return "CC003";
+  if (/\bCONEZION\b/i.test(desc) || /\bCELSIUSCOFFEE\s*C\b/i.test(desc)) return "CC001";
+  if (/\bCELSIUSCOFFEE\s*SA\b/i.test(desc)) return null;       // Shah Alam — outlet code unknown to me
+  if (/\bCELSIUSCOFFEE\s*N\b/i.test(desc)) return null;        // Nilai — same
+  if (/\bCELSIUSCOFFEE\s*P\b/i.test(desc)) return "CC001";     // Putrajaya = Conezion in current data
+  return null;
+}
+
+type Rule = {
+  name: string;
+  // Match on description (case-insensitive) — string substring or regex.
+  match: RegExp;
+  // Optional direction filter — only apply when transaction is CR or DR.
+  direction?: Direction;
+  category: CashCategory;
+  isInterCo?: boolean;
+};
+
+// Inflow rules
+const INFLOW_RULES: Rule[] = [
+  // InterCo inbound — credit from another Celsius entity. Match BEFORE
+  // generic vendor rules so internal transfers don't get classified as
+  // sales or other revenue. Match only the full entity names
+  // ("CELSIUS COFFEE SDN", "...CONEZION", "...TAMARIND") — these are the
+  // legal entities, not the outlet prefixes ("CelsiusCoffee SA" etc).
+  { name: "interco_in_celsius_entity", match: /\bCELSIUS\s*COFFEE\s+(SDN|CONEZION|TAMARIND)\b/i, direction: "CR", category: "INTERCO_PEOPLE" as CashCategory, isInterCo: true },
+
+  // QR — DuitNow QR transactions. Two formats:
+  //   "DUITNOW QR-         <NAME>"
+  //   "<7-digit>Q                             *<long ref>"
+  { name: "qr_duitnow_named", match: /\bDUITNOW QR\b/i, direction: "CR", category: "QR" as CashCategory },
+  { name: "qr_qcode",         match: /\b\d{7,}Q\b/,     direction: "CR", category: "QR" as CashCategory },
+
+  // Card — "DR/CARD SALES M/N <ref>" — debit/credit terminal settlements
+  { name: "card_terminal", match: /\bDR\/?CARD\s*SALES?\b/i, direction: "CR", category: "CARD" as CashCategory },
+  // GHL terminal settlement — "IBG TRANSACTION DMS A3 (FOR GHL)"
+  { name: "card_ghl_settlement", match: /\bDMS\s*A3\b.*\bGHL\b|\bFOR\s*GHL\b/i, direction: "CR", category: "CARD" as CashCategory },
+
+  // StoreHub — Interbank GIRO from STOREHUB SDN BHD
+  { name: "storehub", match: /\bSTOREHUB\b/i, direction: "CR", category: "STOREHUB" as CashCategory },
+
+  // Grab — GPAY NETWORK / GRAB
+  { name: "grab", match: /\b(GPAY NETWORK|GRAB(?!FOOD))\b/i, direction: "CR", category: "GRAB" as CashCategory },
+
+  // Foodpanda — DELIVERY HERO / FOODPANDA / DH MALAYSIA
+  { name: "foodpanda", match: /\b(FOODPANDA|DELIVERY HERO|DH MALAYSIA)\b/i, direction: "CR", category: "FOODPANDA" as CashCategory },
+
+  // GastroHub — GYRO GASTRO SDN BHD weekly settlement
+  { name: "gastrohub", match: /\bGYRO\s*GASTRO\b/i, direction: "CR", category: "GASTROHUB" as CashCategory },
+
+  // Meetings & Events — KIDDYTOPIA, EVENT, CATERING, etc.
+  { name: "meetings_kiddytopia", match: /\bKIDDYTOPIA\b/i, direction: "CR", category: "MEETINGS_EVENTS" as CashCategory },
+];
+
+// Outflow rules
+const OUTFLOW_RULES: Rule[] = [
+  // InterCo outbound — payment to another Celsius entity. Match BEFORE
+  // vendor rules so internal transfers don't get tagged as RAW_MATERIALS
+  // or similar. Restrict to the full entity names
+  // ("CELSIUS COFFEE SDN", "...CONEZION", "...TAMARIND") — outlet
+  // prefixes alone don't qualify.
+  { name: "interco_out_celsius_entity", match: /\bCELSIUS\s*COFFEE\s+(SDN|CONEZION|TAMARIND)\b/i, direction: "DR", category: "INTERCO_PEOPLE" as CashCategory, isInterCo: true },
+
+  // Statutory — EPF / SOCSO / EIS / KWSP / PERKESO / LHDN tax
+  { name: "statutory_epf",   match: /\b(EPF|KWSP|M2UBEPF)\b/i,            direction: "DR", category: "STATUTORY_PAYMENT" as CashCategory },
+  { name: "statutory_socso", match: /\b(SOCSO|PERKESO|SIP)\b/i,            direction: "DR", category: "STATUTORY_PAYMENT" as CashCategory },
+  { name: "tax_lhdn",        match: /\b(LHDN|INLAND REVENUE|HASIL)\b/i,    direction: "DR", category: "TAX" as CashCategory },
+
+  // Rent — known landlords. Add to this list as new outlets onboard.
+  { name: "rent_tujuan_gemilang",     match: /\bTUJUAN\s*GEMILANG\b/i,    direction: "DR", category: "RENT" as CashCategory },
+  { name: "rent_mayang_development",  match: /\bMAYANG\s*DEVELOPMENT\b/i, direction: "DR", category: "RENT" as CashCategory },
+  // Generic property-management hints
+  { name: "rent_properties_sdn_bhd",  match: /\bPROPERTIES\s*SDN\s*BHD\b/i, direction: "DR", category: "RENT" as CashCategory },
+  { name: "rent_holdings_sdn_bhd",    match: /\bHOLDINGS\s*SDN\s*BHD\b/i,   direction: "DR", category: "RENT" as CashCategory },
+  { name: "rent_hartanah",            match: /\bHARTANAH\b/i,               direction: "DR", category: "RENT" as CashCategory },
+
+  // Utilities — TNB / AIR / IWK / TM / MAXIS / DIGI / UNIFI
+  { name: "util_tnb",       match: /\bTNB\b|\bTENAGA NASIONAL\b/i, direction: "DR", category: "UTILITIES" as CashCategory },
+  { name: "util_water",     match: /\b(AIR\s+(SELANGOR|PUTRAJAYA|JOHOR|MELAKA)|INDAH WATER|IWK)\b/i, direction: "DR", category: "UTILITIES" as CashCategory },
+  { name: "util_telco",     match: /\b(MAXIS|DIGI|UNIFI|TM\s|CELCOM|U MOBILE)\b/i, direction: "DR", category: "UTILITIES" as CashCategory },
+
+  // Software / SaaS subscriptions
+  { name: "software_saas",  match: /\b(GOOGLE|MICROSOFT|ADOBE|FIGMA|NOTION|SLACK|ZOOM|AWS|VERCEL|CLAUDE|ANTHROPIC|OPENAI)\b/i, direction: "DR", category: "SOFTWARE" as CashCategory },
+  { name: "software_pos",   match: /\b(STOREHUB|XERO|BUKKU|QUICKBOOKS|HUBSPOT)\b/i, direction: "DR", category: "SOFTWARE" as CashCategory },
+
+  // Loan repayments
+  { name: "loan_payment",   match: /\b(LOAN\s*PAYMENT|FINANCING|HIRE\s*PURCHASE)\b/i, direction: "DR", category: "LOAN" as CashCategory },
+
+  // Bank fees
+  { name: "bank_fee",       match: /\b(SERVICE\s*FEE|HANDLING\s*FEE|BANK\s*CHARGE|MAINTENANCE\s*FEE|GIRO\s*FEE)\b/i, direction: "DR", category: "BANK_FEE" as CashCategory },
+
+  // Marketing — Digital Ads, KOL, content
+  { name: "marketing_digital_ads_meta",  match: /\b(META PLATFORMS|FACEBOOK|INSTAGRAM)\b/i, direction: "DR", category: "DIGITAL_ADS" as CashCategory },
+  { name: "marketing_digital_ads_google",match: /\bGOOGLE\s*ADS\b/i,         direction: "DR", category: "DIGITAL_ADS" as CashCategory },
+  { name: "marketing_pxl",               match: /\bPXL\s*MARKETING\b/i,       direction: "DR", category: "DIGITAL_ADS" as CashCategory },
+
+  // Marketplace fees — GrabFood / FP commissions
+  { name: "marketplace_grab_fee",        match: /\bGRABFOOD\s*COMMISSION\b/i, direction: "DR", category: "MARKETPLACE_FEE" as CashCategory },
+
+  // Partimer payouts — descriptions usually contain "PT Week" or "Partimer"
+  { name: "partimer",       match: /\bPT\s*WEEK\b|\bPARTIMER\b/i, direction: "DR", category: "PARTIMER" as CashCategory },
+
+  // Employee Salary — descriptions like "Salary Nov", "SCC_11/25", direct salary transfers
+  { name: "salary_explicit",match: /\bSALARY\b/i,                  direction: "DR", category: "EMPLOYEE_SALARY" as CashCategory },
+  { name: "salary_scc",     match: /\bSCC[_ ]\d+\/\d+\b/i,         direction: "DR", category: "EMPLOYEE_SALARY" as CashCategory },
+
+  // Directors Allowance — RM 40,000 to Ammar Bin Shahrin (per Apr 2026 pattern)
+  { name: "directors_ammar",match: /\bAMMAR\s*BIN\s*SHAHRIN\b/i,  direction: "DR", category: "DIRECTORS_ALLOWANCE" as CashCategory },
+
+  // Raw Materials — known F&B suppliers (extend as new vendors onboard)
+  { name: "raw_aryzta",      match: /\bARYZTA\b/i,                 direction: "DR", category: "RAW_MATERIALS" as CashCategory },
+  { name: "raw_erul",        match: /\bERUL\s*FOOD\b/i,            direction: "DR", category: "RAW_MATERIALS" as CashCategory },
+  { name: "raw_tmm",         match: /\bTMM\s*RESOURCES\b/i,        direction: "DR", category: "RAW_MATERIALS" as CashCategory },
+  { name: "raw_nyc",         match: /\bNYC\s*TREATS\b/i,           direction: "DR", category: "RAW_MATERIALS" as CashCategory },
+  { name: "raw_global_coffee",match: /\bGLOBAL\s*COFFEE\b/i,       direction: "DR", category: "RAW_MATERIALS" as CashCategory },
+  { name: "raw_js_breadserie",match: /\bJS\s*BREADSERIE\b/i,       direction: "DR", category: "RAW_MATERIALS" as CashCategory },
+  { name: "raw_365eat",      match: /\b365EAT\s*FOOD\b/i,          direction: "DR", category: "RAW_MATERIALS" as CashCategory },
+  { name: "raw_dankoff",     match: /\bDANKOFF\b/i,                direction: "DR", category: "RAW_MATERIALS" as CashCategory },
+  { name: "raw_blancoz",     match: /\bBLANCOZ\b/i,                direction: "DR", category: "RAW_MATERIALS" as CashCategory },
+  { name: "raw_yow_seng",    match: /\bYOW\s*SENG\b/i,             direction: "DR", category: "RAW_MATERIALS" as CashCategory },
+  { name: "raw_milk_moka",   match: /\bMILK\s*&\s*MOKA\b/i,        direction: "DR", category: "RAW_MATERIALS" as CashCategory },
+  { name: "raw_collective",  match: /\bCOLLECTIVE\s*PROJECT\b/i,   direction: "DR", category: "RAW_MATERIALS" as CashCategory },
+  { name: "raw_rosyam",      match: /\bROSYAM\s*MART\b/i,          direction: "DR", category: "RAW_MATERIALS" as CashCategory },
+  { name: "raw_catelux",     match: /\bCATELUX\b/i,                direction: "DR", category: "RAW_MATERIALS" as CashCategory },
+  { name: "raw_poket_capital",match: /\bPOKET\s*CAPITAL\b/i,       direction: "DR", category: "RAW_MATERIALS" as CashCategory },
+
+  // Generic SDN BHD vendor (lowest priority — fires only after the named
+  // vendor list above has missed). Marked OTHER_OUTFLOW so finance can
+  // re-classify; safer than guessing RAW_MATERIALS.
+  { name: "vendor_sdn_bhd",  match: /\bSDN\.?\s*BHD\b/i,           direction: "DR", category: "OTHER_OUTFLOW" as CashCategory },
+];
+
+export function classifyBankLine(input: ClassifyInput): ClassifyResult {
+  const desc = input.description ?? "";
+  const norm = desc.toUpperCase().replace(/\s+/g, " ").trim();
+
+  const rules = input.direction === "CR" ? INFLOW_RULES : OUTFLOW_RULES;
+  for (const rule of rules) {
+    if (rule.direction && rule.direction !== input.direction) continue;
+    if (rule.match.test(norm)) {
+      return {
+        category: rule.category,
+        outletCode: inferOutlet(desc),
+        isInterCo: rule.isInterCo ?? false,
+        ruleName: rule.name,
+      };
+    }
+  }
+
+  return {
+    category: input.direction === "CR" ? ("OTHER_INFLOW" as CashCategory) : ("OTHER_OUTFLOW" as CashCategory),
+    outletCode: inferOutlet(desc),
+    isInterCo: false,
+    ruleName: "fallback_other",
+  };
+}

--- a/apps/backoffice/src/lib/finance/bank-statement-parser.ts
+++ b/apps/backoffice/src/lib/finance/bank-statement-parser.ts
@@ -22,6 +22,14 @@ import * as XLSX from "xlsx";
 // Anything we can't parse becomes a warning the UI surfaces — Finance can
 // still type in the totals manually if the parse fails.
 
+export type ParsedLine = {
+  txnDate: string;            // YYYY-MM-DD
+  description: string;
+  reference: string | null;
+  amount: number;             // always positive
+  direction: "CR" | "DR";
+};
+
 export type ParsedStatement = {
   totalInflows: number;
   totalOutflows: number;
@@ -29,6 +37,7 @@ export type ParsedStatement = {
   periodEnd: string | null;     // YYYY-MM-DD
   rowsParsed: number;
   warnings: string[];
+  lines: ParsedLine[];          // individual transactions for line-item ingest
 };
 
 const INFLOW_HEADERS = ["credit", "deposit", "credits", "kredit", "in"];
@@ -36,6 +45,8 @@ const OUTFLOW_HEADERS = ["debit", "withdrawal", "withdrawals", "debits", "debit 
 const DATE_HEADERS = ["date", "transaction date", "txn date", "value date", "tarikh", "posting date"];
 const AMOUNT_HEADERS = ["amount", "transaction amount", "amt"];
 const DR_CR_HEADERS = ["dr/cr", "dr cr", "type", "debit/credit", "transaction type"];
+const DESC_HEADERS = ["description", "transaction description", "particulars", "narrative", "details", "remark", "remarks"];
+const REF_HEADERS = ["reference", "ref", "reference no", "ref no", "transaction reference"];
 
 function normalize(s: unknown): string {
   return typeof s === "string" ? s.trim().toLowerCase() : "";
@@ -103,11 +114,13 @@ function findHeaderRow(rows: unknown[][]): { idx: number; cols: Record<string, n
     const creditIdx = row.findIndex((c) => INFLOW_HEADERS.some((h) => c === h || c.includes(h)));
     const amountIdx = row.findIndex((c) => AMOUNT_HEADERS.some((h) => c === h));
     const drcrIdx = row.findIndex((c) => DR_CR_HEADERS.some((h) => c.includes(h)));
+    const descIdx = row.findIndex((c) => DESC_HEADERS.some((h) => c === h || c.includes(h)));
+    const refIdx = row.findIndex((c) => REF_HEADERS.some((h) => c === h || c.includes(h)));
     if (debitIdx >= 0 && creditIdx >= 0) {
-      return { idx: i, cols: { date: dateIdx, debit: debitIdx, credit: creditIdx } };
+      return { idx: i, cols: { date: dateIdx, debit: debitIdx, credit: creditIdx, desc: descIdx, ref: refIdx } };
     }
     if (amountIdx >= 0 && drcrIdx >= 0) {
-      return { idx: i, cols: { date: dateIdx, amount: amountIdx, drcr: drcrIdx } };
+      return { idx: i, cols: { date: dateIdx, amount: amountIdx, drcr: drcrIdx, desc: descIdx, ref: refIdx } };
     }
   }
   return null;
@@ -126,6 +139,7 @@ export function parseBankStatementBuffer(buffer: Buffer, filename = "statement")
       periodEnd: null,
       rowsParsed: 0,
       warnings: [`Could not read file as CSV/XLSX: ${err instanceof Error ? err.message : "parse error"}`],
+      lines: [],
     };
   }
 
@@ -137,6 +151,7 @@ export function parseBankStatementBuffer(buffer: Buffer, filename = "statement")
       periodStart: null,
       periodEnd: null,
       rowsParsed: 0,
+      lines: [],
       warnings: [`No worksheets found in ${filename}`],
     };
   }
@@ -152,6 +167,7 @@ export function parseBankStatementBuffer(buffer: Buffer, filename = "statement")
       periodEnd: null,
       rowsParsed: 0,
       warnings: [`Couldn't find a header row with date + debit/credit columns. Expected something like "Date / Debit / Credit" or "Date / Amount / DR/CR". Type the totals in manually.`],
+      lines: [],
     };
   }
 
@@ -160,12 +176,28 @@ export function parseBankStatementBuffer(buffer: Buffer, filename = "statement")
   let periodStart: Date | null = null;
   let periodEnd: Date | null = null;
   let rowsParsed = 0;
+  const lines: ParsedLine[] = [];
+
+  // Maybank quirk: a transaction's description sometimes wraps onto the
+  // following row(s) with a blank date column. Buffer the most recent
+  // parsed line so we can append continuation rows to its description.
+  let lastLineIdx = -1;
 
   for (let i = header.idx + 1; i < rows.length; i++) {
     const row = rows[i];
     if (!row || row.length === 0) continue;
     const date = parseDate(row[header.cols.date!]);
-    if (!date) continue;
+    if (!date) {
+      // Continuation row: blank date, but the description column may have
+      // more text. Append to the previous line if any.
+      if (lastLineIdx >= 0 && header.cols.desc != null) {
+        const more = String(row[header.cols.desc] ?? "").trim();
+        if (more) {
+          lines[lastLineIdx].description = `${lines[lastLineIdx].description} ${more}`.trim();
+        }
+      }
+      continue;
+    }
 
     let inflow = 0;
     let outflow = 0;
@@ -182,13 +214,45 @@ export function parseBankStatementBuffer(buffer: Buffer, filename = "statement")
       else if (/^c|credit|cr|dep|deposit/.test(tag)) inflow = amt;
     }
 
-    if (inflow === 0 && outflow === 0) continue;
+    if (inflow === 0 && outflow === 0) {
+      // Maybe a header repeat or balance-only row — skip but don't reset
+      // lastLineIdx so any continuation text still attaches to the
+      // previous real line.
+      continue;
+    }
 
     totalIn += inflow;
     totalOut += outflow;
     if (!periodStart || date < periodStart) periodStart = date;
     if (!periodEnd || date > periodEnd) periodEnd = date;
     rowsParsed++;
+
+    const description = header.cols.desc != null
+      ? String(row[header.cols.desc] ?? "").trim()
+      : "";
+    const reference = header.cols.ref != null
+      ? (String(row[header.cols.ref] ?? "").trim() || null)
+      : null;
+
+    if (inflow > 0) {
+      lines.push({
+        txnDate: ymd(date),
+        description,
+        reference,
+        amount: Math.round(inflow * 100) / 100,
+        direction: "CR",
+      });
+      lastLineIdx = lines.length - 1;
+    } else if (outflow > 0) {
+      lines.push({
+        txnDate: ymd(date),
+        description,
+        reference,
+        amount: Math.round(outflow * 100) / 100,
+        direction: "DR",
+      });
+      lastLineIdx = lines.length - 1;
+    }
   }
 
   if (rowsParsed === 0) {
@@ -202,5 +266,6 @@ export function parseBankStatementBuffer(buffer: Buffer, filename = "statement")
     periodEnd: periodEnd ? ymd(periodEnd) : null,
     rowsParsed,
     warnings,
+    lines,
   };
 }

--- a/apps/backoffice/src/lib/finance/cash-tracking.ts
+++ b/apps/backoffice/src/lib/finance/cash-tracking.ts
@@ -1,0 +1,203 @@
+import { prisma } from "@/lib/prisma";
+import type { CashCategory, BankLineDirection } from "@celsius/db";
+
+// Cash-tracking matrix builder. Aggregates BankStatementLine rows by
+// (category, outletId, YYYY-MM) so the cash-tracking page can render
+// the per-outlet × category × month grid that mirrors Finance's
+// existing spreadsheet framework.
+//
+// Outlet attribution rules:
+//   - If a line has outletId set (from the classifier's inferOutlet
+//     hint or from a manual edit), it belongs to that outlet.
+//   - Otherwise it falls into a synthetic "HQ" bucket — payments paid
+//     centrally from the HQ account that aren't tagged to a specific
+//     outlet. The user has flagged that statutory/etc. paid by HQ on
+//     behalf of outlets should eventually be re-allocated; for v1 we
+//     keep them in HQ and let Finance re-tag inline.
+
+export type CashCellKey = `${CashCategory}|${string}|${string}`; // category|outletId|YYYY-MM
+
+export type CashTrackingMatrix = {
+  // Outlets present (resolved from the union of line.outletId values
+  // plus an "HQ" pseudo-outlet for unattributed lines).
+  outlets: Array<{ id: string; code: string; name: string; isHQ: boolean }>;
+  months: string[];                // YYYY-MM, ascending
+  // For each (category, outletId, month) → net amount with sign:
+  //   inflows positive, outflows negative.
+  cells: Record<CashCellKey, number>;
+  // Per-month totals across all outlets (also signed).
+  monthTotals: Record<string, number>;
+  // Per-month totals broken out by category (for the bottom summary band).
+  categoryMonthTotals: Record<string, Record<string, number>>; // category → month → amount
+  // Categories actually present in the data, in spreadsheet display order.
+  categories: CashCategory[];
+};
+
+// Display order matches the spreadsheet framework Finance uses — inflow
+// channels first, then COGS, labor, marketing, ops, compliance, capex,
+// InterCo, catch-alls.
+const CATEGORY_ORDER: CashCategory[] = [
+  // Inflow
+  "CARD" as CashCategory,
+  "QR" as CashCategory,
+  "STOREHUB" as CashCategory,
+  "GRAB" as CashCategory,
+  "GRAB_PUTRAJAYA" as CashCategory,
+  "FOODPANDA" as CashCategory,
+  "MEETINGS_EVENTS" as CashCategory,
+  "GASTROHUB" as CashCategory,
+  "CAPITAL" as CashCategory,
+  "MANAGEMENT_FEE" as CashCategory,
+  "ADTD" as CashCategory,
+  "OTHER_INFLOW" as CashCategory,
+  // Outflow — COGS
+  "RAW_MATERIALS" as CashCategory,
+  "DELIVERY" as CashCategory,
+  // Outflow — Labor
+  "DIRECTORS_ALLOWANCE" as CashCategory,
+  "EMPLOYEE_SALARY" as CashCategory,
+  "PARTIMER" as CashCategory,
+  "STATUTORY_PAYMENT" as CashCategory,
+  "STAFF_CLAIM" as CashCategory,
+  "PETTY_CASH" as CashCategory,
+  // Outflow — Marketing
+  "MARKETPLACE_FEE" as CashCategory,
+  "DIGITAL_ADS" as CashCategory,
+  "KOL" as CashCategory,
+  "OTHER_MARKETING" as CashCategory,
+  // Outflow — Ops
+  "RENT" as CashCategory,
+  "UTILITIES" as CashCategory,
+  "SOFTWARE" as CashCategory,
+  // Outflow — Compliance / Finance
+  "CFS_FEE" as CashCategory,
+  "COMPLIANCE" as CashCategory,
+  "TAX" as CashCategory,
+  "LICENSING_FEE" as CashCategory,
+  "ROYALTY_FEE" as CashCategory,
+  "LOAN" as CashCategory,
+  "BANK_FEE" as CashCategory,
+  // Outflow — Capex
+  "EQUIPMENTS" as CashCategory,
+  "MAINTENANCE" as CashCategory,
+  "INVESTMENTS" as CashCategory,
+  // InterCo
+  "INTERCO_PEOPLE" as CashCategory,
+  "INTERCO_RAW_MATERIAL" as CashCategory,
+  "INTERCO_INVESTMENTS" as CashCategory,
+  "INTERCO_EXPENSES" as CashCategory,
+  // Catch-alls
+  "TRANSFER_NOT_SUCCESSFUL" as CashCategory,
+  "OTHER_OUTFLOW" as CashCategory,
+];
+
+const HQ_PSEUDO_OUTLET_ID = "__HQ__";
+
+export async function loadCashTrackingMatrix(opts: {
+  // Months back from current; default 6.
+  monthsBack?: number;
+  outletIds?: string[];      // empty = all outlets including HQ pseudo
+  includeInterCo?: boolean;  // default true; set false to net out internal transfers
+}): Promise<CashTrackingMatrix> {
+  const monthsBack = Math.max(1, Math.min(24, opts.monthsBack ?? 6));
+  const outletIds = opts.outletIds ?? [];
+  const includeInterCo = opts.includeInterCo ?? true;
+
+  const since = new Date();
+  since.setDate(1);
+  since.setHours(0, 0, 0, 0);
+  since.setMonth(since.getMonth() - (monthsBack - 1));
+
+  // Fetch all lines in the window. Outlet filter applied here only for
+  // tagged lines; "HQ" pseudo bucket is only included when the caller
+  // didn't filter (empty array) or explicitly listed it.
+  const lines = await prisma.bankStatementLine.findMany({
+    where: {
+      txnDate: { gte: since },
+      ...(includeInterCo ? {} : { isInterCo: false }),
+    },
+    select: {
+      txnDate: true,
+      direction: true,
+      amount: true,
+      category: true,
+      outletId: true,
+      isInterCo: true,
+    },
+  });
+
+  // Resolve outlets (including HQ pseudo). Outlet uses status enum, not
+  // an isActive boolean — only ACTIVE outlets show up.
+  const outletRecords = await prisma.outlet.findMany({
+    where: { status: "ACTIVE" },
+    select: { id: true, code: true, name: true },
+    orderBy: { code: "asc" },
+  });
+  const outletIdSet = new Set(outletRecords.map((o) => o.id));
+
+  // Bucketing
+  const cells: Record<CashCellKey, number> = {};
+  const monthSet = new Set<string>();
+  const categorySet = new Set<CashCategory>();
+  const monthTotals: Record<string, number> = {};
+  const categoryMonthTotals: Record<string, Record<string, number>> = {};
+  const usedOutletIds = new Set<string>();
+
+  for (const l of lines) {
+    if (!l.category) continue;            // unclassified — skipped from grid for now
+    const month = ymd(l.txnDate).slice(0, 7);
+    const oid = l.outletId && outletIdSet.has(l.outletId) ? l.outletId : HQ_PSEUDO_OUTLET_ID;
+
+    // Outlet filter (HQ pseudo always included when no filter)
+    if (outletIds.length > 0 && !outletIds.includes(oid)) continue;
+
+    const signed = (l.direction as BankLineDirection) === "CR" ? Number(l.amount) : -Number(l.amount);
+    const key: CashCellKey = `${l.category}|${oid}|${month}`;
+    cells[key] = (cells[key] ?? 0) + signed;
+    monthSet.add(month);
+    categorySet.add(l.category);
+    usedOutletIds.add(oid);
+    monthTotals[month] = (monthTotals[month] ?? 0) + signed;
+    if (!categoryMonthTotals[l.category]) categoryMonthTotals[l.category] = {};
+    categoryMonthTotals[l.category][month] = (categoryMonthTotals[l.category][month] ?? 0) + signed;
+  }
+
+  // Build outlet list — only those with data, plus HQ pseudo if used.
+  const outlets: CashTrackingMatrix["outlets"] = [];
+  for (const o of outletRecords) {
+    if (usedOutletIds.has(o.id)) outlets.push({ id: o.id, code: o.code, name: o.name, isHQ: false });
+  }
+  if (usedOutletIds.has(HQ_PSEUDO_OUTLET_ID)) {
+    outlets.push({ id: HQ_PSEUDO_OUTLET_ID, code: "HQ", name: "HQ / unallocated", isHQ: true });
+  }
+
+  // Months ascending
+  const months = Array.from(monthSet).sort();
+
+  // Categories in display order, filtered to those with data
+  const categories = CATEGORY_ORDER.filter((c) => categorySet.has(c));
+
+  // Round all values to 2dp
+  for (const k of Object.keys(cells)) cells[k as CashCellKey] = round2(cells[k as CashCellKey]);
+  for (const k of Object.keys(monthTotals)) monthTotals[k] = round2(monthTotals[k]);
+  for (const c of Object.keys(categoryMonthTotals)) {
+    for (const m of Object.keys(categoryMonthTotals[c])) {
+      categoryMonthTotals[c][m] = round2(categoryMonthTotals[c][m]);
+    }
+  }
+
+  return { outlets, months, cells, monthTotals, categoryMonthTotals, categories };
+}
+
+function ymd(d: Date): string {
+  const y = d.getFullYear();
+  const m = String(d.getMonth() + 1).padStart(2, "0");
+  const dd = String(d.getDate()).padStart(2, "0");
+  return `${y}-${m}-${dd}`;
+}
+
+function round2(n: number): number {
+  return Math.round(n * 100) / 100;
+}
+
+export const HQ_OUTLET_ID = HQ_PSEUDO_OUTLET_ID;

--- a/apps/backoffice/src/lib/finance/cashflow.ts
+++ b/apps/backoffice/src/lib/finance/cashflow.ts
@@ -4,21 +4,30 @@ import { prisma } from "@/lib/prisma";
 // optional outletId, returns weekly buckets with the breakdown that the
 // dashboard renders.
 //
-// Inputs (all read at request time, no side effects):
-//   - Opening balance: latest BankStatement.closingBalance.
-//   - Sales forecast: day-of-week average over the last 12 weeks of
-//     SalesTransaction (per outlet if filtered, else all), projected forward.
-//   - Invoice outflows: unpaid Invoice rows with dueDate in horizon.
-//   - Payroll: avg of the last 3 paid hr_payroll_runs, projected once per
-//     month on the cycle's payday (or 25th-of-month fallback).
-//   - Marketing: avg of the last 3 ads_invoice totals, projected once per
-//     month on (or near) the issue_date day-of-month.
-//   - RecurringExpense: walked forward by cadence from nextDueDate.
+// Source of truth: classified BankStatementLine rows. Per-category daily
+// rates are derived from the last 90 days of bank lines and used to
+// project forward. Sales categories (CARD/QR/STOREHUB/GRAB/FOODPANDA/
+// GASTROHUB/MEETINGS_EVENTS) get a day-of-week shape from their txnDate
+// distribution; outflow categories project as a flat daily rate.
 //
-// Sales forecast scope: when outletId is null we sum all outlets; otherwise
-// we filter both the historical lookback and the projection to that outlet.
-// Payroll/marketing run-rates stay HQ-level — they're not split per outlet
-// in the source data.
+// Inputs (all read at request time, no side effects):
+//   - Opening balance: sum of latest BankStatement.closingBalance per
+//     account.
+//   - Bank-line projection: per-category × DOW (or per-day) averages
+//     from BankStatementLine over the last 90 days. Drives salesIn,
+//     payrollOut, marketingOut, recurringOut, otherIn, otherOut.
+//   - Invoice outflows: unpaid Invoice rows with dueDate in horizon
+//     (additive on top of bank-line residual — these are committed
+//     future payments not yet on the bank statement).
+//   - Synthetic fallback: when bank lines are empty for a category we
+//     fall back to the legacy streams (StoreHub DOW, hr_payroll_runs
+//     avg, ads_invoice avg, RecurringExpense expansion).
+//
+// Sales forecast scope: when outletId is null we sum all outlets; outlet
+// filter applies to both the bank-line lookback and to invoices.
+// Categories with no outletId attribution (paid from HQ on behalf of all
+// outlets — e.g. payroll, central marketing) are dropped from filtered
+// views and surfaced as a warning.
 
 const DAY_MS = 86400_000;
 
@@ -222,6 +231,139 @@ async function projectMarketing(start: Date, end: Date): Promise<{ date: Date; a
   return out;
 }
 
+// --- Bank-line per-category projection ---------------------------------
+//
+// Aggregates BankStatementLine rows into the bucket fields the projection
+// renders. Sales-channel inflows (CARD/QR/STOREHUB/GRAB/FOODPANDA/
+// GASTROHUB/MEETINGS_EVENTS) get a per-DOW shape so weekend revenue
+// projects higher than Tuesday revenue; everything else projects as a
+// flat per-day rate over the lookback window.
+//
+// This is the "projection should be based on this as well" path — when
+// bank-line data exists for a category, that supersedes the synthetic
+// stream (StoreHub DOW averages, hr_payroll_runs, ads_invoice). When a
+// category has no bank-line data (e.g. brand new bank account) the
+// caller falls back to the synthetic stream.
+
+const SALES_INFLOW_CATEGORIES = [
+  "CARD", "QR", "STOREHUB", "GRAB", "GRAB_PUTRAJAYA",
+  "FOODPANDA", "MEETINGS_EVENTS", "GASTROHUB",
+] as const;
+
+const PAYROLL_OUTFLOW_CATEGORIES = [
+  "DIRECTORS_ALLOWANCE", "EMPLOYEE_SALARY", "PARTIMER",
+  "STATUTORY_PAYMENT", "STAFF_CLAIM", "PETTY_CASH",
+] as const;
+
+const MARKETING_OUTFLOW_CATEGORIES = [
+  "DIGITAL_ADS", "KOL", "OTHER_MARKETING", "MARKETPLACE_FEE",
+] as const;
+
+const RECURRING_OUTFLOW_CATEGORIES = [
+  "RENT", "UTILITIES", "SOFTWARE", "CFS_FEE", "COMPLIANCE", "TAX",
+  "LICENSING_FEE", "ROYALTY_FEE", "LOAN", "BANK_FEE", "MAINTENANCE",
+] as const;
+
+// Categories that are "other" — not sales, not payroll, not marketing,
+// not recurring. Includes capex, raw materials, and the catch-alls.
+const OTHER_OUTFLOW_CATEGORIES = [
+  "RAW_MATERIALS", "DELIVERY", "EQUIPMENTS", "INVESTMENTS",
+  "TRANSFER_NOT_SUCCESSFUL", "OTHER_OUTFLOW",
+] as const;
+
+const OTHER_INFLOW_CATEGORIES = [
+  "CAPITAL", "MANAGEMENT_FEE", "ADTD", "OTHER_INFLOW",
+] as const;
+
+type BankLineProjection = {
+  salesByDow: number[];          // [Sun..Sat] daily averages from sales categories
+  payrollPerDay: number;
+  marketingPerDay: number;
+  recurringPerDay: number;
+  otherInPerDay: number;
+  otherOutPerDay: number;
+  sampleDays: number;            // number of distinct calendar days the data covers
+  hasData: boolean;
+};
+
+async function bankLineProjection(outletIds: string[]): Promise<BankLineProjection | null> {
+  const lookback = 90;
+  const since = new Date(Date.now() - lookback * DAY_MS);
+  // Outlet filter: when filtered, only include lines tagged to the
+  // selected outlets; HQ-paid (null outletId) rows are excluded so we
+  // don't double-count central spend against an outlet view.
+  const lines = await prisma.bankStatementLine.findMany({
+    where: {
+      txnDate: { gte: since },
+      isInterCo: false,
+      ...(outletIds.length > 0 ? { outletId: outletIds.length === 1 ? outletIds[0] : { in: outletIds } } : {}),
+    },
+    select: { txnDate: true, direction: true, amount: true, category: true },
+  });
+
+  if (lines.length === 0) return null;
+
+  // Span the actual lookback window — distinct days seen, fall back to
+  // the lookback constant when no data.
+  const daySet = new Set<string>();
+  const salesSumByDow = [0, 0, 0, 0, 0, 0, 0];
+  const salesDistinctDaysByDow: Set<string>[] = [
+    new Set(), new Set(), new Set(), new Set(), new Set(), new Set(), new Set(),
+  ];
+  let payrollSum = 0;
+  let marketingSum = 0;
+  let recurringSum = 0;
+  let otherInSum = 0;
+  let otherOutSum = 0;
+
+  const SALES_SET = new Set<string>(SALES_INFLOW_CATEGORIES as readonly string[]);
+  const PAYROLL_SET = new Set<string>(PAYROLL_OUTFLOW_CATEGORIES as readonly string[]);
+  const MARKETING_SET = new Set<string>(MARKETING_OUTFLOW_CATEGORIES as readonly string[]);
+  const RECURRING_SET = new Set<string>(RECURRING_OUTFLOW_CATEGORIES as readonly string[]);
+  const OTHER_OUT_SET = new Set<string>(OTHER_OUTFLOW_CATEGORIES as readonly string[]);
+  const OTHER_IN_SET = new Set<string>(OTHER_INFLOW_CATEGORIES as readonly string[]);
+
+  for (const l of lines) {
+    if (!l.category) continue;
+    const dayKey = ymd(l.txnDate);
+    daySet.add(dayKey);
+    const amt = Number(l.amount);
+    const cat = l.category as string;
+    if (l.direction === "CR") {
+      if (SALES_SET.has(cat)) {
+        const dow = l.txnDate.getDay();
+        salesSumByDow[dow] += amt;
+        salesDistinctDaysByDow[dow].add(dayKey);
+      } else if (OTHER_IN_SET.has(cat)) {
+        otherInSum += amt;
+      }
+    } else {
+      // DR
+      if (PAYROLL_SET.has(cat)) payrollSum += amt;
+      else if (MARKETING_SET.has(cat)) marketingSum += amt;
+      else if (RECURRING_SET.has(cat)) recurringSum += amt;
+      else if (OTHER_OUT_SET.has(cat)) otherOutSum += amt;
+    }
+  }
+
+  const sampleDays = Math.max(1, daySet.size);
+  const salesByDow = salesSumByDow.map((s, dow) => {
+    const n = salesDistinctDaysByDow[dow].size;
+    return n > 0 ? s / n : 0;
+  });
+
+  return {
+    salesByDow,
+    payrollPerDay: payrollSum / sampleDays,
+    marketingPerDay: marketingSum / sampleDays,
+    recurringPerDay: recurringSum / sampleDays,
+    otherInPerDay: otherInSum / sampleDays,
+    otherOutPerDay: otherOutSum / sampleDays,
+    sampleDays,
+    hasData: true,
+  };
+}
+
 // Hybrid model — derive a per-day inflow/outflow rate from recent bank
 // statements with period totals. With multiple bank accounts each posting
 // statements covering the same calendar dates, naive sum-then-divide
@@ -348,10 +490,20 @@ export async function computeCashflow(opts: {
   const opening = await fetchOpeningBalance();
   if (!opening.statementDate) warnings.push("No bank statement uploaded — opening balance is RM 0.00. Upload one to get a real projection.");
 
-  // Sales forecast — day-of-week averages
-  const dowAvg = await dayOfWeekSalesAverages(outletIds);
+  // Bank-line projection — primary source. When categorized lines exist,
+  // they drive every bucket field. Synthetic streams below act as a
+  // fallback only.
+  const bankProj = await bankLineProjection(outletIds);
+
+  // Sales forecast — bank-line DOW averages take precedence; synthetic
+  // StoreHub DOW is fallback when no bank-line sales data exists for
+  // the scope.
+  const synthDow = await dayOfWeekSalesAverages(outletIds);
+  const dowAvg = bankProj && bankProj.salesByDow.some((v) => v > 0)
+    ? bankProj.salesByDow
+    : synthDow;
   const dowTotal = dowAvg.reduce((a, b) => a + b, 0);
-  if (dowTotal === 0) warnings.push("No StoreHub sales in the last 12 weeks for the selected scope — sales forecast is RM 0.");
+  if (dowTotal === 0) warnings.push("No bank-line sales nor StoreHub history for the selected scope — sales forecast is RM 0.");
 
   // Outflows — invoices in horizon (full-DB scope; outlet filter applies if set)
   const invoices = await prisma.invoice.findMany({
@@ -373,23 +525,38 @@ export async function computeCashflow(opts: {
     },
   });
 
-  // Outflows — payroll + marketing (HQ-level, not outlet-split for v1)
-  const payrollProjected = await projectPayroll(today, horizonEnd);
-  const marketingProjected = isFiltered ? [] : await projectMarketing(today, horizonEnd);
-  if (isFiltered) {
+  // Outflows — payroll + marketing. Bank-line per-day rates take
+  // precedence (smoothed daily); synthetic monthly-pulse streams are
+  // fallback when no bank-line data exists.
+  const useBankLinePayroll = !!(bankProj && bankProj.payrollPerDay > 0);
+  const useBankLineMarketing = !!(bankProj && bankProj.marketingPerDay > 0);
+  const payrollProjected = useBankLinePayroll ? [] : await projectPayroll(today, horizonEnd);
+  const marketingProjected = (useBankLineMarketing || isFiltered) ? [] : await projectMarketing(today, horizonEnd);
+  if (isFiltered && !useBankLineMarketing) {
     warnings.push("Marketing run-rate is HQ-only and not allocated to outlets — it's excluded from the filtered view.");
   }
 
-  // Hybrid residual — bank flows per day minus what the synthetic streams
-  // would already cover. Only applies in "all outlets" mode since
-  // BankStatement isn't outlet-tagged.
-  const bankFlows = isFiltered ? null : await bankFlowsPerDay();
-  if (!isFiltered && !bankFlows) {
-    warnings.push("Bank statement period totals not yet uploaded — \"Other (bank)\" residual is RM 0. Upload a CSV/Excel statement to see the gap between bank actuals and the synthetic forecast.");
+  // Other-bank residual. Two paths:
+  //  1. Bank-line projection available → use the per-category buckets
+  //     directly (otherInPerDay = unclassified inflow run-rate;
+  //     otherOutPerDay = capex/raw-mat/catch-all run-rate). This is
+  //     the "projection should be based on bank lines as well" path.
+  //  2. Fallback to legacy bankStatementsPerDay residual model — bank
+  //     period totals minus the synthetic streams. Only used when no
+  //     classified lines exist yet.
+  const bankFlows = (!bankProj && !isFiltered) ? await bankFlowsPerDay() : null;
+  if (!bankProj && !bankFlows && !isFiltered) {
+    warnings.push("No classified bank lines and no statement period totals — \"Other (bank)\" residual is RM 0. Upload a CSV/Excel statement to enable a real projection.");
   }
   let otherInPerDay = 0;
   let otherOutPerDay = 0;
-  if (bankFlows) {
+  if (bankProj) {
+    // Bank-line model is authoritative — categories already partition
+    // the flow exactly, no residual subtraction needed.
+    otherInPerDay = bankProj.otherInPerDay;
+    otherOutPerDay = bankProj.otherOutPerDay;
+  } else if (bankFlows) {
+    // Legacy residual fallback (no classified lines yet)
     const dailySalesSynthetic = dowAvg.reduce((a, b) => a + b, 0) / 7;
     const monthlyPayrollAvg = payrollProjected.length > 0
       ? payrollProjected.reduce((s, p) => s + p.amount, 0) / Math.max(1, payrollProjected.length)
@@ -406,6 +573,13 @@ export async function computeCashflow(opts: {
     otherInPerDay = Math.max(0, bankFlows.inflow - dailySalesSynthetic);
     otherOutPerDay = Math.max(0, bankFlows.outflow - dailySyntheticOut);
   }
+
+  // When we're using bank-line projection for payroll/marketing, derive
+  // per-day rates so the bucket builder can spread them across days
+  // (versus the monthly-pulse synthetic streams).
+  const bankPayrollPerDay = useBankLinePayroll ? bankProj!.payrollPerDay : 0;
+  const bankMarketingPerDay = useBankLineMarketing ? bankProj!.marketingPerDay : 0;
+  const bankRecurringPerDay = bankProj && bankProj.recurringPerDay > 0 ? bankProj.recurringPerDay : 0;
 
   // Bucket builder
   const buckets: CashflowBucket[] = [];
@@ -457,8 +631,9 @@ export async function computeCashflow(opts: {
       }
     }
 
-    // Other (bank residual) — count days in the week that are >= today, since
-    // partial first weeks shouldn't include past days.
+    // Other (bank residual) + bank-line-driven daily-rate streams
+    // (payroll/marketing/recurring). Count days in the week that are
+    // >= today, since partial first weeks shouldn't include past days.
     let activeDays = 0;
     for (let d = 0; d < 7; d++) {
       const day = new Date(weekStart.getTime() + d * DAY_MS);
@@ -467,7 +642,19 @@ export async function computeCashflow(opts: {
     const otherIn = otherInPerDay * activeDays;
     const otherOut = otherOutPerDay * activeDays;
 
-    const closing = runningOpening + salesIn + otherIn - invoiceOut - payrollOut - marketingOut - recurringOut - otherOut;
+    // Add bank-line daily-rate spend for the categories we promoted from
+    // synthetic monthly pulses. Stacks on top of any synthetic
+    // payrollProjected / marketingProjected entries, but those arrays
+    // are emptied above when bank-line data exists for the category.
+    const bankPayrollOut = bankPayrollPerDay * activeDays;
+    const bankMarketingOut = bankMarketingPerDay * activeDays;
+    const bankRecurringOut = bankRecurringPerDay * activeDays;
+
+    const totalPayrollOut = payrollOut + bankPayrollOut;
+    const totalMarketingOut = marketingOut + bankMarketingOut;
+    const totalRecurringOut = recurringOut + bankRecurringOut;
+
+    const closing = runningOpening + salesIn + otherIn - invoiceOut - totalPayrollOut - totalMarketingOut - totalRecurringOut - otherOut;
 
     buckets.push({
       weekStart: ymd(weekStart),
@@ -476,9 +663,9 @@ export async function computeCashflow(opts: {
       salesIn: round2(salesIn),
       otherIn: round2(otherIn),
       invoiceOut: round2(invoiceOut),
-      payrollOut: round2(payrollOut),
-      marketingOut: round2(marketingOut),
-      recurringOut: round2(recurringOut),
+      payrollOut: round2(totalPayrollOut),
+      marketingOut: round2(totalMarketingOut),
+      recurringOut: round2(totalRecurringOut),
       otherOut: round2(otherOut),
       closing: round2(closing),
       invoiceIds: wkInvoices.map((iv) => iv.id),
@@ -515,9 +702,20 @@ export async function computeCashflow(opts: {
     outletId: outletIds.length === 1 ? outletIds[0] : null,
     outletIds,
     openingBalance: opening,
-    bankFlowsPerDay: bankFlows
-      ? { inflow: round2(bankFlows.inflow), outflow: round2(bankFlows.outflow), sampleDays: bankFlows.sampleDays }
-      : null,
+    bankFlowsPerDay: bankProj
+      ? {
+          // Bank-line model — sum of all per-day rates on each side
+          inflow: round2(
+            (bankProj.salesByDow.reduce((a, b) => a + b, 0) / 7) + bankProj.otherInPerDay,
+          ),
+          outflow: round2(
+            bankProj.payrollPerDay + bankProj.marketingPerDay + bankProj.recurringPerDay + bankProj.otherOutPerDay,
+          ),
+          sampleDays: bankProj.sampleDays,
+        }
+      : bankFlows
+        ? { inflow: round2(bankFlows.inflow), outflow: round2(bankFlows.outflow), sampleDays: bankFlows.sampleDays }
+        : null,
     monthlyHistory,
     cashGeneration,
     buckets,

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -96,6 +96,7 @@ model Outlet {
   internalFeedbacks InternalFeedback[]
   auditReports      AuditReport[]
   recurringExpenses RecurringExpense[]
+  bankStatementLines BankStatementLine[]
 }
 
 enum OutletType {
@@ -1375,8 +1376,104 @@ model BankStatement {
   uploadedById   String
   uploadedBy     User     @relation(fields: [uploadedById], references: [id])
   createdAt      DateTime @default(now())
+  lines          BankStatementLine[]
 
   @@index([statementDate])
+}
+
+// Per-transaction breakdown of a bank statement, populated when CSV/Excel
+// is uploaded. The cash-tracking matrix page reads from these — every row
+// gets classified into one of the CashCategory buckets (matching Finance's
+// existing spreadsheet framework), tagged with an outlet inferred from the
+// transaction description, and InterCo-flagged when the counterparty is
+// another Celsius entity. PDFs only give totals so PDF-sourced statements
+// won't have lines.
+model BankStatementLine {
+  id              String   @id @default(uuid())
+  statementId     String
+  statement       BankStatement @relation(fields: [statementId], references: [id], onDelete: Cascade)
+  txnDate         DateTime
+  description     String
+  reference       String?
+  amount          Decimal  @db.Decimal(12, 2)        // always positive
+  direction       BankLineDirection                  // CR (in) | DR (out)
+  category        CashCategory?
+  outletId        String?
+  outlet          Outlet?  @relation(fields: [outletId], references: [id])
+  isInterCo       Boolean  @default(false)
+  classifiedBy    String?  // 'rule' | 'manual'
+  ruleName        String?  // which regex rule fired
+  notes           String?
+  createdAt       DateTime @default(now())
+  updatedAt       DateTime @updatedAt
+
+  @@index([statementId])
+  @@index([txnDate])
+  @@index([category, outletId])
+}
+
+enum BankLineDirection {
+  CR
+  DR
+}
+
+// Cash-tracking categories — verbatim from the per-outlet spreadsheet
+// framework Finance uses. Same enum is used on both inflow and outflow
+// sides; direction is on the line itself. InterCo categories show on
+// both sides; consolidated views net them across outlets.
+enum CashCategory {
+  // Inflow channels
+  CARD
+  QR
+  STOREHUB
+  GRAB
+  GRAB_PUTRAJAYA
+  FOODPANDA
+  MEETINGS_EVENTS
+  GASTROHUB
+  CAPITAL
+  MANAGEMENT_FEE
+  ADTD
+  // Outflow — COGS
+  RAW_MATERIALS
+  DELIVERY
+  // Outflow — Labor
+  DIRECTORS_ALLOWANCE
+  EMPLOYEE_SALARY
+  PARTIMER
+  STATUTORY_PAYMENT
+  STAFF_CLAIM
+  PETTY_CASH
+  // Outflow — Marketing
+  MARKETPLACE_FEE
+  DIGITAL_ADS
+  KOL
+  OTHER_MARKETING
+  // Outflow — Property / Ops
+  RENT
+  UTILITIES
+  SOFTWARE
+  // Outflow — Compliance / Finance
+  CFS_FEE
+  COMPLIANCE
+  TAX
+  LICENSING_FEE
+  ROYALTY_FEE
+  LOAN
+  BANK_FEE
+  // Outflow — Capex / Maintenance
+  EQUIPMENTS
+  MAINTENANCE
+  INVESTMENTS
+  // InterCo (net to zero across consolidation)
+  INTERCO_PEOPLE
+  INTERCO_RAW_MATERIAL
+  INTERCO_INVESTMENTS
+  INTERCO_EXPENSES
+  // Catch-alls
+  TRANSFER_NOT_SUCCESSFUL
+  OTHER_INFLOW
+  OTHER_OUTFLOW
 }
 
 model RecurringExpense {


### PR DESCRIPTION
## Summary
- Bank-statement uploads now extract individual transactions, auto-classify each into one of 42 spreadsheet categories (Card, QR, StoreHub, Grab, raw materials, rent, payroll, InterCo, …), and persist them as `BankStatementLine` rows.
- New **Cash Tracking** page renders the per-outlet × category × month matrix that mirrors Finance's existing spreadsheet, with InterCo toggle, HQ-unallocated pseudo-outlet, and outlet tabs.
- **Cashflow projection** now sources per-day rates from the last 90 days of categorized bank lines. Sales channels get DOW shape; payroll/marketing/recurring/other run as flat daily rates. Synthetic streams (StoreHub DOW averages, `hr_payroll_runs`, `ads_invoice`, `RecurringExpense`) fall back only when a category has no bank-line history.
- Backfill script re-ingested the 3 April 2026 Maybank CSVs (~3,000 lines) so the existing statements now power the projection from day one.

## Files
- Schema: `BankStatementLine`, `CashCategory` (42 values), `BankLineDirection`
- `bank-line-classifier.ts` — regex rules per category, outlet inference from description
- `bank-statement-parser.ts` — now returns per-row lines (CR/DR + description + reference) alongside totals
- `cash-tracking.ts` — matrix builder
- `cashflow.ts` — `bankLineProjection()` drives bucket fields when data exists
- `/finance/cash-tracking` page + API
- `scripts/backfill-bank-lines.ts` — one-shot Maybank CSV re-ingest

## Test plan
- [ ] Upload a CSV/Excel statement on `/finance/bank-statements` → verify lines persist and appear on `/finance/cash-tracking`
- [ ] Toggle outlet tabs on cash-tracking page (All / Putrajaya / Tamarind / HQ-unallocated) — values shift consistently
- [ ] Toggle InterCo include/exclude — RM 53k InterCo row drops out of totals when off
- [ ] `/finance/cashflow` headline cards still match (RM 45k opening, last-month net, runway)
- [ ] Filter cashflow by single outlet — bank-line projection scopes correctly to outlet-tagged lines
- [ ] Run `pnpm tsc --noEmit` in `apps/backoffice` → zero errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)