### PR TITLE
Post-QA blockers: Stripe CSP, middleware ordering, missed uploads, real session revocation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,15 @@ jobs:
       JWT_SECRET: "ci-test-secret-not-for-production-minimum-32-chars"
       NEXT_PUBLIC_SUPABASE_URL: "https://placeholder.supabase.co"
       NEXT_PUBLIC_SUPABASE_ANON_KEY: "placeholder-anon-key-for-ci-build"
+      NEXT_PUBLIC_LOYALTY_SUPABASE_URL: "https://placeholder.supabase.co"
+      LOYALTY_SUPABASE_SERVICE_ROLE_KEY: "placeholder-loyalty-service-role"
+      SUPABASE_SERVICE_ROLE_KEY: "placeholder-service-role"
+      CLOUDINARY_CLOUD_NAME: "placeholder"
+      CLOUDINARY_API_KEY: "placeholder"
+      CLOUDINARY_API_SECRET: "placeholder"
+      NEXT_PUBLIC_SENTRY_DSN: ""
+      UPSTASH_REDIS_REST_URL: ""
+      UPSTASH_REDIS_REST_TOKEN: ""
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -80,6 +89,15 @@ jobs:
       JWT_SECRET: "ci-test-secret-not-for-production-minimum-32-chars"
       NEXT_PUBLIC_SUPABASE_URL: "https://placeholder.supabase.co"
       NEXT_PUBLIC_SUPABASE_ANON_KEY: "placeholder-anon-key-for-ci-build"
+      NEXT_PUBLIC_LOYALTY_SUPABASE_URL: "https://placeholder.supabase.co"
+      LOYALTY_SUPABASE_SERVICE_ROLE_KEY: "placeholder-loyalty-service-role"
+      SUPABASE_SERVICE_ROLE_KEY: "placeholder-service-role"
+      CLOUDINARY_CLOUD_NAME: "placeholder"
+      CLOUDINARY_API_KEY: "placeholder"
+      CLOUDINARY_API_SECRET: "placeholder"
+      NEXT_PUBLIC_SENTRY_DSN: ""
+      UPSTASH_REDIS_REST_URL: ""
+      UPSTASH_REDIS_REST_TOKEN: ""
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4

--- a/apps/backoffice/src/app/api/ads/payments/[id]/pop/route.ts
+++ b/apps/backoffice/src/app/api/ads/payments/[id]/pop/route.ts
@@ -8,6 +8,13 @@ export const maxDuration = 60;
 
 const BUCKET = "ads-pop";
 
