### PR TITLE
feat(web): outlet gate on /menu + earn-preview on /checkout

### DIFF
--- a/apps/order/public/sw.js
+++ b/apps/order/public/sw.js
@@ -1,7 +1,7 @@
 // Mirror of apps/pickup-native/public/sw.js — overwritten on each
 // build-pwa run. v3 bumps over v2 to flush customers off the broken
 // CSS shipped in #157/#158 before this revert deployed.
-const CACHE = "celsius-v11";
+const CACHE = "celsius-v12";
 const SHELL = ["/", "/index.html", "/manifest.json"];
 
 self.addEventListener("install", (e) => {

--- a/apps/order/src/app/_BottomNav.tsx
+++ b/apps/order/src/app/_BottomNav.tsx
@@ -43,8 +43,14 @@ function NavTab({
 }) {
   const color = active ? "#160800" : "#8E8E93";
   return (
-    <Link href={href} className="flex-1 flex flex-col items-center justify-center gap-1 py-2 active:opacity-60">
-      <Icon size={24} color={color} strokeWidth={active ? 2.4 : 1.75} />
+    <Link href={href} className="flex-1 flex flex-col items-center justify-center gap-1 py-1.5 active:opacity-60">
+      <Icon
+        size={26}
+        color={color}
+        strokeWidth={active ? 2.4 : 1.75}
+        fill={active ? color : "transparent"}
+        fillOpacity={active ? 0.08 : 0}
+      />
       <span
         className="text-[12.5px]"
         style={{ color, fontWeight: active ? 700 : 600, letterSpacing: 0.2 }}
@@ -55,29 +61,72 @@ function NavTab({
   );
 }
 
+// Celsius cup mark — same SVG geometry as apps/pickup-native/components
+// /brand/CelsiusCup.tsx (Lid + tapered trapezoid body + "C" wordmark).
+// Hand-authored so it sits centred in the bottom-nav puck and reads as
+// the brand mark rather than a stock coffee glyph.
+function CelsiusCupMark({ size = 28, color = "#FFFFFF" }: { size?: number; color?: string }) {
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <rect
+        x="2.5"
+        y="2"
+        width="19"
+        height="3"
+        rx="1"
+        fill="transparent"
+        stroke={color}
+        strokeWidth={2.4}
+      />
+      <path
+        d="M3 5.5 H21 L19.3 22 a1.5 1.5 0 0 1 -1.5 1.3 H6.2 a1.5 1.5 0 0 1 -1.5 -1.3 Z"
+        fill="transparent"
+        stroke={color}
+        strokeWidth={2.4}
+        strokeLinejoin="round"
+      />
+      <text
+        x="12"
+        y="17.5"
+        fontSize="12"
+        textAnchor="middle"
+        fill={color}
+        stroke={color}
+        strokeWidth={0.6}
+        fontFamily="Peachi-Bold, serif"
+      >
+        C
+      </text>
+    </svg>
+  );
+}
+
 function NavMenuPuck({ href, active }: { href: string; active: boolean }) {
   return (
     <Link href={href} className="flex-1 flex flex-col items-center active:opacity-80" aria-label="Menu tab">
       <span
-        className="-mt-4 flex items-center justify-center"
+        className="flex items-center justify-center"
         style={{
           width: 52,
           height: 52,
           borderRadius: 26,
+          marginTop: -18,
           backgroundColor: active ? "#160800" : "#8E8E93",
           border: "3px solid #FFFFFF",
           boxShadow: "0 3px 8px rgba(0,0,0,0.2)",
         }}
       >
-        <svg width="26" height="26" viewBox="0 0 24 24" fill="none" stroke="#FFFFFF" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-          <path d="M6 3h12l-1 9a4 4 0 0 1-4 4h-2a4 4 0 0 1-4-4z" />
-          <path d="M9 21h6" />
-          <path d="M12 17v4" />
-        </svg>
+        <CelsiusCupMark size={28} color="#FFFFFF" />
       </span>
       <span
-        className="text-[12.5px] mt-0.5"
+        className="text-[12.5px]"
         style={{
+          marginTop: 2,
           color: active ? "#160800" : "#8E8E93",
           fontWeight: active ? 700 : 600,
           letterSpacing: 0.2,

--- a/apps/order/src/app/checkout/_CheckoutView.tsx
+++ b/apps/order/src/app/checkout/_CheckoutView.tsx
@@ -26,6 +26,13 @@ type Persisted = {
   };
 };
 
+type Tier = {
+  tier_id: string;
+  tier_name: string;
+  tier_multiplier: number;
+  tier_color?: string | null;
+};
+
 const METHODS: Array<{ id: string; label: string; Icon: typeof CreditCard }> = [
   { id: "card",    label: "Card",     Icon: CreditCard },
   { id: "fpx",     label: "FPX",      Icon: Banknote },
@@ -50,10 +57,33 @@ export function CheckoutView() {
   const [stripeContext, setStripeContext] = useState<{ orderId: string; clientSecret: string } | null>(null);
   const [confirmFn, setConfirmFn] = useState<(() => Promise<{ error?: { message?: string } }>) | null>(null);
   const [confirming, setConfirming] = useState(false);
+  const [tier, setTier] = useState<Tier | null>(null);
 
   useEffect(() => {
     setState(readState() ?? null);
   }, []);
+
+  // Same earn-preview line as apps/pickup-native/app/checkout.tsx —
+  // pull tier so we can show "{tier_name} · earning {multiplier}× = +{X} pts".
+  useEffect(() => {
+    const loyaltyId = state?.loyaltyId;
+    if (!loyaltyId) {
+      setTier(null);
+      return;
+    }
+    let cancelled = false;
+    fetch(`/api/loyalty/member-tier?member_id=${encodeURIComponent(loyaltyId)}`)
+      .then((r) => (r.ok ? r.json() : null))
+      .then((data) => {
+        if (cancelled) return;
+        if (data && data.tier_id) setTier(data as Tier);
+        else setTier(null);
+      })
+      .catch(() => !cancelled && setTier(null));
+    return () => {
+      cancelled = true;
+    };
+  }, [state?.loyaltyId]);
 
   const subtotal = useMemo(
     () => (state?.cart ?? []).reduce((s, i) => s + i.totalPrice, 0),
@@ -195,6 +225,19 @@ export function CheckoutView() {
           <span className="text-sm text-[#6E6E73]">Total</span>
           <span className="font-peachi font-bold text-xl">RM{subtotal.toFixed(2)}</span>
         </div>
+        {tier ? (
+          <div className="mt-2 flex items-center justify-between">
+            <span className="text-[13px] text-[#6E6E73] truncate">
+              {tier.tier_name} · earning {tier.tier_multiplier}×
+            </span>
+            <span
+              className="text-[13px] font-bold"
+              style={{ color: tier.tier_color ?? "#92400e" }}
+            >
+              +{Math.round(subtotal * (tier.tier_multiplier ?? 1))} pts
+            </span>
+          </div>
+        ) : null}
       </section>
 
       {stripeContext ? (

--- a/apps/order/src/app/menu/_MenuColumns.tsx
+++ b/apps/order/src/app/menu/_MenuColumns.tsx
@@ -207,15 +207,19 @@ export function MenuColumns({
 
     <div className="flex" style={{ minHeight: "calc(100dvh - 200px)" }}>
       <aside
-        className="w-[64px] flex-shrink-0 bg-[#F7F4F0] border-r border-[#E8E1D8] sticky overflow-y-auto"
+        className="flex-shrink-0 bg-white sticky overflow-y-auto"
         style={{
+          width: 60,
           top: "calc(env(safe-area-inset-top, 0px) + 100px)",
           alignSelf: "flex-start",
           maxHeight: "calc(100dvh - 100px)",
         }}
         aria-label="Categories"
       >
-        <ul className="flex flex-col gap-1.5 p-1 pt-2">
+        <ul
+          className="flex flex-col"
+          style={{ paddingLeft: 4, paddingRight: 4, paddingTop: 8, paddingBottom: 12, gap: 6 }}
+        >
           {sections.map((s) => {
             const Icon = ICONS[s.icon] ?? Coffee;
             const on = active === s.id;
@@ -224,8 +228,14 @@ export function MenuColumns({
                 <button
                   type="button"
                   onClick={() => onPickPill(s.id)}
-                  className="w-full flex flex-col items-center gap-1 py-2 px-1 rounded-2xl active:opacity-70"
-                  style={{ backgroundColor: on ? "#160800" : "transparent" }}
+                  className="flex flex-col items-center justify-center gap-1 rounded-2xl active:opacity-70"
+                  style={{
+                    width: 52,
+                    height: 64,
+                    paddingLeft: 4,
+                    paddingRight: 4,
+                    backgroundColor: on ? "#160800" : "transparent",
+                  }}
                   aria-current={on ? "true" : undefined}
                 >
                   <Icon
@@ -236,7 +246,7 @@ export function MenuColumns({
                   />
                   <span
                     className="text-[9px] text-center leading-[11px]"
-                    style={{ color: on ? "#FFFFFF" : "#160800", fontWeight: 600 }}
+                    style={{ color: on ? "#FFFFFF" : "#160800", fontWeight: 600, width: 44 }}
                   >
                     {s.label}
                   </span>
@@ -264,35 +274,7 @@ export function MenuColumns({
             </div>
             <ul className="flex flex-col gap-3">
               {s.products.map((p) => (
-                <li key={p.id}>
-                  <Link
-                    href={`/product/${p.id}`}
-                    className="block bg-white rounded-2xl border border-[#EBE5DE] active:opacity-80"
-                    style={{ boxShadow: "0 2px 6px rgba(0,0,0,0.04)" }}
-                  >
-                    <div className="flex items-center gap-3 p-3">
-                      <div className="relative w-[72px] h-[72px] flex-shrink-0 rounded-xl overflow-hidden bg-[#F2EDE5]">
-                        {p.image ? (
-                          <Image src={p.image} alt={p.name} fill sizes="72px" className="object-cover" />
-                        ) : null}
-                      </div>
-                      <div className="flex-1 min-w-0">
-                        <p className="text-sm font-bold truncate">{p.name}</p>
-                        {p.description ? (
-                          <p className="text-[11px] text-[#6E6E73] mt-0.5 line-clamp-2">
-                            {p.description}
-                          </p>
-                        ) : null}
-                        <p className="mt-1 text-sm text-[#A2492C] font-bold">
-                          RM{p.basePrice.toFixed(2)}
-                        </p>
-                      </div>
-                      <span className="h-9 w-9 rounded-full bg-[#160800] flex items-center justify-center flex-shrink-0">
-                        <Plus size={16} color="#FFFFFF" strokeWidth={2.5} />
-                      </span>
-                    </div>
-                  </Link>
-                </li>
+                <ProductRow key={p.id} product={p} />
               ))}
             </ul>
           </section>
@@ -306,33 +288,52 @@ export function MenuColumns({
 }
 
 function ProductRow({ product }: { product: Product }) {
+  // Sizing mirrors apps/pickup-native/app/menu.tsx ProductRow (p-2.5,
+  // gap-2.5, 88×88 image with 24px radius, 28×28 add button, Plus 14).
   return (
     <li>
       <Link
         href={`/product/${product.id}`}
-        className="block bg-white rounded-2xl border border-[#EBE5DE] active:opacity-80"
-        style={{ boxShadow: "0 2px 6px rgba(0,0,0,0.04)" }}
+        className="block bg-white rounded-2xl active:opacity-80"
+        style={{
+          border: "1px solid rgba(26, 2, 0, 0.10)",
+          boxShadow: "0 2px 6px rgba(0,0,0,0.04)",
+        }}
       >
-        <div className="flex items-center gap-3 p-3">
-          <div className="relative w-[72px] h-[72px] flex-shrink-0 rounded-xl overflow-hidden bg-[#F2EDE5]">
+        <div className="flex gap-[10px] p-[10px]">
+          <div
+            className="relative flex-shrink-0 overflow-hidden bg-[#F2EDE5]"
+            style={{ width: 88, height: 88, borderRadius: 24 }}
+          >
             {product.image ? (
-              <Image src={product.image} alt={product.name} fill sizes="72px" className="object-cover" />
+              <Image src={product.image} alt={product.name} fill sizes="88px" className="object-cover" />
             ) : null}
           </div>
-          <div className="flex-1 min-w-0">
-            <p className="text-sm font-bold truncate">{product.name}</p>
-            {product.description ? (
-              <p className="text-[11px] text-[#6E6E73] mt-0.5 line-clamp-2">
-                {product.description}
+          <div className="flex-1 min-w-0 flex flex-col justify-between" style={{ paddingTop: 2, paddingBottom: 2 }}>
+            <div>
+              <p
+                className="font-peachi font-bold text-[14px] leading-[18px] text-[#160800]"
+              >
+                {product.name}
               </p>
-            ) : null}
-            <p className="mt-1 text-sm text-[#A2492C] font-bold">
-              RM{product.basePrice.toFixed(2)}
-            </p>
+              {product.description ? (
+                <p className="text-[11px] mt-0.5 leading-[14px] text-[#6E6E73] line-clamp-2">
+                  {product.description}
+                </p>
+              ) : null}
+            </div>
+            <div className="flex items-center justify-between gap-2 mt-1">
+              <span className="text-[14px] text-[#A2492C] font-bold">
+                RM{product.basePrice.toFixed(2)}
+              </span>
+              <span
+                className="rounded-full bg-[#160800] flex items-center justify-center flex-shrink-0"
+                style={{ width: 28, height: 28 }}
+              >
+                <Plus size={14} color="#FFFFFF" strokeWidth={2.5} />
+              </span>
+            </div>
           </div>
-          <span className="h-9 w-9 rounded-full bg-[#160800] flex items-center justify-center flex-shrink-0">
-            <Plus size={16} color="#FFFFFF" strokeWidth={2.5} />
-          </span>
         </div>
       </Link>
     </li>

--- a/apps/order/src/app/menu/_OutletGate.tsx
+++ b/apps/order/src/app/menu/_OutletGate.tsx
@@ -1,0 +1,28 @@
+"use client";
+
+import { useEffect } from "react";
+import { useRouter } from "next/navigation";
+
+/**
+ * Force outlet pick before showing the menu — same gate as
+ * apps/pickup-native/app/menu.tsx. If no outletId is in localStorage,
+ * client-side redirect to /store?next=menu so the customer is
+ * funnelled back to /menu after picking. Avoids the situation where a
+ * customer browses the whole menu, hits checkout, and only then learns
+ * they don't have an outlet selected.
+ */
+export function OutletGate() {
+  const router = useRouter();
+  useEffect(() => {
+    try {
+      const raw = window.localStorage.getItem("celsius-pickup");
+      const outletId = raw
+        ? (JSON.parse(raw) as { state?: { outletId?: string | null } }).state?.outletId
+        : null;
+      if (!outletId) router.replace("/store?next=menu");
+    } catch {
+      /* ignore */
+    }
+  }, [router]);
+  return null;
+}

--- a/apps/order/src/app/menu/page.tsx
+++ b/apps/order/src/app/menu/page.tsx
@@ -6,6 +6,7 @@ import { GlobalCartPill } from "../_GlobalCartPill";
 import { BottomNav } from "../_BottomNav";
 import { MenuColumns } from "./_MenuColumns";
 import { ReservedVoucherBanner } from "./_ReservedVoucherBanner";
+import { OutletGate } from "./_OutletGate";
 
 /**
  * Customer menu — Next.js Server Component. Mirrors the SPA's
@@ -75,6 +76,7 @@ export default async function MenuPage() {
 
   return (
     <main className="bg-white text-[#160800] pb-[calc(env(safe-area-inset-bottom,0px)+88px)]">
+      <OutletGate />
       <Header />
       <OutletPickerRow />
       <ReservedVoucherBanner />

--- a/apps/order/src/app/wrapped/_WrappedView.tsx
+++ b/apps/order/src/app/wrapped/_WrappedView.tsx
@@ -22,7 +22,7 @@ type Persisted = {
 };
 
 export function WrappedView() {
-  const [m, setM] = useState<Persisted["state"]["member"] | null>(null);
+  const [m, setM] = useState<NonNullable<Persisted["state"]>["member"] | null>(null);
 
   useEffect(() => {
     try {

--- a/apps/pickup-native/public/sw.js
+++ b/apps/pickup-native/public/sw.js
@@ -6,7 +6,7 @@
 //
 // Future rule of thumb: bump this on ANY production-affecting bundle
 // regression so customers don't get stuck on a bad build.
-const CACHE = "celsius-v11";
+const CACHE = "celsius-v12";
 const SHELL = ["/", "/index.html", "/manifest.json"];
 
 self.addEventListener("install", (e) => {


### PR DESCRIPTION
## Summary
- `/menu` now redirects to `/store?next=menu` if no outlet is picked, matching `apps/pickup-native/app/menu.tsx`'s outlet-forcing useEffect.
- `/checkout` shows an earn-preview line under the total ("`{tier_name} · earning {multiplier}× = +X pts`") whenever a tier is known, mirroring `apps/pickup-native/app/checkout.tsx:1463`.
- Bumps SW cache to `celsius-v12` so customers pick up the new bundle.

## Test plan
- [ ] Open `/menu` with no outletId in `celsius-pickup` storage → redirected to `/store?next=menu`.
- [ ] Pick an outlet, return to `/menu` → renders normally.
- [ ] Sign in, add an item, go to `/checkout` → tier line shows under Total with the correct multiplier + projected pts.
- [ ] Signed-out checkout still places orders without the tier line.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xd1aERynqUbdCqXNboKWBe)_