### PR TITLE
feat(order/web): rebuild home as a Next.js Server Component — real content + URL bar collapses

### DIFF
--- a/apps/order/src/app/_GlobalCartPill.tsx
+++ b/apps/order/src/app/_GlobalCartPill.tsx
@@ -1,0 +1,70 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import Link from "next/link";
+
+/**
+ * Floating "View cart" pill. Reads the SPA's persisted cart from
+ * localStorage (key "celsius-pickup") and renders if non-empty. Tap →
+ * /cart (still SPA-rendered).
+ *
+ * Pinned to viewport bottom via position: fixed; sits above the
+ * BottomNav (~80px offset for safe-area + nav height).
+ */
+type Persisted = {
+  state?: {
+    cart?: Array<{ quantity?: number; totalPrice?: number }>;
+  };
+};
+
+export function GlobalCartPill() {
+  const [count, setCount] = useState(0);
+  const [total, setTotal] = useState(0);
+
+  useEffect(() => {
+    function read() {
+      try {
+        const raw = window.localStorage.getItem("celsius-pickup");
+        if (!raw) return;
+        const parsed = JSON.parse(raw) as Persisted;
+        const cart = parsed.state?.cart ?? [];
+        setCount(cart.reduce((s, i) => s + (i.quantity ?? 1), 0));
+        setTotal(cart.reduce((s, i) => s + (i.totalPrice ?? 0), 0));
+      } catch {
+        /* ignore */
+      }
+    }
+    read();
+    // Poll periodically so a cart change in the SPA (different React
+    // tree) gets reflected here without forcing a full reload. Cheap.
+    const id = window.setInterval(read, 1500);
+    window.addEventListener("storage", read);
+    return () => {
+      window.clearInterval(id);
+      window.removeEventListener("storage", read);
+    };
+  }, []);
+
+  if (count <= 0) return null;
+
+  return (
+    <Link
+      href="/cart"
+      className="fixed left-4 right-4 z-30 bg-[#A2492C] text-white rounded-full px-5 py-3 flex items-center justify-between active:opacity-80"
+      style={{
+        bottom: "calc(env(safe-area-inset-bottom, 0px) + 80px)",
+        boxShadow: "0 4px 12px rgba(162,73,44,0.3)",
+      }}
+    >
+      <span className="flex items-center gap-2">
+        <span className="bg-white rounded-full w-6 h-6 flex items-center justify-center text-[#A2492C] text-xs font-bold">
+          {count}
+        </span>
+        <span className="font-bold">View cart</span>
+      </span>
+      <span className="font-bold">
+        RM{total.toFixed(2)}
+      </span>
+    </Link>
+  );
+}

