### PR TITLE
fix: floating cart pill leaking onto /cart + /checkout via expo-router Stack

### DIFF
--- a/apps/pickup-native/app/index.tsx
+++ b/apps/pickup-native/app/index.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useState } from "react";
 import { Platform, View, Text, Pressable, ScrollView, Image, RefreshControl } from "react-native";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
-import { router } from "expo-router";
+import { router, usePathname } from "expo-router";
 import { MapPin, ChevronRight, Coffee, Sparkles, Gift, Clock4, ShoppingCart } from "lucide-react-native";
 import * as Haptics from "@/lib/haptics";
 import { supabase, type Outlet } from "../lib/supabase";
@@ -1191,6 +1191,12 @@ function ViewCartFloatingBar({
   onPress: () => void;
 }) {
   const isWeb = Platform.OS === "web";
+  // Expo-router's Stack keeps prior screens mounted while a new one is
+  // pushed on top, so this bar's portal stays in the DOM while the
+  // customer is on /cart / /checkout / /product/[id]. Gate on pathname
+  // so it only renders when home is actually the active route.
+  const pathname = usePathname();
+  if (pathname !== "/") return null;
   const webOverrides = isWeb
     ? ({
         position: "fixed" as unknown as "absolute",

--- a/apps/pickup-native/app/menu.tsx
+++ b/apps/pickup-native/app/menu.tsx
@@ -12,7 +12,7 @@ import {
   type NativeScrollEvent,
   type LayoutChangeEvent,
 } from "react-native";
-import { Stack, router, useLocalSearchParams } from "expo-router";
+import { Stack, router, useLocalSearchParams, usePathname } from "expo-router";
 import { useQuery } from "@tanstack/react-query";
 import * as Haptics from "@/lib/haptics";
 import {
@@ -681,6 +681,15 @@ function MenuCartFloatingBar({
   onPress: () => void;
 }) {
   const isWeb = Platform.OS === "web";
+  // Same trap as ViewCartFloatingBar in index.tsx — expo-router keeps
+  // the menu screen mounted while /cart, /checkout, etc. sit on top of
+  // the Stack, so this bar's body-portal stays in the DOM and shows on
+  // pages where it's redundant. Gate on pathname so it only renders on
+  // the menu / product detail routes that actually want it.
+  const pathname = usePathname();
+  if (!pathname.startsWith("/menu") && !pathname.startsWith("/product")) {
+    return null;
+  }
   const webOverrides = isWeb
     ? ({
         position: "fixed" as unknown as "absolute",


### PR DESCRIPTION
## Summary

Customer screenshot showed a "View cart" terracotta pill stacked above the BottomNav **on the /cart page itself** — redundant and visually confusing.

### Root cause

`ViewCartFloatingBar` (home) and `MenuCartFloatingBar` (menu) are portaled to `document.body` via `createPortal` on web so they pin to the viewport regardless of the body-scroll setup. Expo-router's Stack keeps the previous screen mounted while a new one is pushed on top — so when the customer goes Home → /cart, Home stays alive in the background and its portaled pill is still in the DOM.

### Fix

Both bar components now read `usePathname()` and bail early if the current route isn't one that wants the pill:

- `ViewCartFloatingBar` → only on `/`.
- `MenuCartFloatingBar` → only on `/menu*` or `/product*`.

Native unchanged (RN navigation usually unmounts prior screens, so this was a web-specific Stack side effect — `usePathname` is harmless on native either way).

## Test plan

- [ ] iPhone Safari: navigate Home → /cart. No "View cart" pill on the cart page.
- [ ] /menu → /cart. No floating cart pill on the cart page.
- [ ] /cart → back to home or menu. Pill reappears where it belongs.
- [ ] /product/[id]: pill from menu still shows (intentional — it's the path to add-and-checkout).
- [ ] Checkout: no stray pills.
- [ ] Native iOS pickup app: no visual diff.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Xd1aERynqUbdCqXNboKWBe)_