### PR TITLE
fix(web): empty-cart hero, referral rebuild, settings rows — native parity

### DIFF
--- a/apps/order/public/sw.js
+++ b/apps/order/public/sw.js
@@ -1,7 +1,7 @@
 // Mirror of apps/pickup-native/public/sw.js — overwritten on each
 // build-pwa run. v3 bumps over v2 to flush customers off the broken
 // CSS shipped in #157/#158 before this revert deployed.
-const CACHE = "celsius-v23";
+const CACHE = "celsius-v24";
 const SHELL = ["/", "/index.html", "/manifest.json"];
 
 self.addEventListener("install", (e) => {

--- a/apps/order/src/app/cart/_CartView.tsx
+++ b/apps/order/src/app/cart/_CartView.tsx
@@ -3,7 +3,14 @@
 import { useEffect, useState } from "react";
 import Link from "next/link";
 import Image from "next/image";
-import { ArrowLeft, Trash2, Plus, Minus, Gift, X } from "lucide-react";
+import { ArrowLeft, Trash2, Plus, Minus, Gift, X, Coffee, ChevronRight } from "lucide-react";
+
+type BestSeller = {
+  id: string;
+  name: string;
+  basePrice: number;
+  image: string;
+};
 
 type CartItem = {
   cartId: string;
@@ -84,7 +91,7 @@ function writeCart(items: CartItem[]) {
   }
 }
 
-export function CartView() {
+export function CartView({ bestSellers = [] }: { bestSellers?: BestSeller[] }) {
   const [items, setItems] = useState<CartItem[]>([]);
   const [outletName, setOutletName] = useState<string | null>(null);
   const [phone, setPhone] = useState<string | null>(null);
@@ -132,15 +139,100 @@ export function CartView() {
   if (items.length === 0) {
     return (
       <CartShell outletName={outletName}>
-        <div className="p-8 text-center">
-          <p className="text-sm text-[#8E8E93]">Your cart is empty.</p>
-          <Link
-            href="/menu"
-            className="mt-4 inline-block rounded-full bg-[#A2492C] text-white px-5 py-3 font-bold active:opacity-80"
-          >
-            Browse menu →
-          </Link>
+        {/* Empty cart sells, not just says "empty" — espresso hero +
+            best-seller carousel, matching apps/pickup-native/app
+            /cart.tsx:121-245. */}
+        <div
+          className="mx-4 mt-4 overflow-hidden"
+          style={{
+            backgroundColor: "#160800",
+            borderRadius: 16,
+            boxShadow: "0 6px 14px rgba(22,8,0,0.18)",
+          }}
+        >
+          <div style={{ paddingLeft: 20, paddingRight: 20, paddingTop: 24, paddingBottom: 24 }}>
+            <span
+              className="flex items-center justify-center"
+              style={{ width: 48, height: 48, borderRadius: 24, backgroundColor: "#A2492C", marginBottom: 12 }}
+            >
+              <Coffee size={24} color="#FFFFFF" strokeWidth={2} />
+            </span>
+            <p
+              className="uppercase"
+              style={{ color: "#FBBF24", fontSize: 10, fontWeight: 700, letterSpacing: 2 }}
+            >
+              Cart&apos;s feeling thirsty
+            </p>
+            <p className="font-peachi font-bold" style={{ color: "#FFFFFF", fontSize: 24, marginTop: 4 }}>
+              Let&apos;s brew something
+            </p>
+            <p style={{ color: "rgba(255,255,255,0.7)", fontSize: 12, marginTop: 6, fontWeight: 500 }}>
+              Tap a favourite below or browse the full menu.
+            </p>
+            <Link
+              href="/menu"
+              className="inline-flex items-center gap-1 rounded-full active:opacity-80"
+              style={{ backgroundColor: "#FFFFFF", marginTop: 16, paddingLeft: 20, paddingRight: 20, paddingTop: 10, paddingBottom: 10 }}
+            >
+              <span className="font-peachi font-bold" style={{ color: "#1A0200", fontSize: 13 }}>
+                See what&apos;s brewing
+              </span>
+              <ChevronRight size={14} color="#1A0200" />
+            </Link>
+          </div>
         </div>
+
+        {bestSellers.length > 0 ? (
+          <div className="mt-6">
+            <p
+              className="uppercase px-4 mb-2"
+              style={{ color: "#1A0200", fontSize: 14, fontWeight: 700, letterSpacing: 1.5 }}
+            >
+              Start with these
+            </p>
+            <div
+              className="flex gap-3 px-4 overflow-x-auto pb-1"
+              style={{ scrollSnapType: "x mandatory", WebkitOverflowScrolling: "touch" }}
+            >
+              {bestSellers.map((p) => (
+                <Link
+                  key={p.id}
+                  href={`/product/${p.id}`}
+                  className="flex-shrink-0 bg-white overflow-hidden active:opacity-70"
+                  style={{
+                    width: 160,
+                    borderRadius: 16,
+                    border: "1px solid rgba(26,2,0,0.10)",
+                    boxShadow: "0 3px 8px rgba(0,0,0,0.06)",
+                    scrollSnapAlign: "start",
+                  }}
+                >
+                  <div className="relative bg-[#F2EDE5]" style={{ width: 160, height: 200 }}>
+                    {p.image ? (
+                      <Image src={p.image} alt={p.name} fill sizes="160px" className="object-cover" />
+                    ) : null}
+                  </div>
+                  <div style={{ paddingLeft: 12, paddingRight: 12, paddingTop: 10, paddingBottom: 10 }}>
+                    <p className="font-peachi font-bold truncate" style={{ color: "#1A0200", fontSize: 13 }}>
+                      {p.name}
+                    </p>
+                    <div className="flex items-center justify-between" style={{ marginTop: 4 }}>
+                      <span className="font-peachi font-bold" style={{ color: "#A2492C", fontSize: 14 }}>
+                        RM{p.basePrice.toFixed(2)}
+                      </span>
+                      <span
+                        className="rounded-full flex items-center justify-center"
+                        style={{ width: 24, height: 24, backgroundColor: "#160800" }}
+                      >
+                        <ChevronRight size={14} color="#FFFFFF" />
+                      </span>
+                    </div>
+                  </div>
+                </Link>
+              ))}
+            </div>
+          </div>
+        ) : null}
       </CartShell>
     );
   }

--- a/apps/order/src/app/cart/page.tsx
+++ b/apps/order/src/app/cart/page.tsx
@@ -1,15 +1,26 @@
 import { CartView } from "./_CartView";
 import { BottomNav } from "../_BottomNav";
+import { getMenuData } from "@/lib/menu-data";
 
 /**
  * Cart screen. Cart state lives in localStorage (the SPA's persisted
  * Zustand store), so the contents have to render client-side — see
- * _CartView. This page is just the route shell + chrome.
+ * _CartView. The page is a Server Component so it can fetch best-
+ * sellers for the empty-cart "Start with these" carousel.
  */
-export default function CartPage() {
+export const revalidate = 60;
+
+export default async function CartPage() {
+  const menu = await getMenuData();
+  const bestSellers = menu.products
+    .filter((p) => p.isPopular && p.isAvailable)
+    .sort((a, b) => (a.featuredPosition ?? 9999) - (b.featuredPosition ?? 9999))
+    .slice(0, 6)
+    .map((p) => ({ id: p.id, name: p.name, basePrice: p.basePrice, image: p.image }));
+
   return (
     <main className="bg-white text-[#160800] min-h-screen pb-[calc(env(safe-area-inset-bottom,0px)+88px)]">
-      <CartView />
+      <CartView bestSellers={bestSellers} />
       <BottomNav active="home" />
     </main>
   );

--- a/apps/order/src/app/referral/_ReferralView.tsx
+++ b/apps/order/src/app/referral/_ReferralView.tsx
@@ -2,23 +2,31 @@
 
 import { useEffect, useState } from "react";
 import Link from "next/link";
-import { ArrowLeft, Copy, Check, Users } from "lucide-react";
+import { ArrowLeft, Users, Share2 } from "lucide-react";
 
 /**
- * Referral page — share code + see signups. Wired to /api/loyalty/me
- * /referral (same as the SPA's referral screen).
+ * Referral — share-and-earn screen. Port of apps/pickup-native/app
+ * /referral.tsx: espresso hero with a 56×56 gold tile + 40px Peachi
+ * code + Share button, a 3-up Total/Pending/Rewarded stat row, a
+ * "How it works" 4-step card, and a recent-referrals list.
+ *
+ * Wired to /api/loyalty/me/referral (same endpoint as native's
+ * fetchMyReferral).
  */
+type RecentReferral = { created_at: string; status: string };
+
 type Referral = {
   code?: string | null;
   total_referred?: number;
-  reward_summary?: string | null;
+  pending?: number;
+  rewarded?: number;
+  recent?: RecentReferral[];
 };
 
 type Persisted = { state?: { sessionToken?: string | null } };
 
 export function ReferralView() {
   const [data, setData] = useState<Referral | null>(null);
-  const [copied, setCopied] = useState(false);
 
   useEffect(() => {
     let token: string | null = null;
@@ -35,16 +43,21 @@ export function ReferralView() {
       .catch(() => setData(null));
   }, []);
 
-  const copy = async () => {
+  const share = async () => {
     if (!data?.code) return;
+    const message = `Try Celsius Coffee with me ☕\nUse my code ${data.code} when you sign up — we both get a free drink.\n\nhttps://order.celsiuscoffee.com`;
     try {
-      await navigator.clipboard.writeText(data.code);
-      setCopied(true);
-      window.setTimeout(() => setCopied(false), 1500);
+      if (navigator.share) {
+        await navigator.share({ text: message });
+      } else {
+        await navigator.clipboard.writeText(data.code);
+      }
     } catch {
-      /* ignore */
+      /* user dismissed */
     }
   };
+
+  const recent = data?.recent ?? [];
 
   return (
     <>
@@ -55,49 +68,221 @@ export function ReferralView() {
         <Link href="/rewards" className="-ml-1 p-1 active:opacity-60" aria-label="Back">
           <ArrowLeft size={20} color="#FFFFFF" />
         </Link>
-        <h1 className="font-peachi font-bold text-[22px]">Refer a friend</h1>
+        <h1 className="font-peachi font-bold text-[22px]">Share &amp; Earn</h1>
       </header>
 
-      <section className="px-4 pt-5">
+      <div className="p-4">
+        {/* Hero — code + share */}
         <div
-          className="rounded-2xl bg-[#160800] text-white p-5"
-          style={{ minHeight: 140 }}
+          className="flex flex-col items-center text-center"
+          style={{
+            backgroundColor: "#1A0200",
+            borderRadius: 16,
+            paddingLeft: 24,
+            paddingRight: 24,
+            paddingTop: 32,
+            paddingBottom: 32,
+            boxShadow: "0 8px 18px rgba(26,2,0,0.18)",
+          }}
         >
           <span
             className="flex items-center justify-center"
-            style={{ width: 36, height: 36, borderRadius: 10, backgroundColor: "rgba(251,191,36,0.18)" }}
+            style={{
+              width: 56,
+              height: 56,
+              borderRadius: 16,
+              backgroundColor: "rgba(251,191,36,0.18)",
+              marginBottom: 14,
+            }}
           >
-            <Users size={18} color="#FBBF24" strokeWidth={1.8} />
+            <Users size={28} color="#FBBF24" strokeWidth={1.8} />
           </span>
-          <p className="mt-3 text-[10px] uppercase tracking-widest text-white/60">Your code</p>
-          <p className="mt-1 font-peachi font-bold text-3xl tracking-widest">
-            {data?.code ?? "—"}
+          <p
+            className="uppercase"
+            style={{
+              color: "rgba(251,191,36,0.85)",
+              fontSize: 10,
+              fontWeight: 700,
+              letterSpacing: 2,
+              marginBottom: 8,
+            }}
+          >
+            Your code
           </p>
-          {data?.reward_summary ? (
-            <p className="mt-3 text-[12px] text-white/70 leading-snug">
-              {data.reward_summary}
-            </p>
-          ) : null}
+          <button type="button" onClick={share} className="active:opacity-70">
+            <span
+              className="font-peachi font-bold"
+              style={{ color: "#FBBF24", fontSize: 40, letterSpacing: 4 }}
+            >
+              {data?.code ?? "—"}
+            </span>
+          </button>
           <button
             type="button"
-            onClick={copy}
+            onClick={share}
             disabled={!data?.code}
-            className={`mt-4 rounded-full px-4 py-2 text-[12px] font-bold flex items-center gap-2 active:opacity-80 ${
-              data?.code ? "bg-[#FBBF24] text-[#160800]" : "bg-white/15 text-white/50"
-            }`}
+            className="flex items-center gap-1.5 rounded-full active:opacity-80"
+            style={{
+              backgroundColor: "#A2492C",
+              marginTop: 20,
+              paddingLeft: 20,
+              paddingRight: 20,
+              paddingTop: 10,
+              paddingBottom: 10,
+              opacity: data?.code ? 1 : 0.5,
+            }}
           >
-            {copied ? <Check size={14} /> : <Copy size={14} />}
-            {copied ? "Copied" : "Copy code"}
+            <Share2 size={15} color="#FFFFFF" strokeWidth={2} />
+            <span className="font-peachi font-bold" style={{ color: "#FFFFFF", fontSize: 14 }}>
+              Share code
+            </span>
           </button>
         </div>
-      </section>
 
-      <section className="px-4 pt-5">
-        <p className="text-[11px] uppercase tracking-widest text-[#8E8E93] font-bold mb-1">
-          Friends signed up
-        </p>
-        <p className="font-peachi font-bold text-2xl">{data?.total_referred ?? 0}</p>
-      </section>
+        {/* Stats */}
+        <div className="flex mt-4" style={{ gap: 8 }}>
+          <StatCard label="Total" value={data?.total_referred ?? 0} />
+          <StatCard label="Pending" value={data?.pending ?? 0} tone="warn" />
+          <StatCard label="Rewarded" value={data?.rewarded ?? 0} tone="good" />
+        </div>
+
+        {/* How it works */}
+        <div
+          className="mt-4 bg-white"
+          style={{
+            border: "1px solid rgba(26,2,0,0.10)",
+            borderRadius: 16,
+            padding: 16,
+            boxShadow: "0 2px 6px rgba(0,0,0,0.04)",
+          }}
+        >
+          <p
+            className="uppercase"
+            style={{ color: "#1A0200", fontSize: 12, fontWeight: 700, letterSpacing: 1.5, marginBottom: 12 }}
+          >
+            How it works
+          </p>
+          <Step n={1} text="Share your code with a friend" />
+          <Step n={2} text="They sign up and enter your code" />
+          <Step n={3} text="They complete their first order" />
+          <Step n={4} text="Both of you get a free drink reward 🎉" last />
+        </div>
+
+        {/* Recent referrals */}
+        {recent.length > 0 ? (
+          <div
+            className="mt-4 bg-white"
+            style={{
+              border: "1px solid rgba(26,2,0,0.10)",
+              borderRadius: 16,
+              padding: 16,
+              boxShadow: "0 2px 6px rgba(0,0,0,0.04)",
+            }}
+          >
+            <p
+              className="uppercase"
+              style={{ color: "#1A0200", fontSize: 12, fontWeight: 700, letterSpacing: 1.5, marginBottom: 12 }}
+            >
+              Your referrals
+            </p>
+            {recent.slice(0, 10).map((r, i) => (
+              <div
+                key={i}
+                className="flex items-center justify-between"
+                style={{
+                  paddingTop: 10,
+                  paddingBottom: 10,
+                  borderBottom:
+                    i === Math.min(recent.length, 10) - 1
+                      ? "none"
+                      : "1px solid rgba(26,2,0,0.06)",
+                }}
+              >
+                <span style={{ color: "#6B6B6B", fontSize: 13, fontWeight: 500 }}>
+                  {new Date(r.created_at).toLocaleDateString("en-MY", {
+                    day: "numeric",
+                    month: "short",
+                    year: "numeric",
+                  })}
+                </span>
+                <span
+                  className="rounded-full uppercase"
+                  style={{
+                    paddingLeft: 8,
+                    paddingRight: 8,
+                    paddingTop: 3,
+                    paddingBottom: 3,
+                    fontSize: 10,
+                    fontWeight: 700,
+                    letterSpacing: 0.5,
+                    backgroundColor: r.status === "rewarded" ? "#E6F1DD" : "#FDF3E0",
+                    color: r.status === "rewarded" ? "#2F6A18" : "#8A6614",
+                  }}
+                >
+                  {r.status === "rewarded" ? "Rewarded" : "Pending order"}
+                </span>
+              </div>
+            ))}
+          </div>
+        ) : null}
+      </div>
     </>
+  );
+}
+
+function StatCard({
+  label,
+  value,
+  tone,
+}: {
+  label: string;
+  value: number;
+  tone?: "good" | "warn";
+}) {
+  const color = tone === "good" ? "#2F6A18" : tone === "warn" ? "#8A6614" : "#1A0200";
+  return (
+    <div
+      className="flex-1 bg-white"
+      style={{
+        border: "1px solid rgba(26,2,0,0.10)",
+        borderRadius: 16,
+        padding: 12,
+        boxShadow: "0 2px 6px rgba(0,0,0,0.04)",
+      }}
+    >
+      <p className="font-peachi font-bold" style={{ color, fontSize: 22 }}>
+        {value}
+      </p>
+      <p
+        className="uppercase"
+        style={{ color: "#6B6B6B", fontSize: 10, fontWeight: 700, letterSpacing: 1.2, marginTop: 2 }}
+      >
+        {label}
+      </p>
+    </div>
+  );
+}
+
+function Step({ n, text, last }: { n: number; text: string; last?: boolean }) {
+  return (
+    <div
+      className="flex items-center"
+      style={{
+        paddingTop: 8,
+        paddingBottom: 8,
+        gap: 12,
+        borderBottom: last ? "none" : "1px solid rgba(26,2,0,0.06)",
+      }}
+    >
+      <span
+        className="flex items-center justify-center flex-shrink-0"
+        style={{ width: 24, height: 24, borderRadius: 12, backgroundColor: "#FBEBE8" }}
+      >
+        <span className="font-peachi font-bold" style={{ color: "#A2492C", fontSize: 12 }}>
+          {n}
+        </span>
+      </span>
+      <span style={{ color: "#1A0200", fontSize: 13, fontWeight: 500 }}>{text}</span>
+    </div>
   );
 }

--- a/apps/order/src/app/settings/_SettingsView.tsx
+++ b/apps/order/src/app/settings/_SettingsView.tsx
@@ -2,11 +2,14 @@
 
 import { useEffect, useState } from "react";
 import Link from "next/link";
-import { ArrowLeft, Bell, BellOff, Shield, FileText, Trash2, ChevronRight } from "lucide-react";
+import { ArrowLeft, Bell, BellOff, Shield, CircleHelp, Trash2, ChevronRight } from "lucide-react";
 
 /**
- * Settings — push notifications + privacy + danger zone (account
- * delete). Mirrors apps/pickup-native/app/settings.tsx.
+ * Settings — divider-row list matching apps/pickup-native/app
+ * /settings.tsx: 36×36 rounded icon tile (#FBEBE8 / #FEE2E2 for
+ * destructive), 15px SpaceGrotesk label + 12px sub-text, top hairline
+ * between rows. Push-notifications toggle is web-only (native handles
+ * notifications through the OS) so it sits first as a toggle row.
  */
 export function SettingsView() {
   const [pushOn, setPushOn] = useState<boolean | null>(null);
@@ -25,8 +28,6 @@ export function SettingsView() {
       const r = await Notification.requestPermission();
       setPushOn(r === "granted");
     } else {
-      // Already granted or denied; the customer needs to flip it in
-      // browser settings. Open instructions instead.
       setPushOn(Notification.permission === "granted");
     }
   };
@@ -43,68 +44,118 @@ export function SettingsView() {
         <h1 className="font-peachi font-bold text-[22px]">Settings</h1>
       </header>
 
-      <section className="px-4 pt-5">
-        <h2 className="font-peachi font-bold text-[16px] mb-3">Notifications</h2>
+      <div className="px-4 py-3">
         <button
           type="button"
           onClick={togglePush}
-          className="w-full flex items-center gap-3 rounded-2xl border border-[#EBE5DE] bg-white px-4 py-3 active:opacity-80 text-left"
+          className="w-full flex items-center text-left active:opacity-70"
+          style={{ paddingTop: 14, paddingBottom: 14, gap: 12 }}
         >
-          {pushOn ? (
-            <Bell size={18} color="#A2492C" />
-          ) : (
-            <BellOff size={18} color="#8E8E93" />
-          )}
-          <div className="flex-1">
-            <p className="text-sm font-bold">Push notifications</p>
-            <p className="text-[11px] text-[#6E6E73] mt-0.5">
+          <span
+            className="flex items-center justify-center flex-shrink-0"
+            style={{ width: 36, height: 36, borderRadius: 18, backgroundColor: "#FBEBE8" }}
+          >
+            {pushOn ? (
+              <Bell size={16} color="#A2492C" strokeWidth={2} />
+            ) : (
+              <BellOff size={16} color="#A2492C" strokeWidth={2} />
+            )}
+          </span>
+          <span className="flex-1 min-w-0">
+            <span className="block" style={{ color: "#1A0200", fontSize: 15, fontWeight: 600 }}>
+              Push notifications
+            </span>
+            <span className="block" style={{ color: "rgba(26,2,0,0.55)", fontSize: 12, marginTop: 2 }}>
               {pushOn === null
                 ? "Loading…"
                 : pushOn
                 ? "On — order updates + rewards"
                 : "Off — tap to allow in your browser"}
-            </p>
-          </div>
-          <ChevronRight size={14} color="#8E8E93" />
-        </button>
-      </section>
-
-      <section className="px-4 pt-6">
-        <h2 className="font-peachi font-bold text-[16px] mb-3">Privacy &amp; terms</h2>
-        <ul className="flex flex-col gap-2">
-          <Row href="/privacy" Icon={Shield} label="Privacy policy" />
-          <Row href="/support" Icon={FileText} label="Help &amp; support" />
-        </ul>
-      </section>
-
-      <section className="px-4 pt-6">
-        <h2 className="font-peachi font-bold text-[16px] mb-3">Danger zone</h2>
-        <Link
-          href="/account-delete"
-          className="flex items-center gap-3 rounded-2xl border border-red-200 bg-red-50 px-4 py-3 active:opacity-80"
-        >
-          <Trash2 size={18} color="#B91C1C" />
-          <span className="text-sm font-bold flex-1" style={{ color: "#B91C1C" }}>
-            Delete my account
+            </span>
           </span>
-          <ChevronRight size={14} color="#B91C1C" />
-        </Link>
-      </section>
+          <ChevronRight size={16} color="#8E8E93" />
+        </button>
+
+        <SettingsRow
+          href="/support"
+          Icon={CircleHelp}
+          label="Support"
+          sub="WhatsApp us, FAQ, contact"
+        />
+        <SettingsRow
+          href="/privacy"
+          Icon={Shield}
+          label="Privacy policy"
+          sub="What we store and why"
+        />
+        <SettingsRow
+          href="/account-delete"
+          Icon={Trash2}
+          label="Delete account"
+          sub="Wipe all my data"
+          destructive
+        />
+      </div>
     </>
   );
 }
 
-function Row({ href, Icon, label }: { href: string; Icon: typeof Bell; label: string }) {
+function SettingsRow({
+  href,
+  Icon,
+  label,
+  sub,
+  destructive,
+}: {
+  href: string;
+  Icon: typeof Bell;
+  label: string;
+  sub?: string;
+  destructive?: boolean;
+}) {
   return (
-    <li>
-      <Link
-        href={href}
-        className="flex items-center gap-3 rounded-2xl border border-[#EBE5DE] bg-white px-4 py-3 active:opacity-80"
+    <Link
+      href={href}
+      className="flex items-center active:opacity-70"
+      style={{
+        paddingTop: 14,
+        paddingBottom: 14,
+        gap: 12,
+        borderTop: "1px solid rgba(26,2,0,0.08)",
+      }}
+    >
+      <span
+        className="flex items-center justify-center flex-shrink-0"
+        style={{
+          width: 36,
+          height: 36,
+          borderRadius: 18,
+          backgroundColor: destructive ? "#FEE2E2" : "#FBEBE8",
+        }}
       >
-        <Icon size={18} color="#8E8E93" />
-        <span className="text-sm font-bold flex-1">{label}</span>
-        <ChevronRight size={14} color="#8E8E93" />
-      </Link>
-    </li>
+        <Icon size={16} color={destructive ? "#B91C1C" : "#A2492C"} strokeWidth={2} />
+      </span>
+      <span className="flex-1 min-w-0">
+        <span
+          className="block"
+          style={{ color: destructive ? "#B91C1C" : "#1A0200", fontSize: 15, fontWeight: 600 }}
+        >
+          {label}
+        </span>
+        {sub ? (
+          <span
+            className="block"
+            style={{
+              color: destructive ? "rgba(185,28,28,0.65)" : "rgba(26,2,0,0.55)",
+              fontSize: 12,
+              marginTop: 2,
+            }}
+          >
+            {sub}
+          </span>
+        ) : null}
+      </span>
+      <ChevronRight size={16} color={destructive ? "#B91C1C" : "#8E8E93"} />
+    </Link>
   );
 }

--- a/apps/pickup-native/public/sw.js
+++ b/apps/pickup-native/public/sw.js
@@ -6,7 +6,7 @@
 //
 // Future rule of thumb: bump this on ANY production-affecting bundle
 // regression so customers don't get stuck on a bad build.
-const CACHE = "celsius-v23";
+const CACHE = "celsius-v24";
 const SHELL = ["/", "/index.html", "/manifest.json"];
 
 self.addEventListener("install", (e) => {


### PR DESCRIPTION
## Summary
Three more native-parity fixes from a full-screen audit:

1. **Empty cart** — replaced the plain "Your cart is empty" line with the native espresso hero (48×48 terracotta circle + Coffee icon, "Cart's feeling thirsty" gold eyebrow, "Let's brew something" Peachi 24, "See what's brewing" pill) plus a "Start with these" best-seller carousel (160×200 cards). Cart page is now a Server Component fetching best-sellers.
2. **Referral** — rebuilt to native's share-and-earn screen: centred espresso hero (56×56 gold tile, 40px Peachi amber code, "Share code" via Web Share API), 3-up Total/Pending/Rewarded stat row, "How it works" 4-step card, recent-referrals list with status chips. Title → "Share & Earn".
3. **Settings** — switched to native's divider-row pattern: 36×36 icon tiles, 15px label + 12px sub-text, top hairline. Push toggle stays as a web-only first row.

Bumps SW cache to v24.

## Test plan
- [ ] Empty `/cart` → espresso hero + best-seller carousel scrolls horizontally.
- [ ] `/referral` signed-in → code hero, stat row, steps, recent list; "Share code" opens the share sheet (or copies).
- [ ] `/settings` → divider rows with terracotta icon tiles + sub-text.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xd1aERynqUbdCqXNboKWBe)_