### PR TITLE
feat(web): port remaining secondary routes — referral/support/settings/privacy/tier-benefits/challenge/wrapped/account-delete

### DIFF
--- a/apps/order/public/sw.js
+++ b/apps/order/public/sw.js
@@ -1,7 +1,7 @@
 // Mirror of apps/pickup-native/public/sw.js — overwritten on each
 // build-pwa run. v3 bumps over v2 to flush customers off the broken
 // CSS shipped in #157/#158 before this revert deployed.
-const CACHE = "celsius-v8";
+const CACHE = "celsius-v9";
 const SHELL = ["/", "/index.html", "/manifest.json"];
 
 self.addEventListener("install", (e) => {

--- a/apps/order/src/app/account-delete/_AccountDeleteView.tsx
+++ b/apps/order/src/app/account-delete/_AccountDeleteView.tsx
@@ -1,0 +1,139 @@
+"use client";
+
+import { useState } from "react";
+import Link from "next/link";
+import { ArrowLeft, AlertTriangle } from "lucide-react";
+
+/**
+ * Account delete flow. Wired to POST /api/members/delete with member
+ * id + phone, mirrors the SPA's deletion path. Confirmation step
+ * requires the customer to type 'delete' to avoid taps.
+ */
+export function AccountDeleteView() {
+  const [confirm, setConfirm] = useState("");
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [done, setDone] = useState(false);
+
+  const deleteAccount = async () => {
+    setError(null);
+    setBusy(true);
+    try {
+      let memberId: string | null = null;
+      let phone: string | null = null;
+      try {
+        const raw = window.localStorage.getItem("celsius-pickup");
+        if (raw) {
+          const s = (JSON.parse(raw) as { state?: { loyaltyId?: string | null; phone?: string | null } }).state;
+          memberId = s?.loyaltyId ?? null;
+          phone = s?.phone ?? null;
+        }
+      } catch {
+        /* ignore */
+      }
+      const res = await fetch("/api/members/delete", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ member_id: memberId, phone }),
+      });
+      if (!res.ok) {
+        const data = await res.json().catch(() => ({}));
+        throw new Error(data.error ?? "Failed to delete account");
+      }
+      // Wipe local state.
+      try {
+        window.localStorage.removeItem("celsius-pickup");
+      } catch {
+        /* ignore */
+      }
+      setDone(true);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  if (done) {
+    return (
+      <>
+        <Header />
+        <section className="px-5 pt-8">
+          <p className="font-peachi font-bold text-2xl">Account deleted.</p>
+          <p className="text-[13px] text-[#6E6E73] mt-2 leading-snug">
+            Your member-scoped data has been purged. Payment receipts are kept for 7 years for
+            tax compliance, anonymised after the retention window.
+          </p>
+          <Link
+            href="/"
+            className="mt-6 inline-block rounded-full bg-[#A2492C] text-white px-5 py-3 font-bold active:opacity-80"
+          >
+            Back to home
+          </Link>
+        </section>
+      </>
+    );
+  }
+
+  return (
+    <>
+      <Header />
+
+      <section className="px-5 pt-6">
+        <div
+          className="flex items-start gap-2 rounded-2xl p-3"
+          style={{ backgroundColor: "rgba(185,28,28,0.10)" }}
+        >
+          <AlertTriangle size={18} color="#B91C1C" className="flex-shrink-0 mt-0.5" />
+          <p className="text-[12px] leading-snug" style={{ color: "#B91C1C" }}>
+            This deletes your account, beans balance, wallet vouchers, and order history. It
+            can&apos;t be undone.
+          </p>
+        </div>
+
+        <p className="mt-5 text-sm">
+          Type <span className="font-bold">delete</span> below to confirm.
+        </p>
+        <input
+          type="text"
+          value={confirm}
+          onChange={(e) => setConfirm(e.target.value)}
+          className="mt-2 w-full rounded-2xl border border-[#EBE5DE] px-3 py-3 outline-none text-base"
+        />
+
+        {error ? <p className="mt-3 text-[12px] text-red-600">{error}</p> : null}
+
+        <button
+          type="button"
+          onClick={deleteAccount}
+          disabled={busy || confirm.trim().toLowerCase() !== "delete"}
+          className={`mt-5 w-full rounded-full text-white py-4 font-bold active:opacity-80 ${
+            busy || confirm.trim().toLowerCase() !== "delete" ? "bg-[#B91C1C]/40" : "bg-[#B91C1C]"
+          }`}
+        >
+          {busy ? "Deleting…" : "Delete my account"}
+        </button>
+        <Link
+          href="/settings"
+          className="mt-3 block w-full text-center text-sm text-[#8E8E93] active:opacity-60 py-2"
+        >
+          Cancel
+        </Link>
+      </section>
+    </>
+  );
+}
+
+function Header() {
+  return (
+    <header
+      className="bg-[#160800] text-white px-4 pb-3 flex items-center gap-3"
+      style={{ paddingTop: "calc(env(safe-area-inset-top, 0px) + 12px)" }}
+    >
+      <Link href="/settings" className="-ml-1 p-1 active:opacity-60" aria-label="Back">
+        <ArrowLeft size={20} color="#FFFFFF" />
+      </Link>
+      <h1 className="font-peachi font-bold text-[22px]">Delete account</h1>
+    </header>
+  );
+}

--- a/apps/order/src/app/account-delete/page.tsx
+++ b/apps/order/src/app/account-delete/page.tsx
@@ -1,0 +1,9 @@
+import { AccountDeleteView } from "./_AccountDeleteView";
+
+export default function AccountDeletePage() {
+  return (
+    <main className="bg-white text-[#160800] min-h-screen">
+      <AccountDeleteView />
+    </main>
+  );
+}

--- a/apps/order/src/app/challenge/[id]/_ChallengeView.tsx
+++ b/apps/order/src/app/challenge/[id]/_ChallengeView.tsx
@@ -1,0 +1,144 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import Link from "next/link";
+import { ArrowLeft, Sparkles } from "lucide-react";
+
+/**
+ * Single challenge detail — reads the full mission record from
+ * /api/loyalty/me/missions/active (filtered to the assignmentId), shows
+ * progress, reward, and tips. Matches the SPA's challenge detail
+ * screen layout.
+ */
+type Mission = {
+  assignment_id: string;
+  id: string;
+  title: string;
+  description?: string | null;
+  reward_summary?: string | null;
+  status: string;
+  goal_type?: string;
+  goal_threshold?: number;
+  progress_current?: number;
+  expires_at?: string | null;
+};
+
+type Persisted = { state?: { sessionToken?: string | null } };
+
+export function ChallengeView({ assignmentId }: { assignmentId: string }) {
+  const [mission, setMission] = useState<Mission | null>(null);
+
+  useEffect(() => {
+    let token: string | null = null;
+    try {
+      const raw = window.localStorage.getItem("celsius-pickup");
+      if (raw) token = (JSON.parse(raw) as Persisted).state?.sessionToken ?? null;
+    } catch {
+      /* ignore */
+    }
+    if (!token) return;
+    fetch("/api/loyalty/me/missions/active", {
+      headers: { Authorization: `Bearer ${token}` },
+    })
+      .then((r) => (r.ok ? r.json() : []))
+      .then((data) => {
+        const list = (Array.isArray(data) ? data : (data?.missions ?? [])) as Mission[];
+        setMission(list.find((m) => m.assignment_id === assignmentId) ?? null);
+      })
+      .catch(() => {
+        /* ignore */
+      });
+  }, [assignmentId]);
+
+  return (
+    <>
+      <header
+        className="bg-[#160800] text-white px-4 pb-3 flex items-center gap-3"
+        style={{ paddingTop: "calc(env(safe-area-inset-top, 0px) + 12px)" }}
+      >
+        <Link href="/rewards" className="-ml-1 p-1 active:opacity-60" aria-label="Back">
+          <ArrowLeft size={20} color="#FFFFFF" />
+        </Link>
+        <h1 className="font-peachi font-bold text-[22px] truncate">Challenge</h1>
+      </header>
+
+      {!mission ? (
+        <div className="p-8 text-center text-[#8E8E93] text-sm">Loading…</div>
+      ) : (
+        <>
+          <section className="px-4 pt-5">
+            <div
+              className="rounded-2xl p-5"
+              style={{ backgroundColor: "#1A0200", color: "#FFFFFF" }}
+            >
+              <span
+                className="flex items-center justify-center"
+                style={{
+                  width: 40,
+                  height: 40,
+                  borderRadius: 12,
+                  backgroundColor: "rgba(251,191,36,0.18)",
+                }}
+              >
+                <Sparkles size={20} color="#FBBF24" strokeWidth={1.8} />
+              </span>
+              <p
+                className="mt-3 font-peachi font-bold text-2xl"
+                style={{ letterSpacing: -0.3 }}
+              >
+                {mission.title}
+              </p>
+              {mission.description ? (
+                <p className="mt-1 text-[13px] text-white/70 leading-snug">
+                  {mission.description}
+                </p>
+              ) : null}
+              {mission.reward_summary ? (
+                <p
+                  className="mt-3 text-[11px] uppercase tracking-widest font-bold"
+                  style={{ color: "#FBBF24" }}
+                >
+                  Reward · {mission.reward_summary}
+                </p>
+              ) : null}
+            </div>
+          </section>
+
+          <section className="px-4 pt-5">
+            <h2 className="font-peachi font-bold text-[16px] mb-2">Progress</h2>
+            <Progress mission={mission} />
+          </section>
+
+          {mission.expires_at ? (
+            <p className="px-4 pt-4 text-[11px] text-[#8E8E93]">
+              Ends {new Date(mission.expires_at).toLocaleDateString("en-MY", { day: "numeric", month: "short" })}
+            </p>
+          ) : null}
+        </>
+      )}
+    </>
+  );
+}
+
+function Progress({ mission }: { mission: Mission }) {
+  const current = mission.progress_current ?? 0;
+  const target = mission.goal_threshold ?? 1;
+  const pct = Math.min(1, current / target);
+
+  const display =
+    mission.goal_type === "single_order_total_at_least"
+      ? `RM${Math.floor(current / 100)} / RM${Math.floor(target / 100)}`
+      : `${current} / ${target}`;
+
+  return (
+    <div>
+      <div className="h-2.5 rounded-full bg-[#EBE5DE] overflow-hidden">
+        <div
+          className="h-full"
+          style={{ width: `${Math.round(pct * 100)}%`, backgroundColor: "#A2492C" }}
+        />
+      </div>
+      <p className="mt-2 text-sm font-bold">{display}</p>
+    </div>
+  );
+}

--- a/apps/order/src/app/challenge/[id]/page.tsx
+++ b/apps/order/src/app/challenge/[id]/page.tsx
@@ -1,0 +1,16 @@
+import { ChallengeView } from "./_ChallengeView";
+import { BottomNav } from "../../_BottomNav";
+
+export default async function ChallengePage({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}) {
+  const { id } = await params;
+  return (
+    <main className="bg-white text-[#160800] min-h-screen pb-[calc(env(safe-area-inset-bottom,0px)+88px)]">
+      <ChallengeView assignmentId={id} />
+      <BottomNav active="rewards" />
+    </main>
+  );
+}

--- a/apps/order/src/app/privacy/page.tsx
+++ b/apps/order/src/app/privacy/page.tsx
@@ -1,0 +1,64 @@
+import Link from "next/link";
+import { ArrowLeft } from "lucide-react";
+import { BottomNav } from "../_BottomNav";
+
+/**
+ * Privacy policy — static long-form. Mirrors apps/pickup-native/app/
+ * privacy.tsx content.
+ */
+export default function PrivacyPage() {
+  return (
+    <main className="bg-white text-[#160800] min-h-screen pb-[calc(env(safe-area-inset-bottom,0px)+88px)]">
+      <header
+        className="bg-[#160800] text-white px-4 pb-3 flex items-center gap-3"
+        style={{ paddingTop: "calc(env(safe-area-inset-top, 0px) + 12px)" }}
+      >
+        <Link href="/settings" className="-ml-1 p-1 active:opacity-60" aria-label="Back">
+          <ArrowLeft size={20} color="#FFFFFF" />
+        </Link>
+        <h1 className="font-peachi font-bold text-[22px]">Privacy</h1>
+      </header>
+
+      <article className="px-5 pt-5 pb-10 leading-relaxed text-sm text-[#3F362F]">
+        <h2 className="font-peachi font-bold text-lg text-[#160800] mb-2">What we collect</h2>
+        <p>
+          Phone number (for sign-in), name + email (optional, for profile + email rewards),
+          birthday (optional, for birthday treat), order history, and device push token.
+          That&apos;s it — no third-party trackers, no advertising IDs.
+        </p>
+
+        <h2 className="font-peachi font-bold text-lg text-[#160800] mt-6 mb-2">
+          Why we collect it
+        </h2>
+        <p>
+          To take your order, route it to the right outlet, run our loyalty program (beans +
+          rewards), and remind you when an order is ready. Nothing else.
+        </p>
+
+        <h2 className="font-peachi font-bold text-lg text-[#160800] mt-6 mb-2">
+          Who we share with
+        </h2>
+        <p>
+          Stripe and Revenue Monster for payment processing (PCI-compliant, never see your card
+          number on our side). Supabase hosts our database. Vercel hosts this app. Nobody else.
+        </p>
+
+        <h2 className="font-peachi font-bold text-lg text-[#160800] mt-6 mb-2">
+          How long we keep it
+        </h2>
+        <p>
+          As long as you have an account. Delete your account from Settings → Delete my account
+          and all member-scoped data is purged within 30 days (payment receipts stay 7 years for
+          tax compliance).
+        </p>
+
+        <h2 className="font-peachi font-bold text-lg text-[#160800] mt-6 mb-2">Contact</h2>
+        <p>
+          Questions? Email us at <a className="underline" href="mailto:privacy@celsiuscoffee.com">privacy@celsiuscoffee.com</a>.
+        </p>
+      </article>
+
+      <BottomNav active="account" />
+    </main>
+  );
+}

--- a/apps/order/src/app/referral/_ReferralView.tsx
+++ b/apps/order/src/app/referral/_ReferralView.tsx
@@ -1,0 +1,103 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import Link from "next/link";
+import { ArrowLeft, Copy, Check, Users } from "lucide-react";
+
+/**
+ * Referral page — share code + see signups. Wired to /api/loyalty/me
+ * /referral (same as the SPA's referral screen).
+ */
+type Referral = {
+  code?: string | null;
+  total_referred?: number;
+  reward_summary?: string | null;
+};
+
+type Persisted = { state?: { sessionToken?: string | null } };
+
+export function ReferralView() {
+  const [data, setData] = useState<Referral | null>(null);
+  const [copied, setCopied] = useState(false);
+
+  useEffect(() => {
+    let token: string | null = null;
+    try {
+      const raw = window.localStorage.getItem("celsius-pickup");
+      if (raw) token = (JSON.parse(raw) as Persisted).state?.sessionToken ?? null;
+    } catch {
+      /* ignore */
+    }
+    if (!token) return;
+    fetch("/api/loyalty/me/referral", { headers: { Authorization: `Bearer ${token}` } })
+      .then((r) => (r.ok ? r.json() : null))
+      .then((d) => setData((d ?? null) as Referral | null))
+      .catch(() => setData(null));
+  }, []);
+
+  const copy = async () => {
+    if (!data?.code) return;
+    try {
+      await navigator.clipboard.writeText(data.code);
+      setCopied(true);
+      window.setTimeout(() => setCopied(false), 1500);
+    } catch {
+      /* ignore */
+    }
+  };
+
+  return (
+    <>
+      <header
+        className="bg-[#160800] text-white px-4 pb-3 flex items-center gap-3"
+        style={{ paddingTop: "calc(env(safe-area-inset-top, 0px) + 12px)" }}
+      >
+        <Link href="/rewards" className="-ml-1 p-1 active:opacity-60" aria-label="Back">
+          <ArrowLeft size={20} color="#FFFFFF" />
+        </Link>
+        <h1 className="font-peachi font-bold text-[22px]">Refer a friend</h1>
+      </header>
+
+      <section className="px-4 pt-5">
+        <div
+          className="rounded-2xl bg-[#160800] text-white p-5"
+          style={{ minHeight: 140 }}
+        >
+          <span
+            className="flex items-center justify-center"
+            style={{ width: 36, height: 36, borderRadius: 10, backgroundColor: "rgba(251,191,36,0.18)" }}
+          >
+            <Users size={18} color="#FBBF24" strokeWidth={1.8} />
+          </span>
+          <p className="mt-3 text-[10px] uppercase tracking-widest text-white/60">Your code</p>
+          <p className="mt-1 font-peachi font-bold text-3xl tracking-widest">
+            {data?.code ?? "—"}
+          </p>
+          {data?.reward_summary ? (
+            <p className="mt-3 text-[12px] text-white/70 leading-snug">
+              {data.reward_summary}
+            </p>
+          ) : null}
+          <button
+            type="button"
+            onClick={copy}
+            disabled={!data?.code}
+            className={`mt-4 rounded-full px-4 py-2 text-[12px] font-bold flex items-center gap-2 active:opacity-80 ${
+              data?.code ? "bg-[#FBBF24] text-[#160800]" : "bg-white/15 text-white/50"
+            }`}
+          >
+            {copied ? <Check size={14} /> : <Copy size={14} />}
+            {copied ? "Copied" : "Copy code"}
+          </button>
+        </div>
+      </section>
+
+      <section className="px-4 pt-5">
+        <p className="text-[11px] uppercase tracking-widest text-[#8E8E93] font-bold mb-1">
+          Friends signed up
+        </p>
+        <p className="font-peachi font-bold text-2xl">{data?.total_referred ?? 0}</p>
+      </section>
+    </>
+  );
+}

--- a/apps/order/src/app/referral/page.tsx
+++ b/apps/order/src/app/referral/page.tsx
@@ -1,0 +1,11 @@
+import { ReferralView } from "./_ReferralView";
+import { BottomNav } from "../_BottomNav";
+
+export default function ReferralPage() {
+  return (
+    <main className="bg-white text-[#160800] min-h-screen pb-[calc(env(safe-area-inset-bottom,0px)+88px)]">
+      <ReferralView />
+      <BottomNav active="rewards" />
+    </main>
+  );
+}

--- a/apps/order/src/app/settings/_SettingsView.tsx
+++ b/apps/order/src/app/settings/_SettingsView.tsx
@@ -1,0 +1,110 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import Link from "next/link";
+import { ArrowLeft, Bell, BellOff, Shield, FileText, Trash2, ChevronRight } from "lucide-react";
+
+/**
+ * Settings — push notifications + privacy + danger zone (account
+ * delete). Mirrors apps/pickup-native/app/settings.tsx.
+ */
+export function SettingsView() {
+  const [pushOn, setPushOn] = useState<boolean | null>(null);
+
+  useEffect(() => {
+    if (typeof Notification === "undefined") {
+      setPushOn(false);
+      return;
+    }
+    setPushOn(Notification.permission === "granted");
+  }, []);
+
+  const togglePush = async () => {
+    if (typeof Notification === "undefined") return;
+    if (Notification.permission === "default") {
+      const r = await Notification.requestPermission();
+      setPushOn(r === "granted");
+    } else {
+      // Already granted or denied; the customer needs to flip it in
+      // browser settings. Open instructions instead.
+      setPushOn(Notification.permission === "granted");
+    }
+  };
+
+  return (
+    <>
+      <header
+        className="bg-[#160800] text-white px-4 pb-3 flex items-center gap-3"
+        style={{ paddingTop: "calc(env(safe-area-inset-top, 0px) + 12px)" }}
+      >
+        <Link href="/account" className="-ml-1 p-1 active:opacity-60" aria-label="Back">
+          <ArrowLeft size={20} color="#FFFFFF" />
+        </Link>
+        <h1 className="font-peachi font-bold text-[22px]">Settings</h1>
+      </header>
+
+      <section className="px-4 pt-5">
+        <h2 className="font-peachi font-bold text-[16px] mb-3">Notifications</h2>
+        <button
+          type="button"
+          onClick={togglePush}
+          className="w-full flex items-center gap-3 rounded-2xl border border-[#EBE5DE] bg-white px-4 py-3 active:opacity-80 text-left"
+        >
+          {pushOn ? (
+            <Bell size={18} color="#A2492C" />
+          ) : (
+            <BellOff size={18} color="#8E8E93" />
+          )}
+          <div className="flex-1">
+            <p className="text-sm font-bold">Push notifications</p>
+            <p className="text-[11px] text-[#6E6E73] mt-0.5">
+              {pushOn === null
+                ? "Loading…"
+                : pushOn
+                ? "On — order updates + rewards"
+                : "Off — tap to allow in your browser"}
+            </p>
+          </div>
+          <ChevronRight size={14} color="#8E8E93" />
+        </button>
+      </section>
+
+      <section className="px-4 pt-6">
+        <h2 className="font-peachi font-bold text-[16px] mb-3">Privacy &amp; terms</h2>
+        <ul className="flex flex-col gap-2">
+          <Row href="/privacy" Icon={Shield} label="Privacy policy" />
+          <Row href="/support" Icon={FileText} label="Help &amp; support" />
+        </ul>
+      </section>
+
+      <section className="px-4 pt-6">
+        <h2 className="font-peachi font-bold text-[16px] mb-3">Danger zone</h2>
+        <Link
+          href="/account-delete"
+          className="flex items-center gap-3 rounded-2xl border border-red-200 bg-red-50 px-4 py-3 active:opacity-80"
+        >
+          <Trash2 size={18} color="#B91C1C" />
+          <span className="text-sm font-bold flex-1" style={{ color: "#B91C1C" }}>
+            Delete my account
+          </span>
+          <ChevronRight size={14} color="#B91C1C" />
+        </Link>
+      </section>
+    </>
+  );
+}
+
+function Row({ href, Icon, label }: { href: string; Icon: typeof Bell; label: string }) {
+  return (
+    <li>
+      <Link
+        href={href}
+        className="flex items-center gap-3 rounded-2xl border border-[#EBE5DE] bg-white px-4 py-3 active:opacity-80"
+      >
+        <Icon size={18} color="#8E8E93" />
+        <span className="text-sm font-bold flex-1">{label}</span>
+        <ChevronRight size={14} color="#8E8E93" />
+      </Link>
+    </li>
+  );
+}

--- a/apps/order/src/app/settings/page.tsx
+++ b/apps/order/src/app/settings/page.tsx
@@ -1,0 +1,11 @@
+import { SettingsView } from "./_SettingsView";
+import { BottomNav } from "../_BottomNav";
+
+export default function SettingsPage() {
+  return (
+    <main className="bg-white text-[#160800] min-h-screen pb-[calc(env(safe-area-inset-bottom,0px)+88px)]">
+      <SettingsView />
+      <BottomNav active="account" />
+    </main>
+  );
+}

--- a/apps/order/src/app/support/page.tsx
+++ b/apps/order/src/app/support/page.tsx
@@ -1,0 +1,91 @@
+import Link from "next/link";
+import { ArrowLeft, MessageCircle, Phone, Mail, HelpCircle } from "lucide-react";
+import { BottomNav } from "../_BottomNav";
+
+/**
+ * Support / help — content matches the SPA's support screen
+ * (apps/pickup-native/app/support.tsx). FAQ + contact channels. All
+ * static content so a Server Component is enough.
+ */
+export default function SupportPage() {
+  return (
+    <main className="bg-white text-[#160800] min-h-screen pb-[calc(env(safe-area-inset-bottom,0px)+88px)]">
+      <header
+        className="bg-[#160800] text-white px-4 pb-3 flex items-center gap-3"
+        style={{ paddingTop: "calc(env(safe-area-inset-top, 0px) + 12px)" }}
+      >
+        <Link href="/account" className="-ml-1 p-1 active:opacity-60" aria-label="Back">
+          <ArrowLeft size={20} color="#FFFFFF" />
+        </Link>
+        <h1 className="font-peachi font-bold text-[22px]">Support</h1>
+      </header>
+
+      <section className="px-4 pt-5">
+        <h2 className="font-peachi font-bold text-[16px] mb-3">Get in touch</h2>
+        <ul className="flex flex-col gap-2">
+          <ContactRow Icon={MessageCircle} label="Message us on WhatsApp" href="https://wa.me/60123456789" />
+          <ContactRow Icon={Phone} label="Call the store" href="tel:+60123456789" />
+          <ContactRow Icon={Mail} label="Email celsiuscoffee" href="mailto:hello@celsiuscoffee.com" />
+        </ul>
+      </section>
+
+      <section className="px-4 pt-6">
+        <h2 className="font-peachi font-bold text-[16px] mb-3">Common questions</h2>
+        <ul className="flex flex-col gap-3">
+          <Faq
+            q="How do I redeem a reward?"
+            a="Go to the Rewards tab, tap Apply on the reward you want — it'll be applied at checkout. Show the barista the order on pickup; the discount is automatic."
+          />
+          <Faq
+            q="How long does pickup take?"
+            a="Most orders are ready in 5–15 minutes. The home screen shows the live ETA for your chosen outlet."
+          />
+          <Faq
+            q="Can I cancel an order?"
+            a="Open the order in the Orders tab. If it's still pending, you can cancel — once the barista starts preparing, contact the store directly."
+          />
+          <Faq
+            q="Where are your outlets?"
+            a="Shah Alam, Conezion (Putrajaya), Tamarind Square, and Nilai. Tap the outlet picker on the home screen for full addresses."
+          />
+        </ul>
+      </section>
+
+      <BottomNav active="account" />
+    </main>
+  );
+}
+
+function ContactRow({
+  Icon,
+  label,
+  href,
+}: {
+  Icon: typeof MessageCircle;
+  label: string;
+  href: string;
+}) {
+  return (
+    <li>
+      <a
+        href={href}
+        className="flex items-center gap-3 rounded-2xl border border-[#EBE5DE] bg-white px-4 py-3 active:opacity-80"
+      >
+        <Icon size={18} color="#A2492C" />
+        <span className="text-sm font-bold flex-1">{label}</span>
+      </a>
+    </li>
+  );
+}
+
+function Faq({ q, a }: { q: string; a: string }) {
+  return (
+    <li className="rounded-2xl bg-white border border-[#EBE5DE] p-4">
+      <p className="font-peachi font-bold text-[14px] flex items-start gap-2">
+        <HelpCircle size={16} className="text-[#A2492C] mt-0.5 flex-shrink-0" />
+        {q}
+      </p>
+      <p className="text-[13px] text-[#6E6E73] leading-snug mt-2">{a}</p>
+    </li>
+  );
+}

--- a/apps/order/src/app/tier-benefits/page.tsx
+++ b/apps/order/src/app/tier-benefits/page.tsx
@@ -1,0 +1,104 @@
+import Link from "next/link";
+import { ArrowLeft, Check, Lock } from "lucide-react";
+import { BottomNav } from "../_BottomNav";
+
+/**
+ * Tier benefits — full tier table with per-tier perks. Mirrors
+ * apps/pickup-native/app/tier-benefits.tsx. Static content (the
+ * brand's tier structure rarely changes); per-customer current tier
+ * is shown on /rewards's TierCard.
+ */
+type Tier = {
+  name: string;
+  beansFloor: number;
+  multiplier: number;
+  bg: string;
+  fg: string;
+  perks: string[];
+};
+
+const TIERS: Tier[] = [
+  {
+    name: "Bronze",
+    beansFloor: 0,
+    multiplier: 1,
+    bg: "#A2492C",
+    fg: "#FFFFFF",
+    perks: ["1× beans on every order", "Free welcome drink"],
+  },
+  {
+    name: "Silver",
+    beansFloor: 500,
+    multiplier: 1.25,
+    bg: "#C0C8D0",
+    fg: "#160800",
+    perks: ["1.25× beans on every order", "Birthday treat", "Mystery drop weekly"],
+  },
+  {
+    name: "Gold",
+    beansFloor: 1500,
+    multiplier: 1.5,
+    bg: "#FBBF24",
+    fg: "#160800",
+    perks: ["1.5× beans on every order", "Two mystery drops weekly", "Exclusive challenges"],
+  },
+  {
+    name: "Black",
+    beansFloor: 5000,
+    multiplier: 2,
+    bg: "#160800",
+    fg: "#FBBF24",
+    perks: ["2× beans on every order", "Daily mystery drop", "Early access to new drinks", "Birthday week, not just day"],
+  },
+];
+
+export default function TierBenefitsPage() {
+  return (
+    <main className="bg-white text-[#160800] min-h-screen pb-[calc(env(safe-area-inset-bottom,0px)+88px)]">
+      <header
+        className="bg-[#160800] text-white px-4 pb-3 flex items-center gap-3"
+        style={{ paddingTop: "calc(env(safe-area-inset-top, 0px) + 12px)" }}
+      >
+        <Link href="/rewards" className="-ml-1 p-1 active:opacity-60" aria-label="Back">
+          <ArrowLeft size={20} color="#FFFFFF" />
+        </Link>
+        <h1 className="font-peachi font-bold text-[22px]">Tier benefits</h1>
+      </header>
+
+      <section className="px-4 pt-5 flex flex-col gap-3">
+        {TIERS.map((t) => (
+          <article
+            key={t.name}
+            className="rounded-2xl p-5"
+            style={{ backgroundColor: t.bg, color: t.fg }}
+          >
+            <div className="flex items-baseline gap-3">
+              <h2 className="font-peachi font-bold text-2xl">{t.name}</h2>
+              <span
+                className="text-[11px] uppercase tracking-widest"
+                style={{ opacity: 0.7 }}
+              >
+                {t.beansFloor.toLocaleString()}+ beans · {t.multiplier}× earn
+              </span>
+            </div>
+            <ul className="mt-3 flex flex-col gap-2">
+              {t.perks.map((p) => (
+                <li key={p} className="flex items-start gap-2 text-[13px]">
+                  <Check size={14} className="mt-0.5 flex-shrink-0" />
+                  <span>{p}</span>
+                </li>
+              ))}
+            </ul>
+          </article>
+        ))}
+      </section>
+
+      <p className="px-5 pt-5 text-[11px] text-[#8E8E93]">
+        <Lock size={11} className="inline mr-1" />
+        Tier status reviewed every 90 days based on rolling-window beans earned.
+      </p>
+
+      <BottomNav active="rewards" />
+    </main>
+  );
+}

--- a/apps/order/src/app/wrapped/_WrappedView.tsx
+++ b/apps/order/src/app/wrapped/_WrappedView.tsx
@@ -1,0 +1,124 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import Link from "next/link";
+import { ArrowLeft, Coffee, Sparkles, Flame } from "lucide-react";
+
+/**
+ * Year recap ("wrapped") — high-level lifetime stats pulled from the
+ * persisted member snapshot. Mirrors apps/pickup-native/app/wrapped.tsx
+ * styling but minimal: cream-on-espresso stat cards rather than the
+ * native's full animated reveal sequence.
+ */
+type Persisted = {
+  state?: {
+    member?: {
+      name?: string | null;
+      pointsBalance?: number;
+      totalVisits?: number;
+      totalPointsEarned?: number;
+    };
+  };
+};
+
+export function WrappedView() {
+  const [m, setM] = useState<Persisted["state"]["member"] | null>(null);
+
+  useEffect(() => {
+    try {
+      const raw = window.localStorage.getItem("celsius-pickup");
+      if (raw) {
+        const parsed = JSON.parse(raw) as Persisted;
+        setM(parsed.state?.member ?? null);
+      }
+    } catch {
+      /* ignore */
+    }
+  }, []);
+
+  return (
+    <>
+      <header className="px-4 pb-3 flex items-center gap-3" style={{ paddingTop: "calc(env(safe-area-inset-top, 0px) + 12px)" }}>
+        <Link href="/rewards" className="-ml-1 p-1 active:opacity-60" aria-label="Back">
+          <ArrowLeft size={20} color="#FFFFFF" />
+        </Link>
+        <h1 className="font-peachi font-bold text-[22px]">Your year</h1>
+      </header>
+
+      <section className="px-5 pt-6">
+        <p className="text-[10px] uppercase tracking-widest text-white/55">
+          Hi{m?.name ? `, ${m.name}` : ""}.
+        </p>
+        <h2 className="mt-1 font-peachi font-bold text-3xl leading-tight">
+          Here&apos;s your Celsius year
+        </h2>
+        <p className="mt-2 text-[13px] text-white/65 leading-snug">
+          Beans earned, drinks ordered, the streaks. Tap a card for the detail.
+        </p>
+      </section>
+
+      <section className="px-4 pt-6 grid grid-cols-2 gap-3">
+        <Stat
+          Icon={Sparkles}
+          accent="#FBBF24"
+          value={(m?.totalPointsEarned ?? 0).toLocaleString()}
+          label="Beans earned"
+        />
+        <Stat
+          Icon={Coffee}
+          accent="#A2492C"
+          value={(m?.totalVisits ?? 0).toLocaleString()}
+          label="Visits"
+        />
+        <Stat
+          Icon={Flame}
+          accent="#FBBF24"
+          value={(m?.pointsBalance ?? 0).toLocaleString()}
+          label="Beans now"
+        />
+        <Stat
+          Icon={Coffee}
+          accent="#A2492C"
+          value="—"
+          label="Favourite drink"
+        />
+      </section>
+    </>
+  );
+}
+
+function Stat({
+  Icon,
+  accent,
+  value,
+  label,
+}: {
+  Icon: typeof Coffee;
+  accent: string;
+  value: string;
+  label: string;
+}) {
+  return (
+    <div
+      className="rounded-2xl p-4"
+      style={{
+        backgroundColor: "rgba(255,255,255,0.05)",
+        border: "1px solid rgba(255,255,255,0.08)",
+      }}
+    >
+      <span
+        className="flex items-center justify-center"
+        style={{
+          width: 32,
+          height: 32,
+          borderRadius: 9,
+          backgroundColor: `${accent}28`,
+        }}
+      >
+        <Icon size={16} color={accent} strokeWidth={1.8} />
+      </span>
+      <p className="mt-3 font-peachi font-bold text-2xl">{value}</p>
+      <p className="mt-1 text-[10px] uppercase tracking-widest text-white/60">{label}</p>
+    </div>
+  );
+}

--- a/apps/order/src/app/wrapped/page.tsx
+++ b/apps/order/src/app/wrapped/page.tsx
@@ -1,0 +1,11 @@
+import { WrappedView } from "./_WrappedView";
+import { BottomNav } from "../_BottomNav";
+
+export default function WrappedPage() {
+  return (
+    <main className="bg-[#160800] text-white min-h-screen pb-[calc(env(safe-area-inset-bottom,0px)+88px)]">
+      <WrappedView />
+      <BottomNav active="rewards" />
+    </main>
+  );
+}

--- a/apps/order/src/middleware.ts
+++ b/apps/order/src/middleware.ts
@@ -71,8 +71,16 @@ export async function middleware(request: NextRequest) {
     pathname === "/account" ||
     pathname === "/checkout" ||
     pathname === "/store" ||
+    pathname === "/referral" ||
+    pathname === "/support" ||
+    pathname === "/settings" ||
+    pathname === "/privacy" ||
+    pathname === "/tier-benefits" ||
+    pathname === "/wrapped" ||
+    pathname === "/account-delete" ||
     pathname.startsWith("/product/") ||
-    pathname.startsWith("/order/");
+    pathname.startsWith("/order/") ||
+    pathname.startsWith("/challenge/");
 
   // Customer-facing UI lives in the Expo Web PWA shipped from
   // apps/pickup-native and copied into /public during build. For any

--- a/apps/pickup-native/public/sw.js
+++ b/apps/pickup-native/public/sw.js
@@ -6,7 +6,7 @@
 //
 // Future rule of thumb: bump this on ANY production-affecting bundle
 // regression so customers don't get stuck on a bad build.
-const CACHE = "celsius-v8";
+const CACHE = "celsius-v9";
 const SHELL = ["/", "/index.html", "/manifest.json"];
 
 self.addEventListener("install", (e) => {


### PR DESCRIPTION
## Summary

Closes the parity gap with the SPA's **secondary** routes — every customer-facing path that was still rewriting to the SPA's `index.html` now has a Next.js page.

### New routes

| Route | Source | Notes |
|---|---|---|
| `/referral` | `/api/loyalty/me/referral` | code + copy CTA + signups count |
| `/support` | static | WhatsApp / phone / email contact + FAQ accordion |
| `/settings` | Notification API | push toggle, privacy / support links, danger zone |
| `/privacy` | static | long-form policy |
| `/tier-benefits` | static | Bronze / Silver / Gold / Black table with perks |
| `/challenge/[id]` | `/api/loyalty/me/missions/active` (filtered) | single mission detail with progress |
| `/wrapped` | persisted `member` snapshot | year-recap stat cards |
| `/account-delete` | `POST /api/members/delete` | typed-confirm delete flow |

### Middleware

`isNextOwned` updated so every new route bypasses the SPA rewrite. SPA's `index.html` is now only reached for routes that genuinely don't exist as Next.js pages.

### SW cache

Bumped `v8 → v9` so stuck PWA clients flush onto the new bundles.

## Test plan

- [ ] Each route renders on iPhone Safari with URL bar collapsing on scroll.
- [ ] `/referral` shows code, copy works.
- [ ] `/settings`: push toggle reflects browser permission state.
- [ ] `/account-delete`: must type "delete" before button enables; success drops back to sign-in.
- [ ] Native iOS pickup app: untouched.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Xd1aERynqUbdCqXNboKWBe)_