### PR TITLE
backoffice/posters: AI compose dialog for splash + home

### DIFF
--- a/apps/backoffice/src/app/(admin)/pickup/splash-posters/page.tsx
+++ b/apps/backoffice/src/app/(admin)/pickup/splash-posters/page.tsx
@@ -11,10 +11,12 @@ import {
   Power,
   Clock,
   Crop,
+  Sparkles,
 } from "lucide-react";
 import { adminFetch } from "@/lib/pickup/admin-fetch";
 import { useConfirm, toast } from "@celsius/ui";
 import { PosterCropDialog } from "@/components/pickup/PosterCropDialog";
+import { PosterComposer } from "@/components/pickup/PosterComposer";
 
 type Placement = "splash" | "home";
 
@@ -140,6 +142,10 @@ export default function SplashPostersPage() {
   // cropped output flows back through handleUpload so the rest of the
   // upload pipeline is unchanged.
   const [cropSource, setCropSource] = useState<File | string | null>(null);
+  // AI Composer source. Holds the bg URL (the already-cropped form image)
+  // while the composer is open. When it returns a flattened JPEG, we send
+  // it through the same handleUpload pipeline as a manual upload.
+  const [composeSource, setComposeSource] = useState<string | null>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
   const { confirm, ConfirmDialog } = useConfirm();
 
@@ -622,6 +628,20 @@ export default function SplashPostersPage() {
                         <Crop className="h-3 w-3" />
                         Re-crop
                       </button>
+                      {/* AI compose — opens the composer with the current
+                          (already-cropped) bg, lets the operator type an
+                          objective and have Claude propose headline +
+                          subhead + tint + positions. Output replaces
+                          form.imageUrl with the flattened JPEG. */}
+                      <button
+                        type="button"
+                        onClick={() => setComposeSource(form.imageUrl)}
+                        className="absolute -bottom-3 left-[88px] flex items-center gap-1 rounded-md bg-terracotta px-2 py-1 text-[10px] font-semibold text-white shadow"
+                        title="Compose with AI"
+                      >
+                        <Sparkles className="h-3 w-3" />
+                        AI compose
+                      </button>
                       <button
                         onClick={() => setForm((f) => ({ ...f, imageUrl: "" }))}
                         className="absolute -right-2 -top-2 rounded-full bg-white p-1 shadow"
@@ -828,6 +848,21 @@ export default function SplashPostersPage() {
           onCancel={() => setCropSource(null)}
           onSave={(file) => {
             setCropSource(null);
+            handleUpload(file);
+          }}
+        />
+      )}
+
+      {/* AI composer — bg + tint + draggable text + AI generation. Output
+          is a flattened JPEG that runs through the same upload pipeline
+          as a manual crop, so the rest of the form stays unchanged. */}
+      {composeSource && (
+        <PosterComposer
+          bgUrl={composeSource}
+          placement={form.placement}
+          onCancel={() => setComposeSource(null)}
+          onSave={(file) => {
+            setComposeSource(null);
             handleUpload(file);
           }}
         />

--- a/apps/backoffice/src/app/api/pickup/ai-poster/generate/route.ts
+++ b/apps/backoffice/src/app/api/pickup/ai-poster/generate/route.ts
@@ -1,0 +1,191 @@
+import { NextRequest, NextResponse } from "next/server";
+import Anthropic from "@anthropic-ai/sdk";
+import { requireAuth } from "@/lib/auth";
+
+export const dynamic = "force-dynamic";
+export const maxDuration = 60;
+
+const anthropic = new Anthropic({ apiKey: process.env.ANTHROPIC_API_KEY });
+
+type Placement = "splash" | "home";
+
+// Output schema — strict JSON the composer can drop straight into state.
+// Positions are normalised (0-1) so they survive resolution changes
+// between preview and final rasterise.
+type PosterSuggestion = {
+  tintColor: string;     // "#RRGGBB"
+  tintOpacity: number;   // 0.0 - 0.6
+  headline: {
+    text: string;
+    x: number;           // 0 (left) - 1 (right) — center anchor
+    y: number;           // 0 (top)  - 1 (bottom)
+    color: string;
+    size: number;        // 0.06 - 0.16 of frame height
+    align: "left" | "center" | "right";
+  };
+  subhead: {
+    text: string;
+    x: number;
+    y: number;
+    color: string;
+    size: number;        // 0.025 - 0.06
+    align: "left" | "center" | "right";
+  };
+};
+
+function buildPrompt(objective: string, placement: Placement): string {
+  const surfaceNote =
+    placement === "home"
+      ? "Surface: Home carousel banner, ~15:14 aspect (slightly wider than tall). The bottom 25% of the image is covered by a small dark info card (member greeting + points/vouchers) — KEEP TEXT CLEAR of y > 0.72."
+      : "Surface: App splash screen, 9:16 portrait, full-bleed (no overlays). Use the whole frame.";
+
+  return `You are designing a promotional poster for Celsius Coffee, a specialty coffee chain in Malaysia. The user has provided a background image and an objective. Suggest the overlay: tint color/opacity, a short headline, and a one-line subhead — with positions that look good against THIS specific image.
+
+Objective from operator:
+"""${objective}"""
+
+${surfaceNote}
+
+Look at the image carefully. Identify low-detail areas (sky, flat surfaces, blurred backgrounds) where text will read clearly. Pick text colors with strong contrast against the chosen position (light text on dark areas, dark text on light areas). The tint sits over the entire image and helps unify the look — keep it subtle (opacity 0.15-0.45) unless the image is very busy.
+
+Brand voice: warm, casual, Malaysian English. Headline 2-4 words, punchy. Subhead 4-10 words. No emojis. No exclamation marks unless the objective explicitly calls for hype.
+
+Return STRICT JSON only — no prose, no markdown fences:
+
+{
+  "tintColor": "#RRGGBB",
+  "tintOpacity": 0.0-0.6,
+  "headline": {
+    "text": "string",
+    "x": 0.0-1.0,
+    "y": 0.0-1.0,
+    "color": "#RRGGBB",
+    "size": 0.06-0.16,
+    "align": "left" | "center" | "right"
+  },
+  "subhead": {
+    "text": "string",
+    "x": 0.0-1.0,
+    "y": 0.0-1.0,
+    "color": "#RRGGBB",
+    "size": 0.025-0.06,
+    "align": "left" | "center" | "right"
+  }
+}`;
+}
+
+// Fetch the user-supplied bg image and return it as base64 so Claude
+// can see it. Capped at ~4 MB to keep the vision payload reasonable —
+// posters going through the cropper are already resized to 1440px max.
+async function fetchImageAsBase64(
+  url: string,
+): Promise<{ data: string; mediaType: "image/jpeg" | "image/png" | "image/webp" }> {
+  const res = await fetch(url);
+  if (!res.ok) throw new Error(`Failed to fetch image: ${res.status}`);
+  const ct = (res.headers.get("content-type") || "").toLowerCase();
+  let mediaType: "image/jpeg" | "image/png" | "image/webp";
+  if (ct.includes("png")) mediaType = "image/png";
+  else if (ct.includes("webp")) mediaType = "image/webp";
+  else mediaType = "image/jpeg";
+  const buf = Buffer.from(await res.arrayBuffer());
+  if (buf.byteLength > 4 * 1024 * 1024) {
+    throw new Error("Image too large for vision call (max 4 MB).");
+  }
+  return { data: buf.toString("base64"), mediaType };
+}
+
+export async function POST(request: NextRequest) {
+  const auth = await requireAuth(request);
+  if (auth.error) return auth.error;
+
+  const body = await request.json().catch(() => null);
+  const imageUrl: string | undefined = body?.imageUrl;
+  const objective: string = (body?.objective ?? "").toString().trim();
+  const placement: Placement = body?.placement === "splash" ? "splash" : "home";
+
+  if (!imageUrl) {
+    return NextResponse.json({ error: "imageUrl required" }, { status: 400 });
+  }
+  if (!objective) {
+    return NextResponse.json({ error: "objective required" }, { status: 400 });
+  }
+  if (objective.length > 600) {
+    return NextResponse.json({ error: "objective too long (max 600 chars)" }, { status: 400 });
+  }
+
+  let img: { data: string; mediaType: "image/jpeg" | "image/png" | "image/webp" };
+  try {
+    img = await fetchImageAsBase64(imageUrl);
+  } catch (e: unknown) {
+    const msg = e instanceof Error ? e.message : "Failed to load image";
+    return NextResponse.json({ error: msg }, { status: 400 });
+  }
+
+  try {
+    const resp = await anthropic.messages.create({
+      model: "claude-sonnet-4-5",
+      max_tokens: 800,
+      messages: [
+        {
+          role: "user",
+          content: [
+            {
+              type: "image",
+              source: { type: "base64", media_type: img.mediaType, data: img.data },
+            },
+            { type: "text", text: buildPrompt(objective, placement) },
+          ],
+        },
+      ],
+    });
+
+    const text = resp.content
+      .filter((b): b is Anthropic.TextBlock => b.type === "text")
+      .map((b) => b.text)
+      .join("\n")
+      .trim();
+
+    const clean = text.replace(/^```(?:json)?\s*/i, "").replace(/```\s*$/i, "").trim();
+    const parsed = JSON.parse(clean) as PosterSuggestion;
+
+    // Light validation + clamping — Claude is mostly well-behaved here
+    // but the composer code assumes ranges, so we enforce them.
+    const clamp = (n: unknown, lo: number, hi: number, fb: number): number => {
+      const v = typeof n === "number" && Number.isFinite(n) ? n : fb;
+      return Math.max(lo, Math.min(hi, v));
+    };
+    const hex = (s: unknown, fb: string): string => {
+      if (typeof s === "string" && /^#[0-9a-f]{6}$/i.test(s)) return s;
+      return fb;
+    };
+    const align = (s: unknown, fb: "left" | "center" | "right") => {
+      return s === "left" || s === "center" || s === "right" ? s : fb;
+    };
+
+    const out: PosterSuggestion = {
+      tintColor:   hex(parsed.tintColor, "#160800"),
+      tintOpacity: clamp(parsed.tintOpacity, 0, 0.7, 0.25),
+      headline: {
+        text:  String(parsed.headline?.text ?? "").slice(0, 60),
+        x:     clamp(parsed.headline?.x, 0, 1, 0.5),
+        y:     clamp(parsed.headline?.y, 0, 1, 0.4),
+        color: hex(parsed.headline?.color, "#FFFFFF"),
+        size:  clamp(parsed.headline?.size, 0.04, 0.2, 0.1),
+        align: align(parsed.headline?.align, "center"),
+      },
+      subhead: {
+        text:  String(parsed.subhead?.text ?? "").slice(0, 140),
+        x:     clamp(parsed.subhead?.x, 0, 1, 0.5),
+        y:     clamp(parsed.subhead?.y, 0, 1, 0.55),
+        color: hex(parsed.subhead?.color, "#F5F3F0"),
+        size:  clamp(parsed.subhead?.size, 0.02, 0.08, 0.04),
+        align: align(parsed.subhead?.align, "center"),
+      },
+    };
+
+    return NextResponse.json({ suggestion: out });
+  } catch (err: unknown) {
+    const message = err instanceof Error ? err.message : "Generation failed";
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+}

--- a/apps/backoffice/src/components/pickup/PosterComposer.tsx
+++ b/apps/backoffice/src/components/pickup/PosterComposer.tsx
@@ -1,0 +1,603 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { Loader2, Sparkles, X, RotateCcw } from "lucide-react";
+import { adminFetch } from "@/lib/pickup/admin-fetch";
+import { toast } from "@celsius/ui";
+
+type Placement = "splash" | "home";
+
+type TextLayer = {
+  text: string;
+  x: number;       // 0-1 normalised in frame width — anchor sits here
+  y: number;       // 0-1 normalised in frame height — vertical centre
+  color: string;   // #RRGGBB
+  size: number;    // 0-1 normalised in frame height (e.g. 0.1 = 10% of frame H)
+  align: "left" | "center" | "right";
+};
+
+type State = {
+  bgZoom: number;
+  bgPanX: number;  // normalised, 0 = centred
+  bgPanY: number;
+  tintColor: string;
+  tintOpacity: number;  // 0-1
+  headline: TextLayer;
+  subhead: TextLayer;
+};
+
+const DEFAULT_STATE: State = {
+  bgZoom: 1,
+  bgPanX: 0,
+  bgPanY: 0,
+  tintColor: "#160800",
+  tintOpacity: 0.25,
+  headline: {
+    text: "Your headline",
+    x: 0.5,
+    y: 0.4,
+    color: "#FFFFFF",
+    size: 0.1,
+    align: "center",
+  },
+  subhead: {
+    text: "A short supporting line goes here",
+    x: 0.5,
+    y: 0.52,
+    color: "#F5F3F0",
+    size: 0.035,
+    align: "center",
+  },
+};
+
+// Output canvas dimensions per placement. Keeps file sizes reasonable
+// while matching the aspect that the customer app actually renders.
+const OUTPUT: Record<Placement, { w: number; h: number; previewMax: { w: number; h: number } }> = {
+  splash: { w: 1080, h: 1920, previewMax: { w: 270, h: 480 } },
+  home:   { w: 1200, h: 1120, previewMax: { w: 380, h: 355 } },
+};
+
+type Props = {
+  // Background image URL — already cropped to the placement aspect via
+  // the existing PosterCropDialog upstream. Composer treats it as a
+  // canvas to overlay tint + text on; it does not re-crop the aspect.
+  bgUrl: string;
+  placement: Placement;
+  onCancel: () => void;
+  // Returns a fresh JPEG File ready for upload via the existing
+  // /api/pickup/upload-image route. Parent decides what to do with it.
+  onSave: (file: File) => void;
+};
+
+function hexToRgb(hex: string): { r: number; g: number; b: number } {
+  const m = /^#([0-9a-f]{6})$/i.exec(hex);
+  if (!m) return { r: 0, g: 0, b: 0 };
+  const n = parseInt(m[1], 16);
+  return { r: (n >> 16) & 255, g: (n >> 8) & 255, b: n & 255 };
+}
+
+export function PosterComposer({ bgUrl, placement, onCancel, onSave }: Props) {
+  const [state, setState] = useState<State>(DEFAULT_STATE);
+  const [objective, setObjective] = useState("");
+  const [generating, setGenerating] = useState(false);
+  const [saving, setSaving] = useState(false);
+  // Which layer is active in the right-side editor. The bg is "bg" — its
+  // controls (zoom, pan reset) sit in the same panel for consistency.
+  const [selected, setSelected] = useState<"headline" | "subhead" | "bg">("headline");
+
+  const frameRef = useRef<HTMLDivElement>(null);
+  const bgImgRef = useRef<HTMLImageElement | null>(null);
+  // Hydrate the bg image into an Image element once so the canvas
+  // raster can draw it without re-fetching.
+  useEffect(() => {
+    const img = new Image();
+    img.crossOrigin = "anonymous";
+    img.src = bgUrl;
+    img.onload = () => { bgImgRef.current = img; };
+  }, [bgUrl]);
+
+  const { w: OUT_W, h: OUT_H, previewMax } = OUTPUT[placement];
+
+  // Live preview size — scales the OUT aspect to fit previewMax.
+  const previewScale = Math.min(previewMax.w / OUT_W, previewMax.h / OUT_H);
+  const previewW = Math.round(OUT_W * previewScale);
+  const previewH = Math.round(OUT_H * previewScale);
+
+  // --- Pointer-drag plumbing ----------------------------------------
+  // One generic drag controller for bg and text layers. We capture
+  // the pointer on the frame so drags can leave the layer's bbox
+  // without losing focus.
+  const dragRef = useRef<{
+    kind: "bg" | "headline" | "subhead";
+    startClientX: number;
+    startClientY: number;
+    startState: State;
+  } | null>(null);
+
+  const onPointerDown = (
+    kind: "bg" | "headline" | "subhead",
+    e: React.PointerEvent,
+  ) => {
+    e.stopPropagation();
+    (e.currentTarget as HTMLElement).setPointerCapture(e.pointerId);
+    dragRef.current = {
+      kind,
+      startClientX: e.clientX,
+      startClientY: e.clientY,
+      startState: state,
+    };
+    setSelected(kind);
+  };
+
+  const onPointerMove = (e: React.PointerEvent) => {
+    const drag = dragRef.current;
+    if (!drag) return;
+    const frame = frameRef.current;
+    if (!frame) return;
+    const rect = frame.getBoundingClientRect();
+    const dxN = (e.clientX - drag.startClientX) / rect.width;
+    const dyN = (e.clientY - drag.startClientY) / rect.height;
+
+    setState((s) => {
+      const base = drag.startState;
+      if (drag.kind === "bg") {
+        return { ...s, bgPanX: base.bgPanX + dxN, bgPanY: base.bgPanY + dyN };
+      }
+      if (drag.kind === "headline") {
+        return {
+          ...s,
+          headline: {
+            ...s.headline,
+            x: Math.max(0, Math.min(1, base.headline.x + dxN)),
+            y: Math.max(0, Math.min(1, base.headline.y + dyN)),
+          },
+        };
+      }
+      return {
+        ...s,
+        subhead: {
+          ...s.subhead,
+          x: Math.max(0, Math.min(1, base.subhead.x + dxN)),
+          y: Math.max(0, Math.min(1, base.subhead.y + dyN)),
+        },
+      };
+    });
+  };
+
+  const onPointerUp = (e: React.PointerEvent) => {
+    if (dragRef.current) {
+      (e.currentTarget as HTMLElement).releasePointerCapture(e.pointerId);
+      dragRef.current = null;
+    }
+  };
+
+  // --- AI generate --------------------------------------------------
+  const generate = async () => {
+    const trimmed = objective.trim();
+    if (!trimmed) {
+      toast.error("Type an objective first");
+      return;
+    }
+    setGenerating(true);
+    try {
+      const res = await adminFetch("/api/pickup/ai-poster/generate", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ imageUrl: bgUrl, objective: trimmed, placement }),
+      });
+      const json = await res.json();
+      if (!res.ok) throw new Error(json.error ?? "Generate failed");
+      const s = json.suggestion as {
+        tintColor: string;
+        tintOpacity: number;
+        headline: TextLayer;
+        subhead: TextLayer;
+      };
+      setState((cur) => ({
+        ...cur,
+        tintColor:   s.tintColor,
+        tintOpacity: s.tintOpacity,
+        headline:    s.headline,
+        subhead:     s.subhead,
+      }));
+      toast.success("Generated");
+    } catch (e: unknown) {
+      toast.error(e instanceof Error ? e.message : "Generate failed");
+    } finally {
+      setGenerating(false);
+    }
+  };
+
+  // --- Rasterise + save --------------------------------------------
+  const handleSave = async () => {
+    const img = bgImgRef.current;
+    if (!img) {
+      toast.error("Background still loading");
+      return;
+    }
+    setSaving(true);
+    try {
+      // Make sure Peachi is loaded before drawing — text would otherwise
+      // fall back to serif on first render.
+      await Promise.all([
+        document.fonts.load(`700 ${Math.round(state.headline.size * OUT_H)}px "Peachi"`),
+        document.fonts.load(`500 ${Math.round(state.subhead.size * OUT_H)}px "Peachi"`),
+      ]).catch(() => {});
+
+      const canvas = document.createElement("canvas");
+      canvas.width = OUT_W;
+      canvas.height = OUT_H;
+      const ctx = canvas.getContext("2d");
+      if (!ctx) throw new Error("Canvas unavailable");
+
+      // 1. Background (centre, with user pan/zoom). Image is already
+      //    cropped to the placement aspect upstream, so stretching it
+      //    to (OUT_W, OUT_H) at zoom=1 == "cover".
+      ctx.save();
+      ctx.translate(OUT_W / 2, OUT_H / 2);
+      ctx.translate(state.bgPanX * OUT_W, state.bgPanY * OUT_H);
+      ctx.scale(state.bgZoom, state.bgZoom);
+      ctx.drawImage(img, -OUT_W / 2, -OUT_H / 2, OUT_W, OUT_H);
+      ctx.restore();
+
+      // 2. Tint overlay
+      if (state.tintOpacity > 0) {
+        const { r, g, b } = hexToRgb(state.tintColor);
+        ctx.fillStyle = `rgba(${r},${g},${b},${state.tintOpacity})`;
+        ctx.fillRect(0, 0, OUT_W, OUT_H);
+      }
+
+      // 3. Text layers — middle baseline so the y coord is the vertical
+      //    centre of the glyph bbox; matches the preview where the text
+      //    span is translateY(-50%) about its y position.
+      const drawText = (layer: TextLayer, weight: number) => {
+        if (!layer.text) return;
+        const fontSize = Math.round(layer.size * OUT_H);
+        ctx.font = `${weight} ${fontSize}px "Peachi", Georgia, serif`;
+        ctx.fillStyle = layer.color;
+        ctx.textAlign = layer.align;
+        ctx.textBaseline = "middle";
+        ctx.fillText(layer.text, layer.x * OUT_W, layer.y * OUT_H);
+      };
+      drawText(state.headline, 700);
+      drawText(state.subhead, 500);
+
+      const blob = await new Promise<Blob | null>((resolve) =>
+        canvas.toBlob(resolve, "image/jpeg", 0.9),
+      );
+      if (!blob) throw new Error("Could not encode poster");
+      onSave(new File([blob], `poster-${Date.now()}.jpg`, { type: "image/jpeg" }));
+    } catch (e: unknown) {
+      toast.error(e instanceof Error ? e.message : "Save failed");
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  // --- Render ------------------------------------------------------
+  const updateLayer = (
+    which: "headline" | "subhead",
+    patch: Partial<TextLayer>,
+  ) => {
+    setState((s) => ({ ...s, [which]: { ...s[which], ...patch } }));
+  };
+
+  const selectedLayer =
+    selected === "headline" ? state.headline : selected === "subhead" ? state.subhead : null;
+
+  return (
+    <div className="fixed inset-0 z-[60] flex items-center justify-center bg-black/70 p-4">
+      <div className="flex max-h-[92vh] w-full max-w-5xl flex-col overflow-hidden rounded-2xl bg-white">
+        <div className="flex items-center justify-between border-b border-gray-100 px-5 py-3">
+          <div>
+            <h3 className="text-sm font-semibold text-gray-900">
+              Compose poster · {placement === "home" ? "Home banner" : "Splash"}
+            </h3>
+            <p className="text-[11px] text-gray-500 mt-0.5">
+              Type an objective, hit Generate, then drag to adjust.
+            </p>
+          </div>
+          <button onClick={onCancel} className="rounded-md p-1 hover:bg-gray-100">
+            <X className="h-4 w-4 text-gray-600" />
+          </button>
+        </div>
+
+        <div className="grid flex-1 grid-cols-1 gap-0 overflow-hidden md:grid-cols-[1fr_320px]">
+          {/* PREVIEW pane ------------------------------------------ */}
+          <div className="flex flex-col items-center justify-start gap-3 overflow-y-auto bg-gray-50 p-5">
+            <div
+              ref={frameRef}
+              className="relative overflow-hidden rounded-lg bg-black shadow-lg select-none"
+              style={{ width: previewW, height: previewH, touchAction: "none" }}
+              onPointerMove={onPointerMove}
+              onPointerUp={onPointerUp}
+              onPointerCancel={onPointerUp}
+            >
+              {/* BG — draggable. transform-origin centre matches the
+                  canvas raster (translate(W/2, H/2)). */}
+              {/* eslint-disable-next-line @next/next/no-img-element */}
+              <img
+                src={bgUrl}
+                alt=""
+                draggable={false}
+                onPointerDown={(e) => onPointerDown("bg", e)}
+                className="absolute inset-0 h-full w-full cursor-move"
+                style={{
+                  objectFit: "cover",
+                  transform: `translate(${state.bgPanX * previewW}px, ${state.bgPanY * previewH}px) scale(${state.bgZoom})`,
+                  transformOrigin: "center",
+                }}
+              />
+
+              {/* Tint */}
+              <div
+                className="pointer-events-none absolute inset-0"
+                style={{
+                  backgroundColor: state.tintColor,
+                  opacity: state.tintOpacity,
+                }}
+              />
+
+              {/* Home placement overlay hint — semi-transparent mock of
+                  the info card so the operator avoids placing text in
+                  the reserved zone. */}
+              {placement === "home" && (
+                <div
+                  className="pointer-events-none absolute inset-x-3 bottom-2 rounded-xl border border-white/20 bg-white/10"
+                  style={{ height: previewH * 0.18 }}
+                >
+                  <div className="flex h-full items-center justify-center text-[8px] font-semibold uppercase tracking-wider text-white/60">
+                    Info card area
+                  </div>
+                </div>
+              )}
+
+              {/* Text layers — draggable. translate(-50%) on Y to centre
+                  on the y coord so it matches the canvas middle-baseline. */}
+              {([
+                { key: "headline" as const, layer: state.headline, weight: 700 },
+                { key: "subhead"  as const, layer: state.subhead,  weight: 500 },
+              ]).map(({ key, layer, weight }) => (
+                <div
+                  key={key}
+                  onPointerDown={(e) => onPointerDown(key, e)}
+                  className={`absolute cursor-move whitespace-nowrap ${
+                    selected === key ? "outline outline-1 outline-dashed outline-white/60" : ""
+                  }`}
+                  style={{
+                    left: `${layer.x * 100}%`,
+                    top:  `${layer.y * 100}%`,
+                    transform: `translate(${
+                      layer.align === "center" ? "-50%" : layer.align === "right" ? "-100%" : "0"
+                    }, -50%)`,
+                    color: layer.color,
+                    fontFamily: '"Peachi", Georgia, serif',
+                    fontWeight: weight,
+                    fontSize: `${layer.size * previewH}px`,
+                    lineHeight: 1.05,
+                    textShadow: "0 1px 2px rgba(0,0,0,0.15)",
+                    padding: "2px 4px",
+                  }}
+                >
+                  {layer.text || (key === "headline" ? "Headline" : "Subhead")}
+                </div>
+              ))}
+            </div>
+
+            {/* AI objective input — directly below the preview so it
+                reads top-down: image, what you want, generate. */}
+            <div className="w-full max-w-md rounded-lg border border-gray-200 bg-white p-3">
+              <label className="text-[11px] font-semibold text-gray-700">
+                Objective
+              </label>
+              <textarea
+                value={objective}
+                onChange={(e) => setObjective(e.target.value)}
+                rows={2}
+                placeholder="e.g. Promote Ramadan iftar special, 20% off espresso this week, warm casual tone"
+                className="mt-1 w-full resize-none rounded-md border border-gray-200 px-2 py-1.5 text-xs"
+              />
+              <button
+                type="button"
+                onClick={generate}
+                disabled={generating || !objective.trim()}
+                className="mt-2 flex w-full items-center justify-center gap-2 rounded-md bg-terracotta px-3 py-2 text-xs font-semibold text-white hover:bg-terracotta-dark disabled:opacity-50"
+              >
+                {generating ? (
+                  <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                ) : (
+                  <Sparkles className="h-3.5 w-3.5" />
+                )}
+                {generating ? "Generating…" : "Generate with AI"}
+              </button>
+              <p className="mt-1.5 text-[10px] text-gray-400">
+                AI looks at your image + objective, suggests headline, subhead, tint and text positions.
+              </p>
+            </div>
+          </div>
+
+          {/* CONTROLS pane ----------------------------------------- */}
+          <div className="flex flex-col gap-4 overflow-y-auto border-l border-gray-100 p-5">
+            {/* Layer tabs */}
+            <div className="grid grid-cols-3 gap-1 rounded-lg bg-gray-100 p-1">
+              {([
+                { id: "bg" as const,       label: "Background" },
+                { id: "headline" as const, label: "Headline" },
+                { id: "subhead"  as const, label: "Subhead" },
+              ]).map((t) => (
+                <button
+                  key={t.id}
+                  onClick={() => setSelected(t.id)}
+                  className={`rounded-md px-2 py-1.5 text-[11px] font-semibold ${
+                    selected === t.id ? "bg-white text-gray-900 shadow-sm" : "text-gray-600"
+                  }`}
+                >
+                  {t.label}
+                </button>
+              ))}
+            </div>
+
+            {/* BG controls */}
+            {selected === "bg" && (
+              <div className="space-y-3">
+                <div>
+                  <label className="text-[11px] font-medium text-gray-700">
+                    Zoom · {state.bgZoom.toFixed(2)}×
+                  </label>
+                  <input
+                    type="range"
+                    min={1}
+                    max={3}
+                    step={0.01}
+                    value={state.bgZoom}
+                    onChange={(e) => setState((s) => ({ ...s, bgZoom: Number(e.target.value) }))}
+                    className="mt-1 w-full"
+                  />
+                </div>
+
+                <div>
+                  <label className="text-[11px] font-medium text-gray-700">
+                    Tint colour
+                  </label>
+                  <div className="mt-1 flex items-center gap-2">
+                    <input
+                      type="color"
+                      value={state.tintColor}
+                      onChange={(e) => setState((s) => ({ ...s, tintColor: e.target.value }))}
+                      className="h-8 w-12 cursor-pointer rounded border border-gray-200"
+                    />
+                    <input
+                      type="text"
+                      value={state.tintColor}
+                      onChange={(e) => setState((s) => ({ ...s, tintColor: e.target.value }))}
+                      className="flex-1 rounded-md border border-gray-200 px-2 py-1 text-xs font-mono"
+                    />
+                  </div>
+                </div>
+
+                <div>
+                  <label className="text-[11px] font-medium text-gray-700">
+                    Tint opacity · {(state.tintOpacity * 100).toFixed(0)}%
+                  </label>
+                  <input
+                    type="range"
+                    min={0}
+                    max={0.8}
+                    step={0.01}
+                    value={state.tintOpacity}
+                    onChange={(e) => setState((s) => ({ ...s, tintOpacity: Number(e.target.value) }))}
+                    className="mt-1 w-full"
+                  />
+                </div>
+
+                <button
+                  onClick={() =>
+                    setState((s) => ({ ...s, bgPanX: 0, bgPanY: 0, bgZoom: 1 }))
+                  }
+                  className="flex w-full items-center justify-center gap-1 rounded-md border border-gray-200 px-2 py-1.5 text-[11px] font-semibold text-gray-700 hover:bg-gray-50"
+                >
+                  <RotateCcw className="h-3 w-3" />
+                  Reset position
+                </button>
+              </div>
+            )}
+
+            {/* Text layer controls */}
+            {selectedLayer && (selected === "headline" || selected === "subhead") && (
+              <div className="space-y-3">
+                <div>
+                  <label className="text-[11px] font-medium text-gray-700">
+                    {selected === "headline" ? "Headline text" : "Subhead text"}
+                  </label>
+                  <textarea
+                    value={selectedLayer.text}
+                    onChange={(e) => updateLayer(selected, { text: e.target.value })}
+                    rows={selected === "subhead" ? 2 : 1}
+                    className="mt-1 w-full resize-none rounded-md border border-gray-200 px-2 py-1.5 text-xs"
+                  />
+                </div>
+
+                <div>
+                  <label className="text-[11px] font-medium text-gray-700">
+                    Size · {(selectedLayer.size * 100).toFixed(1)}%
+                  </label>
+                  <input
+                    type="range"
+                    min={selected === "headline" ? 0.04 : 0.02}
+                    max={selected === "headline" ? 0.2 : 0.08}
+                    step={0.001}
+                    value={selectedLayer.size}
+                    onChange={(e) => updateLayer(selected, { size: Number(e.target.value) })}
+                    className="mt-1 w-full"
+                  />
+                </div>
+
+                <div>
+                  <label className="text-[11px] font-medium text-gray-700">
+                    Colour
+                  </label>
+                  <div className="mt-1 flex items-center gap-2">
+                    <input
+                      type="color"
+                      value={selectedLayer.color}
+                      onChange={(e) => updateLayer(selected, { color: e.target.value })}
+                      className="h-8 w-12 cursor-pointer rounded border border-gray-200"
+                    />
+                    <input
+                      type="text"
+                      value={selectedLayer.color}
+                      onChange={(e) => updateLayer(selected, { color: e.target.value })}
+                      className="flex-1 rounded-md border border-gray-200 px-2 py-1 text-xs font-mono"
+                    />
+                  </div>
+                </div>
+
+                <div>
+                  <label className="text-[11px] font-medium text-gray-700">Align</label>
+                  <div className="mt-1 grid grid-cols-3 gap-1">
+                    {(["left", "center", "right"] as const).map((a) => (
+                      <button
+                        key={a}
+                        onClick={() => updateLayer(selected, { align: a })}
+                        className={`rounded-md border px-2 py-1 text-[11px] font-semibold ${
+                          selectedLayer.align === a
+                            ? "border-terracotta bg-terracotta/10 text-terracotta"
+                            : "border-gray-200 text-gray-600"
+                        }`}
+                      >
+                        {a[0].toUpperCase() + a.slice(1)}
+                      </button>
+                    ))}
+                  </div>
+                </div>
+
+                <p className="text-[10px] text-gray-400">
+                  Drag the text in the preview to move it. Position is
+                  saved as a fraction of the poster size, so it stays
+                  put across resolutions.
+                </p>
+              </div>
+            )}
+          </div>
+        </div>
+
+        <div className="flex items-center justify-end gap-2 border-t border-gray-100 px-5 py-3">
+          <button
+            onClick={onCancel}
+            className="rounded-lg border border-gray-200 bg-white px-3 py-1.5 text-sm font-medium text-gray-700 hover:bg-gray-50"
+          >
+            Cancel
+          </button>
+          <button
+            onClick={handleSave}
+            disabled={saving}
+            className="flex items-center gap-2 rounded-lg bg-terracotta px-3 py-1.5 text-sm font-medium text-white hover:bg-terracotta-dark disabled:opacity-60"
+          >
+            {saving && <Loader2 className="h-3.5 w-3.5 animate-spin" />}
+            Save as image
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- New "✨ AI compose" button on the splash-posters form. Operator types an objective; Claude looks at the bg image and proposes headline, subhead, tint colour/opacity, and rough text positions.
- Composer lets operator pan/zoom the bg, adjust tint colour + opacity, drag text layers, edit text/size/colour/align.
- Save flattens bg + tint + text into a single JPEG and runs it through the existing upload pipeline — no schema or customer-app changes.

## Files
- `apps/backoffice/src/app/api/pickup/ai-poster/generate/route.ts` — Claude vision call, returns validated overlay JSON (positions normalised 0-1 so they survive raster resolution changes)
- `apps/backoffice/src/components/pickup/PosterComposer.tsx` — pointer-drag bg + text, Peachi font, canvas rasterise on save
- `apps/backoffice/src/app/(admin)/pickup/splash-posters/page.tsx` — AI compose entry point + dialog mount

## Test plan
- [ ] Upload a bg image, crop it, click ✨ AI compose
- [ ] Type an objective ("Ramadan iftar special, 20% off espresso, warm tone") → Generate → text + tint populate
- [ ] Drag headline + subhead in the preview, pan/zoom bg, adjust tint colour/opacity
- [ ] Save → confirm the active poster shows the composed image on splash + home in the customer app
- [ ] Verify the bottom-25% info-card area is avoided on home posters

https://claude.ai/code/session_01GGtJRqRei7e7ndGBvBSjJW

---
_Generated by [Claude Code](https://claude.ai/code/session_01GGtJRqRei7e7ndGBvBSjJW)_