### PR TITLE
fix: lift BottomNav + View-cart pill to global layout — stop leaking onto cart/checkout

### DIFF
--- a/apps/order/public/sw.js
+++ b/apps/order/public/sw.js
@@ -1,7 +1,7 @@
 // Mirror of apps/pickup-native/public/sw.js — overwritten on each
 // build-pwa run. v3 bumps over v2 to flush customers off the broken
 // CSS shipped in #157/#158 before this revert deployed.
-const CACHE = "celsius-v3";
+const CACHE = "celsius-v4";
 const SHELL = ["/", "/index.html", "/manifest.json"];
 
 self.addEventListener("install", (e) => {

--- a/apps/pickup-native/app/_layout.tsx
+++ b/apps/pickup-native/app/_layout.tsx
@@ -1,5 +1,5 @@
 import "../global.css";
-import { Stack, router } from "expo-router";
+import { Stack, router, usePathname } from "expo-router";
 import { StatusBar } from "expo-status-bar";
 import { SafeAreaProvider } from "react-native-safe-area-context";
 import { GestureHandlerRootView } from "react-native-gesture-handler";
@@ -14,6 +14,8 @@ import { useFonts } from "expo-font";
 import { SplashPoster } from "../components/SplashPoster";
 import { LogoIntro } from "../components/LogoIntro";
 import { MaintenanceBanner } from "../components/MaintenanceBanner";
+import { GlobalCartPill } from "../components/GlobalCartPill";
+import { BottomNav } from "../components/BottomNav";
 import { StripeUrlHandler } from "../components/StripeUrlHandler";
 import { RootErrorBoundary } from "../components/RootErrorBoundary";
 import { Toast } from "../components/Toast";
@@ -70,6 +72,23 @@ const queryClient = new QueryClient({
 // 1.3 still respects the user's preference noticeably, but our cards,
 // pills, and tier-hero overlays were designed against 1.0–1.2× and
 // start clipping past that.
+// Routes where the BottomNav (Home/Rewards/Menu/Orders/Account) is
+// shown. Everything else (cart, checkout, product detail, order
+// detail, store picker, settings, support, etc.) opts out — matches
+// native iOS behaviour where those screens never imported BottomNav.
+const BOTTOM_NAV_ROUTES = (pathname: string) =>
+  pathname === "/" ||
+  pathname.startsWith("/menu") ||
+  pathname === "/orders" ||
+  pathname === "/rewards" ||
+  pathname === "/account";
+
+function GlobalBottomNav() {
+  const pathname = usePathname();
+  if (!BOTTOM_NAV_ROUTES(pathname)) return null;
+  return <BottomNav />;
+}
+
 function applyDefaultFont() {
   const TextAny = Text as any;
   const InputAny = TextInput as any;
@@ -353,6 +372,18 @@ const RootLayout = function RootLayout() {
                     <Stack.Screen name="account" options={{ animation: "none" }} />
                   </Stack>
                   <MaintenanceBanner />
+                  {/* BottomNav + "View cart" pill are mounted globally
+                      here, not inside each screen. Earlier they were
+                      in index.tsx / menu.tsx / orders.tsx / etc., each
+                      portaling its own copy to document.body. Expo-
+                      router's Stack keeps prior screens mounted on web
+                      while a new route is pushed on top, so every
+                      portal stayed in the DOM and leaked onto pages
+                      that explicitly opt out (cart.tsx, checkout.tsx,
+                      product/[id].tsx, etc.). One instance here means
+                      a single portal, controlled by the live pathname. */}
+                  <GlobalBottomNav />
+                  <GlobalCartPill />
                   {/* Global toast layer — sits above stack content but below
                       the cold-launch logo / splash so it doesn't jitter the
                       first-launch sequence. */}

--- a/apps/pickup-native/app/account.tsx
+++ b/apps/pickup-native/app/account.tsx
@@ -34,7 +34,6 @@ import * as Haptics from "@/lib/haptics";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { ScrollView } from "react-native";
 import { EspressoHeader } from "../components/EspressoHeader";
-import { BottomNav } from "../components/BottomNav";
 import { TierCardCarousel, type TierLite } from "../components/TierCardCarousel";
 import { useApp } from "../lib/store";
 import { api } from "../lib/api";
@@ -442,7 +441,6 @@ function SignedIn({ phone, onSignOut }: { phone: string; onSignOut: () => void }
         </View>
       </ScrollView>
 
-      <BottomNav />
 
       <ProfileEditModal
         visible={editing}
@@ -1373,7 +1371,6 @@ function SignIn({ onVerified }: { onVerified: (phone: string) => void }) {
         )}
       </View>
 
-      <BottomNav />
     </KeyboardAvoidingView>
   );
 }

--- a/apps/pickup-native/app/index.tsx
+++ b/apps/pickup-native/app/index.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useState } from "react";
 import { Platform, View, Text, Pressable, ScrollView, Image, RefreshControl } from "react-native";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
-import { router, usePathname } from "expo-router";
+import { router } from "expo-router";
 import { MapPin, ChevronRight, Coffee, Sparkles, Gift, Clock4, ShoppingCart } from "lucide-react-native";
 import * as Haptics from "@/lib/haptics";
 import { supabase, type Outlet } from "../lib/supabase";
@@ -36,7 +36,6 @@ import { PosterCarousel } from "../components/PosterCarousel";
 import { getHomePosters, type HomePoster } from "../lib/posters";
 import { tierStyle } from "../lib/tier-styles";
 import { getSetting } from "../lib/settings";
-import { BottomNav } from "../components/BottomNav";
 import { AddToHomeHint } from "../components/AddToHomeHint";
 import { formatPrice } from "../lib/api";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
@@ -1164,87 +1163,16 @@ export default function Home() {
 
       </ScrollView>
 
-      {cartCount(cart) > 0 && (
-        <ViewCartFloatingBar
-          count={cartCount(cart)}
-          insetBottom={insets.bottom}
-          onPress={() => router.push("/cart")}
-        />
-      )}
+      {/* The "View cart" pill that used to render here moved to
+          _layout.tsx as <GlobalCartPill /> so it can react to path
+          changes correctly — background-mounted screens on web don't
+          refresh their usePathname() subscriptions, so leaving it here
+          made it leak onto /cart / /checkout. */}
 
-      <BottomNav />
     </View>
   );
 }
 
-// Floating "View cart" bar — anchored above the bottom nav. On web it
-// portals to <body> + position:fixed so it pins to the viewport
-// regardless of the body-scroll setup. Native keeps the in-tree
-// absolute positioning.
-function ViewCartFloatingBar({
-  count,
-  insetBottom,
-  onPress,
-}: {
-  count: number;
-  insetBottom: number;
-  onPress: () => void;
-}) {
-  const isWeb = Platform.OS === "web";
-  // Expo-router's Stack keeps prior screens mounted while a new one is
-  // pushed on top, so this bar's portal stays in the DOM while the
-  // customer is on /cart / /checkout / /product/[id]. Gate on pathname
-  // so it only renders when home is actually the active route.
-  const pathname = usePathname();
-  if (pathname !== "/") return null;
-  const webOverrides = isWeb
-    ? ({
-        position: "fixed" as unknown as "absolute",
-        bottom: "calc(env(safe-area-inset-bottom, 0px) + 80px)" as unknown as number,
-        left: 16,
-        right: 16,
-        zIndex: 99,
-      } as const)
-    : null;
-
-  const bar = (
-    <View
-      className="absolute left-4 right-4"
-      style={{
-        bottom: insetBottom + 70,
-        ...(webOverrides ?? {}),
-      }}
-    >
-      <Pressable
-        onPress={onPress}
-        className="bg-primary rounded-full py-3 px-5 flex-row items-center justify-between active:opacity-80"
-        style={{
-          shadowColor: "#A2492C",
-          shadowOpacity: 0.3,
-          shadowRadius: 12,
-          shadowOffset: { width: 0, height: 4 },
-        }}
-      >
-        <View className="flex-row items-center gap-2">
-          <View className="bg-white rounded-full w-6 h-6 items-center justify-center">
-            <Text className="text-primary text-xs font-bold">{count}</Text>
-          </View>
-          <Text className="text-white font-bold">View cart</Text>
-        </View>
-        <Text className="text-white font-bold">
-          {count} item{count === 1 ? "" : "s"}
-        </Text>
-      </Pressable>
-    </View>
-  );
-
-  if (isWeb && typeof document !== "undefined") {
-    // eslint-disable-next-line @typescript-eslint/no-require-imports
-    const { createPortal } = require("react-dom") as typeof import("react-dom");
-    return createPortal(bar, document.body);
-  }
-  return bar;
-}
 
 function statusLabel(status: string | null | undefined): string {
   switch ((status ?? "").toLowerCase()) {

--- a/apps/pickup-native/app/menu.tsx
+++ b/apps/pickup-native/app/menu.tsx
@@ -12,7 +12,7 @@ import {
   type NativeScrollEvent,
   type LayoutChangeEvent,
 } from "react-native";
-import { Stack, router, useLocalSearchParams, usePathname } from "expo-router";
+import { Stack, router, useLocalSearchParams } from "expo-router";
 import { useQuery } from "@tanstack/react-query";
 import * as Haptics from "@/lib/haptics";
 import {
@@ -50,7 +50,6 @@ import { cloudinaryThumb } from "../lib/image";
 import { useActiveSales } from "../lib/use-active-sales";
 import { bestSaleForProduct } from "../lib/product-sales";
 import { PriceTag } from "../components/PriceTag";
-import { BottomNav } from "../components/BottomNav";
 import { ReservedVoucherBanner } from "../components/ReservedVoucherBanner";
 import { CelsiusLoader } from "../components/CelsiusLoader";
 import { ProductImage } from "../components/ProductImage";
@@ -651,91 +650,16 @@ export default function Menu() {
         </ScrollView>
       </View>
 
-      {/* Cart pill — sits above bottom nav */}
-      {cartCount(cart) > 0 && (
-        <MenuCartFloatingBar
-          count={cartCount(cart)}
-          priceLabel={formatPrice(cartTotal(cart))}
-          insetBottom={insets.bottom}
-          onPress={() => router.push("/cart")}
-        />
-      )}
-
-      <BottomNav />
+      {/* "View cart" pill + BottomNav are both rendered globally in
+          _layout.tsx now — having them inside the screen meant the
+          screen's portal stayed on document.body when expo-router's
+          Stack kept menu mounted in the background while /cart or
+          /checkout was on top. Result was the pill + nav leaking onto
+          pages that explicitly opted out (e.g. cart.tsx never imported
+          BottomNav). Move them to one global instance and the
+          usePathname() gating actually works. */}
     </View>
   );
-}
-
-// Floating cart pill — same pattern as the home screen's ViewCart bar.
-// Portals to <body> + position:fixed on web so it pins to the viewport
-// over the body-scroll layout. Native keeps in-tree absolute.
-function MenuCartFloatingBar({
-  count,
-  priceLabel,
-  insetBottom,
-  onPress,
-}: {
-  count: number;
-  priceLabel: string;
-  insetBottom: number;
-  onPress: () => void;
-}) {
-  const isWeb = Platform.OS === "web";
-  // Same trap as ViewCartFloatingBar in index.tsx — expo-router keeps
-  // the menu screen mounted while /cart, /checkout, etc. sit on top of
-  // the Stack, so this bar's body-portal stays in the DOM and shows on
-  // pages where it's redundant. Gate on pathname so it only renders on
-  // the menu / product detail routes that actually want it.
-  const pathname = usePathname();
-  if (!pathname.startsWith("/menu") && !pathname.startsWith("/product")) {
-    return null;
-  }
-  const webOverrides = isWeb
-    ? ({
-        position: "fixed" as unknown as "absolute",
-        bottom:
-          "calc(env(safe-area-inset-bottom, 0px) + 80px)" as unknown as number,
-        left: 16,
-        right: 16,
-        zIndex: 99,
-      } as const)
-    : null;
-
-  const bar = (
-    <View
-      className="absolute left-4 right-4"
-      style={{
-        bottom: insetBottom + 70,
-        ...(webOverrides ?? {}),
-      }}
-    >
-      <Pressable
-        onPress={onPress}
-        className="bg-primary rounded-full py-3 px-5 flex-row items-center justify-between active:opacity-80"
-        style={{
-          shadowColor: "#A2492C",
-          shadowOpacity: 0.3,
-          shadowRadius: 12,
-          shadowOffset: { width: 0, height: 4 },
-        }}
-      >
-        <View className="flex-row items-center gap-2">
-          <View className="bg-white rounded-full w-6 h-6 items-center justify-center">
-            <Text className="text-primary text-xs font-bold">{count}</Text>
-          </View>
-          <Text className="text-white font-bold">View cart</Text>
-        </View>
-        <Text className="text-white font-bold">{priceLabel}</Text>
-      </Pressable>
-    </View>
-  );
-
-  if (isWeb && typeof document !== "undefined") {
-    // eslint-disable-next-line @typescript-eslint/no-require-imports
-    const { createPortal } = require("react-dom") as typeof import("react-dom");
-    return createPortal(bar, document.body);
-  }
-  return bar;
 }
 
 function SideCategoryPill({

--- a/apps/pickup-native/app/orders.tsx
+++ b/apps/pickup-native/app/orders.tsx
@@ -21,7 +21,6 @@ import {
 } from "lucide-react-native";
 import * as Haptics from "@/lib/haptics";
 import { EspressoHeader } from "../components/EspressoHeader";
-import { BottomNav } from "../components/BottomNav";
 import { CelsiusLoader } from "../components/CelsiusLoader";
 import { useApp } from "../lib/store";
 import { fetchMenu } from "../lib/menu";
@@ -214,7 +213,6 @@ export default function OrdersTab() {
         />
       )}
 
-      <BottomNav />
     </View>
   );
 }

--- a/apps/pickup-native/app/rewards-mock.tsx
+++ b/apps/pickup-native/app/rewards-mock.tsx
@@ -38,7 +38,6 @@ import {
   Tag, Sandwich, Star, Clock, Users, DollarSign, Search,
 } from "lucide-react-native";
 import * as Haptics from "@/lib/haptics";
-import { BottomNav } from "../components/BottomNav";
 import { EspressoHeader } from "../components/EspressoHeader";
 
 // ─── Mock data ──────────────────────────────────────────────────────
@@ -272,7 +271,6 @@ export default function RewardsMock() {
         </Stack>
       </ScrollView>
 
-      <BottomNav />
     </View>
   );
 }

--- a/apps/pickup-native/app/rewards.tsx
+++ b/apps/pickup-native/app/rewards.tsx
@@ -5,7 +5,6 @@ import { Stack, router } from "expo-router";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { Gift, ChevronRight, Clock, Lock } from "lucide-react-native";
 import * as Haptics from "@/lib/haptics";
-import { BottomNav } from "../components/BottomNav";
 import { EspressoHeader } from "../components/EspressoHeader";
 import { CelsiusLoader } from "../components/CelsiusLoader";
 import { RewardsListSkeleton } from "../components/RewardsListSkeleton";
@@ -360,7 +359,6 @@ export default function RewardsTab() {
         >
           <SignInPrompt />
         </ScrollView>
-        <BottomNav />
       </View>
     );
   }
@@ -440,7 +438,6 @@ export default function RewardsTab() {
         )}
       </ScrollView>
 
