### PR TITLE
Staff: fix Android camera (drop multiple from capture inputs)

### DIFF
--- a/apps/staff/src/app/(ops)/claims/page.tsx
+++ b/apps/staff/src/app/(ops)/claims/page.tsx
@@ -378,7 +378,7 @@ export default function ClaimsPage() {
           </p>
         </div>
 
-        {/* Hero Upload Zone */}
+        {/* Hero Upload Zone — primary "Take photo" target */}
         <Card
           className="relative cursor-pointer border-2 border-dashed border-terracotta/30 bg-terracotta/5 transition-colors hover:border-terracotta/50 hover:bg-terracotta/10 active:scale-[0.98]"
           onClick={() => fileInputRef.current?.click()}
@@ -397,20 +397,23 @@ export default function ClaimsPage() {
                   <Camera className="h-8 w-8 text-terracotta" />
                 </div>
                 <p className="mt-3 text-sm font-semibold text-terracotta-dark">
-                  {photos.length > 0 ? "Add More Photos" : "Snap or Upload Receipt"}
+                  {photos.length > 0 ? "Add Another Photo" : "Take Photo of Receipt"}
                 </p>
                 <p className="mt-1 text-xs text-gray-400">
-                  Tap to take a photo or choose from gallery
+                  Tap to open camera
                 </p>
               </>
             )}
           </div>
+          {/* Camera-only single-shot input. NO `multiple` (Chrome on
+              Android falls through to the file picker when both
+              `capture` and `multiple` are set) and NO gallery option
+              (audit/integrity — claims must be photographed live). */}
           <input
             ref={fileInputRef}
             type="file"
             accept="image/*"
             capture="environment"
-            multiple
             onChange={handleFileChange}
             className="hidden"
           />

--- a/apps/staff/src/app/(ops)/receiving/page.tsx
+++ b/apps/staff/src/app/(ops)/receiving/page.tsx
@@ -667,13 +667,16 @@ export default function ReceivePage() {
         </div>
       )}
 
-      {/* Hidden file input for camera/gallery */}
+      {/* Camera-only single-shot input. NO `multiple` (Chrome on
+          Android falls through to the file picker when both
+          `capture` and `multiple` are set) and NO gallery option
+          (invoice integrity — must be photographed live). User
+          taps "Add Photo" again to capture additional shots. */}
       <input
         ref={fileInputRef}
         type="file"
         accept="image/*"
         capture="environment"
-        multiple
         className="hidden"
         onChange={handlePhotoCapture}
       />


### PR DESCRIPTION
## Summary

**Root cause:** Chrome on Android falls through to the file picker when an \`<input type=\"file\">\` has BOTH \`capture=\"environment\"\` AND \`multiple\` attributes set. Users tapping \"Take Photo\" on claims and receiving pages got the file browser instead of the camera.

**Fix:** Drop \`multiple\`. Handlers already accumulate photos into state on each tap, so multi-photo flows still work — user taps \"Add Photo\" once per shot.

Bonus side-effect: enforces audit-trail requirement that claim receipts and invoice photos must be captured live, not pulled from the gallery.

## Files
- \`apps/staff/src/app/(ops)/claims/page.tsx\` — receipt photos
- \`apps/staff/src/app/(ops)/receiving/page.tsx\` — invoice photos

Other camera inputs (checklists, audit) were already single-capture and unaffected.

## Test plan
- [ ] Open /claims on Android Chrome — \"Take Photo of Receipt\" opens camera (not file picker)
- [ ] Open /receiving on Android Chrome — \"Add Photo\" opens camera
- [ ] After capturing a photo, tapping \"Add Another Photo\" reopens camera
- [ ] Multi-photo accumulation in state still works
- [ ] No gallery option visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)