### PR TITLE
revert(pickup-native/web): undo body-scroll change — homepage cannot scroll

### DIFF
--- a/apps/pickup-native/app/account.tsx
+++ b/apps/pickup-native/app/account.tsx
@@ -289,13 +289,6 @@ function SignedIn({ phone, onSignOut }: { phone: string; onSignOut: () => void }
 
       <ScrollView
         contentContainerStyle={{ paddingTop: 16, paddingBottom: 160 }}
-        // Web: body owns scroll so iOS Safari can collapse its URL bar.
-        // See index.tsx for the full rationale.
-        style={
-          Platform.OS === "web"
-            ? ({ overflow: "visible", flex: undefined } as any)
-            : undefined
-        }
       >
         {/* Membership tier carousel — same TierCardCarousel that powers
             the legacy /tier-benefits screen. The customer's current

--- a/apps/pickup-native/app/cart.tsx
+++ b/apps/pickup-native/app/cart.tsx
@@ -1,4 +1,4 @@
-import { View, Text, Pressable, ScrollView, Image, Platform } from "react-native";
+import { View, Text, Pressable, ScrollView, Image } from "react-native";
 import { Stack, router } from "expo-router";
 import { Trash2, Gift, X, Coffee, ChevronRight } from "lucide-react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
@@ -245,17 +245,7 @@ export default function Cart() {
         </ScrollView>
       ) : (
         <>
-          <ScrollView
-            contentContainerClassName="px-4 py-4 pb-40 gap-3"
-            // Web: body owns scroll so iOS Safari can collapse its URL bar.
-            // See index.tsx for the full rationale. The sticky cart summary
-            // below switches to position: fixed on web to compensate.
-            style={
-              Platform.OS === "web"
-                ? ({ overflow: "visible", flex: undefined } as any)
-                : undefined
-            }
-          >
+          <ScrollView contentContainerClassName="px-4 py-4 pb-40 gap-3">
             {cart.map((item) => (
               // Whole row tappable → opens the product page in edit
               // mode so customers can change modifiers / notes / qty
@@ -393,17 +383,7 @@ export default function Cart() {
 
           <View
             className="absolute bottom-0 left-0 right-0 px-4 pt-3 bg-background border-t border-border"
-            // On web the body scrolls (so iOS Safari can collapse its URL
-            // bar), which means an `absolute` bar pinned to the page
-            // container would scroll OFF with the body. Switch to fixed so
-            // it tracks the viewport. The ScrollView above pads pb-40 to
-            // keep cart rows from being covered.
-            style={{
-              paddingBottom: insets.bottom + 12,
-              ...(Platform.OS === "web"
-                ? ({ position: "fixed", zIndex: 50 } as any)
-                : null),
-            }}
+            style={{ paddingBottom: insets.bottom + 12 }}
           >
             {appliedReward ? (
               <View

--- a/apps/pickup-native/app/checkout.tsx
+++ b/apps/pickup-native/app/checkout.tsx
@@ -1055,17 +1055,7 @@ export default function Checkout() {
       <Stack.Screen options={{ headerShown: false }} />
       <EspressoHeader title="Checkout" showBack showCart={false} />
 
-      <ScrollView
-        contentContainerClassName="px-4 py-4 pb-32 gap-4"
-        // Web: body owns scroll so iOS Safari can collapse its URL bar.
-        // See index.tsx for the full rationale. The sticky Place Order
-        // panel below switches to position: fixed on web to compensate.
-        style={
-          Platform.OS === "web"
-            ? ({ overflow: "visible", flex: undefined } as any)
-            : undefined
-        }
-      >
+      <ScrollView contentContainerClassName="px-4 py-4 pb-32 gap-4">
         {step === "phone" && (
           <View className="bg-surface rounded-2xl border border-border p-5">
             <Text className="text-espresso text-xs font-bold uppercase tracking-wider">
@@ -1516,18 +1506,10 @@ export default function Checkout() {
       {step === "review" && (
         <View
           className="bg-surface border-t border-border"
-          // On web the ScrollView above releases its scroll to the body
-          // (iOS Safari URL-bar collapse), which means this sibling-flex
-          // bar would scroll off the bottom with the page. Pin it to the
-          // viewport on web; native keeps the flex layout. ScrollView pads
-          // pb-32 to keep content from being covered.
           style={{
             paddingHorizontal: 16,
             paddingTop: 12,
             paddingBottom: insets.bottom + 12,
-            ...(Platform.OS === "web"
-              ? ({ position: "fixed", left: 0, right: 0, bottom: 0, zIndex: 50 } as any)
-              : null),
           }}
         >
           {lastError && (

--- a/apps/pickup-native/app/index.tsx
+++ b/apps/pickup-native/app/index.tsx
@@ -558,17 +558,6 @@ export default function Home() {
 
       <ScrollView
         contentContainerClassName={Platform.OS === "web" ? "pb-32" : "pb-40"}
-        // On web, disable the ScrollView's own scroll so the document
-        // (body) scrolls instead. Body scroll is what iOS Safari watches
-        // to collapse its URL bar — otherwise the bar sits permanently
-        // expanded and eats ~120px of the customer's viewport. Native
-        // keeps the normal ScrollView behaviour (RefreshControl + native
-        // momentum) which is irrelevant on the web bundle.
-        style={
-          Platform.OS === "web"
-            ? ({ overflow: "visible", flex: undefined } as any)
-            : undefined
-        }
         refreshControl={
           <RefreshControl
             refreshing={refreshing}

--- a/apps/pickup-native/app/orders.tsx
+++ b/apps/pickup-native/app/orders.tsx
@@ -5,7 +5,6 @@ import {
   ScrollView,
   Pressable,
   RefreshControl,
-  Platform,
 } from "react-native";
 import { Alert } from "@/lib/alert";
 import { Stack, router, useLocalSearchParams } from "expo-router";
@@ -294,13 +293,6 @@ function OrdersTabView({
       {list.length > 0 ? (
         <ScrollView
           contentContainerClassName="px-4 py-4 pb-32 gap-3"
-          // Web: body owns scroll so iOS Safari can collapse its URL bar.
-          // See index.tsx for the full rationale.
-          style={
-            Platform.OS === "web"
-              ? ({ overflow: "visible", flex: undefined } as any)
-              : undefined
-          }
           refreshControl={
             <RefreshControl
               refreshing={isRefetching}

--- a/apps/pickup-native/app/product/[id].tsx
+++ b/apps/pickup-native/app/product/[id].tsx
@@ -384,14 +384,6 @@ export default function ProductScreen() {
         // matching the bounded-scroll feel of Grab/Foodpanda's
         // product modal.
         contentContainerStyle={{ paddingBottom: keyboardOpen ? 16 : 120 }}
-        // Web: body owns scroll so iOS Safari can collapse its URL bar.
-        // See index.tsx for the full rationale. The Add-to-Cart bar below
-        // switches to position: fixed on web to compensate.
-        style={
-          Platform.OS === "web"
-            ? ({ overflow: "visible", flex: undefined } as any)
-            : undefined
-        }
         stickyHeaderIndices={[]}
         automaticallyAdjustKeyboardInsets
         automaticallyAdjustsScrollIndicatorInsets
@@ -606,15 +598,7 @@ export default function ProductScreen() {
       {!keyboardOpen && (
       <View
         className="absolute bottom-0 left-0 right-0 px-4 pt-3 bg-background border-t border-border"
-        // On web the body scrolls — see ScrollView comment above. Switch
-        // to fixed so the Add-to-Cart bar tracks the viewport instead of
-        // scrolling off with the page.
-        style={{
-          paddingBottom: insets.bottom + 12,
-          ...(Platform.OS === "web"
-            ? ({ position: "fixed", zIndex: 50 } as any)
-            : null),
-        }}
+        style={{ paddingBottom: insets.bottom + 12 }}
       >
         <Pressable
           onPress={onAdd}

--- a/apps/pickup-native/app/rewards.tsx
+++ b/apps/pickup-native/app/rewards.tsx
@@ -1,5 +1,5 @@
 import { useMemo, useState } from "react";
-import { View, Text, ScrollView, Pressable, Image, Dimensions, Platform } from "react-native";
+import { View, Text, ScrollView, Pressable, Image, Dimensions } from "react-native";
 import { Alert } from "@/lib/alert";
 import { Stack, router } from "expo-router";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
@@ -357,14 +357,6 @@ export default function RewardsTab() {
         <ScrollView
           className="flex-1"
           contentContainerStyle={{ padding: 16, paddingBottom: 160 }}
-          // See index.tsx: on web we drop the ScrollView's own scroll so
-          // the body scrolls instead — that's what iOS Safari watches to
-          // collapse its URL bar. Native keeps native momentum scroll.
-          style={
-            Platform.OS === "web"
-              ? ({ overflow: "visible", flex: undefined } as any)
-              : undefined
-          }
         >
           <SignInPrompt />
         </ScrollView>
@@ -388,11 +380,6 @@ export default function RewardsTab() {
         className="flex-1"
         contentContainerStyle={{ padding: 16, paddingBottom: 160, gap: 22 }}
         showsVerticalScrollIndicator={false}
-        style={
-          Platform.OS === "web"
-            ? ({ overflow: "visible", flex: undefined } as any)
-            : undefined
-        }
       >
         <BeansHero
           balance={balance}

--- a/apps/pickup-native/scripts/postbuild-web.mjs
+++ b/apps/pickup-native/scripts/postbuild-web.mjs
@@ -55,23 +55,29 @@ if (html.includes("/manifest.json")) {
 const NEW_VIEWPORT =
   '<meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />';
 
-// Body must be allowed to scroll past viewport height — without that,
-// iOS Safari has no trigger to collapse its URL bar, which permanently
-// eats ~120px of viewport on the customer's phone. Switching from a
-// pinned `height: var(--vph)` to `min-height: 100dvh` (with the older
-// JS-measured --vph as fallback for browsers that ship without dvh)
-// keeps the background filling the visible area at minimum but lets
-// content + the inner ScrollView push the document taller, which is
-// what triggers the URL bar collapse.
+// Use the JS-measured viewport height (--vph) so iOS Safari PWA
+// standalone gets the real pixel viewport — vh/dvh/lvh/svh all
+// under-report by ~150px in standalone mode. We keep `100vh` as
+// the static fallback for browsers that haven't run the JS yet.
+//
+// NOTE: a previous iteration tried switching this to min-height so
+// the body could scroll and iOS Safari would collapse its URL bar,
+// but releasing scroll from the RN ScrollViews didn't actually
+// extend the document — the ScrollView's `flex: 1` default kept its
+// box at viewport height and content just overflowed visually
+// without growing the body. Net effect: no scroll at all. URL-bar
+// collapse needs a different approach (likely sticky-positioned
+// chrome + content rendered as a regular div on web, not via
+// react-native-web's ScrollView). Reverted to the working pinned
+// layout for now.
 const EXPO_RESET_OLD = `      html,
       body {
         height: 100%;
       }`;
 const EXPO_RESET_NEW = `      html,
       body {
-        min-height: 100vh; /* fallback */
-        min-height: var(--vph, 100vh);
-        min-height: 100dvh;
+        height: 100vh; /* fallback */
+        height: var(--vph, 100vh);
       }`;
 const ROOT_OLD = `      #root {
         display: flex;
@@ -80,10 +86,9 @@ const ROOT_OLD = `      #root {
       }`;
 const ROOT_NEW = `      #root {
         display: flex;
-        flex-direction: column;
-        min-height: 100vh;
-        min-height: var(--vph, 100vh);
-        min-height: 100dvh;
+        height: 100vh;
+        height: var(--vph, 100vh);
+        flex: 1;
       }`;
 
 const patched = html


### PR DESCRIPTION
## Summary

**Hotfix.** The body-scroll change shipped in #148/#149 broke scrolling entirely on the customer pickup PWA — the homepage (and every other affected screen) can't scroll at all.

### Why it broke

- `postbuild-web.mjs` switched body + `#root` from `height: var(--vph)` to `min-height: 100dvh`, intending the document to grow past the viewport.
- Each main ScrollView got `style={ overflow: 'visible', flex: undefined }` on web to release its scroll to the body.

What actually happens: react-native-web's `ScrollView` ships `flex: 1` as its own default. Setting `flex: undefined` in the user `style` doesn't unset the default — so the ScrollView's box stays at viewport height. With `overflow: visible` the content paints **outside** the box but doesn't grow it. Body never sees content past the viewport, so body doesn't scroll either. Net result: nothing scrolls.

### What this revert does

- `postbuild-web.mjs` back to `height: var(--vph, 100vh)` on body + `#root` (left a comment explaining why we tried min-height and what to avoid next time).
- Removes the ScrollView `style` overrides on home / rewards / orders / account / cart / checkout / product.
- Restores `absolute bottom-0` (instead of `position: fixed` on web) on the Cart summary, Product Add-to-Cart bar, and Checkout Place Order panel.

### What's kept

The cosmetic chrome trims from #148 are independent of the scroll change and stay:
- Menu sidebar 80→60px and category pills 72→52px on web viewports <420px wide
- Menu product list `pb-44`→`pb-32` on web
- Menu outlet picker row `py-3`→`py-2` on web
- Home `pb-40`→`pb-32` on web

### URL-bar collapse, next steps

iOS Safari URL-bar collapse remains an open problem. The correct fix likely needs the customer-facing content rendered as a regular div on web (not via react-native-web's ScrollView), with the BottomNav + sticky bars portaled to body. That's a bigger refactor and out of scope for this hotfix.

## Test plan

- [ ] Open `order.celsiuscoffee.com` on iPhone — home screen scrolls again.
- [ ] Rewards / Orders / Account / Cart / Checkout / Product detail all scroll.
- [ ] Cart summary + Product Add-to-Cart bar + Checkout Place Order panel still pinned to bottom (now via `absolute`, not `fixed`).
- [ ] Native iOS pickup app build: no diffs.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Xd1aERynqUbdCqXNboKWBe)_