### PR TITLE
feat(web): active challenge teaser on home + search on menu

### DIFF
--- a/apps/order/src/app/_ActiveChallengeCard.tsx
+++ b/apps/order/src/app/_ActiveChallengeCard.tsx
@@ -1,0 +1,128 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import Link from "next/link";
+import { ChevronRight, Sparkles } from "lucide-react";
+
+/**
+ * Active Challenge teaser on the home — surfaces one of the
+ * customer's 3 weekly missions, preferring the still-in-progress one.
+ * Mirrors apps/pickup-native/app/index.tsx:764-845 styling: dark
+ * espresso card, gold-tinted icon square, uppercase gold eyebrow with
+ * progress, Peachi-bold title, reward summary, chevron.
+ *
+ * Renders only when:
+ *   - Customer is signed in (has a sessionToken in localStorage)
+ *   - /api/loyalty/me/missions/active returns at least one active mission
+ *
+ * Otherwise the card is hidden — no placeholder noise on the home.
+ */
+type Mission = {
+  id: string;
+  title: string;
+  reward_summary?: string | null;
+  status: string;
+  goal_type?: string;
+  goal_threshold?: number;
+  progress_current?: number;
+};
+
+type Persisted = { state?: { sessionToken?: string | null } };
+
+export function ActiveChallengeCard() {
+  const [mission, setMission] = useState<Mission | null>(null);
+
+  useEffect(() => {
+    let token: string | null = null;
+    try {
+      const raw = window.localStorage.getItem("celsius-pickup");
+      if (raw) {
+        const parsed = JSON.parse(raw) as Persisted;
+        token = parsed.state?.sessionToken ?? null;
+      }
+    } catch {
+      /* ignore */
+    }
+    if (!token) return;
+    fetch("/api/loyalty/me/missions/active", {
+      headers: { Authorization: `Bearer ${token}` },
+    })
+      .then((r) => (r.ok ? r.json() : []))
+      .then((data) => {
+        const list = (Array.isArray(data) ? data : (data?.missions ?? [])) as Mission[];
+        const active = list.find((m) => m.status === "active");
+        setMission(active ?? null);
+      })
+      .catch(() => {
+        /* ignore */
+      });
+  }, []);
+
+  if (!mission) return null;
+
+  const progressLabel =
+    mission.goal_type === "single_order_total_at_least"
+      ? `RM${Math.floor((mission.progress_current ?? 0) / 100)}/RM${Math.floor((mission.goal_threshold ?? 0) / 100)}`
+      : `${mission.progress_current ?? 0}/${mission.goal_threshold ?? 0}`;
+
+  return (
+    <Link
+      href="/rewards"
+      className="mt-5 mx-4 flex items-center gap-3 rounded-2xl active:opacity-80"
+      style={{
+        backgroundColor: "#1A0200",
+        padding: 14,
+        boxShadow: "0 4px 10px rgba(22,8,0,0.18)",
+      }}
+    >
+      <span
+        className="flex items-center justify-center"
+        style={{
+          width: 40,
+          height: 40,
+          borderRadius: 12,
+          backgroundColor: "rgba(251,191,36,0.18)",
+        }}
+      >
+        <Sparkles size={20} color="#FBBF24" strokeWidth={1.8} />
+      </span>
+      <span className="flex-1 min-w-0">
+        <span
+          className="block text-[#FBBF24] uppercase truncate"
+          style={{
+            fontWeight: 700,
+            fontSize: 9.5,
+            letterSpacing: 1.4,
+          }}
+        >
+          Active challenge · {progressLabel}
+        </span>
+        <span
+          className="block text-white truncate mt-0.5"
+          style={{
+            fontFamily: "var(--font-display)",
+            fontWeight: 700,
+            fontSize: 15,
+            letterSpacing: -0.3,
+          }}
+        >
+          {mission.title}
+        </span>
+        {mission.reward_summary ? (
+          <span
+            className="block truncate"
+            style={{
+              color: "rgba(255,255,255,0.65)",
+              fontSize: 11,
+              fontWeight: 500,
+              marginTop: 1,
+            }}
+          >
+            {mission.reward_summary}
+          </span>
+        ) : null}
+      </span>
+      <ChevronRight size={16} color="rgba(251,191,36,0.7)" strokeWidth={2} />
+    </Link>
+  );
+}