+// Mime allowlist — POP receipts are images or PDFs only.
+const ALLOWED_MIME = new Set([
+  "image/jpeg", "image/png", "image/webp", "image/heic", "image/heif",
+  "application/pdf",
+]);
+const MAX_BYTES = 15 * 1024 * 1024;
+
 function getStorage() {
   const url = process.env.NEXT_PUBLIC_SUPABASE_URL || process.env.NEXT_PUBLIC_LOYALTY_SUPABASE_URL;
   const key = process.env.SUPABASE_SERVICE_ROLE_KEY || process.env.LOYALTY_SUPABASE_SERVICE_ROLE_KEY;
@@ -33,8 +40,14 @@ export async function POST(req: NextRequest, { params }: { params: Promise<{ id:
     return NextResponse.json({ error: "file required" }, { status: 400 });
   }
 
-  if (file.size > 15 * 1024 * 1024) {
-    return NextResponse.json({ error: "File too large (max 15MB)" }, { status: 400 });
+  if (file.size > MAX_BYTES) {
+    return NextResponse.json({ error: "File too large (max 15MB)" }, { status: 413 });
+  }
+  if (!ALLOWED_MIME.has(file.type)) {
+    return NextResponse.json(
+      { error: `Unsupported file type: ${file.type || "unknown"}` },
+      { status: 415 },
+    );
   }
 
   const ext = file.name.split(".").pop() || "jpg";

--- a/apps/backoffice/src/app/api/auth/sign-out-all/route.ts
+++ b/apps/backoffice/src/app/api/auth/sign-out-all/route.ts
@@ -24,6 +24,10 @@ export async function POST(req: NextRequest) {
     data: { tokenRevokedAt: new Date() },
   });
 
+  // The revoked-at cache in @/lib/auth is per-process, so this
+  // user's existing sessions on OTHER lambda instances are still
+  // valid until the 30s TTL expires. For instant cross-instance
+  // revocation, move the cache to Redis.
   await clearSession();
 
   return NextResponse.json({ ok: true, revokedAt: new Date().toISOString() });

--- a/apps/backoffice/src/app/api/finance/bank-statements/parse/route.ts
+++ b/apps/backoffice/src/app/api/finance/bank-statements/parse/route.ts
@@ -9,6 +9,18 @@ import { parseBankStatementBuffer } from "@/lib/finance/bank-statement-parser";
 
 export const runtime = "nodejs"; // xlsx needs Node, not edge
 
+// Server-side validation: xlsx parses arbitrary buffers and has had
+// CVEs (CVE-2023-30533 etc.) — capping size + restricting mime
+// limits attack surface even though the route is admin-only.
+const MAX_BYTES = 20 * 1024 * 1024; // 20 MB — bank statements can be heavy
+const ALLOWED_MIME = new Set([
+  "text/csv",
+  "application/vnd.ms-excel",
+  "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+  "application/octet-stream", // some browsers send this for .csv
+  "",                          // and some send empty type
+]);
+
 export async function POST(req: NextRequest) {
   try { await requireRole(req.headers, "ADMIN"); }
   catch (e) {
@@ -23,6 +35,19 @@ export async function POST(req: NextRequest) {
   const file = formData.get("file");
   if (!(file instanceof File)) {
     return NextResponse.json({ error: "Missing 'file' field" }, { status: 400 });
+  }
+
+  if (file.size > MAX_BYTES) {
+    return NextResponse.json(
+      { error: `File too large (max ${MAX_BYTES / 1024 / 1024} MB)` },
+      { status: 413 },
+    );
+  }
+  if (!ALLOWED_MIME.has(file.type) && !/\.(csv|xlsx?|tsv)$/i.test(file.name)) {
+    return NextResponse.json(
+      { error: `Unsupported file type: ${file.type || "unknown"}. Expected CSV or Excel.` },
+      { status: 415 },
+    );
   }
 
   const buf = Buffer.from(await file.arrayBuffer());

--- a/apps/backoffice/src/app/api/pickup/upload-image/route.ts
+++ b/apps/backoffice/src/app/api/pickup/upload-image/route.ts
@@ -53,12 +53,21 @@ export async function POST(req: NextRequest) {
   // strip anything that could escape the celsius-coffee/products/ path.
   const safeProductId = productId.replace(/[^a-zA-Z0-9_-]/g, "_").slice(0, 100);
 
-  const publicIdOverride = formData.get("publicId") as string | null;
+  // Sanitize the override too. A caller that specifies their own
+  // public_id can still control the leaf name + an optional sub-path,
+  // but only within celsius-coffee/products/. Without this, an
+  // authenticated user could overwrite ANY asset under our cloud
+  // (e.g. `celsius-coffee/banners/homepage`).
+  const publicIdRaw = formData.get("publicId") as string | null;
+  const safeOverride = publicIdRaw
+    ? `celsius-coffee/products/${publicIdRaw.replace(/[^a-zA-Z0-9_/-]/g, "_").slice(0, 200)}`
+    : null;
+
   const buffer = Buffer.from(await file.arrayBuffer());
   const base64 = `data:${file.type};base64,${buffer.toString("base64")}`;
 
   const result = await cloudinary.uploader.upload(base64, {
-    public_id:    publicIdOverride ?? `celsius-coffee/products/${safeProductId}`,
+    public_id:    safeOverride ?? `celsius-coffee/products/${safeProductId}`,
     overwrite:    true,
     resource_type: "image",
     transformation: [{ quality: "auto", fetch_format: "auto" }],

--- a/apps/backoffice/src/lib/auth.ts
+++ b/apps/backoffice/src/lib/auth.ts
@@ -1,12 +1,54 @@
 import { SignJWT, jwtVerify } from "jose";
 import { cookies } from "next/headers";
 import { NextRequest, NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
 
 const SECRET = new TextEncoder().encode(
   process.env.JWT_SECRET!,
 );
 
 const COOKIE_NAME = "celsius-session";
+
+// Cache User.tokenRevokedAt for 30s per user. Checking it on every
+// authenticated request is fine (one indexed PK lookup, ~1-2ms) but
+// the cache halves the burden on hot endpoints. Cache is per-process
+// so worst case is 30s of staleness — fine for "I just clicked
+// sign-out-all" UX. For instant revocation across all instances,
+// move to Redis.
+const REVOKED_CACHE_TTL_MS = 30_000;
+const revokedCache = new Map<string, { revokedAt: Date | null; expiresAt: number }>();
+
+async function getTokenRevokedAt(userId: string): Promise<Date | null> {
+  const cached = revokedCache.get(userId);
+  if (cached && Date.now() < cached.expiresAt) return cached.revokedAt;
+  const row = await prisma.user.findUnique({
+    where: { id: userId },
+    select: { tokenRevokedAt: true },
+  });
+  const revokedAt = row?.tokenRevokedAt ?? null;
+  revokedCache.set(userId, { revokedAt, expiresAt: Date.now() + REVOKED_CACHE_TTL_MS });
+  return revokedAt;
+}
+
+/**
+ * Verify a token's signature AND that it wasn't issued before the
+ * user revoked all sessions. Returns null if either check fails.
+ * Used by getUserFromHeaders + requireAuth so /api/auth/sign-out-all
+ * actually invalidates existing cookies on the next request (within
+ * the 30s revocation cache window).
+ */
+async function verifyTokenFresh(token: string): Promise<SessionUser | null> {
+  try {
+    const { payload } = await jwtVerify(token, SECRET);
+    const user = payload as unknown as SessionUser & { iat?: number };
+    if (!user.iat) return null;     // pre-revocation tokens — reject
+    const revokedAt = await getTokenRevokedAt(user.id);
+    if (revokedAt && user.iat * 1000 < revokedAt.getTime()) return null;
+    return user;
+  } catch {
+    return null;
+  }
+}
 
 export type SessionUser = {
   id: string;
@@ -68,21 +110,15 @@ export async function verifyToken(token: string): Promise<SessionUser | null> {
   }
 }
 
-// Read user from JWT cookie only (for API routes)
+// Read user from JWT cookie only (for API routes). Includes the
+// session-revocation freshness check — if user hit sign-out-all
+// recently, even a valid signed token is rejected.
 export async function getUserFromHeaders(headers: Headers): Promise<SessionUser | null> {
   // Never trust x-user-* headers — always validate JWT
   const cookieHeader = headers.get("cookie") || "";
   const match = cookieHeader.match(/celsius-session=([^;]+)/);
-  if (match) {
-    try {
-      const { payload } = await jwtVerify(match[1], SECRET);
-      return payload as unknown as SessionUser;
-    } catch {
-      return null;
-    }
-  }
-
-  return null;
+  if (!match) return null;
+  return verifyTokenFresh(match[1]);
 }
 
 type Role = "OWNER" | "ADMIN" | "MANAGER" | "STAFF";
@@ -149,15 +185,14 @@ export async function requireAuth(request: NextRequest): Promise<
       error: NextResponse.json({ error: "Unauthorized" }, { status: 401 }),
     };
   }
-
-  try {
-    const { payload } = await jwtVerify(token, SECRET);
-    const user = payload as unknown as SessionUser;
-    return { user, error: null };
-  } catch {
+  // Routes through verifyTokenFresh so /api/auth/sign-out-all actually
+  // invalidates pre-revocation tokens (within the 30s cache window).
+  const user = await verifyTokenFresh(token);
+  if (!user) {
     return {
       user: null,
       error: NextResponse.json({ error: "Unauthorized" }, { status: 401 }),
     };
   }
+  return { user, error: null };
 }

--- a/apps/backoffice/src/middleware.ts
+++ b/apps/backoffice/src/middleware.ts
@@ -13,11 +13,11 @@ const ALLOWED_ORIGINS = [
 
 export async function middleware(request: NextRequest) {
   const { pathname } = request.nextUrl;
+  const isApi = pathname.startsWith("/api/");
 
   // CSRF protection — runs FIRST so state-changing API requests are
   // checked even when we'd otherwise bypass middleware for /api/*.
-  // GET/HEAD/OPTIONS, /api/webhooks/*, and /api/cron/* are exempt
-  // (they have their own auth — HMAC sigs, Bearer tokens).
+  // GET/HEAD/OPTIONS, /api/webhooks/*, and /api/cron/* are exempt.
   const csrfFail = checkCsrf(request, { allowedOrigins: ALLOWED_ORIGINS });
   if (csrfFail) {
     return NextResponse.json(
@@ -26,7 +26,20 @@ export async function middleware(request: NextRequest) {
     );
   }
 
-  // Skip static assets, auth, and internal routes
+  // Build the response we'll return. We attach security headers ONCE
+  // at the end, regardless of which short-circuit path we take, so
+  // CSP/Cache-Control are guaranteed to ship on every response —
+  // including /api/* responses that previously skipped headers.
+  const buildResponse = (
+    inner: () => NextResponse,
+  ): NextResponse => {
+    const r = inner();
+    applySecurityHeaders(r, { isApi });
+    return r;
+  };
+
+  // Skip static assets, auth, and internal routes — but still apply
+  // headers via buildResponse() so API responses get CSP + no-store.
   if (
     pathname === "/login" ||
     pathname.startsWith("/r/") ||
@@ -41,18 +54,16 @@ export async function middleware(request: NextRequest) {
     pathname.startsWith("/images/") ||
     pathname.startsWith("/fonts/")
   ) {
-    return NextResponse.next();
+    return buildResponse(() => NextResponse.next());
   }
 
-  // Just check cookie exists — don't verify JWT in middleware
+  // Authenticated pages: just check cookie exists, don't verify JWT
   const token = request.cookies.get(COOKIE_NAME)?.value;
   if (!token) {
     return NextResponse.redirect(new URL("/login", request.url));
   }
 
-  const response = NextResponse.next();
-  applySecurityHeaders(response, { isApi: pathname.startsWith("/api/") });
-  return response;
+  return buildResponse(() => NextResponse.next());
 }
 
 export const config = {

--- a/apps/order/src/middleware.ts
+++ b/apps/order/src/middleware.ts
@@ -31,6 +31,7 @@ async function isValidAdminToken(token: string): Promise<boolean> {
 
 export async function middleware(request: NextRequest) {
   const { pathname } = request.nextUrl;
+  const isApi = pathname.startsWith("/api/");
 
   // CSRF protection — applies to ALL state-changing /api/* requests
   // except webhooks/cron (auto-exempt). Runs before the per-route
@@ -44,15 +45,24 @@ export async function middleware(request: NextRequest) {
     );
   }
 
+  // Apply headers on every return path. Previously the privileged-API
+  // guard short-circuited via plain NextResponse.next() and shipped
+  // no CSP / no-store on the bulk of /api/* responses.
+  const buildResponse = (inner: () => NextResponse): NextResponse => {
+    const r = inner();
+    applySecurityHeaders(r, { isApi });
+    return r;
+  };
+
   // ── API auth guard for the two privileged endpoints ──
   const isProtectedApi =
     pathname === "/api/push/blast" ||
     pathname === "/api/push/subscriber-count";
 
-  if (!isProtectedApi) return NextResponse.next();
+  if (!isProtectedApi) return buildResponse(() => NextResponse.next());
 
   // Skip preflight requests
-  if (request.method === "OPTIONS") return NextResponse.next();
+  if (request.method === "OPTIONS") return buildResponse(() => NextResponse.next());
 
   const authHeader = request.headers.get("Authorization");
   const token = authHeader?.startsWith("Bearer ") ? authHeader.slice(7) : null;
@@ -66,9 +76,7 @@ export async function middleware(request: NextRequest) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
 
-  const response = NextResponse.next();
-  applySecurityHeaders(response, { isApi: pathname.startsWith("/api/") });
-  return response;
+  return buildResponse(() => NextResponse.next());
 }
 
 // Matcher must include all /api/* routes so the CSRF check runs on

--- a/apps/staff/src/middleware.ts
+++ b/apps/staff/src/middleware.ts
@@ -9,10 +9,9 @@ const ALLOWED_ORIGINS = [
 
 export function middleware(request: NextRequest) {
   const { pathname } = request.nextUrl;
+  const isApi = pathname.startsWith("/api/");
 
-  // CSRF protection — runs FIRST so state-changing API requests are
-  // checked. GET/HEAD/OPTIONS and /api/webhooks/, /api/cron/ paths
-  // are auto-exempt (they have their own auth).
+  // CSRF protection — runs FIRST.
   const csrfFail = checkCsrf(request, { allowedOrigins: ALLOWED_ORIGINS });
   if (csrfFail) {
     return NextResponse.json(
@@ -21,7 +20,14 @@ export function middleware(request: NextRequest) {
     );
   }
 
-  // Skip static assets, auth, and internal routes
+  // Apply headers regardless of short-circuit path so /api/* responses
+  // also get CSP + Cache-Control: no-store (was being skipped before).
+  const buildResponse = (inner: () => NextResponse): NextResponse => {
+    const r = inner();
+    applySecurityHeaders(r, { isApi });
+    return r;
+  };
+
   if (
     pathname === "/login" ||
     pathname.startsWith("/api/") ||
@@ -34,19 +40,15 @@ export function middleware(request: NextRequest) {
     pathname.startsWith("/images/") ||
     pathname.startsWith("/fonts/")
   ) {
-    return NextResponse.next();
+    return buildResponse(() => NextResponse.next());
   }
 
-  // Just check cookie exists — don't verify JWT in middleware (too slow for every nav)
   const token = request.cookies.get(COOKIE_NAME)?.value;
   if (!token) {
     return NextResponse.redirect(new URL("/login", request.url));
   }
 
-  // Add security headers + cache control
-  const response = NextResponse.next();
-  applySecurityHeaders(response, { isApi: pathname.startsWith("/api/") });
-  return response;
+  return buildResponse(() => NextResponse.next());
 }
 
 export const config = {

--- a/packages/shared/src/csrf.ts
+++ b/packages/shared/src/csrf.ts
@@ -94,6 +94,13 @@ export function checkCsrf(
     allowed.add("localhost:3006");
   }
 
+  // Vercel preview deploys: VERCEL_ENV=preview during PR builds. The
+  // hostname is generated per-PR (celsius-<app>-<hash>-<scope>.vercel.app).
+  // Trust the request's own host (already in `allowed`) — preview
+  // requests POST to themselves, not cross-origin to prod. The match
+  // below also accepts any *.vercel.app suffix for redundancy.
+  const isPreview = process.env.VERCEL_ENV === "preview";
+
   // Prefer Origin header (most browsers set it on POST). Fall back to
   // Referer for older / non-browser clients. If both are missing on a
   // state-changing request, reject — we'd rather block a legitimate
@@ -106,8 +113,8 @@ export function checkCsrf(
   }
 
   if (!candidate) return { reason: "Missing Origin/Referer header" };
-  if (!allowed.has(candidate)) {
-    return { reason: `Origin "${candidate}" not in allow list` };
-  }
-  return null;
+  if (allowed.has(candidate)) return null;
+  // Wildcard fallback for Vercel preview deploys
+  if (isPreview && candidate.endsWith(".vercel.app")) return null;
+  return { reason: `Origin "${candidate}" not in allow list` };
 }

--- a/packages/shared/src/security-headers.ts
+++ b/packages/shared/src/security-headers.ts
@@ -35,6 +35,12 @@ const BASE_CONNECT_SRC = [
   "https://*.sentry.io",
   "https://api.cloudinary.com",
   "https://res.cloudinary.com",
+  // Stripe — JS SDK posts to api.stripe.com; analytics calls
+  // *.stripe.com. Without these, every Stripe Elements call XHR-fails.
+  "https://api.stripe.com",
+  "https://*.stripe.com",
+  // Vercel Speed Insights / Analytics beacon
+  "https://vitals.vercel-insights.com",
 ];
 
 const BASE_IMG_SRC = [
@@ -44,6 +50,23 @@ const BASE_IMG_SRC = [
   "https://*.supabase.co",
   "https://res.cloudinary.com",
   "https://lh3.googleusercontent.com",
+  "https://*.stripe.com",
+];
+
+// Hosts loaded as <script src="..."> from across the apps. Stripe.js
+// and Vercel's analytics scripts have to be allowlisted explicitly
+// once we move beyond 'self' + 'unsafe-inline'.
+const BASE_SCRIPT_SRC_HOSTS = [
+  "https://va.vercel-scripts.com",
+  "https://js.stripe.com",
+];
+
+// Hosts loaded into <iframe>. Stripe Elements renders card fields in
+// an iframe served from js.stripe.com / hooks.stripe.com.
+const BASE_FRAME_SRC = [
+  "'self'",
+  "https://js.stripe.com",
+  "https://hooks.stripe.com",
 ];
 
 export function buildCsp(opts: SecurityHeadersOptions = {}): string {
@@ -56,11 +79,12 @@ export function buildCsp(opts: SecurityHeadersOptions = {}): string {
     // 'unsafe-eval' is needed by some dev-mode hot-reload paths —
     // accept it. Tighten to nonces in a future pass when we wire
     // up Next.js' built-in CSP nonce support.
-    "script-src 'self' 'unsafe-inline' 'unsafe-eval' https://va.vercel-scripts.com",
+    `script-src 'self' 'unsafe-inline' 'unsafe-eval' ${BASE_SCRIPT_SRC_HOSTS.join(" ")}`,
     "style-src 'self' 'unsafe-inline'",
     `img-src ${imgSrc.join(" ")}`,
     `connect-src ${connectSrc.join(" ")}`,
     "font-src 'self' data:",
+    `frame-src ${BASE_FRAME_SRC.join(" ")}`,
     "frame-ancestors 'none'",
     "base-uri 'self'",
     "form-action 'self'",


### PR DESCRIPTION
## Summary

Final QA on PRs #125–#129 found six issues that would have hit prod. All fixed.

| # | Issue | Severity | Fix |
|---|-------|----------|-----|
| 1 | **Stripe.js blocked by CSP** | 🔴 Would break every card checkout | Added \`js.stripe.com\`, \`api.stripe.com\`, Stripe iframe \`frame-src\` |
| 2 | **Security headers skipped on /api/* in 3 apps** | 🔴 CSP + Cache-Control didn't ship | Refactored backoffice/staff/order middlewares to use \`buildResponse()\` helper that always applies headers |
| 3 | **publicIdOverride not sanitized** in pickup/upload-image | 🟡 Authenticated user could overwrite any Cloudinary asset | Scope override to \`celsius-coffee/products/\` + sanitize chars |
| 4 | **Two upload endpoints missed validation** | 🟡 ads/payments/pop (no mime check); bank-statements/parse (no size cap, no mime, parses with xlsx — CVE surface) | Added size + mime allowlists |
| 5 | **\`verifyTokenWithFreshness\` was non-functional** | 🟡 sign-out-all 'panic button' did nothing | \`requireAuth\` + \`getUserFromHeaders\` now route through a freshness check (30s cache) |
| 6 | **CI build env + Vercel preview CSRF** | 🟢 CI false-greens; PR previews 403'd | Added missing env vars; CSRF auto-allows \`*.vercel.app\` when \`VERCEL_ENV=preview\` |

## Test plan
- [ ] Order app checkout: place a Stripe payment in preview env — Stripe Elements iframe renders, payment intent succeeds
- [ ] curl any \`/api/*\` route → response has \`Cache-Control: no-store\` AND \`Content-Security-Policy\` headers
- [ ] curl with stale Origin: → 403
- [ ] Hit \`POST /api/auth/sign-out-all\` → wait 30s → previous cookie gets 401 on next request
- [ ] Upload non-image to \`/api/inventory/upload\` → 415

🤖 Generated with [Claude Code](https://claude.com/claude-code)