### PR TITLE
[probe] home/web: defeat ScrollView's flex:1 default so body scrolls + Safari URL bar collapses

### DIFF
--- a/apps/pickup-native/app/index.tsx
+++ b/apps/pickup-native/app/index.tsx
@@ -315,6 +315,28 @@ export default function Home() {
           to the ScrollView's content). */}
       <ScrollView
         contentContainerClassName={Platform.OS === "web" ? "pb-32" : "pb-40"}
+        // On web we deliberately defeat ScrollView's own scroll so the
+        // document itself scrolls — that's what iOS Safari watches to
+        // collapse its URL bar. Just `overflow: visible` isn't enough
+        // because RN-Web ships `flex: 1` as the default and content
+        // would paint outside a viewport-sized box without growing it.
+        // We explicitly set flexGrow:0 + flexBasis:auto + height:auto so
+        // the ScrollView's box sizes to its content, the content
+        // extends the document, body grows, URL bar collapses.
+        // Paired with the postbuild-web.mjs change that makes body +
+        // #root `min-height: 100dvh` instead of pinned height. Native
+        // keeps the normal ScrollView behaviour.
+        style={
+          Platform.OS === "web"
+            ? ({
+                overflow: "visible",
+                flexGrow: 0,
+                flexShrink: 0,
+                flexBasis: "auto",
+                height: "auto",
+              } as any)
+            : undefined
+        }
         refreshControl={
           <RefreshControl
             refreshing={refreshing}

--- a/apps/pickup-native/scripts/postbuild-web.mjs
+++ b/apps/pickup-native/scripts/postbuild-web.mjs
@@ -55,29 +55,29 @@ if (html.includes("/manifest.json")) {
 const NEW_VIEWPORT =
   '<meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />';
 
-// Use the JS-measured viewport height (--vph) so iOS Safari PWA
-// standalone gets the real pixel viewport — vh/dvh/lvh/svh all
-// under-report by ~150px in standalone mode. We keep `100vh` as
-// the static fallback for browsers that haven't run the JS yet.
+// Body uses min-height so the document can grow with content — that's
+// what iOS Safari needs to see for its URL bar to collapse on scroll.
+// Background still fills the visible viewport at minimum (100dvh, with
+// var(--vph)/100vh fallbacks).
 //
-// NOTE: a previous iteration tried switching this to min-height so
-// the body could scroll and iOS Safari would collapse its URL bar,
-// but releasing scroll from the RN ScrollViews didn't actually
-// extend the document — the ScrollView's `flex: 1` default kept its
-// box at viewport height and content just overflowed visually
-// without growing the body. Net effect: no scroll at all. URL-bar
-// collapse needs a different approach (likely sticky-positioned
-// chrome + content rendered as a regular div on web, not via
-// react-native-web's ScrollView). Reverted to the working pinned
-// layout for now.
+// The previous "min-height" attempt (#148/#149) was reverted because
+// the per-screen RN ScrollViews still owned scroll — their `flex: 1`
+// default kept their boxes at viewport height and content didn't extend
+// the document. The matching screen-level fix lives in each screen file
+// (overflow: visible + flexGrow: 0 + flexBasis: auto + height: auto on
+// the outer ScrollView) so this min-height change is paired with code
+// that actually lets the document grow. Currently only the home screen
+// is converted — other screens keep the old behaviour (their content is
+// shorter than viewport anyway, so they don't need to scroll).
 const EXPO_RESET_OLD = `      html,
       body {
         height: 100%;
       }`;
 const EXPO_RESET_NEW = `      html,
       body {
-        height: 100vh; /* fallback */
-        height: var(--vph, 100vh);
+        min-height: 100vh; /* fallback */
+        min-height: var(--vph, 100vh);
+        min-height: 100dvh;
       }`;
 const ROOT_OLD = `      #root {
         display: flex;
@@ -86,9 +86,10 @@ const ROOT_OLD = `      #root {
       }`;
 const ROOT_NEW = `      #root {
         display: flex;
-        height: 100vh;
-        height: var(--vph, 100vh);
-        flex: 1;
+        flex-direction: column;
+        min-height: 100vh;
+        min-height: var(--vph, 100vh);
+        min-height: 100dvh;
       }`;
 
 const patched = html


### PR DESCRIPTION
## ⚠️ Probe — DO NOT MERGE without verifying on the preview deploy

Second attempt at iOS Safari URL-bar collapse. The first attempt (#148/#149) was reverted because it actually broke scrolling. This time the override is more precise:

### What's different from the broken attempt

| | Broken attempt (#148/#149) | This attempt |
|---|---|---|
| body / #root | `min-height: 100dvh` ✓ | `min-height: 100dvh` ✓ |
| ScrollView style | `{ overflow: visible, flex: undefined }` ✗ | `{ overflow: visible, flexGrow: 0, flexShrink: 0, flexBasis: 'auto', height: 'auto' }` |

`flex: undefined` doesn't override RN-Web's default `flex: 1` (React doesn't apply undefined keys, so the default wins on merge). The ScrollView's box stayed clamped at viewport, content painted **outside** the box but the body never grew → no scroll triggered.

This time we explicitly set `flexGrow: 0` + `flexBasis: 'auto'` + `height: 'auto'` so the ScrollView's box sizes to its content. The content extends the document → body grows → iOS Safari sees scroll → URL bar collapses.

### Scope

Home screen only. Rewards / Orders / Menu / Account / Cart / Checkout / Product detail kept on the old (working) behaviour — last time we changed all screens at once it bricked everything. If this lands cleanly we can roll the pattern out one screen at a time.

## Verification before merging

The Vercel preview URL will appear in a comment shortly. **Before merging:**

- [ ] Open the preview on iPhone Safari. Scroll down on the home screen.
- [ ] Confirm URL bar slims / hides as you scroll past a few hundred px.
- [ ] Confirm the whole home content still scrolls (hero + outlet picker + sections + everything below).
- [ ] Confirm `BottomNav` + `View cart` pill stay pinned to the viewport bottom.
- [ ] Confirm pull-to-refresh still works (RefreshControl on the ScrollView).
- [ ] If anything's broken — say so and I'll iterate, **don't merge**.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Xd1aERynqUbdCqXNboKWBe)_