### PR TITLE
fix(pwa/checkout): redirect to hosted payment URL on web — WebView doesn't run there

### DIFF
--- a/apps/order/public/sw.js
+++ b/apps/order/public/sw.js
@@ -1,7 +1,7 @@
 // Mirror of apps/pickup-native/public/sw.js — overwritten on each
 // build-pwa run. v3 bumps over v2 to flush customers off the broken
 // CSS shipped in #157/#158 before this revert deployed.
-const CACHE = "celsius-v5";
+const CACHE = "celsius-v6";
 const SHELL = ["/", "/index.html", "/manifest.json"];
 
 self.addEventListener("install", (e) => {

--- a/apps/pickup-native/components/RmCheckoutModal.tsx
+++ b/apps/pickup-native/components/RmCheckoutModal.tsx
@@ -135,6 +135,21 @@ export function RmCheckoutModal({ visible, url, methodLabel, amountLabel, method
   const [loading, setLoading] = useState(true);
   const [errorMsg, setErrorMsg] = useState<string | null>(null);
   const webViewRef = useRef<WebView | null>(null);
+
+  // On web there's no react-native-webview — it errors with "does not
+  // support this platform" and the modal hangs at "Loading Card…",
+  // making payment impossible on the PWA. Sidestep the WebView entirely:
+  // redirect the browser to the hosted payment URL, let Stripe / RM
+  // collect the card details, and rely on their configured redirectUrl
+  // (set in /api/checkout/initiate to /order/[id]?payment=done) to bring
+  // the customer back. The in-modal cancel button is moot once we
+  // navigate away — the browser back button serves the same purpose.
+  useEffect(() => {
+    if (!visible || !url) return;
+    if (Platform.OS !== "web") return;
+    if (typeof window === "undefined") return;
+    window.location.href = url;
+  }, [visible, url]);
   // useSafeAreaInsets reads from a hook-level context that does propagate
   // into Modal portals — <SafeAreaView edges={["top"]}> often returns 0
   // here on iOS because the modal opens in a separate UIWindow without
@@ -176,6 +191,13 @@ export function RmCheckoutModal({ visible, url, methodLabel, amountLabel, method
     setLoading(true);
     webViewRef.current?.reload();
   };
+
+  // Web takes the redirect path above — render nothing here so the
+  // WebView never instantiates (it'd error with "does not support this
+  // platform" inside a Modal that has no working close affordance once
+  // the WebView fails). The useEffect already kicked the browser onto
+  // the hosted payment URL.
+  if (Platform.OS === "web") return null;
 
   return (
     <Modal

--- a/apps/pickup-native/public/sw.js
+++ b/apps/pickup-native/public/sw.js
@@ -6,7 +6,7 @@
 //
 // Future rule of thumb: bump this on ANY production-affecting bundle
 // regression so customers don't get stuck on a bad build.
-const CACHE = "celsius-v5";
+const CACHE = "celsius-v6";
 const SHELL = ["/", "/index.html", "/manifest.json"];
 
 self.addEventListener("install", (e) => {


### PR DESCRIPTION
## Summary

Customer screenshot showed the real PWA blocker: **`react-native-webview` doesn't run on web.** The `RmCheckoutModal` (full-screen WebView wrapper for Revenue Monster's hosted payment pages — Card, FPX, GrabPay, TNG…) renders that "does not support this platform" message and hangs forever at "Loading Card…". PWA customers cannot complete payment.

## Fix

On web, sidestep the WebView entirely:

- When the modal opens with a payment `url`, `window.location.href = url` — browser navigates to the Stripe / Revenue Monster hosted payment page.
- The hosted page collects card details and redirects to the configured `redirectUrl` (set in `/api/checkout/initiate` to `/order/[id]?payment=done`) — that brings the customer back into the PWA.
- Component returns `null` on web after firing the effect so the WebView never instantiates.

Browser back button replaces the in-modal Cancel button (the modal is moot once we navigate away).

Native iOS/Android pickup app unaffected (`Platform.OS === "web"` guard).

SW cache bumped `v5 → v6` so stuck PWA clients pick up the fix.

## Test plan

- [ ] iPhone Safari → add an item to cart → checkout → pick Card → **browser navigates to the RM hosted card page** (no more "WebView does not support this platform" / stuck Loading Card spinner).
- [ ] Complete payment → redirects back to `/order/[id]?payment=done` → order detail renders the success state.
- [ ] Browser back from the RM page → lands on /checkout (or wherever the previous page was) — customer can retry.
- [ ] FPX / GrabPay / TNG flows: same redirect path works (they all use RmCheckoutModal).
- [ ] Native iOS app build: WebView modal still opens as before, payment unchanged.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Xd1aERynqUbdCqXNboKWBe)_