### PR TITLE
revert(pwa): undo URL-bar collapse CSS — broke layouts in production

### DIFF
--- a/apps/order/public/sw.js
+++ b/apps/order/public/sw.js
@@ -1,8 +1,7 @@
 // Mirror of apps/pickup-native/public/sw.js — overwritten on each
-// build-pwa run. Bumped from v1 to v2 so the new SW deletes the old
-// celsius-v1 cache and pushes existing PWA sessions off the broken
-// bundle that #148/#149 shipped before the #150 revert.
-const CACHE = "celsius-v2";
+// build-pwa run. v3 bumps over v2 to flush customers off the broken
+// CSS shipped in #157/#158 before this revert deployed.
+const CACHE = "celsius-v3";
 const SHELL = ["/", "/index.html", "/manifest.json"];
 
 self.addEventListener("install", (e) => {

--- a/apps/pickup-native/public/sw.js
+++ b/apps/pickup-native/public/sw.js
@@ -1,13 +1,12 @@
-// Bumped from celsius-v1 to invalidate the cache after PR #148/#149
-// shipped a broken bundle (body-scroll experiment) — clients with the
-// old SW were stuck serving the cached broken JS even after the #150
-// revert deployed. Bumping the name forces the activate handler below
-// to delete the old cache; clients.claim() + skipWaiting() then push
-// existing PWA sessions onto the new bundle on next fetch.
+// Bumped to v3 after the brute-force CSS in #157/#158 broke layouts in
+// production. Customers stuck on the broken bundle via the cache need
+// the new SW (with a fresh cache name) to install + activate +
+// clients.claim() before they'll see the revert. Same drill as the
+// v1->v2 bump after #148/#149.
 //
 // Future rule of thumb: bump this on ANY production-affecting bundle
 // regression so customers don't get stuck on a bad build.
-const CACHE = "celsius-v2";
+const CACHE = "celsius-v3";
 const SHELL = ["/", "/index.html", "/manifest.json"];
 
 self.addEventListener("install", (e) => {

--- a/apps/pickup-native/scripts/postbuild-web.mjs
+++ b/apps/pickup-native/scripts/postbuild-web.mjs
@@ -12,35 +12,6 @@ const HEAD_EXTRA = `
   <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
   <meta name="apple-mobile-web-app-title" content="Celsius">
   <meta name="format-detection" content="telephone=no">
-  <style>
-    /* iOS Safari URL-bar collapse — escalated version.
-       Earlier nested-5-level selector didn't reach the ScrollView in
-       practice — RN-Web wraps each context provider as its own div,
-       so the actual depth from #root to the scroll container is 8+.
-       Replaced with a universal descendant selector under #root so
-       EVERY wrapper div is sized to its content, no inner element can
-       keep the document at viewport height.
-
-       Cards / images that need overflow: hidden for rounded corners
-       use it via inline style and that's normally beaten by
-       !important — accept the cosmetic regression on those vs.
-       leaving the URL bar permanently expanded. */
-    html, body {
-      overflow-x: hidden;
-    }
-    #root * {
-      flex-grow: 0 !important;
-      flex-shrink: 0 !important;
-      flex-basis: auto !important;
-      min-height: 0 !important;
-      max-height: none !important;
-      height: auto !important;
-      overflow: visible !important;
-    }
-    /* Keep portals (BottomNav, MenuCartFloatingBar) anchored to the
-       viewport — they're children of <body>, not descendants of #root,
-       so the rules above don't touch them. */
-  </style>
 `;
 
 const BODY_EXTRA = `
@@ -84,21 +55,23 @@ if (html.includes("/manifest.json")) {
 const NEW_VIEWPORT =
   '<meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />';
 
-// Body uses min-height so the document can grow with content. Paired
-// with the brute-force CSS in HEAD_EXTRA that forces every ancestor
-// under #root to be content-sized (flex:0 0 auto, overflow:visible,
-// min-height:0). Without that pairing this min-height does nothing —
-// see PR #150 for the lesson. With it, body actually overflows when
-// content exceeds the viewport, and iOS Safari collapses its URL bar.
+// Use the JS-measured viewport height (--vph) so iOS Safari PWA
+// standalone gets the real pixel viewport — vh/dvh/lvh/svh all
+// under-report by ~150px in standalone mode. We keep `100vh` as
+// the static fallback for browsers that haven't run the JS yet.
+//
+// (URL-bar collapse experiments shipped in #157/#158 broke layouts
+// and are reverted here. The URL bar stays expanded in non-standalone
+// iOS Safari; customers who use the PWA often should install via Add
+// to Home Screen — that's the only reliable way to lose the URL bar.)
 const EXPO_RESET_OLD = `      html,
       body {
         height: 100%;
       }`;
 const EXPO_RESET_NEW = `      html,
       body {
-        min-height: 100vh; /* fallback */
-        min-height: var(--vph, 100vh);
-        min-height: 100dvh;
+        height: 100vh; /* fallback */
+        height: var(--vph, 100vh);
       }`;
 const ROOT_OLD = `      #root {
         display: flex;
@@ -107,10 +80,9 @@ const ROOT_OLD = `      #root {
       }`;
 const ROOT_NEW = `      #root {
         display: flex;
-        flex-direction: column;
-        min-height: 100vh;
-        min-height: var(--vph, 100vh);
-        min-height: 100dvh;
+        height: 100vh;
+        height: var(--vph, 100vh);
+        flex: 1;
       }`;
 
 const patched = html


### PR DESCRIPTION
## Hotfix — revert URL-bar collapse CSS

The brute-force `#root *` CSS shipped in #157 and escalated in #158 broke screen layouts. Reverting both attempts.

### What this removes

- The injected `<style>` block (was forcing every wrapper div under `#root` to `flex-grow: 0 + min-height: 0 + height: auto + overflow: visible` — too aggressive, broke nested layouts that legitimately rely on `flex-grow: 1` or `overflow: hidden`).
- The body + `#root` `min-height: 100dvh` swap. Back to the pinned `height: var(--vph)` model that's been working since the start.

### SW cache bump

`celsius-v2 → celsius-v3` so customers stuck on the broken bundle get the fix on next visit. `skipWaiting()` + `clients.claim()` are already in place, and the new cache name triggers the old-cache delete in the SW's `activate()` handler.

### URL bar — accepting the limit

After three attempts (#148/#149 reverted by #150, #153 closed without merging, #157/#158 reverted here), the conclusion is clear: collapsing iOS Safari's URL bar from inside the RN-Web architecture isn't workable without a deeper refactor. The honest path for power users is the Add-to-Home-Screen hint shipped in #154 — install once, never see the URL bar again.

## Test plan

- [ ] Open `order.celsiuscoffee.com` on iPhone — every screen lays out correctly again (home, menu, cart, checkout, product detail, orders, rewards, account).
- [ ] Rounded product images / tier cards / voucher wallet visuals no longer clipped wrong.
- [ ] BottomNav + cart pill still pinned to viewport.
- [ ] Native iOS pickup app build: no diffs.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Xd1aERynqUbdCqXNboKWBe)_