### PR TITLE
fix(cart): move summary panel inside ScrollView so the cart actually scrolls

### DIFF
--- a/apps/pickup-native/app/cart.tsx
+++ b/apps/pickup-native/app/cart.tsx
@@ -245,7 +245,7 @@ export default function Cart() {
         </ScrollView>
       ) : (
         <>
-          <ScrollView contentContainerClassName="pb-40">
+          <ScrollView>
             <EspressoHeader title="Your cart" subtitle={outletName ? `Pickup from ${outletName}` : undefined} showBack showCart={false} />
             <View className="px-4 py-4" style={{ gap: 12 }}>
             {cart.map((item) => (
@@ -382,10 +382,17 @@ export default function Cart() {
               </Pressable>
             ))}
             </View>
-          </ScrollView>
 
+          {/* Summary + slide-to-confirm — flows at the end of the
+              ScrollView instead of pinning to the viewport. Pinning
+              made the panel sit on top of the scroll surface and
+              intercept touch gestures across the bottom half of the
+              screen, which made the cart feel un-scrollable on mobile
+              browsers. Letting it scroll with the rest of the content
+              matches the home flow (#152) and guarantees the user's
+              swipe lands on the scroll surface, not on dead buttons. */}
           <View
-            className="absolute bottom-0 left-0 right-0 px-4 pt-3 bg-background border-t border-border"
+            className="px-4 pt-3 border-t border-border"
             style={{ paddingBottom: insets.bottom + 12 }}
           >
             {appliedReward ? (
@@ -595,6 +602,7 @@ export default function Cart() {
               </Text>
             </Pressable>
           </View>
+          </ScrollView>
         </>
       )}
     </View>


### PR DESCRIPTION
## Summary

After #155 (header into ScrollView) the cart **still didn't scroll**. The remaining culprit: the summary + slide-to-confirm panel was still `position: absolute` pinned to the viewport bottom, sitting on top of the ScrollView. The panel is tall (rewards row + totals + the big Continue-to-checkout button), often eating 40-50% of the screen on a mobile browser. Any swipe in that area was caught by the panel's Pressables instead of reaching the ScrollView underneath — making the cart feel frozen.

## Fix

Pull the summary panel **into** the ScrollView as the last child. The whole cart screen now scrolls as one unit: header at top, items in the middle, summary + checkout button at the bottom. Same model as home (#152).

## Trade-off

"Continue to checkout" no longer pins to the viewport. With 1-2 items it's visible without scrolling anyway; with many items the customer scrolls past their cart to commit. That's how Grab / Foodpanda already do it in browser, so it's a familiar pattern.

## Test plan

- [ ] iPhone Safari: cart with 1 item → everything fits, scrolling not needed.
- [ ] Cart with 5+ items → swipe up anywhere on the screen scrolls; reach the Continue-to-checkout button by scrolling to the bottom.
- [ ] Slide-to-confirm, applied reward chip, total breakdown all still render correctly inline.
- [ ] Native iOS pickup app: visual diff — the panel was previously pinned, now it's at the bottom of the scroll. Acceptable on phone (one scroll, no behaviour change). If you want the pinned bar back on native specifically, say so — easy to gate with `Platform.OS === "web"`.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Xd1aERynqUbdCqXNboKWBe)_