### PR TITLE
feat(web): /menu Your usual + /rewards tier card — native-parity pass 3

### DIFF
--- a/apps/order/src/app/menu/_MenuColumns.tsx
+++ b/apps/order/src/app/menu/_MenuColumns.tsx
@@ -6,7 +6,7 @@ import Link from "next/link";
 import {
   Star, Coffee, Leaf, Cake, Cookie, Sandwich, Candy, CupSoda, Cherry,
   Sparkles, Croissant, Wheat, UtensilsCrossed, Utensils, FlaskConical, Plus,
-  Search, X,
+  Search, X, Heart,
 } from "lucide-react";
 
 /**
@@ -32,6 +32,7 @@ type Section = {
 };
 
 const ICONS: Record<string, typeof Coffee> = {
+  heart:              Heart,
   star:               Star,
   coffee:             Coffee,
   leaf:               Leaf,
@@ -49,11 +50,63 @@ const ICONS: Record<string, typeof Coffee> = {
   flask:              FlaskConical,
 };
 
-export function MenuColumns({ sections }: { sections: Section[] }) {
-  const [active, setActive] = useState(sections[0]?.id ?? "");
+const USUAL_ID = "__usual__";
+
+export function MenuColumns({
+  sections: baseSections,
+  allProducts,
+}: {
+  sections: Section[];
+  allProducts: Product[];
+}) {
   const [query, setQuery] = useState("");
+  const [usual, setUsual] = useState<Product[]>([]);
   const sectionRefs = useRef<Record<string, HTMLElement | null>>({});
   const userClickedAtRef = useRef(0);
+
+  // Recent items "Usual" pill — same logic as apps/pickup-native/app
+  // /menu.tsx. Fetches the signed-in customer's last 12 ordered items
+  // and resolves them back to in-menu Product records so the section
+  // renders with the same ProductRow design as the rest of the menu.
+  useEffect(() => {
+    let phone: string | null = null;
+    try {
+      const raw = window.localStorage.getItem("celsius-pickup");
+      if (raw) {
+        const parsed = JSON.parse(raw) as { state?: { phone?: string | null } };
+        phone = parsed.state?.phone ?? null;
+      }
+    } catch {
+      /* ignore */
+    }
+    if (!phone) return;
+    fetch(`/api/loyalty/recent-items?phone=${encodeURIComponent(phone)}&limit=12`)
+      .then((r) => (r.ok ? r.json() : []))
+      .then((data) => {
+        const items = (Array.isArray(data) ? data : (data?.items ?? [])) as Array<{
+          id: string;
+        }>;
+        const byId = new Map(allProducts.map((p) => [p.id, p]));
+        const resolved: Product[] = [];
+        for (const it of items) {
+          const p = byId.get(it.id);
+          if (p) resolved.push(p);
+        }
+        setUsual(resolved);
+      })
+      .catch(() => {
+        /* ignore */
+      });
+  }, [allProducts]);
+
+  // Prepend the Usual section above Best Sellers + categories when
+  // the customer has resolved recent items.
+  const sections: Section[] =
+    usual.length > 0
+      ? [{ id: USUAL_ID, label: "Your usual", products: usual, icon: "heart" }, ...baseSections]
+      : baseSections;
+
+  const [active, setActive] = useState(sections[0]?.id ?? "");
 
   // Search results — flat list across all sections, deduped by product
   // id (Best Sellers + the original category section would otherwise

--- a/apps/order/src/app/menu/page.tsx
+++ b/apps/order/src/app/menu/page.tsx
@@ -76,7 +76,17 @@ export default async function MenuPage() {
     <main className="bg-white text-[#160800] pb-[calc(env(safe-area-inset-bottom,0px)+88px)]">
       <Header />
       <OutletPickerRow />
-      <MenuColumns sections={sections} />
+      {/* Pass the complete (visible) product set too so MenuColumns
+          can resolve the customer's recent-item IDs (fetched client-
+          side via /api/loyalty/recent-items) back to full Product
+          records — same hydration the SPA's menu does for its
+          "Usual" pill. */}
+      <MenuColumns
+        sections={sections}
+        allProducts={menu.products.filter(
+          (p) => p.isAvailable && !HIDDEN_CATEGORIES.has(p.categoryId),
+        )}
+      />
       <GlobalCartPill />
       <BottomNav active="menu" />
     </main>

--- a/apps/order/src/app/rewards/_RewardsView.tsx
+++ b/apps/order/src/app/rewards/_RewardsView.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState } from "react";
 import Link from "next/link";
 import { Gift, Sparkles } from "lucide-react";
