### PR TITLE
Payments: TNG/wallet success ack, card-via-RM, picker UX

### DIFF
--- a/apps/order/src/lib/revenue-monster/client.ts
+++ b/apps/order/src/lib/revenue-monster/client.ts
@@ -187,17 +187,18 @@ function nonce() {
 // (https://doc.revenuemonster.my/docs/payment-method) the system method needs
 // the region suffix appended — Malaysia = `_MY` — even for FPX whose system
 // method name is just "FPX". Sending without the suffix returns
-// DOES_NOT_HAVE_ACTIVE_WALLET. CARD is not a valid web-payment method on
-// /v3/payment/online (it's not listed in the appendix at all); card payments
-// have to go through a separate flow or the hosted page without a method
-// filter. We route card through Stripe instead, so it's intentionally absent
-// from this map.
+// DOES_NOT_HAVE_ACTIVE_WALLET.
+//
+// Card has no wallet-app deep link, so we use the hosted card page (step 1)
+// for card payments — see the `directMethod === "CARD_MY"` branch in
+// createPayment below, which mirrors the FPX-no-bank fallback.
 export const PAYMENT_METHOD_MAP: Record<string, string[]> = {
   tng:       ["TNG_MY"],
   grabpay:   ["GRABPAY_MY"],
   fpx:       ["FPX_MY"],
   boost:     ["BOOST_MY"],
   shopeepay: ["SHOPEEPAY_MY"],
+  card:      ["CARD_MY"],
   // "all" → empty array tells RM's hosted page to show every method
   // enabled on the merchant account.
   all:       [],
@@ -320,6 +321,17 @@ export async function createPayment(params: CreatePaymentParams): Promise<Create
   if (directMethod === "FPX_MY" && !params.fpxBankCode) {
     if (!hosted.item?.url) {
       throw new Error("FPX fallback failed: hosted checkout returned no url");
+    }
+    return { paymentUrl: hosted.item.url, checkoutId };
+  }
+
+  // Card has no wallet-app deep link — RM serves the card form on the
+  // hosted page from step 1. The hosted body already filters method to
+  // ["CARD_MY"], so the customer lands directly on the card form rather
+  // than RM's consolidated picker.
+  if (directMethod === "CARD_MY") {
+    if (!hosted.item?.url) {
+      throw new Error("Card fallback failed: hosted checkout returned no url");
     }
     return { paymentUrl: hosted.item.url, checkoutId };
   }

--- a/apps/pickup-native/app/checkout.tsx
+++ b/apps/pickup-native/app/checkout.tsx
@@ -389,7 +389,7 @@ export default function Checkout() {
   useEffect(() => {
     if (selectedCategory !== null) return;
     if (card)          { setSelectedCategory("card"); return; }
-    if (wallets[0])    { setSelectedCategory("ewallet"); setSelectedWalletId(wallets[0].method_id); return; }
+    if (wallets[0])    { setSelectedCategory("ewallet"); return; }
     if (onlineBanking) { setSelectedCategory("online_banking"); return; }
     if (applePay)      { setSelectedCategory("apple_pay"); return; }
     if (googlePay)     { setSelectedCategory("google_pay"); return; }
@@ -1023,7 +1023,6 @@ export default function Checkout() {
                         Haptics.selectionAsync();
                         setSelectedCategory("ewallet");
                         setFpxBankCode(null);
-                        if (!selectedWalletId) setSelectedWalletId(wallets[0].method_id);
                         setWalletSheetOpen(true);
                       }}
                       title="E-Wallet"
@@ -1272,11 +1271,13 @@ export default function Checkout() {
                 ? "Online ordering paused"
                 : outletClosed
                   ? "Outlet closed — switch outlet"
-                  : !selectedMethodId
-                    ? "Select a payment method"
-                    : selectedMethodId === "fpx" && !fpxBankCode
-                      ? "Pick your bank"
-                      : `Place order · ${formatPrice(grandTotal)}`
+                  : selectedCategory === "ewallet" && !selectedWalletId
+                    ? "Pick your wallet"
+                    : !selectedMethodId
+                      ? "Select a payment method"
+                      : selectedMethodId === "fpx" && !fpxBankCode
+                        ? "Pick your bank"
+                        : `Place order · ${formatPrice(grandTotal)}`
             }
             onPress={onPlaceOrder}
             loading={busy}

--- a/apps/pickup-native/app/checkout.tsx
+++ b/apps/pickup-native/app/checkout.tsx
@@ -401,7 +401,10 @@ export default function Checkout() {
   // brief hold. Used by every "we're done, get out of checkout"
   // path (Stripe success, zero-amount skipPayment, payment-cancel
   // fallback) so the customer always sees the same exit moment.
-  const routeAfterSuccess = (orderId: string, opts?: { holdMs?: number }) => {
+  const routeAfterSuccess = (
+    orderId: string,
+    opts?: { holdMs?: number; params?: Record<string, string> },
+  ) => {
     const holdMs = opts?.holdMs ?? 1400;
     setPaymentSuccess(true);
     Animated.parallel([
@@ -419,7 +422,10 @@ export default function Checkout() {
       }),
     ]).start();
     setTimeout(() => {
-      router.replace({ pathname: "/order/[id]", params: { id: orderId } });
+      router.replace({
+        pathname: "/order/[id]",
+        params: { id: orderId, ...(opts?.params ?? {}) },
+      });
     }, holdMs);
   };
 
@@ -656,11 +662,19 @@ export default function Checkout() {
         );
         if (wb.type === "success") {
           trackEvent("payment_rm_returned", { orderId: res.orderId });
+          Haptics.notificationAsync(Haptics.NotificationFeedbackType.Success);
           setBusyLabel("Sending to kitchen…");
+          // Optimistic: RM redirected back, so the customer completed the
+          // wallet flow. The order is still "pending" until our webhook /
+          // poll reconciles (typically 5-30s). Show the success animation
+          // now and pass justPaid so the order page renders a "Confirming
+          // payment…" state instead of the misleading retry UI during
+          // that reconciliation window.
+          routeAfterSuccess(res.orderId, { params: { justPaid: "1" } });
         } else {
           trackEvent("payment_rm_cancelled", { orderId: res.orderId, type: wb.type });
+          router.replace({ pathname: "/order/[id]", params: { id: res.orderId } });
         }
-        router.replace({ pathname: "/order/[id]", params: { id: res.orderId } });
         return;
       }
 

--- a/apps/pickup-native/app/order/[id].tsx
+++ b/apps/pickup-native/app/order/[id].tsx
@@ -52,7 +52,14 @@ const STATUS_INDEX: Record<string, number> = {
 };
 
 export default function OrderStatus() {
-  const { id } = useLocalSearchParams<{ id: string }>();
+  // `justPaid` is set by the checkout screen when the customer just
+  // returned from a Revenue Monster wallet redirect. It tells us the
+  // pending→preparing reconciliation hasn't run yet, so we should show
+  // a "Confirming payment…" panel instead of the misleading retry UI.
+  const { id, justPaid } = useLocalSearchParams<{
+    id: string;
+    justPaid?: string;
+  }>();
   const queryClient = useQueryClient();
   const { data, isLoading, error } = useQuery({
     queryKey: ["order", id],
@@ -391,6 +398,26 @@ export default function OrderStatus() {
   const currentMethodId = (data?.payment_method as string | undefined) ?? "card";
   const currentMethodLabel = METHOD_LABELS[currentMethodId] ?? "the original method";
 
+  // "Confirming payment…" window — Revenue Monster wallet/FPX redirects
+  // back to the app before the webhook fires, so the order sits in
+  // "pending" for a few seconds. Showing the retry UI in that window is
+  // wrong: the customer just paid. Trigger via `justPaid=1` (set by
+  // checkout on successful return) OR by orders created in the last 90s
+  // for someone landing here from history. Past the window we fall
+  // through to the existing retry UI so a genuinely stuck order can be
+  // recovered.
+  const rmConfirmMethods = new Set(["fpx", "tng", "boost", "shopeepay", "grabpay"]);
+  const isRmPending =
+    data?.status === "pending" &&
+    !!data?.payment_method &&
+    rmConfirmMethods.has(data.payment_method);
+  const createdRecently = (() => {
+    if (!data?.created_at) return false;
+    const ageMs = Date.now() - new Date(data.created_at).getTime();
+    return ageMs < 90_000;
+  })();
+  const confirmingPayment = isRmPending && (justPaid === "1" || createdRecently);
+
   return (
     <View className="flex-1 bg-background">
       <Stack.Screen options={{ headerShown: false }} />
@@ -432,7 +459,21 @@ export default function OrderStatus() {
               shadowOffset: { width: 0, height: 2 },
             }}
           >
-            {data.status === "pending" || data.status === "failed" ? (
+            {confirmingPayment ? (
+              <View className="items-center py-2">
+                <ActivityIndicator size="small" color="#C05040" />
+                <Text
+                  className="text-espresso text-lg mt-2"
+                  style={{ fontFamily: "Peachi-Bold" }}
+                >
+                  Confirming payment with {currentMethodLabel}…
+                </Text>
+                <Text className="text-muted-fg text-sm mt-1 text-center">
+                  This usually takes a few seconds. We'll start preparing
+                  your order as soon as it lands.
+                </Text>
+              </View>
+            ) : data.status === "pending" || data.status === "failed" ? (
               <View className="items-center py-2">
                 <Clock size={28} color={data.status === "failed" ? "#B0413E" : "#C05040"} />
                 <Text

--- a/apps/pickup-native/app/order/[id].tsx
+++ b/apps/pickup-native/app/order/[id].tsx
@@ -75,7 +75,7 @@ export default function OrderStatus() {
   // then sees the new status on the next 5s tick.
   useEffect(() => {
     if (!id || !data || data.status !== "pending") return;
-    const rmMethods = new Set(["fpx", "tng", "boost", "shopeepay"]);
+    const rmMethods = new Set(["fpx", "tng", "boost", "shopeepay", "card"]);
     if (!data.payment_method || !rmMethods.has(data.payment_method)) return;
     let cancelled = false;
     const poll = async () => {
@@ -406,7 +406,7 @@ export default function OrderStatus() {
   // for someone landing here from history. Past the window we fall
   // through to the existing retry UI so a genuinely stuck order can be
   // recovered.
-  const rmConfirmMethods = new Set(["fpx", "tng", "boost", "shopeepay", "grabpay"]);
+  const rmConfirmMethods = new Set(["fpx", "tng", "boost", "shopeepay", "grabpay", "card"]);
   const isRmPending =
     data?.status === "pending" &&
     !!data?.payment_method &&


### PR DESCRIPTION
## Summary

- **checkout:** E-Wallet picker no longer auto-defaults to TNG — customer picks explicitly, same as the FPX bank picker. Place Order label flips to "Pick your wallet" when E-Wallet is selected but no wallet chosen.
- **wallet acknowledgement:** Revenue Monster (TNG / Boost / ShopeePay / GrabPay / FPX) success returns now run the same `routeAfterSuccess` animation Stripe gets — green check + success haptic — and pass `justPaid=1` through the route.
- **order page confirming state:** while an RM order is `pending` AND inside the reconciliation window (justPaid=1 OR created within last 90s), the screen shows "Confirming payment with {method}…" + spinner instead of the misleading "Awaiting payment / pay-again" panel. Past the window or for non-RM methods the existing retry UI still shows so genuinely stuck orders are recoverable.
- **card-via-RM wiring:** added `card → ["CARD_MY"]` to RM's PAYMENT_METHOD_MAP and branched `createPayment` to return the hosted card page from step 1 (no Direct deep link exists for cards) — mirrors the FPX-no-bank fallback. Card is now in the order-page poll backstop and confirming set too. **The DB row `payment_gateway_config.card` was already flipped to `revenue_monster` — production card payments require this PR to be deployed.**
- Earlier commits on the branch (icon URLs, build number bumps) also included.

## Test plan

- [ ] Deploy to Vercel (backend has the card-via-RM map + branch)
- [ ] Pay with TNG → green check overlay → "Confirming payment with TNG…" → flips to Preparing within ~30s
- [ ] Pay with FPX → same flow, "Confirming payment with FPX…"
- [ ] Pay with card → opens RM hosted card form, returns to app with same confirming flow
- [ ] OTA the native app: `eas update --branch production`


---
_Generated by [Claude Code](https://claude.ai/code/session_017X4vQcxS3nCF8zbWgY6Ma3)_