### PR TITLE
Relieve Supabase Disk IO budget: indexes + cron tuning + query projection

### DIFF
--- a/apps/backoffice/src/app/api/inventory/reports/cogs/route.ts
+++ b/apps/backoffice/src/app/api/inventory/reports/cogs/route.ts
@@ -20,8 +20,19 @@ export async function GET(req: NextRequest) {
     };
     if (outletId) salesWhere.outletId = outletId;
 
+    // Project only the columns we actually use (menuId, outletId,
+    // quantity, grossAmount). Without this, Prisma returns every
+    // column on every SalesTransaction in the date range — for
+    // 30-day windows that's been ~2M rows of unused payload, which
+    // was the single biggest disk-IO consumer per pg_stat_statements.
     const sales = await prisma.salesTransaction.findMany({
       where: salesWhere,
+      select: {
+        menuId: true,
+        outletId: true,
+        quantity: true,
+        grossAmount: true,
+      },
     });
 
     // 2. Fetch all menu ingredient records (recipes)

--- a/apps/order/vercel.json
+++ b/apps/order/vercel.json
@@ -4,19 +4,19 @@
   "crons": [
     {
       "path": "/api/cron/sync-menu",
-      "schedule": "0,10,20,30,40,50 * * * *"
+      "schedule": "0,30 * * * *"
     },
     {
       "path": "/api/cron/auto-hours",
-      "schedule": "*/5 * * * *"
+      "schedule": "*/30 * * * *"
     },
     {
       "path": "/api/cron/expire-orders",
-      "schedule": "*/10 * * * *"
+      "schedule": "*/15 * * * *"
     },
     {
       "path": "/api/cron/reconcile-pending",
-      "schedule": "* * * * *"
+      "schedule": "*/5 * * * *"
     }
   ],
   "headers": [

--- a/packages/db/prisma/migrations/20260501_io_relief_indexes/migration.sql
+++ b/packages/db/prisma/migrations/20260501_io_relief_indexes/migration.sql
@@ -1,0 +1,17 @@
+-- Phase 1 of disk-IO budget relief — add indexes on hot scan paths.
+-- Per pg_stat_user_tables on 2026-05-01, these tables had 60-95%
+-- sequential scans because they only had PK + unique indexes.
+-- Applied via Supabase MCP on 2026-05-01.
+
+CREATE INDEX IF NOT EXISTS "Invoice_status_dueDate_idx" ON "Invoice" (status, "dueDate");
+CREATE INDEX IF NOT EXISTS "Invoice_outletId_idx" ON "Invoice" ("outletId");
+CREATE INDEX IF NOT EXISTS "Invoice_paidAt_idx" ON "Invoice" ("paidAt") WHERE "paidAt" IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS "Order_outletId_createdAt_idx" ON "Order" ("outletId", "createdAt" DESC);
+CREATE INDEX IF NOT EXISTS "Order_status_createdAt_idx" ON "Order" (status, "createdAt" DESC);
+
+CREATE INDEX IF NOT EXISTS "Receiving_outletId_receivedAt_idx" ON "Receiving" ("outletId", "receivedAt" DESC);
+CREATE INDEX IF NOT EXISTS "SupplierProduct_supplierId_idx" ON "SupplierProduct" ("supplierId");
+CREATE INDEX IF NOT EXISTS "ParLevel_outletId_idx" ON "ParLevel" ("outletId");
+CREATE INDEX IF NOT EXISTS "ChecklistItem_checklistId_idx" ON "ChecklistItem" ("checklistId");
+CREATE INDEX IF NOT EXISTS "hr_attendance_logs_user_clockin_idx" ON hr_attendance_logs (user_id, clock_in DESC);


### PR DESCRIPTION
Supabase warning today: Disk IO Budget being depleted. Three fixes:

1. **10 missing indexes** on tables doing 60-95% sequential scans (Invoice, Receiving, ParLevel, SupplierProduct, Order, ChecklistItem, hr_attendance_logs). Already applied via Supabase MCP; captured as migration file. Expected 60-80% IO drop within hours.

2. **`SalesTransaction.findMany` without projection** in cogs report — was returning ~2M rows of mostly-unused payload per call. Added `select` for the 4 columns actually used. Cuts payload ~80%.

3. **Over-frequent crons** (especially reconcile-pending @ every 1 min): tuned to every 5 min. auto-hours 5→30 min. expire-orders 10→15. sync-menu 10→30. Total cron invocations down 76% (2,016/day → 480/day).

Should resolve the immediate IO pressure. If warnings continue, next step is upgrading the Supabase compute tier (current Small → Medium roughly doubles IOPS).