### PR TITLE
feat(web): orders active/past tabs + cancel pending order

### DIFF
--- a/apps/order/public/sw.js
+++ b/apps/order/public/sw.js
@@ -1,7 +1,7 @@
 // Mirror of apps/pickup-native/public/sw.js — overwritten on each
 // build-pwa run. v3 bumps over v2 to flush customers off the broken
 // CSS shipped in #157/#158 before this revert deployed.
-const CACHE = "celsius-v9";
+const CACHE = "celsius-v10";
 const SHELL = ["/", "/index.html", "/manifest.json"];
 
 self.addEventListener("install", (e) => {

--- a/apps/order/src/app/order/[id]/_OrderTrackingView.tsx
+++ b/apps/order/src/app/order/[id]/_OrderTrackingView.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useState } from "react";
 import Link from "next/link";
-import { ArrowLeft, CheckCircle2, Clock, Coffee, Package, XCircle } from "lucide-react";
+import { ArrowLeft, CheckCircle2, Clock, Coffee, Package, XCircle, X } from "lucide-react";
 
 type OrderItem = {
   product_name: string;
@@ -36,6 +36,28 @@ const STEPS: Array<{ key: string; label: string; Icon: typeof Clock }> = [
 export function OrderTrackingView({ orderId }: { orderId: string }) {
   const [order, setOrder] = useState<Order | null>(null);
   const [error, setError] = useState<string | null>(null);
+  const [cancelling, setCancelling] = useState(false);
+
+  const cancel = async () => {
+    setCancelling(true);
+    try {
+      const res = await fetch(`/api/orders/${orderId}/status`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ status: "cancelled" }),
+      });
+      if (res.ok) {
+        setOrder((prev) => (prev ? { ...prev, status: "cancelled" } : prev));
+      } else {
+        const data = await res.json().catch(() => ({}));
+        setError(data.error ?? "Couldn't cancel the order");
+      }
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setCancelling(false);
+    }
+  };
 
   useEffect(() => {
     let cancelled = false;
@@ -134,6 +156,20 @@ export function OrderTrackingView({ orderId }: { orderId: string }) {
           </ul>
         )}
       </section>
+
+      {order.status.toLowerCase() === "pending" ? (
+        <section className="px-4 pt-4">
+          <button
+            type="button"
+            disabled={cancelling}
+            onClick={cancel}
+            className="w-full flex items-center justify-center gap-2 rounded-full border border-red-200 bg-red-50 text-red-700 py-3 font-bold active:opacity-80"
+          >
+            <X size={16} />
+            {cancelling ? "Cancelling…" : "Cancel order"}
+          </button>
+        </section>
+      ) : null}
 
       <section className="px-4 pt-5">
         <h2 className="font-peachi font-bold text-[16px] mb-2">Your order</h2>

--- a/apps/order/src/app/orders/_OrdersView.tsx
+++ b/apps/order/src/app/orders/_OrdersView.tsx
@@ -26,10 +26,14 @@ function readPhone(): string | null {
   }
 }
 
+type Tab = "active" | "past";
+const ACTIVE_STATUSES = new Set(["pending", "paid", "preparing", "ready"]);
+
 export function OrdersView() {
   const [phone, setPhone] = useState<string | null>(null);
   const [orders, setOrders] = useState<Order[] | null>(null);
   const [error, setError] = useState<string | null>(null);
+  const [tab, setTab] = useState<Tab>("active");
 
   useEffect(() => {
     const p = readPhone();
@@ -46,6 +50,22 @@ export function OrdersView() {
       .catch((err) => setError(String(err)));
   }, []);
 
+  const filtered = orders
+    ? orders.filter((o) =>
+        tab === "active"
+          ? ACTIVE_STATUSES.has(o.status.toLowerCase())
+          : !ACTIVE_STATUSES.has(o.status.toLowerCase()),
+      )
+    : null;
+
+  // Default-flip: if there's no active order but there's history,
+  // land the customer on Past so they don't see an empty list.
+  useEffect(() => {
+    if (!orders || orders.length === 0) return;
+    const hasActive = orders.some((o) => ACTIVE_STATUSES.has(o.status.toLowerCase()));
+    if (!hasActive && tab === "active") setTab("past");
+  }, [orders, tab]);
+
   return (
     <>
       <header
@@ -59,6 +79,13 @@ export function OrdersView() {
           Orders
         </h1>
       </header>
+
+      {phone ? (
+        <div className="flex border-b border-[#EBE5DE] px-4">
+          <TabButton on={tab === "active"} onClick={() => setTab("active")} label="Active" />
+          <TabButton on={tab === "past"} onClick={() => setTab("past")} label="Past" />
+        </div>
+      ) : null}
 
       {!phone ? (
         <EmptyCTA
@@ -78,9 +105,21 @@ export function OrdersView() {
           actionHref="/menu"
           actionLabel="Open the menu"
         />
+      ) : (filtered ?? []).length === 0 ? (
+        <EmptyCTA
+          icon={<ClipboardList size={48} color="#8E8E93" strokeWidth={1.25} />}
+          title={tab === "active" ? "No active orders" : "No past orders"}
+          body={
+            tab === "active"
+              ? "Your in-progress orders will appear here while they're prepared."
+              : "Completed and cancelled orders live here."
+          }
+          actionHref="/menu"
+          actionLabel="Open the menu"
+        />
       ) : (
         <ul className="px-4 py-4 flex flex-col gap-3">
-          {orders.map((o) => (
+          {(filtered ?? []).map((o) => (
             <li key={o.id}>
               <Link
                 href={`/order/${o.id}`}
@@ -151,5 +190,32 @@ function EmptyCTA({
         {actionLabel}
       </Link>
     </div>
+  );
+}
+
+function TabButton({
+  on,
+  onClick,
+  label,
+}: {
+  on: boolean;
+  onClick: () => void;
+  label: string;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className="flex-1 py-3 active:opacity-60"
+      aria-current={on ? "true" : undefined}
+      style={{
+        color: on ? "#160800" : "#8E8E93",
+        fontWeight: on ? 700 : 600,
+        borderBottom: on ? "2px solid #160800" : "2px solid transparent",
+        marginBottom: -1,
+      }}
+    >
+      {label}
+    </button>
   );
 }

--- a/apps/pickup-native/public/sw.js
+++ b/apps/pickup-native/public/sw.js
@@ -6,7 +6,7 @@
 //
 // Future rule of thumb: bump this on ANY production-affecting bundle
 // regression so customers don't get stuck on a bad build.
-const CACHE = "celsius-v9";
+const CACHE = "celsius-v10";
 const SHELL = ["/", "/index.html", "/manifest.json"];
 
 self.addEventListener("install", (e) => {


### PR DESCRIPTION
## Summary

Two final native-parity bits for the customer flow.

### `/orders` — Active / Past tabs

Mirrors the SPA's Orders screen with a tab strip below the header. Active = `pending`/`paid`/`preparing`/`ready`. Past = `completed`/`cancelled`/`failed`. Default-flips to Past if there are no active orders.

### `/order/[id]` — Cancel pending

When the order is still in `pending` status (awaiting payment), a "Cancel order" button shows under the status timeline. PATCH `/api/orders/[orderId]/status` with `{ status: "cancelled" }` — same endpoint the SPA calls.

SW cache bumped `v9 → v10`.

## Test plan

- [ ] `/orders` while signed in with mixed history: tabs switch, both lists populated correctly.
- [ ] Pending order: Cancel button visible, tap → status flips to cancelled inline.
- [ ] Non-pending order: button hidden.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Xd1aERynqUbdCqXNboKWBe)_