### PR TITLE
[probe] pwa: runtime JS-walk to defeat ScrollView clamping → body scroll → URL bar collapses

### DIFF
--- a/apps/order/public/sw.js
+++ b/apps/order/public/sw.js
@@ -1,7 +1,7 @@
 // Mirror of apps/pickup-native/public/sw.js — overwritten on each
 // build-pwa run. v3 bumps over v2 to flush customers off the broken
 // CSS shipped in #157/#158 before this revert deployed.
-const CACHE = "celsius-v3";
+const CACHE = "celsius-v4";
 const SHELL = ["/", "/index.html", "/manifest.json"];
 
 self.addEventListener("install", (e) => {

--- a/apps/pickup-native/public/sw.js
+++ b/apps/pickup-native/public/sw.js
@@ -6,7 +6,7 @@
 //
 // Future rule of thumb: bump this on ANY production-affecting bundle
 // regression so customers don't get stuck on a bad build.
-const CACHE = "celsius-v3";
+const CACHE = "celsius-v4";
 const SHELL = ["/", "/index.html", "/manifest.json"];
 
 self.addEventListener("install", (e) => {

--- a/apps/pickup-native/scripts/postbuild-web.mjs
+++ b/apps/pickup-native/scripts/postbuild-web.mjs
@@ -35,6 +35,84 @@ const BODY_EXTRA = `
       }
     })();
 
+    // Defeat RN-Web's inner ScrollView so the document scrolls — that's
+    // what iOS Safari watches to collapse its URL bar.
+    //
+    // Strategy: on every render, find the OUTERMOST vertical scroller
+    // under #root (the page's main ScrollView), release its
+    // overflow/flex constraints, then walk up the ancestor chain to
+    // #root, doing the same. Deeper elements that legitimately need
+    // overflow:hidden (rounded card images, carousels, tier cards) are
+    // untouched. Horizontal carousels (overflow-x: auto, overflow-y
+    // hidden) are also untouched.
+    //
+    // Earlier attempts (#157/#158) used blanket CSS like '#root *' which
+    // hit every descendant and broke clipping. This is surgical.
+    (function () {
+      var FIXED = '__celsiusBodyScrollFixed';
+      function isVerticalScroller(el) {
+        if (!el || el.nodeType !== 1) return false;
+        var cs = window.getComputedStyle(el);
+        return (cs.overflowY === 'auto' || cs.overflowY === 'scroll')
+          && cs.overflowX !== 'auto' && cs.overflowX !== 'scroll';
+      }
+      function findOutermost(root) {
+        if (!root) return null;
+        var queue = [root];
+        while (queue.length) {
+          var node = queue.shift();
+          if (node !== root && isVerticalScroller(node)) return node;
+          for (var i = 0; i < node.children.length; i++) queue.push(node.children[i]);
+        }
+        return null;
+      }
+      function release(el) {
+        el.style.setProperty('overflow', 'visible', 'important');
+        el.style.setProperty('flex-grow', '0', 'important');
+        el.style.setProperty('flex-shrink', '0', 'important');
+        el.style.setProperty('flex-basis', 'auto', 'important');
+        el.style.setProperty('min-height', '0', 'important');
+        el.style.setProperty('height', 'auto', 'important');
+      }
+      function tick() {
+        var root = document.getElementById('root');
+        if (!root) return;
+        var sv = findOutermost(root);
+        if (!sv) return;
+        if (sv[FIXED]) return;
+        release(sv);
+        var el = sv.parentElement;
+        while (el && el !== document.body) {
+          release(el);
+          if (el === root) break;
+          el = el.parentElement;
+        }
+        sv[FIXED] = true;
+      }
+      var raf = 0;
+      function schedule() {
+        if (raf) return;
+        raf = requestAnimationFrame(function () { raf = 0; tick(); });
+      }
+      window.addEventListener('DOMContentLoaded', schedule);
+      window.addEventListener('load', schedule);
+      window.addEventListener('popstate', schedule);
+      // Patch pushState/replaceState so route changes also trigger the fix.
+      ['pushState', 'replaceState'].forEach(function (m) {
+        var orig = history[m];
+        history[m] = function () {
+          var r = orig.apply(this, arguments);
+          schedule();
+          return r;
+        };
+      });
+      // React re-renders the screen content under #root — re-check after
+      // each batch of DOM mutations. The FIXED flag means each scroller
+      // is only released once.
+      var mo = new MutationObserver(schedule);
+      mo.observe(document.documentElement, { childList: true, subtree: true });
+    })();
+
     if ('serviceWorker' in navigator) {
       window.addEventListener('load', function () {
         navigator.serviceWorker.register('/sw.js').catch(function () {});
@@ -55,23 +133,25 @@ if (html.includes("/manifest.json")) {
 const NEW_VIEWPORT =
   '<meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />';
 
-// Use the JS-measured viewport height (--vph) so iOS Safari PWA
-// standalone gets the real pixel viewport — vh/dvh/lvh/svh all
-// under-report by ~150px in standalone mode. We keep `100vh` as
-// the static fallback for browsers that haven't run the JS yet.
-//
-// (URL-bar collapse experiments shipped in #157/#158 broke layouts
-// and are reverted here. The URL bar stays expanded in non-standalone
-// iOS Safari; customers who use the PWA often should install via Add
-// to Home Screen — that's the only reliable way to lose the URL bar.)
+// Body uses min-height so the document can grow with content — that
+// growth is what iOS Safari watches to collapse its URL bar. Paired
+// with the runtime BODY_SCROLL_SCRIPT below that surgically defeats
+// the outermost RN-Web ScrollView's clamping so its content actually
+// extends the document. Previous CSS-only attempts (#157/#158) reached
+// every descendant with !important and broke cards/images that need
+// overflow: hidden for rounded clipping. The JS-walk approach only
+// touches the chain from #root down to the main ScrollView — deeper
+// elements (ProductImage, TierCard, VoucherWallet, etc.) keep their
+// inline overflow rules.
 const EXPO_RESET_OLD = `      html,
       body {
         height: 100%;
       }`;
 const EXPO_RESET_NEW = `      html,
       body {
-        height: 100vh; /* fallback */
-        height: var(--vph, 100vh);
+        min-height: 100vh; /* fallback */
+        min-height: var(--vph, 100vh);
+        min-height: 100dvh;
       }`;
 const ROOT_OLD = `      #root {
         display: flex;
@@ -80,9 +160,10 @@ const ROOT_OLD = `      #root {
       }`;
 const ROOT_NEW = `      #root {
         display: flex;
-        height: 100vh;
-        height: var(--vph, 100vh);
-        flex: 1;
+        flex-direction: column;
+        min-height: 100vh;
+        min-height: var(--vph, 100vh);
+        min-height: 100dvh;
       }`;
 
 const patched = html


### PR DESCRIPTION
## Summary

Fourth attempt at iOS Safari URL-bar collapse. Authorised by you to "change RN if need to". Previous attempts:
- #148/#149 — per-ScrollView style override → didn't unset RN-Web's flex default → reverted by #150
- #153 — 5-level nested CSS selector → didn't reach ScrollView through RN-Web's wrapper chain → closed
- #157/#158 — universal `#root *` CSS → reached ScrollView but also nuked every `overflow: hidden` card/image → reverted by #159

This time the fix runs at runtime, not via blanket CSS — **surgical, only the ancestor chain from the page's main ScrollView up to `#root`**.

## What it does

`postbuild-web.mjs` injects a small script into the PWA shell. On every render + navigation:

1. Find the OUTERMOST vertical scroller under `#root` (RN-Web's main ScrollView outer div).
2. Release its clamps: `overflow: visible`, `flex: 0/0/auto`, `min-height: 0`, `height: auto`.
3. Walk UP the ancestor chain to `#root`, applying the same release at each level. That's the chain that ships `flex: 1 + min-height: 0` and stops content from extending the document.
4. Mark the element so each scroller is only fixed once.
5. Re-run via `MutationObserver` after every DOM batch and on `popstate`/`pushState`/`replaceState`.

Horizontal carousels (`overflow-x: auto`, `overflow-y: hidden`) are explicitly excluded by an `isVerticalScroller` check. Deeper elements (cards, ProductImage rounded clips, TierCardCarousel, VoucherWallet) keep their inline `overflow: hidden` — the walk **stops at the ScrollView**, doesn't descend.

`body` + `#root` switch from pinned `height: var(--vph)` to `min-height: 100dvh` so the document is free to grow.

SW cache bumped `v3 → v4` to flush stuck clients.

## Risks (please verify on preview)

- The home top bar (logo + cart icon) is `position: absolute` inside the home View. Releasing the ancestor chain's flex changes their `position: relative` containing block — the top bar's `top: insets.top + 8` might now anchor higher up (could end up at body's top). If it visually drifts, the fix is to set `position: relative` on the home View specifically.
- Sticky bottom CTAs (cart summary, product Add-to-Cart bar, checkout Place Order) use `position: absolute bottom-0`. Same containing-block concern — they might end up at the bottom of the document rather than the viewport. If so they need `position: fixed` on web.
- BottomNav + cart pill are already portaled to `document.body` with `position: fixed` — unaffected.

## Test plan

- [ ] iPhone Safari: scroll down on home → URL bar slims/hides within ~200px scroll.
- [ ] Hero/top bar still pinned where expected.
- [ ] Product cards' rounded images still clip correctly (no squared corners).
- [ ] Tier card carousel scrolls horizontally without breaking.
- [ ] Voucher wallet, reward chips render correctly.
- [ ] Cart screen: scrolls, summary panel + checkout button visible.
- [ ] Checkout review step: scrolls.
- [ ] Product detail: scrolls, Add-to-Cart bar reachable.
- [ ] Native iOS pickup app: no visual diff.

If anything looks broken, say "close" or paste a screenshot and I'll iterate.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Xd1aERynqUbdCqXNboKWBe)_