-      <BottomNav />
     </View>
   );
 }

--- a/apps/pickup-native/components/GlobalCartPill.tsx
+++ b/apps/pickup-native/components/GlobalCartPill.tsx
@@ -1,0 +1,94 @@
+import { Platform, View, Text, Pressable } from "react-native";
+import { router, usePathname } from "expo-router";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
+import { useApp, cartCount, cartTotal } from "../lib/store";
+import { formatPrice } from "../lib/api";
+import * as Haptics from "@/lib/haptics";
+
+/**
+ * Global "View cart" pill. Mounted once at the root layout so it
+ * lives outside the Stack — that's the only place where usePathname()
+ * reliably re-renders on every navigation. (Previous attempts to gate
+ * the pill inside the Home / Menu screen components didn't work
+ * because expo-router on web keeps prior screens mounted, and the
+ * background screens' hook subscriptions don't refresh when the route
+ * changes — so the pill stayed visible on /cart even when the parent
+ * screen was no longer "current".)
+ *
+ * Renders the pill only on routes where it adds value (home + menu +
+ * product detail) AND only when the cart has items.
+ *
+ * On web the pill portals to <body> via createPortal so it pins to
+ * the visual viewport regardless of the surrounding flex layout.
+ * Native uses absolute positioning inside the root view.
+ */
+const PILL_ROUTES = (pathname: string) =>
+  pathname === "/" ||
+  pathname.startsWith("/menu") ||
+  pathname.startsWith("/product");
+
+export function GlobalCartPill() {
+  const pathname = usePathname();
+  const cart = useApp((s) => s.cart);
+  const insets = useSafeAreaInsets();
+
+  if (!PILL_ROUTES(pathname)) return null;
+  if (cartCount(cart) <= 0) return null;
+
+  const count = cartCount(cart);
+  const total = cartTotal(cart);
+  const isWeb = Platform.OS === "web";
+
+  const onPress = () => {
+    Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
+    router.push("/cart");
+  };
+
+  const webOverrides = isWeb
+    ? ({
+        position: "fixed" as unknown as "absolute",
+        bottom: "calc(env(safe-area-inset-bottom, 0px) + 80px)" as unknown as number,
+        left: 16,
+        right: 16,
+        zIndex: 99,
+      } as const)
+    : null;
+
+  const bar = (
+    <View
+      className="absolute left-4 right-4"
+      style={{
+        bottom: insets.bottom + 70,
+        ...(webOverrides ?? {}),
+      }}
+    >
+      <Pressable
+        onPress={onPress}
+        className="bg-primary rounded-full py-3 px-5 flex-row items-center justify-between active:opacity-80"
+        style={{
+          shadowColor: "#A2492C",
+          shadowOpacity: 0.3,
+          shadowRadius: 12,
+          shadowOffset: { width: 0, height: 4 },
+        }}
+        accessibilityRole="button"
+        accessibilityLabel={`View cart, ${count} ${count === 1 ? "item" : "items"}, ${formatPrice(total)}`}
+      >
+        <View className="flex-row items-center gap-2">
+          <View className="bg-white rounded-full w-6 h-6 items-center justify-center">
+            <Text className="text-primary text-xs font-bold">{count}</Text>
+          </View>
+          <Text className="text-white font-bold">View cart</Text>
+        </View>
+        <Text className="text-white font-bold">{formatPrice(total)}</Text>
+      </Pressable>
+    </View>
+  );
+
+  if (isWeb && typeof document !== "undefined") {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const { createPortal } = require("react-dom") as typeof import("react-dom");
+    return createPortal(bar, document.body);
+  }
+  return bar;
+}