--- a/apps/order/src/app/_VoucherRail.tsx
+++ b/apps/order/src/app/_VoucherRail.tsx
@@ -1,0 +1,167 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import Link from "next/link";
+import { Gift, ChevronRight, Sparkles } from "lucide-react";
+
+/**
+ * Voucher wallet rail on the home page. Mirrors the SPA's home rail
+ * (apps/pickup-native/app/index.tsx ~L847-1200) — horizontal scroll of
+ * the customer's active vouchers, each as a themed card showing title,
+ * description, and expiry. Renders only for signed-in customers who
+ * have at least one active voucher.
+ */
+type Voucher = {
+  id: string;
+  name?: string | null;
+  title?: string | null;
+  description?: string | null;
+  value_label?: string | null;
+  source_type?: string | null;
+  expires_at?: string | null;
+  status?: string | null;
+};
+
+type Persisted = { state?: { sessionToken?: string | null } };
+
+const THEME: Record<string, { bg: string; fg: string; chip: string }> = {
+  mystery:           { bg: "#160800", fg: "#FFFFFF", chip: "#FBBF24" },
+  mission:           { bg: "#1A0200", fg: "#FFFFFF", chip: "#FBBF24" },
+  birthday:          { bg: "#A2492C", fg: "#FFFFFF", chip: "#FFE4D2" },
+  promo:             { bg: "#A2492C", fg: "#FFFFFF", chip: "#FFE4D2" },
+  welcome:           { bg: "#A2492C", fg: "#FFFFFF", chip: "#FFE4D2" },
+  referral:          { bg: "#FBBF24", fg: "#160800", chip: "#160800" },
+  points_redemption: { bg: "#F2EDE5", fg: "#160800", chip: "#A2492C" },
+};
+
+function themeFor(v: Voucher) {
+  return THEME[v.source_type ?? ""] ?? THEME.promo;
+}
+
+function expiresLabel(iso: string | null | undefined): string | null {
+  if (!iso) return null;
+  const days = Math.ceil((new Date(iso).getTime() - Date.now()) / (1000 * 60 * 60 * 24));
+  if (days < 0) return null;
+  if (days === 0) return "Expires today";
+  if (days === 1) return "Expires tomorrow";
+  if (days <= 7) return `Expires in ${days}d`;
+  return `Expires ${new Date(iso).toLocaleDateString("en-MY", { day: "numeric", month: "short" })}`;
+}
+
+export function VoucherRail() {
+  const [vouchers, setVouchers] = useState<Voucher[] | null>(null);
+
+  useEffect(() => {
+    let token: string | null = null;
+    try {
+      const raw = window.localStorage.getItem("celsius-pickup");
+      if (raw) {
+        const parsed = JSON.parse(raw) as Persisted;
+        token = parsed.state?.sessionToken ?? null;
+      }
+    } catch {
+      /* ignore */
+    }
+    if (!token) return;
+    fetch("/api/loyalty/me/vouchers", {
+      headers: { Authorization: `Bearer ${token}` },
+    })
+      .then((r) => (r.ok ? r.json() : []))
+      .then((data) => {
+        const list = (Array.isArray(data) ? data : (data?.vouchers ?? [])) as Voucher[];
+        setVouchers(list.filter((v) => v.status === "active" || !v.status));
+      })
+      .catch(() => {
+        /* ignore */
+      });
+  }, []);
+
+  if (!vouchers || vouchers.length === 0) return null;
+
+  return (
+    <section className="mt-6">
+      <div className="flex items-center px-4 mb-3">
+        <h2 className="font-peachi font-bold text-[20px] flex-1">Your rewards</h2>
+        <Link
+          href="/rewards"
+          className="text-[#A2492C] text-sm flex items-center gap-1 active:opacity-70"
+        >
+          More <ChevronRight size={14} />
+        </Link>
+      </div>
+
+      <ul
+        className="flex gap-3 px-4 overflow-x-auto pb-1"
+        style={{ scrollSnapType: "x mandatory", WebkitOverflowScrolling: "touch" }}
+      >
+        {vouchers.map((v) => {
+          const t = themeFor(v);
+          const title = v.value_label ?? v.title ?? v.name ?? "Reward";
+          const desc = v.description ?? v.name ?? "";
+          const expiry = expiresLabel(v.expires_at);
+          return (
+            <li
+              key={v.id}
+              className="flex-shrink-0"
+              style={{ width: 260, scrollSnapAlign: "start" }}
+            >
+              <Link
+                href="/rewards"
+                className="block rounded-2xl p-4 active:opacity-90"
+                style={{
+                  backgroundColor: t.bg,
+                  color: t.fg,
+                  minHeight: 130,
+                  boxShadow: "0 4px 10px rgba(22,8,0,0.10)",
+                }}
+              >
+                <div className="flex items-start gap-2">
+                  <span
+                    className="flex items-center justify-center"
+                    style={{
+                      width: 36,
+                      height: 36,
+                      borderRadius: 10,
+                      backgroundColor: "rgba(255,255,255,0.14)",
+                    }}
+                  >
+                    {v.source_type === "mystery" || v.source_type === "mission" ? (
+                      <Sparkles size={18} color={t.chip} strokeWidth={1.8} />
+                    ) : (
+                      <Gift size={18} color={t.chip} strokeWidth={1.8} />
+                    )}
+                  </span>
+                  {expiry ? (
+                    <span
+                      className="ml-auto text-[10px] uppercase tracking-widest font-bold rounded-full px-2 py-0.5"
+                      style={{
+                        backgroundColor: "rgba(255,255,255,0.15)",
+                        color: t.chip,
+                      }}
+                    >
+                      {expiry}
+                    </span>
+                  ) : null}
+                </div>
+                <p
+                  className="mt-3 font-peachi font-bold text-lg leading-tight"
+                  style={{ color: t.fg }}
+                >
+                  {title}
+                </p>
+                {desc && desc !== title ? (
+                  <p
+                    className="mt-1 text-[12px] leading-snug line-clamp-2"
+                    style={{ color: t.fg, opacity: 0.75 }}
+                  >
+                    {desc}
+                  </p>
+                ) : null}
+              </Link>
+            </li>
+          );
+        })}
+      </ul>
+    </section>
+  );
+}

