### PR TITLE
fix(orders): block PO cancel when invoice is INITIATED / DEPOSIT_PAID / PAID

### DIFF
--- a/apps/backoffice/src/app/(admin)/inventory/orders/page.tsx
+++ b/apps/backoffice/src/app/(admin)/inventory/orders/page.tsx
@@ -533,7 +533,11 @@ export default function OrdersPage() {
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ status: newStatus }),
       });
-      if (!res.ok) { alert("Failed to update order status"); return; }
+      if (!res.ok) {
+        const body = await res.json().catch(() => ({} as { error?: string }));
+        alert(body.error || "Failed to update order status");
+        return;
+      }
       loadOrders();
     } finally {
       setUpdatingId(null);
@@ -717,7 +721,10 @@ export default function OrdersPage() {
                             <Pencil className="h-3 w-3" />
                           </button>
                         )}
-                        {["SENT", "APPROVED", "AWAITING_DELIVERY"].includes(order.status) && order.invoice?.status !== "PAID" && (
+                        {/* Cancel hidden once a committed invoice exists (INITIATED/DEPOSIT_PAID/PAID).
+                            API also enforces this — frontend hide is just for UX. */}
+                        {["SENT", "APPROVED", "AWAITING_DELIVERY"].includes(order.status)
+                          && !["INITIATED", "DEPOSIT_PAID", "PAID"].includes(order.invoice?.status ?? "") && (
                           <button onClick={() => { if (confirm("Cancel this order?")) updateStatus(order.id, "CANCELLED"); }} disabled={updatingId === order.id} className="rounded-md px-2 py-1 text-[10px] font-medium text-red-600 border border-red-200 hover:bg-red-50 disabled:opacity-50" title="Cancel Order">
                             Cancel
                           </button>

--- a/apps/backoffice/src/app/api/inventory/orders/[id]/route.ts
+++ b/apps/backoffice/src/app/api/inventory/orders/[id]/route.ts
@@ -30,6 +30,32 @@ export async function PATCH(req: NextRequest, { params }: { params: Promise<{ id
 
     const data: Record<string, unknown> = {};
 
+    // Block PO cancellation if any linked invoice is INITIATED / DEPOSIT_PAID
+    // / PAID — those represent payments mid-flight or money already moved
+    // and need manual reversal first. Placeholder + real-but-PENDING invoices
+    // are fine to cancel through (placeholders cascade-delete below).
+    if (status === "CANCELLED") {
+      const blockingInvoice = await prisma.invoice.findFirst({
+        where: {
+          orderId: id,
+          status: { in: ["INITIATED", "DEPOSIT_PAID", "PAID"] },
+        },
+        select: { invoiceNumber: true, status: true, amount: true },
+      });
+      if (blockingInvoice) {
+        const verb =
+          blockingInvoice.status === "PAID" ? "is already paid" :
+          blockingInvoice.status === "DEPOSIT_PAID" ? "has a paid deposit" :
+          "has payment initiated";
+        return NextResponse.json(
+          {
+            error: `Cannot cancel — invoice ${blockingInvoice.invoiceNumber} (RM ${Number(blockingInvoice.amount).toFixed(2)}) ${verb}. Reverse the payment first, then cancel.`,
+          },
+          { status: 400 },
+        );
+      }
+    }
+
     // Status transition
     if (status) {
       data.status = status;


### PR DESCRIPTION
## Why

Following #118 (cascade-delete placeholders on cancel), the next logical guard is preventing cancellation of POs where money has already moved or is mid-flight. Without this, a user could silently cancel a PO that has an INITIATED bank transfer pending, leaving the payment record orphaned and unreconcilable.

## Behaviour

When `PATCH /api/inventory/orders/[id]` receives `status: "CANCELLED"`:
- ✅ Allow if no invoice exists, or invoice is placeholder, or invoice is real-but-PENDING
- ❌ Reject with `400` if any linked invoice is `INITIATED`, `DEPOSIT_PAID`, or `PAID`

Error message names the offending invoice number, amount, and the action needed:

> Cannot cancel — invoice ABC-1234 (RM 245.00) has payment initiated. Reverse the payment first, then cancel.

## Defense in depth

- **API**: enforces the rule
- **Frontend**: hides the Cancel button when the invoice is in any committed status (extra UX layer; old check only hid for PAID)
- **Frontend**: `updateStatus()` now surfaces the server's error message in the alert instead of the generic "Failed to update order status"

## Test plan

- [ ] Create PO → cancel before any invoice exists → succeeds
- [ ] Create PO → receive (placeholder created) → cancel → succeeds, placeholder cascade-deleted
- [ ] Create PO → receive → upload invoice (real, PENDING) → cancel → succeeds, real invoice stays for manual handling
- [ ] Create PO → receive → upload invoice → mark INITIATED → cancel → blocked with "payment initiated" error, Cancel button hidden in UI
- [ ] Same with DEPOSIT_PAID → blocked with "paid deposit" error
- [ ] Same with PAID → blocked with "already paid" error

🤖 Generated with [Claude Code](https://claude.com/claude-code)