### PR TITLE
[probe] pwa: universal CSS selector — escalation of URL-bar collapse attempt

### DIFF
--- a/apps/pickup-native/scripts/postbuild-web.mjs
+++ b/apps/pickup-native/scripts/postbuild-web.mjs
@@ -13,27 +13,27 @@ const HEAD_EXTRA = `
   <meta name="apple-mobile-web-app-title" content="Celsius">
   <meta name="format-detection" content="telephone=no">
   <style>
-    /* iOS Safari URL-bar collapse probe.
-       Forces body to scroll (not the inner ScrollView) so iOS Safari
-       sees document overflow and minimises its URL bar. Targets the
-       first few levels of div nesting under #root because RN-Web's
-       GestureHandlerRootView, SafeAreaProvider, expo-router Stack, and
-       page-level Views all ship min-height:0 + flex:1 defaults that
-       otherwise clamp content at viewport. Wide blast radius — if it
-       breaks any screen layout, the right answer is to revert this
-       block, not to add per-screen overrides.
+    /* iOS Safari URL-bar collapse — escalated version.
+       Earlier nested-5-level selector didn't reach the ScrollView in
+       practice — RN-Web wraps each context provider as its own div,
+       so the actual depth from #root to the scroll container is 8+.
+       Replaced with a universal descendant selector under #root so
+       EVERY wrapper div is sized to its content, no inner element can
+       keep the document at viewport height.
 
-       Scoped to web only (this whole file is the web postbuild). */
+       Cards / images that need overflow: hidden for rounded corners
+       use it via inline style and that's normally beaten by
+       !important — accept the cosmetic regression on those vs.
+       leaving the URL bar permanently expanded. */
     html, body {
       overflow-x: hidden;
     }
-    #root > *,
-    #root > * > *,
-    #root > * > * > *,
-    #root > * > * > * > *,
-    #root > * > * > * > * > * {
-      flex: 0 0 auto !important;
+    #root * {
+      flex-grow: 0 !important;
+      flex-shrink: 0 !important;
+      flex-basis: auto !important;
       min-height: 0 !important;
+      max-height: none !important;
       height: auto !important;
       overflow: visible !important;
     }


### PR DESCRIPTION
## ⚠️ Probe — verify before merging

Escalation of #157. That PR's nested 5-level selector turned out not to reach the ScrollView in practice — RN-Web wraps each context provider (StripeProvider, QueryClientProvider, RootErrorBoundary, SafeAreaProvider, etc.) as its own div, pushing the scroll container 8+ levels deep under `#root`. Beyond the selector's reach, so the ScrollView's `overflow: auto` + `flex: 1` defaults kept the body clamped at viewport. URL bar stayed expanded.

This version replaces the nested chain with a universal descendant selector:

```css
#root * {
  flex-grow: 0 !important;
  flex-shrink: 0 !important;
  flex-basis: auto !important;
  min-height: 0 !important;
  max-height: none !important;
  height: auto !important;
  overflow: visible !important;
}
```

Hits EVERY descendant. No more guessing depth.

## Trade-off

Wide blast radius — every wrapper div under `#root` becomes content-sized + `overflow: visible`. Cards / images that rely on inline `overflow: hidden` for rounded corners may clip differently. Accepted vs. the URL bar permanently eating ~120px.

## Verify on preview

Same checklist as #157, plus:

- [ ] Rounded product images on the menu / home cards still look correctly clipped (not square outside the rounded mask).
- [ ] Tier card carousel + voucher wallet aren't visually broken.
- [ ] BottomNav + cart pill still pinned (they're under `<body>` not `#root`, so unaffected).
- [ ] **URL bar slims on scroll-down on the home screen** — the actual point of this exercise.

If anything's broken cosmetically beyond what's acceptable, say "close" and I'll close the PR.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Xd1aERynqUbdCqXNboKWBe)_