+import { TierCard } from "./_TierCard";
 
 type Persisted = {
   state?: {
@@ -60,21 +61,12 @@ export function RewardsView() {
         </h1>
       </header>
 
-      {/* BEANS hero */}
-      <section className="px-4 pt-4">
-        <div
-          className="bg-[#160800] text-white rounded-2xl p-5"
-          style={{ minHeight: 120 }}
-        >
-          <p className="text-[10px] uppercase tracking-widest text-white/60">Beans</p>
-          <p
-            className="mt-2 text-3xl"
-            style={{ fontFamily: "Peachi-Bold, serif", fontWeight: 700 }}
-          >
-            {hydrated ? beans.toLocaleString() : "—"}
-          </p>
-        </div>
-      </section>
+      {/* Tier card — espresso hero with current tier badge, beans
+          count, and progress-to-next-tier bar. Wired to
+          /api/loyalty/member-tier which proxies the loyalty service
+          and updates the member's current tier atomically on read.
+          Matches the SPA's TierCardCarousel current-tier card. */}
+      <TierCard />
 
       {!hydrated ? null : !phone ? (
         <div className="flex flex-col items-center px-6 py-12">

--- a/apps/order/src/app/rewards/_TierCard.tsx
+++ b/apps/order/src/app/rewards/_TierCard.tsx
@@ -1,0 +1,115 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { Sparkles } from "lucide-react";
+
+/**
+ * Tier card for the rewards screen. Mirrors the SPA's TierCardCarousel
+ * styling (apps/pickup-native/components/TierCard.tsx) for the
+ * customer's current tier — espresso card with tier name in Peachi
+ * bold, beans count + multiplier eyebrow, soft Sparkles glyph.
+ *
+ * Fetches /api/loyalty/member-tier with the member id from
+ * localStorage. Falls back to a plain beans card when no tier info is
+ * available (guest, new member, API miss).
+ */
+type Tier = {
+  tier_name?: string | null;
+  tier_multiplier?: number | null;
+  current_beans?: number | null;
+  next_tier_beans?: number | null;
+  next_tier_name?: string | null;
+};
+
+type Persisted = {
+  state?: {
+    loyaltyId?: string | null;
+    member?: { pointsBalance?: number };
+  };
+};
+
+export function TierCard() {
+  const [beans, setBeans] = useState<number | null>(null);
+  const [tier, setTier] = useState<Tier | null>(null);
+
+  useEffect(() => {
+    let memberId: string | null = null;
+    try {
+      const raw = window.localStorage.getItem("celsius-pickup");
+      if (raw) {
+        const parsed = JSON.parse(raw) as Persisted;
+        memberId = parsed.state?.loyaltyId ?? null;
+        setBeans(parsed.state?.member?.pointsBalance ?? 0);
+      }
+    } catch {
+      /* ignore */
+    }
+    if (!memberId) return;
+    fetch(`/api/loyalty/member-tier?member_id=${encodeURIComponent(memberId)}`)
+      .then((r) => (r.ok ? r.json() : null))
+      .then((data) => setTier((data ?? null) as Tier | null))
+      .catch(() => {
+        /* ignore */
+      });
+  }, []);
+
+  const displayBeans = tier?.current_beans ?? beans ?? 0;
+  const progress =
+    tier?.current_beans != null && tier.next_tier_beans
+      ? Math.min(1, tier.current_beans / tier.next_tier_beans)
+      : null;
+
+  return (
+    <section className="px-4 pt-4">
+      <div
+        className="bg-[#160800] text-white rounded-2xl p-5"
+        style={{ minHeight: 140, position: "relative", overflow: "hidden" }}
+      >
+        <div className="flex items-start gap-3">
+          <span
+            className="flex items-center justify-center"
+            style={{
+              width: 36,
+              height: 36,
+              borderRadius: 10,
+              backgroundColor: "rgba(251,191,36,0.18)",
+            }}
+          >
+            <Sparkles size={18} color="#FBBF24" strokeWidth={1.8} />
+          </span>
+          {tier?.tier_name ? (
+            <span
+              className="ml-auto rounded-full px-2.5 py-1 text-[10px] uppercase font-bold tracking-widest"
+              style={{ backgroundColor: "rgba(251,191,36,0.18)", color: "#FBBF24" }}
+            >
+              {tier.tier_name}
+              {tier.tier_multiplier && tier.tier_multiplier > 1
+                ? ` · ${tier.tier_multiplier}×`
+                : ""}
+            </span>
+          ) : null}
+        </div>
+        <p className="mt-3 text-[10px] uppercase tracking-widest text-white/60">Beans</p>
+        <p className="mt-1 font-peachi font-bold text-3xl leading-none">
+          {displayBeans.toLocaleString()}
+        </p>
+
+        {progress != null ? (
+          <div className="mt-4">
+            <div className="h-1.5 rounded-full bg-white/12 overflow-hidden">
+              <div
+                className="h-full bg-[#FBBF24]"
+                style={{ width: `${Math.round(progress * 100)}%` }}
+              />
+            </div>
+            <p className="mt-2 text-[11px] text-white/65">
+              {tier?.next_tier_beans! - tier?.current_beans!}
+              {" beans to "}
+              {tier?.next_tier_name ?? "next tier"}
+            </p>
+          </div>
+        ) : null}
+      </div>
+    </section>
+  );
+}


### PR DESCRIPTION
## Summary

Pass 3 of the native-parity rebuild. Two more pieces that the SPA has and the Next.js routes didn't:

### `/menu` Your usual

Sidebar pill (first, above Best Sellers) for signed-in customers with order history. Same data path as the SPA — `/api/loyalty/recent-items?phone=...` returns last 12 items; the Next.js page passes the visible `allProducts` set to the client so each recent-item id resolves to its full Product record and the section renders with the same ProductRow design. Guests / customers without history see nothing change.

### `/rewards` Tier card

Replaces the bare "Beans" block with a current-tier hero card — espresso bg, gold chip with tier name + multiplier, Peachi beans count, progress bar to next tier with the remaining-beans copy. Wired to **the same API** the SPA uses: `/api/loyalty/member-tier` (proxies the loyalty service + atomically updates the member's current_tier_id on read). Member id comes from the SPA's persisted Zustand store in localStorage — no separate auth path.

## Test plan

- [ ] iPhone Safari → `/menu` while signed in with order history → "Your usual" pill is the first sidebar pill, products render.
- [ ] Signed-out / no history → menu unchanged.
- [ ] `/rewards` while signed in → tier card shows current tier badge, beans count, progress bar. Same numbers as the native app.
- [ ] Native iOS pickup app: no diff.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Xd1aERynqUbdCqXNboKWBe)_