### PR TITLE
fix(cart/web): scroll header with cart contents instead of freezing it

### DIFF
--- a/apps/pickup-native/app/cart.tsx
+++ b/apps/pickup-native/app/cart.tsx
@@ -117,7 +117,6 @@ export default function Cart() {
   return (
     <View className="flex-1 bg-background">
       <Stack.Screen options={{ headerShown: false }} />
-      <EspressoHeader title="Your cart" subtitle={outletName ? `Pickup from ${outletName}` : undefined} showBack showCart={false} />
 
       {cart.length === 0 ? (
         // Empty cart should sell, not just say "empty". Espresso hero
@@ -127,6 +126,7 @@ export default function Cart() {
         // them concrete tap targets — most empty-cart customers are
         // first-timers or returning after a flush.
         <ScrollView contentContainerClassName="pb-12">
+          <EspressoHeader title="Your cart" subtitle={outletName ? `Pickup from ${outletName}` : undefined} showBack showCart={false} />
           <View
             className="mx-4 mt-4 bg-espresso rounded-2xl overflow-hidden"
             style={{
@@ -245,7 +245,9 @@ export default function Cart() {
         </ScrollView>
       ) : (
         <>
-          <ScrollView contentContainerClassName="px-4 py-4 pb-40 gap-3">
+          <ScrollView contentContainerClassName="pb-40">
+            <EspressoHeader title="Your cart" subtitle={outletName ? `Pickup from ${outletName}` : undefined} showBack showCart={false} />
+            <View className="px-4 py-4" style={{ gap: 12 }}>
             {cart.map((item) => (
               // Whole row tappable → opens the product page in edit
               // mode so customers can change modifiers / notes / qty
@@ -379,6 +381,7 @@ export default function Cart() {
                 </View>
               </Pressable>
             ))}
+            </View>
           </ScrollView>
 
           <View


### PR DESCRIPTION
## Summary

Same one-scroll treatment that fixed home in #152, now applied to cart.

### What was happening

Cart had `EspressoHeader` frozen above a `flex: 1` ScrollView. On a mobile browser:
- Header eats ~80px
- Absolute bottom summary panel eats ~150-260px (varies with applied rewards / promos / tier hints)
- ScrollView gets the thin middle strip

With a few items the strip is too short to scroll meaningfully, and a customer with a tall bottom panel can feel like nothing scrolls at all.

### What changed

`EspressoHeader` moves **inside** both ScrollViews (empty cart + non-empty cart branches). The header now scrolls with the cart rows. The absolute bottom summary panel stays pinned to the viewport bottom — same as `BottomNav` on home.

Small refactor on the non-empty branch: the previous `contentContainerClassName="px-4 py-4 pb-40 gap-3"` baked padding + gap onto the entire scroll content, which doesn't work when the header needs to sit full-bleed at the top (the header has its own `px-4`). Moved the `px-4/py-4/gap` onto an inner View around just the cart rows.

### Scope

Cart only. Same pattern still pending on Rewards / Orders / Account / Checkout / Product detail / Menu — handle those one at a time if you confirm cart looks right.

## Test plan

- [ ] iPhone Safari: cart with 1 item → header scrolls up off-screen when you scroll down.
- [ ] Cart with 5+ items → list scrolls; summary panel stays pinned to the viewport bottom.
- [ ] Slide-to-confirm + payment buttons still work.
- [ ] Empty cart → espresso hero + best-sellers list scrolls; header scrolls with it.
- [ ] Native iOS pickup app build → no visual diff (header is just the first scroll child).


---
_Generated by [Claude Code](https://claude.ai/code/session_01Xd1aERynqUbdCqXNboKWBe)_