### PR TITLE
fix(backoffice): drop CSS hover label from icon rail

### DIFF
--- a/apps/backoffice/src/app/(admin)/layout.tsx
+++ b/apps/backoffice/src/app/(admin)/layout.tsx
@@ -480,10 +480,6 @@ function IconRail({
                 title={section.label}
               >
                 {section.railIcon}
-                {/* Tooltip */}
-                <span className="pointer-events-none absolute left-full ml-2 hidden whitespace-nowrap rounded-md bg-neutral-900 px-2.5 py-1 text-xs text-white shadow-lg group-hover:block z-50">
-                  {section.label}
-                </span>
               </button>
             </div>
           );


### PR DESCRIPTION
## Summary

Follow-up to PR #138. The `overflow-x: clip` pin closed the scroll axis, but the hover label span itself was still the rightward overhang the user could see (and which on some browsers/inputs was still pannable). The button already has `title="…"`, so the native browser tooltip handles labeling on hover. Dropping the absolute-positioned span eliminates the overhang entirely with no UX loss.

## Test plan

- [ ] Hover an icon in the admin sidebar — native tooltip appears after the browser delay; no styled chip extending past the rail
- [ ] Trackpad / touch sideways swipe on the rail — bar stays put
- [ ] Active module still shows its label in the sub-nav panel header (separate component, unchanged)

https://claude.ai/code/session_01GUmVWbfcvxYuvr4XgSKXmJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01GUmVWbfcvxYuvr4XgSKXmJ)_