### PR TITLE
fix(order/web): drop h-full from html so URL bar can collapse on body scroll

### DIFF
--- a/apps/order/src/app/layout.tsx
+++ b/apps/order/src/app/layout.tsx
@@ -47,9 +47,15 @@ export default function RootLayout({
     <html
       lang="en"
       suppressHydrationWarning
-      className={`${spaceGrotesk.variable} h-full antialiased bg-[#160800]`}
+      // Deliberately NOT setting h-full on html — that pins the
+      // document to viewport height, which prevents iOS Safari from
+      // collapsing its URL bar on body scroll. Globals.css already
+      // sets body min-height:100dvh so the background still fills the
+      // visible area; without an html height clamp, the document can
+      // grow with content and Safari sees scroll on the body.
+      className={`${spaceGrotesk.variable} antialiased bg-[#160800]`}
     >
-      <body className="min-h-full flex flex-col">
+      <body className="flex flex-col">
         {children}
         <Toaster />
       </body>


### PR DESCRIPTION
## Summary

After PR #164 shipped the Next.js placeholder home, URL bar still didn't collapse. Cause: `apps/order/src/app/layout.tsx` pins `<html>` to viewport height via Tailwind's `h-full` (= `height: 100%`). With html locked at viewport, the document never overflows even when body content does — iOS Safari watches `documentElement`'s scrollable area, sees none, keeps the URL bar up.

## Fix

Drop `h-full` from `<html>` and `min-h-full` from `<body>`. `globals.css` already sets `body { min-height: 100dvh }` so the espresso background still fills the visible area at minimum. Without an html height clamp, the document is free to grow with content — body scrolls, iOS Safari sees scroll on the document, URL bar collapses.

This is the equivalent of the body-min-height switch we tried inside the RN-Web bundle earlier (and reverted) — but here it actually works because there's no `ScrollView` wrapper chain undoing it.

## Test plan

- [ ] iPhone Safari → `order.celsiuscoffee.com/` → scroll down on the placeholder. **URL bar slims/hides.**
- [ ] Page still looks correct (background still fills, content centered with the 430px max-width).
- [ ] Tap "Open the menu" → SPA loads as before.
- [ ] Other routes still served by the SPA via middleware.

If URL bar collapses → say so and I'll start rebuilding the real home content as a proper Next.js page.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Xd1aERynqUbdCqXNboKWBe)_