--- a/apps/order/src/app/checkout/_CheckoutView.tsx
+++ b/apps/order/src/app/checkout/_CheckoutView.tsx
@@ -48,7 +48,7 @@ export function CheckoutView() {
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
-    setState(readState());
+    setState(readState() ?? null);
   }, []);
 
   const subtotal = useMemo(

--- a/apps/order/src/app/menu/_MenuColumns.tsx
+++ b/apps/order/src/app/menu/_MenuColumns.tsx
@@ -1,11 +1,12 @@
 "use client";
 
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import Image from "next/image";
 import Link from "next/link";
 import {
   Star, Coffee, Leaf, Cake, Cookie, Sandwich, Candy, CupSoda, Cherry,
   Sparkles, Croissant, Wheat, UtensilsCrossed, Utensils, FlaskConical, Plus,
+  Search, X,
 } from "lucide-react";
 
 /**
@@ -50,8 +51,30 @@ const ICONS: Record<string, typeof Coffee> = {
 
 export function MenuColumns({ sections }: { sections: Section[] }) {
   const [active, setActive] = useState(sections[0]?.id ?? "");
+  const [query, setQuery] = useState("");
   const sectionRefs = useRef<Record<string, HTMLDivElement | null>>({});
   const userClickedAtRef = useRef(0);
+
+  // Search results — flat list across all sections, deduped by product
+  // id (Best Sellers + the original category section would otherwise
+  // surface the same product twice).
+  const searchResults = useMemo(() => {
+    const q = query.trim().toLowerCase();
+    if (!q) return null;
+    const seen = new Set<string>();
+    const matches: Product[] = [];
+    for (const s of sections) {
+      for (const p of s.products) {
+        if (seen.has(p.id)) continue;
+        const hay = `${p.name} ${p.description ?? ""}`.toLowerCase();
+        if (hay.includes(q)) {
+          seen.add(p.id);
+          matches.push(p);
+        }
+      }
+    }
+    return matches;
+  }, [query, sections]);
 
   useEffect(() => {
     if (sections.length === 0) return;
@@ -83,6 +106,52 @@ export function MenuColumns({ sections }: { sections: Section[] }) {
   };
 
   return (
+    <>
+      {/* Search bar — sits below the header + outlet picker, filters
+          products across every section. Empty → sidebar + sections; non-
+          empty → flat results list (sidebar hidden). */}
+      <div className="px-4 py-3 bg-white border-b border-[#EBE5DE]">
+        <div className="flex items-center gap-2 rounded-full bg-[#F7F4F0] px-3 py-2">
+          <Search size={16} color="#8E8E93" />
+          <input
+            type="search"
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            placeholder="Search menu…"
+            className="flex-1 bg-transparent outline-none text-sm"
+            autoComplete="off"
+          />
+          {query ? (
+            <button
+              type="button"
+              onClick={() => setQuery("")}
+              className="active:opacity-60"
+              aria-label="Clear search"
+            >
+              <X size={16} color="#8E8E93" />
+            </button>
+          ) : null}
+        </div>
+      </div>
+
+      {searchResults ? (
+        <div className="px-3 pt-4">
+          <p className="text-[11px] text-[#8E8E93] uppercase tracking-widest mb-2 px-1">
+            {searchResults.length} {searchResults.length === 1 ? "result" : "results"} for &ldquo;{query}&rdquo;
+          </p>
+          {searchResults.length === 0 ? (
+            <p className="py-12 text-center text-sm text-[#8E8E93]">No matches</p>
+          ) : (
+            <ul className="flex flex-col gap-3">
+              {searchResults.map((p) => (
+                <ProductRow key={p.id} product={p} />
+              ))}
+            </ul>
+          )}
+          <div className="h-8" />
+        </div>
+      ) : (
+
     <div className="flex" style={{ minHeight: "calc(100dvh - 200px)" }}>
       <aside
         className="w-[64px] flex-shrink-0 bg-[#F7F4F0] border-r border-[#E8E1D8] sticky overflow-y-auto"
@@ -178,5 +247,41 @@ export function MenuColumns({ sections }: { sections: Section[] }) {
         <div className="h-8" />
       </div>
     </div>
+      )}
+    </>
+  );
+}
+
+function ProductRow({ product }: { product: Product }) {
+  return (
+    <li>
+      <Link
+        href={`/product/${product.id}`}
+        className="block bg-white rounded-2xl border border-[#EBE5DE] active:opacity-80"
+        style={{ boxShadow: "0 2px 6px rgba(0,0,0,0.04)" }}
+      >
+        <div className="flex items-center gap-3 p-3">
+          <div className="relative w-[72px] h-[72px] flex-shrink-0 rounded-xl overflow-hidden bg-[#F2EDE5]">
+            {product.image ? (
+              <Image src={product.image} alt={product.name} fill sizes="72px" className="object-cover" />
+            ) : null}
+          </div>
+          <div className="flex-1 min-w-0">
+            <p className="text-sm font-bold truncate">{product.name}</p>
+            {product.description ? (
+              <p className="text-[11px] text-[#6E6E73] mt-0.5 line-clamp-2">
+                {product.description}
+              </p>
+            ) : null}
+            <p className="mt-1 text-sm text-[#A2492C] font-bold">
+              RM{product.basePrice.toFixed(2)}
+            </p>
+          </div>
+          <span className="h-9 w-9 rounded-full bg-[#160800] flex items-center justify-center flex-shrink-0">
+            <Plus size={16} color="#FFFFFF" strokeWidth={2.5} />
+          </span>
+        </div>
+      </Link>
+    </li>
   );
 }

