### PR TITLE
fix(web/support): native content + contact cards

### DIFF
--- a/apps/order/public/sw.js
+++ b/apps/order/public/sw.js
@@ -1,7 +1,7 @@
 // Mirror of apps/pickup-native/public/sw.js — overwritten on each
 // build-pwa run. v3 bumps over v2 to flush customers off the broken
 // CSS shipped in #157/#158 before this revert deployed.
-const CACHE = "celsius-v28";
+const CACHE = "celsius-v29";
 const SHELL = ["/", "/index.html", "/manifest.json"];
 
 self.addEventListener("install", (e) => {

--- a/apps/order/src/app/support/page.tsx
+++ b/apps/order/src/app/support/page.tsx
@@ -1,11 +1,11 @@
 import Link from "next/link";
-import { ArrowLeft, MessageCircle, Phone, Mail, HelpCircle } from "lucide-react";
+import { ArrowLeft, Mail, AtSign, ChevronRight } from "lucide-react";
 import { BottomNav } from "../_BottomNav";
 
 /**
- * Support / help — content matches the SPA's support screen
- * (apps/pickup-native/app/support.tsx). FAQ + contact channels. All
- * static content so a Server Component is enough.
+ * Support / help — ports apps/pickup-native/app/support.tsx: intro,
+ * email + Instagram contact cards, a 7-entry FAQ, and an "About
+ * Celsius Coffee" block. All static so a Server Component is enough.
  */
 export default function SupportPage() {
   return (
@@ -20,72 +20,161 @@ export default function SupportPage() {
         <h1 className="font-peachi font-bold text-[22px]">Support</h1>
       </header>
 
-      <section className="px-4 pt-5">
-        <h2 className="font-peachi font-bold text-[16px] mb-3">Get in touch</h2>
-        <ul className="flex flex-col gap-2">
-          <ContactRow Icon={MessageCircle} label="Message us on WhatsApp" href="https://wa.me/60123456789" />
-          <ContactRow Icon={Phone} label="Call the store" href="tel:+60123456789" />
-          <ContactRow Icon={Mail} label="Email celsiuscoffee" href="mailto:hello@celsiuscoffee.com" />
-        </ul>
-      </section>
+      <div className="px-5 py-5 flex flex-col" style={{ gap: 24 }}>
+        <div>
+          <h2 className="font-peachi font-bold text-xl" style={{ color: "#1A0200" }}>
+            How can we help?
+          </h2>
+          <p className="text-xs mt-1" style={{ color: "#6B6B6B" }}>
+            Help with your account, orders, and rewards.
+          </p>
+        </div>
 
-      <section className="px-4 pt-6">
-        <h2 className="font-peachi font-bold text-[16px] mb-3">Common questions</h2>
-        <ul className="flex flex-col gap-3">
-          <Faq
-            q="How do I redeem a reward?"
-            a="Go to the Rewards tab, tap Apply on the reward you want — it'll be applied at checkout. Show the barista the order on pickup; the discount is automatic."
+        <div>
+          <p className="font-peachi font-bold text-[15px] mb-2" style={{ color: "#1A0200" }}>
+            Contact us
+          </p>
+          <p className="text-[13px] mb-3" style={{ color: "#1A0200", lineHeight: "20px" }}>
+            The fastest way to reach us is by email. We reply within one business day, Mon–Fri.
+          </p>
+
+          <ContactCard
+            Icon={Mail}
+            label="Email us"
+            sub="barista@celsiuscoffee.com"
+            href="mailto:barista@celsiuscoffee.com"
           />
-          <Faq
-            q="How long does pickup take?"
-            a="Most orders are ready in 5–15 minutes. The home screen shows the live ETA for your chosen outlet."
+          <div style={{ height: 8 }} />
+          <ContactCard
+            Icon={AtSign}
+            label="Instagram"
+            sub="@celsiuscoffeemy"
+            href="https://instagram.com/celsiuscoffeemy"
           />
-          <Faq
-            q="Can I cancel an order?"
-            a="Open the order in the Orders tab. If it's still pending, you can cancel — once the barista starts preparing, contact the store directly."
-          />
-          <Faq
-            q="Where are your outlets?"
-            a="Shah Alam, Conezion (Putrajaya), Tamarind Square, and Nilai. Tap the outlet picker on the home screen for full addresses."
-          />
-        </ul>
-      </section>
+        </div>
+
+        <div>
+          <p className="font-peachi font-bold text-[15px] mb-3" style={{ color: "#1A0200" }}>
+            Common questions
+          </p>
+          <Faq q="I didn't receive my OTP code">
+            OTP codes are sent by SMS and usually arrive within 30 seconds. Check signal, wait a minute, then tap Resend code. If still nothing, email us with your phone number.
+          </Faq>
+          <Faq q="My order didn't go through">
+            If your payment was charged but the order didn't appear, show your bank notification to a barista at the outlet — they can manually fulfil or refund. For failed payments, no money was taken; just try again.
+          </Faq>
+          <Faq q="My loyalty points are missing">
+            Points are awarded after the order is marked complete by outlet staff. If they don't show up after 24 hours, email us with your phone number and visit details and we'll credit them manually.
+          </Faq>
+          <Faq q="How do I redeem a reward?">
+            Go to the Rewards tab, tap Apply on the reward you want — it'll be applied at checkout. Show the barista the order on pickup; the discount is automatic.
+          </Faq>
+          <Faq q="How do I update my profile?">
+            Account → tap your profile to edit name, email, birthday. To change phone, email barista@celsiuscoffee.com from your registered email — phone changes need extra verification.
+          </Faq>
+          <Faq q="Stop promotional SMS">
+            Reply STOP to any promotional message. Transactional messages like OTP codes will continue. You can also opt out by emailing us.
+          </Faq>
+          <FaqLink q="How do I delete my account?" href="/account-delete">
+            Tap to see deletion options.
+          </FaqLink>
+        </div>
+
+        <div>
+          <p className="font-peachi font-bold text-[15px] mb-2" style={{ color: "#1A0200" }}>
+            About Celsius Coffee
+          </p>
+          <p className="text-[13px]" style={{ color: "#1A0200", lineHeight: "20px" }}>
+            Celsius Coffee Sdn. Bhd. is a Malaysian specialty coffee brand. Find us at
+            celsiuscoffee.com and on Instagram @celsiuscoffeemy.
+          </p>
+        </div>
+
+        <p
+          className="text-[11px]"
+          style={{ color: "#6B6B6B", lineHeight: "16px", borderTop: "1px solid rgba(26,2,0,0.10)", paddingTop: 16 }}
+        >
+          See our{" "}
+          <Link href="/privacy" className="underline">
+            Privacy Policy
+          </Link>{" "}
+          for details on how we handle your personal data.
+        </p>
+      </div>
 
       <BottomNav active="account" />
     </main>
   );
 }
 
-function ContactRow({
+function ContactCard({
   Icon,
   label,
+  sub,
   href,
 }: {
-  Icon: typeof MessageCircle;
+  Icon: typeof Mail;
   label: string;
+  sub: string;
   href: string;
 }) {
   return (
-    <li>
-      <a
-        href={href}
-        className="flex items-center gap-3 rounded-2xl border border-[#EBE5DE] bg-white px-4 py-3 active:opacity-80"
+    <a
+      href={href}
+      className="flex items-center bg-white active:opacity-70"
+      style={{ border: "1px solid rgba(26,2,0,0.10)", borderRadius: 16, padding: 12, gap: 12 }}
+    >
+      <span
+        className="flex items-center justify-center flex-shrink-0"
+        style={{ width: 40, height: 40, borderRadius: 8, backgroundColor: "rgba(162,73,44,0.10)" }}
       >
-        <Icon size={18} color="#A2492C" />
-        <span className="text-sm font-bold flex-1">{label}</span>
-      </a>
-    </li>
+        <Icon size={18} color="#A2492C" strokeWidth={1.75} />
+      </span>
+      <span className="flex-1 min-w-0">
+        <span className="block font-peachi font-bold text-[14px]" style={{ color: "#1A0200" }}>
+          {label}
+        </span>
+        <span className="block text-[12px]" style={{ color: "#6B6B6B" }}>
+          {sub}
+        </span>
+      </span>
+      <ChevronRight size={16} color="#8E8E93" />
+    </a>
   );
 }
 
-function Faq({ q, a }: { q: string; a: string }) {
+function Faq({ q, children }: { q: string; children: React.ReactNode }) {
   return (
-    <li className="rounded-2xl bg-white border border-[#EBE5DE] p-4">
-      <p className="font-peachi font-bold text-[14px] flex items-start gap-2">
-        <HelpCircle size={16} className="text-[#A2492C] mt-0.5 flex-shrink-0" />
+    <div
+      className="bg-white"
+      style={{ border: "1px solid rgba(26,2,0,0.10)", borderRadius: 16, padding: 12, marginBottom: 8 }}
+    >
+      <p className="font-peachi font-bold text-[13px]" style={{ color: "#1A0200" }}>
         {q}
       </p>
-      <p className="text-[13px] text-[#6E6E73] leading-snug mt-2">{a}</p>
-    </li>
+      <p className="text-[12px] mt-1" style={{ color: "#6B6B6B", lineHeight: "18px" }}>
+        {children}
+      </p>
+    </div>
+  );
+}
+
+function FaqLink({ q, href, children }: { q: string; href: string; children: React.ReactNode }) {
+  return (
+    <Link
+      href={href}
+      className="block bg-white active:opacity-70"
+      style={{ border: "1px solid rgba(26,2,0,0.10)", borderRadius: 16, padding: 12, marginBottom: 8 }}
+    >
+      <span className="flex items-center gap-2">
+        <span className="font-peachi font-bold text-[13px] flex-1" style={{ color: "#1A0200" }}>
+          {q}
+        </span>
+        <ChevronRight size={14} color="#8E8E93" />
+      </span>
+      <p className="text-[12px] mt-1" style={{ color: "#6B6B6B", lineHeight: "18px" }}>
+        {children}
+      </p>
+    </Link>
   );
 }

--- a/apps/pickup-native/public/sw.js
+++ b/apps/pickup-native/public/sw.js
@@ -6,7 +6,7 @@
 //
 // Future rule of thumb: bump this on ANY production-affecting bundle
 // regression so customers don't get stuck on a bad build.
-const CACHE = "celsius-v28";
+const CACHE = "celsius-v29";
 const SHELL = ["/", "/index.html", "/manifest.json"];
 
 self.addEventListener("install", (e) => {


### PR DESCRIPTION
## Summary
Support page now matches `apps/pickup-native/app/support.tsx`: "How can we help?" intro, a "Contact us" lead + Email (barista@celsiuscoffee.com) and Instagram (@celsiuscoffeemy) cards with terracotta-tint icon tiles, the 7 real FAQ entries (OTP, failed order, missing points, redeem reward, update profile, stop SMS, delete account → links to /account-delete), an "About Celsius Coffee" block, and a privacy-policy footer line. Was 3 WhatsApp/Call/Email rows + 4 generic FAQs.

Bumps SW cache to v29.

## Test plan
- [ ] `/support` → intro, Email + Instagram cards (tap opens mailto / IG), 7 FAQs, About block; "How do I delete my account?" links to /account-delete.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xd1aERynqUbdCqXNboKWBe)_