### PR TITLE
fix(audit-reports): surface auditee on report list & detail

### DIFF
--- a/apps/backoffice/src/app/(admin)/ops/audit-reports/[id]/page.tsx
+++ b/apps/backoffice/src/app/(admin)/ops/audit-reports/[id]/page.tsx
@@ -36,6 +36,7 @@ type Report = {
   template: { id: string; name: string; description: string | null; roleType: string; version: number };
   outlet: { id: string; name: string; code: string };
   auditor: { id: string; name: string; role: string };
+  auditee: { id: string; name: string; role: string } | null;
   sections: Section[];
   summary: {
     totalItems: number;
@@ -177,8 +178,13 @@ export default function AuditReportDetailPage({
             <span className="flex items-center gap-1">
               <Building2 className="h-3 w-3" /> {report.outlet.name}
             </span>
+            {report.auditee && (
+              <span className="flex items-center gap-1">
+                <User className="h-3 w-3" /> Auditee: {report.auditee.name}
+              </span>
+            )}
             <span className="flex items-center gap-1">
-              <User className="h-3 w-3" /> {report.auditor.name}
+              <User className="h-3 w-3" /> Auditor: {report.auditor.name}
             </span>
             <span>Date: {report.date}</span>
             {report.completedAt && (

--- a/apps/backoffice/src/app/(admin)/ops/audit-reports/page.tsx
+++ b/apps/backoffice/src/app/(admin)/ops/audit-reports/page.tsx
@@ -25,6 +25,7 @@ type AuditReport = {
   template: { id: string; name: string; roleType: string };
   outlet: { id: string; name: string; code: string };
   auditor: { id: string; name: string };
+  auditee: { id: string; name: string } | null;
   totalItems: number;
   ratedItems: number;
   totalPhotos: number;
@@ -88,7 +89,8 @@ export default function AuditReportsPage() {
     return (
       r.template.name.toLowerCase().includes(q) ||
       r.outlet.name.toLowerCase().includes(q) ||
-      r.auditor.name.toLowerCase().includes(q)
+      r.auditor.name.toLowerCase().includes(q) ||
+      (r.auditee?.name.toLowerCase().includes(q) ?? false)
     );
   });
 
@@ -161,7 +163,7 @@ export default function AuditReportsPage() {
             </div>
             <div className="relative flex-1 min-w-[200px]">
               <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-gray-400" />
-              <Input placeholder="Search template, outlet, auditor..." value={search} onChange={(e) => setSearch(e.target.value)} className="pl-9 h-9" />
+              <Input placeholder="Search template, outlet, auditor, auditee..." value={search} onChange={(e) => setSearch(e.target.value)} className="pl-9 h-9" />
             </div>
           </div>
         </CardContent>
@@ -239,8 +241,13 @@ export default function AuditReportsPage() {
                     <span className="flex items-center gap-1">
                       <Building2 className="h-3 w-3" /> {r.outlet.name}
                     </span>
+                    {r.auditee && (
+                      <span className="flex items-center gap-1">
+                        <User className="h-3 w-3" /> Auditee: {r.auditee.name}
+                      </span>
+                    )}
                     <span className="flex items-center gap-1">
-                      <User className="h-3 w-3" /> {r.auditor.name}
+                      <User className="h-3 w-3" /> Auditor: {r.auditor.name}
                     </span>
                     <span>{r.date}</span>
                     <span>

--- a/apps/backoffice/src/app/api/ops/audit-reports/[id]/route.ts
+++ b/apps/backoffice/src/app/api/ops/audit-reports/[id]/route.ts
@@ -25,6 +25,7 @@ export async function GET(
       },
       outlet: { select: { id: true, name: true, code: true } },
       auditor: { select: { id: true, name: true, role: true } },
+      auditee: { select: { id: true, name: true, fullName: true, role: true } },
       items: { orderBy: { sortOrder: "asc" } },
     },
   });
@@ -68,6 +69,13 @@ export async function GET(
     template: report.template,
     outlet: report.outlet,
     auditor: report.auditor,
+    auditee: report.auditee
+      ? {
+          id: report.auditee.id,
+          name: report.auditee.fullName ?? report.auditee.name,
+          role: report.auditee.role,
+        }
+      : null,
     sections: sections.map((s) => ({
       name: s.name,
       items: s.items.map((i) => ({

--- a/apps/backoffice/src/app/api/ops/audit-reports/route.ts
+++ b/apps/backoffice/src/app/api/ops/audit-reports/route.ts
@@ -33,6 +33,7 @@ export async function GET(req: NextRequest) {
       template: { select: { id: true, name: true, roleType: true } },
       outlet: { select: { id: true, name: true, code: true } },
       auditor: { select: { id: true, name: true } },
+      auditee: { select: { id: true, name: true, fullName: true } },
       items: { select: { id: true, rating: true, ratingType: true, photos: true } },
     },
     orderBy: { date: "desc" },
@@ -53,6 +54,9 @@ export async function GET(req: NextRequest) {
       template: r.template,
       outlet: r.outlet,
       auditor: r.auditor,
+      auditee: r.auditee
+        ? { id: r.auditee.id, name: r.auditee.fullName ?? r.auditee.name }
+        : null,
       totalItems,
       ratedItems,
       totalPhotos,


### PR DESCRIPTION
## Summary

Staff-skill audit reports omitted the auditee (the person being audited) in both the backoffice list and detail API responses, so ops users could only see the auditor — never who was actually audited.

- `GET /api/ops/audit-reports` and `GET /api/ops/audit-reports/[id]` now include `auditee` (`{ id, name }`, with `fullName ?? name` for consistency with the existing `/staff` endpoint).
- The list page at `/ops/audit-reports` renders "Auditee: …" alongside the auditor and includes auditee name in the search filter / placeholder.
- The detail page at `/ops/audit-reports/[id]` renders "Auditee: …" in the header.

The standalone Staff Skills pages were unaffected because they call separate endpoints that already selected `auditee` — only the generic audit-reports endpoints were missing it.

## Test plan

- [ ] Open `/ops/audit-reports` — rows for staff-target audits show "Auditee: <name>"
- [ ] Search box matches by auditee name
- [ ] Outlet-target audits (no auditee) still render cleanly (no row, no error)
- [ ] Open an audit report detail — header shows Auditee + Auditor side-by-side
- [ ] Spot-check Staff Skills overview / per-staff history pages — unchanged

Preview: https://celsius-backoffice-git-clau-70ee08-celsiuscoffee-2969s-projects.vercel.app/ops/audit-reports

https://claude.ai/code/session_01GUmVWbfcvxYuvr4XgSKXmJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01GUmVWbfcvxYuvr4XgSKXmJ)_