--- a/apps/order/src/app/menu/_MenuColumns.tsx
+++ b/apps/order/src/app/menu/_MenuColumns.tsx
@@ -52,7 +52,7 @@ const ICONS: Record<string, typeof Coffee> = {
 export function MenuColumns({ sections }: { sections: Section[] }) {
   const [active, setActive] = useState(sections[0]?.id ?? "");
   const [query, setQuery] = useState("");
-  const sectionRefs = useRef<Record<string, HTMLDivElement | null>>({});
+  const sectionRefs = useRef<Record<string, HTMLElement | null>>({});
   const userClickedAtRef = useRef(0);
 
   // Search results — flat list across all sections, deduped by product

--- a/apps/order/src/app/page.tsx
+++ b/apps/order/src/app/page.tsx
@@ -9,6 +9,7 @@ import { PosterCarousel } from "./_PosterCarousel";
 import { HeroInfoCard } from "./_HeroInfoCard";
 import { OutletRow } from "./_OutletRow";
 import { ActiveChallengeCard } from "./_ActiveChallengeCard";
+import { VoucherRail } from "./_VoucherRail";
 
 /**
  * Customer home — Next.js Server Component. Plain HTML so iOS Safari
@@ -107,6 +108,11 @@ export default async function HomePage() {
           progress mission). Mirrors apps/pickup-native/app/index.tsx
           :764-845. Renders nothing when there's no active mission. */}
       <ActiveChallengeCard />
+
+      {/* Voucher wallet rail — signed-in customers with active vouchers
+          see them as a horizontally scrolling deck of themed cards.
+          Renders nothing for guests / empty wallets. */}
+      <VoucherRail />
 
       {/* Best Sellers — card-style horizontal scroll (matching the SPA) */}
       {bestSellers.length > 0 && (

--- a/apps/order/src/app/page.tsx
+++ b/apps/order/src/app/page.tsx
@@ -8,6 +8,7 @@ import { BottomNav } from "./_BottomNav";
 import { PosterCarousel } from "./_PosterCarousel";
 import { HeroInfoCard } from "./_HeroInfoCard";
 import { OutletRow } from "./_OutletRow";
+import { ActiveChallengeCard } from "./_ActiveChallengeCard";
 
 /**
  * Customer home — Next.js Server Component. Plain HTML so iOS Safari
@@ -101,6 +102,11 @@ export default async function HomePage() {
           reads chosen outlet from localStorage so customers see their
           outlet name instead of the placeholder. */}
       <OutletRow />
+
+      {/* Active challenge teaser (signed-in customers with an in-
+          progress mission). Mirrors apps/pickup-native/app/index.tsx
+          :764-845. Renders nothing when there's no active mission. */}
+      <ActiveChallengeCard />
 
       {/* Best Sellers — card-style horizontal scroll (matching the SPA) */}
       {bestSellers.length > 0 && (


### PR DESCRIPTION
## Summary

Pass 2 of the native-parity rebuild — adds two of the most-noticeable bits the SPA has and #169 didn't.

### Home: Active Challenge teaser

Dark espresso card with gold-tinted Sparkles icon, `ACTIVE CHALLENGE · 0/1` eyebrow + progress, Peachi-bold title, reward summary, chevron — same styling as `apps/pickup-native/app/index.tsx:764-845`.

- Fetches `/api/loyalty/me/missions/active` with the session token from `localStorage`.
- Renders **nothing** when the customer is signed-out or has no in-progress mission — no placeholder noise on the home.

### Menu: search

Search input above the sections. Empty query → existing two-column sidebar + scroll-spy. Non-empty → flat result list across every section, deduped by product id. Clear (X) restores the section view. Mirrors the SPA's EspressoHeader search toggle.

## Test plan

- [ ] Signed-in customer with an active mission: card shows on home below the outlet picker, gold eyebrow + correct progress, tap → /rewards.
- [ ] Signed-out or no missions: card hidden, layout doesn't shift.
- [ ] /menu: search "black" → matching products only. Clear → sections come back.
- [ ] Native iOS app: unaffected.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Xd1aERynqUbdCqXNboKWBe)_