### PR TITLE
catalog: per-channel modifier visibility (POS / Pickup / Grab / Foodpanda / Dine-in)

### DIFF
--- a/apps/backoffice/src/app/(admin)/pickup/menu/_ModifierGroupsEditor.tsx
+++ b/apps/backoffice/src/app/(admin)/pickup/menu/_ModifierGroupsEditor.tsx
@@ -9,12 +9,25 @@ export interface ModifierOption {
   isDefault: boolean;
 }
 
+export type ModifierChannel = "pos" | "pickup" | "grab" | "foodpanda" | "dinein";
+
+// Channels the customer / cashier can see this modifier group on.
+// Empty / missing = show everywhere (backward compatible with pre-channel data).
 export interface ModifierGroup {
   id: string;
   name: string;
   multiSelect: boolean;
   options: ModifierOption[];
+  channels?: ModifierChannel[];
 }
+
+const CHANNELS: { value: ModifierChannel; label: string }[] = [
+  { value: "pos",       label: "POS" },
+  { value: "pickup",    label: "Pickup" },
+  { value: "grab",      label: "GrabFood" },
+  { value: "foodpanda", label: "Foodpanda" },
+  { value: "dinein",    label: "Dine-in" },
+];
 
 // Local id generator — modifier groups/options live as jsonb on the product
 // row, so they don't have DB-generated ids. A short random suffix is enough
@@ -132,6 +145,55 @@ export function ModifierGroupsEditor({ value, onChange }: Props) {
             >
               <Trash2 className="h-3.5 w-3.5" />
             </button>
+          </div>
+
+          {/* Channels — leave all unchecked = show everywhere */}
+          <div className="pl-5 flex items-center gap-2 flex-wrap">
+            <span className="text-[11px] font-semibold uppercase tracking-wide text-muted-foreground">
+              Show on:
+            </span>
+            {CHANNELS.map(({ value, label }) => {
+              const selected = group.channels ?? [];
+              const on = selected.length === 0 || selected.includes(value);
+              const allSelected = selected.length === 0;
+              return (
+                <button
+                  key={value}
+                  type="button"
+                  onClick={() => {
+                    // Toggle channel. If toggling makes the set equal to "all
+                    // channels", normalise to undefined (show-everywhere).
+                    const allValues = CHANNELS.map((c) => c.value);
+                    const current = allSelected ? allValues : [...selected];
+                    const next = current.includes(value)
+                      ? current.filter((c) => c !== value)
+                      : [...current, value];
+                    const normalised = next.length === 0 || next.length === allValues.length
+                      ? undefined
+                      : (next as ModifierChannel[]);
+                    updateGroup(gIdx, { channels: normalised });
+                  }}
+                  className={`px-2.5 py-1 rounded-full text-[11px] font-medium border transition-colors ${
+                    on
+                      ? "bg-[#160800] text-white border-[#160800]"
+                      : "bg-white text-muted-foreground border-gray-200 hover:border-[#160800]"
+                  }`}
+                  title={allSelected ? "All channels (default)" : on ? `Visible on ${label}` : `Hidden on ${label}`}
+                >
+                  {label}
+                </button>
+              );
+            })}
+            {(group.channels?.length ?? 0) > 0 && (
+              <button
+                type="button"
+                onClick={() => updateGroup(gIdx, { channels: undefined })}
+                className="text-[11px] text-muted-foreground hover:text-[#160800] underline"
+                title="Reset to all channels"
+              >
+                reset
+              </button>
+            )}
           </div>
 
           {/* Options */}

--- a/apps/order/src/lib/menu-data.ts
+++ b/apps/order/src/lib/menu-data.ts
@@ -8,6 +8,7 @@
 import { getSupabaseAdmin } from "@/lib/supabase/server";
 import { products as mockProducts, categories as mockCategories } from "@/data/mock";
 import type { Product, Category } from "@/lib/types";
+import { filterModifiersForChannel } from "@celsius/shared";
 
 export interface MenuData {
   products: Product[];
@@ -95,7 +96,10 @@ export async function getMenuData(): Promise<MenuData> {
         isPopular:      (p.is_featured as boolean) ?? false,
         isNew:          false,
         variants:       [],
-        modifierGroups: Array.isArray(p.modifiers) ? (p.modifiers as Product["modifierGroups"]) : [],
+        modifierGroups: filterModifiersForChannel(
+          Array.isArray(p.modifiers) ? (p.modifiers as Product["modifierGroups"]) : [],
+          "pickup",
+        ),
         featuredPosition: (p.featured_position as number) ?? 9999,
       }));
 

