### PR TITLE
feat(staff): receive against SENT POs without Confirm step

### DIFF
--- a/apps/staff/src/app/(ops)/receiving/page.tsx
+++ b/apps/staff/src/app/(ops)/receiving/page.tsx
@@ -76,7 +76,19 @@ interface UserSession {
 /*  Helpers                                                            */
 /* ------------------------------------------------------------------ */
 
-const PENDING_STATUSES = ["AWAITING_DELIVERY", "PARTIALLY_RECEIVED"];
+// Receivable PO statuses — anything Sent onwards. DRAFT / PENDING_APPROVAL /
+// APPROVED don't appear in the staff picker because procurement hasn't yet
+// transmitted the PO to the supplier (so no goods would be in transit).
+// Once procurement clicks Send, the PO shows up here for staff to receive
+// against — even if the supplier invoice arrives days later (credit terms).
+const PENDING_STATUSES = ["SENT", "AWAITING_DELIVERY", "PARTIALLY_RECEIVED"];
+
+// Pill label + color for the PO card so staff can see at a glance whether
+// the PO is freshly sent, expected, or already partially received.
+const STATUS_PILL: Record<string, { label: string; cls: string }> = {
+  SENT: { label: "Sent", cls: "border-indigo-300 text-indigo-700 bg-indigo-50" },
+  PARTIALLY_RECEIVED: { label: "Partial", cls: "border-orange-300 text-orange-700 bg-orange-50" },
+};
 
 function isPerishable(name: string): boolean {
   const lower = name.toLowerCase();
@@ -326,7 +338,7 @@ export default function ReceivePage() {
                     No pending deliveries
                   </p>
                   <p className="mt-0.5 text-[10px] text-gray-300">
-                    Orders marked as Sent will appear here
+                    POs sent by procurement will appear here
                   </p>
                 </div>
               ) : (
@@ -348,7 +360,12 @@ export default function ReceivePage() {
                             &middot; RM {po.totalAmount.toFixed(2)}
                           </p>
                         </div>
-                        <div className="flex items-center gap-2">
+                        <div className="flex items-center gap-1.5">
+                          {STATUS_PILL[po.status] && po.status !== "AWAITING_DELIVERY" && (
+                            <span className={`rounded-full border px-1.5 py-0.5 text-[9px] font-medium ${STATUS_PILL[po.status].cls}`}>
+                              {STATUS_PILL[po.status].label}
+                            </span>
+                          )}
                           <Badge variant="outline" className="text-[10px]">
                             {po.deliveryDate
                               ? formatRelativeDate(po.deliveryDate)

--- a/apps/staff/src/app/api/receivings/route.ts
+++ b/apps/staff/src/app/api/receivings/route.ts
@@ -87,16 +87,21 @@ export async function POST(req: NextRequest) {
 
   let receivingStatus = status || "COMPLETE";
   if (orderId) {
-    // Enforce Confirm Order flow — only allow receiving for AWAITING_DELIVERY orders
+    // Receivable from SENT onwards — procurement must have transmitted the PO
+    // to the supplier before goods would be in transit. Credit-term suppliers
+    // can still deliver days/weeks before the invoice arrives, so we don't
+    // require an attached invoice at receive time.
     const order = await prisma.order.findUnique({
       where: { id: orderId },
       select: { status: true },
     });
-    if (order && !["AWAITING_DELIVERY", "PARTIALLY_RECEIVED"].includes(order.status)) {
-      return NextResponse.json(
-        { error: "Order must be confirmed before receiving. Ask backoffice to Confirm Order first." },
-        { status: 400 },
-      );
+    const RECEIVABLE = ["SENT", "AWAITING_DELIVERY", "PARTIALLY_RECEIVED"];
+    if (order && !RECEIVABLE.includes(order.status)) {
+      const msg =
+        order.status === "COMPLETED" ? "Order already fully received." :
+        order.status === "CANCELLED" ? "Order was cancelled and cannot be received." :
+        "PO must be Sent to the supplier before goods can be received. Ask procurement to send it first.";
+      return NextResponse.json({ error: msg }, { status: 400 });
     }
 
     const hasShort = items.some(


### PR DESCRIPTION
## Summary

Pairs with the pending-invoice flow shipped in #113. Staff app receivings was hard-locked to `AWAITING_DELIVERY` / `PARTIALLY_RECEIVED`, which forced an extra Confirm Order step in backoffice — friction we don't need for credit-term suppliers who deliver days before sending the invoice.

### Behaviour change

| PO status | Before | After |
|---|---|---|
| DRAFT | hidden, blocked | hidden, blocked |
| PENDING_APPROVAL | hidden, blocked | hidden, blocked |
| APPROVED | hidden, blocked | hidden, blocked |
| **SENT** | hidden, blocked | **shows in picker, receivable** |
| AWAITING_DELIVERY | shows, receivable | shows, receivable |
| PARTIALLY_RECEIVED | shows, receivable | shows, receivable |
| COMPLETED | blocked (clearer error) | blocked (clearer error) |
| CANCELLED | blocked | blocked |

The threshold matches the user's intent: "draft = don't appear at receivings, after sent = appear."

### How it fits the credit-term flow

1. Procurement creates PO → clicks Send → status `SENT`
2. Goods arrive at outlet → staff opens app → sees the SENT PO in pending list (with "Sent" pill)
3. Staff records receiving → stock goes up + placeholder invoice auto-created (already implemented in #113)
4. Days later, supplier emails invoice → finance opens `/inventory/invoices` → "Pending Invoice" card → clicks Attach Invoice → fills supplier number + due date
5. Invoice moves to Payable → paid per terms

No schema changes. Two files touched.

## Test plan

- [ ] Procurement creates a PO and clicks Send (status = `SENT`)
- [ ] Staff app `/receiving` shows the PO in the pending list with an indigo "Sent" pill
- [ ] Staff records receiving — stock updates, no "must confirm first" error
- [ ] PO transitions to `PARTIALLY_RECEIVED` or `COMPLETED` based on quantities
- [ ] DRAFT/PENDING_APPROVAL/APPROVED POs do NOT appear in the staff picker
- [ ] Trying to POST a receiving for a DRAFT order returns the new clearer error message

🤖 Generated with [Claude Code](https://claude.com/claude-code)