### PR TITLE
fix(orders): cancelling a PO now cascades to delete its placeholder invoice

### DIFF
--- a/apps/backoffice/src/app/api/inventory/orders/[id]/route.ts
+++ b/apps/backoffice/src/app/api/inventory/orders/[id]/route.ts
@@ -100,6 +100,30 @@ export async function PATCH(req: NextRequest, { params }: { params: Promise<{ id
       },
     });
 
+    // Cascade cancel: when a PO is cancelled, drop any GRNI placeholder
+    // invoices auto-attached to it. Without this, the placeholder lingers
+    // forever in the Pending Invoice card after the PO is dead. Real
+    // (non-placeholder) invoices and any PAID/INITIATED records are left
+    // alone — those represent commitments or money already moved and
+    // require manual handling.
+    if (status === "CANCELLED") {
+      try {
+        const deleted = await prisma.invoice.deleteMany({
+          where: {
+            orderId: id,
+            status: "PENDING",
+            dueDate: null,
+            invoiceNumber: { startsWith: "INV-" },
+          },
+        });
+        if (deleted.count > 0) {
+          console.log(`[orders/[id] PATCH] Cascaded ${deleted.count} placeholder invoice(s) on PO cancel: ${id}`);
+        }
+      } catch (e) {
+        console.error("[orders/[id] PATCH] Placeholder cascade-delete failed:", e);
+      }
+    }
+
     // Auto-create invoice + receiving when order is confirmed (AWAITING_DELIVERY)
     if (status === "AWAITING_DELIVERY") {
       const caller = await getUserFromHeaders(req.headers);


### PR DESCRIPTION
## Bug

Cancelling a PO from the orders list (Cancel button) left the auto-created GRNI placeholder invoice attached to the dead order. The placeholder stayed `PENDING` and continued to show forever in the Pending Invoice card and the soft sub-line on Payable, inflating the apparent liability.

## Fix

`PATCH /api/inventory/orders/[id]` now deletes placeholder invoices when the order transitions to `CANCELLED`. Placeholder is identified the same way as everywhere else: `status=PENDING` + `dueDate=null` + `invoiceNumber LIKE 'INV-%'`.

Real (non-placeholder) invoices and any `PAID`/`INITIATED` records are intentionally left alone — those represent actual commitments or money already moved and require manual reversal/refund.

## Backfilled in production

One orphaned placeholder already existed: `INV-0262` (RM 245) on cancelled PO `CC-CC001-0052`. Deleted via SQL.

## Test plan

- [ ] Create a PO, send it (status `AWAITING_DELIVERY`)
- [ ] Receive it (placeholder invoice auto-created)
- [ ] Cancel the PO from the orders list
- [ ] Pending Invoice card no longer shows the placeholder
- [ ] Payable card sub-line "+RM X awaiting invoice" no longer counts it

🤖 Generated with [Claude Code](https://claude.com/claude-code)