### PR TITLE
feat(inventory): credit-term flow redesign — SENT collapse, PO reflects received, hide GRNI placeholders

### DIFF
--- a/apps/backoffice/src/app/(admin)/inventory/invoices/page.tsx
+++ b/apps/backoffice/src/app/(admin)/inventory/invoices/page.tsx
@@ -681,6 +681,17 @@ export default function InvoicesPage() {
               )}
             </div>
             <p className={`text-lg font-bold ${card.color}`}>RM {card.amount.toFixed(2)}</p>
+            {card.key === "payable" && pendingInvoiceCount > 0 && (
+              // Soft-hide: GRNI placeholders are excluded from Payable count/amount,
+              // but the sub-line keeps the full liability visible for cashflow planning.
+              <p
+                onClick={(e) => { e.stopPropagation(); setCardFilter("pending_invoice"); }}
+                className="mt-0.5 text-[10px] text-yellow-700 hover:underline cursor-pointer"
+                title="Click to view Pending Invoice rows"
+              >
+                + RM {totalPendingInvoice.toFixed(2)} awaiting invoice
+              </p>
+            )}
             {card.key === "due_today" && card.count > 0 && cardFilter === "due_today" && (
               <div
                 onClick={(e) => { e.stopPropagation(); batchInitiateDueToday(); }}

--- a/apps/backoffice/src/app/(admin)/inventory/orders/[id]/page.tsx
+++ b/apps/backoffice/src/app/(admin)/inventory/orders/[id]/page.tsx
@@ -165,7 +165,7 @@ export default function EditOrderPage({ params }: { params: Promise<{ id: string
       await fetch(`/api/inventory/orders/${order.id}`, {
         method: "PATCH",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ status: "SENT" }),
+        body: JSON.stringify({ status: "AWAITING_DELIVERY" }),
       });
       router.push("/inventory/orders");
     } finally {

--- a/apps/backoffice/src/app/(admin)/inventory/orders/create/page.tsx
+++ b/apps/backoffice/src/app/(admin)/inventory/orders/create/page.tsx
@@ -603,11 +603,11 @@ export default function CreateOrderPage() {
       let orderId = editingDraftId;
 
       if (editingDraftId) {
-        // Update existing draft then mark as SENT
+        // Update existing draft then mark as Awaiting Delivery (transmit step)
         await fetch(`/api/inventory/orders/${editingDraftId}`, {
           method: "PATCH",
           headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ status: "SENT" }),
+          body: JSON.stringify({ status: "AWAITING_DELIVERY" }),
         });
       } else {
         // Create new order
@@ -634,7 +634,7 @@ export default function CreateOrderPage() {
           await fetch(`/api/inventory/orders/${order.id}`, {
             method: "PATCH",
             headers: { "Content-Type": "application/json" },
-            body: JSON.stringify({ status: "SENT" }),
+            body: JSON.stringify({ status: "AWAITING_DELIVERY" }),
           });
         }
       }

--- a/apps/backoffice/src/app/(admin)/inventory/orders/page.tsx
+++ b/apps/backoffice/src/app/(admin)/inventory/orders/page.tsx
@@ -695,9 +695,16 @@ export default function OrdersPage() {
                             {updatingId === order.id ? <Loader2 className="h-3 w-3 animate-spin" /> : a.label}
                           </button>
                         ))}
