### PR TITLE
fix(backoffice): stop horizontal scroll on admin icon rail

### DIFF
--- a/apps/backoffice/src/app/(admin)/layout.tsx
+++ b/apps/backoffice/src/app/(admin)/layout.tsx
@@ -455,7 +455,7 @@ function IconRail({
       </Link>
 
       {/* Module icons */}
-      <div className="mt-1 flex flex-1 flex-col items-center gap-1 overflow-y-auto scrollbar-thin">
+      <div className="mt-1 flex flex-1 flex-col items-center gap-1 overflow-y-auto overflow-x-clip scrollbar-thin">
         {NAV_SECTIONS.map((section) => {
           const visible = getVisibleItems(section, user);
           if (visible.length === 0) return null;


### PR DESCRIPTION
## Summary

The backoffice admin icon rail could be panned right with a trackpad/touch sideways swipe, drifting the whole bar out of place. Root cause: the module-icons column had `overflow-y-auto` with `overflow-x` left at its default `visible` — a known CSS quirk where browsers silently promote `overflow-x: visible` to `auto` whenever the other axis isn't `visible`. With the hover tooltip on each icon (`absolute left-full ml-2`) extending past the 64px-wide rail, that scroll axis had content to scroll into.

Fix: pin `overflow-x: clip` on that column. Vertical scroll still works (for accounts with many module icons), the rail can't be panned sideways, and the native `title="…"` attribute already on each button keeps the label fallback.

## Test plan

- [ ] On a wide screen, try two-finger horizontal swipe on the icon rail — bar stays put
- [ ] On a narrow viewport where icons would scroll vertically, vertical scroll still works
- [ ] Hover an icon — native browser tooltip appears (styled hover label gets clipped at rail edge by design)
- [ ] No regression on the mobile sidebar (different component)

https://claude.ai/code/session_01GUmVWbfcvxYuvr4XgSKXmJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01GUmVWbfcvxYuvr4XgSKXmJ)_