### PR TITLE
fix(web): brand C-mark in nav puck, native sidebar, scroll best-sellers, tier card

### DIFF
--- a/apps/order/public/sw.js
+++ b/apps/order/public/sw.js
@@ -1,7 +1,7 @@
 // Mirror of apps/pickup-native/public/sw.js — overwritten on each
 // build-pwa run. v3 bumps over v2 to flush customers off the broken
 // CSS shipped in #157/#158 before this revert deployed.
-const CACHE = "celsius-v12";
+const CACHE = "celsius-v13";
 const SHELL = ["/", "/index.html", "/manifest.json"];
 
 self.addEventListener("install", (e) => {

--- a/apps/order/src/app/_BottomNav.tsx
+++ b/apps/order/src/app/_BottomNav.tsx
@@ -61,51 +61,6 @@ function NavTab({
   );
 }
 
-// Celsius cup mark — same SVG geometry as apps/pickup-native/components
-// /brand/CelsiusCup.tsx (Lid + tapered trapezoid body + "C" wordmark).
-// Hand-authored so it sits centred in the bottom-nav puck and reads as
-// the brand mark rather than a stock coffee glyph.
-function CelsiusCupMark({ size = 28, color = "#FFFFFF" }: { size?: number; color?: string }) {
-  return (
-    <svg
-      width={size}
-      height={size}
-      viewBox="0 0 24 24"
-      xmlns="http://www.w3.org/2000/svg"
-    >
-      <rect
-        x="2.5"
-        y="2"
-        width="19"
-        height="3"
-        rx="1"
-        fill="transparent"
-        stroke={color}
-        strokeWidth={2.4}
-      />
-      <path
-        d="M3 5.5 H21 L19.3 22 a1.5 1.5 0 0 1 -1.5 1.3 H6.2 a1.5 1.5 0 0 1 -1.5 -1.3 Z"
-        fill="transparent"
-        stroke={color}
-        strokeWidth={2.4}
-        strokeLinejoin="round"
-      />
-      <text
-        x="12"
-        y="17.5"
-        fontSize="12"
-        textAnchor="middle"
-        fill={color}
-        stroke={color}
-        strokeWidth={0.6}
-        fontFamily="Peachi-Bold, serif"
-      >
-        C
-      </text>
-    </svg>
-  );
-}
-
 function NavMenuPuck({ href, active }: { href: string; active: boolean }) {
   return (
     <Link href={href} className="flex-1 flex flex-col items-center active:opacity-80" aria-label="Menu tab">
@@ -121,7 +76,19 @@ function NavMenuPuck({ href, active }: { href: string; active: boolean }) {
           boxShadow: "0 3px 8px rgba(0,0,0,0.2)",
         }}
       >
-        <CelsiusCupMark size={28} color="#FFFFFF" />
+        {/* Brand °C mark from /public/images/icon-192.png — the actual
+            Celsius logo (serif C + degree dot), flipped to white via
+            CSS filter. Drops the previous hand-drawn cup outline since
+            the brand mark itself is the C-with-degree, not a takeaway
+            cup. */}
+        {/* eslint-disable-next-line @next/next/no-img-element */}
+        <img
+          src="/images/icon-192.png"
+          alt=""
+          width={30}
+          height={30}
+          style={{ filter: "brightness(0) invert(1)", display: "block" }}
+        />
       </span>
       <span
         className="text-[12.5px]"

--- a/apps/order/src/app/menu/_MenuColumns.tsx
+++ b/apps/order/src/app/menu/_MenuColumns.tsx
@@ -207,30 +207,30 @@ export function MenuColumns({
 
     <div className="flex" style={{ minHeight: "calc(100dvh - 200px)" }}>
       <aside
-        className="flex-shrink-0 bg-white sticky overflow-y-auto"
+        className="flex-shrink-0 bg-white overflow-y-auto w-[60px] min-[420px]:w-20"
         style={{
-          width: 60,
+          position: "sticky",
           top: "calc(env(safe-area-inset-top, 0px) + 100px)",
           alignSelf: "flex-start",
-          maxHeight: "calc(100dvh - 100px)",
+          height: "calc(100dvh - 140px)",
+          WebkitOverflowScrolling: "touch",
         }}
         aria-label="Categories"
       >
         <ul
           className="flex flex-col"
-          style={{ paddingLeft: 4, paddingRight: 4, paddingTop: 8, paddingBottom: 12, gap: 6 }}
+          style={{ paddingLeft: 4, paddingRight: 4, paddingTop: 8, paddingBottom: 180, gap: 6 }}
         >
           {sections.map((s) => {
             const Icon = ICONS[s.icon] ?? Coffee;
             const on = active === s.id;
             return (
-              <li key={s.id}>
+              <li key={s.id} className="flex justify-center">
                 <button
                   type="button"
                   onClick={() => onPickPill(s.id)}
-                  className="flex flex-col items-center justify-center gap-1 rounded-2xl active:opacity-70"
+                  className="flex flex-col items-center justify-center gap-1 rounded-2xl active:opacity-70 w-[52px] min-[420px]:w-[72px]"
                   style={{
-                    width: 52,
                     height: 64,
                     paddingLeft: 4,
                     paddingRight: 4,
@@ -246,7 +246,7 @@ export function MenuColumns({
                   />
                   <span
                     className="text-[9px] text-center leading-[11px]"
-                    style={{ color: on ? "#FFFFFF" : "#160800", fontWeight: 600, width: 44 }}
+                    style={{ color: on ? "#FFFFFF" : "#160800", fontWeight: 600 }}
                   >
                     {s.label}
                   </span>

--- a/apps/order/src/app/page.tsx
+++ b/apps/order/src/app/page.tsx
@@ -1,6 +1,6 @@
 import Image from "next/image";
 import Link from "next/link";
-import { Plus, ChevronRight } from "lucide-react";
+import { ChevronRight } from "lucide-react";
 import { getSupabaseAdmin } from "@/lib/supabase/server";
 import { getMenuData } from "@/lib/menu-data";
 import { GlobalCartPill } from "./_GlobalCartPill";
@@ -114,46 +114,57 @@ export default async function HomePage() {
           Renders nothing for guests / empty wallets. */}
       <VoucherRail />
 
-      {/* Best Sellers — card-style horizontal scroll (matching the SPA) */}
+      {/* Best Sellers — horizontal scroll matching apps/pickup-native/app
+          /index.tsx: w-44 cards, 4/5 image aspect, ChevronRight CTA. */}
       {bestSellers.length > 0 && (
         <section className="mt-5">
           <div className="flex items-center px-4 mb-3">
             <h2 className="font-peachi font-bold text-[20px] flex-1">Best Sellers</h2>
             <Link
               href="/menu"
-              className="text-[#A2492C] text-sm flex items-center gap-1 active:opacity-70"
+              className="text-[#A2492C] text-xs font-bold flex items-center gap-0.5 active:opacity-70"
             >
               More <ChevronRight size={14} />
             </Link>
           </div>
 
-          <div className="grid grid-cols-2 gap-3 px-4">
+          <div
+            className="flex gap-3 overflow-x-auto px-4 pb-1"
+            style={{ scrollSnapType: "x mandatory", WebkitOverflowScrolling: "touch" }}
+          >
             {bestSellers.map((p) => (
               <Link
                 key={p.id}
                 href={`/product/${p.id}`}
-                className="rounded-2xl bg-white border border-[#EBE5DE] overflow-hidden active:opacity-80"
-                style={{ boxShadow: "0 2px 6px rgba(0,0,0,0.04)" }}
+                className="flex-shrink-0 w-44 rounded-2xl bg-white overflow-hidden active:opacity-70"
+                style={{
+                  border: "1px solid rgba(26, 2, 0, 0.10)",
+                  boxShadow: "0 3px 8px rgba(0,0,0,0.06)",
+                  scrollSnapAlign: "start",
+                }}
               >
-                <div className="relative w-full aspect-square bg-[#F2EDE5]">
+                <div className="relative w-full bg-white" style={{ aspectRatio: "4 / 5" }}>
                   {p.image ? (
                     <Image
                       src={p.image}
                       alt={p.name}
                       fill
-                      sizes="(max-width: 430px) 50vw, 215px"
+                      sizes="176px"
                       className="object-cover"
                     />
                   ) : null}
                 </div>
                 <div className="p-3">
-                  <p className="text-sm font-bold truncate">{p.name}</p>
-                  <div className="mt-1 flex items-center justify-between">
-                    <span className="text-sm text-[#A2492C] font-bold">
+                  <p className="font-peachi font-bold text-[14px] text-[#160800] truncate">{p.name}</p>
+                  <div className="mt-2 flex items-center justify-between">
+                    <span className="font-peachi font-bold text-[16px] text-[#A2492C]">
                       RM{p.basePrice.toFixed(2)}
                     </span>
-                    <span className="h-7 w-7 rounded-full bg-[#160800] flex items-center justify-center">
-                      <Plus size={14} color="#FFFFFF" strokeWidth={2.5} />
+                    <span
+                      className="rounded-full bg-[#160800] flex items-center justify-center"
+                      style={{ width: 28, height: 28 }}
+                    >
+                      <ChevronRight size={16} color="#FFFFFF" />
                     </span>
                   </div>
                 </div>

--- a/apps/order/src/app/rewards/_TierCard.tsx
+++ b/apps/order/src/app/rewards/_TierCard.tsx
@@ -1,35 +1,50 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import { Sparkles } from "lucide-react";
 
 /**
- * Tier card for the rewards screen. Mirrors the SPA's TierCardCarousel
- * styling (apps/pickup-native/components/TierCard.tsx) for the
- * customer's current tier — espresso card with tier name in Peachi
- * bold, beans count + multiplier eyebrow, soft Sparkles glyph.
+ * Tier hero card — port of apps/pickup-native/components/TierCard.tsx.
+ * Tier-colour rail across the top, 48×48 tile with emoji icon, tier
+ * name in 20px bold tier-colour, multiplier pill on the right, and a
+ * progress strip showing visits-or-spend toward the next tier.
  *
- * Fetches /api/loyalty/member-tier with the member id from
- * localStorage. Falls back to a plain beans card when no tier info is
+ * Pulls tier from /api/loyalty/member-tier with the member id stored
+ * in the persisted Zustand state. Renders nothing if no tier info is
  * available (guest, new member, API miss).
  */
 type Tier = {
+  tier_id?: string | null;
   tier_name?: string | null;
+  tier_color?: string | null;
+  tier_icon?: string | null;
   tier_multiplier?: number | null;
-  current_beans?: number | null;
-  next_tier_beans?: number | null;
+  next_tier_id?: string | null;
   next_tier_name?: string | null;
+  next_tier_min_visits?: number | null;
+  next_tier_min_spend?: number | null;
+  visits_this_period?: number | null;
+  spend_this_period?: number | null;
+  visits_to_next_tier?: number | null;
+  spend_to_next_tier?: number | null;
 };
 
 type Persisted = {
   state?: {
     loyaltyId?: string | null;
-    member?: { pointsBalance?: number };
   };
 };
 
+function hexWithAlpha(hex: string, alpha: number): string {
+  const m = /^#([0-9a-f]{6})$/i.exec((hex || "").trim());
+  if (!m) return `rgba(146, 64, 14, ${alpha})`;
+  const num = parseInt(m[1], 16);
+  const r = (num >> 16) & 0xff;
+  const g = (num >> 8) & 0xff;
+  const b = num & 0xff;
+  return `rgba(${r}, ${g}, ${b}, ${alpha})`;
+}
+
 export function TierCard() {
-  const [beans, setBeans] = useState<number | null>(null);
   const [tier, setTier] = useState<Tier | null>(null);
 
   useEffect(() => {
@@ -37,9 +52,7 @@ export function TierCard() {
     try {
       const raw = window.localStorage.getItem("celsius-pickup");
       if (raw) {
-        const parsed = JSON.parse(raw) as Persisted;
-        memberId = parsed.state?.loyaltyId ?? null;
-        setBeans(parsed.state?.member?.pointsBalance ?? 0);
+        memberId = (JSON.parse(raw) as Persisted).state?.loyaltyId ?? null;
       }
     } catch {
       /* ignore */
@@ -53,62 +66,143 @@ export function TierCard() {
       });
   }, []);
 
-  const displayBeans = tier?.current_beans ?? beans ?? 0;
-  const progress =
-    tier?.current_beans != null && tier.next_tier_beans
-      ? Math.min(1, tier.current_beans / tier.next_tier_beans)
-      : null;
+  if (!tier || !tier.tier_name) return null;
+
+  const color = tier.tier_color || "#92400e";
+  const icon = tier.tier_icon || "☕";
+  const name = tier.tier_name;
+  const mul = tier.tier_multiplier ?? 1;
+
+  const visitsTotal = tier.next_tier_min_visits ?? 0;
+  const visitsCurrent = tier.visits_this_period ?? 0;
+  const visitsPct = visitsTotal > 0 ? Math.min(visitsCurrent / visitsTotal, 1) : 0;
+
+  const spendTotal = tier.next_tier_min_spend ?? 0;
+  const spendCurrent = tier.spend_this_period ?? 0;
+  const spendPct = spendTotal > 0 ? Math.min(spendCurrent / spendTotal, 1) : 0;
+
+  const useSpendBar = spendPct > visitsPct && spendTotal > 0;
+  const progressPct = tier.next_tier_id ? (useSpendBar ? spendPct : visitsPct) : 1;
+
+  const bgFill = hexWithAlpha(color, 0.08);
+  const borderFill = hexWithAlpha(color, 0.18);
+  const tileFill = hexWithAlpha(color, 0.18);
+  const trackFill = hexWithAlpha(color, 0.15);
 
   return (
     <section className="px-4 pt-4">
       <div
-        className="bg-[#160800] text-white rounded-2xl p-5"
-        style={{ minHeight: 140, position: "relative", overflow: "hidden" }}
+        style={{
+          borderRadius: 16,
+          overflow: "hidden",
+          backgroundColor: bgFill,
+          border: `1px solid ${borderFill}`,
+        }}
       >
-        <div className="flex items-start gap-3">
-          <span
-            className="flex items-center justify-center"
-            style={{
-              width: 36,
-              height: 36,
-              borderRadius: 10,
-              backgroundColor: "rgba(251,191,36,0.18)",
-            }}
-          >
-            <Sparkles size={18} color="#FBBF24" strokeWidth={1.8} />
-          </span>
-          {tier?.tier_name ? (
-            <span
-              className="ml-auto rounded-full px-2.5 py-1 text-[10px] uppercase font-bold tracking-widest"
-              style={{ backgroundColor: "rgba(251,191,36,0.18)", color: "#FBBF24" }}
-            >
-              {tier.tier_name}
-              {tier.tier_multiplier && tier.tier_multiplier > 1
-                ? ` · ${tier.tier_multiplier}×`
-                : ""}
-            </span>
-          ) : null}
-        </div>
-        <p className="mt-3 text-[10px] uppercase tracking-widest text-white/60">Beans</p>
-        <p className="mt-1 font-peachi font-bold text-3xl leading-none">
-          {displayBeans.toLocaleString()}
-        </p>
+        {/* Top tier-colour rail */}
+        <div style={{ height: 4, backgroundColor: color }} />
 
-        {progress != null ? (
-          <div className="mt-4">
-            <div className="h-1.5 rounded-full bg-white/12 overflow-hidden">
-              <div
-                className="h-full bg-[#FBBF24]"
-                style={{ width: `${Math.round(progress * 100)}%` }}
-              />
+        <div style={{ paddingLeft: 20, paddingRight: 20, paddingTop: 16, paddingBottom: 18 }}>
+          {/* Header row — tile + tier name + multiplier pill */}
+          <div className="flex items-center justify-between" style={{ marginBottom: 14 }}>
+            <div className="flex items-center">
+              <span
+                className="flex items-center justify-center"
+                style={{
+                  width: 48,
+                  height: 48,
+                  borderRadius: 14,
+                  backgroundColor: tileFill,
+                  marginRight: 12,
+                }}
+              >
+                <span style={{ fontSize: 26, lineHeight: 1 }}>{icon}</span>
+              </span>
+              <div>
+                <p
+                  style={{
+                    fontSize: 10,
+                    letterSpacing: 1.5,
+                    textTransform: "uppercase",
+                    color: hexWithAlpha(color, 0.7),
+                    fontWeight: 600,
+                  }}
+                >
+                  Your tier
+                </p>
+                <p
+                  style={{
+                    fontSize: 20,
+                    fontWeight: 700,
+                    color,
+                    marginTop: 2,
+                  }}
+                >
+                  {name}
+                </p>
+              </div>
             </div>
-            <p className="mt-2 text-[11px] text-white/65">
-              {tier?.next_tier_beans! - tier?.current_beans!}
-              {" beans to "}
-              {tier?.next_tier_name ?? "next tier"}
-            </p>
+            <span
+              style={{
+                backgroundColor: color,
+                paddingLeft: 10,
+                paddingRight: 10,
+                paddingTop: 4,
+                paddingBottom: 4,
+                borderRadius: 999,
+                color: "white",
+                fontSize: 12,
+                fontWeight: 700,
+              }}
+            >
+              {mul}× pts
+            </span>
           </div>
-        ) : null}
+
+          {/* Progress strip */}
+          {tier.next_tier_id ? (
+            <div>
+              <div className="flex justify-between" style={{ marginBottom: 6 }}>
+                <span style={{ fontSize: 12, color: "rgba(0,0,0,0.65)" }}>
+                  {useSpendBar
+                    ? `RM${Math.round(spendCurrent)} / RM${spendTotal}`
+                    : `${visitsCurrent} / ${visitsTotal} visits`}
+                </span>
+                <span style={{ fontSize: 12, fontWeight: 700, color }}>
+                  → {tier.next_tier_name}
+                </span>
+              </div>
+              <div
+                style={{
+                  height: 6,
+                  borderRadius: 999,
+                  backgroundColor: trackFill,
+                  overflow: "hidden",
+                }}
+              >
+                <div
+                  style={{
+                    height: 6,
+                    width: `${Math.round(progressPct * 100)}%`,
+                    backgroundColor: color,
+                    borderRadius: 999,
+                  }}
+                />
+              </div>
+              <p style={{ fontSize: 11, color: "rgba(0,0,0,0.55)", marginTop: 8 }}>
+                {useSpendBar
+                  ? `RM${(tier.spend_to_next_tier ?? 0).toFixed(0)} more to unlock`
+                  : `${tier.visits_to_next_tier ?? 0} more visit${
+                      (tier.visits_to_next_tier ?? 0) === 1 ? "" : "s"
+                    } to unlock`}
+              </p>
+            </div>
+          ) : (
+            <p style={{ fontSize: 13, fontWeight: 700, color }}>
+              👑 You&apos;ve reached the top tier
+            </p>
+          )}
+        </div>
       </div>
     </section>
   );

--- a/apps/pickup-native/public/sw.js
+++ b/apps/pickup-native/public/sw.js
@@ -6,7 +6,7 @@
 //
 // Future rule of thumb: bump this on ANY production-affecting bundle
 // regression so customers don't get stuck on a bad build.
-const CACHE = "celsius-v12";
+const CACHE = "celsius-v13";
 const SHELL = ["/", "/index.html", "/manifest.json"];
 
 self.addEventListener("install", (e) => {


### PR DESCRIPTION
## Summary
Four native-app parity fixes per customer feedback:

1. **Bottom-nav Menu puck** — replaces the hand-drawn cup glyph with the real brand mark from `/public/images/icon-192.png` (the `°C` letterform), flipped to white via CSS `filter: brightness(0) invert(1)`.
2. **Menu sidebar** — width tracks native exactly: 60/52-pill on narrow web (<420px), 80/72-pill at >=420px. Adds 180px paddingBottom inside the list so the last categories are reachable; switched from `maxHeight` to fixed `height` so internal scroll works reliably (fixes "cannot scroll properly").
3. **Home Best Sellers** — converted from a 2-col grid into the native horizontal rail: 176px (w-44) cards, 4/5 image aspect, Peachi-Bold 14px name + 16px price, 28×28 ChevronRight CTA, scroll-snap-x.
4. **Rewards TierCard** — rebuilt to match `apps/pickup-native/components/TierCard.tsx`: 4px tier-colour rail, 48×48 emoji tile, 20px tier name in tier colour, multiplier pill, progress strip with "X / Y visits → Next Tier".

Bumps SW cache to v13.

## Test plan
- [ ] Open the PWA → bottom-nav Menu puck shows the proper °C brand mark, white inside the dark puck.
- [ ] Open `/menu` → sidebar pills are 52 wide (or 72 on a ≥420px viewport). Sidebar scrolls independently of the body. Last category reachable.
- [ ] Open `/` → Best Sellers is a horizontal rail; flick lands on a card edge.
- [ ] Open `/rewards` while signed in → tier card uses tier-colour theming with progress strip.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xd1aERynqUbdCqXNboKWBe)_