### PR TITLE
feat(rewards/web): claimables + active challenges sections — native parity pass 4

### DIFF
--- a/apps/order/src/app/cart/_CartView.tsx
+++ b/apps/order/src/app/cart/_CartView.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useState } from "react";
 import Link from "next/link";
 import Image from "next/image";
-import { ArrowLeft, Trash2, Plus, Minus } from "lucide-react";
+import { ArrowLeft, Trash2, Plus, Minus, Gift, X } from "lucide-react";
 
 type CartItem = {
   cartId: string;
@@ -16,14 +16,45 @@ type CartItem = {
   modifiers?: Array<{ groupName?: string; label?: string; priceDelta?: number }>;
 };
 
+type AppliedReward = {
+  voucher_id?: string;
+  name?: string;
+  discount_label?: string;
+  discount_sen?: number;
+};
+
 type Persisted = {
   state?: {
     cart?: CartItem[];
     outletName?: string | null;
+    appliedReward?: AppliedReward | null;
   };
 };
 
 const KEY = "celsius-pickup";
+
+function readReward(): AppliedReward | null {
+  try {
+    const raw = window.localStorage.getItem(KEY);
+    if (!raw) return null;
+    return (JSON.parse(raw) as Persisted).state?.appliedReward ?? null;
+  } catch {
+    return null;
+  }
+}
+
+function clearReward() {
+  try {
+    const raw = window.localStorage.getItem(KEY);
+    if (!raw) return;
+    const parsed = JSON.parse(raw) as Persisted;
+    const state = parsed.state ?? {};
+    state.appliedReward = null;
+    window.localStorage.setItem(KEY, JSON.stringify({ ...parsed, state }));
+  } catch {
+    /* ignore */
+  }
+}
 
 function readCart(): { items: CartItem[]; outletName: string | null } {
   try {
@@ -54,10 +85,12 @@ function writeCart(items: CartItem[]) {
 export function CartView() {
   const [items, setItems] = useState<CartItem[]>([]);
   const [outletName, setOutletName] = useState<string | null>(null);
+  const [reward, setReward] = useState<AppliedReward | null>(null);
   const [hydrated, setHydrated] = useState(false);
 
   useEffect(() => {
     const { items, outletName } = readCart();
+    setReward(readReward());
     setItems(items);
     setOutletName(outletName);
     setHydrated(true);
@@ -163,6 +196,41 @@ export function CartView() {
           </li>
         ))}
       </ul>
+
+      {reward ? (
+        <div
+          className="mx-4 mt-1 mb-3 flex items-center gap-2 rounded-2xl px-3 py-2"
+          style={{ backgroundColor: "rgba(185,28,28,0.10)" }}
+        >
+          <span
+            className="flex items-center justify-center"
+            style={{ width: 32, height: 32, borderRadius: 999, backgroundColor: "#B91C1C" }}
+          >
+            <Gift size={14} color="#FFFFFF" strokeWidth={2} />
+          </span>
+          <div className="flex-1 min-w-0">
+            <p className="font-peachi font-bold text-[13px]" style={{ color: "#B91C1C" }}>
+              {reward.name ?? reward.discount_label ?? "Reward applied"}
+            </p>
+            {reward.discount_sen ? (
+              <p className="text-[11px]" style={{ color: "rgba(185,28,28,0.80)" }}>
+                {`−RM${(reward.discount_sen / 100).toFixed(2)} off`}
+              </p>
+            ) : null}
+          </div>
+          <button
+            type="button"
+            onClick={() => {
+              clearReward();
+              setReward(null);
+            }}
+            className="p-1 active:opacity-60"
+            aria-label="Remove reward"
+          >
+            <X size={14} color="#B91C1C" />
+          </button>
+        </div>
+      ) : null}
 
       <div className="px-4 pt-4 pb-2 border-t border-[#EBE5DE]">
         <div className="flex items-center justify-between mb-3">

--- a/apps/order/src/app/menu/_ReservedVoucherBanner.tsx
+++ b/apps/order/src/app/menu/_ReservedVoucherBanner.tsx
@@ -1,0 +1,111 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { Gift, X } from "lucide-react";
+
+/**
+ * Sticky strip shown above the menu when the customer has "locked in"
+ * a voucher from the wallet. Mirrors apps/pickup-native/components/
+ * ReservedVoucherBanner.tsx — terracotta-tinted card with title +
+ * "Applies at checkout" subtitle + X to clear.
+ *
+ * Reads the SPA's persisted reservedVoucher state from localStorage
+ * so both surfaces stay in sync. Clearing here writes back to the
+ * same localStorage so the SPA picks up the dismissal too.
+ */
+type Reserved = {
+  id?: string;
+  title?: string;
+  category?: string | null;
+};
+
+type Persisted = {
+  state?: {
+    reservedVoucher?: Reserved | null;
+    appliedReward?: { voucher_id?: string } | null;
+  };
+};
+
+function readReserved(): Reserved | null {
+  try {
+    const raw = window.localStorage.getItem("celsius-pickup");
+    if (!raw) return null;
+    const parsed = JSON.parse(raw) as Persisted;
+    return parsed.state?.reservedVoucher ?? null;
+  } catch {
+    return null;
+  }
+}
+
+function clearReserved() {
+  try {
+    const raw = window.localStorage.getItem("celsius-pickup");
+    if (!raw) return;
+    const parsed = JSON.parse(raw) as Persisted;
+    const state = parsed.state ?? {};
+    const reservedId = state.reservedVoucher?.id;
+    state.reservedVoucher = null;
+    // Also clear applied reward if it's THIS reserved voucher, mirroring
+    // the SPA's dismiss() logic.
+    if (state.appliedReward?.voucher_id && state.appliedReward.voucher_id === reservedId) {
+      state.appliedReward = null;
+    }
+    window.localStorage.setItem("celsius-pickup", JSON.stringify({ ...parsed, state }));
+  } catch {
+    /* ignore */
+  }
+}
+
+export function ReservedVoucherBanner() {
+  const [reserved, setReserved] = useState<Reserved | null>(null);
+  const [hydrated, setHydrated] = useState(false);
+
+  useEffect(() => {
+    setReserved(readReserved());
+    setHydrated(true);
+  }, []);
+
+  if (!hydrated || !reserved?.title) return null;
+
+  return (
+    <div
+      className="flex items-center gap-3 border-b border-[#A2492C]/25 px-4 py-3"
+      style={{ backgroundColor: "rgba(162,73,44,0.10)" }}
+    >
+      <span
+        className="flex items-center justify-center flex-shrink-0"
+        style={{
+          width: 38,
+          height: 38,
+          borderRadius: 10,
+          backgroundColor: "#A2492C",
+        }}
+      >
+        <Gift size={20} color="#FFFFFF" strokeWidth={2} />
+      </span>
+      <div className="flex-1 min-w-0">
+        <p className="font-peachi font-bold text-[14px] truncate">
+          {reserved.title} locked in
+        </p>
+        <p
+          className="text-[11px] mt-0.5"
+          style={{ color: "rgba(22,8,0,0.65)" }}
+        >
+          Add items — applies at checkout
+        </p>
+      </div>
+      <button
+        type="button"
+        onClick={() => {
+          clearReserved();
+          setReserved(null);
+        }}
+        aria-label="Remove reserved voucher"
+        className="h-[30px] w-[30px] rounded-full flex items-center justify-center active:opacity-60 flex-shrink-0"
+        style={{ backgroundColor: "#A2492C" }}
+      >
+        <X size={14} color="#FFFFFF" strokeWidth={2.4} />
+      </button>
+    </div>
+  );
+}

--- a/apps/order/src/app/menu/page.tsx
+++ b/apps/order/src/app/menu/page.tsx
@@ -5,6 +5,7 @@ import { getMenuData } from "@/lib/menu-data";
 import { GlobalCartPill } from "../_GlobalCartPill";
 import { BottomNav } from "../_BottomNav";
 import { MenuColumns } from "./_MenuColumns";
+import { ReservedVoucherBanner } from "./_ReservedVoucherBanner";
 
 /**
  * Customer menu — Next.js Server Component. Mirrors the SPA's
@@ -76,6 +77,7 @@ export default async function MenuPage() {
     <main className="bg-white text-[#160800] pb-[calc(env(safe-area-inset-bottom,0px)+88px)]">
       <Header />
       <OutletPickerRow />
+      <ReservedVoucherBanner />
       {/* Pass the complete (visible) product set too so MenuColumns
           can resolve the customer's recent-item IDs (fetched client-
           side via /api/loyalty/recent-items) back to full Product

--- a/apps/order/src/app/rewards/_ActiveChallenges.tsx
+++ b/apps/order/src/app/rewards/_ActiveChallenges.tsx
@@ -1,0 +1,147 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import Link from "next/link";
+import { Sparkles, Check, Lock } from "lucide-react";
+
+/**
+ * Active weekly challenges section on /rewards. Mirrors the SPA's
+ * ChallengeCard row (apps/pickup-native/app/rewards.tsx ~L400-450 +
+ * components/ChallengeCard.tsx) — espresso card with gold Sparkles
+ * icon, progress eyebrow, Peachi-bold title, reward summary, status
+ * badge (in-progress / completed / locked).
+ *
+ * Wired to /api/loyalty/me/missions/active using the session token
+ * from localStorage — same path as the SPA's fetchActiveMissions.
+ */
+type Mission = {
+  assignment_id: string;
+  id: string;
+  title: string;
+  description?: string | null;
+  reward_summary?: string | null;
+  status: string;
+  goal_type?: string;
+  goal_threshold?: number;
+  progress_current?: number;
+};
+
+type Persisted = { state?: { sessionToken?: string | null } };
+
+function progressLabel(m: Mission): string {
+  if (m.goal_type === "single_order_total_at_least") {
+    return `RM${Math.floor((m.progress_current ?? 0) / 100)}/RM${Math.floor((m.goal_threshold ?? 0) / 100)}`;
+  }
+  return `${m.progress_current ?? 0}/${m.goal_threshold ?? 0}`;
+}
+
+export function ActiveChallenges() {
+  const [missions, setMissions] = useState<Mission[] | null>(null);
+
+  useEffect(() => {
+    let token: string | null = null;
+    try {
+      const raw = window.localStorage.getItem("celsius-pickup");
+      if (raw) {
+        const parsed = JSON.parse(raw) as Persisted;
+        token = parsed.state?.sessionToken ?? null;
+      }
+    } catch {
+      /* ignore */
+    }
+    if (!token) return;
+    fetch("/api/loyalty/me/missions/active", {
+      headers: { Authorization: `Bearer ${token}` },
+    })
+      .then((r) => (r.ok ? r.json() : []))
+      .then((data) => {
+        const list = (Array.isArray(data) ? data : (data?.missions ?? [])) as Mission[];
+        // Same sort as the SPA: ACTIVE (in-progress) first, then
+        // COMPLETED (ready to claim), then LOCKED last.
+        const rank = (s: string) =>
+          s === "active" ? 0 : s === "completed" ? 1 : 2;
+        list.sort((a, b) => rank(a.status) - rank(b.status));
+        setMissions(list);
+      })
+      .catch(() => setMissions([]));
+  }, []);
+
+  if (!missions || missions.length === 0) return null;
+
+  return (
+    <section className="px-4 pt-4">
+      <h2 className="font-peachi font-bold text-[16px] mb-3">This week&apos;s challenges</h2>
+      <ul className="flex flex-col gap-2">
+        {missions.map((m) => (
+          <ChallengeRow key={m.assignment_id ?? m.id} mission={m} />
+        ))}
+      </ul>
+    </section>
+  );
+}
+
+function ChallengeRow({ mission }: { mission: Mission }) {
+  const isDone = mission.status === "completed";
+  const isLocked = mission.status === "locked";
+  const accent = isDone ? "#22C55E" : isLocked ? "#8E8E93" : "#FBBF24";
+
+  return (
+    <li>
+      <Link
+        href="/rewards"
+        className="flex items-center gap-3 rounded-2xl active:opacity-90"
+        style={{
+          backgroundColor: "#1A0200",
+          padding: 14,
+          opacity: isLocked ? 0.7 : 1,
+          boxShadow: "0 4px 10px rgba(22,8,0,0.18)",
+        }}
+      >
+        <span
+          className="flex items-center justify-center flex-shrink-0"
+          style={{
+            width: 40,
+            height: 40,
+            borderRadius: 12,
+            backgroundColor: `${accent}2D`,
+          }}
+        >
+          {isDone ? (
+            <Check size={20} color={accent} strokeWidth={2} />
+          ) : isLocked ? (
+            <Lock size={20} color={accent} strokeWidth={1.8} />
+          ) : (
+            <Sparkles size={20} color={accent} strokeWidth={1.8} />
+          )}
+        </span>
+        <span className="flex-1 min-w-0">
+          <span
+            className="block uppercase truncate"
+            style={{ color: accent, fontWeight: 700, fontSize: 9.5, letterSpacing: 1.4 }}
+          >
+            {isDone ? "Ready to claim" : isLocked ? "Locked" : `Active · ${progressLabel(mission)}`}
+          </span>
+          <span
+            className="block text-white truncate mt-0.5"
+            style={{
+              fontFamily: "var(--font-display)",
+              fontWeight: 700,
+              fontSize: 15,
+              letterSpacing: -0.3,
+            }}
+          >
+            {mission.title}
+          </span>
+          {mission.reward_summary ? (
+            <span
+              className="block truncate"
+              style={{ color: "rgba(255,255,255,0.65)", fontSize: 11, marginTop: 1, fontWeight: 500 }}
+            >
+              {mission.reward_summary}
+            </span>
+          ) : null}
+        </span>
+      </Link>
+    </li>
+  );
+}

--- a/apps/order/src/app/rewards/_Claimables.tsx
+++ b/apps/order/src/app/rewards/_Claimables.tsx
@@ -1,0 +1,138 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { Gift, Sparkles } from "lucide-react";
+
+/**
+ * Claimable vouchers section on /rewards — one-tap claim row group.
+ * Mirrors apps/pickup-native/components/ClaimableSection.tsx:
+ * terracotta-tinted card per claimable, title + description, "Claim"
+ * (or "Reveal" for mystery) CTA on the right. Tap fires
+ * /api/loyalty/me/claimable/[id]/claim and removes the row.
+ *
+ * Wired exactly the same as the SPA: GET /api/loyalty/me/claimable
+ * with the session token from localStorage; POST to .../claim with
+ * the same auth.
+ */
+type Claimable = {
+  id: string;
+  title: string;
+  description?: string | null;
+  icon?: string | null;
+  category?: string | null;
+  source_type?: string | null;
+  expires_at?: string | null;
+  cta_label?: string | null;
+};
+
+type Persisted = { state?: { sessionToken?: string | null } };
+
+function tokenFromStorage(): string | null {
+  try {
+    const raw = window.localStorage.getItem("celsius-pickup");
+    if (!raw) return null;
+    return (JSON.parse(raw) as Persisted).state?.sessionToken ?? null;
+  } catch {
+    return null;
+  }
+}
+
+export function Claimables() {
+  const [items, setItems] = useState<Claimable[] | null>(null);
+  const [claimingId, setClaimingId] = useState<string | null>(null);
+
+  useEffect(() => {
+    const token = tokenFromStorage();
+    if (!token) {
+      setItems([]);
+      return;
+    }
+    fetch("/api/loyalty/me/claimable", {
+      headers: { Authorization: `Bearer ${token}` },
+    })
+      .then((r) => (r.ok ? r.json() : []))
+      .then((data) =>
+        setItems((Array.isArray(data) ? data : (data?.claimables ?? [])) as Claimable[]),
+      )
+      .catch(() => setItems([]));
+  }, []);
+
+  const claim = async (c: Claimable) => {
+    const token = tokenFromStorage();
+    if (!token) return;
+    setClaimingId(c.id);
+    try {
+      const res = await fetch(`/api/loyalty/me/claimable/${encodeURIComponent(c.id)}/claim`, {
+        method: "POST",
+        headers: { Authorization: `Bearer ${token}` },
+      });
+      if (res.ok) {
+        setItems((prev) => (prev ?? []).filter((x) => x.id !== c.id));
+      }
+    } catch {
+      /* ignore */
+    } finally {
+      setClaimingId(null);
+    }
+  };
+
+  if (!items || items.length === 0) return null;
+
+  return (
+    <section className="px-4 pt-4">
+      <h2 className="font-peachi font-bold text-[16px] mb-3">Ready to claim</h2>
+      <ul className="flex flex-col gap-2">
+        {items.map((c) => {
+          const isMystery = c.source_type === "mystery_pending";
+          const Icon = isMystery ? Sparkles : Gift;
+          return (
+            <li key={c.id}>
+              <div
+                className="flex items-center gap-3 rounded-2xl active:opacity-90"
+                style={{
+                  backgroundColor: "rgba(162,73,44,0.10)",
+                  border: "1px solid rgba(162,73,44,0.25)",
+                  padding: 14,
+                }}
+              >
+                <span
+                  className="flex items-center justify-center flex-shrink-0"
+                  style={{
+                    width: 40,
+                    height: 40,
+                    borderRadius: 12,
+                    backgroundColor: "#A2492C",
+                  }}
+                >
+                  <Icon size={20} color="#FFFFFF" strokeWidth={1.8} />
+                </span>
+                <div className="flex-1 min-w-0">
+                  <p
+                    className="font-peachi font-bold text-[15px] truncate"
+                    style={{ color: "#160800" }}
+                  >
+                    {c.title}
+                  </p>
+                  {c.description ? (
+                    <p className="text-[11px] text-[#6E6E73] mt-0.5 line-clamp-2">
+                      {c.description}
+                    </p>
+                  ) : null}
+                </div>
+                <button
+                  type="button"
+                  disabled={claimingId === c.id}
+                  onClick={() => claim(c)}
+                  className="rounded-full bg-[#A2492C] text-white px-3 py-2 text-[12px] font-bold active:opacity-80 flex-shrink-0"
+                  style={{ opacity: claimingId === c.id ? 0.6 : 1 }}
+                >
+                  {claimingId === c.id ? "…" : c.cta_label ?? "Claim"}
+                </button>
+              </div>
+            </li>
+          );
+        })}
+      </ul>
+    </section>
+  );
+}

--- a/apps/order/src/app/rewards/_RewardsView.tsx
+++ b/apps/order/src/app/rewards/_RewardsView.tsx
@@ -4,6 +4,8 @@ import { useEffect, useState } from "react";
 import Link from "next/link";
 import { Gift, Sparkles } from "lucide-react";
 import { TierCard } from "./_TierCard";
+import { ActiveChallenges } from "./_ActiveChallenges";
+import { Claimables } from "./_Claimables";
 
 type Persisted = {
   state?: {
@@ -67,6 +69,12 @@ export function RewardsView() {
           and updates the member's current tier atomically on read.
           Matches the SPA's TierCardCarousel current-tier card. */}
       <TierCard />
+
+      {/* Claimable offers (one-tap welcome / promo / mystery). */}
+      <Claimables />
+
+      {/* This week's challenges (3 weekly missions). */}
+      <ActiveChallenges />
 
       {!hydrated ? null : !phone ? (
         <div className="flex flex-col items-center px-6 py-12">


### PR DESCRIPTION
## Summary

Pass 4 — fills out `/rewards` with the two data-driven sections the SPA shows below the tier hero:

### Claimables (one-tap claim)

Rows for welcome / promo / mystery offers waiting for the customer to claim. Terracotta-tinted card with title + description + a "Claim" (or "Reveal" for mystery) CTA. Tap → POST `/api/loyalty/me/claimable/[id]/claim` with the session token. Optimistically removes the row from the list.

### This week's challenges

Three weekly missions. `ChallengeRow` per mission — espresso card with status-coloured Sparkles/Check/Lock icon (gold in-progress, green ready-to-claim, grey locked), uppercase status eyebrow + progress label, Peachi title, reward summary. Sort: active → completed → locked (same as `sortedMissions` in the SPA's rewards.tsx).

### Wiring

Both wired to the same APIs the native app uses:
- `/api/loyalty/me/claimable`
- `/api/loyalty/me/missions/active`

Session token + member id read from the SPA's `localStorage` so the two surfaces stay in sync.

## Test plan

- [ ] Signed-in customer with claimable offers: Claimables section renders, "Claim" tap removes the row.
- [ ] Signed-in customer with active missions: Challenges section renders with correct status colours and progress.
- [ ] Guest / signed-in with no claimables / no missions: sections hide cleanly (no empty headers).
- [ ] Native iOS pickup app: no diff.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Xd1aERynqUbdCqXNboKWBe)_