### PR TITLE
[probe] order/web: real Next.js page at / to verify iOS Safari URL-bar collapse

### DIFF
--- a/apps/order/src/app/page.tsx
+++ b/apps/order/src/app/page.tsx
@@ -1,0 +1,95 @@
+/**
+ * Probe — pure Next.js page at /, bypassing the pickup-native Expo Web
+ * SPA. Goal: confirm iOS Safari's URL bar collapses on body scroll
+ * here (it has to — there's no react-native-web wrapper chain
+ * clamping document height). If this works, the real home content
+ * gets rebuilt as a Next.js page in a follow-up. If it doesn't,
+ * URL-bar collapse is unfixable and we accept it.
+ *
+ * Middleware (apps/order/src/middleware.ts) was updated to NOT rewrite
+ * "/" to the SPA's index.html so this Next.js page actually wins.
+ * Inner routes (/menu, /cart, /product/[id], etc.) still rewrite to
+ * the SPA — those keep their existing rendering.
+ *
+ * The customer can tap "Open the menu" to enter the SPA at /menu.
+ */
+export default function ProbeHome() {
+  return (
+    <main
+      style={{
+        // min-height so the document can grow with content; body uses
+        // its browser-default scrolling on this page (no RN-Web in the
+        // way). iOS Safari collapses its URL bar on the first scroll.
+        minHeight: "100dvh",
+        background: "#FFFFFF",
+        color: "#160800",
+        fontFamily: "system-ui, -apple-system, Segoe UI, sans-serif",
+        padding: "24px 20px 96px",
+        boxSizing: "border-box",
+      }}
+    >
+      <header
+        style={{
+          background: "#160800",
+          color: "#FFFFFF",
+          padding: "32px 20px",
+          borderRadius: 18,
+          marginBottom: 20,
+        }}
+      >
+        <p style={{ margin: 0, opacity: 0.6, fontSize: 12, letterSpacing: 1.5, textTransform: "uppercase" }}>
+          Celsius Coffee
+        </p>
+        <h1 style={{ margin: "6px 0 0", fontSize: 28, fontWeight: 700, letterSpacing: -0.5 }}>
+          Order &amp; pickup
+        </h1>
+        <p style={{ margin: "12px 0 0", opacity: 0.75, fontSize: 14, lineHeight: 1.5 }}>
+          Scroll down. The Safari URL bar should slim/hide once the document overflows the viewport.
+        </p>
+      </header>
+
+      <a
+        href="/menu"
+        style={{
+          display: "block",
+          background: "#A2492C",
+          color: "#FFFFFF",
+          textDecoration: "none",
+          textAlign: "center",
+          padding: "14px 20px",
+          borderRadius: 999,
+          fontWeight: 600,
+          marginBottom: 24,
+        }}
+      >
+        Open the menu →
+      </a>
+
+      {/* Filler content so the document is taller than the viewport,
+          giving iOS Safari something to scroll. */}
+      {Array.from({ length: 14 }).map((_, i) => (
+        <section
+          key={i}
+          style={{
+            background: i % 2 === 0 ? "#F7F4F0" : "#FFFFFF",
+            border: "1px solid #E8E1D8",
+            borderRadius: 16,
+            padding: 20,
+            marginBottom: 16,
+          }}
+        >
+          <h2 style={{ margin: "0 0 6px", fontSize: 16, fontWeight: 700 }}>
+            Section {i + 1}
+          </h2>
+          <p style={{ margin: 0, fontSize: 14, lineHeight: 1.5, color: "#5C534A" }}>
+            Filler so the page is taller than the viewport. The Safari URL bar
+            collapses when the body actually scrolls — that&apos;s what this
+            probe is verifying. If it works, the real home content (hero,
+            BEANS card, outlet picker, sections) gets rebuilt as a Next.js
+            page in a follow-up. Native iOS pickup app is unaffected.
+          </p>
+        </section>
+      ))}
+    </main>
+  );
+}

