### PR TITLE
fix(home/web): scroll the hero with the page, not just the section list

### DIFF
--- a/apps/pickup-native/app/index.tsx
+++ b/apps/pickup-native/app/index.tsx
@@ -305,6 +305,25 @@ export default function Home() {
 
   return (
     <View className="flex-1 bg-background">
+      {/* One scrollable container for the whole home screen — hero,
+          outlet row, and the rest below all scroll together. Previously
+          only the bottom half (the section list inside an inner
+          ScrollView) scrolled; the hero stayed frozen, which made the
+          page feel uncscrollable in a mobile browser. The top-bar logo
+          + cart icon is `position: absolute` and now scrolls with the
+          page content (its containing block moved from this outer View
+          to the ScrollView's content). */}
+      <ScrollView
+        contentContainerClassName={Platform.OS === "web" ? "pb-32" : "pb-40"}
+        refreshControl={
+          <RefreshControl
+            refreshing={refreshing}
+            onRefresh={onRefresh}
+            tintColor="#A2492C"
+            colors={["#A2492C"]}
+          />
+        }
+      >
       {/* Top bar — small wordmark + cart, sits over the poster top edge.
           Espresso ink against the cream backdrop on the carousel
           (posters generally have darker bottoms; the top is fine).
@@ -556,17 +575,6 @@ export default function Home() {
         <ChevronRight size={13} color="#8E8E93" />
       </Pressable>
 
-      <ScrollView
-        contentContainerClassName={Platform.OS === "web" ? "pb-32" : "pb-40"}
-        refreshControl={
-          <RefreshControl
-            refreshing={refreshing}
-            onRefresh={onRefresh}
-            tintColor="#A2492C"
-            colors={["#A2492C"]}
-          />
-        }
-      >
         {/* Guest sign-in CTA — surfaces FIRST for logged-out users so the
             membership ask lands the moment the app opens. Espresso panel
             with terracotta gift icon mirrors brand promo styling, so it


### PR DESCRIPTION
## Summary

Restructures the home screen so the **whole page scrolls as one unit** instead of just a strip below the frozen hero.

### What was happening

The hero (poster + Hi-Ammar BEANS/REWARDS card) and outlet picker were rendered as **siblings** of the ScrollView, not inside it. Only the bottom half (challenges, voucher rail, sections) scrolled; the hero stayed pinned. With iOS Safari's URL bar eating ~120px on top of the BottomNav + the frozen hero on top, the actual scrollable strip was tiny and the page felt un-scrollable.

### What changed

- Single `ScrollView` opens right after the outer `flex-1` View and wraps the hero, outlet row, and everything below.
- The top-bar logo + cart icon stays `position: absolute` but its containing block is now the ScrollView's content div — so it scrolls with the page (slides off-screen as the customer scrolls down).
- `BottomNav` + the floating `ViewCartFloatingBar` still sit **outside** the ScrollView (portaled to document.body on web, position-fixed) so they stay pinned to the viewport.

### Scope

Only `apps/pickup-native/app/index.tsx`. Rewards / Menu / Orders / Account / Cart / Checkout / Product detail untouched — the user specifically called out the homepage hero. If this lands cleanly the same pattern can roll onto the EspressoHeader screens next.

## Test plan

- [ ] iPhone Safari: open `order.celsiuscoffee.com` → entire home scrolls as one. The hero poster + Hi-Ammar card slides up off-screen as you scroll down.
- [ ] BottomNav + cart pill still pinned to the viewport bottom while scrolling.
- [ ] Pull-to-refresh still triggers the RefreshControl (which now sits on the outer ScrollView).
- [ ] Standalone PWA mode (Add to Home Screen): same behaviour.
- [ ] Native iOS app build: no visual diff.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Xd1aERynqUbdCqXNboKWBe)_