### PR TITLE
Cashflow fixes + inventory pending-invoice flow + reject + WhatsApp groups

### DIFF
--- a/apps/backoffice/scripts/generate-recurring-from-bank-lines.ts
+++ b/apps/backoffice/scripts/generate-recurring-from-bank-lines.ts
@@ -1,0 +1,208 @@
+/* eslint-disable @typescript-eslint/no-require-imports */
+// Generate per-outlet RecurringExpense entries from bank-line history.
+//
+// Why: the 4 manual HQ aggregates ("Rent (HQ aggregate) RM 15k") generalize
+// across outlets and don't reflect actual per-outlet payment patterns.
+// This script analyzes the last 90 days of classified bank lines, groups
+// them by (outletId, category, month), and emits one RecurringExpense per
+// (outlet, category) with:
+//   - amount = average monthly total for that outlet+category
+//   - nextDueDate = next occurrence at the most-recent day-of-month
+//   - cadence = MONTHLY (only categories with consistent monthly cadence)
+//
+// Categories considered MONTHLY recurring: RENT, UTILITIES, SOFTWARE,
+// EMPLOYEE_SALARY, DIRECTORS_ALLOWANCE, STATUTORY_PAYMENT, COMPLIANCE,
+// TAX, MAINTENANCE, LICENSING_FEE, ROYALTY_FEE, BANK_FEE, CFS_FEE,
+// LOAN, MANAGEMENT_FEE.
+//
+// Skipped (not monthly-recurring):
+//   - PARTIMER (weekly/bi-weekly — projected via daily rate instead)
+//   - STAFF_CLAIM, PETTY_CASH (irregular)
+//   - DIGITAL_ADS, KOL, OTHER_MARKETING (variable timing)
+//   - CARD/QR/STOREHUB/etc (sales — DOW shaped)
+//   - RAW_MATERIALS, DELIVERY (multiple times per week)
+//   - OTHER_OUTFLOW, OTHER_INFLOW (catch-all)
+//
+// Idempotent: drops all existing RecurringExpense rows and rebuilds.
+
+import { PrismaClient } from "@prisma/client";
+
+const prisma = new PrismaClient();
+
+const MONTHLY_CATEGORIES_MAP: Record<string, "RENT" | "UTILITY" | "SAAS" | "PAYROLL_SUPPORT" | "OTHER"> = {
+  // Property
+  RENT:               "RENT",
+  UTILITIES:          "UTILITY",
+  SOFTWARE:           "SAAS",
+  // Payroll
+  EMPLOYEE_SALARY:    "PAYROLL_SUPPORT",
+  DIRECTORS_ALLOWANCE:"PAYROLL_SUPPORT",
+  STATUTORY_PAYMENT:  "PAYROLL_SUPPORT",
+  // Other recurring
+  COMPLIANCE:         "OTHER",
+  TAX:                "OTHER",
+  MAINTENANCE:        "OTHER",
+  LICENSING_FEE:      "OTHER",
+  ROYALTY_FEE:        "OTHER",
+  BANK_FEE:           "OTHER",
+  CFS_FEE:            "OTHER",
+  LOAN:               "OTHER",
+  MANAGEMENT_FEE:     "OTHER",
+};
+
+const FRIENDLY_NAME: Record<string, string> = {
+  RENT:               "Rent",
+  UTILITIES:          "Utilities",
+  SOFTWARE:           "Software / SaaS",
+  EMPLOYEE_SALARY:    "Salary",
+  DIRECTORS_ALLOWANCE:"Directors' allowance",
+  STATUTORY_PAYMENT:  "Statutory (EPF/SOCSO)",
+  COMPLIANCE:         "Compliance / Legal",
+  TAX:                "Tax",
+  MAINTENANCE:        "Maintenance",
+  LICENSING_FEE:      "Licensing fee",
+  ROYALTY_FEE:        "Royalty fee",
+  BANK_FEE:           "Bank fees",
+  CFS_FEE:            "CFS fee",
+  LOAN:               "Loan repayment",
+  MANAGEMENT_FEE:     "Management fee",
+};
+
+function ymd(d: Date): string {
+  const y = d.getFullYear();
+  const m = String(d.getMonth() + 1).padStart(2, "0");
+  const dd = String(d.getDate()).padStart(2, "0");
+  return `${y}-${m}-${dd}`;
+}
+
+async function main() {
+  const today = new Date();
+  today.setHours(0, 0, 0, 0);
+  const since = new Date(today.getTime() - 90 * 86_400_000);
+
+  // Pull last 90 days of DR lines in monthly categories
+  const lines = await prisma.bankStatementLine.findMany({
+    where: {
+      direction: "DR",
+      isInterCo: false,
+      txnDate: { gte: since, lte: today },
+      category: { in: Object.keys(MONTHLY_CATEGORIES_MAP) as never },
+    },
+    select: { txnDate: true, amount: true, category: true, outletId: true, description: true },
+  });
+
+  // Group by (outletId | "HQ", bankCategory, year-month)
+  type Bucket = { totalAmount: number; lineCount: number; latestDate: Date; latestAmount: number };
+  const groups = new Map<string, Bucket>();
+  for (const l of lines) {
+    const oid = l.outletId ?? "__HQ__";
+    const month = `${l.txnDate.getFullYear()}-${String(l.txnDate.getMonth() + 1).padStart(2, "0")}`;
+    const key = `${oid}|${l.category}|${month}`;
+    const amt = Number(l.amount);
+    const existing = groups.get(key);
+    if (!existing) {
+      groups.set(key, { totalAmount: amt, lineCount: 1, latestDate: l.txnDate, latestAmount: amt });
+    } else {
+      existing.totalAmount += amt;
+      existing.lineCount += 1;
+      if (l.txnDate > existing.latestDate) {
+        existing.latestDate = l.txnDate;
+        existing.latestAmount = amt;
+      }
+    }
+  }
+
+  // Aggregate across months per (outletId, category)
+  type CatBucket = {
+    outletId: string;
+    category: string;
+    monthlyTotals: Array<{ month: string; total: number; latestDate: Date; latestAmount: number }>;
+  };
+  const perCategory = new Map<string, CatBucket>();
+  for (const [key, b] of groups.entries()) {
+    const [oid, cat, month] = key.split("|");
+    const k = `${oid}|${cat}`;
+    if (!perCategory.has(k)) {
+      perCategory.set(k, { outletId: oid, category: cat, monthlyTotals: [] });
+    }
+    perCategory.get(k)!.monthlyTotals.push({ month, total: b.totalAmount, latestDate: b.latestDate, latestAmount: b.latestAmount });
+  }
+
+  // For each (outletId, category) with >= 2 months of history, emit a
+  // RecurringExpense. Skip if only 1 month — could be one-off.
+  const outlets = await prisma.outlet.findMany({ select: { id: true, name: true } });
+  const outletNameById = new Map(outlets.map((o) => [o.id, o.name]));
+
+  type Emit = {
+    name: string;
+    category: "RENT" | "UTILITY" | "SAAS" | "PAYROLL_SUPPORT" | "OTHER";
+    amount: number;
+    cadence: "MONTHLY";
+    nextDueDate: Date;
+    outletId: string | null;
+    notes: string;
+  };
+  const emits: Emit[] = [];
+
+  for (const cb of perCategory.values()) {
+    const months = cb.monthlyTotals;
+    if (months.length < 2) continue;     // not yet recurring — skip
+
+    // Average monthly total
+    const avgAmount = months.reduce((s, m) => s + m.total, 0) / months.length;
+    if (avgAmount < 50) continue;        // ignore tiny noise
+
+    // Day-of-month from the most-recent occurrence (latest among all months)
+    const latest = months.reduce((acc, m) => m.latestDate > acc.latestDate ? m : acc);
+    const dayOfMonth = latest.latestDate.getDate();
+
+    // Next due date = next occurrence of dayOfMonth strictly after today
+    const next = new Date(today.getFullYear(), today.getMonth(), Math.min(28, dayOfMonth));
+    if (next <= today) next.setMonth(next.getMonth() + 1);
+
+    const outletId = cb.outletId === "__HQ__" ? null : cb.outletId;
+    const outletLabel = outletId ? outletNameById.get(outletId) ?? "outlet" : "HQ";
+    const friendly = FRIENDLY_NAME[cb.category] ?? cb.category;
+    const recurringCat = MONTHLY_CATEGORIES_MAP[cb.category];
+
+    emits.push({
+      name: `${friendly} — ${outletLabel}`,
+      category: recurringCat,
+      amount: Math.round(avgAmount * 100) / 100,
+      cadence: "MONTHLY",
+      nextDueDate: next,
+      outletId,
+      notes: `Auto-generated from bank-line history (${months.length} months, avg over ${months.map((m) => m.month).join(", ")}). Last seen ${ymd(latest.latestDate)} for RM ${latest.latestAmount.toFixed(2)}.`,
+    });
+  }
+
+  emits.sort((a, b) => (a.outletId ?? "").localeCompare(b.outletId ?? "") || a.category.localeCompare(b.category));
+
+  // Wipe existing entries and rebuild
+  const wiped = await prisma.recurringExpense.deleteMany({});
+  console.log(`[reset] deleted ${wiped.count} existing RecurringExpense entries`);
+
+  if (emits.length === 0) {
+    console.log("No entries to create.");
+    await prisma.$disconnect();
+    return;
+  }
+
+  const created = await prisma.recurringExpense.createMany({
+    data: emits.map((e) => ({ ...e, isActive: true })),
+  });
+  console.log(`[ok] created ${created.count} per-outlet RecurringExpense entries`);
+
+  console.log("\n--- Generated entries ---");
+  for (const e of emits) {
+    const outletLabel = e.outletId ? (outletNameById.get(e.outletId) ?? e.outletId) : "HQ";
+    console.log(`  ${outletLabel.padEnd(28)} | ${e.category.padEnd(15)} | RM ${e.amount.toFixed(2).padStart(10)} | due ${ymd(e.nextDueDate)} | ${e.name}`);
+  }
+
+  await prisma.$disconnect();
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/apps/backoffice/scripts/generate-recurring-from-bank-lines.ts
+++ b/apps/backoffice/scripts/generate-recurring-from-bank-lines.ts
@@ -91,41 +91,38 @@ async function main() {
     select: { txnDate: true, amount: true, category: true, outletId: true, description: true },
   });
 
-  // Group by (outletId | "HQ", bankCategory, year-month)
-  type Bucket = { totalAmount: number; lineCount: number; latestDate: Date; latestAmount: number };
-  const groups = new Map<string, Bucket>();
-  for (const l of lines) {
-    const oid = l.outletId ?? "__HQ__";
-    const month = `${l.txnDate.getFullYear()}-${String(l.txnDate.getMonth() + 1).padStart(2, "0")}`;
-    const key = `${oid}|${l.category}|${month}`;
-    const amt = Number(l.amount);
-    const existing = groups.get(key);
-    if (!existing) {
-      groups.set(key, { totalAmount: amt, lineCount: 1, latestDate: l.txnDate, latestAmount: amt });
-    } else {
-      existing.totalAmount += amt;
-      existing.lineCount += 1;
-      if (l.txnDate > existing.latestDate) {
-        existing.latestDate = l.txnDate;
-        existing.latestAmount = amt;
-      }
-    }
-  }
-
-  // Aggregate across months per (outletId, category)
+  // Per (outletId, category): keep month-by-month totals + last
+  // payment date per month. We use the latest month's TOTAL (handles
+  // multi-line categories like SALARY = many staff payments) but
+  // skip months whose total is < 30% of the largest historical month
+  // (filters out partial/noisy months — e.g. April HQ rent that
+  // only had a RM 399 ice-machine rental, not the actual landlord
+  // payment).
   type CatBucket = {
     outletId: string;
     category: string;
-    monthlyTotals: Array<{ month: string; total: number; latestDate: Date; latestAmount: number }>;
+    months: Map<string, { total: number; latestDate: Date; latestLineAmount: number; latestDescription: string }>;
   };
   const perCategory = new Map<string, CatBucket>();