--- a/apps/pickup-native/public/sw.js
+++ b/apps/pickup-native/public/sw.js
@@ -6,7 +6,7 @@
 //
 // Future rule of thumb: bump this on ANY production-affecting bundle
 // regression so customers don't get stuck on a bad build.
-const CACHE = "celsius-v3";
+const CACHE = "celsius-v4";
 const SHELL = ["/", "/index.html", "/manifest.json"];
 
 self.addEventListener("install", (e) => {


### PR DESCRIPTION
## Summary

Customer screenshot on /cart showed two pieces of chrome that shouldn't be there:
- The "View cart" terracotta pill (already meaningless on /cart).
- The BottomNav (Home / Rewards / Menu / Orders / Account) — native iOS doesn't render this on /cart because cart.tsx never imported `BottomNav`.

## Root cause

Both pieces lived inside per-screen components (`index.tsx`, `menu.tsx`, `orders.tsx`, `rewards.tsx`, `account.tsx`) and portaled to `document.body` on web. Expo-router's `Stack` keeps prior screens mounted on web while a new route is pushed on top, and those background screens' hook subscriptions (`usePathname`) **don't refresh** — so every screen's portal stayed in the DOM and leaked onto pages that opted out.

The earlier #160 attempt to gate-with-`usePathname` inside each pill component didn't help because the hook in the background-mounted screen returns a stale path.

## Fix

Render both pieces **once**, at the root, in `app/_layout.tsx` — a single portal whose `usePathname()` is driven by the live router state.

- New `components/GlobalCartPill.tsx` — renders only on `/`, `/menu*`, `/product*` AND when cart > 0.
- New `GlobalBottomNav` helper in `_layout.tsx` — renders BottomNav only on `/`, `/menu*`, `/orders`, `/rewards`, `/account`. Other routes get no bottom chrome (matches native iOS).

### Cleaned up

- Deleted `ViewCartFloatingBar` from `index.tsx`.
- Deleted `MenuCartFloatingBar` from `menu.tsx`.
- Removed `BottomNav` imports + render from every per-screen file.
- Bumped SW cache `v3 → v4` so stuck clients get the new bundle.

Net: 10 files changed, **−33 lines** (143 inserts vs 176 deletes).

## Test plan (preview)

- [ ] iPhone Safari: navigate Home → /cart → no "View cart" pill, no BottomNav on /cart.
- [ ] Same on /checkout, /product/[id], /order/[id], /store, /settings.
- [ ] Back to Home, Menu, Orders, Rewards, Account → BottomNav + pill (if cart has items) reappear correctly.
- [ ] Tap a tab in BottomNav → correct screen, correct active highlight.
- [ ] Tap "View cart" pill → /cart.
- [ ] Native iOS app build: no visual diff (BottomNav was never on cart/checkout/product on native anyway).


---
_Generated by [Claude Code](https://claude.ai/code/session_01Xd1aERynqUbdCqXNboKWBe)_