### PR TITLE
feat(checkout/web): Stripe Elements inline payment confirmation

### DIFF
--- a/apps/order/public/sw.js
+++ b/apps/order/public/sw.js
@@ -1,7 +1,7 @@
 // Mirror of apps/pickup-native/public/sw.js — overwritten on each
 // build-pwa run. v3 bumps over v2 to flush customers off the broken
 // CSS shipped in #157/#158 before this revert deployed.
-const CACHE = "celsius-v10";
+const CACHE = "celsius-v11";
 const SHELL = ["/", "/index.html", "/manifest.json"];
 
 self.addEventListener("install", (e) => {

--- a/apps/order/src/app/checkout/_CheckoutView.tsx
+++ b/apps/order/src/app/checkout/_CheckoutView.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useMemo, useState } from "react";
 import Link from "next/link";
 import { ArrowLeft, CreditCard, Wallet, Banknote } from "lucide-react";
+import { StripePaymentForm } from "@/components/stripe-payment-form";
 
 type CartItem = {
   cartId: string;
@@ -46,6 +47,9 @@ export function CheckoutView() {
   const [method, setMethod] = useState("card");
   const [placing, setPlacing] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [stripeContext, setStripeContext] = useState<{ orderId: string; clientSecret: string } | null>(null);
+  const [confirmFn, setConfirmFn] = useState<(() => Promise<{ error?: { message?: string } }>) | null>(null);
+  const [confirming, setConfirming] = useState(false);
 
   useEffect(() => {
     setState(readState() ?? null);
@@ -107,11 +111,11 @@ export function CheckoutView() {
         return;
       }
       if (data.clientSecret) {
-        // For Stripe we'd normally use Stripe.js client-side. For
-        // now, hand the customer over to the order detail page which
-        // polls for status; full Stripe Elements integration is a
-        // follow-up.
-        window.location.href = `/order/${data.orderId}?payment=pending`;
+        // Stripe path — render Stripe Elements inline so the customer
+        // can confirm the payment without leaving the PWA. The form
+        // calls /api/orders/[id]/confirm-stripe on success and
+        // redirects to the order page.
+        setStripeContext({ orderId: data.orderId, clientSecret: data.clientSecret });
         return;
       }
       if (data.freeOrder) {
@@ -193,11 +197,46 @@ export function CheckoutView() {
         </div>
       </section>
 
+      {stripeContext ? (
+        <section className="mt-4 px-4">
+          <h2 className="font-peachi font-bold text-[16px] mb-3">Payment details</h2>
+          <StripePaymentForm
+            clientSecret={stripeContext.clientSecret}
+            paymentMethod={method}
+            orderId={stripeContext.orderId}
+            onReady={(fn) => setConfirmFn(() => fn)}
+          />
+        </section>
+      ) : null}
+
       {error ? (
         <p className="px-4 pt-3 text-[12px] text-red-600">{error}</p>
       ) : null}
 
       <div className="mt-5 px-4">
+        {stripeContext ? (
+          <button
+            type="button"
+            disabled={!confirmFn || confirming}
+            onClick={async () => {
+              if (!confirmFn) return;
+              setConfirming(true);
+              setError(null);
+              const r = await confirmFn();
+              if (r.error) {
+                setError(r.error.message ?? "Payment failed");
+                setConfirming(false);
+                return;
+              }
+              window.location.href = `/order/${stripeContext.orderId}?payment=done`;
+            }}
+            className={`block w-full rounded-full text-white text-center py-4 font-bold active:opacity-80 ${
+              !confirmFn || confirming ? "bg-[#A2492C]/40" : "bg-[#A2492C]"
+            }`}
+          >
+            {confirming ? "Confirming payment…" : `Pay RM${subtotal.toFixed(2)}`}
+          </button>
+        ) : (
         <button
           type="button"
           disabled={placing || !state.outletId}
@@ -208,6 +247,7 @@ export function CheckoutView() {
         >
           {placing ? "Placing order…" : !state.outletId ? "Select an outlet first" : "Place order"}
         </button>
+        )}
       </div>
     </>
   );

--- a/apps/pickup-native/public/sw.js
+++ b/apps/pickup-native/public/sw.js
@@ -6,7 +6,7 @@
 //
 // Future rule of thumb: bump this on ANY production-affecting bundle
 // regression so customers don't get stuck on a bad build.
-const CACHE = "celsius-v10";
+const CACHE = "celsius-v11";
 const SHELL = ["/", "/index.html", "/manifest.json"];
 
 self.addEventListener("install", (e) => {


### PR DESCRIPTION
## Summary

`/checkout` now confirms Stripe payments **inline** (PaymentElement) instead of redirecting to the order page in a half-paid state.

### Flow

1. Customer taps Place Order → `/api/checkout/initiate` returns `{ orderId, clientSecret }` for the Stripe path.
2. `<StripePaymentForm>` (existing component) mounts below the order summary — PaymentElement with the brand's espresso theme.
3. "Pay RM…" button calls the Stripe `confirmPayment` fn the form exposes via `onReady`.
4. On success, `POST /api/orders/[id]/confirm-stripe` so the order advances to `preparing` before the customer lands on `/order/[id]?payment=done`. FPX still redirects to the bank — Stripe handles that internally.

Same wiring as the native pickup app — no new endpoints. SW cache `v10 → v11`.

## Test plan

- [ ] Card flow on iPhone Safari: place order → Stripe Elements appears, fill test card, Pay → order page shows preparing.
- [ ] RM-routed flows (FPX / GrabPay / TNG via RM) still redirect to the hosted payment page.
- [ ] Free-order zero-total flow still bypasses payment.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Xd1aERynqUbdCqXNboKWBe)_