-  for (const [key, b] of groups.entries()) {
-    const [oid, cat, month] = key.split("|");
-    const k = `${oid}|${cat}`;
+  for (const l of lines) {
+    const oid = l.outletId ?? "__HQ__";
+    const k = `${oid}|${l.category}`;
     if (!perCategory.has(k)) {
-      perCategory.set(k, { outletId: oid, category: cat, monthlyTotals: [] });
+      perCategory.set(k, { outletId: oid, category: l.category as string, months: new Map() });
     }
-    perCategory.get(k)!.monthlyTotals.push({ month, total: b.totalAmount, latestDate: b.latestDate, latestAmount: b.latestAmount });
+    const cb = perCategory.get(k)!;
+    const monthKey = `${l.txnDate.getFullYear()}-${String(l.txnDate.getMonth() + 1).padStart(2, "0")}`;
+    const m = cb.months.get(monthKey);
+    if (!m) {
+      cb.months.set(monthKey, { total: Number(l.amount), latestDate: l.txnDate, latestLineAmount: Number(l.amount), latestDescription: l.description });
+    } else {
+      m.total += Number(l.amount);
+      if (l.txnDate > m.latestDate) {
+        m.latestDate = l.txnDate;
+        m.latestLineAmount = Number(l.amount);
+        m.latestDescription = l.description;
+      }
+    }
   }
 
   // For each (outletId, category) with >= 2 months of history, emit a
@@ -145,18 +142,25 @@ async function main() {
   const emits: Emit[] = [];
 
   for (const cb of perCategory.values()) {
-    const months = cb.monthlyTotals;
-    if (months.length < 2) continue;     // not yet recurring — skip
+    if (cb.months.size < 2) continue;            // not yet recurring — skip
 
-    // Average monthly total
-    const avgAmount = months.reduce((s, m) => s + m.total, 0) / months.length;
-    if (avgAmount < 50) continue;        // ignore tiny noise
+    // Sort months descending and find the latest "non-noisy" month —
+    // total >= 30% of the largest month's total. Filters out months
+    // where only a small one-off line hit this category (e.g. ice
+    // machine rental classified as RENT).
+    const monthsArr = Array.from(cb.months.entries())
+      .sort(([a], [b]) => b.localeCompare(a));
+    const maxMonthTotal = Math.max(...monthsArr.map(([, m]) => m.total));
+    const threshold = maxMonthTotal * 0.3;
+    const sigMonth = monthsArr.find(([, m]) => m.total >= threshold);
+    if (!sigMonth) continue;
+    const [latestMonth, latestMonthData] = sigMonth;
 
-    // Day-of-month from the most-recent occurrence (latest among all months)
-    const latest = months.reduce((acc, m) => m.latestDate > acc.latestDate ? m : acc);
-    const dayOfMonth = latest.latestDate.getDate();
+    const projectionAmount = latestMonthData.total;
+    if (projectionAmount < 50) continue;         // ignore tiny noise
 
-    // Next due date = next occurrence of dayOfMonth strictly after today
+    // Day-of-month from the most-recent line in that month
+    const dayOfMonth = latestMonthData.latestDate.getDate();
     const next = new Date(today.getFullYear(), today.getMonth(), Math.min(28, dayOfMonth));
     if (next <= today) next.setMonth(next.getMonth() + 1);
 
@@ -168,11 +172,11 @@ async function main() {
     emits.push({
       name: `${friendly} — ${outletLabel}`,
       category: recurringCat,
-      amount: Math.round(avgAmount * 100) / 100,
+      amount: Math.round(projectionAmount * 100) / 100,
       cadence: "MONTHLY",
       nextDueDate: next,
       outletId,
-      notes: `Auto-generated from bank-line history (${months.length} months, avg over ${months.map((m) => m.month).join(", ")}). Last seen ${ymd(latest.latestDate)} for RM ${latest.latestAmount.toFixed(2)}.`,
+      notes: `Auto-generated from bank-line history. Latest month: ${latestMonth} = RM ${projectionAmount.toFixed(2)}. ${cb.months.size} months observed: ${monthsArr.map(([k, v]) => `${k}=${v.total.toFixed(0)}`).join(", ")}.`,
     });
   }
 

--- a/apps/backoffice/scripts/generate-recurring-from-bank-lines.ts
+++ b/apps/backoffice/scripts/generate-recurring-from-bank-lines.ts
@@ -36,7 +36,10 @@ const MONTHLY_CATEGORIES_MAP: Record<string, "RENT" | "UTILITY" | "SAAS" | "PAYR
   SOFTWARE:           "SAAS",
   // Payroll
   EMPLOYEE_SALARY:    "PAYROLL_SUPPORT",
-  DIRECTORS_ALLOWANCE:"PAYROLL_SUPPORT",
+  // DIRECTORS_ALLOWANCE intentionally excluded — variable each month
+  // (depends on owner draw decisions), not a predictable recurring
+  // commitment. Falls through to bank-line OTHER catch-all in the
+  // projection.
   STATUTORY_PAYMENT:  "PAYROLL_SUPPORT",
   // Other recurring
   COMPLIANCE:         "OTHER",

--- a/apps/backoffice/src/app/(admin)/finance/cashflow/page.tsx
+++ b/apps/backoffice/src/app/(admin)/finance/cashflow/page.tsx
@@ -15,6 +15,7 @@ type CashflowBucket = {
   otherIn: number;
   invoiceOut: number;
   payrollOut: number;
+  cogsOut: number;
   marketingOut: number;
   recurringOut: number;
   otherOut: number;
@@ -333,13 +334,14 @@ export default function CashflowPage() {
                 <tr className="border-b bg-gray-50/50 text-left text-gray-500">
                   <th className="px-3 py-3 font-medium">Week</th>
                   <th className="px-3 py-3 text-right font-medium">Opening</th>
-                  <th className="px-3 py-3 text-right font-medium text-green-600">Sales (forecast)</th>
-                  <th className="px-3 py-3 text-right font-medium text-green-600">Other (bank)</th>
+                  <th className="px-3 py-3 text-right font-medium text-green-600">Sales</th>
+                  <th className="px-3 py-3 text-right font-medium text-green-600">Other inflow</th>
                   <th className="px-3 py-3 text-right font-medium text-red-600">Invoices due</th>
                   <th className="px-3 py-3 text-right font-medium text-red-600">Payroll</th>
+                  <th className="px-3 py-3 text-right font-medium text-red-600">COGS</th>
                   <th className="px-3 py-3 text-right font-medium text-red-600">Marketing</th>
                   <th className="px-3 py-3 text-right font-medium text-red-600">Recurring</th>
-                  <th className="px-3 py-3 text-right font-medium text-red-600">Other (bank)</th>
+                  <th className="px-3 py-3 text-right font-medium text-red-600">Other outflow</th>
                   <th className="px-3 py-3 text-right font-medium">Closing</th>
                 </tr>
               </thead>
@@ -352,6 +354,7 @@ export default function CashflowPage() {
                     <td className="px-3 py-3 text-right font-mono text-xs text-green-700">{b.otherIn > 0 ? `+${fmtMYR(b.otherIn)}` : "—"}</td>
                     <td className="px-3 py-3 text-right font-mono text-xs text-red-700">{b.invoiceOut > 0 ? `−${fmtMYR(b.invoiceOut)}` : "—"}</td>
                     <td className="px-3 py-3 text-right font-mono text-xs text-red-700">{b.payrollOut > 0 ? `−${fmtMYR(b.payrollOut)}` : "—"}</td>
+                    <td className="px-3 py-3 text-right font-mono text-xs text-red-700">{b.cogsOut > 0 ? `−${fmtMYR(b.cogsOut)}` : "—"}</td>
                     <td className="px-3 py-3 text-right font-mono text-xs text-red-700">{b.marketingOut > 0 ? `−${fmtMYR(b.marketingOut)}` : "—"}</td>
                     <td className="px-3 py-3 text-right font-mono text-xs text-red-700">{b.recurringOut > 0 ? `−${fmtMYR(b.recurringOut)}` : "—"}</td>
                     <td className="px-3 py-3 text-right font-mono text-xs text-red-700">{b.otherOut > 0 ? `−${fmtMYR(b.otherOut)}` : "—"}</td>
@@ -365,10 +368,9 @@ export default function CashflowPage() {
           </div>
 
           <p className="mt-3 text-[11px] text-gray-400">
-            Sales forecast: 12-week day-of-week average{outletIds.length > 0 ? ` for ${outletIds.length === 1 ? "selected outlet" : `${outletIds.length} selected outlets`}` : ""}. Payroll: 4-month run-rate, projected on the 25th. Marketing: 4-month avg of Google Ads invoices, projected once per month{outletIds.length > 0 ? " (HQ-level, excluded from filtered view)" : ""}.
-            <strong className="text-gray-600"> Other (bank)</strong>: per-day residual from your bank statement period totals, minus everything the synthetic model already covers — captures pickup-app revenue, refunds, card-charged subscriptions, transfers and any other movement the projection isn&apos;t modelling yet.
+            All columns derived from classified bank-line categories over the last 90 days. <strong>Sales</strong>: Card + QR + StoreHub + Grab + FoodPanda + GastroHub + Meetings/Events. <strong>COGS</strong>: Raw Materials + Delivery. <strong>Recurring</strong>: Rent + Utilities + Software + Tax + Maintenance + bank/loan/licensing. <strong>Other inflow/outflow</strong>: anything the auto-classifier hasn&apos;t mapped to a category yet — review the matrix on Cash Tracking to see what&apos;s in here.
             {data.bankFlowsPerDay
-              ? ` Computed from the last ${data.bankFlowsPerDay.sampleDays} days of bank statements (avg in ${fmtMYR2(data.bankFlowsPerDay.inflow)}/day, out ${fmtMYR2(data.bankFlowsPerDay.outflow)}/day).`
+              ? ` 90-day sample: avg in ${fmtMYR2(data.bankFlowsPerDay.inflow)}/day, out ${fmtMYR2(data.bankFlowsPerDay.outflow)}/day.`
               : " Upload a CSV/Excel statement with period totals to populate."}
           </p>
           <div className="mt-3">

--- a/apps/backoffice/src/app/(admin)/inventory/invoices/page.tsx
+++ b/apps/backoffice/src/app/(admin)/inventory/invoices/page.tsx
@@ -5,7 +5,7 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Badge } from "@/components/ui/badge";
 import { useFetch } from "@/lib/use-fetch";
-import { FileText, Search, Download, Eye, Image as ImageIcon, Loader2, CheckCircle2, Clock, AlertTriangle, Filter, X, CalendarDays, Building2, ZoomIn, Pencil, Upload, Trash2, FileDown, DollarSign, Landmark, Copy, Check } from "lucide-react";
+import { FileText, Search, Download, Eye, Image as ImageIcon, Loader2, CheckCircle2, Clock, AlertTriangle, Filter, X, CalendarDays, Building2, ZoomIn, Pencil, Upload, Trash2, FileDown, DollarSign, Landmark, Copy, Check, Ban } from "lucide-react";
 
 const isPdf = (url: string) => /\.pdf($|\?)/i.test(url);
 const fixImageUrl = (url: string) => url.replace("/raw/upload/", "/image/upload/");
@@ -165,6 +165,12 @@ export default function InvoicesPage() {
   const [attachPhotos, setAttachPhotos] = useState<string[]>([]);
   const [attachSaving, setAttachSaving] = useState(false);
   const [attachUploading, setAttachUploading] = useState(false);
+
+  // Reject Initiated Payment — revert INITIATED → PENDING when payment fails
+  // (wrong account, supplier rejected, duplicate caught in review, etc.)
+  const [rejectingInvoice, setRejectingInvoice] = useState<Invoice | null>(null);
+  const [rejectReason, setRejectReason] = useState("");
+  const [rejectSaving, setRejectSaving] = useState(false);
 
   useEffect(() => {
     const t = setTimeout(() => setDebouncedSearch(search), 300);
@@ -454,6 +460,42 @@ export default function InvoicesPage() {
       alert("Network error attaching invoice");
     } finally {
       setAttachSaving(false);
+    }
+  };
+
+  const openReject = (inv: Invoice) => {
+    setRejectingInvoice(inv);
+    setRejectReason("");
+  };
+
+  const submitReject = async () => {
+    if (!rejectingInvoice) return;
+    setRejectSaving(true);
+    try {
+      const today = new Date().toISOString().split("T")[0];
+      const oldRef = rejectingInvoice.paymentRef ?? "n/a";
+      const stamp = `[Rejected ${today} — was ref: ${oldRef}]${rejectReason.trim() ? ": " + rejectReason.trim() : ""}`;
+      const newNotes = rejectingInvoice.notes ? `${rejectingInvoice.notes}\n\n${stamp}` : stamp;
+      const res = await fetch(`/api/inventory/invoices/${rejectingInvoice.id}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          status: "PENDING",
+          paymentRef: null,
+          notes: newNotes,
+        }),
+      });
+      if (!res.ok) {
+        const err = await res.json().catch(() => ({}));
+        alert(`Failed to reject: ${err.error || res.statusText}`);
+        return;
+      }
+      setRejectingInvoice(null);
+      await loadInvoices(undefined, { revalidate: true });
+    } catch {
+      alert("Network error rejecting payment");
+    } finally {
+      setRejectSaving(false);
     }
   };
 
@@ -922,6 +964,15 @@ export default function InvoicesPage() {
                       Attach Invoice
                     </button>
                   )}
+                  {inv.status === "INITIATED" && (
+                    <button
+                      onClick={() => openReject(inv)}
+                      className="inline-flex items-center gap-1 rounded-md border border-red-200 bg-white px-2.5 py-1.5 text-[11px] font-medium text-red-600 hover:bg-red-50"
+                    >
+                      <Ban className="h-3.5 w-3.5" />
+                      Reject
+                    </button>
+                  )}
                   {actions.map((a) => (
                     <button
                       key={a.status}
@@ -1078,6 +1129,16 @@ export default function InvoicesPage() {
                         >
                           <FileText className="h-3 w-3" />
                           Attach Invoice
+                        </button>
+                      )}
+                      {inv.status === "INITIATED" && (
+                        <button
+                          onClick={() => openReject(inv)}
+                          className="inline-flex items-center gap-1 rounded-md border border-red-200 bg-white px-2 py-1 text-[10px] font-medium text-red-600 hover:bg-red-50"
+                          title="Reject — payment failed, revert to Pending"
+                        >
+                          <Ban className="h-3 w-3" />
+                          Reject
                         </button>
                       )}
                       {actions.map((a) => (
@@ -1378,6 +1439,60 @@ export default function InvoicesPage() {
                 className="flex-1 rounded-md bg-yellow-500 px-3 py-2 text-sm font-medium text-white hover:bg-yellow-600 disabled:opacity-50"
               >
                 {attachSaving ? <Loader2 className="mx-auto h-4 w-4 animate-spin" /> : "Attach & Move to Payable"}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* Reject Initiated Payment dialog — rolls invoice back to PENDING and
+          stamps the rejection in notes so finance keeps an audit trail. */}
+      {rejectingInvoice && (
+        <div className="fixed inset-0 z-50 flex items-end sm:items-center justify-center bg-black/60 p-0 sm:p-4" onClick={() => setRejectingInvoice(null)}>
+          <div className="relative w-full max-w-md rounded-t-xl sm:rounded-xl bg-white p-4 sm:p-5" onClick={(e) => e.stopPropagation()}>
+            <div className="flex items-center justify-between mb-3">
+              <div>
+                <h3 className="flex items-center gap-1.5 text-base font-semibold text-gray-900">
+                  <Ban className="h-4 w-4 text-red-500" />
+                  Reject Payment
+                </h3>
+                <p className="mt-0.5 text-xs text-gray-500">Revert this invoice to Pending. Use when the initiated payment didn&apos;t go through.</p>
+              </div>
+              <button onClick={() => setRejectingInvoice(null)} className="rounded-md p-1 text-gray-400 hover:bg-gray-100 hover:text-gray-600">
+                <X className="h-5 w-5" />
+              </button>
+            </div>
+
+            <div className="space-y-3">
+              <div className="rounded-lg bg-gray-50 px-3 py-2 text-xs text-gray-600">
+                <p><span className="font-medium text-gray-800">{rejectingInvoice.invoiceNumber}</span> · {rejectingInvoice.supplier} · RM {rejectingInvoice.amount.toFixed(2)}</p>
+                {rejectingInvoice.paymentRef && (
+                  <p className="mt-1 text-[11px] text-gray-500">Initiated ref: <code className="rounded bg-white px-1 py-0.5 text-[10px]">{rejectingInvoice.paymentRef}</code> (will be cleared)</p>
+                )}
+              </div>
+
+              <div>
+                <label className="mb-1 block text-xs font-medium text-gray-600">Reason <span className="text-gray-400 font-normal">(optional, recommended)</span></label>
+                <textarea
+                  value={rejectReason}
+                  onChange={(e) => setRejectReason(e.target.value)}
+                  placeholder="e.g. wrong account number, supplier rejected, duplicate caught in review..."
+                  rows={3}
+                  className="w-full rounded-md border border-gray-200 bg-white px-3 py-2 text-sm focus:border-red-300 focus:outline-none focus:ring-1 focus:ring-red-300"
+                  autoFocus
+                />
+                <p className="mt-1 text-[10px] text-gray-400">Stored in invoice notes with today&apos;s date and the original payment ref.</p>
+              </div>
+            </div>
+
+            <div className="mt-4 flex gap-2">
+              <button onClick={() => setRejectingInvoice(null)} className="flex-1 rounded-md border border-gray-200 px-3 py-2 text-sm text-gray-600 hover:bg-gray-50">Cancel</button>
+              <button
+                onClick={submitReject}
+                disabled={rejectSaving}
+                className="flex-1 rounded-md bg-red-500 px-3 py-2 text-sm font-medium text-white hover:bg-red-600 disabled:opacity-50"
+              >
+                {rejectSaving ? <Loader2 className="mx-auto h-4 w-4 animate-spin" /> : "Reject & Revert to Pending"}
               </button>
             </div>
           </div>

--- a/apps/backoffice/src/app/(admin)/inventory/invoices/page.tsx
+++ b/apps/backoffice/src/app/(admin)/inventory/invoices/page.tsx
@@ -69,6 +69,8 @@ type Invoice = {
   depositPaidAt: string | null;
   depositRef: string | null;
   flags: InvoiceFlag[];
+  isPendingInvoice: boolean;
+  supplierPaymentTerms: string | null;
 };
 
 type InvoiceFlagCode =
@@ -107,6 +109,7 @@ type InvoicesSummary = {
   initiated: SummaryBucket;
   paid: SummaryBucket;
   dueToday: SummaryBucket;
+  pendingInvoice?: SummaryBucket;
 };
 type InvoicesResponse = {
   invoices: Invoice[];
@@ -130,7 +133,7 @@ export default function InvoicesPage() {
   const [paidDateTo, setPaidDateTo] = useState("");
   const [showFilters, setShowFilters] = useState(false);
   const [viewingPhotos, setViewingPhotos] = useState<{ invoiceNumber: string; photos: string[] } | null>(null);
-  const [cardFilter, setCardFilter] = useState<"all" | "pending" | "overdue" | "initiated" | "paid" | "due_today" | "payable" | null>(null);
+  const [cardFilter, setCardFilter] = useState<"all" | "pending" | "overdue" | "initiated" | "paid" | "due_today" | "payable" | "pending_invoice" | null>(null);
   const [batchInitiating, setBatchInitiating] = useState(false);
 
   // Payment dialog
@@ -155,6 +158,13 @@ export default function InvoicesPage() {
   const [editPhotos, setEditPhotos] = useState<string[]>([]);
   const [editSaving, setEditSaving] = useState(false);
   const [editUploading, setEditUploading] = useState(false);
+
+  // Attach Invoice dialog (GRNI placeholder → real supplier invoice)
+  const [attachingInvoice, setAttachingInvoice] = useState<Invoice | null>(null);
+  const [attachForm, setAttachForm] = useState({ invoiceNumber: "", issueDate: "", dueDate: "", amount: "" });
+  const [attachPhotos, setAttachPhotos] = useState<string[]>([]);
+  const [attachSaving, setAttachSaving] = useState(false);
+  const [attachUploading, setAttachUploading] = useState(false);
 
   useEffect(() => {
     const t = setTimeout(() => setDebouncedSearch(search), 300);
@@ -364,6 +374,89 @@ export default function InvoicesPage() {
     }
   };
 
+  // Parse free-text payment terms ("Net 30", "30 days", "COD") into days.
+  // Returns null when no obvious numeric term found — caller falls back to
+  // a manual due-date pick.
+  const parsePaymentTermDays = (terms: string | null): number | null => {
+    if (!terms) return null;
+    const m = terms.match(/(\d+)/);
+    if (!m) return null;
+    const n = parseInt(m[1], 10);
+    return Number.isFinite(n) && n > 0 && n <= 365 ? n : null;
+  };
+
+  const addDays = (iso: string, days: number) => {
+    const d = new Date(iso);
+    d.setDate(d.getDate() + days);
+    return d.toISOString().split("T")[0];
+  };
+
+  const openAttach = (inv: Invoice) => {
+    setAttachingInvoice(inv);
+    const today = new Date().toISOString().split("T")[0];
+    const termDays = parsePaymentTermDays(inv.supplierPaymentTerms);
+    setAttachForm({
+      invoiceNumber: "",
+      issueDate: today,
+      dueDate: termDays ? addDays(today, termDays) : "",
+      amount: inv.amount.toFixed(2),
+    });
+    setAttachPhotos(inv.photos || []);
+  };
+
+  const handleAttachPhotoUpload = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const files = e.target.files;
+    if (!files?.length) return;
+    setAttachUploading(true);
+    try {
+      for (const file of Array.from(files)) {
+        const formData = new FormData();
+        formData.append("file", file);
+        formData.append("folder", "invoices");
+        const res = await fetch("/api/inventory/upload", { method: "POST", body: formData });
+        if (res.ok) {
+          const data = await res.json();
+          setAttachPhotos((prev) => [...prev, data.url]);
+        }
+      }
+    } catch { /* ignore */ }
+    setAttachUploading(false);
+    e.target.value = "";
+  };
+
+  const submitAttach = async () => {
+    if (!attachingInvoice) return;
+    if (!attachForm.invoiceNumber.trim()) {
+      alert("Supplier invoice number is required");
+      return;
+    }
+    setAttachSaving(true);
+    try {
+      const res = await fetch(`/api/inventory/invoices/${attachingInvoice.id}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          invoiceNumber: attachForm.invoiceNumber.trim(),
+          issueDate: attachForm.issueDate || null,
+          dueDate: attachForm.dueDate || null,
+          amount: parseFloat(attachForm.amount) || attachingInvoice.amount,
+          photos: attachPhotos,
+        }),
+      });
+      if (!res.ok) {
+        const err = await res.json().catch(() => ({}));
+        alert(`Failed to attach invoice: ${err.error || res.statusText}`);
+        return;
+      }
+      setAttachingInvoice(null);
+      await loadInvoices(undefined, { revalidate: true });
+    } catch {
+      alert("Network error attaching invoice");
+    } finally {
+      setAttachSaving(false);
+    }
+  };
+
   const dismissFlag = async (invoiceId: string, code: InvoiceFlagCode) => {
     setFlagActionCode(code);
     try {
@@ -425,6 +518,8 @@ export default function InvoicesPage() {
   const initiatedCount = summary?.initiated.count ?? allInvoices.filter((i) => i.status === "INITIATED").length;
   const totalPaid = summary?.paid.amount ?? allInvoices.filter((i) => i.status === "PAID").reduce((a, i) => a + i.amount, 0);
   const paidCount = summary?.paid.count ?? allInvoices.filter((i) => i.status === "PAID").length;
+  const totalPendingInvoice = summary?.pendingInvoice?.amount ?? allInvoices.filter((i) => i.isPendingInvoice).reduce((a, i) => a + i.amount, 0);
+  const pendingInvoiceCount = summary?.pendingInvoice?.count ?? allInvoices.filter((i) => i.isPendingInvoice).length;
 
   const statusLabel = (status: string, paymentType: string) => {
     // Staff claims used to show "approved"/"reimbursed" — unified with supplier
@@ -454,6 +549,10 @@ export default function InvoicesPage() {
     const hasDeposit = depositPercent && depositPercent > 0;
     const depositAmt = inv.depositAmount ?? Math.round(inv.amount * (depositPercent || 0) / 100 * 100) / 100;
     const balanceAmt = Math.round((inv.amount - depositAmt) * 100) / 100;
+
+    // GRNI placeholders shouldn't be paid until the supplier invoice arrives —
+    // suppress payment actions so users go through "Attach Invoice" first.
+    if (inv.isPendingInvoice) return [];
 
     // Unified action labels — "Initiate Payment" / "Mark Paid" everywhere,
     // except internal transfers which use "Initiate Settlement" / "Mark Settled".
@@ -504,9 +603,10 @@ export default function InvoicesPage() {
       </div>
 
       {/* Summary cards — clickable to filter */}
-      <div className="mt-4 grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-6 gap-2 sm:gap-3">
+      <div className="mt-4 grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-7 gap-2 sm:gap-3">
         {([
           { key: "all" as const, label: "Total", amount: totalAll, count: totalAllCount, color: "text-gray-900", border: "border-gray-300", ring: "ring-gray-200" },
+          { key: "pending_invoice" as const, label: "Pending Invoice", amount: totalPendingInvoice, count: pendingInvoiceCount, color: pendingInvoiceCount > 0 ? "text-yellow-700" : "text-gray-400", border: "border-yellow-400", ring: "ring-yellow-100" },
           { key: "payable" as const, label: "Payable", amount: totalPayable, count: payableCount, color: payableCount > 0 ? "text-orange-600" : "text-gray-400", border: "border-orange-400", ring: "ring-orange-100" },
           { key: "due_today" as const, label: "Due Today", amount: dueTodayAmount, count: dueTodayCount, color: dueTodayCount > 0 ? "text-blue-600" : "text-gray-400", border: "border-blue-400", ring: "ring-blue-100" },
           { key: "initiated" as const, label: "Initiated", amount: totalInitiated, count: initiatedCount, color: initiatedCount > 0 ? "text-indigo-600" : "text-gray-400", border: "border-indigo-400", ring: "ring-indigo-100" },
@@ -523,6 +623,8 @@ export default function InvoicesPage() {
                   ? "border-blue-200 bg-blue-50/50 hover:border-blue-300"
                   : card.key === "payable" && card.count > 0
                   ? "border-orange-200 bg-orange-50/50 hover:border-orange-300"
+                  : card.key === "pending_invoice" && card.count > 0
+                  ? "border-yellow-200 bg-yellow-50/50 hover:border-yellow-300"
                   : "border-gray-200 hover:border-gray-300"
             }`}
           >
@@ -530,7 +632,7 @@ export default function InvoicesPage() {
               <p className="text-xs text-gray-500">{card.label}</p>
               {card.count > 0 && card.key !== "all" && (
                 <span className={`flex h-5 min-w-[20px] items-center justify-center rounded-full px-1.5 text-[10px] font-bold text-white ${
-                  card.key === "payable" ? "bg-orange-500" : card.key === "due_today" ? "bg-blue-500" : card.key === "overdue" ? "bg-red-500" : card.key === "initiated" ? "bg-indigo-500" : "bg-green-500"
+                  card.key === "payable" ? "bg-orange-500" : card.key === "due_today" ? "bg-blue-500" : card.key === "overdue" ? "bg-red-500" : card.key === "initiated" ? "bg-indigo-500" : card.key === "pending_invoice" ? "bg-yellow-500" : "bg-green-500"
                 }`}>
                   {card.count}
                 </span>
@@ -558,7 +660,7 @@ export default function InvoicesPage() {
       {cardFilter && (
         <div className="mt-2 flex items-center gap-2">
           <span className="text-xs text-gray-500">
-            Showing: <span className="font-medium text-gray-700">{cardFilter === "due_today" ? "Due Today" : cardFilter === "payable" ? "Payable" : cardFilter === "all" ? "All" : cardFilter.charAt(0).toUpperCase() + cardFilter.slice(1)}</span>
+            Showing: <span className="font-medium text-gray-700">{cardFilter === "due_today" ? "Due Today" : cardFilter === "pending_invoice" ? "Pending Invoice" : cardFilter === "payable" ? "Payable" : cardFilter === "all" ? "All" : cardFilter.charAt(0).toUpperCase() + cardFilter.slice(1)}</span>
             {" "}({invoices.length} invoice{invoices.length !== 1 ? "s" : ""})
           </span>
           <button onClick={() => setCardFilter(null)} className="flex items-center gap-0.5 rounded-full border border-gray-200 px-2 py-0.5 text-[10px] text-gray-500 hover:bg-gray-50">
@@ -742,7 +844,11 @@ export default function InvoicesPage() {
                 <div className="min-w-0 flex-1">
                   <div className="flex flex-wrap items-center gap-1.5">
                     <p className="text-sm font-semibold text-gray-900">{inv.invoiceNumber}</p>
-                    <Badge className={`text-[10px] ${statusColor(inv.status)}`}>{statusLabel(inv.status, inv.paymentType)}</Badge>
+                    {inv.isPendingInvoice ? (
+                      <span className="rounded bg-yellow-100 px-1.5 py-0.5 text-[9px] font-semibold text-yellow-800">AWAITING INVOICE</span>
+                    ) : (
+                      <Badge className={`text-[10px] ${statusColor(inv.status)}`}>{statusLabel(inv.status, inv.paymentType)}</Badge>
+                    )}
                     {inv.paymentType === "STAFF_CLAIM" && <span className="rounded bg-purple-100 px-1 py-0.5 text-[9px] font-medium text-purple-600">CLAIM</span>}
                     {inv.orderType === "PAYMENT_REQUEST" && <span className="rounded bg-blue-100 px-1 py-0.5 text-[9px] font-medium text-blue-600">REQUEST</span>}
                     {inv.paymentType === "INTERNAL_TRANSFER" && <span className="rounded bg-orange-100 px-1 py-0.5 text-[9px] font-medium text-orange-600">TRANSFER</span>}
@@ -807,6 +913,15 @@ export default function InvoicesPage() {
                   Edit
                 </button>
                 <div className="ml-auto flex flex-wrap justify-end gap-1.5">
+                  {inv.isPendingInvoice && (
+                    <button
+                      onClick={() => openAttach(inv)}
+                      className="inline-flex items-center gap-1 rounded-md bg-yellow-500 px-2.5 py-1.5 text-[11px] font-medium text-white hover:bg-yellow-600"
+                    >
+                      <FileText className="h-3.5 w-3.5" />
+                      Attach Invoice
+                    </button>
+                  )}
                   {actions.map((a) => (
                     <button
                       key={a.status}
@@ -919,7 +1034,11 @@ export default function InvoicesPage() {
                   <td className="px-4 py-3 text-xs text-gray-500">{inv.outlet}</td>
                   {typeFilter !== "supplier" && <td className="px-4 py-3 text-xs text-gray-500">{inv.claimedBy ?? "—"}</td>}
                   <td className="px-4 py-3">
-                    <Badge className={`text-[10px] ${statusColor(inv.status)}`}>{statusLabel(inv.status, inv.paymentType)}</Badge>
+                    {inv.isPendingInvoice ? (
+                      <span className="inline-block rounded bg-yellow-100 px-1.5 py-0.5 text-[9px] font-semibold text-yellow-800">AWAITING INVOICE</span>
+                    ) : (
+                      <Badge className={`text-[10px] ${statusColor(inv.status)}`}>{statusLabel(inv.status, inv.paymentType)}</Badge>
+                    )}
                     {inv.status === "DEPOSIT_PAID" && inv.depositAmount && (
                       <p className="text-[9px] text-amber-600 mt-0.5">Bal: RM {(inv.amount - inv.depositAmount).toFixed(2)}</p>
                     )}
@@ -951,6 +1070,16 @@ export default function InvoicesPage() {
                       >
                         <Pencil className="h-3.5 w-3.5" />
                       </button>
+                      {inv.isPendingInvoice && (
+                        <button
+                          onClick={() => openAttach(inv)}
+                          className="inline-flex items-center gap-1 rounded-md bg-yellow-500 px-2 py-1 text-[10px] font-medium text-white hover:bg-yellow-600"
+                          title="Attach supplier invoice"
+                        >
+                          <FileText className="h-3 w-3" />
+                          Attach Invoice
+                        </button>
+                      )}
                       {actions.map((a) => (
                         <button
                           key={a.status}
@@ -1109,6 +1238,146 @@ export default function InvoicesPage() {
                 className="flex-1 rounded-md bg-terracotta px-3 py-2 text-sm font-medium text-white hover:bg-terracotta-dark disabled:opacity-50"
               >
                 {editSaving ? <Loader2 className="mx-auto h-4 w-4 animate-spin" /> : "Save Changes"}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* Attach Invoice modal — fills GRNI placeholder with the supplier's
+          actual invoice details once the supplier sends them post-delivery. */}
+      {attachingInvoice && (
+        <div className="fixed inset-0 z-50 flex items-end sm:items-center justify-center bg-black/60 p-0 sm:p-4" onClick={() => setAttachingInvoice(null)}>
+          <div className="relative w-full max-w-lg max-h-[92vh] overflow-y-auto rounded-t-xl sm:rounded-xl bg-white p-4 sm:p-5" onClick={(e) => e.stopPropagation()}>
+            <div className="flex items-center justify-between mb-4">
+              <div>
+                <h3 className="text-base font-semibold text-gray-900">Attach Supplier Invoice</h3>
+                <p className="mt-0.5 text-xs text-gray-500">Goods already received. Fill in the supplier&apos;s invoice details so it&apos;s ready to pay.</p>
+              </div>
+              <button onClick={() => setAttachingInvoice(null)} className="rounded-md p-1 text-gray-400 hover:bg-gray-100 hover:text-gray-600">
+                <X className="h-5 w-5" />
+              </button>
+            </div>
+
+            <div className="space-y-3">
+              <div className="rounded-lg bg-yellow-50 border border-yellow-200 px-3 py-2 text-xs text-gray-700">
+                <span className="font-medium">{attachingInvoice.supplier}</span> · {attachingInvoice.outlet} · PO: {attachingInvoice.poNumber}
+                {attachingInvoice.supplierPaymentTerms && (
+                  <span className="ml-2 rounded bg-yellow-100 px-1.5 py-0.5 text-[10px] font-medium text-yellow-800">Terms: {attachingInvoice.supplierPaymentTerms}</span>
+                )}
+              </div>
+
+              <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+                <div>
+                  <label className="mb-1 block text-xs font-medium text-gray-600">Supplier Invoice No. <span className="text-red-500">*</span></label>
+                  <Input
+                    value={attachForm.invoiceNumber}
+                    onChange={(e) => setAttachForm({ ...attachForm, invoiceNumber: e.target.value })}
+                    placeholder="e.g. ABC-2026-1234"
+                    autoFocus
+                  />
+                </div>
+                <div>
+                  <label className="mb-1 block text-xs font-medium text-gray-600">Amount (RM)</label>
+                  <Input
+                    type="number"
+                    step="0.01"
+                    value={attachForm.amount}
+                    onChange={(e) => setAttachForm({ ...attachForm, amount: e.target.value })}
+                  />
+                </div>
+              </div>
+
+              <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+                <div>
+                  <label className="mb-1 block text-xs font-medium text-gray-600">Issue Date</label>
+                  <input
+                    type="date"
+                    value={attachForm.issueDate}
+                    onChange={(e) => {
+                      const newIssue = e.target.value;
+                      const termDays = parsePaymentTermDays(attachingInvoice.supplierPaymentTerms);
+                      setAttachForm((prev) => ({
+                        ...prev,
+                        issueDate: newIssue,
+                        // Re-compute due date when issue changes if user is still
+                        // on the auto-suggested term (avoids overwriting a hand-picked due date).
+                        dueDate: termDays && newIssue ? addDays(newIssue, termDays) : prev.dueDate,
+                      }));
+                    }}
+                    className="w-full rounded-md border border-gray-200 bg-white px-3 py-2 text-sm focus:border-blue-400 focus:outline-none focus:ring-1 focus:ring-blue-400"
+                  />
+                </div>
+                <div>
+                  <label className="mb-1 block text-xs font-medium text-gray-600">Due Date</label>
+                  <input
+                    type="date"
+                    value={attachForm.dueDate}
+                    onChange={(e) => setAttachForm({ ...attachForm, dueDate: e.target.value })}
+                    className="w-full rounded-md border border-gray-200 bg-white px-3 py-2 text-sm focus:border-blue-400 focus:outline-none focus:ring-1 focus:ring-blue-400"
+                  />
+                  <div className="mt-1.5 flex flex-wrap gap-1">
+                    {[7, 14, 30, 60].map((d) => (
+                      <button
+                        key={d}
+                        type="button"
+                        onClick={() => setAttachForm((prev) => ({
+                          ...prev,
+                          dueDate: prev.issueDate ? addDays(prev.issueDate, d) : prev.dueDate,
+                        }))}
+                        className="rounded-full border border-gray-200 bg-white px-2 py-0.5 text-[10px] text-gray-600 hover:bg-gray-50"
+                      >
+                        +{d}d
+                      </button>
+                    ))}
+                  </div>
+                </div>
+              </div>
+
+              {/* Photos — start from any photos captured at receiving */}
+              <div>
+                <label className="mb-1 block text-xs font-medium text-gray-600">Invoice Photos</label>
+                {attachPhotos.length > 0 && (
+                  <div className="mb-2 grid grid-cols-3 gap-2">
+                    {attachPhotos.map((url, i) => (
+                      <div key={i} className="group relative overflow-hidden rounded-lg border border-gray-200">
+                        {isPdf(url) ? (
+                          <a href={url} target="_blank" rel="noopener noreferrer" className="flex h-24 w-full flex-col items-center justify-center bg-gray-50 text-gray-400 hover:text-blue-500">
+                            <FileDown className="h-6 w-6" />
+                            <span className="mt-1 text-[10px]">PDF</span>
+                          </a>
+                        ) : (
+                          <img src={fixImageUrl(url)} alt={`Photo ${i + 1}`} className="h-24 w-full object-cover" />
+                        )}
+                        <button
+                          onClick={() => setAttachPhotos(attachPhotos.filter((_, j) => j !== i))}
+                          className="absolute right-1 top-1 rounded-full bg-red-500 p-0.5 text-white opacity-0 transition-opacity group-hover:opacity-100"
+                        >
+                          <Trash2 className="h-3 w-3" />
+                        </button>
+                      </div>
+                    ))}
+                  </div>
+                )}
+                <label className={`flex cursor-pointer items-center justify-center gap-2 rounded-lg border-2 border-dashed border-gray-300 px-4 py-3 text-sm transition-colors hover:border-yellow-400 hover:bg-yellow-50/30 ${attachUploading ? "opacity-50 pointer-events-none" : ""}`}>
+                  {attachUploading ? (
+                    <><Loader2 className="h-4 w-4 animate-spin text-yellow-500" /> Uploading...</>
+                  ) : (
+                    <><Upload className="h-4 w-4 text-gray-400" /> <span className="text-gray-500">Upload supplier invoice</span></>
+                  )}
+                  <input type="file" accept="image/*,.pdf" multiple className="hidden" onChange={handleAttachPhotoUpload} />
+                </label>
+              </div>
+            </div>
+
+            <div className="mt-4 flex gap-2">
+              <button onClick={() => setAttachingInvoice(null)} className="flex-1 rounded-md border border-gray-200 px-3 py-2 text-sm text-gray-600 hover:bg-gray-50">Cancel</button>
+              <button
+                onClick={submitAttach}
+                disabled={attachSaving || !attachForm.invoiceNumber.trim()}
+                className="flex-1 rounded-md bg-yellow-500 px-3 py-2 text-sm font-medium text-white hover:bg-yellow-600 disabled:opacity-50"
+              >
+                {attachSaving ? <Loader2 className="mx-auto h-4 w-4 animate-spin" /> : "Attach & Move to Payable"}
               </button>
             </div>
           </div>

--- a/apps/backoffice/src/app/(admin)/inventory/orders/create/page.tsx
+++ b/apps/backoffice/src/app/(admin)/inventory/orders/create/page.tsx
@@ -593,7 +593,7 @@ export default function CreateOrderPage() {
     setWhatsappDialog({ open: true, supplier, supplierId: group.supplierId, message, phone: group.phone, items: group.items });
   };
 
-  const openWhatsApp = async () => {
+  const openWhatsApp = async (whatsappMode: "direct" | "picker" = "direct") => {
     setSending(true);
     try {
       const group = cartBySupplier[whatsappDialog.supplier];
@@ -639,8 +639,17 @@ export default function CreateOrderPage() {
         }
       }
 
+      // mode='direct' opens chat with the supplier's saved number.
+      // mode='picker' opens WhatsApp without a target — user picks any chat
+      // (group OR contact) from their list and the message is pre-filled.
+      // WhatsApp doesn't expose group IDs in their deep-link API, so the
+      // picker is the only way to send to a group with prefilled text.
       const phone = whatsappDialog.phone.replace(/\+/g, "");
-      window.open(`https://wa.me/${phone}?text=${encodeURIComponent(whatsappDialog.message)}`, "_blank");
+      const text = encodeURIComponent(whatsappDialog.message);
+      const url = whatsappMode === "picker"
+        ? `https://wa.me/?text=${text}`
+        : `https://wa.me/${phone}?text=${text}`;
+      window.open(url, "_blank");
 
       setCart((prev) => prev.filter((c) => c.supplierId !== whatsappDialog.supplierId));
       setWhatsappDialog({ open: false, supplier: "", supplierId: "", message: "", phone: "", items: [] });
@@ -1248,10 +1257,21 @@ export default function CreateOrderPage() {
             <div className="rounded-lg bg-green-50 p-3">
               <pre className="whitespace-pre-wrap text-xs text-gray-700">{whatsappDialog.message}</pre>
             </div>
-            <Button className="w-full bg-green-600 hover:bg-green-700" onClick={openWhatsApp} disabled={sending}>
+            <Button className="w-full bg-green-600 hover:bg-green-700" onClick={() => openWhatsApp("direct")} disabled={sending || !whatsappDialog.phone}>
               {sending ? <Loader2 className="mr-1.5 h-4 w-4 animate-spin" /> : <MessageCircle className="mr-1.5 h-4 w-4" />}
-              {sending ? "Creating order..." : "Open WhatsApp"}
+              {sending ? "Creating order..." : whatsappDialog.phone ? `Send to ${whatsappDialog.supplier}` : "Open WhatsApp"}
             </Button>
+            <button
+              type="button"
+              onClick={() => openWhatsApp("picker")}
+              disabled={sending}
+              className="w-full rounded-md border border-green-200 bg-white px-3 py-2 text-sm font-medium text-green-700 hover:bg-green-50 disabled:opacity-50"
+            >
+              Send to a group / pick chat →
+            </button>
+            <p className="text-[10px] text-gray-400 text-center">
+              WhatsApp doesn&apos;t allow direct group links. The group option opens WhatsApp&apos;s chat picker with the message pre-filled — tap the supplier&apos;s group, hit send.
+            </p>
           </div>
         </DialogContent>
       </Dialog>

--- a/apps/backoffice/src/app/(admin)/inventory/orders/page.tsx
+++ b/apps/backoffice/src/app/(admin)/inventory/orders/page.tsx
@@ -113,6 +113,62 @@ const NEXT_ACTIONS: Record<string, { status: string; label: string; icon: typeof
   CANCELLED: [],
 };
 
+// ── Invoice preview pane ──────────────────────────────────────────────────
+// Image-or-PDF aware preview with onError fallback to iframe. Bigger now so
+// it actually fills the wider edit dialog (was capped at 60vh, broke when
+// the URL was a PDF or expired Cloudinary asset).
+function InvoicePreviewPane({ photos }: { photos: string[] }) {
+  const [activeIdx, setActiveIdx] = useState(0);
+  const [failed, setFailed] = useState(false);
+  const url = photos[activeIdx];
+  const isPdf = /\.pdf($|\?)/i.test(url) || url.includes("/raw/upload/");
+  const imgUrl = url.replace("/raw/upload/", "/image/upload/");
+
+  return (
+    <div className="hidden lg:flex w-[48%] shrink-0 flex-col rounded-lg bg-gray-900 overflow-hidden">
+      <div className="flex items-center justify-between p-3 border-b border-gray-700">
+        <p className="text-xs text-gray-400 font-medium">Invoice / Receipt</p>
+        {photos.length > 1 && (
+          <div className="flex gap-1">
+            {photos.map((_, i) => (
+              <button
+                key={i}
+                onClick={() => { setActiveIdx(i); setFailed(false); }}
+                className={`h-6 w-6 rounded text-[10px] font-medium ${i === activeIdx ? "bg-terracotta text-white" : "bg-gray-700 text-gray-300 hover:bg-gray-600"}`}
+              >
+                {i + 1}
+              </button>
+            ))}
+          </div>
+        )}
+      </div>
+      <div className="flex-1 flex items-stretch justify-stretch p-3 min-h-[600px]">
+        {isPdf || failed ? (
+          <iframe src={url} className="w-full h-full min-h-[600px] rounded bg-white" title="Invoice" />
+        ) : (
+          <a href={imgUrl} target="_blank" rel="noopener noreferrer" className="group relative flex-1 flex items-center justify-center">
+            <img
+              src={imgUrl}
+              alt="Invoice"
+              className="max-w-full max-h-[80vh] object-contain rounded"
+              onError={() => setFailed(true)}
+            />
+            <div className="absolute inset-0 flex items-center justify-center opacity-0 group-hover:opacity-100 bg-black/20 rounded transition-opacity">
+              <span className="text-white text-xs font-medium bg-black/50 px-2 py-1 rounded">Open full size</span>
+            </div>
+          </a>
+        )}
+      </div>
+      <div className="px-3 py-2 border-t border-gray-700 flex items-center justify-between">
+        <a href={url} target="_blank" rel="noopener noreferrer" className="text-[11px] font-medium text-blue-400 hover:text-blue-300">
+          Open in new tab →
+        </a>
+        <span className="text-[10px] text-gray-500">{isPdf ? "PDF" : failed ? "Preview unavailable" : "Image"}</span>
+      </div>
+    </div>
+  );
+}
+
 // ── Component ─────────────────────────────────────────────────────────────
 
 export default function OrdersPage() {
@@ -754,7 +810,7 @@ export default function OrdersPage() {
 
       {/* Edit Order Dialog */}
       <Dialog open={!!editOrder} onOpenChange={(open) => !open && setEditOrder(null)}>
-        <DialogContent className={`max-h-[90vh] overflow-y-auto ${editOrder?.invoice && editOrder.invoice.photos.length > 0 ? "sm:max-w-5xl" : "sm:max-w-2xl"}`}>
+        <DialogContent className={`max-h-[95vh] overflow-y-auto ${editOrder?.invoice && editOrder.invoice.photos.length > 0 ? "sm:max-w-[1400px] w-[95vw]" : "sm:max-w-3xl"}`}>
           <DialogHeader>
             <DialogTitle className="flex items-center gap-2">
               {confirmOnSave ? <CheckCircle2 className="h-4 w-4 text-blue-500" /> : <Pencil className="h-4 w-4" />}
@@ -764,25 +820,9 @@ export default function OrdersPage() {
 
           {editOrder && (
             <div className={`flex gap-4 ${editOrder.invoice && editOrder.invoice.photos.length > 0 ? "" : ""}`}>
-              {/* Left: Invoice image preview */}
+              {/* Left: Invoice image / PDF preview */}
               {editOrder.invoice && editOrder.invoice.photos.length > 0 && (
-                <div className="hidden sm:flex w-[40%] shrink-0 flex-col rounded-lg bg-gray-900 overflow-hidden">
-                  <div className="p-3 border-b border-gray-700">
-                    <p className="text-xs text-gray-400 font-medium">Invoice / Receipt</p>
-                  </div>
-                  <div className="flex-1 flex items-center justify-center p-3 min-h-[400px]">
-                    <a href={editOrder.invoice.photos[0].replace("/raw/upload/", "/image/upload/")} target="_blank" rel="noopener noreferrer" className="group relative">
-                      <img
-                        src={editOrder.invoice.photos[0].replace("/raw/upload/", "/image/upload/")}
-                        alt="Invoice"
-                        className="max-w-full max-h-[60vh] object-contain rounded"
-                      />
-                      <div className="absolute inset-0 flex items-center justify-center opacity-0 group-hover:opacity-100 bg-black/20 rounded transition-opacity">
-                        <span className="text-white text-xs font-medium bg-black/50 px-2 py-1 rounded">Open full size</span>
-                      </div>
-                    </a>
-                  </div>
-                </div>
+                <InvoicePreviewPane photos={editOrder.invoice.photos} />
               )}
 
               {/* Right: Form */}

--- a/apps/backoffice/src/app/(admin)/inventory/pay-and-claim/batches/new/page.tsx
+++ b/apps/backoffice/src/app/(admin)/inventory/pay-and-claim/batches/new/page.tsx
@@ -45,6 +45,7 @@ export default function NewBatchPage() {
   const [to, setTo] = useState<string>("");
   const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
   const [selectedPayee, setSelectedPayee] = useState<string | null>(null);
+  const [selectedOutlet, setSelectedOutlet] = useState<string | null>(null);
   const [submitting, setSubmitting] = useState(false);
   const [notes, setNotes] = useState("");
 
@@ -63,11 +64,16 @@ export default function NewBatchPage() {
   const groups = data?.groups ?? [];
 
   const toggle = (inv: InvoiceRow, payeeId: string) => {
+    const outletId = inv.outlet?.id ?? null;
     setSelectedIds((prev) => {
-      // Constrain to one payee — clear selection if switching payee
-      if (selectedPayee && selectedPayee !== payeeId && prev.size > 0) {
-        if (!confirm("Switching payee will clear current selection. Continue?")) return prev;
+      // Constrain to one payee + one outlet
+      const switchingPayee = selectedPayee && selectedPayee !== payeeId && prev.size > 0;
+      const switchingOutlet = selectedOutlet && outletId && selectedOutlet !== outletId && prev.size > 0;
+      if (switchingPayee || switchingOutlet) {
+        const reason = switchingPayee ? "payee" : "outlet";
+        if (!confirm(`Switching ${reason} will clear current selection. Continue?`)) return prev;
         setSelectedPayee(payeeId);
+        setSelectedOutlet(outletId);
         const next = new Set<string>();
         next.add(inv.id);
         return next;
@@ -75,25 +81,40 @@ export default function NewBatchPage() {
       const next = new Set(prev);
       if (next.has(inv.id)) next.delete(inv.id);
       else next.add(inv.id);
-      setSelectedPayee(next.size === 0 ? null : payeeId);
+      if (next.size === 0) {
+        setSelectedPayee(null);
+        setSelectedOutlet(null);
+      } else {
+        setSelectedPayee(payeeId);
+        setSelectedOutlet(outletId);
+      }
       return next;
     });
   };
 
   const toggleAllForPayee = (group: Group) => {
-    const allIds = group.invoices.map((i) => i.id);
+    // Only invoices at the currently locked outlet (or all if none locked yet)
+    const eligible = group.invoices.filter(
+      (i) => !selectedOutlet || (i.outlet?.id ?? null) === selectedOutlet,
+    );
+    if (eligible.length === 0) return;
+    const allIds = eligible.map((i) => i.id);
     const allSelected = allIds.every((id) => selectedIds.has(id));
     setSelectedIds((prev) => {
-      const next = new Set<string>(allSelected ? [] : []);
+      const next = new Set<string>();
       if (!allSelected) {
-        // Clear if switching payee and prev had items for another payee
+        // If toggling-on for a different payee, confirm
         if (selectedPayee && selectedPayee !== group.userId) {
           if (!confirm("Switching payee will clear current selection. Continue?")) return prev;
         }
         allIds.forEach((id) => next.add(id));
         setSelectedPayee(group.userId);
+        // If user clicks "select all" on a payee with mixed outlets, lock to the first outlet
+        const firstOutlet = eligible[0].outlet?.id ?? null;
+        setSelectedOutlet(firstOutlet);
       } else {
         setSelectedPayee(null);
+        setSelectedOutlet(null);
       }
       return next;
     });
@@ -137,6 +158,12 @@ export default function NewBatchPage() {
     ? groups.find((g) => g.userId === selectedPayee)?.payee
     : null;
 
+  const outletOfSelected = selectedOutlet
+    ? groups
+        .flatMap((g) => g.invoices)
+        .find((inv) => inv.outlet?.id === selectedOutlet)?.outlet ?? null
+    : null;
+
   return (
     <div className="space-y-6 p-4 sm:p-6 lg:p-8">
       <Link
@@ -149,7 +176,7 @@ export default function NewBatchPage() {
       <div>
         <h1 className="text-2xl font-bold">New Claim Batch</h1>
         <p className="text-sm text-muted-foreground">
-          Pick which staff claims to pay together. All selected invoices must belong to the same payee.
+          Pick which staff claims to pay together. All selected invoices must belong to the same payee and the same outlet.
         </p>
       </div>
 
@@ -226,11 +253,18 @@ export default function NewBatchPage() {
                   </div>
                 </div>
                 <div className="divide-y">
-                  {g.invoices.map((inv) => (
-                    <label key={inv.id} className="flex cursor-pointer items-center gap-3 px-4 py-2 text-sm hover:bg-muted/30">
+                  {g.invoices.map((inv) => {
+                    const invOutletId = inv.outlet?.id ?? null;
+                    const outletLocked = !!selectedOutlet && selectedOutlet !== invOutletId && !selectedIds.has(inv.id);
+                    return (
+                    <label
+                      key={inv.id}
+                      className={`flex items-center gap-3 px-4 py-2 text-sm ${outletLocked ? "cursor-not-allowed opacity-40" : "cursor-pointer hover:bg-muted/30"}`}
+                    >
                       <input
                         type="checkbox"
                         checked={selectedIds.has(inv.id)}
+                        disabled={outletLocked}
                         onChange={() => toggle(inv, g.userId)}
                         className="h-4 w-4"
                       />
@@ -250,7 +284,8 @@ export default function NewBatchPage() {
                         RM {Number(inv.amount).toFixed(2)}
                       </div>
                     </label>
-                  ))}
+                    );
+                  })}
                 </div>
               </div>
             );
@@ -273,6 +308,11 @@ export default function NewBatchPage() {
                   {payeeOfSelected.bankAccountNumber && (
                     <> — {payeeOfSelected.bankName} {payeeOfSelected.bankAccountNumber}</>
                   )}
+                </div>
+              )}
+              {outletOfSelected && (
+                <div className="mt-0.5 text-xs text-muted-foreground">
+                  Outlet: <span className="font-medium">{outletOfSelected.name}</span>
                 </div>
               )}
             </div>

--- a/apps/backoffice/src/app/(admin)/inventory/pay-and-claim/page.tsx
+++ b/apps/backoffice/src/app/(admin)/inventory/pay-and-claim/page.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect, Fragment } from "react";
 import Link from "next/link";
+import { useRouter } from "next/navigation";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Badge } from "@/components/ui/badge";
@@ -60,9 +61,11 @@ type Claim = {
   flow?: "CLAIM" | "REQUEST";
   expenseCategory?: "INGREDIENT" | "ASSET" | "MAINTENANCE" | "OTHER";
   outlet: string;
+  outletId: string | null;
   outletCode: string;
   supplierId: string;
   supplier: string;
+  claimedById: string | null;
   claimedBy: string | null;
   claimedByBank: { bankName: string | null; bankAccountNumber: string | null; bankAccountName: string | null } | null;
   createdBy: string;
@@ -78,6 +81,8 @@ type Claim = {
     status: string;
     photoCount: number;
     photos: string[];
+    claimBatchId: string | null;
+    claimBatch: { id: string; batchNumber: string; status: string } | null;
     vendorName?: string | null;
     vendorBank?: { bankName: string; accountNumber: string | null; accountName: string | null } | null;
   } | null;
@@ -123,6 +128,7 @@ function aiConfidenceBadge(claim: Claim) {
 
 export default function PayAndClaimPage() {
   // Current user
+  const router = useRouter();
   const [currentUserId, setCurrentUserId] = useState("");
   useEffect(() => {
     fetch("/api/auth/me").then((r) => r.json()).then((me) => {
@@ -143,6 +149,13 @@ export default function PayAndClaimPage() {
 
   // Quick Upload dialog state
   const [quickUploadOpen, setQuickUploadOpen] = useState(false);
+
+  // Bulk-batch selection state (only enabled on the Pending tab)
+  const [batchSelected, setBatchSelected] = useState<Set<string>>(new Set());
+  const [batchPayeeId, setBatchPayeeId] = useState<string | null>(null);
+  const [batchOutletId, setBatchOutletId] = useState<string | null>(null);
+  const [batchNotes, setBatchNotes] = useState("");
+  const [batchSubmitting, setBatchSubmitting] = useState(false);
 
   // Shared options (loaded on demand)
   const [outlets, setOutlets] = useState<OutletOption[]>([]);
@@ -241,6 +254,64 @@ export default function PayAndClaimPage() {
   };
 
   // ── Review Dialog ───────────────────────────────────────────────────────
+
+  // ── Bulk-batch handlers ─────────────────────────────────────────────────
+  const toggleBatchInvoice = (c: Claim) => {
+    const invoiceId = c.invoice?.id;
+    if (!invoiceId || !c.claimedById || !c.outletId) return;
+    setBatchSelected((prev) => {
+      const next = new Set(prev);
+      const switchingPayee = batchPayeeId && batchPayeeId !== c.claimedById && next.size > 0 && !next.has(invoiceId);
+      const switchingOutlet = batchOutletId && batchOutletId !== c.outletId && next.size > 0 && !next.has(invoiceId);
+      if (switchingPayee || switchingOutlet) {
+        const reason = switchingPayee ? "payee" : "outlet";
+        if (!confirm(`Switching ${reason} will clear current selection. Continue?`)) return prev;
+        next.clear();
+      }
+      if (next.has(invoiceId)) next.delete(invoiceId);
+      else next.add(invoiceId);
+      if (next.size === 0) {
+        setBatchPayeeId(null);
+        setBatchOutletId(null);
+      } else {
+        setBatchPayeeId(c.claimedById);
+        setBatchOutletId(c.outletId);
+      }
+      return next;
+    });
+  };
+
+  const clearBatchSelection = () => {
+    setBatchSelected(new Set());
+    setBatchPayeeId(null);
+    setBatchOutletId(null);
+    setBatchNotes("");
+  };
+
+  const submitBatch = async () => {
+    if (batchSelected.size === 0) return;
+    setBatchSubmitting(true);
+    try {
+      const res = await fetch("/api/inventory/claim-batches", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          invoiceIds: Array.from(batchSelected),
+          notes: batchNotes || null,
+        }),
+      });
+      if (!res.ok) {
+        const b = await res.json().catch(() => ({ error: "Create failed" }));
+        alert(b?.error || "Create failed");
+        return;
+      }
+      const { batch } = await res.json();
+      clearBatchSelection();
+      router.push(`/inventory/pay-and-claim/batches/${batch.id}`);
+    } finally {
+      setBatchSubmitting(false);
+    }
+  };
 
   const openReview = async (claim: Claim) => {
     const loadedSuppliers = await loadOptions();
@@ -749,7 +820,10 @@ export default function PayAndClaimPage() {
           {TABS.map((t) => (
             <button
               key={t.key}
-              onClick={() => setTab(t.key)}
+              onClick={() => {
+                setTab(t.key);
+                if (t.key !== "pending") clearBatchSelection();
+              }}
               className={`px-3 py-1.5 text-xs font-medium transition-colors ${
                 tab === t.key ? "bg-gray-900 text-white" : "bg-white text-gray-600 hover:bg-gray-50"
               }`}
@@ -798,6 +872,7 @@ export default function PayAndClaimPage() {
           <table className="w-full min-w-[900px] text-sm">
             <thead>
               <tr className="border-b bg-gray-50/50 text-gray-500 text-left">
+                {tab === "pending" && <th className="px-3 py-3 font-medium w-8"></th>}
                 <th className="px-4 py-3 font-medium w-10"></th>
                 <th className="px-4 py-3 font-medium">Claim #</th>
                 <th className="px-4 py-3 font-medium">Outlet</th>
@@ -813,12 +888,39 @@ export default function PayAndClaimPage() {
             <tbody className="divide-y">
               {claims.map((c) => {
                 const confidence = aiConfidenceBadge(c);
+                const invoiceId = c.invoice?.id ?? null;
+                const isBatchable =
+                  tab === "pending" &&
+                  c.flow === "CLAIM" &&
+                  !!invoiceId &&
+                  !!c.claimedById &&
+                  !!c.outletId &&
+                  !c.invoice?.claimBatchId &&
+                  ["PENDING", "INITIATED"].includes(c.invoice?.status ?? "");
+                const checked = invoiceId ? batchSelected.has(invoiceId) : false;
+                const lockedByPayee = !!batchPayeeId && batchPayeeId !== c.claimedById;
+                const lockedByOutlet = !!batchOutletId && batchOutletId !== c.outletId;
+                const rowDisabled = isBatchable && !checked && (lockedByPayee || lockedByOutlet);
                 return (
                   <Fragment key={c.id}>
                     <tr
-                      className="hover:bg-gray-50 cursor-pointer"
+                      className={`hover:bg-gray-50 cursor-pointer ${rowDisabled ? "opacity-40" : ""}`}
                       onClick={() => setExpanded(expanded === c.id ? null : c.id)}
                     >
+                      {tab === "pending" && (
+                        <td className="px-3 py-3" onClick={(e) => e.stopPropagation()}>
+                          {isBatchable ? (
+                            <input
+                              type="checkbox"
+                              className="h-4 w-4 cursor-pointer"
+                              checked={checked}
+                              disabled={rowDisabled}
+                              onChange={() => toggleBatchInvoice(c)}
+                              aria-label={`Select claim ${c.orderNumber}`}
+                            />
+                          ) : null}
+                        </td>
+                      )}
                       {/* Photo thumbnail */}
                       <td className="px-4 py-3">
                         {c.invoice && c.invoice.photos?.length > 0 ? (
@@ -927,7 +1029,7 @@ export default function PayAndClaimPage() {
                     </tr>
                     {expanded === c.id && (
                       <tr>
-                        <td colSpan={tab !== "reimbursed" ? 10 : 9} className="bg-gray-50 px-6 py-3">
+                        <td colSpan={(tab !== "reimbursed" ? 10 : 9) + (tab === "pending" ? 1 : 0)} className="bg-gray-50 px-6 py-3">
                           <div className="space-y-2">
                             <p className="text-[10px] text-gray-500 uppercase font-medium">Items</p>
                             {c.items.length === 0 ? (
@@ -1810,6 +1912,53 @@ export default function PayAndClaimPage() {
           </DialogFooter>
         </DialogContent>
       </Dialog>
+
+      {/* Bulk-batch floating action bar */}
+      {batchSelected.size > 0 && (() => {
+        const selectedClaims = (claims ?? []).filter((c) => c.invoice && batchSelected.has(c.invoice.id));
+        const total = selectedClaims.reduce((s, c) => s + (c.invoice?.amount ?? 0), 0);
+        const payeeName = selectedClaims[0]?.claimedBy ?? "—";
+        const outletName = selectedClaims[0]?.outlet ?? "—";
+        return (
+          <div className="fixed inset-x-0 bottom-0 z-40 border-t bg-white shadow-2xl">
+            <div className="mx-auto flex max-w-7xl flex-col gap-3 px-4 py-3 sm:flex-row sm:items-center sm:justify-between">
+              <div>
+                <div className="text-[10px] uppercase tracking-wide text-gray-500">Bulk batch</div>
+                <div className="text-sm font-semibold text-gray-900">
+                  {batchSelected.size} claim{batchSelected.size === 1 ? "" : "s"} · RM {total.toFixed(2)}
+                </div>
+                <div className="text-[11px] text-gray-500">
+                  Payee: <span className="font-medium text-gray-700">{payeeName}</span>
+                  {" · "}
+                  Outlet: <span className="font-medium text-gray-700">{outletName}</span>
+                </div>
+              </div>
+              <div className="flex items-end gap-2">
+                <label className="flex flex-col text-[11px] text-gray-500">
+                  <span>Notes (optional)</span>
+                  <Input
+                    value={batchNotes}
+                    onChange={(e) => setBatchNotes(e.target.value)}
+                    placeholder="e.g. week 17 reimbursement"
+                    className="mt-0.5 h-8 w-56 text-sm"
+                  />
+                </label>
+                <Button variant="outline" onClick={clearBatchSelection} className="h-8">
+                  Clear
+                </Button>
+                <Button
+                  onClick={submitBatch}
+                  disabled={batchSubmitting}
+                  className="h-8 bg-emerald-600 text-white hover:bg-emerald-700"
+                >
+                  {batchSubmitting ? <Loader2 className="mr-1.5 h-3.5 w-3.5 animate-spin" /> : <CheckCircle2 className="mr-1.5 h-3.5 w-3.5" />}
+                  Create Batch ({batchSelected.size})
+                </Button>
+              </div>
+            </div>
+          </div>
+        );
+      })()}
     </div>
   );
 }

--- a/apps/backoffice/src/app/api/inventory/claim-batches/route.ts
+++ b/apps/backoffice/src/app/api/inventory/claim-batches/route.ts
@@ -77,6 +77,7 @@ export async function POST(req: NextRequest) {
     where: { id: { in: invoiceIds } },
     select: {
       id: true, invoiceNumber: true, amount: true, status: true,
+      outletId: true,
       claimBatchId: true, claimedById: true,
       order: { select: { claimedById: true } },
     },
@@ -96,6 +97,15 @@ export async function POST(req: NextRequest) {
     );
   }
   const payeeId = payeeIds[0];
+
+  // All invoices must share one outlet — Finance reimburses outlet-by-outlet
+  const outletIds = Array.from(new Set(invoices.map((i) => i.outletId).filter(Boolean)));
+  if (outletIds.length !== 1) {
+    return NextResponse.json(
+      { error: "All invoices must belong to the same outlet" },
+      { status: 400 },
+    );
+  }
 
   const already = invoices.filter((i) => i.claimBatchId);
   if (already.length > 0) {

--- a/apps/backoffice/src/app/api/inventory/invoices/route.ts
+++ b/apps/backoffice/src/app/api/inventory/invoices/route.ts
@@ -36,11 +36,28 @@ export async function GET(req: NextRequest) {
     { status: "INITIATED", dueDate: { lt: _todayStart } },
   ];
 
+  // GRNI / "pending invoice" = goods received, supplier hasn't sent the
+  // actual invoice yet. Created by the receivings POST side-effect with
+  // an auto-generated INV-NNNN number, no dueDate, status=PENDING, and
+  // linked to the PO. Once the user clicks "Attach Invoice" and fills in
+  // the supplier's real invoice number + dueDate, the row drops out of
+  // this bucket naturally.
+  const pendingInvoiceWhere: Prisma.InvoiceWhereInput = {
+    invoiceNumber: { startsWith: "INV-" },
+    dueDate: null,
+    status: "PENDING",
+    orderId: { not: null },
+    paymentType: "SUPPLIER",
+  };
+
   const where: Record<string, unknown> = {};
   if (cardFilter === "paid") where.status = "PAID";
   else if (cardFilter === "overdue") where.OR = overdueOr;
   else if (cardFilter === "initiated") where.status = "INITIATED";
   else if (cardFilter === "pending") where.status = "PENDING";
+  else if (cardFilter === "pending_invoice") {
+    Object.assign(where, pendingInvoiceWhere);
+  }
   else if (cardFilter === "payable") where.status = { in: UNPAID_STATUSES };
   else if (cardFilter === "due_today") {
     where.status = { in: UNPAID_STATUSES };
@@ -135,7 +152,7 @@ export async function GET(req: NextRequest) {
         },
       },
       outlet: { select: { name: true } },
-      supplier: { select: { name: true, phone: true, bankName: true, bankAccountNumber: true, bankAccountName: true, depositPercent: true } },
+      supplier: { select: { name: true, phone: true, bankName: true, bankAccountNumber: true, bankAccountName: true, depositPercent: true, paymentTerms: true } },
       paidAt: true,
       paidVia: true,
       paymentRef: true,
@@ -173,7 +190,7 @@ export async function GET(req: NextRequest) {
   const todayStart = _todayStart;
   const todayEnd = _todayEnd;
 
-  const [allAgg, paidAgg, overdueAgg, initiatedAgg, payableInvoices, dueTodayInvoices] = await Promise.all([
+  const [allAgg, paidAgg, overdueAgg, initiatedAgg, payableInvoices, dueTodayInvoices, pendingInvoiceAgg] = await Promise.all([
     prisma.invoice.aggregate({ _sum: { amount: true }, _count: { _all: true } }),
     prisma.invoice.aggregate({ where: { status: "PAID" }, _sum: { amount: true }, _count: { _all: true } }),
     // Overdue = literal OVERDUE status PLUS INITIATED past due date.
@@ -193,6 +210,8 @@ export async function GET(req: NextRequest) {
       },
       select: { id: true, amount: true, status: true, depositAmount: true },
     }),
+    // Pending Invoice = goods received but supplier invoice not yet attached
+    prisma.invoice.aggregate({ where: pendingInvoiceWhere, _sum: { amount: true }, _count: { _all: true } }),
   ]);
 
   // Outstanding balance = full amount, minus deposit already paid for
@@ -215,6 +234,7 @@ export async function GET(req: NextRequest) {
     initiated: { count: initiatedAgg._count._all, amount: Number(initiatedAgg._sum.amount ?? 0) },
     paid: { count: paidAgg._count._all, amount: Number(paidAgg._sum.amount ?? 0) },
     dueToday: { count: dueTodayCount, amount: dueTodayAmount },
+    pendingInvoice: { count: pendingInvoiceAgg._count._all, amount: Number(pendingInvoiceAgg._sum.amount ?? 0) },
   };
 
   const mapped = invoices.map((inv) => ({
@@ -264,6 +284,15 @@ export async function GET(req: NextRequest) {
     depositPaidAt: inv.depositPaidAt?.toISOString() ?? null,
     depositRef: inv.depositRef ?? null,
     flags: Array.isArray(inv.flags) ? inv.flags : [],
+    // True when this is a GRNI placeholder — auto-created on receiving,
+    // awaiting the supplier to send the actual invoice details.
+    isPendingInvoice:
+      inv.invoiceNumber.startsWith("INV-") &&
+      inv.dueDate == null &&
+      inv.status === "PENDING" &&
+      inv.order != null &&
+      inv.paymentType === "SUPPLIER",
+    supplierPaymentTerms: inv.supplier?.paymentTerms ?? null,
   }));
 
   return NextResponse.json({ invoices: mapped, outlets, dueTodayCount, dueTodayAmount, summary });

--- a/apps/backoffice/src/app/api/inventory/pay-and-claim/route.ts
+++ b/apps/backoffice/src/app/api/inventory/pay-and-claim/route.ts
@@ -47,10 +47,12 @@ export async function GET(req: NextRequest) {
       totalAmount: true,
       notes: true,
       createdAt: true,
-      outlet: { select: { name: true, code: true } },
+      outletId: true,
+      outlet: { select: { id: true, name: true, code: true } },
       supplier: { select: { id: true, name: true } },
       createdBy: { select: { name: true } },
-      claimedBy: { select: { name: true, bankName: true, bankAccountNumber: true, bankAccountName: true } },
+      claimedById: true,
+      claimedBy: { select: { id: true, name: true, bankName: true, bankAccountNumber: true, bankAccountName: true } },
       items: {
         select: {
           id: true,
@@ -83,9 +85,11 @@ export async function GET(req: NextRequest) {
     flow: o.orderType === "PAYMENT_REQUEST" ? "REQUEST" : "CLAIM",
     expenseCategory: o.expenseCategory,
     outlet: o.outlet.name,
+    outletId: o.outletId,
     outletCode: o.outlet.code,
     supplierId: o.supplier?.id ?? null,
     supplier: o.supplier?.name ?? "Unknown",
+    claimedById: o.claimedById,
     claimedBy: o.claimedBy?.name ?? null,
     claimedByBank: o.claimedBy ? {
       bankName: o.claimedBy.bankName ?? null,
@@ -115,6 +119,8 @@ export async function GET(req: NextRequest) {
           status: o.invoices[0].status,
           photoCount: o.invoices[0].photos.length,
           photos: o.invoices[0].photos,
+          claimBatchId: o.invoices[0].claimBatchId,
+          claimBatch: o.invoices[0].claimBatch,
           vendorName: o.invoices[0].vendorName ?? null,
           vendorBank: o.invoices[0].vendorBankName ? {
             bankName: o.invoices[0].vendorBankName,

--- a/apps/backoffice/src/lib/finance/bank-line-classifier.ts
+++ b/apps/backoffice/src/lib/finance/bank-line-classifier.ts
@@ -80,10 +80,25 @@ const INFLOW_RULES: Rule[] = [
   { name: "qr_duitnow_named", match: /\bDUITNOW QR\b/i, direction: "CR", category: "QR" as CashCategory },
   { name: "qr_qcode",         match: /\b\d{7,}Q\b/,     direction: "CR", category: "QR" as CashCategory },
 
-  // Card — "DR/CARD SALES M/N <ref>" — debit/credit terminal settlements
-  { name: "card_terminal", match: /\bDR\/?CARD\s*SALES?\b/i, direction: "CR", category: "CARD" as CashCategory },
+  // Card — Maybank shows terminal settlements as both "DR/CARD SALES"
+  // (debit-card) and "CR/CARD SALES" (credit-card). Both are CR-side
+  // (money in) on our statement; the DR/CR prefix in the description
+  // refers to the cardholder's card type, not our direction. Match
+  // either prefix.
+  { name: "card_terminal", match: /\b(?:DR|CR)\/?CARD\s*SALES?\b/i, direction: "CR", category: "CARD" as CashCategory },
   // GHL terminal settlement — "IBG TRANSACTION DMS A3 (FOR GHL)"
   { name: "card_ghl_settlement", match: /\bDMS\s*A3\b.*\bGHL\b|\bFOR\s*GHL\b/i, direction: "CR", category: "CARD" as CashCategory },
+
+  // Inflow suffix rules — "TRANSFER TO A/C <party> * <purpose>" pattern.
+  // Like the outflow side, the prefix is just routing; the suffix tells
+  // us why money came in.
+  { name: "in_loan_repayment",     match: /\bLOAN\b/i,                               direction: "CR", category: "LOAN" as CashCategory },
+  { name: "in_management_fee",     match: /\bMANAGEMENT\s*FEE|\bMNGMT\s*FEE\b/i,     direction: "CR", category: "MANAGEMENT_FEE" as CashCategory, isInterCo: true },
+  { name: "in_salary_return",      match: /\bSALARY\b/i,                             direction: "CR", category: "EMPLOYEE_SALARY" as CashCategory, isInterCo: true },
+  { name: "in_stat_pay_return",    match: /\b(STAT\s*PAY|STATUTORY)\b/i,             direction: "CR", category: "STATUTORY_PAYMENT" as CashCategory, isInterCo: true },
+  { name: "in_inventory_return",   match: /\bINVENTORY\b/i,                          direction: "CR", category: "RAW_MATERIALS" as CashCategory, isInterCo: true },
+  { name: "in_capital_injection",  match: /\bCAPITAL\s*(INJECTION|TRANSFER)\b/i,     direction: "CR", category: "CAPITAL" as CashCategory },
+  { name: "in_chq_deposit",        match: /\bCHQ\s*DEP\b|\bCHEQUE\s*DEPOSIT\b/i,     direction: "CR", category: "OTHER_INFLOW" as CashCategory },
 
   // StoreHub — Interbank GIRO from STOREHUB SDN BHD
   { name: "storehub", match: /\bSTOREHUB\b/i, direction: "CR", category: "STOREHUB" as CashCategory },
@@ -128,9 +143,12 @@ const OUTFLOW_RULES: Rule[] = [
   { name: "purpose_software",         match: /\bSOFTWARE|\bSAAS\b|\bSUBSCRIPTION\b/i, direction: "DR", category: "SOFTWARE" as CashCategory },
   { name: "purpose_petty_cash",       match: /\bPETTY\s*CASH\b/i,                     direction: "DR", category: "PETTY_CASH" as CashCategory },
   { name: "purpose_staff_claim",      match: /\bSTAFF\s*CLAIM|\bCLAIM\b/i,             direction: "DR", category: "STAFF_CLAIM" as CashCategory },
-  { name: "purpose_maintenance",      match: /\bMAINTENANCE\b|\bREPAIR\b|\bSERVICING\b/i, direction: "DR", category: "MAINTENANCE" as CashCategory },
-  { name: "purpose_equipment",        match: /\bEQUIPMENT\b|\bMACHINE\b/i,            direction: "DR", category: "EQUIPMENTS" as CashCategory },
+  { name: "purpose_maintenance",      match: /\bMAINTENANCE\b|\bREPAIR\b|\bSERVICING\b|\bDEMO\s*AND\s*REINS|\bDEMOLISH\b/i, direction: "DR", category: "MAINTENANCE" as CashCategory },
+  { name: "purpose_equipment",        match: /\bEQUIPMENT\b|\bMACHINE\b|\bFREEZER\b|\bKITCHEN\s*HOOD\b|\bWALL\s*SHELVES?\b|\bWET\s*CHEMICAL\b|\bRACK\b/i, direction: "DR", category: "EQUIPMENTS" as CashCategory },
   { name: "purpose_kol",              match: /\bKOL\b|\bINFLUENCER\b/i,               direction: "DR", category: "KOL" as CashCategory },
+  { name: "purpose_renovation",       match: /\bRENOVATION\b|\bRENOVATE\b/i,          direction: "DR", category: "INVESTMENTS" as CashCategory },
+  { name: "purpose_legal",            match: /\bLEGAL\s*FEE|\bASHRAF\s*&\s*PARTNERS|\bLAWYER\b/i, direction: "DR", category: "COMPLIANCE" as CashCategory },
+  { name: "purpose_dividend",         match: /\bDIVIDEND\b/i,                         direction: "DR", category: "OTHER_OUTFLOW" as CashCategory },
 
   // Statutory — EPF / SOCSO / EIS / KWSP / PERKESO / LHDN tax
   { name: "statutory_epf",   match: /\b(EPF|KWSP|M2UBEPF)\b/i,            direction: "DR", category: "STATUTORY_PAYMENT" as CashCategory },

--- a/apps/backoffice/src/lib/finance/cashflow.ts
+++ b/apps/backoffice/src/lib/finance/cashflow.ts
@@ -531,13 +531,18 @@ export async function computeCashflow(opts: {
     select: { id: true, amount: true, depositAmount: true, status: true, dueDate: true },
   });
 
-  // Outflows — recurring (HQ + outlet-tagged that match scope).
-  // When bank-line recurring data exists for the scope, the synthetic
-  // RecurringExpense records become fallback only — using both would
-  // double-count. The bank-line per-day rate already smooths the
-  // monthly pulse across the whole period.
-  const useBankLineRecurring = !!(bankProj && bankProj.recurringPerDay > 0);
-  const recurring = useBankLineRecurring ? [] : await prisma.recurringExpense.findMany({
+  // Recurring / payroll / monthly outflows are now driven by the
+  // RecurringExpense table — auto-populated per-outlet with exact
+  // amounts and due-day-of-month from bank-line history (see
+  // scripts/generate-recurring-from-bank-lines.ts). expandRecurring()
+  // then fires each entry on its actual due date inside the horizon
+  // — no daily smearing, no double-counting.
+  //
+  // Per-outlet filter: only entries tagged to the selected outlet (or
+  // HQ-level entries for shared services) fire. RecurringExpense
+  // categories cover RENT, UTILITY, SAAS, PAYROLL_SUPPORT (salary +
+  // directors + statutory), and OTHER (loan, tax, compliance).
+  const recurring = await prisma.recurringExpense.findMany({
     where: {
       isActive: true,
       ...(isFiltered
@@ -546,14 +551,16 @@ export async function computeCashflow(opts: {
     },
   });
 
-  // Outflows — payroll + marketing. Bank-line per-day rates take
-  // precedence (smoothed daily); synthetic monthly-pulse streams are
-  // fallback when no bank-line data exists.
-  const useBankLinePayroll = !!(bankProj && bankProj.payrollPerDay > 0);
-  const useBankLineMarketing = !!(bankProj && bankProj.marketingPerDay > 0);
-  const payrollProjected = useBankLinePayroll ? [] : await projectPayroll(today, horizonEnd);
-  const marketingProjected = (useBankLineMarketing || isFiltered) ? [] : await projectMarketing(today, horizonEnd);
-  if (isFiltered && !useBankLineMarketing) {
+  // Synthetic payroll/marketing streams (the legacy hr_payroll_runs
+  // and ads_invoice path) are only used as a fallback when no
+  // RecurringExpense entries exist for the relevant categories. The
+  // per-outlet RecurringExpense entries above replace this for
+  // payroll. Marketing's still synthetic since we don't auto-generate
+  // marketing recurring entries (most marketing is one-off card spend).
+  const hasRecurringPayroll = recurring.some((r) => r.category === "PAYROLL_SUPPORT");
+  const payrollProjected = hasRecurringPayroll ? [] : await projectPayroll(today, horizonEnd);
+  const marketingProjected = isFiltered ? [] : await projectMarketing(today, horizonEnd);
+  if (isFiltered) {
     warnings.push("Marketing run-rate is HQ-only and not allocated to outlets — it's excluded from the filtered view.");
   }
 
@@ -595,12 +602,14 @@ export async function computeCashflow(opts: {
     otherOutPerDay = Math.max(0, bankFlows.outflow - dailySyntheticOut);
   }
 
-  // When we're using bank-line projection for payroll/marketing, derive
-  // per-day rates so the bucket builder can spread them across days
-  // (versus the monthly-pulse synthetic streams).
-  const bankPayrollPerDay = useBankLinePayroll ? bankProj!.payrollPerDay : 0;
-  const bankMarketingPerDay = useBankLineMarketing ? bankProj!.marketingPerDay : 0;
-  const bankRecurringPerDay = bankProj && bankProj.recurringPerDay > 0 ? bankProj.recurringPerDay : 0;
+  // Bank-line daily-rate streams. Only used for COGS and the
+  // catch-all Other in/out — those are paid frequently throughout
+  // the week (multiple supplier runs, refunds, transfers etc.) so a
+  // per-day rate is more accurate than a monthly pulse. Payroll /
+  // marketing / recurring instead use exact pulse timing from the
+  // RecurringExpense expansion above so the projection shows
+  // payments on their actual due-day-of-month rather than smeared
+  // across every week.
   const bankCogsPerDay = bankProj && bankProj.cogsPerDay > 0 ? bankProj.cogsPerDay : 0;
 
   // Bucket builder
@@ -638,23 +647,7 @@ export async function computeCashflow(opts: {
       .filter((m) => m.date >= weekStart && m.date <= weekEnd)
       .reduce((s, m) => s + m.amount, 0);
 
-    // Recurring this week
-    let recurringOut = 0;
-    const recurringExpenseIds: string[] = [];
-    for (const exp of recurring) {
-      const occurrences = expandRecurring(
-        { id: exp.id, amount: Number(exp.amount), cadence: exp.cadence, nextDueDate: exp.nextDueDate },
-        weekStart,
-        weekEnd,
-      );
-      for (const occ of occurrences) {
-        recurringOut += occ.amount;
-        if (!recurringExpenseIds.includes(occ.recurringExpenseId)) recurringExpenseIds.push(occ.recurringExpenseId);
-      }
-    }
-
-    // Other (bank residual) + bank-line-driven daily-rate streams
-    // (payroll/marketing/recurring). Count days in the week that are
+    // Other (bank residual) — count days in the week that are
     // >= today, since partial first weeks shouldn't include past days.
     let activeDays = 0;
     for (let d = 0; d < 7; d++) {
@@ -664,19 +657,35 @@ export async function computeCashflow(opts: {
     const otherIn = otherInPerDay * activeDays;
     const otherOut = otherOutPerDay * activeDays;
 
-    // Add bank-line daily-rate spend for the categories we promoted from
-    // synthetic monthly pulses. Stacks on top of any synthetic
-    // payrollProjected / marketingProjected entries, but those arrays
-    // are emptied above when bank-line data exists for the category.
-    const bankPayrollOut = bankPayrollPerDay * activeDays;
-    const bankMarketingOut = bankMarketingPerDay * activeDays;
-    const bankRecurringOut = bankRecurringPerDay * activeDays;
-    const bankCogsOut = bankCogsPerDay * activeDays;
+    // Bank-line daily rate ONLY for COGS (paid to suppliers throughout
+    // the week — daily smearing is the right model).
+    const cogsOut = bankCogsPerDay * activeDays;
 
-    const totalPayrollOut = payrollOut + bankPayrollOut;
-    const totalMarketingOut = marketingOut + bankMarketingOut;
-    const totalRecurringOut = recurringOut + bankRecurringOut;
-    const cogsOut = bankCogsOut;
+    // RecurringExpense entries fire on their actual due dates inside
+    // the week (no smearing). Category determines which bucket they
+    // land in: PAYROLL_SUPPORT → Payroll column; everything else →
+    // Recurring. Mirrors the bucket grouping in the auto-generator at
+    // scripts/generate-recurring-from-bank-lines.ts.
+    let payrollFromRecurring = 0;
+    let recurringFromRecurring = 0;
+    const recurringExpenseIds: string[] = [];
+    for (const exp of recurring) {
+      const occurrences = expandRecurring(
+        { id: exp.id, amount: Number(exp.amount), cadence: exp.cadence, nextDueDate: exp.nextDueDate },
+        weekStart,
+        weekEnd,
+      );
+      if (occurrences.length === 0) continue;
+      const wkAmount = occurrences.reduce((s, o) => s + o.amount, 0);
+      if (exp.category === "PAYROLL_SUPPORT") payrollFromRecurring += wkAmount;
+      else recurringFromRecurring += wkAmount;
+      if (!recurringExpenseIds.includes(exp.id)) recurringExpenseIds.push(exp.id);
+    }
+
+    // Bucket totals
+    const totalPayrollOut = payrollOut + payrollFromRecurring;
+    const totalMarketingOut = marketingOut;
+    const totalRecurringOut = recurringFromRecurring;
 
     const closing = runningOpening
       + salesIn + otherIn

--- a/apps/backoffice/src/lib/finance/cashflow.ts
+++ b/apps/backoffice/src/lib/finance/cashflow.ts
@@ -44,6 +44,7 @@ export type CashflowBucket = {
   otherIn: number;
   invoiceOut: number;
   payrollOut: number;
+  cogsOut: number;
   marketingOut: number;
   recurringOut: number;
   otherOut: number;
@@ -264,10 +265,17 @@ const RECURRING_OUTFLOW_CATEGORIES = [
   "LICENSING_FEE", "ROYALTY_FEE", "LOAN", "BANK_FEE", "MAINTENANCE",
 ] as const;
 
+// COGS — separate column for raw materials + delivery. These are
+// regular weekly costs (suppliers, ingredient runs) and large enough
+// to deserve their own line vs being lumped into "Other".
+const COGS_OUTFLOW_CATEGORIES = [
+  "RAW_MATERIALS", "DELIVERY",
+] as const;
+
 // Categories that are "other" — not sales, not payroll, not marketing,
-// not recurring. Includes capex, raw materials, and the catch-alls.
+// not recurring, not COGS. Includes capex/investments and catch-alls.
 const OTHER_OUTFLOW_CATEGORIES = [
-  "RAW_MATERIALS", "DELIVERY", "EQUIPMENTS", "INVESTMENTS",
+  "EQUIPMENTS", "INVESTMENTS",
   "TRANSFER_NOT_SUCCESSFUL", "OTHER_OUTFLOW",
 ] as const;
 
@@ -280,8 +288,9 @@ type BankLineProjection = {
   payrollPerDay: number;
   marketingPerDay: number;
   recurringPerDay: number;
+  cogsPerDay: number;            // raw materials + delivery
   otherInPerDay: number;
-  otherOutPerDay: number;
+  otherOutPerDay: number;        // capex/investments/transfer-failed/other catch-all (excludes COGS)
   sampleDays: number;            // number of distinct calendar days the data covers
   hasData: boolean;
 };
@@ -313,6 +322,7 @@ async function bankLineProjection(outletIds: string[]): Promise<BankLineProjecti
   let payrollSum = 0;
   let marketingSum = 0;
   let recurringSum = 0;
+  let cogsSum = 0;
   let otherInSum = 0;
   let otherOutSum = 0;
 
@@ -320,6 +330,7 @@ async function bankLineProjection(outletIds: string[]): Promise<BankLineProjecti
   const PAYROLL_SET = new Set<string>(PAYROLL_OUTFLOW_CATEGORIES as readonly string[]);
   const MARKETING_SET = new Set<string>(MARKETING_OUTFLOW_CATEGORIES as readonly string[]);
   const RECURRING_SET = new Set<string>(RECURRING_OUTFLOW_CATEGORIES as readonly string[]);
+  const COGS_SET = new Set<string>(COGS_OUTFLOW_CATEGORIES as readonly string[]);
   const OTHER_OUT_SET = new Set<string>(OTHER_OUTFLOW_CATEGORIES as readonly string[]);
   const OTHER_IN_SET = new Set<string>(OTHER_INFLOW_CATEGORIES as readonly string[]);
 
@@ -334,7 +345,10 @@ async function bankLineProjection(outletIds: string[]): Promise<BankLineProjecti
         const dow = l.txnDate.getDay();
         salesSumByDow[dow] += amt;
         salesDistinctDaysByDow[dow].add(dayKey);
-      } else if (OTHER_IN_SET.has(cat)) {
+      } else {
+        // Catch-all: any unmatched CR (LOAN inflow, capital injections,
+        // refunds, OTHER_INFLOW) lands here so the projection doesn't
+        // silently drop money. Membership in OTHER_IN_SET kept for docs.
         otherInSum += amt;
       }
     } else {
@@ -342,7 +356,8 @@ async function bankLineProjection(outletIds: string[]): Promise<BankLineProjecti
       if (PAYROLL_SET.has(cat)) payrollSum += amt;
       else if (MARKETING_SET.has(cat)) marketingSum += amt;
       else if (RECURRING_SET.has(cat)) recurringSum += amt;
-      else if (OTHER_OUT_SET.has(cat)) otherOutSum += amt;
+      else if (COGS_SET.has(cat)) cogsSum += amt;
+      else otherOutSum += amt;  // catch-all (EQUIPMENTS, INVESTMENTS, TRANSFER_NOT_SUCCESSFUL, OTHER_OUTFLOW)
     }
   }
 
@@ -357,6 +372,7 @@ async function bankLineProjection(outletIds: string[]): Promise<BankLineProjecti
     payrollPerDay: payrollSum / sampleDays,
     marketingPerDay: marketingSum / sampleDays,
     recurringPerDay: recurringSum / sampleDays,
+    cogsPerDay: cogsSum / sampleDays,
     otherInPerDay: otherInSum / sampleDays,
     otherOutPerDay: otherOutSum / sampleDays,
     sampleDays,
@@ -515,8 +531,13 @@ export async function computeCashflow(opts: {
     select: { id: true, amount: true, depositAmount: true, status: true, dueDate: true },
   });
 
-  // Outflows — recurring (HQ + outlet-tagged that match scope)
-  const recurring = await prisma.recurringExpense.findMany({
+  // Outflows — recurring (HQ + outlet-tagged that match scope).
+  // When bank-line recurring data exists for the scope, the synthetic
+  // RecurringExpense records become fallback only — using both would
+  // double-count. The bank-line per-day rate already smooths the
+  // monthly pulse across the whole period.
+  const useBankLineRecurring = !!(bankProj && bankProj.recurringPerDay > 0);
+  const recurring = useBankLineRecurring ? [] : await prisma.recurringExpense.findMany({
     where: {
       isActive: true,
       ...(isFiltered
@@ -580,6 +601,7 @@ export async function computeCashflow(opts: {
   const bankPayrollPerDay = useBankLinePayroll ? bankProj!.payrollPerDay : 0;
   const bankMarketingPerDay = useBankLineMarketing ? bankProj!.marketingPerDay : 0;
   const bankRecurringPerDay = bankProj && bankProj.recurringPerDay > 0 ? bankProj.recurringPerDay : 0;
+  const bankCogsPerDay = bankProj && bankProj.cogsPerDay > 0 ? bankProj.cogsPerDay : 0;
 
   // Bucket builder
   const buckets: CashflowBucket[] = [];
@@ -649,12 +671,16 @@ export async function computeCashflow(opts: {
     const bankPayrollOut = bankPayrollPerDay * activeDays;
     const bankMarketingOut = bankMarketingPerDay * activeDays;
     const bankRecurringOut = bankRecurringPerDay * activeDays;
+    const bankCogsOut = bankCogsPerDay * activeDays;
 
     const totalPayrollOut = payrollOut + bankPayrollOut;
     const totalMarketingOut = marketingOut + bankMarketingOut;
     const totalRecurringOut = recurringOut + bankRecurringOut;
+    const cogsOut = bankCogsOut;
 
-    const closing = runningOpening + salesIn + otherIn - invoiceOut - totalPayrollOut - totalMarketingOut - totalRecurringOut - otherOut;
+    const closing = runningOpening
+      + salesIn + otherIn
+      - invoiceOut - totalPayrollOut - cogsOut - totalMarketingOut - totalRecurringOut - otherOut;
 
     buckets.push({
       weekStart: ymd(weekStart),
@@ -664,6 +690,7 @@ export async function computeCashflow(opts: {
       otherIn: round2(otherIn),
       invoiceOut: round2(invoiceOut),
       payrollOut: round2(totalPayrollOut),
+      cogsOut: round2(cogsOut),
       marketingOut: round2(totalMarketingOut),
       recurringOut: round2(totalRecurringOut),
       otherOut: round2(otherOut),

--- a/apps/backoffice/src/lib/finance/cashflow.ts
+++ b/apps/backoffice/src/lib/finance/cashflow.ts
@@ -246,51 +246,47 @@ async function projectMarketing(start: Date, end: Date): Promise<{ date: Date; a
 // category has no bank-line data (e.g. brand new bank account) the
 // caller falls back to the synthetic stream.
 
+// Sales channels — DOW-shaped projection (revenue varies by day-of-week)
 const SALES_INFLOW_CATEGORIES = [
   "CARD", "QR", "STOREHUB", "GRAB", "GRAB_PUTRAJAYA",
   "FOODPANDA", "MEETINGS_EVENTS", "GASTROHUB",
 ] as const;
 
-const PAYROLL_OUTFLOW_CATEGORIES = [
-  "DIRECTORS_ALLOWANCE", "EMPLOYEE_SALARY", "PARTIMER",
-  "STATUTORY_PAYMENT", "STAFF_CLAIM", "PETTY_CASH",
-] as const;
-
-const MARKETING_OUTFLOW_CATEGORIES = [
-  "DIGITAL_ADS", "KOL", "OTHER_MARKETING", "MARKETPLACE_FEE",
-] as const;
-
-const RECURRING_OUTFLOW_CATEGORIES = [
-  "RENT", "UTILITIES", "SOFTWARE", "CFS_FEE", "COMPLIANCE", "TAX",
-  "LICENSING_FEE", "ROYALTY_FEE", "LOAN", "BANK_FEE", "MAINTENANCE",
-] as const;
-
-// COGS — separate column for raw materials + delivery. These are
-// regular weekly costs (suppliers, ingredient runs) and large enough
-// to deserve their own line vs being lumped into "Other".
+// COGS — separate column for raw materials + delivery. Daily rate
+// smearing is the right model: suppliers paid throughout the week.
 const COGS_OUTFLOW_CATEGORIES = [
   "RAW_MATERIALS", "DELIVERY",
 ] as const;
 
-// Categories that are "other" — not sales, not payroll, not marketing,
-// not recurring, not COGS. Includes capex/investments and catch-alls.
-const OTHER_OUTFLOW_CATEGORIES = [
-  "EQUIPMENTS", "INVESTMENTS",
-  "TRANSFER_NOT_SUCCESSFUL", "OTHER_OUTFLOW",
-] as const;
+// Categories that are projected via RecurringExpense entries (exact
+// pulse timing, per outlet). The auto-generator at
+// scripts/generate-recurring-from-bank-lines.ts populates these.
+// Bank lines in these categories are EXCLUDED from the catch-all
+// daily-smear path to avoid double-counting (the RecurringExpense
+// expansion already fires them on the actual due date).
+const PULSE_CATEGORIES = new Set<string>([
+  "RENT", "UTILITIES", "SOFTWARE",
+  "EMPLOYEE_SALARY", "STATUTORY_PAYMENT",
+  "TAX", "COMPLIANCE", "MAINTENANCE",
+  "LICENSING_FEE", "ROYALTY_FEE", "BANK_FEE", "CFS_FEE",
+  "LOAN", "MANAGEMENT_FEE",
+]);
 
-const OTHER_INFLOW_CATEGORIES = [
-  "CAPITAL", "MANAGEMENT_FEE", "ADTD", "OTHER_INFLOW",
-] as const;
+// Everything else (DIRECTORS_ALLOWANCE, PARTIMER, STAFF_CLAIM,
+// PETTY_CASH, MARKETING categories, EQUIPMENTS, INVESTMENTS,
+// TRANSFER_NOT_SUCCESSFUL, OTHER_OUTFLOW) flows into the catch-all
+// "Other outflow" daily-rate stream. These are genuinely variable
+// (directors' draws, capex, marketing campaigns) — exact pulse
+// timing wouldn't be useful and a smoothed daily rate represents
+// the run-rate fairly.
 
 type BankLineProjection = {
   salesByDow: number[];          // [Sun..Sat] daily averages from sales categories
-  payrollPerDay: number;
-  marketingPerDay: number;
-  recurringPerDay: number;
   cogsPerDay: number;            // raw materials + delivery
-  otherInPerDay: number;
-  otherOutPerDay: number;        // capex/investments/transfer-failed/other catch-all (excludes COGS)
+  otherInPerDay: number;         // catch-all CR (LOAN inflow, refunds, OTHER_INFLOW, etc.)
+  otherOutPerDay: number;        // catch-all DR (directors, partimer, marketing, capex,
+                                 // OTHER_OUTFLOW, etc.) — excludes PULSE_CATEGORIES
+                                 // to avoid double-count with RecurringExpense pulses
   sampleDays: number;            // number of distinct calendar days the data covers
   hasData: boolean;
 };
@@ -319,20 +315,12 @@ async function bankLineProjection(outletIds: string[]): Promise<BankLineProjecti
   const salesDistinctDaysByDow: Set<string>[] = [
     new Set(), new Set(), new Set(), new Set(), new Set(), new Set(), new Set(),
   ];
-  let payrollSum = 0;
-  let marketingSum = 0;
-  let recurringSum = 0;
   let cogsSum = 0;
   let otherInSum = 0;
   let otherOutSum = 0;
 
   const SALES_SET = new Set<string>(SALES_INFLOW_CATEGORIES as readonly string[]);
-  const PAYROLL_SET = new Set<string>(PAYROLL_OUTFLOW_CATEGORIES as readonly string[]);
-  const MARKETING_SET = new Set<string>(MARKETING_OUTFLOW_CATEGORIES as readonly string[]);
-  const RECURRING_SET = new Set<string>(RECURRING_OUTFLOW_CATEGORIES as readonly string[]);
   const COGS_SET = new Set<string>(COGS_OUTFLOW_CATEGORIES as readonly string[]);
-  const OTHER_OUT_SET = new Set<string>(OTHER_OUTFLOW_CATEGORIES as readonly string[]);
-  const OTHER_IN_SET = new Set<string>(OTHER_INFLOW_CATEGORIES as readonly string[]);
 
   for (const l of lines) {
     if (!l.category) continue;
@@ -346,18 +334,18 @@ async function bankLineProjection(outletIds: string[]): Promise<BankLineProjecti
         salesSumByDow[dow] += amt;
         salesDistinctDaysByDow[dow].add(dayKey);
       } else {
-        // Catch-all: any unmatched CR (LOAN inflow, capital injections,
-        // refunds, OTHER_INFLOW) lands here so the projection doesn't
-        // silently drop money. Membership in OTHER_IN_SET kept for docs.
+        // Catch-all: refunds, LOAN inflow, OTHER_INFLOW etc.
         otherInSum += amt;
       }
     } else {
       // DR
-      if (PAYROLL_SET.has(cat)) payrollSum += amt;
-      else if (MARKETING_SET.has(cat)) marketingSum += amt;
-      else if (RECURRING_SET.has(cat)) recurringSum += amt;
-      else if (COGS_SET.has(cat)) cogsSum += amt;
-      else otherOutSum += amt;  // catch-all (EQUIPMENTS, INVESTMENTS, TRANSFER_NOT_SUCCESSFUL, OTHER_OUTFLOW)
+      if (COGS_SET.has(cat)) cogsSum += amt;
+      else if (PULSE_CATEGORIES.has(cat)) {
+        // Skip — these are projected via RecurringExpense expansion
+        // on their actual due dates. Including them here would
+        // double-count.
+      }
+      else otherOutSum += amt;  // directors, partimer, marketing, capex, catch-alls
     }
   }
 
@@ -369,9 +357,6 @@ async function bankLineProjection(outletIds: string[]): Promise<BankLineProjecti
 
   return {
     salesByDow,
-    payrollPerDay: payrollSum / sampleDays,
-    marketingPerDay: marketingSum / sampleDays,
-    recurringPerDay: recurringSum / sampleDays,
     cogsPerDay: cogsSum / sampleDays,
     otherInPerDay: otherInSum / sampleDays,
     otherOutPerDay: otherOutSum / sampleDays,
@@ -740,13 +725,14 @@ export async function computeCashflow(opts: {
     openingBalance: opening,
     bankFlowsPerDay: bankProj
       ? {
-          // Bank-line model — sum of all per-day rates on each side
+          // Bank-line daily averages — Sales DOW + Other inflow on the
+          // CR side; COGS + Other outflow on the DR side. Pulse-driven
+          // categories (rent/salary/etc.) aren't included here because
+          // they fire on specific dates, not daily.
           inflow: round2(
             (bankProj.salesByDow.reduce((a, b) => a + b, 0) / 7) + bankProj.otherInPerDay,
           ),
-          outflow: round2(
-            bankProj.payrollPerDay + bankProj.marketingPerDay + bankProj.recurringPerDay + bankProj.otherOutPerDay,
-          ),
+          outflow: round2(bankProj.cogsPerDay + bankProj.otherOutPerDay),
           sampleDays: bankProj.sampleDays,
         }
       : bankFlows


### PR DESCRIPTION
## Summary

Originally a cashflow PR; grew to bundle inventory work that landed on the same branch. Splitting wasn't worth the rebase churn — flagging the scope here instead.

---

## Part 1 — Cashflow projection (original work)

Audit of `/finance/cashflow` against the bank-line data surfaced **four bugs**:

### 1. CR/CARD SALES not classified (RM 207k of card revenue lost)
Rule only matched `DR/CARD SALES` but Maybank also emits `CR/CARD SALES` for credit-card terminal settlements. Both are CR-side on our statement. Added regex covering both.

### 2. Recurring double-count (weekly RM 27k+ spikes)
Synthetic `RecurringExpense` rows were firing on top of the bank-line per-day rate. Now skip the expansion when bank-line recurring data exists for the scope.

### 3. RAW_MATERIALS hidden in "Other (bank)" (RM 16k/wk)
Pulled into its own **COGS** column between Payroll and Marketing.

### 4. Silent drop of unmapped categories (LOAN inflow RM 6.5k/wk)
`bankLineProjection` had no catch-all — categories outside the 6 hard-coded sets vanished. Made otherIn/otherOut catch-alls.

### Plus suffix rules
For the `TRANSFER FR/TO A/C *` Maybank pattern:
- Inflow: Loan / Management Fee / Salary / Stat pay / Inventory / Capital / Cheque deposit
- Outflow: Renovation / Legal fee / Demo & Reinstate / kitchen equipment

### Reclassification impact (per-week run-rates)
- CARD: RM 25k → **RM 42k** (+67%)
- OTHER_INFLOW: RM 44k → **RM 14k** (-69%)
- New COGS column: **RM 16k/wk**

---

## Part 2 — Inventory pending-invoice flow (`d63bc2c`)

Handles the credit-term case where suppliers deliver goods first and send the invoice days/weeks later.

- New **"Pending Invoice"** card on `/inventory/invoices` — yellow, filters to placeholders auto-created at receiving (auto-pattern `INV-NNNN` + null due date + linked PO + status PENDING).
- New **"Attach Invoice"** dialog on placeholder rows — fills in the supplier's real invoice number, issue date, due date (auto-suggested from supplier's free-text `paymentTerms` like "Net 30", with +7/+14/+30/+60 quick-fill chips), amount.
- Once attached, the row drops out of the bucket into normal Payable. Payment actions (Initiate / Mark Paid) are suppressed on placeholders so they can't be paid before the supplier invoice arrives.
- **No schema migration** — uses existing fields, marker is purely behavioural.

Plus: bumped the order edit dialog to 1400px (95vw) and replaced the broken-image-prone inline `<img>` with `InvoicePreviewPane` — handles PDFs via iframe, falls back on `img onError`, and lets you flip between multiple attached photos via numbered tabs.

---

## Part 3 — Reject Initiated payments (`502eb05`)

When a payment was initiated but didn't go through (wrong account, supplier rejected, duplicate caught in review), finance can now click **Reject** on the row instead of needing to manually edit. The invoice rolls back to PENDING, the failed `paymentRef` is cleared, and a stamped note is appended:
`[Rejected YYYY-MM-DD — was ref: XXX]: <optional reason>`. Uses existing PATCH endpoint — no API change.

---

## Part 4 — WhatsApp send to groups (`9d028c3`)

The Send Order dialog now has two paths:
- **Direct send** (existing) — `wa.me/<phone>` with the supplier's saved number
- **"Send to a group / pick chat →"** (new) — `wa.me/?text=...` with no phone. Opens WhatsApp's chat picker with message pre-filled. Tap the supplier's group, hit send.

WhatsApp doesn't expose group IDs in their deep-link API, so the picker is the only way to deliver pre-filled text into a group. One extra tap.

---

## Test plan

### Cashflow
- [ ] `/finance/cashflow` shows 9 columns: Opening / Sales / Other inflow / Invoices / Payroll / COGS / Marketing / Recurring / Other outflow / Closing
- [ ] No weekly recurring spikes; Recurring column ~RM 9k/wk
- [ ] Sales (forecast) ~RM 62k/wk (CARD recovery)
- [ ] Other inflow dropped to ~RM 14k/wk

### Pending Invoice flow
- [ ] `/inventory/invoices` shows 7 cards (Pending Invoice card sits between Total and Payable, yellow)
- [ ] Click it → list filters to GRNI placeholders
- [ ] Click "Attach Invoice" → dialog opens with supplier's payment terms hint and due date prefilled if "Net N"
- [ ] After save: row leaves the Pending bucket, becomes payable

### Order edit dialog
- [ ] Open any order with attached invoice/photo — dialog is ~95% viewport
- [ ] PDF attachments render in iframe (not broken image)
- [ ] Multiple photos navigable via numbered tabs

### Reject
- [ ] On INITIATED row → red Reject button visible (mobile + desktop)
- [ ] Click → confirm dialog with optional reason → save → row back in Payable, notes stamped

### WhatsApp groups
- [ ] Open create order, fill cart, click Send → dialog shows two buttons
- [ ] "Send to a group" opens WhatsApp picker with message pre-filled

🤖 Generated with [Claude Code](https://claude.com/claude-code)