### PR TITLE
feat(staff/receiving): require invoice photo to confirm received

### DIFF
--- a/apps/staff/src/app/(ops)/receiving/page.tsx
+++ b/apps/staff/src/app/(ops)/receiving/page.tsx
@@ -238,6 +238,7 @@ export default function ReceivePage() {
 
   const submitReceiving = async () => {
     if (!selectedPO || !user) return;
+    if (invoicePhotos.length === 0) return;
     setSubmitting(true);
 
     const payload = {
@@ -607,7 +608,7 @@ export default function ReceivePage() {
             {/* Invoice photo capture */}
             <div>
               <h3 className="mb-1.5 text-sm font-medium text-gray-900">
-                Invoice Photo
+                Invoice Photo <span className="text-terracotta">*</span>
               </h3>
               <div className="flex flex-wrap gap-2">
                 {invoicePhotos.map((photo, i) => (
@@ -656,9 +657,17 @@ export default function ReceivePage() {
                   </span>
                 </div>
               )}
+              {allReceived && invoicePhotos.length === 0 && (
+                <div className="mb-2 flex items-center gap-2 rounded-lg bg-terracotta/5 px-3 py-2 text-xs text-terracotta-dark">
+                  <AlertTriangle className="h-4 w-4 shrink-0" />
+                  <span>Add an invoice photo to confirm receiving.</span>
+                </div>
+              )}
               <Button
                 className="w-full bg-terracotta hover:bg-terracotta-dark"
-                disabled={!allReceived || submitting}
+                disabled={
+                  !allReceived || invoicePhotos.length === 0 || submitting
+                }
                 onClick={submitReceiving}
               >
                 {submitting ? (


### PR DESCRIPTION
## Summary
- Mark Invoice Photo as a required field on the Receive & Capture screen (red `*` next to the label).
- Disable the **Confirm Received** button until at least one invoice photo is attached, in addition to the existing all-items-received check.
- Surface an inline terracotta hint ("Add an invoice photo to confirm receiving.") when all quantities are filled but no photo is attached.
- Guard `submitReceiving` as a defense-in-depth safety net.

## Test plan
- [ ] Open Receive & Capture for a PO, fill in all received quantities, leave Invoice Photo empty → **Confirm Received** stays disabled and the hint appears.
- [ ] Add an invoice photo → button enables and submission succeeds.
- [ ] Remove the photo after adding it → button re-disables and hint re-appears.
- [ ] Items not fully received + no photo → no regression in existing disabled-state behavior.

https://claude.ai/code/session_01SwgxwhwNnVhkWTwfYiPzzn

---
_Generated by [Claude Code](https://claude.ai/code/session_01SwgxwhwNnVhkWTwfYiPzzn)_