### PR TITLE
feat(order/web): Next.js pages for /menu, /cart, /orders, /rewards, /account

### DIFF
--- a/apps/order/public/sw.js
+++ b/apps/order/public/sw.js
@@ -1,7 +1,7 @@
 // Mirror of apps/pickup-native/public/sw.js — overwritten on each
 // build-pwa run. v3 bumps over v2 to flush customers off the broken
 // CSS shipped in #157/#158 before this revert deployed.
-const CACHE = "celsius-v6";
+const CACHE = "celsius-v7";
 const SHELL = ["/", "/index.html", "/manifest.json"];
 
 self.addEventListener("install", (e) => {

--- a/apps/order/src/app/_BottomNav.tsx
+++ b/apps/order/src/app/_BottomNav.tsx
@@ -1,0 +1,90 @@
+import Link from "next/link";
+import { Home, Gift, ClipboardList, User } from "lucide-react";
+
+/**
+ * Persistent BottomNav for the customer-facing Next.js routes. Each
+ * page passes the active tab so the corresponding label/icon weight
+ * gets the espresso-on-grey treatment matching apps/pickup-native/
+ * components/BottomNav.tsx.
+ *
+ * Inner SPA routes (the ones whose Next.js page hasn't shipped yet)
+ * still render <BottomNav> from the SPA when active there — for now
+ * the two implementations coexist. Once every customer route is a
+ * Next.js page, the SPA's BottomNav can go.
+ */
+type Tab = "home" | "rewards" | "menu" | "orders" | "account";
+
+export function BottomNav({ active }: { active: Tab }) {
+  return (
+    <nav
+      className="fixed bottom-0 left-0 right-0 bg-white border-t border-[#EBE5DE] flex items-stretch z-20"
+      style={{ paddingBottom: "env(safe-area-inset-bottom, 0px)" }}
+      aria-label="Primary"
+    >
+      <NavTab href="/" label="Home" Icon={Home} active={active === "home"} />
+      <NavTab href="/rewards" label="Rewards" Icon={Gift} active={active === "rewards"} />
+      <NavMenuPuck href="/menu" active={active === "menu"} />
+      <NavTab href="/orders" label="Orders" Icon={ClipboardList} active={active === "orders"} />
+      <NavTab href="/account" label="Account" Icon={User} active={active === "account"} />
+    </nav>
+  );
+}
+
+function NavTab({
+  href,
+  label,
+  Icon,
+  active,
+}: {
+  href: string;
+  label: string;
+  Icon: typeof Home;
+  active: boolean;
+}) {
+  const color = active ? "#160800" : "#8E8E93";
+  return (
+    <Link href={href} className="flex-1 flex flex-col items-center justify-center gap-1 py-2 active:opacity-60">
+      <Icon size={24} color={color} strokeWidth={active ? 2.4 : 1.75} />
+      <span
+        className="text-[12.5px]"
+        style={{ color, fontWeight: active ? 700 : 600, letterSpacing: 0.2 }}
+      >
+        {label}
+      </span>
+    </Link>
+  );
+}
+
+function NavMenuPuck({ href, active }: { href: string; active: boolean }) {
+  return (
+    <Link href={href} className="flex-1 flex flex-col items-center active:opacity-80" aria-label="Menu tab">
+      <span
+        className="-mt-4 flex items-center justify-center"
+        style={{
+          width: 52,
+          height: 52,
+          borderRadius: 26,
+          backgroundColor: active ? "#160800" : "#8E8E93",
+          border: "3px solid #FFFFFF",
+          boxShadow: "0 3px 8px rgba(0,0,0,0.2)",
+        }}
+      >
+        <svg width="26" height="26" viewBox="0 0 24 24" fill="none" stroke="#FFFFFF" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+          <path d="M6 3h12l-1 9a4 4 0 0 1-4 4h-2a4 4 0 0 1-4-4z" />
+          <path d="M9 21h6" />
+          <path d="M12 17v4" />
+        </svg>
+      </span>
+      <span
+        className="text-[12.5px] mt-0.5"
+        style={{
+          color: active ? "#160800" : "#8E8E93",
+          fontWeight: active ? 700 : 600,
+          letterSpacing: 0.2,
+        }}
+      >
+        Menu
+      </span>
+    </Link>
+  );
+}

--- a/apps/order/src/app/account/_AccountView.tsx
+++ b/apps/order/src/app/account/_AccountView.tsx
@@ -1,0 +1,139 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import Link from "next/link";
+import { User, ChevronRight, LogOut } from "lucide-react";
+
+type Persisted = {
+  state?: {
+    phone?: string | null;
+    member?: {
+      name?: string | null;
+      pointsBalance?: number;
+      totalVisits?: number;
+      email?: string | null;
+    };
+  };
+};
+
+/**
+ * Account screen. OTP sign-in is a complex multi-step flow with the
+ * server's /api/otp endpoints — to keep this minimal, the actual
+ * sign-in flow still lives in the SPA. This Next.js page shows
+ * profile info if already signed in, otherwise a sign-in CTA that
+ * deep-links to the SPA's /account.
+ *
+ * (When the SPA's account screen ports to Next.js, the OTP flow will
+ * live here too.)
+ */
+export function AccountView() {
+  const [phone, setPhone] = useState<string | null>(null);
+  const [name, setName] = useState<string | null>(null);
+  const [beans, setBeans] = useState(0);
+  const [visits, setVisits] = useState(0);
+  const [hydrated, setHydrated] = useState(false);
+
+  useEffect(() => {
+    try {
+      const raw = window.localStorage.getItem("celsius-pickup");
+      if (raw) {
+        const parsed = JSON.parse(raw) as Persisted;
+        setPhone(parsed.state?.phone ?? null);
+        setName(parsed.state?.member?.name ?? null);
+        setBeans(parsed.state?.member?.pointsBalance ?? 0);
+        setVisits(parsed.state?.member?.totalVisits ?? 0);
+      }
+    } catch {
+      /* ignore */
+    }
+    setHydrated(true);
+  }, []);
+
+  return (
+    <>
+      <header
+        className="bg-[#160800] text-white px-4 pb-3"
+        style={{ paddingTop: "calc(env(safe-area-inset-top, 0px) + 12px)" }}
+      >
+        <h1
+          className="text-[22px]"
+          style={{ fontFamily: "Peachi-Bold, serif", letterSpacing: -0.3, fontWeight: 700 }}
+        >
+          Account
+        </h1>
+      </header>
+
+      {!hydrated ? null : !phone ? (
+        <div className="flex flex-col items-center px-6 py-12">
+          <User size={48} color="#8E8E93" strokeWidth={1.25} />
+          <p
+            className="mt-4 text-base"
+            style={{ fontFamily: "Peachi-Bold, serif", fontWeight: 700 }}
+          >
+            Sign in to Celsius
+          </p>
+          <p className="text-sm text-[#6E6E73] mt-1 text-center">
+            Earn beans, redeem rewards, see your order history.
+          </p>
+          <a
+            href="/account?signin=1"
+            className="mt-6 rounded-full bg-[#A2492C] text-white px-5 py-3 font-bold active:opacity-80"
+          >
+            Sign in with phone
+          </a>
+        </div>
+      ) : (
+        <div className="px-4 pt-4 flex flex-col gap-3">
+          <section
+            className="bg-[#160800] text-white rounded-2xl p-5"
+            style={{ minHeight: 120 }}
+          >
+            <p className="text-[10px] uppercase tracking-widest text-white/60">Hello</p>
+            <p
+              className="mt-1 text-2xl"
+              style={{ fontFamily: "Peachi-Bold, serif", fontWeight: 700 }}
+            >
+              {name ?? phone}
+            </p>
+            <div className="mt-4 flex gap-6">
+              <div>
+                <p className="text-xl font-bold">{beans.toLocaleString()}</p>
+                <p className="text-[10px] uppercase tracking-widest text-white/60">Beans</p>
+              </div>
+              <div>
+                <p className="text-xl font-bold">{visits}</p>
+                <p className="text-[10px] uppercase tracking-widest text-white/60">Visits</p>
+              </div>
+            </div>
+          </section>
+
+          <Row href="/orders" label="Order history" />
+          <Row href="/rewards" label="Rewards" />
+          <Row href="/account?edit=1" label="Edit profile" />
+          <Row href="/account?signout=1" label="Sign out" Icon={LogOut} />
+        </div>
+      )}
+    </>
+  );
+}
+
+function Row({
+  href,
+  label,
+  Icon,
+}: {
+  href: string;
+  label: string;
+  Icon?: typeof User;
+}) {
+  return (
+    <Link
+      href={href}
+      className="flex items-center gap-3 bg-white border border-[#EBE5DE] rounded-2xl px-4 py-3 active:opacity-80"
+    >
+      {Icon ? <Icon size={18} color="#8E8E93" /> : null}
+      <span className="text-sm font-bold flex-1">{label}</span>
+      <ChevronRight size={14} color="#8E8E93" />
+    </Link>
+  );
+}

--- a/apps/order/src/app/account/page.tsx
+++ b/apps/order/src/app/account/page.tsx
@@ -1,0 +1,11 @@
+import { AccountView } from "./_AccountView";
+import { BottomNav } from "../_BottomNav";
+
+export default function AccountPage() {
+  return (
+    <main className="bg-white text-[#160800] min-h-screen pb-[calc(env(safe-area-inset-bottom,0px)+88px)]">
+      <AccountView />
+      <BottomNav active="account" />
+    </main>
+  );
+}

--- a/apps/order/src/app/cart/_CartView.tsx
+++ b/apps/order/src/app/cart/_CartView.tsx
@@ -1,0 +1,218 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import Link from "next/link";
+import Image from "next/image";
+import { ArrowLeft, Trash2, Plus, Minus } from "lucide-react";
+
+type CartItem = {
+  cartId: string;
+  productId: string;
+  name: string;
+  image?: string;
+  basePrice: number;
+  quantity: number;
+  totalPrice: number;
+  modifiers?: Array<{ groupName?: string; label?: string; priceDelta?: number }>;
+};
+
+type Persisted = {
+  state?: {
+    cart?: CartItem[];
+    outletName?: string | null;
+  };
+};
+
+const KEY = "celsius-pickup";
+
+function readCart(): { items: CartItem[]; outletName: string | null } {
+  try {
+    const raw = window.localStorage.getItem(KEY);
+    if (!raw) return { items: [], outletName: null };
+    const parsed = JSON.parse(raw) as Persisted;
+    return {
+      items: parsed.state?.cart ?? [],
+      outletName: parsed.state?.outletName ?? null,
+    };
+  } catch {
+    return { items: [], outletName: null };
+  }
+}
+
+function writeCart(items: CartItem[]) {
+  try {
+    const raw = window.localStorage.getItem(KEY);
+    const parsed = raw ? (JSON.parse(raw) as Persisted) : { state: {} };
+    const state = parsed.state ?? {};
+    state.cart = items;
+    window.localStorage.setItem(KEY, JSON.stringify({ ...parsed, state }));
+  } catch {
+    /* ignore */
+  }
+}
+
+export function CartView() {
+  const [items, setItems] = useState<CartItem[]>([]);
+  const [outletName, setOutletName] = useState<string | null>(null);
+  const [hydrated, setHydrated] = useState(false);
+
+  useEffect(() => {
+    const { items, outletName } = readCart();
+    setItems(items);
+    setOutletName(outletName);
+    setHydrated(true);
+  }, []);
+
+  const subtotal = items.reduce((s, i) => s + i.totalPrice, 0);
+  const count = items.reduce((s, i) => s + i.quantity, 0);
+
+  const updateQty = (cartId: string, delta: number) => {
+    const next = items
+      .map((i) => {
+        if (i.cartId !== cartId) return i;
+        const q = Math.max(0, i.quantity + delta);
+        return { ...i, quantity: q, totalPrice: (i.totalPrice / i.quantity) * q };
+      })
+      .filter((i) => i.quantity > 0);
+    setItems(next);
+    writeCart(next);
+  };
+
+  const remove = (cartId: string) => {
+    const next = items.filter((i) => i.cartId !== cartId);
+    setItems(next);
+    writeCart(next);
+  };
+
+  if (!hydrated) {
+    return <CartShell outletName={null}>
+      <div className="p-8 text-center text-[#8E8E93] text-sm">Loading…</div>
+    </CartShell>;
+  }
+
+  if (items.length === 0) {
+    return (
+      <CartShell outletName={outletName}>
+        <div className="p-8 text-center">
+          <p className="text-sm text-[#8E8E93]">Your cart is empty.</p>
+          <Link
+            href="/menu"
+            className="mt-4 inline-block rounded-full bg-[#A2492C] text-white px-5 py-3 font-bold active:opacity-80"
+          >
+            Browse menu →
+          </Link>
+        </div>
+      </CartShell>
+    );
+  }
+
+  return (
+    <CartShell outletName={outletName}>
+      <ul className="px-4 py-4 flex flex-col gap-3">
+        {items.map((item) => (
+          <li
+            key={item.cartId}
+            className="bg-white rounded-2xl border border-[#EBE5DE] p-3 flex gap-3"
+            style={{ boxShadow: "0 2px 6px rgba(0,0,0,0.04)" }}
+          >
+            <Link
+              href={`/product/${item.productId}?cartId=${item.cartId}`}
+              className="relative w-[72px] h-[72px] flex-shrink-0 rounded-xl overflow-hidden bg-[#F2EDE5]"
+            >
+              {item.image ? (
+                <Image src={item.image} alt={item.name} fill sizes="72px" className="object-cover" />
+              ) : null}
+            </Link>
+            <div className="flex-1 min-w-0">
+              <Link href={`/product/${item.productId}?cartId=${item.cartId}`}>
+                <p className="text-sm font-bold truncate">{item.name}</p>
+              </Link>
+              {item.modifiers && item.modifiers.length > 0 ? (
+                <p className="text-[11px] text-[#6E6E73] mt-0.5 line-clamp-1">
+                  {item.modifiers.map((m) => m.label).filter(Boolean).join(", ")}
+                </p>
+              ) : null}
+              <div className="mt-2 flex items-center gap-3">
+                <button
+                  onClick={() => updateQty(item.cartId, -1)}
+                  className="h-7 w-7 rounded-full border border-[#E0D8CE] flex items-center justify-center active:opacity-60"
+                  aria-label="Decrease quantity"
+                >
+                  <Minus size={14} className="text-[#160800]" />
+                </button>
+                <span className="font-bold w-5 text-center">{item.quantity}</span>
+                <button
+                  onClick={() => updateQty(item.cartId, +1)}
+                  className="h-7 w-7 rounded-full bg-[#160800] flex items-center justify-center active:opacity-80"
+                  aria-label="Increase quantity"
+                >
+                  <Plus size={14} color="#FFFFFF" />
+                </button>
+                <span className="ml-auto text-sm text-[#A2492C] font-bold">
+                  RM{item.totalPrice.toFixed(2)}
+                </span>
+                <button
+                  onClick={() => remove(item.cartId)}
+                  className="ml-2 p-1 active:opacity-60"
+                  aria-label="Remove"
+                >
+                  <Trash2 size={16} color="#8E8E93" />
+                </button>
+              </div>
+            </div>
+          </li>
+        ))}
+      </ul>
+
+      <div className="px-4 pt-4 pb-2 border-t border-[#EBE5DE]">
+        <div className="flex items-center justify-between mb-3">
+          <span className="text-sm text-[#6E6E73]">
+            {count} {count === 1 ? "item" : "items"}
+          </span>
+          <span className="text-base font-bold">RM{subtotal.toFixed(2)}</span>
+        </div>
+        <Link
+          href="/checkout"
+          className="block w-full rounded-full bg-[#A2492C] text-white text-center py-4 font-bold active:opacity-80"
+        >
+          Continue to checkout
+        </Link>
+      </div>
+    </CartShell>
+  );
+}
+
+function CartShell({
+  outletName,
+  children,
+}: {
+  outletName: string | null;
+  children: React.ReactNode;
+}) {
+  return (
+    <>
+      <header
+        className="bg-[#160800] text-white px-4 pb-3 flex items-center gap-3"
+        style={{ paddingTop: "calc(env(safe-area-inset-top, 0px) + 12px)" }}
+      >
+        <Link href="/" className="-ml-1 p-1 active:opacity-60" aria-label="Back">
+          <ArrowLeft size={20} color="#FFFFFF" />
+        </Link>
+        <div className="flex-1 min-w-0">
+          {outletName ? (
+            <p className="text-[10px] text-white/50 uppercase tracking-widest truncate">
+              Pickup from {outletName}
+            </p>
+          ) : null}
+          <h1
+            className="text-[22px] truncate"
+            style={{ fontFamily: "Peachi-Bold, serif", letterSpacing: -0.3, fontWeight: 700 }}
+          >
+            Your cart
+          </h1>
+        </div>
+      </header>
+      {children}
+    </>
+  );
+}

--- a/apps/order/src/app/cart/page.tsx
+++ b/apps/order/src/app/cart/page.tsx
@@ -1,0 +1,16 @@
+import { CartView } from "./_CartView";
+import { BottomNav } from "../_BottomNav";
+
+/**
+ * Cart screen. Cart state lives in localStorage (the SPA's persisted
+ * Zustand store), so the contents have to render client-side — see
+ * _CartView. This page is just the route shell + chrome.
+ */
+export default function CartPage() {
+  return (
+    <main className="bg-white text-[#160800] min-h-screen pb-[calc(env(safe-area-inset-bottom,0px)+88px)]">
+      <CartView />
+      <BottomNav active="home" />
+    </main>
+  );
+}

--- a/apps/order/src/app/menu/page.tsx
+++ b/apps/order/src/app/menu/page.tsx
@@ -1,0 +1,170 @@
+import Image from "next/image";
+import Link from "next/link";
+import { ArrowLeft, ShoppingCart, MapPin, ChevronDown, Plus } from "lucide-react";
+import { getMenuData } from "@/lib/menu-data";
+import { GlobalCartPill } from "../_GlobalCartPill";
+import { BottomNav } from "../_BottomNav";
+
+/**
+ * Customer menu — Next.js Server Component, plain HTML so iOS Safari's
+ * URL bar collapses on body scroll. Replaces the SPA's /menu render.
+ *
+ * Layout simplifies the SPA's two-column (sidebar pills + product
+ * list) to a single column with category sections — fits a mobile
+ * browser viewport better and matches GrabFood / Foodpanda's mobile
+ * pattern. Tapping a product card drops into the SPA at /product/[id]
+ * for modifier selection (the product detail flow is a follow-up
+ * Next.js rebuild).
+ */
+
+export const revalidate = 60;
+
+const HIDDEN_CATEGORIES = new Set(["bottles"]);
+
+export default async function MenuPage() {
+  const menu = await getMenuData();
+
+  const visibleCats = menu.categories.filter((c) => !HIDDEN_CATEGORIES.has(c.id));
+  const bestSellers = menu.products
+    .filter((p) => p.isPopular && p.isAvailable && !HIDDEN_CATEGORIES.has(p.categoryId))
+    .sort((a, b) => (a.featuredPosition ?? 9999) - (b.featuredPosition ?? 9999));
+
+  const productsByCat: Record<string, typeof menu.products> = {};
+  for (const p of menu.products) {
+    if (!p.isAvailable) continue;
+    if (HIDDEN_CATEGORIES.has(p.categoryId)) continue;
+    (productsByCat[p.categoryId] ??= []).push(p);
+  }
+
+  return (
+    <main className="bg-white text-[#160800] pb-[calc(env(safe-area-inset-bottom,0px)+88px)]">
+      <Header />
+
+      <OutletPickerRow />
+
+      {/* Best Sellers — pinned section at the top */}
+      {bestSellers.length > 0 && (
+        <section className="mt-2 px-4 pt-4">
+          <h2
+            className="text-[20px] mb-3"
+            style={{ fontFamily: "Peachi-Bold, serif", letterSpacing: -0.3, fontWeight: 700 }}
+          >
+            Best Sellers
+          </h2>
+          <ProductList products={bestSellers.slice(0, 12)} />
+        </section>
+      )}
+
+      {/* Each visible category as its own section */}
+      {visibleCats.map((cat) => {
+        const items = productsByCat[cat.id] ?? [];
+        if (items.length === 0) return null;
+        return (
+          <section key={cat.id} className="mt-6 px-4">
+            <h2
+              className="text-[20px] mb-3"
+              style={{ fontFamily: "Peachi-Bold, serif", letterSpacing: -0.3, fontWeight: 700 }}
+            >
+              {cat.name}
+            </h2>
+            <ProductList products={items} />
+          </section>
+        );
+      })}
+
+      <GlobalCartPill />
+      <BottomNav active="menu" />
+    </main>
+  );
+}
+
+function Header() {
+  return (
+    <header
+      className="bg-[#160800] text-white px-4 pb-3 flex items-center gap-3"
+      style={{ paddingTop: "calc(env(safe-area-inset-top, 0px) + 12px)" }}
+    >
+      <Link href="/" className="-ml-1 p-1 active:opacity-60" aria-label="Back to home">
+        <ArrowLeft size={20} color="#FFFFFF" />
+      </Link>
+      <h1
+        className="flex-1 text-[22px] truncate"
+        style={{ fontFamily: "Peachi-Bold, serif", letterSpacing: -0.3, fontWeight: 700 }}
+      >
+        Pickup
+      </h1>
+      <Link href="/cart" className="p-1 active:opacity-60" aria-label="Cart">
+        <ShoppingCart size={20} color="rgba(255,255,255,0.85)" />
+      </Link>
+    </header>
+  );
+}
+
+function OutletPickerRow() {
+  return (
+    <Link
+      href="/store"
+      className="flex items-center gap-2 bg-[#F7F4F0] border-b border-[#E8E1D8] px-4 py-2 active:opacity-70"
+    >
+      <MapPin size={14} className="text-[#A2492C]" />
+      <span className="text-sm font-bold flex-1 truncate">Select outlet</span>
+      <ChevronDown size={14} className="text-[#8E8E93]" />
+    </Link>
+  );
+}
+
+function ProductList({
+  products,
+}: {
+  products: Array<{
+    id: string;
+    name: string;
+    description?: string;
+    basePrice: number;
+    image: string;
+  }>;
+}) {
+  return (
+    <ul className="flex flex-col gap-3">
+      {products.map((p) => (
+        <li key={p.id}>
+          <Link
+            href={`/product/${p.id}`}
+            className="block bg-white rounded-2xl border border-[#EBE5DE] active:opacity-80"
+            style={{
+              boxShadow: "0 2px 6px rgba(0,0,0,0.04)",
+            }}
+          >
+            <div className="flex items-center gap-3 p-3">
+              <div className="relative w-[72px] h-[72px] flex-shrink-0 rounded-xl overflow-hidden bg-[#F2EDE5]">
+                {p.image ? (
+                  <Image
+                    src={p.image}
+                    alt={p.name}
+                    fill
+                    sizes="72px"
+                    className="object-cover"
+                  />
+                ) : null}
+              </div>
+              <div className="flex-1 min-w-0">
+                <p className="text-sm font-bold truncate">{p.name}</p>
+                {p.description ? (
+                  <p className="text-[11px] text-[#6E6E73] mt-0.5 line-clamp-2">
+                    {p.description}
+                  </p>
+                ) : null}
+                <p className="mt-1 text-sm text-[#A2492C] font-bold">
+                  RM{p.basePrice.toFixed(2)}
+                </p>
+              </div>
+              <span className="h-9 w-9 rounded-full bg-[#160800] flex items-center justify-center flex-shrink-0">
+                <Plus size={16} color="#FFFFFF" strokeWidth={2.5} />
+              </span>
+            </div>
+          </Link>
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/apps/order/src/app/orders/_OrdersView.tsx
+++ b/apps/order/src/app/orders/_OrdersView.tsx
@@ -1,0 +1,155 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import Link from "next/link";
+import { ClipboardList, ChevronRight } from "lucide-react";
+
+type Order = {
+  id: string;
+  order_number: string;
+  status: string;
+  total: number;
+  created_at: string;
+  order_items?: Array<{ product_name: string; quantity: number }>;
+};
+
+type Persisted = { state?: { phone?: string | null } };
+
+function readPhone(): string | null {
+  try {
+    const raw = window.localStorage.getItem("celsius-pickup");
+    if (!raw) return null;
+    const parsed = JSON.parse(raw) as Persisted;
+    return parsed.state?.phone ?? null;
+  } catch {
+    return null;
+  }
+}
+
+export function OrdersView() {
+  const [phone, setPhone] = useState<string | null>(null);
+  const [orders, setOrders] = useState<Order[] | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const p = readPhone();
+    setPhone(p);
+    if (!p) {
+      setOrders([]);
+      return;
+    }
+    fetch(`/api/loyalty/orders?phone=${encodeURIComponent(p)}&limit=20`)
+      .then((r) => r.json())
+      .then((data) => {
+        setOrders((data?.orders ?? data ?? []) as Order[]);
+      })
+      .catch((err) => setError(String(err)));
+  }, []);
+
+  return (
+    <>
+      <header
+        className="bg-[#160800] text-white px-4 pb-3"
+        style={{ paddingTop: "calc(env(safe-area-inset-top, 0px) + 12px)" }}
+      >
+        <h1
+          className="text-[22px]"
+          style={{ fontFamily: "Peachi-Bold, serif", letterSpacing: -0.3, fontWeight: 700 }}
+        >
+          Orders
+        </h1>
+      </header>
+
+      {!phone ? (
+        <EmptyCTA
+          icon={<ClipboardList size={48} color="#8E8E93" strokeWidth={1.25} />}
+          title="Sign in to see your orders"
+          body="Your past orders will live here once you sign in."
+          actionHref="/account"
+          actionLabel="Sign in"
+        />
+      ) : orders === null ? (
+        <div className="p-8 text-center text-[#8E8E93] text-sm">Loading…</div>
+      ) : orders.length === 0 ? (
+        <EmptyCTA
+          icon={<ClipboardList size={48} color="#8E8E93" strokeWidth={1.25} />}
+          title="No orders yet"
+          body="Once you place your first order, it'll show up here."
+          actionHref="/menu"
+          actionLabel="Open the menu"
+        />
+      ) : (
+        <ul className="px-4 py-4 flex flex-col gap-3">
+          {orders.map((o) => (
+            <li key={o.id}>
+              <Link
+                href={`/order/${o.id}`}
+                className="flex items-center gap-3 bg-white rounded-2xl border border-[#EBE5DE] p-3 active:opacity-80"
+              >
+                <div className="flex-1 min-w-0">
+                  <p className="text-sm font-bold">#{o.order_number}</p>
+                  <p className="text-[11px] text-[#6E6E73] mt-0.5">
+                    {new Date(o.created_at).toLocaleDateString("en-MY", {
+                      day: "numeric",
+                      month: "short",
+                      hour: "2-digit",
+                      minute: "2-digit",
+                    })}
+                    {" · "}
+                    {o.status}
+                  </p>
+                  {o.order_items && o.order_items.length > 0 ? (
+                    <p className="text-[11px] text-[#6E6E73] mt-0.5 line-clamp-1">
+                      {o.order_items.map((i) => `${i.quantity}× ${i.product_name}`).join(", ")}
+                    </p>
+                  ) : null}
+                </div>
+                <span className="text-sm text-[#A2492C] font-bold">
+                  RM{((o.total ?? 0) / 100).toFixed(2)}
+                </span>
+                <ChevronRight size={14} color="#8E8E93" />
+              </Link>
+            </li>
+          ))}
+        </ul>
+      )}
+
+      {error ? (
+        <p className="px-4 pb-4 text-[11px] text-red-600">Couldn't load orders: {error}</p>
+      ) : null}
+    </>
+  );
+}
+
+function EmptyCTA({
+  icon,
+  title,
+  body,
+  actionHref,
+  actionLabel,
+}: {
+  icon: React.ReactNode;
+  title: string;
+  body: string;
+  actionHref: string;
+  actionLabel: string;
+}) {
+  return (
+    <div className="flex flex-col items-center justify-center px-6 py-16">
+      {icon}
+      <p
+        className="mt-4 text-base"
+        style={{ fontFamily: "Peachi-Bold, serif", fontWeight: 700 }}
+      >
+        {title}
+      </p>
+      <p className="text-sm text-[#6E6E73] mt-1 text-center">{body}</p>
+      <Link
+        href={actionHref}
+        className="mt-6 rounded-full bg-[#160800] text-white px-5 py-3 font-bold active:opacity-80"
+      >
+        {actionLabel}
+      </Link>
+    </div>
+  );
+}

--- a/apps/order/src/app/orders/page.tsx
+++ b/apps/order/src/app/orders/page.tsx
@@ -1,0 +1,11 @@
+import { OrdersView } from "./_OrdersView";
+import { BottomNav } from "../_BottomNav";
+
+export default function OrdersPage() {
+  return (
+    <main className="bg-white text-[#160800] min-h-screen pb-[calc(env(safe-area-inset-bottom,0px)+88px)]">
+      <OrdersView />
+      <BottomNav active="orders" />
+    </main>
+  );
+}

--- a/apps/order/src/app/page.tsx
+++ b/apps/order/src/app/page.tsx
@@ -1,10 +1,11 @@
 import Image from "next/image";
 import Link from "next/link";
-import { Home, Gift, ClipboardList, User, ChevronDown, MapPin, Plus, ChevronRight } from "lucide-react";
+import { ChevronDown, MapPin, Plus, ChevronRight } from "lucide-react";
 import { getSupabaseAdmin } from "@/lib/supabase/server";
 import { getMenuData } from "@/lib/menu-data";
 import { GlobalCartPill } from "./_GlobalCartPill";
 import { MemberBeansCard } from "./_MemberBeansCard";
+import { BottomNav } from "./_BottomNav";
 
 /**
  * Customer home (Next.js Server Component) — replaces the pickup-native
@@ -199,69 +200,8 @@ export default async function HomePage() {
           localStorage and renders if non-empty). */}
       <GlobalCartPill />
 
-      {/* BottomNav — fixed at viewport bottom. Plain <a> links to inner
-          SPA routes; Home is the current page so it gets the active
-          treatment. */}
-      <nav
-        className="fixed bottom-0 left-0 right-0 bg-white border-t border-[#EBE5DE] flex items-stretch z-20"
-        style={{ paddingBottom: "env(safe-area-inset-bottom, 0px)" }}
-        aria-label="Primary"
-      >
-        <NavTab href="/" label="Home" Icon={Home} active />
-        <NavTab href="/rewards" label="Rewards" Icon={Gift} />
-        <NavMenuPuck href="/menu" />
-        <NavTab href="/orders" label="Orders" Icon={ClipboardList} />
-        <NavTab href="/account" label="Account" Icon={User} />
-      </nav>
+      {/* BottomNav — shared component, gets the active tab as a prop. */}
+      <BottomNav active="home" />
     </main>
-  );
-}
-
-function NavTab({ href, label, Icon, active }: { href: string; label: string; Icon: typeof Home; active?: boolean }) {
-  const color = active ? "#160800" : "#8E8E93";
-  return (
-    <Link
-      href={href}
-      className="flex-1 flex flex-col items-center justify-center gap-1 py-2 active:opacity-60"
-    >
-      <Icon size={24} color={color} strokeWidth={active ? 2.4 : 1.75} />
-      <span className="text-[12.5px]" style={{ color, fontWeight: active ? 700 : 600, letterSpacing: 0.2 }}>
-        {label}
-      </span>
-    </Link>
-  );
-}
-
-// Menu tab: elevated terracotta-on-dark puck CTA in the centre, mirrors
-// the SPA's BottomNav design.
-function NavMenuPuck({ href }: { href: string }) {
-  return (
-    <Link
-      href={href}
-      className="flex-1 flex flex-col items-center active:opacity-80"
-      aria-label="Menu"
-    >
-      <span
-        className="-mt-4 flex items-center justify-center"
-        style={{
-          width: 52,
-          height: 52,
-          borderRadius: 26,
-          backgroundColor: "#8E8E93",
-          border: "3px solid #FFFFFF",
-          boxShadow: "0 3px 8px rgba(0,0,0,0.2)",
-        }}
-      >
-        {/* Celsius cup glyph — simple svg fallback */}
-        <svg width="26" height="26" viewBox="0 0 24 24" fill="none" stroke="#FFFFFF" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-          <path d="M6 3h12l-1 9a4 4 0 0 1-4 4h-2a4 4 0 0 1-4-4z" />
-          <path d="M9 21h6" />
-          <path d="M12 17v4" />
-        </svg>
-      </span>
-      <span className="text-[12.5px] mt-0.5" style={{ color: "#8E8E93", fontWeight: 600, letterSpacing: 0.2 }}>
-        Menu
-      </span>
-    </Link>
   );
 }

--- a/apps/order/src/app/rewards/_RewardsView.tsx
+++ b/apps/order/src/app/rewards/_RewardsView.tsx
@@ -1,0 +1,141 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import Link from "next/link";
+import { Gift, Sparkles } from "lucide-react";
+
+type Persisted = {
+  state?: {
+    phone?: string | null;
+    member?: { name?: string | null; pointsBalance?: number };
+  };
+};
+
+type Reward = {
+  id: string;
+  name: string;
+  description?: string;
+  beans_cost?: number;
+};
+
+export function RewardsView() {
+  const [phone, setPhone] = useState<string | null>(null);
+  const [beans, setBeans] = useState(0);
+  const [rewards, setRewards] = useState<Reward[] | null>(null);
+  const [hydrated, setHydrated] = useState(false);
+
+  useEffect(() => {
+    try {
+      const raw = window.localStorage.getItem("celsius-pickup");
+      if (raw) {
+        const parsed = JSON.parse(raw) as Persisted;
+        setPhone(parsed.state?.phone ?? null);
+        setBeans(parsed.state?.member?.pointsBalance ?? 0);
+      }
+    } catch {
+      /* ignore */
+    }
+    setHydrated(true);
+  }, []);
+
+  useEffect(() => {
+    if (!phone) return;
+    fetch(`/api/loyalty/rewards?phone=${encodeURIComponent(phone)}`)
+      .then((r) => r.json())
+      .then((data) => setRewards((data?.rewards ?? []) as Reward[]))
+      .catch(() => setRewards([]));
+  }, [phone]);
+
+  return (
+    <>
+      <header
+        className="bg-[#160800] text-white px-4 pb-3"
+        style={{ paddingTop: "calc(env(safe-area-inset-top, 0px) + 12px)" }}
+      >
+        <h1
+          className="text-[22px]"
+          style={{ fontFamily: "Peachi-Bold, serif", letterSpacing: -0.3, fontWeight: 700 }}
+        >
+          Rewards
+        </h1>
+      </header>
+
+      {/* BEANS hero */}
+      <section className="px-4 pt-4">
+        <div
+          className="bg-[#160800] text-white rounded-2xl p-5"
+          style={{ minHeight: 120 }}
+        >
+          <p className="text-[10px] uppercase tracking-widest text-white/60">Beans</p>
+          <p
+            className="mt-2 text-3xl"
+            style={{ fontFamily: "Peachi-Bold, serif", fontWeight: 700 }}
+          >
+            {hydrated ? beans.toLocaleString() : "—"}
+          </p>
+        </div>
+      </section>
+
+      {!hydrated ? null : !phone ? (
+        <div className="flex flex-col items-center px-6 py-12">
+          <Gift size={48} color="#8E8E93" strokeWidth={1.25} />
+          <p
+            className="mt-4 text-base"
+            style={{ fontFamily: "Peachi-Bold, serif", fontWeight: 700 }}
+          >
+            Sign in to claim rewards
+          </p>
+          <p className="text-sm text-[#6E6E73] mt-1 text-center">
+            Earn beans on every order. Trade beans for free drinks.
+          </p>
+          <Link
+            href="/account"
+            className="mt-6 rounded-full bg-[#A2492C] text-white px-5 py-3 font-bold active:opacity-80"
+          >
+            Sign in
+          </Link>
+        </div>
+      ) : rewards === null ? (
+        <div className="p-8 text-center text-[#8E8E93] text-sm">Loading…</div>
+      ) : rewards.length === 0 ? (
+        <div className="flex flex-col items-center px-6 py-12">
+          <Sparkles size={48} color="#8E8E93" strokeWidth={1.25} />
+          <p
+            className="mt-4 text-base"
+            style={{ fontFamily: "Peachi-Bold, serif", fontWeight: 700 }}
+          >
+            No rewards available yet
+          </p>
+          <p className="text-sm text-[#6E6E73] mt-1 text-center">
+            Keep ordering — rewards unlock as you earn beans.
+          </p>
+        </div>
+      ) : (
+        <ul className="px-4 py-4 flex flex-col gap-3">
+          {rewards.map((r) => (
+            <li
+              key={r.id}
+              className="bg-white rounded-2xl border border-[#EBE5DE] p-4"
+              style={{ boxShadow: "0 2px 6px rgba(0,0,0,0.04)" }}
+            >
+              <p
+                className="text-base"
+                style={{ fontFamily: "Peachi-Bold, serif", fontWeight: 700 }}
+              >
+                {r.name}
+              </p>
+              {r.description ? (
+                <p className="text-[12px] text-[#6E6E73] mt-1">{r.description}</p>
+              ) : null}
+              {r.beans_cost ? (
+                <p className="mt-2 text-sm text-[#A2492C] font-bold">
+                  {r.beans_cost.toLocaleString()} beans
+                </p>
+              ) : null}
+            </li>
+          ))}
+        </ul>
+      )}
+    </>
+  );
+}

--- a/apps/order/src/app/rewards/page.tsx
+++ b/apps/order/src/app/rewards/page.tsx
@@ -1,0 +1,11 @@
+import { RewardsView } from "./_RewardsView";
+import { BottomNav } from "../_BottomNav";
+
+export default function RewardsPage() {
+  return (
+    <main className="bg-white text-[#160800] min-h-screen pb-[calc(env(safe-area-inset-bottom,0px)+88px)]">
+      <RewardsView />
+      <BottomNav active="rewards" />
+    </main>
+  );
+}

--- a/apps/order/src/middleware.ts
+++ b/apps/order/src/middleware.ts
@@ -55,13 +55,20 @@ export async function middleware(request: NextRequest) {
   const { pathname } = request.nextUrl;
   const isApi = pathname.startsWith("/api/");
 
-  // "/" is handled by a real Next.js page (apps/order/src/app/page.tsx)
-  // instead of the SPA. The Next.js page renders plain HTML/CSS so iOS
-  // Safari's URL bar collapses on body scroll — the RN-Web SPA can't do
-  // that because its ScrollView clamps the document at viewport height.
-  // Every OTHER customer route (/menu, /cart, /product/[id], etc.)
-  // still rewrites to the SPA shell.
-  const isNextOwned = pathname === "/";
+  // Customer routes that are NOW Next.js pages (apps/order/src/app/…/page.tsx)
+  // bypass the SPA rewrite — they render plain HTML so iOS Safari can
+  // collapse its URL bar on body scroll. Each route added here means
+  // one less screen the customer hits through the RN-Web SPA. Inner
+  // routes that haven't been ported yet (cart, product/[id], orders,
+  // rewards, account, checkout, store, etc.) still rewrite to the
+  // SPA's index.html below.
+  const isNextOwned =
+    pathname === "/" ||
+    pathname === "/menu" ||
+    pathname === "/cart" ||
+    pathname === "/orders" ||
+    pathname === "/rewards" ||
+    pathname === "/account";
 
   // Customer-facing UI lives in the Expo Web PWA shipped from
   // apps/pickup-native and copied into /public during build. For any

--- a/apps/pickup-native/public/sw.js
+++ b/apps/pickup-native/public/sw.js
@@ -6,7 +6,7 @@
 //
 // Future rule of thumb: bump this on ANY production-affecting bundle
 // regression so customers don't get stuck on a bad build.
-const CACHE = "celsius-v6";
+const CACHE = "celsius-v7";
 const SHELL = ["/", "/index.html", "/manifest.json"];
 
 self.addEventListener("install", (e) => {


### PR DESCRIPTION
## Summary

Continuing the rebuild from #167 — five more customer-facing routes now render as plain HTML Next.js pages instead of routing through the RN-Web SPA. **URL bar collapses on each.**

### Routes landed

| Route | Type | Notes |
|---|---|---|
| `/menu` | Server Component | Best Sellers section + each category. Uses `getMenuData()` (same helper home uses). |
| `/cart` | Client Component | Reads + writes the SPA's persisted Zustand cart in `localStorage` — qty +/-, remove, totals, checkout CTA. |
| `/orders` | Client Component | Fetches `/api/loyalty/orders` with the customer's phone from localStorage. Empty / signed-out CTAs. |
| `/rewards` | Client Component | Beans hero + `/api/loyalty/rewards` catalog. |
| `/account` | Client Component | Profile snapshot (name, beans, visits) + row links. OTP sign-in still in SPA for now. |

### Shared chrome

- `_BottomNav.tsx` — 5-tab persistent nav, takes an active prop.
- `_GlobalCartPill.tsx`, `_MemberBeansCard.tsx` — unchanged from #167.

### What's still SPA

- `/product/[id]` — modifier picker, complex state. Next port.
- `/checkout` — Stripe + RM hosted-page redirect already shipped in #165, but the form itself stays SPA.
- `/order/[id]` — order tracking + RmCheckoutModal flow.
- `/store`, `/support`, `/settings`, etc.

Middleware updated so the new routes bypass the SPA rewrite. Old routes still rewrite to `index.html`.

SW cache bumped `v6 → v7` so stuck clients flush onto the new bundles.

## Test plan

For each new route, on iPhone Safari:
- [ ] `/menu`: products render, sections show, URL bar collapses on scroll, "+" tap goes to /product/[id] (SPA).
- [ ] `/cart`: cart items render from localStorage, +/- updates qty, trash removes, totals update, "Continue to checkout" goes to /checkout (SPA).
- [ ] `/orders`: signed-in customers see their history, signed-out see CTA to /account.
- [ ] `/rewards`: beans count + rewards list (or empty/sign-in CTAs).
- [ ] `/account`: profile card if signed in, sign-in CTA otherwise.
- [ ] BottomNav tab navigation works on every page.
- [ ] Native iOS pickup app: no visual diff.

Each page is a discrete rebuild — if any specific one looks wrong, say which and I'll iterate without touching the others.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Xd1aERynqUbdCqXNboKWBe)_