--- a/apps/order/src/app/_MemberBeansCard.tsx
+++ b/apps/order/src/app/_MemberBeansCard.tsx
@@ -1,0 +1,95 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import Link from "next/link";
+import { ChevronRight } from "lucide-react";
+
+/**
+ * Hi-[name] / BEANS / REWARDS card. Reads the SPA's persisted Zustand
+ * state from localStorage (key "celsius-pickup", set by
+ * apps/pickup-native/lib/store.ts). No network round-trip on the
+ * critical-path render — the card just hydrates with whatever the SPA
+ * last persisted on the customer's device.
+ *
+ * For first-time visitors (no persisted state) it falls back to a
+ * guest-style prompt that links to /account to sign in.
+ */
+type Persisted = {
+  state?: {
+    member?: { name?: string | null; pointsBalance?: number };
+    phone?: string | null;
+  };
+};
+
+export function MemberBeansCard() {
+  const [name, setName] = useState<string | null>(null);
+  const [beans, setBeans] = useState<number | null>(null);
+  const [signedIn, setSignedIn] = useState<boolean | null>(null);
+
+  useEffect(() => {
+    try {
+      const raw = window.localStorage.getItem("celsius-pickup");
+      if (!raw) {
+        setSignedIn(false);
+        return;
+      }
+      const parsed = JSON.parse(raw) as Persisted;
+      const s = parsed.state ?? {};
+      setSignedIn(!!s.phone);
+      setName(s.member?.name ?? null);
+      setBeans(s.member?.pointsBalance ?? null);
+    } catch {
+      setSignedIn(false);
+    }
+  }, []);
+
+  if (signedIn === null) {
+    // Server-rendered + client-hydrating: render a stable placeholder
+    // shape so there's no layout shift between SSR and hydration.
+    return (
+      <div className="bg-[#160800] rounded-2xl p-4 h-[88px]" aria-hidden />
+    );
+  }
+
+  if (!signedIn) {
+    return (
+      <Link
+        href="/account"
+        className="block bg-[#160800] rounded-2xl p-4 text-white active:opacity-80"
+      >
+        <div className="flex items-center gap-3">
+          <span className="text-2xl">🎁</span>
+          <div className="flex-1">
+            <p className="font-bold text-sm">Sign in for a free drink</p>
+            <p className="text-[11px] text-white/60 mt-0.5">
+              Earn beans, unlock rewards.
+            </p>
+          </div>
+          <ChevronRight size={16} className="text-white/60" />
+        </div>
+      </Link>
+    );
+  }
+
+  return (
+    <Link
+      href="/rewards"
+      className="block bg-[#160800] rounded-2xl p-4 text-white active:opacity-80"
+    >
+      <p className="text-white text-base font-bold" style={{ fontFamily: "Peachi-Bold, serif", letterSpacing: -0.3 }}>
+        Hi{name ? `, ${name}.` : "."}
+      </p>
+      <div className="mt-2 flex items-center gap-4">
+        <div className="flex-1">
+          <p className="text-white text-xl font-bold">
+            {beans?.toLocaleString() ?? "—"}
+          </p>
+          <p className="text-[10px] text-white/60 uppercase tracking-widest">
+            Beans
+          </p>
+        </div>
+        <ChevronRight size={16} className="text-white/40" />
+      </div>
+    </Link>
+  );
+}

--- a/apps/order/src/app/page.tsx
+++ b/apps/order/src/app/page.tsx
@@ -1,95 +1,267 @@
+import Image from "next/image";
+import Link from "next/link";
+import { Home, Gift, ClipboardList, User, ChevronDown, MapPin, Plus, ChevronRight } from "lucide-react";
+import { getSupabaseAdmin } from "@/lib/supabase/server";
+import { getMenuData } from "@/lib/menu-data";
+import { GlobalCartPill } from "./_GlobalCartPill";
+import { MemberBeansCard } from "./_MemberBeansCard";
+
 /**
- * Probe — pure Next.js page at /, bypassing the pickup-native Expo Web
- * SPA. Goal: confirm iOS Safari's URL bar collapses on body scroll
- * here (it has to — there's no react-native-web wrapper chain
- * clamping document height). If this works, the real home content
- * gets rebuilt as a Next.js page in a follow-up. If it doesn't,
- * URL-bar collapse is unfixable and we accept it.
+ * Customer home (Next.js Server Component) — replaces the pickup-native
+ * SPA at `/`.
  *
- * Middleware (apps/order/src/middleware.ts) was updated to NOT rewrite
- * "/" to the SPA's index.html so this Next.js page actually wins.
- * Inner routes (/menu, /cart, /product/[id], etc.) still rewrite to
- * the SPA — those keep their existing rendering.
+ * Why this exists: the SPA renders through react-native-web's wrapper
+ * chain (GestureHandlerRootView → SafeAreaProvider → Stack → page View
+ * → ScrollView), each level clamping the document at viewport height
+ * so iOS Safari never sees scroll on the body and never collapses its
+ * URL bar. Four attempts to defeat that chain via CSS / JS broke
+ * either scroll or layouts and were reverted. Rendering the home as
+ * plain HTML here sidesteps the whole problem: body scrolls natively,
+ * URL bar collapses, customers get back ~120px of viewport.
  *
- * The customer can tap "Open the menu" to enter the SPA at /menu.
+ * Native iOS/Android pickup app is untouched — it never hits this
+ * Next.js route, it runs the RN bundle directly.
+ *
+ * Inner routes (/menu, /cart, /product/[id], /order/[id], /rewards,
+ * /orders, /account, /store) still rewrite to the SPA's index.html
+ * via the middleware. Customers tap a BottomNav tab here and drop
+ * into the SPA for those screens. URL bar may re-expand on those
+ * routes — to be fixed by rebuilding them in Next.js next.
  */
