### PR TITLE
Staff camera: replace <input> with getUserMedia modal (bulletproof Android)

### DIFF
--- a/apps/staff/src/app/(ops)/audit/[id]/page.tsx
+++ b/apps/staff/src/app/(ops)/audit/[id]/page.tsx
@@ -6,6 +6,7 @@ import { useRouter } from "next/navigation";
 import { Card, CardContent } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
+import { CameraCaptureModal } from "@/components/camera-capture-modal";
 import {
   ArrowLeft, CheckCircle2, Loader2, Camera, X, MessageSquare, RotateCcw,
   Image as ImageIcon, Star, ThumbsUp, ThumbsDown, Minus, Building2,
@@ -52,8 +53,8 @@ export default function AuditDetailPage({ params }: { params: Promise<{ id: stri
   const [overallNotes, setOverallNotes] = useState("");
   const [showComplete, setShowComplete] = useState(false);
 
-  const fileInputRef = useRef<HTMLInputElement>(null);
   const activeItemRef = useRef<string | null>(null);
+  const [cameraOpen, setCameraOpen] = useState(false);
   const replacingPhotoRef = useRef<string | null>(null);
 
   const setRating = async (item: AuditItem, rating: number) => {
@@ -93,17 +94,17 @@ export default function AuditDetailPage({ params }: { params: Promise<{ id: stri
 
   const handlePhotoClick = (itemId: string) => {
     activeItemRef.current = itemId;
-    fileInputRef.current?.click();
+    setCameraOpen(true);
   };
 
-  const handleFileChange = async (e: React.ChangeEvent<HTMLInputElement>) => {
-    const file = e.target.files?.[0];
+  // Upload a captured photo blob and attach it to the active audit item
+  const handleCameraCapture = async (blob: Blob) => {
     const itemId = activeItemRef.current;
-    if (!file || !itemId) return;
-    e.target.value = "";
+    if (!itemId) return;
 
     setUploadingItem(itemId);
     try {
+      const file = new File([blob], `audit-${itemId}-${Date.now()}.jpg`, { type: "image/jpeg" });
       const formData = new FormData();
       formData.append("file", file);
       const uploadRes = await fetch("/api/upload", { method: "POST", body: formData });
@@ -146,7 +147,7 @@ export default function AuditDetailPage({ params }: { params: Promise<{ id: stri
   const handleRetakeAuditPhoto = (itemId: string, url: string) => {
     activeItemRef.current = itemId;
     replacingPhotoRef.current = url;
-    fileInputRef.current?.click();
+    setCameraOpen(true);
   };
 
   const handleComplete = async () => {
@@ -195,7 +196,15 @@ export default function AuditDetailPage({ params }: { params: Promise<{ id: stri
 
   return (
     <div className="p-4 lg:p-6">
-      <input ref={fileInputRef} type="file" accept="image/*" capture="environment" className="hidden" onChange={handleFileChange} />
+      {/* Fullscreen camera modal — getUserMedia-based, 100% camera-only.
+          Replaces the legacy <input type="file" capture> path. */}
+      <CameraCaptureModal
+        open={cameraOpen}
+        facingMode="environment"
+        title="Audit Photo"
+        onCapture={handleCameraCapture}
+        onClose={() => setCameraOpen(false)}
+      />
 
       {/* Photo preview */}
       {photoPreview && (

--- a/apps/staff/src/app/(ops)/checklists/[id]/page.tsx
+++ b/apps/staff/src/app/(ops)/checklists/[id]/page.tsx
@@ -5,6 +5,7 @@ import Link from "next/link";
 import { Card, CardContent } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
+import { CameraCaptureModal } from "@/components/camera-capture-modal";
 import {
   ArrowLeft, CheckCircle2, Circle, Loader2, MessageSquare, Clock,
   Camera, X, Image as ImageIcon, RotateCcw,
@@ -54,8 +55,8 @@ export default function ChecklistDetailPage({ params }: { params: Promise<{ id: 
   const [notesOpen, setNotesOpen] = useState<string | null>(null);
   const [noteText, setNoteText] = useState("");
   const [photoPreview, setPhotoPreview] = useState<string | null>(null);
-  const fileInputRef = useRef<HTMLInputElement>(null);
   const activeItemRef = useRef<string | null>(null);
+  const [cameraOpenForItem, setCameraOpenForItem] = useState<string | null>(null);
 
   const toggleItem = async (item: ChecklistItem) => {
     if (!item.isCompleted && item.photoRequired && !item.photoUrl) {
@@ -110,7 +111,7 @@ export default function ChecklistDetailPage({ params }: { params: Promise<{ id: 
 
   const handlePhotoClick = (itemId: string) => {
     activeItemRef.current = itemId;
-    fileInputRef.current?.click();
+    setCameraOpenForItem(itemId);
   };
 
   const handleDeletePhoto = async (itemId: string) => {
@@ -128,16 +129,14 @@ export default function ChecklistDetailPage({ params }: { params: Promise<{ id: 
     }
   };
 
-  const handleFileChange = async (e: React.ChangeEvent<HTMLInputElement>) => {
-    const file = e.target.files?.[0];
+  // Upload a captured photo blob and attach it to the active checklist item
+  const handleCameraCapture = async (blob: Blob) => {
     const itemId = activeItemRef.current;
-    if (!file || !itemId) return;
-
-    // Reset input
-    e.target.value = "";
+    if (!itemId) return;
 
     setUploadingItem(itemId);
     try {
+      const file = new File([blob], `checklist-${itemId}-${Date.now()}.jpg`, { type: "image/jpeg" });
       const formData = new FormData();
       formData.append("file", file);
 
@@ -180,14 +179,15 @@ export default function ChecklistDetailPage({ params }: { params: Promise<{ id: 
 
   return (
     <div className="p-6 lg:p-8">
-      {/* Hidden file input */}
-      <input
-        ref={fileInputRef}
-        type="file"
-        accept="image/*"
-        capture="environment"
-        className="hidden"
-        onChange={handleFileChange}
+      {/* Fullscreen camera modal — getUserMedia-based, 100% camera-only.
+          Replaces the legacy <input type="file" capture> path which
+          some Android browsers fell through to a gallery chooser. */}
+      <CameraCaptureModal
+        open={cameraOpenForItem !== null}
+        facingMode="environment"
+        title="Photo Proof"
+        onCapture={handleCameraCapture}
+        onClose={() => setCameraOpenForItem(null)}
       />
 
       {/* Photo preview modal */}

--- a/apps/staff/src/app/(ops)/claims/page.tsx
+++ b/apps/staff/src/app/(ops)/claims/page.tsx
@@ -1,9 +1,10 @@
 "use client";
 
-import { useState, useEffect, useRef } from "react";
+import { useState, useEffect } from "react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Card } from "@/components/ui/card";
+import { CameraCaptureModal } from "@/components/camera-capture-modal";
 import { compressImage } from "@/lib/compress-image";
 import {
   Camera,
@@ -57,7 +58,7 @@ export default function ClaimsPage() {
   // Upload state
   const [photos, setPhotos] = useState<string[]>([]);
   const [uploading, setUploading] = useState(false);
-  const fileInputRef = useRef<HTMLInputElement>(null);
+  const [cameraOpen, setCameraOpen] = useState(false);
 
   // AI extraction state
   const [extracting, setExtracting] = useState(false);
@@ -129,53 +130,36 @@ export default function ClaimsPage() {
       .catch(() => {});
   }, []);
 
-  // Handle file selection
-  const handleFileChange = async (e: React.ChangeEvent<HTMLInputElement>) => {
-    const files = e.target.files;
-    if (!files?.length) return;
+  // Compress + upload one file, return the resulting URL
+  const uploadOne = async (file: File): Promise<string> => {
+    const dataUrl = await compressImage(file);
+    const blob = await fetch(dataUrl).then((r) => r.blob());
+    const compressedFile = new File([blob], file.name, { type: "image/jpeg" });
+    const formData = new FormData();
+    formData.append("file", compressedFile);
+    const res = await fetch("/api/upload", { method: "POST", body: formData });
+    if (!res.ok) {
+      const err = await res.json();
+      throw new Error(err.error || "Upload failed");
+    }
+    const { url } = await res.json();
+    return url as string;
+  };
 
+  // Handle a freshly-captured photo from the camera modal
+  const handleCameraCapture = async (blob: Blob) => {
     setUploading(true);
     setError("");
-
     try {
-      const uploadedUrls: string[] = [];
-
-      for (const file of Array.from(files)) {
-        // Compress image before uploading
-        const dataUrl = await compressImage(file);
-        const blob = await fetch(dataUrl).then((r) => r.blob());
-        const compressedFile = new File([blob], file.name, {
-          type: "image/jpeg",
-        });
-
-        const formData = new FormData();
-        formData.append("file", compressedFile);
-
-        const res = await fetch("/api/upload", {
-          method: "POST",
-          body: formData,
-        });
-
-        if (!res.ok) {
-          const err = await res.json();
-          throw new Error(err.error || "Upload failed");
-        }
-
-        const { url } = await res.json();
-        uploadedUrls.push(url);
-      }
-
-      const allPhotos = [...photos, ...uploadedUrls];
+      const file = new File([blob], `receipt-${Date.now()}.jpg`, { type: "image/jpeg" });
+      const url = await uploadOne(file);
+      const allPhotos = [...photos, url];
       setPhotos(allPhotos);
-
-      // Trigger AI extraction immediately
       triggerExtraction(allPhotos);
     } catch (err) {
       setError(err instanceof Error ? err.message : "Upload failed");
     } finally {
       setUploading(false);
-      // Reset file input
-      if (fileInputRef.current) fileInputRef.current.value = "";
     }
   };
 
@@ -378,10 +362,10 @@ export default function ClaimsPage() {
           </p>
         </div>
 
-        {/* Hero Upload Zone — primary "Take photo" target */}
+        {/* Hero Upload Zone — opens fullscreen camera modal */}
         <Card
           className="relative cursor-pointer border-2 border-dashed border-terracotta/30 bg-terracotta/5 transition-colors hover:border-terracotta/50 hover:bg-terracotta/10 active:scale-[0.98]"
-          onClick={() => fileInputRef.current?.click()}
+          onClick={() => setCameraOpen(true)}
         >
           <div className="flex flex-col items-center justify-center py-10">
             {uploading ? (
@@ -408,15 +392,8 @@ export default function ClaimsPage() {
           {/* Camera-only single-shot input. NO `multiple` (Chrome on
               Android falls through to the file picker when both
               `capture` and `multiple` are set) and NO gallery option
-              (audit/integrity — claims must be photographed live). */}
-          <input
-            ref={fileInputRef}
-            type="file"
-            accept="image/*"
-            capture="environment"
-            onChange={handleFileChange}
-            className="hidden"
-          />
+              (audit/integrity — claims must be photographed live). The
+              CameraCaptureModal below is the actual capture mechanism. */}
         </Card>
 
         {/* Photo Thumbnails */}
@@ -777,6 +754,16 @@ export default function ClaimsPage() {
           </div>
         )}
       </div>
+
+      {/* Fullscreen camera modal — only camera, never gallery. Uses
+          getUserMedia so all Android browsers behave consistently. */}
+      <CameraCaptureModal
+        open={cameraOpen}
+        facingMode="environment"
+        title={photos.length > 0 ? "Add Another Receipt Photo" : "Photograph Receipt"}
+        onCapture={handleCameraCapture}
+        onClose={() => setCameraOpen(false)}
+      />
     </div>
   );
 }

--- a/apps/staff/src/app/(ops)/receiving/page.tsx
+++ b/apps/staff/src/app/(ops)/receiving/page.tsx
@@ -1,11 +1,12 @@
 "use client";
 
-import { useState, useEffect, useRef, useCallback } from "react";
+import { useState, useEffect, useCallback } from "react";
 import { TopBar } from "@/components/top-bar";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { Card } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
+import { CameraCaptureModal } from "@/components/camera-capture-modal";
 import { compressImage } from "@/lib/compress-image";
 import {
   Package,
@@ -131,7 +132,7 @@ export default function ReceivePage() {
   const [discrepancyReasons, setDiscrepancyReasons] = useState<Record<string, string>>({});
   const [submitting, setSubmitting] = useState(false);
   const [submitSuccess, setSubmitSuccess] = useState(false);
-  const fileInputRef = useRef<HTMLInputElement>(null);
+  const [cameraOpen, setCameraOpen] = useState(false);
 
   /* ---- Fetch data ------------------------------------------------ */
 
@@ -197,21 +198,17 @@ export default function ReceivePage() {
 
   const [compressing, setCompressing] = useState(false);
 
-  const handlePhotoCapture = async (e: React.ChangeEvent<HTMLInputElement>) => {
-    const files = e.target.files;
-    if (!files || files.length === 0) return;
+  // Compress + accumulate a freshly-captured photo blob from the camera modal
+  const handleCameraCapture = async (blob: Blob) => {
     setCompressing(true);
     try {
-      const compressed = await Promise.all(
-        Array.from(files).map((file) => compressImage(file)),
-      );
-      setInvoicePhotos((prev) => [...prev, ...compressed]);
+      const file = new File([blob], `invoice-${Date.now()}.jpg`, { type: "image/jpeg" });
+      const compressed = await compressImage(file);
+      setInvoicePhotos((prev) => [...prev, compressed]);
     } catch (err) {
       console.error("Failed to compress image:", err);
     } finally {
       setCompressing(false);
-      // Reset input so the same file can be re-selected
-      e.target.value = "";
     }
   };
 
@@ -383,7 +380,7 @@ export default function ReceivePage() {
             {/* Quick capture -- no PO linked */}
             <Card className="border-dashed border-gray-300">
               <button
-                onClick={() => fileInputRef.current?.click()}
+                onClick={() => setCameraOpen(true)}
                 className="flex w-full items-center gap-3 px-3 py-3"
               >
                 <div className="flex h-10 w-10 items-center justify-center rounded-full bg-gray-100">
@@ -629,7 +626,7 @@ export default function ReceivePage() {
                   </div>
                 ) : (
                   <button
-                    onClick={() => fileInputRef.current?.click()}
+                    onClick={() => setCameraOpen(true)}
                     className="flex h-20 w-20 flex-col items-center justify-center gap-1 rounded-lg border-2 border-dashed border-gray-300 text-gray-400 hover:border-terracotta hover:text-terracotta"
                   >
                     <Camera className="h-5 w-5" />
@@ -667,18 +664,16 @@ export default function ReceivePage() {
         </div>
       )}
 
-      {/* Camera-only single-shot input. NO `multiple` (Chrome on
-          Android falls through to the file picker when both
-          `capture` and `multiple` are set) and NO gallery option
-          (invoice integrity — must be photographed live). User
-          taps "Add Photo" again to capture additional shots. */}
-      <input
-        ref={fileInputRef}
-        type="file"
-        accept="image/*"
-        capture="environment"
-        className="hidden"
-        onChange={handlePhotoCapture}
+      {/* Fullscreen camera modal — getUserMedia-based, 100% camera-
+          only with no gallery option. Replaces the legacy <input
+          type="file" capture> path which Android browsers handled
+          inconsistently. */}
+      <CameraCaptureModal
+        open={cameraOpen}
+        facingMode="environment"
+        title="Photograph Invoice"
+        onCapture={handleCameraCapture}
+        onClose={() => setCameraOpen(false)}
       />
     </>
   );

--- a/apps/staff/src/components/camera-capture-modal.tsx
+++ b/apps/staff/src/components/camera-capture-modal.tsx
@@ -1,0 +1,239 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { Camera, X, Check, RefreshCw, AlertTriangle } from "lucide-react";
+
+// Fullscreen camera capture modal. Uses getUserMedia directly so we
+// have a live preview, a custom capture button, and 100% camera-only
+// behavior — no gallery picker fallback, no browser chooser dialog.
+//
+// Why not <input type="file" capture="environment">? On Android the
+// `capture` attribute is a HINT — many browsers (Samsung Internet,
+// MIUI, some OEM skins) still show a chooser with both Camera and
+// Files options. Combining it with `multiple` flips Chrome itself
+// into file-picker mode. getUserMedia is the only way to enforce
+// camera-only on the web.
+//
+// Constraints note: ALWAYS use { ideal: N } not { N }. Android
+// device cameras typically only expose 720p/1080p natively and
+// reject exact constraints with OverconstrainedError. The capture
+// canvas crops/scales to whatever the calling page wants, so the
+// stream resolution doesn't have to match.
+
+export type CameraCaptureModalProps = {
+  open: boolean;
+  facingMode?: "user" | "environment";   // selfie vs rear (default rear)
+  mirror?: boolean;                       // mirror preview + captured pixels (default: matches selfie)
+  onCapture: (blob: Blob, dataUrl: string) => void | Promise<void>;
+  onClose: () => void;
+  // Quality for JPEG output (0..1). Default 0.85.
+  quality?: number;
+  // Optional title shown in the header.
+  title?: string;
+};
+
+export function CameraCaptureModal({
+  open,
+  facingMode = "environment",
+  mirror,
+  onCapture,
+  onClose,
+  quality = 0.85,
+  title,
+}: CameraCaptureModalProps) {
+  const videoRef = useRef<HTMLVideoElement>(null);
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+  const streamRef = useRef<MediaStream | null>(null);
+
+  const [error, setError] = useState<string | null>(null);
+  const [ready, setReady] = useState(false);
+  const [previewUrl, setPreviewUrl] = useState<string | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+
+  // Default mirror behaviour: mirror selfies (so the user sees themselves
+  // as in a real mirror), don't mirror rear-camera shots.
+  const shouldMirror = mirror ?? facingMode === "user";
+
+  useEffect(() => {
+    if (!open) return;
+    setError(null);
+    setReady(false);
+    setPreviewUrl(null);
+    setSubmitting(false);
+
+    let cancelled = false;
+    async function start() {
+      try {
+        const stream = await navigator.mediaDevices.getUserMedia({
+          video: {
+            facingMode,
+            // Hints, not requirements — Android cameras typically only
+            // support standard resolutions and will reject exact specs.
+            width:  { ideal: 1920 },
+            height: { ideal: 1080 },
+          },
+        });
+        if (cancelled) {
+          stream.getTracks().forEach((t) => t.stop());
+          return;
+        }
+        streamRef.current = stream;
+        if (videoRef.current) {
+          videoRef.current.srcObject = stream;
+          videoRef.current.onloadedmetadata = () => {
+            if (!cancelled) setReady(true);
+          };
+        }
+      } catch (err) {
+        if (cancelled) return;
+        const msg = err instanceof Error
+          ? (err.name === "NotAllowedError"
+              ? "Camera permission denied. Allow camera access in your browser settings, then close and reopen."
+              : err.name === "NotFoundError"
+                ? "No camera found on this device."
+                : err.name === "NotReadableError"
+                  ? "Camera is already in use by another app. Close other camera apps and try again."
+                  : err.name === "OverconstrainedError"
+                    ? "This camera doesn't support the requested settings."
+                    : err.message)
+          : "Camera not available";
+        setError(msg);
+      }
+    }
+    start();
+
+    return () => {
+      cancelled = true;
+      streamRef.current?.getTracks().forEach((t) => t.stop());
+      streamRef.current = null;
+    };
+  }, [open, facingMode]);
+
+  const capture = () => {
+    if (!videoRef.current || !canvasRef.current) return;
+    const video = videoRef.current;
+    const canvas = canvasRef.current;
+    const vw = video.videoWidth || 1280;
+    const vh = video.videoHeight || 720;
+    canvas.width = vw;
+    canvas.height = vh;
+    const ctx = canvas.getContext("2d");
+    if (!ctx) return;
+    if (shouldMirror) {
+      ctx.translate(vw, 0);
+      ctx.scale(-1, 1);
+    }
+    ctx.drawImage(video, 0, 0, vw, vh);
+    if (shouldMirror) ctx.setTransform(1, 0, 0, 1, 0, 0);
+    setPreviewUrl(canvas.toDataURL("image/jpeg", quality));
+  };
+
+  const retake = () => setPreviewUrl(null);
+
+  const accept = async () => {
+    if (!previewUrl || !canvasRef.current) return;
+    setSubmitting(true);
+    await new Promise<void>((resolve) => {
+      canvasRef.current!.toBlob(
+        async (blob) => {
+          if (blob) {
+            try { await onCapture(blob, previewUrl); }
+            catch (err) {
+              setError(err instanceof Error ? err.message : "Save failed");
+              setSubmitting(false);
+              resolve();
+              return;
+            }
+          }
+          onClose();
+          resolve();
+        },
+        "image/jpeg",
+        quality,
+      );
+    });
+  };
+
+  if (!open) return null;
+
+  return (
+    <div className="fixed inset-0 z-[60] flex flex-col bg-black">
+      {/* Header */}
+      <div className="flex items-center justify-between bg-black/80 px-4 py-3 text-white">
+        <button onClick={onClose} className="rounded-full p-2 hover:bg-white/10" aria-label="Close camera">
+          <X className="h-5 w-5" />
+        </button>
+        <p className="text-sm font-medium">{title ?? "Take Photo"}</p>
+        <div className="w-9" />
+      </div>
+
+      {/* Live preview / captured preview / error */}
+      <div className="relative flex flex-1 items-center justify-center overflow-hidden">
+        {error ? (
+          <div className="flex max-w-sm flex-col items-center gap-3 px-6 text-center text-white">
+            <AlertTriangle className="h-10 w-10 text-amber-400" />
+            <p className="text-sm">{error}</p>
+            <button
+              onClick={onClose}
+              className="mt-2 rounded-md bg-white/10 px-4 py-2 text-sm font-medium hover:bg-white/20"
+            >
+              Close
+            </button>
+          </div>
+        ) : previewUrl ? (
+          // eslint-disable-next-line @next/next/no-img-element
+          <img src={previewUrl} alt="Captured" className="max-h-full max-w-full object-contain" />
+        ) : (
+          <video
+            ref={videoRef}
+            autoPlay
+            playsInline
+            muted
+            className={`h-full w-full object-cover ${shouldMirror ? "scale-x-[-1]" : ""}`}
+          />
+        )}
+        <canvas ref={canvasRef} className="hidden" />
+      </div>
+
+      {/* Footer controls */}
+      <div className="flex items-center justify-around bg-black/80 px-6 py-5">
+        {error ? null : previewUrl ? (
+          <>
+            <button
+              onClick={retake}
+              disabled={submitting}
+              className="flex flex-col items-center gap-1 rounded-full px-4 py-2 text-white disabled:opacity-50"
+            >
+              <RefreshCw className="h-6 w-6" />
+              <span className="text-[11px]">Retake</span>
+            </button>
+            <button
+              onClick={accept}
+              disabled={submitting}
+              className="flex h-16 w-16 items-center justify-center rounded-full bg-green-500 text-white shadow-lg active:scale-95 disabled:opacity-50"
+              aria-label="Use photo"
+            >
+              <Check className="h-8 w-8" />
+            </button>
+            <div className="w-16" />
+          </>
+        ) : (
+          <>
+            <div className="w-16" />
+            <button
+              onClick={capture}
+              disabled={!ready}
+              className="flex h-20 w-20 items-center justify-center rounded-full border-4 border-white bg-white/10 active:scale-95 disabled:opacity-40"
+              aria-label="Capture photo"
+            >
+              <div className="h-14 w-14 rounded-full bg-white" />
+            </button>
+            <div className="flex h-16 w-16 items-center justify-center text-white/40">
+              <Camera className="h-6 w-6" />
+            </div>
+          </>
+        )}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

Replaces all \`<input type=\"file\" capture=\"environment\">\` photo capture points with a shared \`CameraCaptureModal\` using getUserMedia directly. Fixes Android camera issues at the root.

## Why

The \`<input capture>\` approach had two failure modes on Android:
1. \`capture\` is a HINT — Samsung Internet, MIUI, and some OEM browsers still showed a chooser dialog (Camera + Files).
2. \`capture\` + \`multiple\` flipped Chrome into file-picker mode.

These are fragile cross-browser behaviors. **getUserMedia is the only way to enforce 100% camera-only on the web**, with predictable behavior across all Android browsers.

## What's new

- **\`apps/staff/src/components/camera-capture-modal.tsx\`** — shared fullscreen modal:
  - Live video preview (\`getUserMedia\`)
  - Capture button → preview → Retake / Use Photo flow
  - Clear error messages for permission denied / no camera / camera in use / OverconstrainedError
  - Resolution constraints use \`{ ideal: 1920 }\` (not exact) so Android cameras accept it
  - Mirrors preview + captured pixels for selfie mode

- Wired into 4 pages: claims, receiving, checklists, audit
- Clock-in already used getUserMedia (constraint bugs fixed in PR #123)

## Test plan
- [ ] Open /claims on Android → camera modal opens directly, no gallery picker
- [ ] Open /receiving on Android → same
- [ ] Open /checklists/:id with photo-required item → tap photo button, camera opens
- [ ] Open /audit/:id, tap photo on an item → camera opens
- [ ] Permission denied flow shows clear message + close button
- [ ] Captured photo previews correctly, retake works, save uploads correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)