### PR TITLE
fix(web): voucher rail ticket-stubs + product hero overlap

### DIFF
--- a/apps/order/public/sw.js
+++ b/apps/order/public/sw.js
@@ -1,7 +1,7 @@
 // Mirror of apps/pickup-native/public/sw.js — overwritten on each
 // build-pwa run. v3 bumps over v2 to flush customers off the broken
 // CSS shipped in #157/#158 before this revert deployed.
-const CACHE = "celsius-v21";
+const CACHE = "celsius-v22";
 const SHELL = ["/", "/index.html", "/manifest.json"];
 
 self.addEventListener("install", (e) => {

--- a/apps/order/public/sw.js
+++ b/apps/order/public/sw.js
@@ -1,7 +1,7 @@
 // Mirror of apps/pickup-native/public/sw.js — overwritten on each
 // build-pwa run. v3 bumps over v2 to flush customers off the broken
 // CSS shipped in #157/#158 before this revert deployed.
-const CACHE = "celsius-v22";
+const CACHE = "celsius-v23";
 const SHELL = ["/", "/index.html", "/manifest.json"];
 
 self.addEventListener("install", (e) => {

--- a/apps/order/public/sw.js
+++ b/apps/order/public/sw.js
@@ -1,7 +1,7 @@
 // Mirror of apps/pickup-native/public/sw.js — overwritten on each
 // build-pwa run. v3 bumps over v2 to flush customers off the broken
 // CSS shipped in #157/#158 before this revert deployed.
-const CACHE = "celsius-v17";
+const CACHE = "celsius-v18";
 const SHELL = ["/", "/index.html", "/manifest.json"];
 
 self.addEventListener("install", (e) => {

--- a/apps/order/public/sw.js
+++ b/apps/order/public/sw.js
@@ -1,7 +1,7 @@
 // Mirror of apps/pickup-native/public/sw.js — overwritten on each
 // build-pwa run. v3 bumps over v2 to flush customers off the broken
 // CSS shipped in #157/#158 before this revert deployed.
-const CACHE = "celsius-v16";
+const CACHE = "celsius-v17";
 const SHELL = ["/", "/index.html", "/manifest.json"];
 
 self.addEventListener("install", (e) => {

--- a/apps/order/public/sw.js
+++ b/apps/order/public/sw.js
@@ -1,7 +1,7 @@
 // Mirror of apps/pickup-native/public/sw.js — overwritten on each
 // build-pwa run. v3 bumps over v2 to flush customers off the broken
 // CSS shipped in #157/#158 before this revert deployed.
-const CACHE = "celsius-v19";
+const CACHE = "celsius-v20";
 const SHELL = ["/", "/index.html", "/manifest.json"];
 
 self.addEventListener("install", (e) => {

--- a/apps/order/public/sw.js
+++ b/apps/order/public/sw.js
@@ -1,7 +1,7 @@
 // Mirror of apps/pickup-native/public/sw.js — overwritten on each
 // build-pwa run. v3 bumps over v2 to flush customers off the broken
 // CSS shipped in #157/#158 before this revert deployed.
-const CACHE = "celsius-v20";
+const CACHE = "celsius-v21";
 const SHELL = ["/", "/index.html", "/manifest.json"];
 
 self.addEventListener("install", (e) => {

--- a/apps/order/public/sw.js
+++ b/apps/order/public/sw.js
@@ -1,7 +1,7 @@
 // Mirror of apps/pickup-native/public/sw.js — overwritten on each
 // build-pwa run. v3 bumps over v2 to flush customers off the broken
 // CSS shipped in #157/#158 before this revert deployed.
-const CACHE = "celsius-v18";
+const CACHE = "celsius-v19";
 const SHELL = ["/", "/index.html", "/manifest.json"];
 
 self.addEventListener("install", (e) => {

--- a/apps/order/public/sw.js
+++ b/apps/order/public/sw.js
@@ -1,7 +1,7 @@
 // Mirror of apps/pickup-native/public/sw.js — overwritten on each
 // build-pwa run. v3 bumps over v2 to flush customers off the broken
 // CSS shipped in #157/#158 before this revert deployed.
-const CACHE = "celsius-v15";
+const CACHE = "celsius-v16";
 const SHELL = ["/", "/index.html", "/manifest.json"];
 
 self.addEventListener("install", (e) => {

--- a/apps/order/src/app/_ActiveChallengeCard.tsx
+++ b/apps/order/src/app/_ActiveChallengeCard.tsx
@@ -67,55 +67,65 @@ export function ActiveChallengeCard() {
 
   return (
     <Link
-      href="/rewards"
-      className="mt-5 mx-4 flex items-center gap-3 rounded-2xl active:opacity-80"
+      href={`/challenge/${mission.id}`}
+      className="block mt-5 mx-4 flex items-start active:opacity-90"
       style={{
         backgroundColor: "#1A0200",
-        padding: 14,
-        boxShadow: "0 4px 10px rgba(22,8,0,0.18)",
+        border: "1px solid #1A0200",
+        borderRadius: 18,
+        paddingLeft: 14,
+        paddingRight: 14,
+        paddingTop: 14,
+        paddingBottom: 14,
+        gap: 14,
+        boxShadow: "0 4px 10px rgba(0,0,0,0.12)",
       }}
     >
       <span
-        className="flex items-center justify-center"
+        className="flex items-center justify-center flex-shrink-0"
         style={{
-          width: 40,
-          height: 40,
+          width: 48,
+          height: 48,
           borderRadius: 12,
-          backgroundColor: "rgba(251,191,36,0.18)",
+          backgroundColor: "rgba(251,191,36,0.20)",
         }}
       >
-        <Sparkles size={20} color="#FBBF24" strokeWidth={1.8} />
+        <Sparkles size={24} color="#FBBF24" strokeWidth={2} />
       </span>
       <span className="flex-1 min-w-0">
         <span
-          className="block text-[#FBBF24] uppercase truncate"
+          className="block uppercase truncate"
           style={{
+            color: "#FBBF24",
             fontWeight: 700,
             fontSize: 9.5,
             letterSpacing: 1.4,
+            marginBottom: 3,
           }}
         >
-          Active challenge · {progressLabel}
+          Challenge · {progressLabel}
         </span>
         <span
-          className="block text-white truncate mt-0.5"
+          className="block truncate"
           style={{
+            color: "#FFFFFF",
             fontFamily: "var(--font-display)",
             fontWeight: 700,
-            fontSize: 15,
-            letterSpacing: -0.3,
+            fontSize: 17,
+            lineHeight: "21px",
           }}
         >
           {mission.title}
         </span>
         {mission.reward_summary ? (
           <span
-            className="block truncate"
+            className="block line-clamp-2"
             style={{
               color: "rgba(255,255,255,0.65)",
-              fontSize: 11,
+              fontSize: 12,
+              lineHeight: "16px",
+              marginTop: 2,
               fontWeight: 500,
-              marginTop: 1,
             }}
           >
             {mission.reward_summary}

--- a/apps/order/src/app/_ActiveOrderTracker.tsx
+++ b/apps/order/src/app/_ActiveOrderTracker.tsx
@@ -1,0 +1,134 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import Link from "next/link";
+import { Clock, ChevronRight } from "lucide-react";
+
+/**
+ * Active order banner on home. Polls /api/loyalty/orders for the
+ * customer's most recent in-progress order; renders a colored panel
+ * (red/yellow/green) showing the status + order number when one is
+ * found. Mirrors apps/pickup-native/app/index.tsx:653-699.
+ */
+type Order = {
+  id: string;
+  order_number: string;
+  status: string;
+};
+
+type Persisted = { state?: { phone?: string | null } };
+
+const ACTIVE = new Set(["pending", "paid", "preparing", "ready"]);
+
+function statusLabel(status: string): string {
+  const s = (status ?? "").toLowerCase();
+  if (s === "pending") return "Awaiting payment";
+  if (s === "paid") return "Payment confirmed";
+  if (s === "preparing") return "Brewing";
+  if (s === "ready") return "Ready for pickup";
+  return s;
+}
+
+export function ActiveOrderTracker() {
+  const [order, setOrder] = useState<Order | null>(null);
+
+  useEffect(() => {
+    let phone: string | null = null;
+    try {
+      const raw = window.localStorage.getItem("celsius-pickup");
+      if (raw) phone = (JSON.parse(raw) as Persisted).state?.phone ?? null;
+    } catch {
+      /* ignore */
+    }
+    if (!phone) return;
+
+    const fetchActive = async () => {
+      try {
+        const res = await fetch(
+          `/api/loyalty/orders?phone=${encodeURIComponent(phone!)}&limit=5`,
+        );
+        const data = await res.json();
+        const list = (data?.orders ?? data ?? []) as Order[];
+        const inflight = list.find((o) => ACTIVE.has((o.status ?? "").toLowerCase()));
+        setOrder(inflight ?? null);
+      } catch {
+        /* ignore */
+      }
+    };
+    fetchActive();
+    // Refresh every 15s so the customer sees the status flip from
+    // Brewing → Ready without reloading the page.
+    const id = window.setInterval(fetchActive, 15000);
+    return () => window.clearInterval(id);
+  }, []);
+
+  if (!order) return null;
+
+  const s = (order.status ?? "").toLowerCase();
+  const tone =
+    s === "ready" || s === "completed"
+      ? {
+          fg: "#2E7D32",
+          tint: "rgba(46,125,50,0.10)",
+          border: "rgba(46,125,50,0.25)",
+          chip: "rgba(46,125,50,0.15)",
+        }
+      : s === "pending" || s === "failed" || s === "cancelled"
+      ? {
+          fg: "#B91C1C",
+          tint: "rgba(185,28,28,0.10)",
+          border: "rgba(185,28,28,0.25)",
+          chip: "rgba(185,28,28,0.15)",
+        }
+      : {
+          fg: "#B45309",
+          tint: "rgba(180,83,9,0.10)",
+          border: "rgba(180,83,9,0.25)",
+          chip: "rgba(180,83,9,0.15)",
+        };
+
+  return (
+    <Link
+      href={`/order/${order.id}`}
+      className="block mx-4 mt-4 active:opacity-85"
+      style={{
+        backgroundColor: tone.tint,
+        border: `1px solid ${tone.border}`,
+        borderRadius: 16,
+        paddingLeft: 14,
+        paddingRight: 14,
+        paddingTop: 12,
+        paddingBottom: 12,
+      }}
+    >
+      <div className="flex items-center gap-3">
+        <span
+          className="flex items-center justify-center flex-shrink-0"
+          style={{ width: 36, height: 36, borderRadius: 18, backgroundColor: tone.chip }}
+        >
+          <Clock size={18} color={tone.fg} strokeWidth={2} />
+        </span>
+        <span className="flex-1 min-w-0">
+          <span
+            className="block uppercase truncate"
+            style={{
+              color: tone.fg,
+              fontSize: 10,
+              fontWeight: 700,
+              letterSpacing: 1.5,
+            }}
+          >
+            {statusLabel(order.status)}
+          </span>
+          <span
+            className="block font-peachi font-bold truncate"
+            style={{ color: "#1A0200", fontSize: 14, marginTop: 2 }}
+          >
+            Order #{order.order_number}
+          </span>
+        </span>
+        <ChevronRight size={16} color={tone.fg} />
+      </div>
+    </Link>
+  );
+}

--- a/apps/order/src/app/_BottomNav.tsx
+++ b/apps/order/src/app/_BottomNav.tsx
@@ -76,19 +76,37 @@ function NavMenuPuck({ href, active }: { href: string; active: boolean }) {
           boxShadow: "0 3px 8px rgba(0,0,0,0.2)",
         }}
       >
-        {/* Brand °C mark from /public/images/icon-192.png — the actual
-            Celsius logo (serif C + degree dot), flipped to white via
-            CSS filter. Drops the previous hand-drawn cup outline since
-            the brand mark itself is the C-with-degree, not a takeaway
-            cup. */}
-        {/* eslint-disable-next-line @next/next/no-img-element */}
-        <img
-          src="/images/icon-192.png"
-          alt=""
-          width={30}
-          height={30}
-          style={{ filter: "brightness(0) invert(1)", display: "block" }}
-        />
+        {/* °C brand mark — small degree circle + bold serif C, matching
+            apps/pickup-native/assets/icon.png. Inline SVG keeps it
+            crisp at any DPR and avoids the filter:invert workaround
+            that wasn't reliably flipping the black PNG to white. */}
+        <svg
+          width="30"
+          height="30"
+          viewBox="0 0 32 32"
+          xmlns="http://www.w3.org/2000/svg"
+          aria-hidden="true"
+        >
+          {/* Degree ring — open circle, top-left of the C */}
+          <circle cx="8.5" cy="10" r="2.25" fill="none" stroke="#FFFFFF" strokeWidth="1.4" />
+          {/* Bold serif C — Peachi-Bold glyph drawn as text so the
+              browser uses the loaded brand font. Stroke gives a tiny
+              extra weight bump matching the chunky letterform in
+              icon-192.png. */}
+          <text
+            x="20"
+            y="24"
+            textAnchor="middle"
+            fontFamily="Peachi, serif"
+            fontWeight="700"
+            fontSize="22"
+            fill="#FFFFFF"
+            stroke="#FFFFFF"
+            strokeWidth="0.6"
+          >
+            C
+          </text>
+        </svg>
       </span>
       <span
         className="text-[12.5px]"

--- a/apps/order/src/app/_GuestSignInCTA.tsx
+++ b/apps/order/src/app/_GuestSignInCTA.tsx
@@ -1,0 +1,96 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import Link from "next/link";
+import { Gift, ChevronRight } from "lucide-react";
+
+/**
+ * Guest sign-in CTA on the home screen. Surfaces FIRST for logged-out
+ * customers so the membership ask lands the moment the app opens.
+ * Mirrors apps/pickup-native/app/index.tsx:586-644 — espresso panel
+ * with a terracotta gift tile, "Free to join" eyebrow, "Become a
+ * member" headline, member-benefit subline, and a white "Sign in"
+ * pill. Renders nothing once signed in.
+ */
+type Persisted = { state?: { phone?: string | null } };
+
+export function GuestSignInCTA() {
+  const [signedIn, setSignedIn] = useState<boolean | null>(null);
+
+  useEffect(() => {
+    try {
+      const raw = window.localStorage.getItem("celsius-pickup");
+      if (raw) {
+        const phone = (JSON.parse(raw) as Persisted).state?.phone ?? null;
+        setSignedIn(!!phone);
+        return;
+      }
+    } catch {
+      /* ignore */
+    }
+    setSignedIn(false);
+  }, []);
+
+  if (signedIn !== false) return null;
+
+  return (
+    <Link
+      href="/account"
+      className="block mx-4 mt-4 active:opacity-90 overflow-hidden"
+      style={{
+        backgroundColor: "#1A0200",
+        borderRadius: 16,
+        boxShadow: "0 6px 14px rgba(22,8,0,0.18)",
+      }}
+    >
+      <div className="flex items-center" style={{ paddingLeft: 20, paddingRight: 20, paddingTop: 16, paddingBottom: 16, gap: 12 }}>
+        <span
+          className="flex items-center justify-center flex-shrink-0"
+          style={{ width: 48, height: 48, borderRadius: 24, backgroundColor: "#A2492C" }}
+        >
+          <Gift size={24} color="#FFFFFF" strokeWidth={2} />
+        </span>
+        <span className="flex-1 min-w-0">
+          <span
+            className="block uppercase"
+            style={{
+              color: "#FBBF24",
+              fontSize: 10,
+              fontWeight: 700,
+              letterSpacing: 2,
+            }}
+          >
+            Free to join
+          </span>
+          <span
+            className="block font-peachi font-bold"
+            style={{ color: "#FFFFFF", fontSize: 17, marginTop: 2 }}
+          >
+            Become a member
+          </span>
+          <span
+            className="block truncate"
+            style={{ color: "rgba(255,255,255,0.7)", fontSize: 12, marginTop: 2, fontWeight: 500 }}
+          >
+            Earn points · unlock free drinks · members-only deals
+          </span>
+        </span>
+        <span
+          className="flex items-center gap-1 rounded-full flex-shrink-0"
+          style={{
+            backgroundColor: "#FFFFFF",
+            paddingLeft: 14,
+            paddingRight: 14,
+            paddingTop: 8,
+            paddingBottom: 8,
+          }}
+        >
+          <span className="font-peachi font-bold" style={{ color: "#1A0200", fontSize: 12 }}>
+            Sign in
+          </span>
+          <ChevronRight size={13} color="#1A0200" />
+        </span>
+      </div>
+    </Link>
+  );
+}

--- a/apps/order/src/app/_OutletRow.tsx
+++ b/apps/order/src/app/_OutletRow.tsx
@@ -7,17 +7,23 @@ import { MapPin, ChevronRight } from "lucide-react";
 /**
  * Outlet picker chip below the hero. Reads the chosen outlet from the
  * SPA's localStorage (key 'celsius-pickup'). Shows the actual outlet
- * name when one is selected — same visual treatment as the SPA's
- * apps/pickup-native/app/index.tsx:535-580 row.
+ * name + status dot/label when one is selected — mirrors
+ * apps/pickup-native/app/index.tsx:535-584.
  */
 type Persisted = {
   state?: {
     outletName?: string | null;
+    outletIsOpen?: boolean;
+    outletIsBusy?: boolean;
+    outletPickupTimeMins?: number | null;
   };
 };
 
 export function OutletRow() {
   const [name, setName] = useState<string | null>(null);
+  const [isOpen, setIsOpen] = useState<boolean | null>(null);
+  const [isBusy, setIsBusy] = useState<boolean | null>(null);
+  const [pickupMins, setPickupMins] = useState<number | null>(null);
 
   useEffect(() => {
     try {
@@ -25,22 +31,53 @@ export function OutletRow() {
       if (!raw) return;
       const parsed = JSON.parse(raw) as Persisted;
       setName(parsed.state?.outletName ?? null);
+      setIsOpen(parsed.state?.outletIsOpen ?? null);
+      setIsBusy(parsed.state?.outletIsBusy ?? null);
+      setPickupMins(parsed.state?.outletPickupTimeMins ?? null);
     } catch {
       /* ignore */
     }
   }, []);
 
+  const dot =
+    isOpen === false
+      ? { bg: "#EF4444", label: "Closed" }
+      : isBusy
+      ? { bg: "#F59E0B", label: "Busy" }
+      : isOpen === true
+      ? { bg: "#22C55E", label: pickupMins ? `~${pickupMins} min` : "Open" }
+      : null;
+
   return (
     <Link
       href="/store"
-      className="flex items-center self-start active:opacity-70"
+      className="flex items-center self-start active:opacity-75"
       style={{ marginLeft: 20, marginTop: 14, marginBottom: 4, gap: 6 }}
     >
       <MapPin size={14} color="#8E8E93" />
-      <span className="font-peachi font-bold text-sm">
+      <span
+        className="font-peachi font-bold truncate"
+        style={{ color: "#160800", fontSize: 14 }}
+      >
         {name ?? "Select pickup outlet"}
       </span>
-      <ChevronRight size={14} color="#8E8E93" />
+      {dot ? (
+        <>
+          <span
+            style={{
+              width: 6,
+              height: 6,
+              borderRadius: 3,
+              backgroundColor: dot.bg,
+              marginLeft: 4,
+            }}
+          />
+          <span style={{ color: "#8E8E93", fontSize: 12, fontWeight: 500 }}>
+            {dot.label}
+          </span>
+        </>
+      ) : null}
+      <ChevronRight size={13} color="#8E8E93" />
     </Link>
   );
 }

--- a/apps/order/src/app/_VoucherRail.tsx
+++ b/apps/order/src/app/_VoucherRail.tsx
@@ -5,11 +5,15 @@ import Link from "next/link";
 import { Gift, ChevronRight, Sparkles } from "lucide-react";
 
 /**
- * Voucher wallet rail on the home page. Mirrors the SPA's home rail
- * (apps/pickup-native/app/index.tsx ~L847-1200) — horizontal scroll of
- * the customer's active vouchers, each as a themed card showing title,
- * description, and expiry. Renders only for signed-in customers who
- * have at least one active voucher.
+ * Home rewards rail — 144px ticket-stub cards mirroring apps/pickup-
+ * native/components/RewardTicket.tsx. Each card splits into a coloured
+ * top stub (eyebrow + Peachi-Bold headline + optional urgency pill) and
+ * a white bottom stub (reward name + "Free to claim" cost label), with
+ * a perforated separator (half-circle punches + dashed line) so the
+ * card reads as a tear-off coupon rather than a generic card.
+ *
+ * Renders only for signed-in customers who have at least one active
+ * voucher.
  */
 type Voucher = {
   id: string;
@@ -24,28 +28,36 @@ type Voucher = {
 
 type Persisted = { state?: { sessionToken?: string | null } };
 
-const THEME: Record<string, { bg: string; fg: string; chip: string }> = {
-  mystery:           { bg: "#160800", fg: "#FFFFFF", chip: "#FBBF24" },
-  mission:           { bg: "#1A0200", fg: "#FFFFFF", chip: "#FBBF24" },
-  birthday:          { bg: "#A2492C", fg: "#FFFFFF", chip: "#FFE4D2" },
-  promo:             { bg: "#A2492C", fg: "#FFFFFF", chip: "#FFE4D2" },
-  welcome:           { bg: "#A2492C", fg: "#FFFFFF", chip: "#FFE4D2" },
-  referral:          { bg: "#FBBF24", fg: "#160800", chip: "#160800" },
-  points_redemption: { bg: "#F2EDE5", fg: "#160800", chip: "#A2492C" },
-};
-
-function themeFor(v: Voucher) {
-  return THEME[v.source_type ?? ""] ?? THEME.promo;
-}
-
 function expiresLabel(iso: string | null | undefined): string | null {
   if (!iso) return null;
   const days = Math.ceil((new Date(iso).getTime() - Date.now()) / (1000 * 60 * 60 * 24));
   if (days < 0) return null;
-  if (days === 0) return "Expires today";
-  if (days === 1) return "Expires tomorrow";
-  if (days <= 7) return `Expires in ${days}d`;
-  return `Expires ${new Date(iso).toLocaleDateString("en-MY", { day: "numeric", month: "short" })}`;
+  if (days === 0) return "Today";
+  if (days === 1) return "Tomorrow";
+  if (days <= 7) return `${days}d left`;
+  return new Date(iso).toLocaleDateString("en-MY", { day: "numeric", month: "short" });
+}
+
+// Native pattern: auto-issued rewards (welcome / birthday / mystery /
+// mission) get the gold accent on espresso; everything else gets the
+// terracotta colourway.
+function toneFor(v: Voucher): "gold" | "terracotta" {
+  if (v.source_type === "welcome" || v.source_type === "birthday") return "gold";
+  if (v.source_type === "mystery" || v.source_type === "mission") return "gold";
+  return "terracotta";
+}
+
+function eyebrowFor(v: Voucher): string {
+  switch (v.source_type) {
+    case "welcome":           return "Welcome gift";
+    case "birthday":          return "Birthday gift";
+    case "mission":           return "Challenge reward";
+    case "mystery":           return "Mystery reward";
+    case "referral":          return "Referral";
+    case "points_redemption": return "Bean reward";
+    case "promo":             return "Promo";
+    default:                  return "Reward";
+  }
 }
 
 export function VoucherRail() {
@@ -81,10 +93,10 @@ export function VoucherRail() {
   return (
     <section className="mt-6">
       <div className="flex items-center px-4 mb-3">
-        <h2 className="font-peachi font-bold text-[20px] flex-1">Your rewards</h2>
+        <h2 className="font-peachi font-bold text-[18px] flex-1">Available rewards</h2>
         <Link
           href="/rewards"
-          className="text-[#A2492C] text-sm flex items-center gap-1 active:opacity-70"
+          className="text-[#A2492C] text-xs font-bold flex items-center gap-0.5 active:opacity-70"
         >
           More <ChevronRight size={14} />
         </Link>
@@ -94,74 +106,183 @@ export function VoucherRail() {
         className="flex gap-3 px-4 overflow-x-auto pb-1"
         style={{ scrollSnapType: "x mandatory", WebkitOverflowScrolling: "touch" }}
       >
-        {vouchers.map((v) => {
-          const t = themeFor(v);
-          const title = v.value_label ?? v.title ?? v.name ?? "Reward";
-          const desc = v.description ?? v.name ?? "";
-          const expiry = expiresLabel(v.expires_at);
-          return (
-            <li
-              key={v.id}
-              className="flex-shrink-0"
-              style={{ width: 260, scrollSnapAlign: "start" }}
-            >
-              <Link
-                href="/rewards"
-                className="block rounded-2xl p-4 active:opacity-90"
-                style={{
-                  backgroundColor: t.bg,
-                  color: t.fg,
-                  minHeight: 130,
-                  boxShadow: "0 4px 10px rgba(22,8,0,0.10)",
-                }}
-              >
-                <div className="flex items-start gap-2">
-                  <span
-                    className="flex items-center justify-center"
-                    style={{
-                      width: 36,
-                      height: 36,
-                      borderRadius: 10,
-                      backgroundColor: "rgba(255,255,255,0.14)",
-                    }}
-                  >
-                    {v.source_type === "mystery" || v.source_type === "mission" ? (
-                      <Sparkles size={18} color={t.chip} strokeWidth={1.8} />
-                    ) : (
-                      <Gift size={18} color={t.chip} strokeWidth={1.8} />
-                    )}
-                  </span>
-                  {expiry ? (
-                    <span
-                      className="ml-auto text-[10px] uppercase tracking-widest font-bold rounded-full px-2 py-0.5"
-                      style={{
-                        backgroundColor: "rgba(255,255,255,0.15)",
-                        color: t.chip,
-                      }}
-                    >
-                      {expiry}
-                    </span>
-                  ) : null}
-                </div>
-                <p
-                  className="mt-3 font-peachi font-bold text-lg leading-tight"
-                  style={{ color: t.fg }}
-                >
-                  {title}
-                </p>
-                {desc && desc !== title ? (
-                  <p
-                    className="mt-1 text-[12px] leading-snug line-clamp-2"
-                    style={{ color: t.fg, opacity: 0.75 }}
-                  >
-                    {desc}
-                  </p>
-                ) : null}
-              </Link>
-            </li>
-          );
-        })}
+        {vouchers.map((v) => (
+          <RewardTicket key={v.id} voucher={v} />
+        ))}
       </ul>
     </section>
+  );
+}
+
+function RewardTicket({ voucher }: { voucher: Voucher }) {
+  const tone = toneFor(voucher);
+  const topBg = tone === "gold" ? "#1A0200" : "#A2492C";
+  const topAccent = tone === "gold" ? "#FBBF24" : "#FFFFFF";
+  const topMuted = tone === "gold" ? "rgba(251,191,36,0.65)" : "rgba(255,255,255,0.75)";
+  const headline = voucher.value_label ?? voucher.title ?? voucher.name ?? "Reward";
+  const urgency = expiresLabel(voucher.expires_at);
+  const eyebrow = eyebrowFor(voucher);
+  const isGift = tone === "gold" || voucher.source_type === "welcome";
+
+  return (
+    <li
+      className="flex-shrink-0"
+      style={{
+        width: 144,
+        scrollSnapAlign: "start",
+        borderRadius: 14,
+        overflow: "hidden",
+        boxShadow: "0 2px 6px rgba(0,0,0,0.06)",
+      }}
+    >
+      <Link href="/rewards" className="block active:opacity-80">
+        {/* Top stub */}
+        <div
+          className="relative"
+          style={{
+            backgroundColor: topBg,
+            paddingLeft: 12,
+            paddingRight: 12,
+            paddingTop: 12,
+            paddingBottom: 14,
+            minHeight: 92,
+          }}
+        >
+          <div className="flex items-center justify-between">
+            <span
+              className="uppercase"
+              style={{
+                color: topMuted,
+                fontWeight: 700,
+                fontSize: 9,
+                letterSpacing: 1.6,
+              }}
+            >
+              {eyebrow}
+            </span>
+            {tone === "gold" ? (
+              <Gift size={12} color={topAccent} strokeWidth={2} />
+            ) : null}
+          </div>
+          <p
+            className="font-peachi font-bold whitespace-pre-line"
+            style={{
+              color: topAccent,
+              fontSize: 19,
+              lineHeight: "21px",
+              marginTop: 5,
+              paddingRight: 36,
+            }}
+          >
+            {headline}
+          </p>
+          {urgency ? (
+            <span
+              className="absolute"
+              style={{
+                top: 10,
+                right: 10,
+                backgroundColor: tone === "gold" ? "#FBBF24" : "#FFFFFF",
+                color: tone === "gold" ? "#1A0200" : "#A2492C",
+                paddingLeft: 6,
+                paddingRight: 6,
+                paddingTop: 2,
+                paddingBottom: 2,
+                borderRadius: 999,
+                fontFamily: "Peachi-Bold, serif",
+                fontWeight: 700,
+                fontSize: 9,
+              }}
+            >
+              {urgency}
+            </span>
+          ) : null}
+          {/* Brand glyph anchored bottom-right of the top stub */}
+          <span
+            aria-hidden
+            className="absolute"
+            style={{ right: 6, bottom: 6, opacity: 0.85, pointerEvents: "none" }}
+          >
+            {isGift ? (
+              <Gift size={36} color={topAccent} strokeWidth={1.6} />
+            ) : (
+              <Sparkles size={36} color={topAccent} strokeWidth={1.6} />
+            )}
+          </span>
+        </div>
+
+        {/* Perforated separator — half-circle punches on each edge +
+            dashed line connecting them. */}
+        <div className="relative" style={{ height: 0 }}>
+          <span
+            aria-hidden
+            style={{
+              position: "absolute",
+              left: -7,
+              top: -7,
+              width: 14,
+              height: 14,
+              borderRadius: 7,
+              backgroundColor: "#FFFFFF",
+            }}
+          />
+          <span
+            aria-hidden
+            style={{
+              position: "absolute",
+              right: -7,
+              top: -7,
+              width: 14,
+              height: 14,
+              borderRadius: 7,
+              backgroundColor: "#FFFFFF",
+            }}
+          />
+          <span
+            aria-hidden
+            style={{
+              position: "absolute",
+              left: 12,
+              right: 12,
+              top: -1,
+              height: 2,
+              borderTop: "1px dashed rgba(26, 2, 0, 0.18)",
+            }}
+          />
+        </div>
+
+        {/* Bottom stub */}
+        <div
+          style={{
+            backgroundColor: "#FFFFFF",
+            paddingLeft: 12,
+            paddingRight: 12,
+            paddingTop: 13,
+            paddingBottom: 10,
+            border: "1px solid rgba(26, 2, 0, 0.10)",
+            borderTop: "none",
+          }}
+        >
+          <p
+            className="font-peachi font-bold truncate"
+            style={{ color: "#1A0200", fontSize: 12 }}
+          >
+            {voucher.name ?? voucher.title ?? "Reward"}
+          </p>
+          <p
+            className="uppercase truncate"
+            style={{
+              color: tone === "gold" ? "#A2492C" : "rgba(26, 2, 0, 0.55)",
+              fontWeight: 700,
+              fontSize: 10,
+              letterSpacing: 1.2,
+              marginTop: 4,
+            }}
+          >
+            Free to claim
+          </p>
+        </div>
+      </Link>
+    </li>
   );
 }

--- a/apps/order/src/app/account/_AccountView.tsx
+++ b/apps/order/src/app/account/_AccountView.tsx
@@ -2,7 +2,10 @@
 
 import { useEffect, useState } from "react";
 import Link from "next/link";
-import { User, ChevronRight, LogOut } from "lucide-react";
+import {
+  User, ChevronRight, LogOut, Phone, ShoppingBag, Sparkles,
+  Settings as SettingsIcon, CircleHelp, Shield,
+} from "lucide-react";
 import { TierCard } from "@/components/TierCard";
 
 type Persisted = {
@@ -143,9 +146,14 @@ export function AccountView() {
             TierCardCarousel on apps/pickup-native/app/account.tsx. */}
         <TierCard />
 
-        <div className="px-4 pt-4 flex flex-col gap-3">
-          <Row href="/orders" label="Order history" />
-          <Row href="/rewards" label="Rewards" />
+        <div className="px-4 pt-4 flex flex-col gap-2">
+          <SectionLabel>Account</SectionLabel>
+          <Row href="/orders" label="Order history" Icon={ShoppingBag} />
+          <Row
+            href={`/wrapped`}
+            label={`Coffee Wrapped ${new Date().getFullYear()}`}
+            Icon={Sparkles}
+          />
           <EditProfileRow
             phone={phone}
             onSaved={(member) => {
@@ -164,6 +172,14 @@ export function AccountView() {
               }
             }}
           />
+
+          <SectionLabel>Preferences</SectionLabel>
+          <Row href="/settings" label="Settings" Icon={SettingsIcon} />
+
+          <SectionLabel>About</SectionLabel>
+          <Row href="/support" label="Help & support" Icon={CircleHelp} />
+          <Row href="/privacy" label="Privacy policy" Icon={Shield} />
+
           <SignOutRow
             onConfirm={() => {
               try {
@@ -258,82 +274,147 @@ function SignInForm({
   };
 
   return (
-    <div className="px-6 pt-8 pb-4 flex flex-col items-center">
-      <User size={48} color="#8E8E93" strokeWidth={1.25} />
-      <p className="mt-4 font-peachi font-bold text-base">Sign in to Celsius</p>
-      <p className="text-sm text-[#6E6E73] mt-1 text-center max-w-xs">
-        Earn beans, redeem rewards, see your order history.
-      </p>
+    <div className="px-5 pt-8 pb-4">
+      {step === "phone" ? (
+        <>
+          <div
+            className="flex items-center justify-center"
+            style={{
+              width: 64,
+              height: 64,
+              borderRadius: 32,
+              backgroundColor: "rgba(162,73,44,0.10)",
+              marginBottom: 16,
+            }}
+          >
+            <Phone size={28} color="#A2492C" strokeWidth={1.5} />
+          </div>
+          <h2 className="font-peachi font-bold text-2xl" style={{ color: "#1A0200" }}>
+            What&apos;s your number?
+          </h2>
+          <p
+            className="text-sm"
+            style={{ color: "#6B6B6B", marginTop: 6, marginBottom: 24 }}
+          >
+            We&apos;ll text you a 6-digit code to verify it&apos;s you.
+          </p>
 
-      <div className="w-full max-w-sm mt-8">
-        {step === "phone" ? (
-          <>
-            <label className="block text-[11px] uppercase tracking-widest text-[#8E8E93] font-bold mb-2">
-              Phone number
-            </label>
-            <div className="flex items-center gap-2 rounded-2xl border border-[#EBE5DE] px-3">
-              <span className="text-[#8E8E93] font-bold">+60</span>
-              <input
-                type="tel"
-                inputMode="tel"
-                autoComplete="tel"
-                placeholder="12 345 6789"
-                value={phone}
-                onChange={(e) => setPhone(e.target.value)}
-                className="flex-1 py-3 outline-none text-base"
-              />
-            </div>
-            {error ? (
-              <p className="mt-3 text-[12px] text-red-600">{error}</p>
-            ) : null}
-            <button
-              type="button"
-              onClick={sendOtp}
-              disabled={busy || normalisedPhone.length < 11}
-              className={`mt-5 w-full rounded-full text-white py-4 font-bold active:opacity-80 ${
-                busy || normalisedPhone.length < 11 ? "bg-[#A2492C]/40" : "bg-[#A2492C]"
-              }`}
+          <div
+            className="bg-white flex items-center"
+            style={{
+              border: "1px solid rgba(26,2,0,0.10)",
+              borderRadius: 16,
+              paddingLeft: 16,
+              paddingRight: 16,
+              height: 56,
+            }}
+          >
+            <span
+              style={{
+                color: "#8E8E93",
+                fontSize: 16,
+                fontWeight: 500,
+                marginRight: 8,
+                fontVariantNumeric: "tabular-nums",
+              }}
             >
-              {busy ? "Sending…" : "Send code"}
-            </button>
-          </>
-        ) : (
-          <>
-            <label className="block text-[11px] uppercase tracking-widest text-[#8E8E93] font-bold mb-2">
-              6-digit code sent to {normalisedPhone}
-            </label>
+              +60
+            </span>
             <input
               type="tel"
-              inputMode="numeric"
-              autoComplete="one-time-code"
-              placeholder="000000"
-              value={code}
-              onChange={(e) => setCode(e.target.value.replace(/\D/g, "").slice(0, 6))}
-              className="w-full rounded-2xl border border-[#EBE5DE] px-3 py-3 outline-none text-2xl text-center tracking-widest font-bold"
+              inputMode="tel"
+              autoComplete="tel"
+              placeholder="12 345 6789"
+              value={phone}
+              onChange={(e) => setPhone(e.target.value)}
+              className="flex-1 outline-none bg-transparent"
+              style={{
+                color: "#160800",
+                fontSize: 16,
+                fontWeight: 500,
+                fontVariantNumeric: "tabular-nums",
+              }}
+              maxLength={11}
             />
-            {error ? (
-              <p className="mt-3 text-[12px] text-red-600">{error}</p>
-            ) : null}
-            <button
-              type="button"
-              onClick={verifyOtp}
-              disabled={busy || code.length !== 6}
-              className={`mt-5 w-full rounded-full text-white py-4 font-bold active:opacity-80 ${
-                busy || code.length !== 6 ? "bg-[#A2492C]/40" : "bg-[#A2492C]"
-              }`}
-            >
-              {busy ? "Verifying…" : "Verify"}
-            </button>
-            <button
-              type="button"
-              onClick={() => { setStep("phone"); setCode(""); setError(null); }}
-              className="mt-3 w-full text-sm text-[#8E8E93] active:opacity-60"
-            >
-              ← Change number
-            </button>
-          </>
-        )}
-      </div>
+          </div>
+          {error ? (
+            <p className="mt-3 text-[12px] text-red-600">{error}</p>
+          ) : null}
+          <button
+            type="button"
+            onClick={sendOtp}
+            disabled={busy || normalisedPhone.length < 11}
+            className={`mt-5 w-full rounded-full text-white py-4 font-bold active:opacity-80 ${
+              busy || normalisedPhone.length < 11 ? "bg-[#A2492C]/40" : "bg-[#A2492C]"
+            }`}
+          >
+            {busy ? "Sending…" : "Send code"}
+          </button>
+        </>
+      ) : (
+        <>
+          <div
+            className="flex items-center justify-center"
+            style={{
+              width: 64,
+              height: 64,
+              borderRadius: 32,
+              backgroundColor: "rgba(162,73,44,0.10)",
+              marginBottom: 16,
+            }}
+          >
+            <Phone size={28} color="#A2492C" strokeWidth={1.5} />
+          </div>
+          <h2 className="font-peachi font-bold text-2xl" style={{ color: "#1A0200" }}>
+            Enter your code
+          </h2>
+          <p
+            className="text-sm"
+            style={{ color: "#6B6B6B", marginTop: 6, marginBottom: 24 }}
+          >
+            Sent to {normalisedPhone}.
+          </p>
+
+          <input
+            type="tel"
+            inputMode="numeric"
+            autoComplete="one-time-code"
+            placeholder="000000"
+            value={code}
+            onChange={(e) => setCode(e.target.value.replace(/\D/g, "").slice(0, 6))}
+            className="w-full bg-white outline-none text-center tracking-[0.5em] font-bold"
+            style={{
+              border: "1px solid rgba(26,2,0,0.10)",
+              borderRadius: 16,
+              height: 56,
+              fontSize: 22,
+              color: "#1A0200",
+              fontVariantNumeric: "tabular-nums",
+            }}
+          />
+          {error ? (
+            <p className="mt-3 text-[12px] text-red-600">{error}</p>
+          ) : null}
+          <button
+            type="button"
+            onClick={verifyOtp}
+            disabled={busy || code.length !== 6}
+            className={`mt-5 w-full rounded-full text-white py-4 font-bold active:opacity-80 ${
+              busy || code.length !== 6 ? "bg-[#A2492C]/40" : "bg-[#A2492C]"
+            }`}
+          >
+            {busy ? "Verifying…" : "Verify"}
+          </button>
+          <button
+            type="button"
+            onClick={() => { setStep("phone"); setCode(""); setError(null); }}
+            className="mt-3 w-full text-sm active:opacity-60"
+            style={{ color: "#8E8E93" }}
+          >
+            ← Change number
+          </button>
+        </>
+      )}
     </div>
   );
 }
@@ -522,11 +603,44 @@ function Row({
   return (
     <Link
       href={href}
-      className="flex items-center gap-3 bg-white border border-[#EBE5DE] rounded-2xl px-4 py-3 active:opacity-80"
+      className="flex items-center bg-white active:opacity-80"
+      style={{
+        border: "1px solid rgba(26,2,0,0.10)",
+        borderRadius: 14,
+        paddingLeft: 14,
+        paddingRight: 14,
+        paddingTop: 12,
+        paddingBottom: 12,
+        gap: 12,
+      }}
     >
-      {Icon ? <Icon size={18} color="#8E8E93" /> : null}
-      <span className="text-sm font-bold flex-1">{label}</span>
-      <ChevronRight size={14} color="#8E8E93" />
+      {Icon ? <Icon size={18} color="#6B6B6B" strokeWidth={1.75} /> : null}
+      <span
+        className="font-peachi font-bold flex-1"
+        style={{ color: "#1A0200", fontSize: 15 }}
+      >
+        {label}
+      </span>
+      <ChevronRight size={16} color="#8E8E93" />
     </Link>
+  );
+}
+
+function SectionLabel({ children }: { children: React.ReactNode }) {
+  return (
+    <p
+      className="uppercase"
+      style={{
+        color: "#8E8E93",
+        fontSize: 10,
+        fontWeight: 700,
+        letterSpacing: 1.4,
+        marginTop: 8,
+        marginBottom: 2,
+        paddingLeft: 4,
+      }}
+    >
+      {children}
+    </p>
   );
 }

--- a/apps/order/src/app/cart/_CartView.tsx
+++ b/apps/order/src/app/cart/_CartView.tsx
@@ -28,6 +28,7 @@ type Persisted = {
     cart?: CartItem[];
     outletName?: string | null;
     appliedReward?: AppliedReward | null;
+    phone?: string | null;
   };
 };
 
@@ -56,17 +57,18 @@ function clearReward() {
   }
 }
 
-function readCart(): { items: CartItem[]; outletName: string | null } {
+function readCart(): { items: CartItem[]; outletName: string | null; phone: string | null } {
   try {
     const raw = window.localStorage.getItem(KEY);
-    if (!raw) return { items: [], outletName: null };
+    if (!raw) return { items: [], outletName: null, phone: null };
     const parsed = JSON.parse(raw) as Persisted;
     return {
       items: parsed.state?.cart ?? [],
       outletName: parsed.state?.outletName ?? null,
+      phone: parsed.state?.phone ?? null,
     };
   } catch {
-    return { items: [], outletName: null };
+    return { items: [], outletName: null, phone: null };
   }
 }
 
@@ -85,19 +87,23 @@ function writeCart(items: CartItem[]) {
 export function CartView() {
   const [items, setItems] = useState<CartItem[]>([]);
   const [outletName, setOutletName] = useState<string | null>(null);
+  const [phone, setPhone] = useState<string | null>(null);
   const [reward, setReward] = useState<AppliedReward | null>(null);
   const [hydrated, setHydrated] = useState(false);
 
   useEffect(() => {
-    const { items, outletName } = readCart();
+    const { items, outletName, phone } = readCart();
     setReward(readReward());
     setItems(items);
     setOutletName(outletName);
+    setPhone(phone);
     setHydrated(true);
   }, []);
 
   const subtotal = items.reduce((s, i) => s + i.totalPrice, 0);
-  const count = items.reduce((s, i) => s + i.quantity, 0);
+  const rewardDiscount = Math.min(reward?.discount_sen ? reward.discount_sen / 100 : 0, subtotal);
+  const grandTotal = Math.max(0, subtotal - rewardDiscount);
+  const signedIn = typeof phone === "string" && phone.length > 0;
 
   const updateQty = (cartId: string, delta: number) => {
     const next = items
@@ -251,13 +257,43 @@ export function CartView() {
         </div>
       ) : null}
 
-      <div className="px-4 pt-4 pb-2 border-t border-[#EBE5DE]">
-        <div className="flex items-center justify-between mb-3">
-          <span className="text-sm text-[#6E6E73]">
-            {count} {count === 1 ? "item" : "items"}
+      <div className="px-4 pt-4 pb-2 border-t border-[rgba(26,2,0,0.10)]">
+        <div className="flex items-center justify-between" style={{ marginBottom: 4 }}>
+          <span className="text-[13px]" style={{ color: "#6B6B6B" }}>Subtotal</span>
+          <span className="text-[14px]" style={{ color: "#1A0200", fontWeight: 500 }}>
+            RM{subtotal.toFixed(2)}
           </span>
-          <span className="text-base font-bold">RM{subtotal.toFixed(2)}</span>
         </div>
+        {rewardDiscount > 0 ? (
+          <div className="flex items-center justify-between" style={{ marginBottom: 4 }}>
+            <span className="text-[13px]" style={{ color: "#B91C1C" }}>
+              Reward discount
+            </span>
+            <span className="text-[14px]" style={{ color: "#B91C1C", fontWeight: 500 }}>
+              −RM{rewardDiscount.toFixed(2)}
+            </span>
+          </div>
+        ) : null}
+        <div className="flex items-center justify-between" style={{ marginBottom: 4 }}>
+          <span className="font-peachi font-bold" style={{ color: "#1A0200", fontSize: 15 }}>
+            Total
+          </span>
+          <span className="font-peachi font-bold" style={{ color: "#1A0200", fontSize: 18 }}>
+            RM{grandTotal.toFixed(2)}
+          </span>
+        </div>
+        {signedIn && grandTotal > 0 ? (
+          <div className="flex items-center justify-between" style={{ marginBottom: 12 }}>
+            <span style={{ color: "#6B6B6B", fontSize: 11, fontWeight: 500 }}>
+              You&apos;ll earn
+            </span>
+            <span style={{ color: "#6B6B6B", fontSize: 11, fontWeight: 700 }}>
+              +{Math.floor(grandTotal)} pts
+            </span>
+          </div>
+        ) : (
+          <div style={{ marginBottom: 12 }} />
+        )}
         <Link
           href="/checkout"
           className="block w-full rounded-full bg-[#A2492C] text-white text-center py-4 font-bold active:opacity-80"

--- a/apps/order/src/app/checkout/_CheckoutView.tsx
+++ b/apps/order/src/app/checkout/_CheckoutView.tsx
@@ -33,10 +33,16 @@ type Tier = {
   tier_color?: string | null;
 };
 
-const METHODS: Array<{ id: string; label: string; Icon: typeof CreditCard }> = [
-  { id: "card",    label: "Card",     Icon: CreditCard },
-  { id: "fpx",     label: "FPX",      Icon: Banknote },
-  { id: "grabpay", label: "GrabPay",  Icon: Wallet },
+const METHODS: Array<{
+  id: string;
+  label: string;
+  subtitle?: string;
+  iconSrc?: string;
+  iconFallback?: typeof CreditCard;
+}> = [
+  { id: "card",    label: "Credit / Debit Card", iconSrc: "/payment-icons/card.svg",        iconFallback: CreditCard },
+  { id: "fpx",     label: "Online Banking",      subtitle: "FPX",      iconSrc: "/payment-icons/fpx.svg",         iconFallback: Banknote },
+  { id: "grabpay", label: "E-Wallet",            subtitle: "GrabPay",  iconSrc: "/payment-icons/grabpay.svg",     iconFallback: Wallet },
 ];
 
 function readState(): Persisted["state"] {
@@ -172,47 +178,151 @@ export function CheckoutView() {
       </header>
 
       <section className="px-4 pt-4">
-        <h2 className="font-peachi font-bold text-[16px]">Pickup from</h2>
-        <p className="mt-1 text-sm text-[#6E6E73]">{state.outletName ?? "Select an outlet"}</p>
+        <div
+          className="bg-white"
+          style={{
+            border: "1px solid rgba(26,2,0,0.10)",
+            borderRadius: 16,
+            padding: 16,
+          }}
+        >
+          <p
+            className="uppercase"
+            style={{ color: "#6B6B6B", fontSize: 10, fontWeight: 700, letterSpacing: 1.4 }}
+          >
+            Pickup from
+          </p>
+          <p
+            className="font-peachi font-bold truncate"
+            style={{ color: "#1A0200", fontSize: 15, marginTop: 4 }}
+          >
+            {state.outletName ?? "Select an outlet"}
+          </p>
+        </div>
       </section>
 
-      <section className="px-4 pt-5">
-        <h2 className="font-peachi font-bold text-[16px]">Your order</h2>
-        <ul className="mt-2 flex flex-col gap-1">
-          {cart.map((i) => (
-            <li key={i.cartId} className="flex items-baseline gap-3 text-sm">
-              <span className="text-[#160800] font-bold w-6">{i.quantity}×</span>
-              <span className="flex-1 truncate">{i.name}</span>
-              <span className="text-[#A2492C] font-bold">RM{i.totalPrice.toFixed(2)}</span>
-            </li>
-          ))}
-        </ul>
+      <section className="px-4 pt-3">
+        <div
+          className="bg-white"
+          style={{
+            border: "1px solid rgba(26,2,0,0.10)",
+            borderRadius: 16,
+            padding: 16,
+          }}
+        >
+          <p
+            className="uppercase"
+            style={{ color: "#6B6B6B", fontSize: 10, fontWeight: 700, letterSpacing: 1.4 }}
+          >
+            Order
+          </p>
+          <ul className="mt-2 flex flex-col gap-2">
+            {cart.map((i) => (
+              <li key={i.cartId} className="flex items-baseline gap-3 text-sm">
+                <span className="font-peachi font-bold w-6" style={{ color: "#1A0200" }}>
+                  {i.quantity}×
+                </span>
+                <span className="flex-1 truncate" style={{ color: "#1A0200" }}>
+                  {i.name}
+                </span>
+                <span className="font-peachi font-bold" style={{ color: "#1A0200" }}>
+                  RM{i.totalPrice.toFixed(2)}
+                </span>
+              </li>
+            ))}
+          </ul>
+        </div>
       </section>
 
       <section className="px-4 pt-5">
         <h2 className="font-peachi font-bold text-[16px]">Pay with</h2>
-        <ul className="mt-2 flex flex-col gap-2">
-          {METHODS.map((m) => {
-            const Icon = m.Icon;
+        <ul className="mt-2 flex flex-col">
+          {METHODS.map((m, idx) => {
+            const Fallback = m.iconFallback ?? CreditCard;
             const active = method === m.id;
+            const isLast = idx === METHODS.length - 1;
             return (
               <li key={m.id}>
                 <button
                   type="button"
                   onClick={() => setMethod(m.id)}
-                  className={`w-full flex items-center gap-3 rounded-2xl border px-4 py-3 text-left active:opacity-80 ${
-                    active ? "border-[#160800] bg-[#F7F4F0]" : "border-[#EBE5DE] bg-white"
-                  }`}
+                  className="w-full flex items-center text-left active:opacity-80"
+                  style={{
+                    backgroundColor: "#FFFFFF",
+                    border: active
+                      ? "2px solid #160800"
+                      : "1px solid rgba(26,2,0,0.10)",
+                    borderRadius: 16,
+                    padding: 14,
+                    gap: 14,
+                    marginBottom: isLast ? 0 : 8,
+                  }}
                 >
-                  <Icon size={20} color={active ? "#160800" : "#8E8E93"} />
-                  <span className="text-sm font-bold flex-1">{m.label}</span>
                   <span
-                    className="h-5 w-5 rounded-full border"
+                    className="flex items-center justify-center flex-shrink-0"
                     style={{
+                      width: 44,
+                      height: 36,
+                      borderRadius: 8,
+                      backgroundColor: "#F7F4F0",
+                      overflow: "hidden",
+                    }}
+                  >
+                    {m.iconSrc ? (
+                      // eslint-disable-next-line @next/next/no-img-element
+                      <img
+                        src={m.iconSrc}
+                        alt=""
+                        style={{
+                          maxWidth: "70%",
+                          maxHeight: "70%",
+                          objectFit: "contain",
+                        }}
+                      />
+                    ) : (
+                      <Fallback size={20} color="#1A0200" />
+                    )}
+                  </span>
+                  <span className="flex-1 min-w-0">
+                    <span
+                      className="block truncate"
+                      style={{ color: "#1A0200", fontSize: 14, fontWeight: 700 }}
+                    >
+                      {m.label}
+                    </span>
+                    {m.subtitle ? (
+                      <span
+                        className="block truncate"
+                        style={{ color: "#6B6B6B", fontSize: 12, marginTop: 2, fontWeight: 500 }}
+                      >
+                        {m.subtitle}
+                      </span>
+                    ) : null}
+                  </span>
+                  <span
+                    className="flex-shrink-0 rounded-full border"
+                    style={{
+                      width: 20,
+                      height: 20,
                       borderColor: active ? "#160800" : "#C4BDB3",
                       backgroundColor: active ? "#160800" : "transparent",
+                      borderWidth: active ? 0 : 1,
+                      display: "flex",
+                      alignItems: "center",
+                      justifyContent: "center",
                     }}
-                  />
+                  >
+                    {active ? (
+                      <span
+                        style={{
+                          width: 8,
+                          height: 8,
+                          borderRadius: 4,
+                          backgroundColor: "#FFFFFF",
+                        }}
+                      />
+                    ) : null}
+                  </span>
                 </button>
               </li>
             );
@@ -220,24 +330,43 @@ export function CheckoutView() {
         </ul>
       </section>
 
-      <section className="px-4 pt-5 border-t border-[#EBE5DE] mt-5">
-        <div className="flex items-center justify-between">
-          <span className="text-sm text-[#6E6E73]">Total</span>
-          <span className="font-peachi font-bold text-xl">RM{subtotal.toFixed(2)}</span>
+      <section className="px-4 pt-4">
+        <div
+          className="bg-white"
+          style={{
+            border: "1px solid rgba(26,2,0,0.10)",
+            borderRadius: 16,
+            padding: 16,
+          }}
+        >
+        <div className="flex items-center justify-between" style={{ marginBottom: 6 }}>
+          <span className="text-[13px]" style={{ color: "#6B6B6B" }}>Subtotal</span>
+          <span className="text-[14px]" style={{ color: "#1A0200", fontWeight: 500 }}>
+            RM{subtotal.toFixed(2)}
+          </span>
+        </div>
+        <div className="flex items-center justify-between pt-3 border-t border-[rgba(26,2,0,0.10)]">
+          <span className="font-peachi font-bold" style={{ color: "#1A0200", fontSize: 15 }}>
+            Total
+          </span>
+          <span className="font-peachi font-bold" style={{ color: "#1A0200", fontSize: 18 }}>
+            RM{subtotal.toFixed(2)}
+          </span>
         </div>
         {tier ? (
           <div className="mt-2 flex items-center justify-between">
-            <span className="text-[13px] text-[#6E6E73] truncate">
+            <span className="text-[12px] truncate" style={{ color: "#6B6B6B" }}>
               {tier.tier_name} · earning {tier.tier_multiplier}×
             </span>
             <span
-              className="text-[13px] font-bold"
+              className="text-[12px] font-bold"
               style={{ color: tier.tier_color ?? "#92400e" }}
             >
               +{Math.round(subtotal * (tier.tier_multiplier ?? 1))} pts
             </span>
           </div>
         ) : null}
+        </div>
       </section>
 
       {stripeContext ? (

--- a/apps/order/src/app/menu/_OutletPickerRow.tsx
+++ b/apps/order/src/app/menu/_OutletPickerRow.tsx
@@ -1,0 +1,49 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import Link from "next/link";
+import { MapPin, ChevronDown } from "lucide-react";
+
+/**
+ * Outlet picker row at the top of /menu. Shows the actual selected
+ * outlet name from localStorage; same visual as apps/pickup-native
+ * /app/menu.tsx:460-473 (MapPin terracotta + Peachi/sans bold name +
+ * ChevronDown).
+ */
+type Persisted = {
+  state?: {
+    outletName?: string | null;
+  };
+};
+
+export function OutletPickerRow() {
+  const [name, setName] = useState<string | null>(null);
+
+  useEffect(() => {
+    try {
+      const raw = window.localStorage.getItem("celsius-pickup");
+      if (raw) {
+        const parsed = JSON.parse(raw) as Persisted;
+        setName(parsed.state?.outletName ?? null);
+      }
+    } catch {
+      /* ignore */
+    }
+  }, []);
+
+  return (
+    <Link
+      href="/store"
+      className="flex items-center gap-2 bg-white border-b border-[rgba(26,2,0,0.10)] px-4 py-2 active:opacity-70"
+    >
+      <MapPin size={14} color="#A2492C" />
+      <span
+        className="font-bold flex-1 truncate"
+        style={{ color: "#1A0200", fontSize: 14 }}
+      >
+        {name ?? "Select outlet"}
+      </span>
+      <ChevronDown size={14} color="#8E8E93" />
+    </Link>
+  );
+}

--- a/apps/order/src/app/menu/page.tsx
+++ b/apps/order/src/app/menu/page.tsx
@@ -1,12 +1,13 @@
 import Image from "next/image";
 import Link from "next/link";
-import { ArrowLeft, ShoppingCart, MapPin, ChevronRight, Plus, Star, Coffee, Leaf, Cake, Cookie, Sandwich, Candy, CupSoda, Cherry, Sparkles, Croissant, Wheat, UtensilsCrossed, Utensils, FlaskConical } from "lucide-react";
+import { ArrowLeft, ShoppingCart, Plus, Star, Coffee, Leaf, Cake, Cookie, Sandwich, Candy, CupSoda, Cherry, Sparkles, Croissant, Wheat, UtensilsCrossed, Utensils, FlaskConical } from "lucide-react";
 import { getMenuData } from "@/lib/menu-data";
 import { GlobalCartPill } from "../_GlobalCartPill";
 import { BottomNav } from "../_BottomNav";
 import { MenuColumns } from "./_MenuColumns";
 import { ReservedVoucherBanner } from "./_ReservedVoucherBanner";
 import { OutletGate } from "./_OutletGate";
+import { OutletPickerRow } from "./_OutletPickerRow";
 
 /**
  * Customer menu — Next.js Server Component. Mirrors the SPA's
@@ -114,18 +115,9 @@ function Header() {
   );
 }
 
-function OutletPickerRow() {
-  return (
-    <Link
-      href="/store"
-      className="flex items-center gap-2 bg-[#F7F4F0] border-b border-[#E8E1D8] px-4 py-2 active:opacity-70"
-    >
-      <MapPin size={14} className="text-[#A2492C]" />
-      <span className="text-sm font-bold flex-1 truncate">Select outlet</span>
-      <ChevronRight size={14} className="text-[#8E8E93]" />
-    </Link>
-  );
-}
+// OutletPickerRow moved to ./_OutletPickerRow so it can read the
+// chosen outlet from localStorage and show its name (was a static
+// "Select outlet" placeholder here).
 
 // Re-export icon components for the client _MenuColumns to use without
 // pulling lucide-react itself (so the client bundle is leaner). Not

--- a/apps/order/src/app/order/[id]/_OrderTrackingView.tsx
+++ b/apps/order/src/app/order/[id]/_OrderTrackingView.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useState } from "react";
 import Link from "next/link";
-import { ArrowLeft, CheckCircle2, Clock, Coffee, Package, XCircle, X } from "lucide-react";
+import { ArrowLeft, ShoppingBag, Coffee, CheckCircle2, XCircle, X } from "lucide-react";
 
 type OrderItem = {
   product_name: string;
@@ -40,13 +40,23 @@ function rm(cents: number | null | undefined): string {
   return `RM${((cents ?? 0) / 100).toFixed(2)}`;
 }
 
-const STEPS: Array<{ key: string; label: string; Icon: typeof Clock }> = [
-  { key: "pending",    label: "Awaiting payment", Icon: Clock },
-  { key: "paid",       label: "Payment confirmed", Icon: CheckCircle2 },
-  { key: "preparing",  label: "Preparing",         Icon: Coffee },
-  { key: "ready",      label: "Ready for pickup",  Icon: Package },
-  { key: "completed",  label: "Collected",         Icon: CheckCircle2 },
+// Horizontal 3-step pipeline matching apps/pickup-native/components
+// /OrderStepper.tsx. Web order status → stepper index:
+//   pending/paid           → 0 (Received)
+//   preparing              → 1 (Brewing)
+//   ready/completed        → 2 (Ready)
+const STEPPER: Array<{ title: string; sub: string; Icon: typeof ShoppingBag }> = [
+  { title: "Received",  sub: "Order placed",   Icon: ShoppingBag },
+  { title: "Brewing",   sub: "Being prepared", Icon: Coffee },
+  { title: "Ready",     sub: "Pick up now",    Icon: CheckCircle2 },
 ];
+
+function stepperIndex(status: string): number {
+  const s = status.toLowerCase();
+  if (s === "preparing") return 1;
+  if (s === "ready" || s === "completed" || s === "collected") return 2;
+  return 0;
+}
 
 export function OrderTrackingView({ orderId }: { orderId: string }) {
   const [order, setOrder] = useState<Order | null>(null);
@@ -105,7 +115,7 @@ export function OrderTrackingView({ orderId }: { orderId: string }) {
     );
   }
 
-  const stepIdx = STEPS.findIndex((s) => s.key === order.status.toLowerCase());
+  const stepIdx = stepperIndex(order.status);
 
   return (
     <>
@@ -143,32 +153,105 @@ export function OrderTrackingView({ orderId }: { orderId: string }) {
             </div>
           </div>
         ) : (
-          <ul className="flex flex-col gap-3">
-            {STEPS.map((s, i) => {
-              const Icon = s.Icon;
-              const done = i <= stepIdx;
-              const current = i === stepIdx;
+          // Horizontal 3-step pipeline. Done steps fill terracotta-tint,
+          // current step pulses with a subtle scale animation, pending
+          // steps stay hollow. Connected by hairline rails that fill
+          // when the step before them is done.
+          <div className="flex items-start">
+            {STEPPER.map((step, i) => {
+              const isLast = i === STEPPER.length - 1;
+              const state =
+                i < stepIdx ? "done" : i === stepIdx ? "current" : "pending";
+              const bg =
+                state === "done"
+                  ? "#FBEBE8"
+                  : state === "current"
+                  ? "#A2492C"
+                  : "#FFFFFF";
+              const iconColor =
+                state === "done"
+                  ? "#A2492C"
+                  : state === "current"
+                  ? "#FFFFFF"
+                  : "#8E8E93";
+              const border =
+                state === "pending" ? "1px solid rgba(26,2,0,0.12)" : "none";
+              const Icon = step.Icon;
               return (
-                <li
-                  key={s.key}
-                  className="flex items-center gap-3 rounded-2xl border px-3 py-2.5"
-                  style={{
-                    borderColor: done ? "#160800" : "#EBE5DE",
-                    backgroundColor: current ? "#F7F4F0" : "transparent",
-                    opacity: done ? 1 : 0.55,
-                  }}
-                >
-                  <Icon size={18} color={done ? "#160800" : "#8E8E93"} />
-                  <span className="text-sm font-bold flex-1">{s.label}</span>
-                  {current ? (
-                    <span className="text-[10px] uppercase tracking-widest text-[#A2492C] font-bold">
-                      Now
+                <div key={step.title} className="flex-1">
+                  <div className="flex items-center">
+                    <span
+                      className="flex items-center justify-center flex-shrink-0"
+                      style={{
+                        width: 36,
+                        height: 36,
+                        borderRadius: 18,
+                        backgroundColor: bg,
+                        border,
+                        animation:
+                          state === "current"
+                            ? "celsius-step-pulse 1.4s ease-in-out infinite"
+                            : undefined,
+                      }}
+                    >
+                      <Icon
+                        size={18}
+                        color={iconColor}
+                        strokeWidth={state === "current" ? 2.2 : 1.8}
+                      />
                     </span>
-                  ) : null}
-                </li>
+                    {!isLast ? (
+                      <span
+                        className="flex-1"
+                        style={{
+                          height: 2,
+                          marginLeft: 4,
+                          marginRight: 4,
+                          backgroundColor:
+                            i < stepIdx ? "#A2492C" : "rgba(26,2,0,0.10)",
+                        }}
+                      />
+                    ) : null}
+                  </div>
+                  <div className="mt-2.5" style={{ paddingRight: isLast ? 0 : 12 }}>
+                    <p
+                      className="uppercase truncate"
+                      style={{
+                        fontSize: 11,
+                        fontWeight: 700,
+                        letterSpacing: 1.5,
+                        color:
+                          state === "current"
+                            ? "#A2492C"
+                            : state === "done"
+                            ? "#1A0200"
+                            : "#8E8E93",
+                      }}
+                    >
+                      {step.title}
+                    </p>
+                    <p
+                      className="truncate"
+                      style={{
+                        fontSize: 11,
+                        marginTop: 2,
+                        fontWeight: 500,
+                        color: state === "current" ? "#A2492C" : "#8E8E93",
+                      }}
+                    >
+                      {step.sub}
+                    </p>
+                  </div>
+                </div>
               );
             })}
-          </ul>
+            <style>{`
+              @keyframes celsius-step-pulse {
+                0%, 100% { transform: scale(1); }
+                50%      { transform: scale(1.12); }
+              }
+            `}</style>
+          </div>
         )}
       </section>
 

--- a/apps/order/src/app/orders/_OrdersView.tsx
+++ b/apps/order/src/app/orders/_OrdersView.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useState } from "react";
 import Link from "next/link";
-import { ClipboardList, ChevronRight } from "lucide-react";
+import { ClipboardList, ChevronRight, CheckCircle2, XCircle, Coffee, Clock, MapPin } from "lucide-react";
 
 type Order = {
   id: string;
@@ -11,6 +11,7 @@ type Order = {
   total: number;
   created_at: string;
   order_items?: Array<{ product_name: string; quantity: number }>;
+  store_name?: string | null;
 };
 
 type Persisted = { state?: { phone?: string | null } };
@@ -120,35 +121,7 @@ export function OrdersView() {
       ) : (
         <ul className="px-4 py-4 flex flex-col gap-3">
           {(filtered ?? []).map((o) => (
-            <li key={o.id}>
-              <Link
-                href={`/order/${o.id}`}
-                className="flex items-center gap-3 bg-white rounded-2xl border border-[#EBE5DE] p-3 active:opacity-80"
-              >
-                <div className="flex-1 min-w-0">
-                  <p className="text-sm font-bold">#{o.order_number}</p>
-                  <p className="text-[11px] text-[#6E6E73] mt-0.5">
-                    {new Date(o.created_at).toLocaleDateString("en-MY", {
-                      day: "numeric",
-                      month: "short",
-                      hour: "2-digit",
-                      minute: "2-digit",
-                    })}
-                    {" · "}
-                    {o.status}
-                  </p>
-                  {o.order_items && o.order_items.length > 0 ? (
-                    <p className="text-[11px] text-[#6E6E73] mt-0.5 line-clamp-1">
-                      {o.order_items.map((i) => `${i.quantity}× ${i.product_name}`).join(", ")}
-                    </p>
-                  ) : null}
-                </div>
-                <span className="text-sm text-[#A2492C] font-bold">
-                  RM{((o.total ?? 0) / 100).toFixed(2)}
-                </span>
-                <ChevronRight size={14} color="#8E8E93" />
-              </Link>
-            </li>
+            <OrderRow key={o.id} order={o} />
           ))}
         </ul>
       )}
@@ -157,6 +130,124 @@ export function OrdersView() {
         <p className="px-4 pb-4 text-[11px] text-red-600">Couldn't load orders: {error}</p>
       ) : null}
     </>
+  );
+}
+
+function OrderRow({ order }: { order: Order }) {
+  const status = order.status.toLowerCase();
+  const StatusIcon =
+    status === "completed" || status === "ready"
+      ? CheckCircle2
+      : status === "cancelled" || status === "failed"
+      ? XCircle
+      : status === "preparing" || status === "paid"
+      ? Coffee
+      : Clock;
+  const statusColor =
+    status === "completed" || status === "ready"
+      ? "#16A34A"
+      : status === "cancelled" || status === "failed"
+      ? "#A2492C"
+      : "#8E8E93";
+
+  const date = new Date(order.created_at);
+  const dateLabel = date.toLocaleDateString("en-MY", {
+    day: "numeric",
+    month: "short",
+    year: "numeric",
+  });
+  const timeLabel = date.toLocaleTimeString("en-MY", {
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+
+  const items = order.order_items ?? [];
+  const itemSummary =
+    items
+      .slice(0, 2)
+      .map((i) => `${i.quantity}× ${i.product_name}`)
+      .join(", ") + (items.length > 2 ? ` · +${items.length - 2} more` : "");
+
+  const totalRm = (order.total ?? 0) / 100;
+
+  return (
+    <li
+      className="bg-white"
+      style={{
+        border: "1px solid rgba(26,2,0,0.10)",
+        borderRadius: 16,
+        padding: 16,
+        boxShadow: "0 2px 6px rgba(0,0,0,0.04)",
+      }}
+    >
+      <Link href={`/order/${order.id}`} className="block active:opacity-70">
+        <div className="flex items-center justify-between">
+          <div className="flex items-center gap-2">
+            <StatusIcon size={16} color={statusColor} strokeWidth={2} />
+            <span
+              className="uppercase"
+              style={{ color: statusColor, fontSize: 12, fontWeight: 700, letterSpacing: 0.8 }}
+            >
+              {status}
+            </span>
+          </div>
+          <span style={{ color: "#6B6B6B", fontSize: 11, fontWeight: 500 }}>
+            #{order.order_number}
+          </span>
+        </div>
+
+        <p
+          className="font-peachi font-bold truncate"
+          style={{ color: "#1A0200", fontSize: 15, marginTop: 8 }}
+        >
+          {itemSummary || "Order"}
+        </p>
+        {order.store_name ? (
+          <div className="flex items-center" style={{ marginTop: 6, gap: 4 }}>
+            <MapPin size={11} color="#8E8E93" strokeWidth={2} />
+            <span className="truncate" style={{ color: "#6B6B6B", fontSize: 12, fontWeight: 500 }}>
+              {order.store_name}
+            </span>
+          </div>
+        ) : null}
+        <p style={{ color: "#6B6B6B", fontSize: 12, marginTop: 2 }}>
+          {dateLabel} · {timeLabel} · RM{totalRm.toFixed(2)}
+        </p>
+      </Link>
+
+      <div
+        className="mt-3 pt-3 flex"
+        style={{ borderTop: "1px solid rgba(26,2,0,0.10)", gap: 8 }}
+      >
+        <Link
+          href={`/order/${order.id}`}
+          className="flex-1 flex items-center justify-center gap-1 rounded-full bg-white active:opacity-70"
+          style={{
+            border: "1px solid rgba(26,2,0,0.10)",
+            paddingTop: 10,
+            paddingBottom: 10,
+          }}
+        >
+          <span className="font-peachi font-bold" style={{ color: "#1A0200", fontSize: 13 }}>
+            View
+          </span>
+          <ChevronRight size={14} color="#160800" />
+        </Link>
+        <Link
+          href="/menu"
+          className="flex-1 flex items-center justify-center gap-1 rounded-full active:opacity-80"
+          style={{
+            backgroundColor: "#1A0200",
+            paddingTop: 10,
+            paddingBottom: 10,
+          }}
+        >
+          <span className="font-peachi font-bold" style={{ color: "#FFFFFF", fontSize: 13 }}>
+            Order again
+          </span>
+        </Link>
+      </div>
+    </li>
   );
 }
 

--- a/apps/order/src/app/page.tsx
+++ b/apps/order/src/app/page.tsx
@@ -73,17 +73,24 @@ export default async function HomePage() {
         style={{ top: "calc(env(safe-area-inset-top, 0px) + 12px)" }}
       >
         <Image
-          src="/icons/icon-192.png"
+          src="/images/icon-192.png"
           alt="Celsius"
           width={28}
           height={28}
-          className="rounded-md"
+          style={{ borderRadius: 6 }}
         />
         <div className="flex-1" />
         <Link
           href="/cart"
-          className="flex h-9 w-9 items-center justify-center rounded-full bg-white/90 active:opacity-80"
+          className="flex items-center justify-center active:opacity-60"
           aria-label="Cart"
+          style={{
+            width: 36,
+            height: 36,
+            borderRadius: 18,
+            backgroundColor: "rgba(255,255,255,0.92)",
+            boxShadow: "0 2px 6px rgba(0,0,0,0.10)",
+          }}
         >
           <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="#160800" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
             <circle cx="9" cy="21" r="1" />

--- a/apps/order/src/app/page.tsx
+++ b/apps/order/src/app/page.tsx
@@ -10,6 +10,8 @@ import { HeroInfoCard } from "./_HeroInfoCard";
 import { OutletRow } from "./_OutletRow";
 import { ActiveChallengeCard } from "./_ActiveChallengeCard";
 import { VoucherRail } from "./_VoucherRail";
+import { GuestSignInCTA } from "./_GuestSignInCTA";
+import { ActiveOrderTracker } from "./_ActiveOrderTracker";
 
 /**
  * Customer home — Next.js Server Component. Plain HTML so iOS Safari
@@ -110,6 +112,16 @@ export default async function HomePage() {
           reads chosen outlet from localStorage so customers see their
           outlet name instead of the placeholder. */}
       <OutletRow />
+
+      {/* Guest sign-in CTA — espresso panel with gift icon, surfaces
+          for logged-out customers as the first conversion ask. Hidden
+          once signed in. Mirrors apps/pickup-native/app/index.tsx
+          :586-644. */}
+      <GuestSignInCTA />
+
+      {/* In-progress order banner — colored panel that links to the
+          order detail page. Refreshes every 15s. */}
+      <ActiveOrderTracker />
 
       {/* Active challenge teaser (signed-in customers with an in-
           progress mission). Mirrors apps/pickup-native/app/index.tsx

--- a/apps/order/src/app/product/[id]/_ProductView.tsx
+++ b/apps/order/src/app/product/[id]/_ProductView.tsx
@@ -136,7 +136,10 @@ export function ProductView({ product }: { product: Product }) {
 
   return (
     <>
-      <div className="relative w-full aspect-square bg-[#F2EDE5]">
+      <div
+        className="relative w-full bg-[#F2EDE5]"
+        style={{ height: "50vh" }}
+      >
         {product.image ? (
           <Image
             src={product.image}
@@ -149,31 +152,51 @@ export function ProductView({ product }: { product: Product }) {
         ) : null}
         <Link
           href="/menu"
-          className="absolute left-4 flex h-9 w-9 items-center justify-center rounded-full bg-white/90 active:opacity-80"
-          style={{ top: "calc(env(safe-area-inset-top, 0px) + 12px)" }}
+          className="absolute left-4 flex items-center justify-center rounded-full bg-white active:opacity-80"
+          style={{
+            top: "calc(env(safe-area-inset-top, 0px) + 12px)",
+            width: 40,
+            height: 40,
+            boxShadow: "0 2px 6px rgba(0,0,0,0.12)",
+          }}
           aria-label="Back"
         >
-          <ArrowLeft size={18} color="#160800" />
+          <ArrowLeft size={20} color="#160800" />
         </Link>
       </div>
 
-      <div className="px-4 pt-4">
-        <h1 className="font-peachi font-bold text-2xl">{product.name}</h1>
+      <div
+        className="relative bg-white"
+        style={{ marginTop: -24, borderTopLeftRadius: 16, borderTopRightRadius: 16, paddingTop: 6 }}
+      >
+      <div className="px-5 pt-4">
+        <h1 className="font-peachi font-bold text-2xl text-[#1A0200]">{product.name}</h1>
         {product.description ? (
-          <p className="text-sm text-[#6E6E73] mt-2 leading-snug">
+          <p className="text-sm text-[#6E6E73] mt-2 leading-relaxed">
             {product.description}
           </p>
         ) : null}
-        <p className="mt-3 text-base text-[#A2492C] font-bold">
+        <p className="mt-3 font-peachi font-bold text-[18px] text-[#A2492C]">
           RM{product.basePrice.toFixed(2)}
         </p>
       </div>
 
       {product.modifierGroups.map((g) => (
-        <section key={g.id} className="mt-5 px-4">
-          <h2 className="font-peachi font-bold text-[16px]">{g.name}</h2>
-          <p className="text-[11px] text-[#8E8E93] uppercase tracking-widest mt-0.5">
-            {g.multiSelect ? "Pick any" : "Pick one"}
+        <section key={g.id} className="mt-5 px-5">
+          <p
+            className="uppercase"
+            style={{
+              fontFamily: "var(--font-sans)",
+              fontSize: 12,
+              fontWeight: 700,
+              letterSpacing: 1.4,
+              color: "#1A0200",
+            }}
+          >
+            {g.name}
+            <span style={{ color: "#A2492C", marginLeft: 6 }}>
+              · {g.multiSelect ? "Pick any" : "Pick one"}
+            </span>
           </p>
           <ul className="mt-3 flex flex-col gap-2">
             {g.options.map((opt) => {
@@ -215,17 +238,29 @@ export function ProductView({ product }: { product: Product }) {
         </section>
       ))}
 
-      <section className="mt-5 px-4">
-        <h2 className="font-peachi font-bold text-[16px]">Special instructions</h2>
+      <section className="mt-5 px-5">
+        <p
+          className="uppercase"
+          style={{
+            fontFamily: "var(--font-sans)",
+            fontSize: 12,
+            fontWeight: 700,
+            letterSpacing: 1.4,
+            color: "#1A0200",
+          }}
+        >
+          Special instructions
+        </p>
         <textarea
           value={notes}
           onChange={(e) => setNotes(e.target.value)}
           placeholder="Less ice, no cream, etc."
-          className="mt-2 w-full rounded-2xl border border-[#EBE5DE] bg-white p-3 text-sm min-h-[88px]"
+          className="mt-2 w-full rounded-2xl bg-white p-3 text-sm min-h-[88px]"
+          style={{ border: "1px solid rgba(26,2,0,0.10)" }}
         />
       </section>
 
-      <section className="mt-5 px-4 flex items-center gap-3">
+      <section className="mt-5 px-5 flex items-center gap-3">
         <button
           type="button"
           onClick={() => setQty((q) => Math.max(1, q - 1))}
@@ -245,7 +280,7 @@ export function ProductView({ product }: { product: Product }) {
         </button>
       </section>
 
-      <div className="mt-6 px-4">
+      <div className="mt-6 px-5 pb-8">
         <button
           type="button"
           onClick={onAdd}
@@ -256,6 +291,7 @@ export function ProductView({ product }: { product: Product }) {
         >
           {requiredAllPicked ? `Add ${qty} · RM${totalPrice.toFixed(2)}` : "Pick required options"}
         </button>
+      </div>
       </div>
     </>
   );

--- a/apps/order/src/app/rewards/_BeansHero.tsx
+++ b/apps/order/src/app/rewards/_BeansHero.tsx
@@ -1,0 +1,172 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+/**
+ * Beans hero card for /rewards — port of the BeansHero function in
+ * apps/pickup-native/app/rewards.tsx:447-680. Compact 110px-tall
+ * horizontal card with the customer's bean balance as the protagonist
+ * (Peachi-Bold 28px) and a progress line "Spend RMx in N days to
+ * unlock NextTier" + thin progress bar on the right.
+ *
+ * Themed by tier_color at 8% / 18% alpha so each tier gets its own
+ * colourway. Replaces the prior account-style TierCard on the rewards
+ * screen — native uses BeansHero there, TierCard only on the Account
+ * tab.
+ */
+type Tier = {
+  tier_id?: string | null;
+  tier_name?: string | null;
+  tier_color?: string | null;
+  tier_multiplier?: number | null;
+  next_tier_id?: string | null;
+  next_tier_name?: string | null;
+  next_tier_min_spend?: number | null;
+  spend_to_next_tier?: number | null;
+  spend_this_period?: number | null;
+  quarter_end?: string | null;
+};
+
+type Persisted = {
+  state?: {
+    loyaltyId?: string | null;
+    member?: { pointsBalance?: number };
+  };
+};
+
+function hexWithAlpha(hex: string, alpha: number): string {
+  const m = /^#([0-9a-f]{6})$/i.exec((hex || "").trim());
+  if (!m) return `rgba(146, 64, 14, ${alpha})`;
+  const num = parseInt(m[1], 16);
+  const r = (num >> 16) & 0xff;
+  const g = (num >> 8) & 0xff;
+  const b = num & 0xff;
+  return `rgba(${r}, ${g}, ${b}, ${alpha})`;
+}
+
+function daysUntil(iso: string | null | undefined): number | null {
+  if (!iso) return null;
+  const diff = new Date(iso).getTime() - Date.now();
+  if (diff <= 0) return 0;
+  return Math.ceil(diff / (1000 * 60 * 60 * 24));
+}
+
+export function BeansHero() {
+  const [balance, setBalance] = useState(0);
+  const [tier, setTier] = useState<Tier | null>(null);
+
+  useEffect(() => {
+    let memberId: string | null = null;
+    try {
+      const raw = window.localStorage.getItem("celsius-pickup");
+      if (raw) {
+        const parsed = JSON.parse(raw) as Persisted;
+        memberId = parsed.state?.loyaltyId ?? null;
+        setBalance(parsed.state?.member?.pointsBalance ?? 0);
+      }
+    } catch {
+      /* ignore */
+    }
+    if (!memberId) return;
+    fetch(`/api/loyalty/member-tier?member_id=${encodeURIComponent(memberId)}`)
+      .then((r) => (r.ok ? r.json() : null))
+      .then((data) => setTier((data ?? null) as Tier | null))
+      .catch(() => {
+        /* ignore */
+      });
+  }, []);
+
+  const color = tier?.tier_color || "#92400e";
+  const bgFill = hexWithAlpha(color, 0.08);
+  const borderFill = hexWithAlpha(color, 0.18);
+  const subtle = hexWithAlpha(color, 0.7);
+
+  const nextName = tier?.next_tier_name ?? null;
+  const spendToNext = Math.max(0, tier?.spend_to_next_tier ?? 0);
+  const nextMin = Math.max(0, tier?.next_tier_min_spend ?? 0);
+  const spent = Math.max(0, tier?.spend_this_period ?? 0);
+  const daysLeft = daysUntil(tier?.quarter_end);
+
+  let progressText: string | null = null;
+  let progressRatio: number | null = null;
+  if (nextName && spendToNext > 0 && nextMin > 0) {
+    progressRatio = Math.max(0, Math.min(1, spent / nextMin));
+    const window =
+      daysLeft != null && daysLeft > 0
+        ? ` in ${daysLeft} day${daysLeft === 1 ? "" : "s"}`
+        : "";
+    progressText = `Spend RM${Math.round(spendToNext)}${window} to unlock ${nextName}`;
+  }
+
+  return (
+    <section className="px-4 pt-4">
+      <div
+        className="flex items-center"
+        style={{
+          height: 110,
+          borderRadius: 18,
+          backgroundColor: bgFill,
+          border: `1px solid ${borderFill}`,
+          paddingLeft: 14,
+          paddingRight: 14,
+          paddingTop: 14,
+          paddingBottom: 14,
+          gap: 14,
+          boxShadow: "0 4px 10px rgba(0,0,0,0.06)",
+        }}
+      >
+        <div className="flex-shrink-0">
+          <p
+            className="uppercase"
+            style={{ color: subtle, fontSize: 9.5, fontWeight: 700, letterSpacing: 1.4 }}
+          >
+            Beans
+          </p>
+          <p
+            className="font-peachi font-bold"
+            style={{
+              color: "#1A0200",
+              fontSize: 28,
+              letterSpacing: -0.6,
+              lineHeight: "32px",
+              marginTop: 2,
+            }}
+          >
+            {balance.toLocaleString()}
+          </p>
+        </div>
+
+        {progressText ? (
+          <div className="flex-1 min-w-0">
+            <p
+              className="line-clamp-2"
+              style={{ color: subtle, fontSize: 12, lineHeight: "16px", fontWeight: 500 }}
+            >
+              {progressText}
+            </p>
+            {progressRatio != null ? (
+              <div
+                style={{
+                  marginTop: 6,
+                  height: 4,
+                  borderRadius: 2,
+                  backgroundColor: "rgba(0,0,0,0.10)",
+                  overflow: "hidden",
+                }}
+              >
+                <div
+                  style={{
+                    width: `${Math.round(progressRatio * 100)}%`,
+                    height: "100%",
+                    backgroundColor: color,
+                    borderRadius: 2,
+                  }}
+                />
+              </div>
+            ) : null}
+          </div>
+        ) : null}
+      </div>
+    </section>
+  );
+}

--- a/apps/order/src/app/rewards/_RewardsView.tsx
+++ b/apps/order/src/app/rewards/_RewardsView.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useState } from "react";
 import Link from "next/link";
-import { Gift, Sparkles } from "lucide-react";
+import { Gift, Sparkles, Coffee, Tag, Cookie, Ticket } from "lucide-react";
 import { BeansHero } from "./_BeansHero";
 import { ActiveChallenges } from "./_ActiveChallenges";
 import { Claimables } from "./_Claimables";
@@ -110,31 +110,157 @@ export function RewardsView() {
           </p>
         </div>
       ) : (
-        <ul className="px-4 py-4 flex flex-col gap-3">
-          {rewards.map((r) => (
-            <li
-              key={r.id}
-              className="bg-white rounded-2xl border border-[#EBE5DE] p-4"
-              style={{ boxShadow: "0 2px 6px rgba(0,0,0,0.04)" }}
+        <ul className="px-4 py-4 flex flex-col gap-2">
+          <li>
+            <p
+              className="uppercase"
+              style={{
+                color: "#8E8E93",
+                fontSize: 10,
+                fontWeight: 700,
+                letterSpacing: 1.4,
+                marginBottom: 4,
+                paddingLeft: 4,
+              }}
             >
-              <p
-                className="text-base"
-                style={{ fontFamily: "Peachi-Bold, serif", fontWeight: 700 }}
-              >
-                {r.name}
-              </p>
-              {r.description ? (
-                <p className="text-[12px] text-[#6E6E73] mt-1">{r.description}</p>
-              ) : null}
-              {r.beans_cost ? (
-                <p className="mt-2 text-sm text-[#A2492C] font-bold">
-                  {r.beans_cost.toLocaleString()} beans
-                </p>
-              ) : null}
-            </li>
+              Spend your beans
+            </p>
+          </li>
+          {rewards.map((r) => (
+            <CatalogCard key={r.id} reward={r} balance={beans} />
           ))}
         </ul>
       )}
     </>
+  );
+}
+
+// Pick a glyph + colourway that matches the reward's flavour, mirroring
+// apps/pickup-native/app/rewards.tsx's themeForReward + pickRewardIcon
+// shorthand. Web doesn't have access to discount_type/flat-vs-percent
+// breakdown so we fall back to keyword matching on the name.
+function themeFor(reward: Reward): {
+  bg: string;
+  fg: string;
+  fgDim: string;
+  accent: string;
+  iconBg: string;
+  Icon: typeof Gift;
+} {
+  const name = (reward.name ?? "").toLowerCase();
+  if (/free|bogo|buy.*free/.test(name)) {
+    return {
+      bg: "#1A0200",
+      fg: "#FFFFFF",
+      fgDim: "rgba(255,255,255,0.65)",
+      accent: "#FBBF24",
+      iconBg: "rgba(251,191,36,0.20)",
+      Icon: Coffee,
+    };
+  }
+  if (/cookie|pastry|cake|croissant/.test(name)) {
+    return {
+      bg: "#FBEBE8",
+      fg: "#1A0200",
+      fgDim: "rgba(26,2,0,0.65)",
+      accent: "#A2492C",
+      iconBg: "rgba(162,73,44,0.18)",
+      Icon: Cookie,
+    };
+  }
+  if (/rm\s*\d|%\s*off|off$/i.test(reward.name ?? "")) {
+    return {
+      bg: "rgba(162,73,44,0.10)",
+      fg: "#1A0200",
+      fgDim: "rgba(26,2,0,0.65)",
+      accent: "#A2492C",
+      iconBg: "rgba(162,73,44,0.18)",
+      Icon: Tag,
+    };
+  }
+  return {
+    bg: "#FBEBE8",
+    fg: "#1A0200",
+    fgDim: "rgba(26,2,0,0.65)",
+    accent: "#A2492C",
+    iconBg: "rgba(162,73,44,0.18)",
+    Icon: Ticket,
+  };
+}
+
+function CatalogCard({ reward, balance }: { reward: Reward; balance: number }) {
+  const required = reward.beans_cost ?? 0;
+  const canUse = balance >= required;
+  const theme = themeFor(reward);
+  const Icon = theme.Icon;
+  return (
+    <li
+      style={{
+        backgroundColor: theme.bg,
+        border: `1px solid ${theme.bg}`,
+        borderRadius: 18,
+        padding: 14,
+        opacity: canUse ? 1 : 0.78,
+        boxShadow: "0 4px 10px rgba(0,0,0,0.06)",
+      }}
+    >
+      <div className="flex items-center" style={{ gap: 14 }}>
+        <span
+          className="flex items-center justify-center flex-shrink-0"
+          style={{
+            width: 48,
+            height: 48,
+            borderRadius: 12,
+            backgroundColor: theme.iconBg,
+          }}
+        >
+          <Icon size={24} color={theme.accent} strokeWidth={2} />
+        </span>
+        <div className="flex-1 min-w-0">
+          <p
+            className="uppercase truncate"
+            style={{
+              color: theme.accent,
+              fontSize: 9.5,
+              fontWeight: 700,
+              letterSpacing: 1.4,
+              marginBottom: 3,
+            }}
+          >
+            Reward
+          </p>
+          <p
+            className="font-peachi font-bold truncate"
+            style={{ color: theme.fg, fontSize: 17, lineHeight: "21px" }}
+          >
+            {reward.name}
+          </p>
+          <p
+            className="truncate"
+            style={{ color: theme.fgDim, fontSize: 11, marginTop: 2, fontWeight: 500 }}
+          >
+            {canUse
+              ? required > 0 ? `Spend ${required.toLocaleString()} beans` : "Free to claim"
+              : `${(required - balance).toLocaleString()} beans to go`}
+          </p>
+        </div>
+        <span
+          className="rounded-full flex items-center justify-center flex-shrink-0"
+          style={{
+            backgroundColor: canUse ? theme.accent : "rgba(0,0,0,0.10)",
+            color: canUse ? "#FFFFFF" : theme.fgDim,
+            paddingLeft: 14,
+            paddingRight: 14,
+            paddingTop: 7,
+            paddingBottom: 7,
+            fontFamily: "var(--font-display)",
+            fontWeight: 700,
+            fontSize: 12,
+          }}
+        >
+          {canUse ? "Use" : `${required}`}
+        </span>
+      </div>
+    </li>
   );
 }

--- a/apps/order/src/app/rewards/_RewardsView.tsx
+++ b/apps/order/src/app/rewards/_RewardsView.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useState } from "react";
 import Link from "next/link";
 import { Gift, Sparkles } from "lucide-react";
-import { TierCard } from "./_TierCard";
+import { BeansHero } from "./_BeansHero";
 import { ActiveChallenges } from "./_ActiveChallenges";
 import { Claimables } from "./_Claimables";
 
@@ -63,12 +63,11 @@ export function RewardsView() {
         </h1>
       </header>
 
-      {/* Tier card — espresso hero with current tier badge, beans
-          count, and progress-to-next-tier bar. Wired to
-          /api/loyalty/member-tier which proxies the loyalty service
-          and updates the member's current tier atomically on read.
-          Matches the SPA's TierCardCarousel current-tier card. */}
-      <TierCard />
+      {/* Beans hero — compact themed card with the customer's bean
+          balance + progress-to-next-tier line. Mirrors the BeansHero
+          on apps/pickup-native/app/rewards.tsx (rewards page uses the
+          compact hero; the larger TierCard lives on /account). */}
+      <BeansHero />
 
       {/* Claimable offers (one-tap welcome / promo / mystery). */}
       <Claimables />

--- a/apps/order/src/app/store/_StoreList.tsx
+++ b/apps/order/src/app/store/_StoreList.tsx
@@ -14,7 +14,15 @@ type Outlet = {
   pickup_time_mins: number | null;
 };
 
-type Persisted = { state?: { outletId?: string | null; outletName?: string | null } };
+type Persisted = {
+  state?: {
+    outletId?: string | null;
+    outletName?: string | null;
+    outletIsOpen?: boolean;
+    outletIsBusy?: boolean;
+    outletPickupTimeMins?: number | null;
+  };
+};
 
 export function StoreList({ outlets }: { outlets: Outlet[] }) {
   const router = useRouter();
@@ -40,6 +48,12 @@ export function StoreList({ outlets }: { outlets: Outlet[] }) {
       const state = parsed.state ?? {};
       state.outletId = o.store_id;
       state.outletName = o.name;
+      // Snapshot status fields so the home OutletRow can render the
+      // green/amber/red dot + "~N min" label without a separate fetch,
+      // matching apps/pickup-native/app/index.tsx:554-580.
+      state.outletIsOpen = o.is_open;
+      state.outletIsBusy = o.is_busy;
+      state.outletPickupTimeMins = o.pickup_time_mins;
       window.localStorage.setItem("celsius-pickup", JSON.stringify({ ...parsed, state }));
     } catch {
       /* ignore */

--- a/apps/order/src/app/store/_StoreList.tsx
+++ b/apps/order/src/app/store/_StoreList.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useState } from "react";
 import Link from "next/link";
 import { useRouter, useSearchParams } from "next/navigation";
-import { ArrowLeft, MapPin, Check } from "lucide-react";
+import { ArrowLeft, MapPin, CheckCircle2, Clock, Users } from "lucide-react";
 
 type Outlet = {
   store_id: string;
@@ -68,38 +68,87 @@ export function StoreList({ outlets }: { outlets: Outlet[] }) {
       <ul className="px-4 py-4 flex flex-col gap-3">
         {outlets.map((o) => {
           const active = selected === o.store_id;
-          const dot = !o.is_open
-            ? { bg: "#EF4444", label: "Closed" }
-            : o.is_busy
-            ? { bg: "#F59E0B", label: "Busy" }
-            : { bg: "#22C55E", label: o.pickup_time_mins ? `~${o.pickup_time_mins} min` : "Open" };
           return (
             <li key={o.store_id}>
               <button
                 type="button"
                 onClick={() => choose(o)}
-                className={`w-full text-left rounded-2xl border p-4 active:opacity-80 ${
-                  active ? "border-[#160800] bg-[#F7F4F0]" : "border-[#EBE5DE] bg-white"
-                }`}
-                style={{ boxShadow: "0 2px 6px rgba(0,0,0,0.04)" }}
+                disabled={!o.is_open}
+                className="w-full text-left bg-white rounded-2xl active:opacity-70 flex items-start"
+                style={{
+                  border: active ? "2px solid #160800" : "1px solid rgba(26,2,0,0.10)",
+                  padding: 16,
+                  gap: 14,
+                  opacity: !o.is_open ? 0.5 : 1,
+                  boxShadow: "0 2px 6px rgba(0,0,0,0.04)",
+                }}
               >
-                <div className="flex items-start gap-3">
-                  <MapPin size={18} color="#A2492C" className="mt-0.5" />
-                  <div className="flex-1 min-w-0">
-                    <p className="font-peachi font-bold text-base truncate">{o.name}</p>
-                    <p className="text-[12px] text-[#6E6E73] mt-0.5 truncate">{o.address}</p>
-                    <div className="mt-2 flex items-center gap-1.5">
+                <span
+                  className="flex items-center justify-center flex-shrink-0"
+                  style={{
+                    marginTop: 2,
+                    padding: 10,
+                    borderRadius: 16,
+                    backgroundColor: active ? "rgba(162,73,44,0.15)" : "rgba(162,73,44,0.10)",
+                  }}
+                >
+                  <MapPin size={20} color="#A2492C" />
+                </span>
+                <span className="flex-1 min-w-0">
+                  <span className="flex items-center gap-2 flex-wrap">
+                    <span
+                      className="font-bold"
+                      style={{ color: "#1A0200", fontSize: 15 }}
+                    >
+                      {o.name}
+                    </span>
+                    {o.is_busy && o.is_open ? (
                       <span
-                        className="w-1.5 h-1.5 rounded-full"
-                        style={{ backgroundColor: dot.bg }}
-                      />
-                      <span className="text-[11px] font-bold" style={{ color: dot.bg }}>
-                        {dot.label}
+                        className="flex items-center gap-1 rounded"
+                        style={{
+                          backgroundColor: "#FEF3C7",
+                          paddingLeft: 6,
+                          paddingRight: 6,
+                          paddingTop: 2,
+                          paddingBottom: 2,
+                        }}
+                      >
+                        <Users size={10} color="#B45309" />
+                        <span style={{ fontSize: 10, color: "#F59E0B", fontWeight: 500 }}>Busy</span>
                       </span>
-                    </div>
-                  </div>
-                  {active ? <Check size={18} color="#160800" /> : null}
-                </div>
+                    ) : null}
+                    {!o.is_open ? (
+                      <span
+                        className="rounded"
+                        style={{
+                          backgroundColor: "#FFFFFF",
+                          paddingLeft: 6,
+                          paddingRight: 6,
+                          paddingTop: 2,
+                          paddingBottom: 2,
+                          border: "1px solid rgba(26,2,0,0.10)",
+                        }}
+                      >
+                        <span style={{ fontSize: 10, color: "#6B6B6B", fontWeight: 500 }}>Closed</span>
+                      </span>
+                    ) : null}
+                  </span>
+                  <span
+                    className="block leading-relaxed line-clamp-2"
+                    style={{ color: "#6B6B6B", fontSize: 12, marginTop: 4 }}
+                  >
+                    {o.address}
+                  </span>
+                  {o.pickup_time_mins ? (
+                    <span className="mt-2 flex items-center gap-1">
+                      <Clock size={12} color="#6E6E73" />
+                      <span style={{ color: "#6B6B6B", fontSize: 12 }}>
+                        ~{o.pickup_time_mins} min
+                      </span>
+                    </span>
+                  ) : null}
+                </span>
+                {active ? <CheckCircle2 size={20} color="#160800" /> : null}
               </button>
             </li>
           );

--- a/apps/pickup-native/public/sw.js
+++ b/apps/pickup-native/public/sw.js
@@ -6,7 +6,7 @@
 //
 // Future rule of thumb: bump this on ANY production-affecting bundle
 // regression so customers don't get stuck on a bad build.
-const CACHE = "celsius-v20";
+const CACHE = "celsius-v21";
 const SHELL = ["/", "/index.html", "/manifest.json"];
 
 self.addEventListener("install", (e) => {

--- a/apps/pickup-native/public/sw.js
+++ b/apps/pickup-native/public/sw.js
@@ -6,7 +6,7 @@
 //
 // Future rule of thumb: bump this on ANY production-affecting bundle
 // regression so customers don't get stuck on a bad build.
-const CACHE = "celsius-v21";
+const CACHE = "celsius-v22";
 const SHELL = ["/", "/index.html", "/manifest.json"];
 
 self.addEventListener("install", (e) => {

--- a/apps/pickup-native/public/sw.js
+++ b/apps/pickup-native/public/sw.js
@@ -6,7 +6,7 @@
 //
 // Future rule of thumb: bump this on ANY production-affecting bundle
 // regression so customers don't get stuck on a bad build.
-const CACHE = "celsius-v22";
+const CACHE = "celsius-v23";
 const SHELL = ["/", "/index.html", "/manifest.json"];
 
 self.addEventListener("install", (e) => {

--- a/apps/pickup-native/public/sw.js
+++ b/apps/pickup-native/public/sw.js
@@ -6,7 +6,7 @@
 //
 // Future rule of thumb: bump this on ANY production-affecting bundle
 // regression so customers don't get stuck on a bad build.
-const CACHE = "celsius-v17";
+const CACHE = "celsius-v18";
 const SHELL = ["/", "/index.html", "/manifest.json"];
 
 self.addEventListener("install", (e) => {

--- a/apps/pickup-native/public/sw.js
+++ b/apps/pickup-native/public/sw.js
@@ -6,7 +6,7 @@
 //
 // Future rule of thumb: bump this on ANY production-affecting bundle
 // regression so customers don't get stuck on a bad build.
-const CACHE = "celsius-v18";
+const CACHE = "celsius-v19";
 const SHELL = ["/", "/index.html", "/manifest.json"];
 
 self.addEventListener("install", (e) => {

--- a/apps/pickup-native/public/sw.js
+++ b/apps/pickup-native/public/sw.js
@@ -6,7 +6,7 @@
 //
 // Future rule of thumb: bump this on ANY production-affecting bundle
 // regression so customers don't get stuck on a bad build.
-const CACHE = "celsius-v16";
+const CACHE = "celsius-v17";
 const SHELL = ["/", "/index.html", "/manifest.json"];
 
 self.addEventListener("install", (e) => {

--- a/apps/pickup-native/public/sw.js
+++ b/apps/pickup-native/public/sw.js
@@ -6,7 +6,7 @@
 //
 // Future rule of thumb: bump this on ANY production-affecting bundle
 // regression so customers don't get stuck on a bad build.
-const CACHE = "celsius-v15";
+const CACHE = "celsius-v16";
 const SHELL = ["/", "/index.html", "/manifest.json"];
 
 self.addEventListener("install", (e) => {

--- a/apps/pickup-native/public/sw.js
+++ b/apps/pickup-native/public/sw.js
@@ -6,7 +6,7 @@
 //
 // Future rule of thumb: bump this on ANY production-affecting bundle
 // regression so customers don't get stuck on a bad build.
-const CACHE = "celsius-v19";
+const CACHE = "celsius-v20";
 const SHELL = ["/", "/index.html", "/manifest.json"];
 
 self.addEventListener("install", (e) => {


### PR DESCRIPTION
## Summary
Two more native-parity fixes:

1. **Home VoucherRail** — rebuilt to mirror `apps/pickup-native/components/RewardTicket.tsx`. 144px ticket-stub cards with a coloured top stub (espresso+gold for auto/mystery/mission, terracotta for promo/etc), perforated separator (half-circle punches + dashed line), and a white bottom stub with reward name + "Free to claim" caps label. Replaces the prior 260px generic dark card. Section heading renamed "Available rewards".
2. **Product detail** — aligned to `apps/pickup-native/app/product/[id].tsx`: hero now 50vh with -24px body overlap and rounded top corners, back button bumped to 40×40 solid white with soft shadow, px-5 body padding, modifier group header collapsed to one uppercase eyebrow "Name · Pick one", description `leading-relaxed`, price bumped to 18px Peachi.

Bumps SW cache to v16.

## Test plan
- [ ] Open `/` while signed in with vouchers → rail shows 144px ticket cards with perforated edges, gold/terracotta tones depending on source.
- [ ] Open a product → hero is half-viewport, body card slides over bottom edge with rounded top, back button is solid white 40px.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xd1aERynqUbdCqXNboKWBe)_