-export default function ProbeHome() {
+
+// Re-render the home content at most once a minute. Posters change
+// rarely; product list a bit more often. 60s revalidate keeps the
+// page near-instant on subsequent visits without pinning a stale
+// menu for hours after a backoffice edit.
+export const revalidate = 60;
+
+type HomePoster = {
+  id: string;
+  image_url: string;
+  title: string | null;
+  deeplink: string | null;
+};
+
+async function fetchPosters(): Promise<HomePoster[]> {
+  try {
+    const supabase = getSupabaseAdmin();
+    const now = new Date().toISOString();
+    const { data } = await supabase
+      .from("splash_posters")
+      .select("id, image_url, title, deeplink, starts_at, ends_at, sort_order")
+      .eq("brand_id", "brand-celsius")
+      .eq("active", true)
+      .eq("placement", "home")
+      .order("sort_order", { ascending: true, nullsFirst: false });
+    if (!data) return [];
+    return data
+      .filter((p) => {
+        if (p.starts_at && new Date(p.starts_at).toISOString() > now) return false;
+        if (p.ends_at && new Date(p.ends_at).toISOString() < now) return false;
+        return true;
+      })
+      .map((p) => ({ id: p.id, image_url: p.image_url, title: p.title, deeplink: p.deeplink }));
+  } catch {
+    return [];
+  }
+}
+
+export default async function HomePage() {
+  const [posters, menu] = await Promise.all([fetchPosters(), getMenuData()]);
+  const hero = posters[0] ?? null;
+  const bestSellers = menu.products
+    .filter((p) => p.isPopular && p.isAvailable)
+    .sort((a, b) => (a.featuredPosition ?? 9999) - (b.featuredPosition ?? 9999))
+    .slice(0, 4);
+
   return (
-    <main
-      style={{
-        // min-height so the document can grow with content; body uses
-        // its browser-default scrolling on this page (no RN-Web in the
-        // way). iOS Safari collapses its URL bar on the first scroll.
-        minHeight: "100dvh",
-        background: "#FFFFFF",
-        color: "#160800",
-        fontFamily: "system-ui, -apple-system, Segoe UI, sans-serif",
-        padding: "24px 20px 96px",
-        boxSizing: "border-box",
-      }}
-    >
-      <header
-        style={{
-          background: "#160800",
-          color: "#FFFFFF",
-          padding: "32px 20px",
-          borderRadius: 18,
-          marginBottom: 20,
-        }}
+    <main className="bg-white text-[#160800] pb-[calc(env(safe-area-inset-bottom,0px)+88px)]">
+      {/* Hero — single poster, links to its deeplink (e.g. /menu?promo=…)
+          if set. Falls back to /menu so the CTA always lands somewhere. */}
+      <Link
+        href={hero?.deeplink || "/menu"}
+        className="relative block w-full aspect-[3/4] bg-[#160800]"
       >
-        <p style={{ margin: 0, opacity: 0.6, fontSize: 12, letterSpacing: 1.5, textTransform: "uppercase" }}>
-          Celsius Coffee
-        </p>
-        <h1 style={{ margin: "6px 0 0", fontSize: 28, fontWeight: 700, letterSpacing: -0.5 }}>
-          Order &amp; pickup
-        </h1>
-        <p style={{ margin: "12px 0 0", opacity: 0.75, fontSize: 14, lineHeight: 1.5 }}>
-          Scroll down. The Safari URL bar should slim/hide once the document overflows the viewport.
-        </p>
-      </header>
+        {hero ? (
+          <Image
+            src={hero.image_url}
+            alt={hero.title ?? "Celsius Coffee"}
+            fill
+            priority
+            sizes="(max-width: 430px) 100vw, 430px"
+            className="object-cover"
+          />
+        ) : (
+          <div className="flex h-full items-center justify-center text-white/60 text-sm">
+            Celsius Coffee
+          </div>
+        )}
+        {/* Top bar overlaid on the hero — small logo + cart icon */}
+        <div className="absolute top-3 left-4 right-4 flex items-center" style={{ paddingTop: "env(safe-area-inset-top, 0px)" }}>
+          <Image
+            src="/icons/icon-192.png"
+            alt="Celsius"
+            width={28}
+            height={28}
+            className="rounded-md"
+          />
+          <div className="flex-1" />
+          <Link
+            href="/cart"
+            className="flex h-9 w-9 items-center justify-center rounded-full bg-white/90"
+            aria-label="Cart"
+          >
+            <span className="text-[#160800]" style={{ fontWeight: 700 }}>
+              {/* cart icon — use a simple svg to avoid layout shift */}
+              <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                <circle cx="9" cy="21" r="1" />
+                <circle cx="20" cy="21" r="1" />
+                <path d="M1 1h4l2.68 13.39a2 2 0 0 0 2 1.61h9.72a2 2 0 0 0 2-1.61L23 6H6" />
+              </svg>
+            </span>
+          </Link>
+        </div>
+      </Link>
 
-      <a
-        href="/menu"
-        style={{
-          display: "block",
-          background: "#A2492C",
-          color: "#FFFFFF",
-          textDecoration: "none",
-          textAlign: "center",
-          padding: "14px 20px",
-          borderRadius: 999,
-          fontWeight: 600,
-          marginBottom: 24,
-        }}
+      {/* Member BEANS / REWARDS card — client component, hydrates from
+          localStorage (the SPA's persisted Zustand store key). */}
+      <div className="-mt-10 mx-4 relative z-10">
+        <MemberBeansCard />
+      </div>
+
+      {/* Outlet picker → /store (still SPA for the picker flow) */}
+      <Link
+        href="/store"
+        className="mt-4 mx-4 flex items-center gap-2 bg-[#F7F4F0] border border-[#E8E1D8] rounded-2xl px-4 py-3 active:opacity-70"
       >
-        Open the menu →
-      </a>
+        <MapPin size={14} className="text-[#A2492C]" />
+        <span className="text-sm font-bold flex-1 truncate">Select outlet</span>
+        <ChevronDown size={14} className="text-[#8E8E93]" />
+      </Link>
 
-      {/* Filler content so the document is taller than the viewport,
-          giving iOS Safari something to scroll. */}
-      {Array.from({ length: 14 }).map((_, i) => (
-        <section
-          key={i}
-          style={{
-            background: i % 2 === 0 ? "#F7F4F0" : "#FFFFFF",
-            border: "1px solid #E8E1D8",
-            borderRadius: 16,
-            padding: 20,
-            marginBottom: 16,
-          }}
-        >
-          <h2 style={{ margin: "0 0 6px", fontSize: 16, fontWeight: 700 }}>
-            Section {i + 1}
-          </h2>
-          <p style={{ margin: 0, fontSize: 14, lineHeight: 1.5, color: "#5C534A" }}>
-            Filler so the page is taller than the viewport. The Safari URL bar
-            collapses when the body actually scrolls — that&apos;s what this
-            probe is verifying. If it works, the real home content (hero,
-            BEANS card, outlet picker, sections) gets rebuilt as a Next.js
-            page in a follow-up. Native iOS pickup app is unaffected.
-          </p>
+      {/* Best Sellers */}
+      {bestSellers.length > 0 && (
+        <section className="mt-6 mx-4">
+          <div className="flex items-center mb-3">
+            <h2 className="text-lg font-bold flex-1" style={{ fontFamily: "Peachi-Bold, serif", letterSpacing: -0.3 }}>
+              Best Sellers
+            </h2>
+            <Link href="/menu" className="text-sm text-[#A2492C] flex items-center gap-1">
+              More <ChevronRight size={14} />
+            </Link>
+          </div>
+          <div className="grid grid-cols-2 gap-3">
+            {bestSellers.map((p) => (
+              <Link
+                key={p.id}
+                href={`/product/${p.id}`}
+                className="rounded-2xl bg-white border border-[#EBE5DE] overflow-hidden active:opacity-80"
+              >
+                <div className="relative w-full aspect-square bg-[#F2EDE5]">
+                  {p.image ? (
+                    <Image
+                      src={p.image}
+                      alt={p.name}
+                      fill
+                      sizes="(max-width: 430px) 50vw, 215px"
+                      className="object-cover"
+                    />
+                  ) : null}
+                </div>
+                <div className="p-3">
+                  <p className="text-sm font-bold truncate">{p.name}</p>
+                  <div className="mt-1 flex items-center justify-between">
+                    <span className="text-sm text-[#A2492C] font-bold">
+                      RM{p.basePrice.toFixed(2)}
+                    </span>
+                    <span className="h-7 w-7 rounded-full bg-[#160800] flex items-center justify-center">
+                      <Plus size={14} color="#FFFFFF" strokeWidth={2.5} />
+                    </span>
+                  </div>
+                </div>
+              </Link>
+            ))}
+          </div>
         </section>
-      ))}
+      )}
+
+      {/* "Open the menu" CTA */}
+      <div className="mt-6 mx-4">
+        <Link
+          href="/menu"
+          className="block w-full rounded-full bg-[#A2492C] text-white text-center py-4 font-bold active:opacity-80"
+        >
+          Open the menu →
+        </Link>
+      </div>
+
+      {/* Floating "View cart" pill (client component reads cart from
+          localStorage and renders if non-empty). */}
+      <GlobalCartPill />
+
+      {/* BottomNav — fixed at viewport bottom. Plain <a> links to inner
+          SPA routes; Home is the current page so it gets the active
+          treatment. */}
+      <nav
+        className="fixed bottom-0 left-0 right-0 bg-white border-t border-[#EBE5DE] flex items-stretch z-20"
+        style={{ paddingBottom: "env(safe-area-inset-bottom, 0px)" }}
+        aria-label="Primary"
+      >
+        <NavTab href="/" label="Home" Icon={Home} active />
+        <NavTab href="/rewards" label="Rewards" Icon={Gift} />
+        <NavMenuPuck href="/menu" />
+        <NavTab href="/orders" label="Orders" Icon={ClipboardList} />
+        <NavTab href="/account" label="Account" Icon={User} />
+      </nav>
     </main>
+  );
+}
+
+function NavTab({ href, label, Icon, active }: { href: string; label: string; Icon: typeof Home; active?: boolean }) {
+  const color = active ? "#160800" : "#8E8E93";
+  return (
+    <Link
+      href={href}
+      className="flex-1 flex flex-col items-center justify-center gap-1 py-2 active:opacity-60"
+    >
+      <Icon size={24} color={color} strokeWidth={active ? 2.4 : 1.75} />
+      <span className="text-[12.5px]" style={{ color, fontWeight: active ? 700 : 600, letterSpacing: 0.2 }}>
+        {label}
+      </span>
+    </Link>
+  );
+}
+
+// Menu tab: elevated terracotta-on-dark puck CTA in the centre, mirrors
+// the SPA's BottomNav design.
+function NavMenuPuck({ href }: { href: string }) {
+  return (
+    <Link
+      href={href}
+      className="flex-1 flex flex-col items-center active:opacity-80"
+      aria-label="Menu"
+    >
+      <span
+        className="-mt-4 flex items-center justify-center"
+        style={{
+          width: 52,
+          height: 52,
+          borderRadius: 26,
+          backgroundColor: "#8E8E93",
+          border: "3px solid #FFFFFF",
+          boxShadow: "0 3px 8px rgba(0,0,0,0.2)",
+        }}
+      >
+        {/* Celsius cup glyph — simple svg fallback */}
+        <svg width="26" height="26" viewBox="0 0 24 24" fill="none" stroke="#FFFFFF" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+          <path d="M6 3h12l-1 9a4 4 0 0 1-4 4h-2a4 4 0 0 1-4-4z" />
+          <path d="M9 21h6" />
+          <path d="M12 17v4" />
+        </svg>
+      </span>
+      <span className="text-[12.5px] mt-0.5" style={{ color: "#8E8E93", fontWeight: 600, letterSpacing: 0.2 }}>
+        Menu
+      </span>
+    </Link>
   );
 }


### PR DESCRIPTION
## Summary

Replaces the placeholder probe from #164 with the **real home content** rendered as a Next.js Server Component. URL bar collapses on body scroll (proven by #166); customers see actual home UI not "Section 1, Section 2…" filler.

### What renders

- **Hero**: top active poster from `splash_posters` table (`placement='home'`), full-bleed 3:4 aspect with a top bar overlay (small logo + cart icon).
- **Member BEANS card**: "Hi, [name]" + beans count, hydrated client-side from the SPA's persisted Zustand state in localStorage. Guest variant ("Sign in for a free drink") when not signed in.
- **Outlet picker** → `/store` (still SPA).
- **Best Sellers**: 2×2 grid of featured products from `getMenuData()` — links to `/product/[id]` (SPA).
- **"Open the menu" CTA** → `/menu` (SPA).
- **Floating "View cart" pill**: client component, polls localStorage, shows when cart has items.
- **BottomNav**: 5 tabs as plain `<Link>`s, Home is the active tab.

### How

- `apps/order/src/app/page.tsx` — Server Component, `revalidate: 60`, fetches posters + menu via existing helpers. No new API endpoints.
- `apps/order/src/app/_MemberBeansCard.tsx` — `"use client"`, reads localStorage key `celsius-pickup` (the SPA's Zustand persist key).
- `apps/order/src/app/_GlobalCartPill.tsx` — same pattern, polls every 1.5s + listens to `storage` events.

### Native unaffected

Native iOS/Android pickup app runs the RN bundle directly — never hits this Next.js route. Web visitors land here.

### What's still SPA

`/menu`, `/cart`, `/product/[id]`, `/order/[id]`, `/rewards`, `/orders`, `/account`, `/store` — all still rewrite to the SPA's index.html. URL bar will re-expand on those routes. To be fixed by rebuilding them as Next.js pages in follow-up work.

## Test plan

- [ ] iPhone Safari → `order.celsiuscoffee.com/` → see real home (hero, BEANS card, outlet picker, Best Sellers, BottomNav).
- [ ] Scroll down → **URL bar slims/hides**.
- [ ] Hi-Ammar / Beans count visible if signed in (after SPA has populated localStorage).
- [ ] Tap "Open the menu" → /menu loads SPA.
- [ ] Tap a Best Seller → /product/[id] loads SPA.
- [ ] Tap a BottomNav tab → corresponding SPA screen.
- [ ] Cart pill appears when cart has items (after the SPA's cart screen adds something).
- [ ] Native iOS pickup app build: no visual diff.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Xd1aERynqUbdCqXNboKWBe)_