-                        {["SENT", "APPROVED"].includes(order.status) && (
-                          <button onClick={() => openEditDialog(order)} disabled={updatingId === order.id} className="rounded-md px-2 py-1 text-[10px] font-medium text-white bg-purple-500 hover:bg-purple-600 disabled:opacity-50" title="Confirm Order">
-                            {updatingId === order.id ? <Loader2 className="h-3 w-3 animate-spin" /> : "Confirm Order"}
+                        {/* Upload Invoice — appears when there's a placeholder invoice waiting for the
+                            supplier's real invoice details. Hidden once the invoice is fully attached
+                            (has dueDate) or paid. New flow: PO → AWAITING_DELIVERY → staff receives →
+                            COMPLETED (placeholder invoice) → procurement clicks here to attach. */}
+                        {["AWAITING_DELIVERY", "PARTIALLY_RECEIVED", "COMPLETED", "SENT", "APPROVED"].includes(order.status)
+                          && order.invoice
+                          && !order.invoice.dueDate
+                          && order.invoice.status !== "PAID" && (
+                          <button onClick={() => openEditDialog(order)} disabled={updatingId === order.id} className="rounded-md px-2 py-1 text-[10px] font-medium text-white bg-yellow-500 hover:bg-yellow-600 disabled:opacity-50" title="Upload Invoice">
+                            {updatingId === order.id ? <Loader2 className="h-3 w-3 animate-spin" /> : "Upload Invoice"}
                           </button>
                         )}
                         {order.status === "DRAFT" && (
@@ -813,8 +820,8 @@ export default function OrdersPage() {
         <DialogContent className={`max-h-[95vh] overflow-y-auto ${editOrder?.invoice && editOrder.invoice.photos.length > 0 ? "sm:max-w-[1400px] w-[95vw]" : "sm:max-w-3xl"}`}>
           <DialogHeader>
             <DialogTitle className="flex items-center gap-2">
-              {confirmOnSave ? <CheckCircle2 className="h-4 w-4 text-blue-500" /> : <Pencil className="h-4 w-4" />}
-              {confirmOnSave ? `Confirm ${editOrder?.orderNumber}` : `Edit ${editOrder?.orderNumber}`}
+              {confirmOnSave ? <CheckCircle2 className="h-4 w-4 text-yellow-500" /> : <Pencil className="h-4 w-4" />}
+              {confirmOnSave ? `Upload Invoice — ${editOrder?.orderNumber}` : `Edit ${editOrder?.orderNumber}`}
             </DialogTitle>
           </DialogHeader>
 
@@ -1095,9 +1102,9 @@ export default function OrdersPage() {
 
           <DialogFooter className="flex gap-2">
             <Button variant="outline" onClick={() => setEditOrder(null)}>Cancel</Button>
-            <Button onClick={saveEdit} disabled={editSaving || uploading} className={confirmOnSave ? "bg-blue-500 hover:bg-blue-600" : "bg-terracotta hover:bg-terracotta-dark"}>
+            <Button onClick={saveEdit} disabled={editSaving || uploading} className={confirmOnSave ? "bg-yellow-500 hover:bg-yellow-600" : "bg-terracotta hover:bg-terracotta-dark"}>
               {editSaving ? <Loader2 className="mr-1.5 h-4 w-4 animate-spin" /> : <CheckCircle2 className="mr-1.5 h-4 w-4" />}
-              {confirmOnSave ? "Confirm Order" : "Save Changes"}
+              {confirmOnSave ? "Upload Invoice" : "Save Changes"}
             </Button>
             {editOrder && ["SENT", "APPROVED"].includes(editOrder.status) && (
               <Button
@@ -1119,7 +1126,7 @@ export default function OrdersPage() {
                 }}
               >
                 {editSaving ? <Loader2 className="mr-1.5 h-4 w-4 animate-spin" /> : <Truck className="mr-1.5 h-4 w-4" />}
-                Confirm Order
+                Upload Invoice &amp; Send
               </Button>
             )}
           </DialogFooter>

--- a/apps/backoffice/src/app/api/inventory/invoices/route.ts
+++ b/apps/backoffice/src/app/api/inventory/invoices/route.ts
@@ -50,20 +50,30 @@ export async function GET(req: NextRequest) {
     paymentType: "SUPPLIER",
   };
 
+  // NOT-placeholder shape — the inverse of pendingInvoiceWhere. Used to
+  // filter placeholders out of all default views (Unpaid / Paid / All
+  // tabs and Payable / Due Today / Overdue cards). Only the explicit
+  // "Pending Invoice" cardFilter shows them.
+  const notPlaceholder: Prisma.InvoiceWhereInput = {
+    NOT: pendingInvoiceWhere,
+  };
+
   const where: Record<string, unknown> = {};
   if (cardFilter === "paid") where.status = "PAID";
-  else if (cardFilter === "overdue") where.OR = overdueOr;
+  else if (cardFilter === "overdue") { where.OR = overdueOr; Object.assign(where, notPlaceholder); }
   else if (cardFilter === "initiated") where.status = "INITIATED";
-  else if (cardFilter === "pending") where.status = "PENDING";
+  else if (cardFilter === "pending") { where.status = "PENDING"; Object.assign(where, notPlaceholder); }
   else if (cardFilter === "pending_invoice") {
     Object.assign(where, pendingInvoiceWhere);
   }
-  else if (cardFilter === "payable") where.status = { in: UNPAID_STATUSES };
+  else if (cardFilter === "payable") { where.status = { in: UNPAID_STATUSES }; Object.assign(where, notPlaceholder); }
   else if (cardFilter === "due_today") {
     where.status = { in: UNPAID_STATUSES };
     where.dueDate = { gte: _todayStart, lt: _todayEnd };
-  } else if (tab === "unpaid") where.status = { in: UNPAID_STATUSES };
+    Object.assign(where, notPlaceholder);
+  } else if (tab === "unpaid") { where.status = { in: UNPAID_STATUSES }; Object.assign(where, notPlaceholder); }
   else if (tab === "paid") where.status = "PAID";
+  else { Object.assign(where, notPlaceholder); }
 
   if (type === "supplier") {
     // "Supplier" = ingredient supplier invoices only (exclude one-off vendor
@@ -200,13 +210,20 @@ export async function GET(req: NextRequest) {
     // Useful for Finance to see how many payments are mid-flight.
     prisma.invoice.aggregate({ where: { status: "INITIATED" }, _sum: { amount: true }, _count: { _all: true } }),
     prisma.invoice.findMany({
-      where: { status: { in: UNPAID_STATUSES as ("DRAFT" | "INITIATED" | "PENDING" | "DEPOSIT_PAID" | "OVERDUE")[] } },
+      // Payable = unpaid AND NOT a GRNI placeholder. Placeholders surface
+      // separately in the Pending Invoice card (and on the Payable card as
+      // a soft sub-line) so cashflow planning still sees the full liability.
+      where: {
+        status: { in: UNPAID_STATUSES as ("DRAFT" | "INITIATED" | "PENDING" | "DEPOSIT_PAID" | "OVERDUE")[] },
+        NOT: pendingInvoiceWhere,
+      },
       select: { id: true, amount: true, status: true, depositAmount: true },
     }),
     prisma.invoice.findMany({
       where: {
         status: { in: UNPAID_STATUSES as ("DRAFT" | "INITIATED" | "PENDING" | "DEPOSIT_PAID" | "OVERDUE")[] },
         dueDate: { gte: todayStart, lt: todayEnd },
+        NOT: pendingInvoiceWhere,
       },
       select: { id: true, amount: true, status: true, depositAmount: true },
     }),

--- a/apps/backoffice/src/app/api/inventory/orders/[id]/route.ts
+++ b/apps/backoffice/src/app/api/inventory/orders/[id]/route.ts
@@ -43,7 +43,11 @@ export async function PATCH(req: NextRequest, { params }: { params: Promise<{ id
         data.approvedAt = new Date();
       }
 
-      if (status === "SENT") {
+      // Capture transmit timestamp on first transition to a "supplier has it"
+      // state. Order flow used to step through SENT before AWAITING_DELIVERY,
+      // but the new flow goes straight to AWAITING_DELIVERY — both should
+      // stamp sentAt so audit/lead-time analytics keep working.
+      if (status === "SENT" || status === "AWAITING_DELIVERY") {
         data.sentAt = new Date();
       }
     }

--- a/apps/backoffice/src/app/api/inventory/receivings/route.ts
+++ b/apps/backoffice/src/app/api/inventory/receivings/route.ts
@@ -154,22 +154,61 @@ export async function POST(req: NextRequest) {
     ),
   );
 
-  // Update order status if linked to a PO
+  // PO reconciliation: hard-overwrite each PO line to reflect cumulative
+  // receivedQty across all receivings on this PO. This way the PO total
+  // matches what the supplier should actually invoice us for — critical
+  // for the credit-term flow where the placeholder invoice (and downstream
+  // Pending Invoice card) need the real received value, not the original
+  // ordered total. Discrepancy is preserved on the receiving rows
+  // (orderedQty vs receivedQty).
   if (orderId) {
     const allReceivings = await prisma.receiving.findMany({
       where: { orderId },
-      select: { items: { select: { receivedQty: true } } },
+      select: {
+        items: {
+          select: {
+            productId: true,
+            productPackageId: true,
+            receivedQty: true,
+          },
+        },
+      },
     });
-    const order = await prisma.order.findUnique({
-      where: { id: orderId },
-      select: { items: { select: { quantity: true } } },
-    });
-    if (order) {
-      const totalOrdered = order.items.reduce((s, i) => s + Number(i.quantity), 0);
-      const totalReceived = allReceivings.flatMap((r) => r.items).reduce((s, i) => s + Number(i.receivedQty), 0);
-      const newStatus = totalReceived >= totalOrdered ? "COMPLETED" : "PARTIALLY_RECEIVED";
-      await prisma.order.update({ where: { id: orderId }, data: { status: newStatus } });
+    const cumulativeByLine = new Map<string, number>();
+    for (const r of allReceivings) {
+      for (const it of r.items) {
+        const key = `${it.productId}::${it.productPackageId ?? ""}`;
+        cumulativeByLine.set(key, (cumulativeByLine.get(key) ?? 0) + Number(it.receivedQty));
+      }
     }
+
+    const orderItems = await prisma.orderItem.findMany({
+      where: { orderId },
+      select: { id: true, productId: true, productPackageId: true, unitPrice: true, quantity: true },
+    });
+
+    let newTotalAmount = 0;
+    for (const oi of orderItems) {
+      const key = `${oi.productId}::${oi.productPackageId ?? ""}`;
+      const cumReceived = cumulativeByLine.get(key);
+      const newQty = cumReceived ?? Number(oi.quantity);
+      const lineTotal = newQty * Number(oi.unitPrice);
+      newTotalAmount += lineTotal;
+      if (cumReceived !== undefined && cumReceived !== Number(oi.quantity)) {
+        await prisma.orderItem.update({
+          where: { id: oi.id },
+          data: { quantity: cumReceived, totalPrice: lineTotal },
+        });
+      }
+    }
+
+    // After overwrite, ordered == received per line, so status always
+    // collapses to COMPLETED. If supplier delivers more later, another
+    // receiving will expand the PO line again and re-mark COMPLETED.
+    await prisma.order.update({
+      where: { id: orderId },
+      data: { totalAmount: newTotalAmount, status: "COMPLETED" },
+    });
   }
 
   // Update transfer status to RECEIVED if linked to a transfer
@@ -187,25 +226,45 @@ export async function POST(req: NextRequest) {
 
   // Attach/create supplier invoice for non-transfer receivings.
   //
-  // If the PO already has an invoice (e.g. created earlier via the Telegram
-  // POP webhook and possibly already PAID), append the receiving photos to
-  // it and never touch its status. Only create a new PENDING invoice when
-  // the order has no invoice yet, or for ad-hoc receivings without a PO.
+  // For an existing PLACEHOLDER (auto-created INV-NNNN with null due date —
+  // i.e. supplier hasn't sent the real invoice yet), update its amount to
+  // match the freshly-overwritten PO total and append any new photos.
+  // For an already-attached invoice (real supplier invoice number, has due
+  // date, possibly PAID), don't touch the amount — finance owns that record.
+  // For orders with no invoice yet, or ad-hoc receivings, create a new
+  // PENDING placeholder.
   if (!isTransfer) {
     try {
       const existingForOrder = orderId
         ? await prisma.invoice.findFirst({
             where: { orderId },
             orderBy: { createdAt: "desc" },
-            select: { id: true },
+            select: { id: true, invoiceNumber: true, dueDate: true, status: true },
           })
         : null;
 
       if (existingForOrder) {
+        const isPlaceholder =
+          existingForOrder.invoiceNumber.startsWith("INV-") &&
+          existingForOrder.dueDate == null &&
+          existingForOrder.status === "PENDING";
+
+        const updateData: Record<string, unknown> = {};
         if (invoicePhotos && invoicePhotos.length > 0) {
+          updateData.photos = { push: invoicePhotos };
+        }
+        if (isPlaceholder && orderId) {
+          // Sync placeholder amount with the freshly-recalculated PO total.
+          const o = await prisma.order.findUnique({
+            where: { id: orderId },
+            select: { totalAmount: true },
+          });
+          if (o) updateData.amount = o.totalAmount;
+        }
+        if (Object.keys(updateData).length > 0) {
           await prisma.invoice.update({
             where: { id: existingForOrder.id },
-            data: { photos: { push: invoicePhotos } },
+            data: updateData,
           });
         }
       } else {

--- a/apps/staff/src/app/api/receivings/route.ts
+++ b/apps/staff/src/app/api/receivings/route.ts
@@ -140,21 +140,94 @@ export async function POST(req: NextRequest) {
     ),
   );
 
-  // Update order status if linked
+  // PO reconciliation: hard-overwrite each PO line to reflect cumulative
+  // receivedQty so the PO total matches what the supplier should bill us.
+  // Discrepancy is preserved on receiving rows (orderedQty vs receivedQty).
   if (orderId) {
     const allReceivings = await prisma.receiving.findMany({
       where: { orderId },
-      select: { items: { select: { receivedQty: true } } },
+      select: {
+        items: {
+          select: { productId: true, productPackageId: true, receivedQty: true },
+        },
+      },
     });
-    const order = await prisma.order.findUnique({
+    const cumulativeByLine = new Map<string, number>();
+    for (const r of allReceivings) {
+      for (const it of r.items) {
+        const key = `${it.productId}::${it.productPackageId ?? ""}`;
+        cumulativeByLine.set(key, (cumulativeByLine.get(key) ?? 0) + Number(it.receivedQty));
+      }
+    }
+
+    const orderItems = await prisma.orderItem.findMany({
+      where: { orderId },
+      select: { id: true, productId: true, productPackageId: true, unitPrice: true, quantity: true },
+    });
+
+    let newTotalAmount = 0;
+    for (const oi of orderItems) {
+      const key = `${oi.productId}::${oi.productPackageId ?? ""}`;
+      const cumReceived = cumulativeByLine.get(key);
+      const newQty = cumReceived ?? Number(oi.quantity);
+      const lineTotal = newQty * Number(oi.unitPrice);
+      newTotalAmount += lineTotal;
+      if (cumReceived !== undefined && cumReceived !== Number(oi.quantity)) {
+        await prisma.orderItem.update({
+          where: { id: oi.id },
+          data: { quantity: cumReceived, totalPrice: lineTotal },
+        });
+      }
+    }
+
+    await prisma.order.update({
       where: { id: orderId },
-      select: { items: { select: { quantity: true } } },
+      data: { totalAmount: newTotalAmount, status: "COMPLETED" },
     });
-    if (order) {
-      const totalOrdered = order.items.reduce((s, i) => s + Number(i.quantity), 0);
-      const totalReceived = allReceivings.flatMap((r) => r.items).reduce((s, i) => s + Number(i.receivedQty), 0);
-      const newStatus = totalReceived >= totalOrdered ? "COMPLETED" : "PARTIALLY_RECEIVED";
-      await prisma.order.update({ where: { id: orderId }, data: { status: newStatus } });
+
+    // Placeholder invoice (GRNI). Staff app needs this so the supplier
+    // invoice can be attached later via backoffice. If a placeholder
+    // already exists for this order, update its amount to match the
+    // freshly-overwritten PO total. Don't touch a real (non-placeholder)
+    // invoice — finance owns those.
+    try {
+      const existing = await prisma.invoice.findFirst({
+        where: { orderId },
+        orderBy: { createdAt: "desc" },
+        select: { id: true, invoiceNumber: true, dueDate: true, status: true },
+      });
+
+      if (existing) {
+        const isPlaceholder =
+          existing.invoiceNumber.startsWith("INV-") &&
+          existing.dueDate == null &&
+          existing.status === "PENDING";
+        const updateData: Record<string, unknown> = {};
+        if (invoicePhotos && invoicePhotos.length > 0) {
+          updateData.photos = { push: invoicePhotos };
+        }
+        if (isPlaceholder) updateData.amount = newTotalAmount;
+        if (Object.keys(updateData).length > 0) {
+          await prisma.invoice.update({ where: { id: existing.id }, data: updateData });
+        }
+      } else if (supplierId) {
+        const invCount = await prisma.invoice.count();
+        const invoiceNumber = `INV-${String(invCount + 1).padStart(4, "0")}`;
+        await prisma.invoice.create({
+          data: {
+            invoiceNumber,
+            orderId,
+            outletId,
+            supplierId,
+            amount: newTotalAmount,
+            status: "PENDING",
+            photos: invoicePhotos || [],
+            notes: notes ? `From receiving: ${notes}` : null,
+          },
+        });
+      }
+    } catch (err) {
+      console.error("[staff receivings] placeholder invoice attach/create failed:", err);
     }
   }
 


### PR DESCRIPTION
## Summary

Coordinated 4-change redesign of the credit-term receiving flow. Continues from #113 (pending-invoice flow) and #114 (staff receiving for SENT POs).

## What changes

### 1. SENT → AWAITING_DELIVERY collapse
Procurement no longer steps through a separate SENT status. Send-to-supplier moves the PO straight to AWAITING_DELIVERY. `sentAt` is captured on either transition.

**Files:** `orders/[id]/route.ts` (sentAt setter), `orders/[id]/page.tsx` + `orders/create/page.tsx` (write sites).

Read filters in dashboards / receivings UI / Telegram webhook still include `SENT` for backwards compat with any legacy data.

### 2. PO hard-overwrite on receiving
Every receiving updates the PO line items so `quantity` = cumulative receivedQty per (productId, productPackageId), and `totalAmount` recalculates. The PO becomes the source of truth for what the supplier should bill — placeholder invoice amount = real received value, not original ordered total.

If supplier delivers partial first then more later, the line expands on the second receiving. Status goes to COMPLETED on every receiving (under hard-overwrite, ordered always equals received per line).

Discrepancy is preserved on receiving rows (`orderedQty` vs `receivedQty`).

**Files:** backoffice + staff app `receivings/route.ts`. Staff app also gains placeholder invoice creation/update (previously only backoffice did this).

### 3. GRNI placeholders hidden from default invoice views
Placeholder = `invoiceNumber LIKE 'INV-%' AND dueDate IS NULL AND status='PENDING' AND linked PO`.

| View | Before | After |
|---|---|---|
| Unpaid / Paid / All tabs | shows placeholders | excludes placeholders |
| Payable card count + amount | includes placeholders | excludes placeholders |
| Due Today / Overdue cards | counted placeholders | excludes placeholders |
| **Pending Invoice card** | shows placeholders only | shows placeholders only |
| Payable card | (no GRNI hint) | **soft sub-line: "+RM X,XXX awaiting invoice"** (clickable → jumps to Pending Invoice filter) |

Cashflow planning still sees the full liability via the soft sub-line.

**Files:** `api/inventory/invoices/route.ts` (NOT placeholder filter, payable/dueToday excludes placeholders), `inventory/invoices/page.tsx` (sub-line on Payable card).

### 4. "Confirm Order" → "Upload Invoice"
Old label was misleading — the workflow's actual job is uploading the supplier's invoice details. Relabelled everywhere:
- List action button: "Confirm Order" → "Upload Invoice" (yellow). Visibility tightened: shows when invoice has no `dueDate` yet (i.e. placeholder waiting for supplier details), regardless of PO status.
- Edit dialog title: "Confirm <PO#>" → "Upload Invoice — <PO#>"
- Save CTA in dialog: "Confirm Order" → "Upload Invoice"
- "Confirm Order" footer button (the validate-required-fields-and-transition variant): "Upload Invoice & Send"

**Files:** `inventory/orders/page.tsx`.

## End-to-end flow (now)

1. Procurement creates PO → clicks Send → status `AWAITING_DELIVERY`
2. Goods arrive → outlet staff opens staff app `/receiving` → records receipt
3. PO line items + totalAmount overwrite to actual received → status `COMPLETED` → placeholder invoice auto-created with received-actual amount
4. Placeholder visible only in Pending Invoice card (yellow). Payable card shows "+ RM X awaiting invoice" sub-line so cashflow still sees it.
5. Days later supplier emails real invoice → procurement opens PO → clicks **Upload Invoice** → fills supplier inv# + due date + photo → placeholder gets enriched → leaves Pending bucket → enters Payable
6. Finance pays per terms (or Reject rolls it back to Pending if bank rejects)

## Test plan

- [ ] Procurement creates a PO and clicks Send — status goes directly to `AWAITING_DELIVERY` (not `SENT`)
- [ ] `sentAt` is set on the order
- [ ] Staff records partial receiving (8 of 10 ordered) — PO line `quantity` updates to 8, `totalAmount` recalculates to 8 × unitPrice
- [ ] PO status flips to `COMPLETED` on receiving
- [ ] Placeholder invoice amount = updated PO total = received-actual
- [ ] Second receiving for the same PO (supplier brings missing 2): line expands to 10, placeholder amount updates
- [ ] `/inventory/invoices` Unpaid tab does NOT show the placeholder
- [ ] Payable card amount excludes placeholders
- [ ] Payable card shows yellow "+ RM X,XXX awaiting invoice" sub-line
- [ ] Clicking the sub-line jumps to Pending Invoice filter
- [ ] Pending Invoice card lists the placeholder
- [ ] On the orders list, Upload Invoice button (yellow) appears on rows with placeholder invoices
- [ ] Click Upload Invoice → dialog title says "Upload Invoice — <PO#>" → save CTA says "Upload Invoice"
- [ ] Fill supplier invoice number + due date → save → placeholder leaves Pending bucket, appears in Payable

🤖 Generated with [Claude Code](https://claude.com/claude-code)