--- a/apps/order/src/lib/menu-data.ts
+++ b/apps/order/src/lib/menu-data.ts
@@ -99,7 +99,7 @@ export async function getMenuData(): Promise<MenuData> {
         modifierGroups: filterModifiersForChannel(
           Array.isArray(p.modifiers) ? (p.modifiers as Product["modifierGroups"]) : [],
           "pickup",
-        ),
+        ) as Product["modifierGroups"],
         featuredPosition: (p.featured_position as number) ?? 9999,
       }));
 

--- a/apps/pos/src/app/api/delivery/menu/route.ts
+++ b/apps/pos/src/app/api/delivery/menu/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { createClient } from "@supabase/supabase-js";
+import { filterModifiersForChannel } from "@celsius/shared";
 
 /**
  * Menu Sync API for Delivery Platforms
@@ -36,8 +37,10 @@ export async function GET(req: NextRequest) {
     const cat = p.category ?? "uncategorized";
     if (!categories[cat]) categories[cat] = [];
 
-    // Parse modifiers from StoreHub JSONB format
-    const modifierGroups = (p.modifiers ?? []).map((m: any) => ({
+    // Parse modifiers from StoreHub JSONB format. Filter by "foodpanda"
+    // channel first so groups/options opted out of delivery are dropped.
+    const visibleMods = filterModifiersForChannel(p.modifiers ?? [], "foodpanda");
+    const modifierGroups = visibleMods.map((m: any) => ({
       name: m.name,
       multiSelect: m.multiSelect ?? false,
       options: (m.options ?? []).map((o: any) => ({

--- a/apps/pos/src/app/api/grab/menu/route.ts
+++ b/apps/pos/src/app/api/grab/menu/route.ts
@@ -18,6 +18,7 @@ import {
   type GrabMenuPayload,
 } from "@/lib/grab";
 import { createClient } from "@/lib/supabase-server";
+import { filterModifiersForChannel } from "@celsius/shared";
 
 interface RawProduct {
   id: string;
@@ -64,6 +65,12 @@ function convertToGrabModifiers(
 }
 
 function convertProductToGrabItem(product: RawProduct): GrabMenuItem {
+  // Drop modifier groups (or options) that opt out of the "grab" channel.
+  const visibleMods = filterModifiersForChannel(
+    product.modifiers as unknown as Parameters<typeof filterModifiersForChannel>[0],
+    "grab",
+  ) as unknown as RawProduct["modifiers"];
+
   return {
     id: product.id,
     name: product.name,
@@ -72,7 +79,7 @@ function convertProductToGrabItem(product: RawProduct): GrabMenuItem {
     description: product.description || undefined,
     price: Math.round(product.sell_price * 100), // RM → sen
     photos: product.image_url ? [product.image_url] : undefined,
-    modifierGroups: convertToGrabModifiers(product.id, product.modifiers),
+    modifierGroups: convertToGrabModifiers(product.id, visibleMods),
   };
 }
 

--- a/apps/pos/src/lib/supabase-queries.ts
+++ b/apps/pos/src/lib/supabase-queries.ts
@@ -1,4 +1,5 @@
 import { createClient } from "./supabase-browser";
+import { filterModifiersForChannel } from "@celsius/shared";
 
 const supabase = createClient();
 
@@ -29,7 +30,15 @@ export async function fetchProducts() {
     .select("*")
     .order("name");
   if (error) throw error;
-  return data ?? [];
+  // Drop modifier groups/options the merchant scoped to other channels
+  // (Pickup, Grab, Foodpanda) so the cashier only sees POS-applicable ones.
+  return (data ?? []).map((p: Record<string, unknown>) => ({
+    ...p,
+    modifiers: filterModifiersForChannel(
+      (p.modifiers as Parameters<typeof filterModifiersForChannel>[0]) ?? [],
+      "pos",
+    ),
+  }));
 }
 
 export async function fetchCategories() {

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -33,6 +33,8 @@ export {
 } from "./format";
 export { sendSMS, getSMSProvider } from "./sms";
 export type { SMSProvider } from "./sms";
+export { filterModifiersForChannel } from "./modifier-channels";
+export type { ModifierChannel, ModifierGroupLike, ModifierOptionLike } from "./modifier-channels";
 // OTP is intentionally NOT re-exported here — it imports node:crypto,
 // which Turbopack pulls into every consumer of this barrel (including
 // Edge Middleware + client bundles) and crashes the build. API routes

--- a/packages/shared/src/modifier-channels.ts
+++ b/packages/shared/src/modifier-channels.ts
@@ -1,0 +1,55 @@
+// Per-channel modifier visibility helper. Shared by POS register, customer
+// pickup app, Grab menu sync, and delivery-platform menu sync so all of them
+// apply the same rule when reading products.modifiers (jsonb) from the
+// products table.
+//
+// Backward compatibility:
+//   - A modifier group with no `channels` field (or an empty array) is
+//     visible on every channel. Pre-channel data continues to work.
+//   - A non-empty `channels` array restricts visibility to the listed
+//     channels only.
+//
+// Channels are intentionally a small fixed set; see ModifierChannel below.
+
+export type ModifierChannel = "pos" | "pickup" | "grab" | "foodpanda" | "dinein";
+
+export interface ModifierOptionLike {
+  id?: string;
+  label?: string;
+  priceDelta?: number;
+  isDefault?: boolean;
+  channels?: ModifierChannel[];
+  [key: string]: unknown;
+}
+
+export interface ModifierGroupLike {
+  id?: string;
+  name?: string;
+  multiSelect?: boolean;
+  options?: ModifierOptionLike[];
+  channels?: ModifierChannel[];
+  [key: string]: unknown;
+}
+
+function visibleOnChannel(channels: ModifierChannel[] | undefined, channel: ModifierChannel): boolean {
+  if (!channels || channels.length === 0) return true;
+  return channels.includes(channel);
+}
+
+// Filter a product's modifier groups to those visible on the given channel.
+// Also drops any options that opt out of the channel (option-level
+// `channels`), but options without `channels` always remain.
+export function filterModifiersForChannel<T extends ModifierGroupLike>(
+  groups: T[] | null | undefined,
+  channel: ModifierChannel,
+): T[] {
+  if (!Array.isArray(groups)) return [];
+  return groups
+    .filter((g) => visibleOnChannel(g.channels, channel))
+    .map((g) => ({
+      ...g,
+      options: Array.isArray(g.options)
+        ? g.options.filter((o) => visibleOnChannel(o.channels, channel))
+        : g.options,
+    }));
+}

--- a/packages/shared/src/modifier-channels.ts
+++ b/packages/shared/src/modifier-channels.ts
@@ -19,7 +19,6 @@ export interface ModifierOptionLike {
   priceDelta?: number;
   isDefault?: boolean;
   channels?: ModifierChannel[];
-  [key: string]: unknown;
 }
 
 export interface ModifierGroupLike {
@@ -28,7 +27,6 @@ export interface ModifierGroupLike {
   multiSelect?: boolean;
   options?: ModifierOptionLike[];
   channels?: ModifierChannel[];
-  [key: string]: unknown;
 }
 
 function visibleOnChannel(channels: ModifierChannel[] | undefined, channel: ModifierChannel): boolean {


### PR DESCRIPTION
## Summary

Each modifier group (and option) on a product can now be restricted to a subset of sales channels (POS / Pickup / GrabFood / Foodpanda / Dine-in). Empty/missing `channels` field keeps existing behaviour — visible on every channel — so the 84 existing products and 25-ish surviving modifier groups continue to work unchanged.

- **Editor**: Row of channel chips per modifier group in the backoffice product form. Toggle chips to restrict; click "reset" or re-tick all to return to "show everywhere".
- **Shared helper**: `filterModifiersForChannel(groups, channel)` in `@celsius/shared` so every consumer enforces the same rule.
- **Wired into 4 read sites**:
  - `apps/order/src/lib/menu-data.ts` → `pickup`
  - `apps/pos/src/lib/supabase-queries.ts` (POS register) → `pos`
  - `apps/pos/src/app/api/grab/menu/route.ts` → `grab`
  - `apps/pos/src/app/api/delivery/menu/route.ts` (Deliverect/Foodpanda) → `foodpanda`

Backoffice editor still loads the full unfiltered list so the merchant manages every channel in one place.

## Test plan

- [ ] In backoffice product edit, toggle channel chips on a modifier group — chips reflect state, "reset" link clears the override.
- [ ] Group with no chips selected → still visible everywhere (default).
- [ ] Customer pickup app menu hides modifiers marked Grab/POS-only.
- [ ] POS register fetch hides modifiers marked Pickup/Grab-only.
- [ ] Grab + Deliverect menu syncs emit only modifiers that include their channel.
- [ ] Existing products with no `channels` field still show all modifiers everywhere (backward compat).

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xd1aERynqUbdCqXNboKWBe)_