### PR TITLE
fix(pwa/sw): bump cache version v1→v2 so old SW invalidates broken bundle

### DIFF
--- a/apps/order/public/sw.js
+++ b/apps/order/public/sw.js
@@ -1,4 +1,8 @@
-const CACHE = "celsius-v1";
+// Mirror of apps/pickup-native/public/sw.js — overwritten on each
+// build-pwa run. Bumped from v1 to v2 so the new SW deletes the old
+// celsius-v1 cache and pushes existing PWA sessions off the broken
+// bundle that #148/#149 shipped before the #150 revert.
+const CACHE = "celsius-v2";
 const SHELL = ["/", "/index.html", "/manifest.json"];
 
 self.addEventListener("install", (e) => {

--- a/apps/pickup-native/public/sw.js
+++ b/apps/pickup-native/public/sw.js
@@ -1,4 +1,13 @@
-const CACHE = "celsius-v1";
+// Bumped from celsius-v1 to invalidate the cache after PR #148/#149
+// shipped a broken bundle (body-scroll experiment) — clients with the
+// old SW were stuck serving the cached broken JS even after the #150
+// revert deployed. Bumping the name forces the activate handler below
+// to delete the old cache; clients.claim() + skipWaiting() then push
+// existing PWA sessions onto the new bundle on next fetch.
+//
+// Future rule of thumb: bump this on ANY production-affecting bundle
+// regression so customers don't get stuck on a bad build.
+const CACHE = "celsius-v2";
 const SHELL = ["/", "/index.html", "/manifest.json"];
 
 self.addEventListener("install", (e) => {


### PR DESCRIPTION
## Summary

After #148/#149 shipped the body-scroll regression and #150 reverted it, existing PWA sessions can still be stuck on the broken bundle because the service worker (`sw.js:23-36`) serves `/_expo/static/*` **cache-first with no revalidation**. The cached broken JS keeps loading even after the corrected bundle deployed.

Bumping `CACHE = "celsius-v1"` → `"celsius-v2"` invalidates that cache:

1. New `sw.js` differs by byte content → browser detects the update on next navigation.
2. `skipWaiting()` (existing handler) activates the new SW immediately.
3. `activate()` deletes every cache that isn't `celsius-v2` → the old `celsius-v1` cache (with the bad bundle) is purged.
4. `clients.claim()` puts existing PWA sessions under the new SW.
5. Next `/_expo/static/*` fetch: cache miss → network → fresh, working bundle served.

Mirroring the bump in `apps/order/public/sw.js` — `build-pwa.mjs` overwrites that file from `pickup-native/dist/` on each build, but keeping the repo snapshot in sync avoids drift.

## Test plan

- [ ] After deploy: open `order.celsiuscoffee.com` on an iPhone that previously had the broken bundle → scroll works without a hard-reload.
- [ ] DevTools Application → Service Workers shows `celsius-v2` cache, `celsius-v1` is gone.
- [ ] Fresh install (Add to Home Screen on a new device): scroll works.
- [ ] Future bundle deploys still benefit from cache-first speed on `/_expo/static/*` — only the bundle hash changes drive the cache, the cache name stays at v2.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Xd1aERynqUbdCqXNboKWBe)_