### PR TITLE
fix(web/challenge): full detail screen matching native

### DIFF
--- a/apps/order/public/sw.js
+++ b/apps/order/public/sw.js
@@ -1,7 +1,7 @@
 // Mirror of apps/pickup-native/public/sw.js — overwritten on each
 // build-pwa run. v3 bumps over v2 to flush customers off the broken
 // CSS shipped in #157/#158 before this revert deployed.
-const CACHE = "celsius-v27";
+const CACHE = "celsius-v28";
 const SHELL = ["/", "/index.html", "/manifest.json"];
 
 self.addEventListener("install", (e) => {

--- a/apps/order/src/app/challenge/[id]/_ChallengeView.tsx
+++ b/apps/order/src/app/challenge/[id]/_ChallengeView.tsx
@@ -2,13 +2,14 @@
 
 import { useEffect, useState } from "react";
 import Link from "next/link";
-import { ArrowLeft, Sparkles } from "lucide-react";
+import { ArrowLeft, Sparkles, Gift, Target, Coffee, Cookie, Tag } from "lucide-react";
 
 /**
- * Single challenge detail — reads the full mission record from
- * /api/loyalty/me/missions/active (filtered to the assignmentId), shows
- * progress, reward, and tips. Matches the SPA's challenge detail
- * screen layout.
+ * Single challenge detail — port of apps/pickup-native/app/challenge
+ * /[id]/index.tsx. Espresso hero card + gold reward callout + white
+ * progress card (big Peachi label + bar) + "How it works" rule list +
+ * time-remaining footer. Reads the mission from /api/loyalty/me
+ * /missions/active filtered to the assignmentId.
  */
 type Mission = {
   assignment_id: string;
@@ -21,12 +22,99 @@ type Mission = {
   goal_threshold?: number;
   progress_current?: number;
   expires_at?: string | null;
+  week_end_at?: string | null;
 };
 
 type Persisted = { state?: { sessionToken?: string | null } };
 
+// THEME_CHALLENGE — apps/pickup-native/components/VoucherWallet.tsx
+const THEME = {
+  bg: "#1A0200",
+  accent: "#FBBF24",
+  fg: "#FFFFFF",
+  fgDim: "rgba(255,255,255,0.65)",
+  iconBg: "rgba(251,191,36,0.20)",
+  iconColor: "#FBBF24",
+};
+
+function progressLabel(m: Mission): string {
+  const cur = m.progress_current ?? 0;
+  const goal = m.goal_threshold ?? 0;
+  if (m.goal_type === "single_order_total_at_least") {
+    return `RM${Math.floor(cur / 100)} of RM${Math.floor(goal / 100)}`;
+  }
+  return `${cur} of ${goal}`;
+}
+
+function remainingHint(m: Mission): string {
+  const remaining = Math.max(0, (m.goal_threshold ?? 0) - (m.progress_current ?? 0));
+  if (remaining === 0) return "You're done — claim your reward!";
+  if (m.goal_type === "single_order_total_at_least") {
+    return `RM${Math.ceil(remaining / 100)} more to unlock`;
+  }
+  return remaining === 1 ? "1 more to unlock" : `${remaining} more to unlock`;
+}
+
+function expiryCopy(iso: string | null | undefined): { label: string; urgent: boolean } | null {
+  if (!iso) return null;
+  const ms = new Date(iso).getTime() - Date.now();
+  if (ms <= 0) return { label: "Challenge ended", urgent: true };
+  const hours = Math.ceil(ms / (1000 * 60 * 60));
+  if (hours <= 24) return { label: `Ends in ${hours}h`, urgent: true };
+  const days = Math.ceil(hours / 24);
+  return { label: `Ends in ${days}d`, urgent: days <= 1 };
+}
+
+function howToWin(m: Mission): string[] {
+  const goal = m.goal_threshold ?? 0;
+  switch (m.goal_type) {
+    case "single_order_total_at_least":
+      return [
+        `Spend at least RM${Math.floor(goal / 100)} in a single order.`,
+        "Add-ons, sides and pastries all count toward the total.",
+        "Discounts and vouchers don't reduce the qualifying amount.",
+      ];
+    case "drinks_count":
+    case "cups_count":
+      return [
+        `Order ${goal} drinks before the challenge ends.`,
+        "Drinks can be on the same order or split across visits.",
+        "Both hot and iced count.",
+      ];
+    case "distinct_products":
+    case "distinct_drinks_count":
+      return [
+        `Try ${goal} different items you haven't ordered before.`,
+        "We only count the first time you ever buy a given item.",
+        "Both drinks and food count unless the description says otherwise.",
+      ];
+    case "single_order_items_count":
+      return [
+        `Order ${goal}+ items in a single transaction.`,
+        "Each individual cup or plate counts as one item.",
+        "Mix and match across drinks and food.",
+      ];
+    case "drink_and_food":
+      return [
+        "Order at least one drink and one food item in the same order.",
+        "Roti bakar, pastries and cakes all count as food.",
+      ];
+    default:
+      return m.description ? [m.description] : [];
+  }
+}
+
+function rewardIcon(label?: string | null): typeof Gift {
+  const s = (label ?? "").toLowerCase();
+  if (/free|drink|coffee|latte|brew/.test(s)) return Coffee;
+  if (/cookie|pastry|cake|food/.test(s)) return Cookie;
+  if (/rm|%|off|discount/.test(s)) return Tag;
+  return Gift;
+}
+
 export function ChallengeView({ assignmentId }: { assignmentId: string }) {
   const [mission, setMission] = useState<Mission | null>(null);
+  const [loaded, setLoaded] = useState(false);
 
   useEffect(() => {
     let token: string | null = null;
@@ -36,19 +124,32 @@ export function ChallengeView({ assignmentId }: { assignmentId: string }) {
     } catch {
       /* ignore */
     }
-    if (!token) return;
+    if (!token) {
+      setLoaded(true);
+      return;
+    }
     fetch("/api/loyalty/me/missions/active", {
       headers: { Authorization: `Bearer ${token}` },
     })
       .then((r) => (r.ok ? r.json() : []))
       .then((data) => {
         const list = (Array.isArray(data) ? data : (data?.missions ?? [])) as Mission[];
-        setMission(list.find((m) => m.assignment_id === assignmentId) ?? null);
+        setMission(list.find((m) => (m.assignment_id ?? m.id) === assignmentId) ?? null);
       })
       .catch(() => {
         /* ignore */
-      });
+      })
+      .finally(() => setLoaded(true));
   }, [assignmentId]);
+
+  const isCompleted = mission?.status === "completed";
+  const isExpired = mission?.status === "expired";
+  const ratio = mission
+    ? Math.min(1, (mission.progress_current ?? 0) / Math.max(1, mission.goal_threshold ?? 1))
+    : 0;
+  const Icon = rewardIcon(mission?.reward_summary);
+  const expiry = expiryCopy(mission?.week_end_at ?? mission?.expires_at);
+  const rules = mission ? howToWin(mission) : [];
 
   return (
     <>
@@ -62,83 +163,216 @@ export function ChallengeView({ assignmentId }: { assignmentId: string }) {
         <h1 className="font-peachi font-bold text-[22px] truncate">Challenge</h1>
       </header>
 
-      {!mission ? (
+      {!loaded ? (
         <div className="p-8 text-center text-[#8E8E93] text-sm">Loading…</div>
+      ) : !mission ? (
+        <div className="flex flex-col items-center justify-center px-8 py-20 text-center">
+          <p className="font-peachi font-bold text-xl" style={{ color: "#1A0200" }}>
+            Challenge not found
+          </p>
+          <p className="mt-2 text-sm" style={{ color: "rgba(26,2,0,0.65)" }}>
+            It may have already expired or rolled over to a new week.
+          </p>
+          <Link
+            href="/rewards"
+            className="mt-6 rounded-full bg-[#A2492C] text-white px-5 py-3 font-bold active:opacity-80"
+          >
+            Back to rewards
+          </Link>
+        </div>
       ) : (
-        <>
-          <section className="px-4 pt-5">
+        <div className="px-4">
+          {/* Hero card */}
+          <div
+            className="relative overflow-hidden"
+            style={{
+              marginTop: 16,
+              borderRadius: 22,
+              backgroundColor: THEME.bg,
+              border: `1px solid ${isCompleted ? THEME.accent : THEME.bg}`,
+              opacity: isExpired ? 0.55 : 1,
+              padding: 20,
+            }}
+          >
+            <div className="flex items-center" style={{ gap: 14 }}>
+              <span
+                className="flex items-center justify-center flex-shrink-0"
+                style={{ width: 64, height: 64, borderRadius: 16, backgroundColor: THEME.iconBg }}
+              >
+                <Icon size={32} color={THEME.iconColor} strokeWidth={2} />
+              </span>
+              <div className="flex-1 min-w-0">
+                <p
+                  className="uppercase"
+                  style={{ color: THEME.accent, fontSize: 10, fontWeight: 700, letterSpacing: 1.6 }}
+                >
+                  Challenge{isCompleted ? " · Done" : isExpired ? " · Missed" : ""}
+                </p>
+                <p
+                  className="font-peachi font-bold"
+                  style={{ color: THEME.fg, fontSize: 22, lineHeight: "26px", marginTop: 3 }}
+                >
+                  {mission.title}
+                </p>
+              </div>
+            </div>
+            {mission.description ? (
+              <p style={{ color: THEME.fgDim, fontSize: 14, lineHeight: "20px", marginTop: 16, fontWeight: 500 }}>
+                {mission.description}
+              </p>
+            ) : null}
+          </div>
+
+          {/* Reward callout */}
+          {mission.reward_summary ? (
             <div
-              className="rounded-2xl p-5"
-              style={{ backgroundColor: "#1A0200", color: "#FFFFFF" }}
+              className="flex items-center"
+              style={{
+                marginTop: 14,
+                borderRadius: 18,
+                backgroundColor: "#FFFBEA",
+                border: "1px solid rgba(217,148,4,0.30)",
+                padding: 16,
+                gap: 12,
+              }}
             >
               <span
-                className="flex items-center justify-center"
-                style={{
-                  width: 40,
-                  height: 40,
-                  borderRadius: 12,
-                  backgroundColor: "rgba(251,191,36,0.18)",
-                }}
+                className="flex items-center justify-center flex-shrink-0"
+                style={{ width: 44, height: 44, borderRadius: 12, backgroundColor: "rgba(217,148,4,0.18)" }}
               >
-                <Sparkles size={20} color="#FBBF24" strokeWidth={1.8} />
+                <Gift size={22} color="#D99404" strokeWidth={2.2} />
               </span>
-              <p
-                className="mt-3 font-peachi font-bold text-2xl"
-                style={{ letterSpacing: -0.3 }}
-              >
-                {mission.title}
-              </p>
-              {mission.description ? (
-                <p className="mt-1 text-[13px] text-white/70 leading-snug">
-                  {mission.description}
-                </p>
-              ) : null}
-              {mission.reward_summary ? (
+              <div className="flex-1 min-w-0">
                 <p
-                  className="mt-3 text-[11px] uppercase tracking-widest font-bold"
-                  style={{ color: "#FBBF24" }}
+                  className="uppercase"
+                  style={{ color: "#A37200", fontSize: 10, fontWeight: 700, letterSpacing: 1.4 }}
                 >
-                  Reward · {mission.reward_summary}
+                  {isCompleted ? "You earned" : "You'll earn"}
                 </p>
-              ) : null}
+                <p
+                  className="font-peachi font-bold"
+                  style={{ color: "#1A0200", fontSize: 17, lineHeight: "22px", marginTop: 2 }}
+                >
+                  {mission.reward_summary}
+                </p>
+              </div>
             </div>
-          </section>
+          ) : null}
 
-          <section className="px-4 pt-5">
-            <h2 className="font-peachi font-bold text-[16px] mb-2">Progress</h2>
-            <Progress mission={mission} />
-          </section>
+          {/* Progress */}
+          <div
+            style={{
+              marginTop: 14,
+              borderRadius: 18,
+              backgroundColor: "#FFFFFF",
+              border: "1px solid rgba(0,0,0,0.06)",
+              padding: 16,
+            }}
+          >
+            <div className="flex items-center" style={{ gap: 8 }}>
+              <Target size={16} color="#1A0200" strokeWidth={2.4} />
+              <span
+                className="uppercase"
+                style={{ color: "#1A0200", fontSize: 10.5, fontWeight: 700, letterSpacing: 1.4 }}
+              >
+                Your progress
+              </span>
+            </div>
+            <p
+              className="font-peachi font-bold"
+              style={{ color: "#1A0200", fontSize: 28, lineHeight: "32px", marginTop: 10 }}
+            >
+              {progressLabel(mission)}
+            </p>
+            <p
+              style={{
+                fontSize: 12,
+                marginTop: 2,
+                fontWeight: 500,
+                color: isCompleted ? "#1F7A33" : "rgba(26,2,0,0.55)",
+              }}
+            >
+              {isExpired ? "This challenge has ended." : remainingHint(mission)}
+            </p>
+            <div
+              style={{
+                marginTop: 12,
+                height: 8,
+                borderRadius: 4,
+                backgroundColor: "rgba(0,0,0,0.08)",
+                overflow: "hidden",
+              }}
+            >
+              <div
+                style={{
+                  width: `${Math.round(ratio * 100)}%`,
+                  height: "100%",
+                  backgroundColor: isCompleted ? "#1F7A33" : "#D99404",
+                  borderRadius: 4,
+                }}
+              />
+            </div>
+          </div>
 
-          {mission.expires_at ? (
-            <p className="px-4 pt-4 text-[11px] text-[#8E8E93]">
-              Ends {new Date(mission.expires_at).toLocaleDateString("en-MY", { day: "numeric", month: "short" })}
+          {/* How it works */}
+          {rules.length > 0 ? (
+            <div
+              style={{
+                marginTop: 14,
+                borderRadius: 18,
+                backgroundColor: "#FFFFFF",
+                border: "1px solid rgba(0,0,0,0.06)",
+                padding: 16,
+              }}
+            >
+              <div className="flex items-center" style={{ gap: 8 }}>
+                <Sparkles size={16} color="#1A0200" strokeWidth={2.4} />
+                <span
+                  className="uppercase"
+                  style={{ color: "#1A0200", fontSize: 10.5, fontWeight: 700, letterSpacing: 1.4 }}
+                >
+                  How it works
+                </span>
+              </div>
+              <div style={{ marginTop: 10 }} className="flex flex-col gap-2">
+                {rules.map((line, idx) => (
+                  <div key={idx} className="flex items-start" style={{ gap: 8 }}>
+                    <span
+                      style={{
+                        width: 6,
+                        height: 6,
+                        borderRadius: 3,
+                        backgroundColor: "#D99404",
+                        marginTop: 7,
+                        flexShrink: 0,
+                      }}
+                    />
+                    <span style={{ color: "rgba(26,2,0,0.80)", fontSize: 13.5, lineHeight: "20px", fontWeight: 500 }}>
+                      {line}
+                    </span>
+                  </div>
+                ))}
+              </div>
+            </div>
+          ) : null}
+
+          {/* Time remaining */}
+          {expiry ? (
+            <p
+              className="text-center"
+              style={{
+                marginTop: 14,
+                fontSize: 12,
+                fontWeight: 600,
+                color: expiry.urgent ? "#B91C1C" : "#8E8E93",
+              }}
+            >
+              {expiry.label}
             </p>
           ) : null}
-        </>
+          <div className="h-8" />
+        </div>
       )}
     </>
-  );
-}
-
-function Progress({ mission }: { mission: Mission }) {
-  const current = mission.progress_current ?? 0;
-  const target = mission.goal_threshold ?? 1;
-  const pct = Math.min(1, current / target);
-
-  const display =
-    mission.goal_type === "single_order_total_at_least"
-      ? `RM${Math.floor(current / 100)} / RM${Math.floor(target / 100)}`
-      : `${current} / ${target}`;
-
-  return (
-    <div>
-      <div className="h-2.5 rounded-full bg-[#EBE5DE] overflow-hidden">
-        <div
-          className="h-full"
-          style={{ width: `${Math.round(pct * 100)}%`, backgroundColor: "#A2492C" }}
-        />
-      </div>
-      <p className="mt-2 text-sm font-bold">{display}</p>
-    </div>
   );
 }

--- a/apps/pickup-native/public/sw.js
+++ b/apps/pickup-native/public/sw.js
@@ -6,7 +6,7 @@
 //
 // Future rule of thumb: bump this on ANY production-affecting bundle
 // regression so customers don't get stuck on a bad build.
-const CACHE = "celsius-v27";
+const CACHE = "celsius-v28";
 const SHELL = ["/", "/index.html", "/manifest.json"];
 
 self.addEventListener("install", (e) => {


### PR DESCRIPTION
## Summary
Rebuilt the challenge detail screen (`/challenge/[id]`) to match `apps/pickup-native/app/challenge/[id]/index.tsx`. It was a thin espresso card + plain bar; now:

- **Hero card** — 22px radius, gold-tinted 64×64 reward-icon tile, "Challenge · Done/Missed" eyebrow, 22/26 Peachi title, description in dimmed white. Completed gets a gold border; expired dims to 55%.
- **Reward callout** — cream/gold card, "You'll earn / You earned" + reward title.
- **Progress card** — Target eyebrow, big 28px Peachi "X of Y", remaining-hint, 8px bar (gold in-progress / green done).
- **"How it works"** — per-`goal_type` bullet rules (same copy as native's `howToWin`).
- **Time-remaining footer** + a "Challenge not found" empty state for expired/rolled-over links.

Bumps SW cache to v28.

## Test plan
- [ ] Tap a challenge from home/rewards → hero + reward + progress + rules render; progress bar matches; rules match the goal type.
- [ ] Open a stale challenge id → "Challenge not found" with a back-to-rewards CTA.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xd1aERynqUbdCqXNboKWBe)_