### PR TITLE
fix(staff): let receivings-only staff read pending POs

### DIFF
--- a/apps/staff/src/app/api/orders/route.ts
+++ b/apps/staff/src/app/api/orders/route.ts
@@ -5,10 +5,15 @@ import { checkModuleAccess } from "@/lib/check-module-access";
 import { logActivity } from "@/lib/activity-log";
 
 export async function GET(req: NextRequest) {
-  // Phase 8 — gate behind `inventory:orders`. Existing web staff app
-  // never hit this endpoint (no PO UI on web), so adding the gate is
-  // safe.
-  const guard = await checkModuleAccess(req, "inventory:orders");
+  // Staff with `inventory:receivings` need to read the pending PO list to
+  // receive against — the Receive & Capture screen ("Expected Today")
+  // calls this endpoint. Gating GET on `inventory:orders` alone locked
+  // out every line-staff receiver (only managers/owners hold that key).
+  // Mutations below stay gated to `inventory:orders`.
+  const guard = await checkModuleAccess(req, [
+    "inventory:orders",
+    "inventory:receivings",
+  ]);
   if (!guard.ok) return guard.response;
   const session = guard.session;
   const url = new URL(req.url);

--- a/apps/staff/src/lib/check-module-access.ts
+++ b/apps/staff/src/lib/check-module-access.ts
@@ -25,7 +25,7 @@ type GuardErr = { ok: false; response: NextResponse };
 // response } with a 401/403 to return directly.
 export async function checkModuleAccess(
   req: Request,
-  moduleKey: string,
+  moduleKey: string | string[],
 ): Promise<GuardOk | GuardErr> {
   const session = await getUser(req.headers);
   if (!session) {
@@ -53,12 +53,13 @@ export async function checkModuleAccess(
 
   // `moduleAccess` is JSON in Postgres — defensively coerce to object.
   const access = (user.moduleAccess ?? {}) as Record<string, unknown>;
-  const granted = hasAccess(session.role, access, moduleKey);
+  const keys = Array.isArray(moduleKey) ? moduleKey : [moduleKey];
+  const granted = keys.some((k) => hasAccess(session.role, access, k));
   if (!granted) {
     return {
       ok: false,
       response: NextResponse.json(
-        { error: `Access denied: ${moduleKey}` },
+        { error: `Access denied: ${keys.join(" or ")}` },
         { status: 403 },
       ),
     };


### PR DESCRIPTION
## Summary
- Phase 8 access enforcement (49be43d) gated `GET /api/orders` on `inventory:orders`, which silently broke the Receive & Capture screen for every line-staff user across all 3 outlets (Sherry at Shah Alam reported it; ~30 other STAFF users are affected the same way). They saw "No pending deliveries" because the page fetches `/api/orders` to populate "Expected Today" and the request 403'd.
- `checkModuleAccess` now accepts a string or string[] (passes if any key grants access; existing single-key callers unchanged).
- `GET /api/orders` accepts `inventory:orders` OR `inventory:receivings`.
- `POST /api/orders` and `PATCH /api/orders/[id]` stay gated to `inventory:orders` (creating/transitioning POs is still manager-only). The `/orders` management page route guard is unchanged, so this doesn't expose the PO management UI to staff — only the pending list they need to receive against.

## Test plan
- [ ] Deploy and have Sherry (or any STAFF at Shah Alam) reload the Receive & Capture screen — "Expected Today" should show the same POs the owner view sees.
- [ ] Confirm staff still cannot reach `/orders` management page (route guard still requires `inventory:orders`).
- [ ] Confirm managers can still create POs (POST `/api/orders`) and transition status (PATCH `/api/orders/[id]`).

https://claude.ai/code/session_01KE2frALejecp3kiCDyG8Nc

---
_Generated by [Claude Code](https://claude.ai/code/session_01KE2frALejecp3kiCDyG8Nc)_