### PR TITLE
HOTFIX: backoffice 401 — accept legacy tokens without iat

### DIFF
--- a/apps/backoffice/src/lib/auth.ts
+++ b/apps/backoffice/src/lib/auth.ts
@@ -41,7 +41,13 @@ async function verifyTokenFresh(token: string): Promise<SessionUser | null> {
   try {
     const { payload } = await jwtVerify(token, SECRET);
     const user = payload as unknown as SessionUser & { iat?: number };
-    if (!user.iat) return null;     // pre-revocation tokens — reject
+    // Tokens without iat predate the freshness mechanism — accept them
+    // and skip the revocation check. This keeps every existing user
+    // session working after this code rolls out. Once createSession
+    // (below) starts stamping iat on every new token, eventually all
+    // tokens in circulation will be checkable; until then we degrade
+    // to "valid signature = valid session" for legacy tokens.
+    if (!user.iat) return user;
     const revokedAt = await getTokenRevokedAt(user.id);
     if (revokedAt && user.iat * 1000 < revokedAt.getTime()) return null;
     return user;
@@ -67,6 +73,7 @@ export async function createSession(user: SessionUser) {
     outletName: user.outletName ?? null,
   })
     .setProtectedHeader({ alg: "HS256" })
+    .setIssuedAt() // required for verifyTokenFresh to do revocation checks
     .setExpirationTime("7d")
     .sign(SECRET);
 


### PR DESCRIPTION
P0: PR #130 wired `verifyTokenFresh` into `requireAuth` which rejected any token missing the `iat` field. **Every backoffice cookie issued before today is missing `iat`** (createSession never called setIssuedAt). Result: every authenticated request 401s, every page redirects to /login, no data anywhere.

Fix: tokens without iat are accepted (skip revocation check) — they grandfather in until natural 7-day expiry. createSession now stamps iat going forward.

Trade-off: `/api/auth/sign-out-all` is non-functional for ~7 days while old tokens cycle out. Acceptable — it was non-functional before #130 anyway.