--- a/apps/order/src/middleware.ts
+++ b/apps/order/src/middleware.ts
@@ -55,13 +55,21 @@ export async function middleware(request: NextRequest) {
   const { pathname } = request.nextUrl;
   const isApi = pathname.startsWith("/api/");
 
+  // "/" is handled by a real Next.js page (apps/order/src/app/page.tsx)
+  // instead of the SPA. The Next.js page renders plain HTML/CSS so iOS
+  // Safari's URL bar collapses on body scroll — the RN-Web SPA can't do
+  // that because its ScrollView clamps the document at viewport height.
+  // Every OTHER customer route (/menu, /cart, /product/[id], etc.)
+  // still rewrites to the SPA shell.
+  const isNextOwned = pathname === "/";
+
   // Customer-facing UI lives in the Expo Web PWA shipped from
   // apps/pickup-native and copied into /public during build. For any
   // non-Next route, rewrite to /index.html so the SPA bootstraps and
   // client-side routing handles the rest. Apply security headers on
   // this branch too — these are the customer-facing pages and need
   // CSP / X-Frame-Options / Referrer-Policy just like any other page.
-  if (!isApi && !PWA_PASSTHROUGH.some((rx) => rx.test(pathname))) {
+  if (!isApi && !isNextOwned && !PWA_PASSTHROUGH.some((rx) => rx.test(pathname))) {
     const url = request.nextUrl.clone();
     url.pathname = "/index.html";
     const r = NextResponse.rewrite(url);


### PR DESCRIPTION
## Probe — confirm iOS Safari URL-bar collapse via a real Next.js page

Four CSS/JS attempts to make the RN-Web SPA's body scroll all failed (#148/#149, #157/#158, #162). The architectural mismatch — ScrollView swallowing scroll, ancestor chain clamping at viewport — keeps the document at exactly viewport height, so iOS Safari has no trigger to collapse its URL bar.

This probe **sidesteps the SPA entirely for `/`**:

- New `apps/order/src/app/page.tsx` — plain Next.js page with `min-height: 100dvh` content (header + 14 filler sections + "Open the menu" CTA). No react-native-web in the rendering path → body scrolls natively → iOS Safari collapses its URL bar.
- `apps/order/src/middleware.ts` — `/` no longer rewrites to the SPA's `index.html`. Every other customer route (/menu, /cart, /product/[id], /order/[id], /rewards, /orders, /account, …) **still rewrites to the SPA shell** unchanged.

Tapping "Open the menu" on the probe page navigates to `/menu`, which serves the existing SPA. Once iOS Safari has collapsed the URL bar via the home scroll, it typically stays slim through inner-page navigation in the same session — so customers benefit on inner routes too.

## Risks

- Production currently serves the SPA at `/` (the home you've been seeing in screenshots — hero poster, Hi-Ammar card, outlet picker, sections). This probe replaces that with a **plain placeholder page**. Customers who land on production briefly see a "Section 1, Section 2, …" filler page instead of the real home, until they tap "Open the menu".
- This is the explicit point of the probe: prove URL-bar collapse first, rebuild content second. If you want to skip the placeholder phase and go straight to a full home rebuild, say so and I'll close this and start the bigger build instead.

## Verify on production (preview gated)

Once live:

- [ ] iPhone Safari → `order.celsiuscoffee.com` → scroll down. **URL bar slims/hides.**
- [ ] Tap "Open the menu" → lands on the existing SPA `/menu`.
- [ ] Native iOS pickup app → unaffected (doesn't hit the web middleware).

If URL bar collapses, say so and I'll start rebuilding the real home content as a Next.js page (hero, BEANS, outlet picker, sections, etc.). If it doesn't, URL-bar collapse is genuinely impossible on iOS Safari for this app and we accept the limit.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Xd1aERynqUbdCqXNboKWBe)_