### PR TITLE
fix(web): repair checkout order-creation wiring + account-delete/wrapped rebuilds

### DIFF
--- a/apps/order/public/sw.js
+++ b/apps/order/public/sw.js
@@ -1,7 +1,7 @@
 // Mirror of apps/pickup-native/public/sw.js — overwritten on each
 // build-pwa run. v3 bumps over v2 to flush customers off the broken
 // CSS shipped in #157/#158 before this revert deployed.
-const CACHE = "celsius-v32";
+const CACHE = "celsius-v33";
 const SHELL = ["/", "/index.html", "/manifest.json"];
 
 self.addEventListener("install", (e) => {

--- a/apps/order/public/sw.js
+++ b/apps/order/public/sw.js
@@ -1,7 +1,7 @@
 // Mirror of apps/pickup-native/public/sw.js — overwritten on each
 // build-pwa run. v3 bumps over v2 to flush customers off the broken
 // CSS shipped in #157/#158 before this revert deployed.
-const CACHE = "celsius-v31";
+const CACHE = "celsius-v32";
 const SHELL = ["/", "/index.html", "/manifest.json"];
 
 self.addEventListener("install", (e) => {

--- a/apps/order/public/sw.js
+++ b/apps/order/public/sw.js
@@ -1,7 +1,7 @@
 // Mirror of apps/pickup-native/public/sw.js — overwritten on each
 // build-pwa run. v3 bumps over v2 to flush customers off the broken
 // CSS shipped in #157/#158 before this revert deployed.
-const CACHE = "celsius-v30";
+const CACHE = "celsius-v31";
 const SHELL = ["/", "/index.html", "/manifest.json"];
 
 self.addEventListener("install", (e) => {

--- a/apps/order/public/sw.js
+++ b/apps/order/public/sw.js
@@ -1,7 +1,7 @@
 // Mirror of apps/pickup-native/public/sw.js — overwritten on each
 // build-pwa run. v3 bumps over v2 to flush customers off the broken
 // CSS shipped in #157/#158 before this revert deployed.
-const CACHE = "celsius-v33";
+const CACHE = "celsius-v34";
 const SHELL = ["/", "/index.html", "/manifest.json"];
 
 self.addEventListener("install", (e) => {

--- a/apps/order/src/app/account-delete/_AccountDeleteView.tsx
+++ b/apps/order/src/app/account-delete/_AccountDeleteView.tsx
@@ -2,29 +2,45 @@
 
 import { useState } from "react";
 import Link from "next/link";
-import { ArrowLeft, AlertTriangle } from "lucide-react";
+import { ArrowLeft, Trash2, AlertTriangle } from "lucide-react";
 
 /**
- * Account delete flow. Wired to POST /api/members/delete with member
- * id + phone, mirrors the SPA's deletion path. Confirmation step
- * requires the customer to type 'delete' to avoid taps.
+ * Account & data deletion — ports apps/pickup-native/app
+ * /account-delete.tsx: a PDPA data-deletion policy page (espresso /
+ * primary, not destructive-red) with "What gets deleted" + "Important
+ * note" sections, a trigger card that opens a typed-DELETE confirm
+ * modal, and a privacy footnote. Wired to POST /api/members/delete.
  */
+type Persisted = { state?: { loyaltyId?: string | null; phone?: string | null } };
+
 export function AccountDeleteView() {
-  const [confirm, setConfirm] = useState("");
-  const [busy, setBusy] = useState(false);
+  const [signedIn] = useState(() => {
+    try {
+      const raw = window.localStorage.getItem("celsius-pickup");
+      if (!raw) return false;
+      const s = (JSON.parse(raw) as Persisted).state;
+      return !!(s?.phone && s?.loyaltyId);
+    } catch {
+      return false;
+    }
+  });
+  const [confirming, setConfirming] = useState(false);
+  const [confirmText, setConfirmText] = useState("");
+  const [deleting, setDeleting] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [done, setDone] = useState(false);
 
-  const deleteAccount = async () => {
+  const onDelete = async () => {
+    if (confirmText.trim().toUpperCase() !== "DELETE") return;
     setError(null);
-    setBusy(true);
+    setDeleting(true);
     try {
       let memberId: string | null = null;
       let phone: string | null = null;
       try {
         const raw = window.localStorage.getItem("celsius-pickup");
         if (raw) {
-          const s = (JSON.parse(raw) as { state?: { loyaltyId?: string | null; phone?: string | null } }).state;
+          const s = (JSON.parse(raw) as Persisted).state;
           memberId = s?.loyaltyId ?? null;
           phone = s?.phone ?? null;
         }
@@ -38,19 +54,19 @@ export function AccountDeleteView() {
       });
       if (!res.ok) {
         const data = await res.json().catch(() => ({}));
-        throw new Error(data.error ?? "Failed to delete account");
+        throw new Error(data.error ?? "Could not delete the account.");
       }
-      // Wipe local state.
       try {
         window.localStorage.removeItem("celsius-pickup");
       } catch {
         /* ignore */
       }
+      setConfirming(false);
       setDone(true);
     } catch (e) {
       setError(e instanceof Error ? e.message : String(e));
     } finally {
-      setBusy(false);
+      setDeleting(false);
     }
   };
 
@@ -58,11 +74,12 @@ export function AccountDeleteView() {
     return (
       <>
         <Header />
-        <section className="px-5 pt-8">
-          <p className="font-peachi font-bold text-2xl">Account deleted.</p>
-          <p className="text-[13px] text-[#6E6E73] mt-2 leading-snug">
-            Your member-scoped data has been purged. Payment receipts are kept for 7 years for
-            tax compliance, anonymised after the retention window.
+        <div className="px-5 py-8">
+          <p className="font-peachi font-bold text-2xl" style={{ color: "#1A0200" }}>
+            Account deleted
+          </p>
+          <p className="text-[13px] mt-2" style={{ color: "#6B6B6B", lineHeight: "20px" }}>
+            Your account and data have been removed.
           </p>
           <Link
             href="/"
@@ -70,7 +87,7 @@ export function AccountDeleteView() {
           >
             Back to home
           </Link>
-        </section>
+        </div>
       </>
     );
   }
@@ -79,47 +96,165 @@ export function AccountDeleteView() {
     <>
       <Header />
 
-      <section className="px-5 pt-6">
-        <div
-          className="flex items-start gap-2 rounded-2xl p-3"
-          style={{ backgroundColor: "rgba(185,28,28,0.10)" }}
-        >
-          <AlertTriangle size={18} color="#B91C1C" className="flex-shrink-0 mt-0.5" />
-          <p className="text-[12px] leading-snug" style={{ color: "#B91C1C" }}>
-            This deletes your account, beans balance, wallet vouchers, and order history. It
-            can&apos;t be undone.
+      <div className="px-5 py-5 flex flex-col" style={{ gap: 24 }}>
+        <div>
+          <p className="font-peachi font-bold text-xl" style={{ color: "#1A0200" }}>
+            Delete your account
+          </p>
+          <p className="text-xs mt-1" style={{ color: "#6B6B6B" }}>
+            Celsius Coffee account &amp; data deletion
           </p>
         </div>
 
-        <p className="mt-5 text-sm">
-          Type <span className="font-bold">delete</span> below to confirm.
+        <Section title="What gets deleted">
+          <Bullet>Your name, email, phone number, and birthday</Bullet>
+          <Bullet>Your points balance and rewards history</Bullet>
+          <Bullet>Your full transaction and visit history</Bullet>
+          <Bullet>Push notification tokens linked to your devices</Bullet>
+          <Bullet>SMS opt-in records and marketing preferences</Bullet>
+          <p className="text-[12px] mt-2" style={{ color: "#6B6B6B", lineHeight: "18px" }}>
+            Anonymised aggregate analytics that cannot be linked back to you may be retained.
+          </p>
+        </Section>
+
+        <Section title="Important note">
+          <p className="text-[14px]" style={{ color: "#1A0200", lineHeight: "22px" }}>
+            Deletion is permanent and cannot be reversed. Unredeemed points will be forfeited at the
+            time of deletion. If you simply want to stop promotional SMS, reply STOP to any
+            promotional message instead.
+          </p>
+        </Section>
+
+        {signedIn ? (
+          <button
+            type="button"
+            onClick={() => setConfirming(true)}
+            className="flex items-center text-left active:opacity-70"
+            style={{
+              border: "1px solid rgba(162,73,44,0.40)",
+              backgroundColor: "rgba(162,73,44,0.05)",
+              borderRadius: 16,
+              padding: 16,
+              gap: 12,
+            }}
+          >
+            <span
+              className="flex items-center justify-center flex-shrink-0"
+              style={{ width: 40, height: 40, borderRadius: 8, backgroundColor: "rgba(162,73,44,0.15)" }}
+            >
+              <Trash2 size={18} color="#A2492C" strokeWidth={1.75} />
+            </span>
+            <span className="flex-1 min-w-0">
+              <span className="block font-peachi font-bold text-[15px]" style={{ color: "#A2492C" }}>
+                Delete my account
+              </span>
+              <span className="block text-[12px] mt-0.5" style={{ color: "#6B6B6B" }}>
+                Permanent · cannot be undone
+              </span>
+            </span>
+          </button>
+        ) : (
+          <div
+            style={{
+              border: "1px solid rgba(26,2,0,0.10)",
+              backgroundColor: "#FFFFFF",
+              borderRadius: 16,
+              padding: 16,
+            }}
+          >
+            <p className="text-[14px]" style={{ color: "#1A0200", lineHeight: "22px" }}>
+              Sign in first to delete your account.
+            </p>
+          </div>
+        )}
+
+        <p className="text-[11px]" style={{ color: "#6B6B6B", lineHeight: "16px" }}>
+          See our{" "}
+          <Link href="/privacy" className="underline">
+            Privacy Policy
+          </Link>{" "}
+          for full details on how we handle your personal data under the Personal Data Protection Act
+          2010 (Act 709) of Malaysia.
         </p>
-        <input
-          type="text"
-          value={confirm}
-          onChange={(e) => setConfirm(e.target.value)}
-          className="mt-2 w-full rounded-2xl border border-[#EBE5DE] px-3 py-3 outline-none text-base"
-        />
+      </div>
 
-        {error ? <p className="mt-3 text-[12px] text-red-600">{error}</p> : null}
-
-        <button
-          type="button"
-          onClick={deleteAccount}
-          disabled={busy || confirm.trim().toLowerCase() !== "delete"}
-          className={`mt-5 w-full rounded-full text-white py-4 font-bold active:opacity-80 ${
-            busy || confirm.trim().toLowerCase() !== "delete" ? "bg-[#B91C1C]/40" : "bg-[#B91C1C]"
-          }`}
+      {confirming ? (
+        <div
+          className="fixed inset-0 flex items-center justify-center px-6 z-50"
+          style={{ backgroundColor: "rgba(0,0,0,0.60)" }}
         >
-          {busy ? "Deleting…" : "Delete my account"}
-        </button>
-        <Link
-          href="/settings"
-          className="mt-3 block w-full text-center text-sm text-[#8E8E93] active:opacity-60 py-2"
-        >
-          Cancel
-        </Link>
-      </section>
+          <div className="w-full" style={{ backgroundColor: "#FFFFFF", borderRadius: 16, padding: 20, maxWidth: 400 }}>
+            <div className="flex items-center gap-2" style={{ marginBottom: 8 }}>
+              <AlertTriangle size={18} color="#A2492C" />
+              <p className="font-peachi font-bold text-[16px]" style={{ color: "#1A0200" }}>
+                Delete account?
+              </p>
+            </div>
+            <p className="text-[13px]" style={{ color: "#1A0200", lineHeight: "20px" }}>
+              This will permanently delete your account and all data. To confirm, type{" "}
+              <span className="font-peachi font-bold">DELETE</span> below.
+            </p>
+            <input
+              type="text"
+              value={confirmText}
+              onChange={(e) => setConfirmText(e.target.value)}
+              autoCapitalize="characters"
+              autoCorrect="off"
+              placeholder="Type DELETE"
+              disabled={deleting}
+              className="mt-3 w-full outline-none"
+              style={{
+                border: "1px solid rgba(26,2,0,0.10)",
+                backgroundColor: "#FFFFFF",
+                borderRadius: 8,
+                paddingLeft: 12,
+                paddingRight: 12,
+                paddingTop: 8,
+                paddingBottom: 8,
+                fontSize: 14,
+                color: "#1A0200",
+              }}
+            />
+            {error ? <p className="mt-2 text-[12px] text-red-600">{error}</p> : null}
+            <div className="flex gap-2 mt-4">
+              <button
+                type="button"
+                onClick={() => {
+                  setConfirming(false);
+                  setConfirmText("");
+                  setError(null);
+                }}
+                disabled={deleting}
+                className="flex-1 active:opacity-70"
+                style={{ border: "1px solid rgba(26,2,0,0.10)", borderRadius: 8, paddingTop: 10, paddingBottom: 10 }}
+              >
+                <span className="font-peachi font-bold text-[14px]" style={{ color: "#1A0200" }}>
+                  Cancel
+                </span>
+              </button>
+              <button
+                type="button"
+                onClick={onDelete}
+                disabled={deleting || confirmText.trim().toUpperCase() !== "DELETE"}
+                className="flex-1"
+                style={{
+                  borderRadius: 8,
+                  paddingTop: 10,
+                  paddingBottom: 10,
+                  backgroundColor:
+                    confirmText.trim().toUpperCase() === "DELETE" && !deleting
+                      ? "#A2492C"
+                      : "rgba(162,73,44,0.40)",
+                }}
+              >
+                <span className="font-peachi font-bold text-[14px]" style={{ color: "#FFFFFF" }}>
+                  {deleting ? "Deleting…" : "Delete"}
+                </span>
+              </button>
+            </div>
+          </div>
+        </div>
+      ) : null}
     </>
   );
 }
@@ -135,5 +270,27 @@ function Header() {
       </Link>
       <h1 className="font-peachi font-bold text-[22px]">Delete account</h1>
     </header>
+  );
+}
+
+function Section({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <div>
+      <p className="font-peachi font-bold text-[15px] mb-2" style={{ color: "#1A0200" }}>
+        {title}
+      </p>
+      {children}
+    </div>
+  );
+}
+
+function Bullet({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="flex gap-2" style={{ marginBottom: 4 }}>
+      <span style={{ color: "#A2492C", fontSize: 14 }}>•</span>
+      <span className="flex-1 text-[14px]" style={{ color: "#1A0200", lineHeight: "22px" }}>
+        {children}
+      </span>
+    </div>
   );
 }

--- a/apps/order/src/app/account/_AccountView.tsx
+++ b/apps/order/src/app/account/_AccountView.tsx
@@ -65,14 +65,18 @@ export function AccountView() {
 
       {!hydrated ? null : !phone ? (
         <SignInForm
-          onSignedIn={(p, member) => {
-            // Persist phone + member into the SPA's localStorage shape
-            // so the rest of the app picks them up.
+          onSignedIn={(p, member, sessionToken) => {
+            // Persist phone + member + session token into the SPA's
+            // localStorage shape so the rest of the app picks them up.
+            // The token is REQUIRED — every /me/* read (rewards,
+            // vouchers, missions, claimables, referral, orders under
+            // strict auth) sends it as a Bearer header.
             try {
               const raw = window.localStorage.getItem("celsius-pickup");
               const parsed = raw ? JSON.parse(raw) : { state: {} };
               const state = parsed.state ?? {};
               state.phone = p;
+              if (sessionToken) state.sessionToken = sessionToken;
               if (member) {
                 state.member = member;
                 state.loyaltyId = member.id;
@@ -182,6 +186,7 @@ function SignInForm({
   onSignedIn: (
     phone: string,
     member: { id: string; name?: string | null; pointsBalance?: number; totalVisits?: number } | null,
+    sessionToken: string | null,
   ) => void;
 }) {
   const [step, setStep] = useState<"phone" | "code">("phone");
@@ -205,7 +210,7 @@ function SignInForm({
       const res = await fetch("/api/otp/send", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ phone: normalisedPhone, purpose: "signin" }),
+        body: JSON.stringify({ phone: normalisedPhone, purpose: "login" }),
       });
       const data = await res.json().catch(() => ({}));
       if (!res.ok) throw new Error(data.error ?? "Failed to send code");
@@ -224,11 +229,13 @@ function SignInForm({
       const res = await fetch("/api/otp/verify", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ phone: normalisedPhone, code, purpose: "signin" }),
+        body: JSON.stringify({ phone: normalisedPhone, code, purpose: "login" }),
       });
       const data = await res.json().catch(() => ({}));
-      if (!res.ok) throw new Error(data.error ?? "Invalid code");
-      onSignedIn(normalisedPhone, data.member ?? null);
+      if (!res.ok || data.success === false) {
+        throw new Error(data.error ?? "Invalid code");
+      }
+      onSignedIn(normalisedPhone, data.member ?? null, data.sessionToken ?? null);
     } catch (e) {
       setError(e instanceof Error ? e.message : String(e));
     } finally {

--- a/apps/order/src/app/api/otp/verify/route.ts
+++ b/apps/order/src/app/api/otp/verify/route.ts
@@ -15,7 +15,15 @@ import { ensureNewMemberRewards } from '@/lib/loyalty/welcome';
  *  brand-new signups. Now we always create the row up front; same
  *  pattern the /api/loyalty/otp/verify proxy used. Falls safe to
  *  null if creation fails — caller can retry later. */
-async function ensureMemberRow(phone: string): Promise<string | null> {
+type MemberSnapshot = {
+  id: string;
+  name: string | null;
+  email: string | null;
+  pointsBalance: number;
+  totalVisits: number;
+};
+
+async function ensureMemberRow(phone: string): Promise<MemberSnapshot | null> {
   try {
     const member = await findOrCreateMember(phone);
     if (!member?.id) return null;
@@ -26,7 +34,13 @@ async function ensureMemberRow(phone: string): Promise<string | null> {
     ensureNewMemberRewards(member.id).catch((e) => {
       console.warn('[otp/verify] ensureNewMemberRewards failed:', e);
     });
-    return member.id;
+    return {
+      id: member.id,
+      name: member.name ?? null,
+      email: member.email ?? null,
+      pointsBalance: member.points_balance ?? 0,
+      totalVisits: member.total_visits ?? 0,
+    };
   } catch (e) {
     console.error('[otp/verify] ensureMemberRow failed:', e);
     return null;
@@ -59,9 +73,9 @@ export async function POST(request: NextRequest) {
         diff |= code.charCodeAt(i) ^ reviewerCode.charCodeAt(i);
       }
       if (diff === 0) {
-        const memberId = await ensureMemberRow(phone);
-        const sessionToken = signCustomerSession({ memberId, phone });
-        return NextResponse.json({ success: true, sessionToken });
+        const member = await ensureMemberRow(phone);
+        const sessionToken = signCustomerSession({ memberId: member?.id ?? null, phone });
+        return NextResponse.json({ success: true, sessionToken, member });
       }
     }
 
@@ -84,9 +98,9 @@ export async function POST(request: NextRequest) {
     // carries a non-null memberId now (provided findOrCreateMember
     // succeeded), so downstream /me/* calls don't need the loyalty-
     // service fallback to resolve the member.
-    const memberId = await ensureMemberRow(phone);
-    const sessionToken = signCustomerSession({ memberId, phone });
-    return NextResponse.json({ success: true, sessionToken });
+    const member = await ensureMemberRow(phone);
+    const sessionToken = signCustomerSession({ memberId: member?.id ?? null, phone });
+    return NextResponse.json({ success: true, sessionToken, member });
   } catch {
     return NextResponse.json({ success: false, error: 'Verification failed' }, { status: 500 });
   }

--- a/apps/order/src/app/cart/_CartView.tsx
+++ b/apps/order/src/app/cart/_CartView.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState } from "react";
 import Link from "next/link";
 import Image from "next/image";
 import { ArrowLeft, Trash2, Plus, Minus, Gift, X, Coffee, ChevronRight } from "lucide-react";
+import { calcRewardDiscount, formatRewardValue, type AppliedReward } from "@/lib/reward-discount";
 
 type BestSeller = {
   id: string;
@@ -21,13 +22,6 @@ type CartItem = {
   quantity: number;
   totalPrice: number;
   modifiers?: Array<{ groupName?: string; label?: string; priceDelta?: number }>;
-};
-
-type AppliedReward = {
-  voucher_id?: string;
-  name?: string;
-  discount_label?: string;
-  discount_sen?: number;
 };
 
 type Persisted = {
@@ -108,7 +102,19 @@ export function CartView({ bestSellers = [] }: { bestSellers?: BestSeller[] }) {
   }, []);
 
   const subtotal = items.reduce((s, i) => s + i.totalPrice, 0);
-  const rewardDiscount = Math.min(reward?.discount_sen ? reward.discount_sen / 100 : 0, subtotal);
+  const rewardDiscount = Math.min(
+    calcRewardDiscount(
+      reward,
+      items.map((i) => ({
+        productId: i.productId,
+        basePrice: i.basePrice,
+        totalPrice: i.totalPrice,
+        quantity: i.quantity,
+      })),
+      subtotal,
+    ),
+    subtotal,
+  );
   const grandTotal = Math.max(0, subtotal - rewardDiscount);
   const signedIn = typeof phone === "string" && phone.length > 0;
 
@@ -327,11 +333,11 @@ export function CartView({ bestSellers = [] }: { bestSellers?: BestSeller[] }) {
           </span>
           <div className="flex-1 min-w-0">
             <p className="font-peachi font-bold text-[13px]" style={{ color: "#B91C1C" }}>
-              {reward.name ?? reward.discount_label ?? "Reward applied"}
+              {reward.name ?? formatRewardValue(reward)}
             </p>
-            {reward.discount_sen ? (
+            {rewardDiscount > 0 ? (
               <p className="text-[11px]" style={{ color: "rgba(185,28,28,0.80)" }}>
-                {`−RM${(reward.discount_sen / 100).toFixed(2)} off`}
+                {`−RM${rewardDiscount.toFixed(2)} off`}
               </p>
             ) : null}
           </div>

--- a/apps/order/src/app/checkout/_CheckoutView.tsx
+++ b/apps/order/src/app/checkout/_CheckoutView.tsx
@@ -4,6 +4,7 @@ import { useEffect, useMemo, useState } from "react";
 import Link from "next/link";
 import { ArrowLeft, CreditCard, Wallet, Banknote } from "lucide-react";
 import { StripePaymentForm } from "@/components/stripe-payment-form";
+import { calcRewardDiscount, type AppliedReward } from "@/lib/reward-discount";
 
 type CartItem = {
   cartId: string;
@@ -23,6 +24,7 @@ type Persisted = {
     outletName?: string | null;
     phone?: string | null;
     loyaltyId?: string | null;
+    appliedReward?: AppliedReward | null;
   };
 };
 
@@ -96,6 +98,26 @@ export function CheckoutView() {
     [state],
   );
 
+  const reward = state?.appliedReward ?? null;
+  const rewardDiscount = useMemo(
+    () =>
+      Math.min(
+        calcRewardDiscount(
+          reward,
+          (state?.cart ?? []).map((i) => ({
+            productId: i.productId,
+            basePrice: i.basePrice,
+            totalPrice: i.totalPrice,
+            quantity: i.quantity,
+          })),
+          subtotal,
+        ),
+        subtotal,
+      ),
+    [reward, state, subtotal],
+  );
+  const grandTotal = Math.max(0, subtotal - rewardDiscount);
+
   if (!state) {
     return <div className="p-8 text-center text-[#8E8E93]">Loading…</div>;
   }
@@ -129,10 +151,22 @@ export function CheckoutView() {
             quantity:  i.quantity,
             totalPrice: i.totalPrice,
           })),
-          storeId: state.outletId,
+          // The route requires `selectedStore` (with .id) — sending a
+          // bare `storeId` string 400s with "Invalid order data".
+          // `total` is the pre-discount subtotal in RM; the server
+          // applies the reward discount + SST itself.
+          selectedStore: { id: state.outletId, name: state.outletName ?? undefined },
+          total: subtotal,
           paymentMethod: method,
           loyaltyPhone: state.phone ?? null,
           loyaltyId:    state.loyaltyId ?? null,
+          // Forward the applied reward so the server actually discounts
+          // the order (otherwise the customer is charged full price).
+          rewardId:          reward?.id ?? null,
+          rewardName:        reward?.name ?? null,
+          rewardPointsCost:  reward?.points_required ?? 0,
+          rewardDiscountSen: Math.round(rewardDiscount * 100),
+          voucherId:         reward?.voucher_id ?? null,
           orderType:    "pickup",
         }),
       });
@@ -345,12 +379,22 @@ export function CheckoutView() {
             RM{subtotal.toFixed(2)}
           </span>
         </div>
+        {rewardDiscount > 0 ? (
+          <div className="flex items-center justify-between" style={{ marginBottom: 6 }}>
+            <span className="text-[13px] truncate" style={{ color: "#A2492C" }}>
+              Reward{reward?.name ? ` · ${reward.name}` : ""}
+            </span>
+            <span className="text-[14px]" style={{ color: "#A2492C", fontWeight: 500 }}>
+              −RM{rewardDiscount.toFixed(2)}
+            </span>
+          </div>
+        ) : null}
         <div className="flex items-center justify-between pt-3 border-t border-[rgba(26,2,0,0.10)]">
           <span className="font-peachi font-bold" style={{ color: "#1A0200", fontSize: 15 }}>
             Total
           </span>
           <span className="font-peachi font-bold" style={{ color: "#1A0200", fontSize: 18 }}>
-            RM{subtotal.toFixed(2)}
+            RM{grandTotal.toFixed(2)}
           </span>
         </div>
         {tier ? (
@@ -362,7 +406,7 @@ export function CheckoutView() {
               className="text-[12px] font-bold"
               style={{ color: tier.tier_color ?? "#92400e" }}
             >
-              +{Math.round(subtotal * (tier.tier_multiplier ?? 1))} pts
+              +{Math.round(grandTotal * (tier.tier_multiplier ?? 1))} pts
             </span>
           </div>
         ) : null}
@@ -406,7 +450,7 @@ export function CheckoutView() {
               !confirmFn || confirming ? "bg-[#A2492C]/40" : "bg-[#A2492C]"
             }`}
           >
-            {confirming ? "Confirming payment…" : `Pay RM${subtotal.toFixed(2)}`}
+            {confirming ? "Confirming payment…" : `Pay RM${grandTotal.toFixed(2)}`}
           </button>
         ) : (
         <button

--- a/apps/order/src/app/order/[id]/_OrderTrackingView.tsx
+++ b/apps/order/src/app/order/[id]/_OrderTrackingView.tsx
@@ -334,7 +334,7 @@ export function OrderTrackingView({ orderId }: { orderId: string }) {
             ) : null}
             {order.discount_amount && order.discount_amount > 0 ? (
               <div className="flex justify-between text-[13px]">
-                <span className="text-[#A2492C]">Tier perk</span>
+                <span className="text-[#A2492C]">Voucher</span>
                 <span className="text-[#A2492C]">−{rm(order.discount_amount)}</span>
               </div>
             ) : null}

--- a/apps/order/src/app/product/[id]/_ProductView.tsx
+++ b/apps/order/src/app/product/[id]/_ProductView.tsx
@@ -118,7 +118,16 @@ export function ProductView({ product }: { product: Product }) {
       specialInstructions: notes || undefined,
       totalPrice,
     });
-    router.push("/cart");
+    // Return to where the customer came from (the menu) rather than
+    // pushing them to the cart — matches apps/pickup-native/app
+    // /product/[id].tsx's router.back(). The floating cart pill keeps
+    // the cart one tap away. Falls back to /menu when there's no
+    // in-app history (e.g. a deep link straight to the product).
+    if (window.history.length > 1) {
+      router.back();
+    } else {
+      router.push("/menu");
+    }
   };
 
   const togglePick = (group: ModifierGroup, optId: string) => {

--- a/apps/order/src/app/wrapped/_WrappedView.tsx
+++ b/apps/order/src/app/wrapped/_WrappedView.tsx
@@ -1,124 +1,281 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import Link from "next/link";
-import { ArrowLeft, Coffee, Sparkles, Flame } from "lucide-react";
+import { useRouter } from "next/navigation";
+import { Sparkles, Coffee, Clock, MapPin, Share2, ChevronLeft } from "lucide-react";
 
 /**
- * Year recap ("wrapped") — high-level lifetime stats pulled from the
- * persisted member snapshot. Mirrors apps/pickup-native/app/wrapped.tsx
- * styling but minimal: cream-on-espresso stat cards rather than the
- * native's full animated reveal sequence.
+ * Coffee Wrapped — annual recap, Spotify-style. Port of
+ * apps/pickup-native/app/wrapped.tsx: giant cups headline, BigCard
+ * stat rows (favourite drink/hour, outlets, streak), a "The damage"
+ * spend/saved card, and a Share pill. Espresso bg + amber accents.
+ * Wired to /api/loyalty/me/wrapped with the session token.
  */
-type Persisted = {
-  state?: {
-    member?: {
-      name?: string | null;
-      pointsBalance?: number;
-      totalVisits?: number;
-      totalPointsEarned?: number;
-    };
+const MONTH = [
+  "January", "February", "March", "April", "May", "June",
+  "July", "August", "September", "October", "November", "December",
+];
+
+type Wrapped = {
+  year: number;
+  summary: {
+    total_orders: number;
+    total_spent_sen: number;
+    total_saved_sen: number;
+    distinct_outlets: number;
+    distinct_products: number;
+    longest_streak_weeks: number;
+  };
+  favorites: {
+    product_name: string | null;
+    product_count: number;
+    hour: number | null;
+    month: number | null;
   };
 };
 
+type Persisted = { state?: { sessionToken?: string | null; phone?: string | null } };
+
+function formatHour(h: number | null): string {
+  if (h === null) return "—";
+  const local = (h + 8) % 24; // UTC → MYT
+  const ampm = local < 12 ? "AM" : "PM";
+  const h12 = local % 12 === 0 ? 12 : local % 12;
+  return `${h12}${ampm}`;
+}
+
+function formatRM(sen: number): string {
+  return `RM${(sen / 100).toFixed(2).replace(/\.00$/, "")}`;
+}
+
 export function WrappedView() {
-  const [m, setM] = useState<NonNullable<Persisted["state"]>["member"] | null>(null);
+  const router = useRouter();
+  const year = new Date().getFullYear();
+  const [data, setData] = useState<Wrapped | null>(null);
+  const [loaded, setLoaded] = useState(false);
 
   useEffect(() => {
+    let token: string | null = null;
+    let phone: string | null = null;
     try {
       const raw = window.localStorage.getItem("celsius-pickup");
       if (raw) {
-        const parsed = JSON.parse(raw) as Persisted;
-        setM(parsed.state?.member ?? null);
+        const s = (JSON.parse(raw) as Persisted).state;
+        token = s?.sessionToken ?? null;
+        phone = s?.phone ?? null;
       }
     } catch {
       /* ignore */
     }
-  }, []);
+    if (!token && !phone) {
+      setLoaded(true);
+      return;
+    }
+    fetch(`/api/loyalty/me/wrapped?year=${year}`, {
+      headers: token ? { Authorization: `Bearer ${token}` } : undefined,
+    })
+      .then((r) => (r.ok ? r.json() : null))
+      .then((d) => setData((d ?? null) as Wrapped | null))
+      .catch(() => setData(null))
+      .finally(() => setLoaded(true));
+  }, [year]);
+
+  const share = async () => {
+    if (!data) return;
+    const lines = [
+      `My Celsius Coffee Wrapped ${data.year} ☕`,
+      `${data.summary.total_orders} cups · ${data.summary.distinct_outlets} outlets`,
+    ];
+    if (data.favorites.product_name) lines.push(`Favourite: ${data.favorites.product_name}`);
+    if (data.summary.longest_streak_weeks > 0)
+      lines.push(`Longest streak: ${data.summary.longest_streak_weeks} weeks 🔥`);
+    lines.push("\nhttps://celsiuscoffee.com");
+    try {
+      if (navigator.share) await navigator.share({ text: lines.join("\n") });
+      else await navigator.clipboard.writeText(lines.join("\n"));
+    } catch {
+      /* dismissed */
+    }
+  };
+
+  const total = data?.summary.total_orders ?? 0;
 
   return (
-    <>
-      <header className="px-4 pb-3 flex items-center gap-3" style={{ paddingTop: "calc(env(safe-area-inset-top, 0px) + 12px)" }}>
-        <Link href="/rewards" className="-ml-1 p-1 active:opacity-60" aria-label="Back">
-          <ArrowLeft size={20} color="#FFFFFF" />
-        </Link>
-        <h1 className="font-peachi font-bold text-[22px]">Your year</h1>
-      </header>
+    <div style={{ minHeight: "100dvh", backgroundColor: "#1A0200" }}>
+      {/* Top bar */}
+      <div
+        className="flex items-center px-4 pb-2"
+        style={{ paddingTop: "calc(env(safe-area-inset-top, 0px) + 8px)" }}
+      >
+        <button
+          type="button"
+          onClick={() => router.back()}
+          className="flex items-center justify-center active:opacity-60"
+          style={{ width: 32, height: 32 }}
+          aria-label="Back"
+        >
+          <ChevronLeft size={22} color="#FBBF24" />
+        </button>
+        <span
+          className="uppercase"
+          style={{ color: "rgba(251,191,36,0.7)", fontSize: 11, fontWeight: 700, letterSpacing: 2, marginLeft: 4 }}
+        >
+          Wrapped {year}
+        </span>
+      </div>
 
-      <section className="px-5 pt-6">
-        <p className="text-[10px] uppercase tracking-widest text-white/55">
-          Hi{m?.name ? `, ${m.name}` : ""}.
-        </p>
-        <h2 className="mt-1 font-peachi font-bold text-3xl leading-tight">
-          Here&apos;s your Celsius year
-        </h2>
-        <p className="mt-2 text-[13px] text-white/65 leading-snug">
-          Beans earned, drinks ordered, the streaks. Tap a card for the detail.
-        </p>
-      </section>
+      {!loaded ? (
+        <div className="flex items-center justify-center" style={{ minHeight: "60vh", color: "#FBBF24" }}>
+          Loading…
+        </div>
+      ) : !data || total === 0 ? (
+        <div className="flex flex-col items-center justify-center px-8 text-center" style={{ minHeight: "60vh" }}>
+          <Coffee size={48} color="#FBBF24" strokeWidth={1.5} />
+          <p className="font-peachi font-bold" style={{ color: "#FBBF24", fontSize: 24, marginTop: 16 }}>
+            You&apos;re still warming up
+          </p>
+          <p style={{ color: "rgba(255,255,255,0.7)", fontSize: 14, marginTop: 8, lineHeight: "20px" }}>
+            Place your first order to start brewing your {year} Wrapped story ☕
+          </p>
+        </div>
+      ) : (
+        <div style={{ padding: 24, paddingBottom: "calc(env(safe-area-inset-bottom,0px) + 32px)" }}>
+          {/* Headline cups count */}
+          <div className="flex flex-col items-center" style={{ paddingTop: 24, paddingBottom: 24 }}>
+            <span
+              className="uppercase"
+              style={{ color: "rgba(251,191,36,0.7)", fontSize: 10, fontWeight: 700, letterSpacing: 2.5 }}
+            >
+              You drank
+            </span>
+            <span
+              className="font-peachi font-bold"
+              style={{ color: "#FBBF24", fontSize: 120, letterSpacing: -6, lineHeight: "120px", marginTop: 4 }}
+            >
+              {total}
+            </span>
+            <span className="font-peachi font-bold" style={{ color: "#FFFFFF", fontSize: 28, marginTop: -8 }}>
+              cup{total === 1 ? "" : "s"}
+            </span>
+            <span style={{ color: "rgba(255,255,255,0.6)", fontSize: 14, marginTop: 8, textAlign: "center" }}>
+              in {year} · that&apos;s {(total / 52).toFixed(1)} every week
+            </span>
+          </div>
 
-      <section className="px-4 pt-6 grid grid-cols-2 gap-3">
-        <Stat
-          Icon={Sparkles}
-          accent="#FBBF24"
-          value={(m?.totalPointsEarned ?? 0).toLocaleString()}
-          label="Beans earned"
-        />
-        <Stat
-          Icon={Coffee}
-          accent="#A2492C"
-          value={(m?.totalVisits ?? 0).toLocaleString()}
-          label="Visits"
-        />
-        <Stat
-          Icon={Flame}
-          accent="#FBBF24"
-          value={(m?.pointsBalance ?? 0).toLocaleString()}
-          label="Beans now"
-        />
-        <Stat
-          Icon={Coffee}
-          accent="#A2492C"
-          value="—"
-          label="Favourite drink"
-        />
-      </section>
-    </>
+          {/* Stat cards */}
+          <div className="flex flex-col" style={{ gap: 10 }}>
+            {data.favorites.product_name ? (
+              <BigCard
+                eyebrow="Favourite drink"
+                value={data.favorites.product_name}
+                detail={`${data.favorites.product_count} order${data.favorites.product_count === 1 ? "" : "s"}`}
+                Icon={Coffee}
+              />
+            ) : null}
+            {data.favorites.hour !== null ? (
+              <BigCard
+                eyebrow="Favourite hour"
+                value={formatHour(data.favorites.hour)}
+                detail={data.favorites.month ? `usually ${MONTH[data.favorites.month - 1]}` : undefined}
+                Icon={Clock}
+              />
+            ) : null}
+            <BigCard
+              eyebrow="Outlets visited"
+              value={String(data.summary.distinct_outlets)}
+              detail={`${data.summary.distinct_products} different drinks tried`}
+              Icon={MapPin}
+            />
+            {data.summary.longest_streak_weeks > 0 ? (
+              <BigCard
+                eyebrow="Longest streak"
+                value={`${data.summary.longest_streak_weeks} wks`}
+                detail="Weekly visit chain 🔥"
+                Icon={Sparkles}
+              />
+            ) : null}
+
+            {/* The damage */}
+            <div
+              style={{ backgroundColor: "rgba(251,191,36,0.08)", borderRadius: 18, padding: 18, marginTop: 4 }}
+            >
+              <p
+                className="uppercase"
+                style={{ color: "rgba(251,191,36,0.75)", fontSize: 10, fontWeight: 700, letterSpacing: 2, marginBottom: 6 }}
+              >
+                The damage
+              </p>
+              <div className="flex" style={{ gap: 18 }}>
+                <div className="flex-1">
+                  <p className="font-peachi font-bold" style={{ color: "#FFFFFF", fontSize: 24 }}>
+                    {formatRM(data.summary.total_spent_sen)}
+                  </p>
+                  <p style={{ color: "rgba(255,255,255,0.5)", fontSize: 11, marginTop: 2 }}>Total spent</p>
+                </div>
+                <div className="flex-1">
+                  <p className="font-peachi font-bold" style={{ color: "#FBBF24", fontSize: 24 }}>
+                    {formatRM(data.summary.total_saved_sen)}
+                  </p>
+                  <p style={{ color: "rgba(255,255,255,0.5)", fontSize: 11, marginTop: 2 }}>Saved with rewards</p>
+                </div>
+              </div>
+            </div>
+          </div>
+
+          {/* Share */}
+          <button
+            type="button"
+            onClick={share}
+            className="w-full flex items-center justify-center active:opacity-80"
+            style={{ marginTop: 28, backgroundColor: "#FBBF24", borderRadius: 100, paddingTop: 16, paddingBottom: 16, gap: 8 }}
+          >
+            <Share2 size={16} color="#1A0200" strokeWidth={2.4} />
+            <span className="font-peachi font-bold" style={{ color: "#1A0200", fontSize: 15 }}>
+              Share my Wrapped
+            </span>
+          </button>
+        </div>
+      )}
+    </div>
   );
 }
 
-function Stat({
-  Icon,
-  accent,
+function BigCard({
+  eyebrow,
   value,
-  label,
+  detail,
+  Icon,
 }: {
-  Icon: typeof Coffee;
-  accent: string;
+  eyebrow: string;
   value: string;
-  label: string;
+  detail?: string;
+  Icon: typeof Coffee;
 }) {
   return (
     <div
-      className="rounded-2xl p-4"
-      style={{
-        backgroundColor: "rgba(255,255,255,0.05)",
-        border: "1px solid rgba(255,255,255,0.08)",
-      }}
+      className="flex items-center"
+      style={{ backgroundColor: "rgba(255,255,255,0.04)", borderRadius: 18, padding: 18, gap: 14 }}
     >
       <span
-        className="flex items-center justify-center"
-        style={{
-          width: 32,
-          height: 32,
-          borderRadius: 9,
-          backgroundColor: `${accent}28`,
-        }}
+        className="flex items-center justify-center flex-shrink-0"
+        style={{ width: 44, height: 44, borderRadius: 12, backgroundColor: "rgba(251,191,36,0.18)" }}
       >
-        <Icon size={16} color={accent} strokeWidth={1.8} />
+        <Icon size={22} color="#FBBF24" strokeWidth={1.8} />
       </span>
-      <p className="mt-3 font-peachi font-bold text-2xl">{value}</p>
-      <p className="mt-1 text-[10px] uppercase tracking-widest text-white/60">{label}</p>
+      <div className="flex-1 min-w-0">
+        <p
+          className="uppercase"
+          style={{ color: "rgba(251,191,36,0.65)", fontSize: 9, fontWeight: 700, letterSpacing: 1.8, marginBottom: 3 }}
+        >
+          {eyebrow}
+        </p>
+        <p className="font-peachi font-bold truncate" style={{ color: "#FFFFFF", fontSize: 20, letterSpacing: -0.3 }}>
+          {value}
+        </p>
+        {detail ? (
+          <p style={{ color: "rgba(255,255,255,0.55)", fontSize: 11, marginTop: 2 }}>{detail}</p>
+        ) : null}
+      </div>
     </div>
   );
 }

--- a/apps/order/src/app/wrapped/page.tsx
+++ b/apps/order/src/app/wrapped/page.tsx
@@ -1,11 +1,11 @@
 import { WrappedView } from "./_WrappedView";
-import { BottomNav } from "../_BottomNav";
 
+// Wrapped is a full-bleed espresso recap with its own back button —
+// no BottomNav, matching apps/pickup-native/app/wrapped.tsx.
 export default function WrappedPage() {
   return (
-    <main className="bg-[#160800] text-white min-h-screen pb-[calc(env(safe-area-inset-bottom,0px)+88px)]">
+    <main className="text-white" style={{ backgroundColor: "#1A0200" }}>
       <WrappedView />
-      <BottomNav active="rewards" />
     </main>
   );
 }

--- a/apps/order/src/lib/reward-discount.ts
+++ b/apps/order/src/lib/reward-discount.ts
@@ -1,0 +1,107 @@
+/**
+ * Applied-reward shape persisted in the SPA's Zustand store
+ * (localStorage key "celsius-pickup", state.appliedReward). Mirrors
+ * apps/pickup-native/lib/store.ts AppliedReward so a reward applied on
+ * one surface reads correctly on the other.
+ */
+export type AppliedReward = {
+  id: string;
+  name: string;
+  points_required?: number;
+  discount_type:
+    | "flat"
+    | "percent"
+    | "free_item"
+    | "bogo"
+    | "fixed_amount"
+    | "percentage"
+    | "none"
+    | null;
+  discount_value: number | null;
+  bogo_buy_qty?: number;
+  bogo_free_qty?: number;
+  free_product_name?: string | null;
+  applicable_categories?: string[] | null;
+  applicable_products?: string[] | null;
+  min_order_value?: number | null;
+  voucher_id?: string;
+};
+
+type CartLine = {
+  productId?: string;
+  category?: string;
+  basePrice: number;
+  totalPrice: number;
+  quantity: number;
+};
+
+/**
+ * Client-side reward-discount preview. Port of
+ * apps/pickup-native/lib/rewards.ts calcRewardDiscount. The server
+ * recomputes the authoritative discount at checkout; this keeps the
+ * cart/checkout totals honest so the customer sees the same number.
+ */
+export function calcRewardDiscount(
+  reward: AppliedReward | null,
+  cartItems: CartLine[],
+  subtotal: number,
+): number {
+  if (!reward) return 0;
+  if (reward.min_order_value != null && subtotal < reward.min_order_value) return 0;
+
+  const cats = reward.applicable_categories;
+  const prods = reward.applicable_products;
+  const hasFilter = (cats && cats.length > 0) || (prods && prods.length > 0);
+  const someHaveCategory = cartItems.some((i) => !!i.category);
+  const eligible =
+    hasFilter && someHaveCategory
+      ? cartItems.filter((i) => {
+          if (cats && cats.length > 0 && i.category && cats.includes(i.category)) return true;
+          if (prods && prods.length > 0 && i.productId && prods.includes(i.productId)) return true;
+          return false;
+        })
+      : cartItems;
+
+  const t = reward.discount_type;
+  if (t === "free_item") {
+    if (eligible.length === 0) return 0;
+    return Math.min(...eligible.map((i) => i.basePrice));
+  }
+  if (t === "bogo") {
+    if (eligible.length === 0) return 0;
+    const unitPrices = eligible.flatMap((i) =>
+      Array(i.quantity).fill(i.totalPrice / i.quantity),
+    ) as number[];
+    unitPrices.sort((a, b) => b - a);
+    // Free the cheaper of the top pair (preview only; engine is authoritative).
+    return unitPrices.length >= 2 ? unitPrices[1] : 0;
+  }
+  if ((t === "percent" || t === "percentage") && reward.discount_value) {
+    return subtotal * (reward.discount_value / 100);
+  }
+  if (t === "flat" && reward.discount_value) {
+    return reward.discount_value / 100;
+  }
+  if (t === "fixed_amount" && reward.discount_value) {
+    return reward.discount_value;
+  }
+  return 0;
+}
+
+export function formatRewardValue(r: AppliedReward): string {
+  if (r.discount_type === "flat" || r.discount_type === "fixed_amount") {
+    const cents = r.discount_value ?? 0;
+    const value = r.discount_type === "flat" ? cents / 100 : cents;
+    return `RM${value.toFixed(2).replace(/\.00$/, "")} off`;
+  }
+  if (r.discount_type === "percent" || r.discount_type === "percentage") {
+    return `${r.discount_value ?? 0}% off`;
+  }
+  if (r.discount_type === "free_item") {
+    return r.free_product_name ? `Free ${r.free_product_name}` : "Free item";
+  }
+  if (r.discount_type === "bogo") {
+    return `Buy ${r.bogo_buy_qty} get ${r.bogo_free_qty} free`;
+  }
+  return "Reward";
+}

--- a/apps/pickup-native/public/sw.js
+++ b/apps/pickup-native/public/sw.js
@@ -6,7 +6,7 @@
 //
 // Future rule of thumb: bump this on ANY production-affecting bundle
 // regression so customers don't get stuck on a bad build.
-const CACHE = "celsius-v32";
+const CACHE = "celsius-v33";
 const SHELL = ["/", "/index.html", "/manifest.json"];
 
 self.addEventListener("install", (e) => {

--- a/apps/pickup-native/public/sw.js
+++ b/apps/pickup-native/public/sw.js
@@ -6,7 +6,7 @@
 //
 // Future rule of thumb: bump this on ANY production-affecting bundle
 // regression so customers don't get stuck on a bad build.
-const CACHE = "celsius-v31";
+const CACHE = "celsius-v32";
 const SHELL = ["/", "/index.html", "/manifest.json"];
 
 self.addEventListener("install", (e) => {

--- a/apps/pickup-native/public/sw.js
+++ b/apps/pickup-native/public/sw.js
@@ -6,7 +6,7 @@
 //
 // Future rule of thumb: bump this on ANY production-affecting bundle
 // regression so customers don't get stuck on a bad build.
-const CACHE = "celsius-v30";
+const CACHE = "celsius-v31";
 const SHELL = ["/", "/index.html", "/manifest.json"];
 
 self.addEventListener("install", (e) => {

--- a/apps/pickup-native/public/sw.js
+++ b/apps/pickup-native/public/sw.js
@@ -6,7 +6,7 @@
 //
 // Future rule of thumb: bump this on ANY production-affecting bundle
 // regression so customers don't get stuck on a bad build.
-const CACHE = "celsius-v33";
+const CACHE = "celsius-v34";
 const SHELL = ["/", "/index.html", "/manifest.json"];
 
 self.addEventListener("install", (e) => {


### PR DESCRIPTION
## Summary
Started as account-delete + wrapped rebuilds; grew to include a **critical checkout fix** found during a full flow + backend-wiring audit.

### Critical — web checkout never created orders
`/api/checkout/initiate` requires `selectedStore` (with `.id`) and 400s "Invalid order data" otherwise; the web sent a bare `storeId` string, so **every web checkout failed**. Also missing `total`. Now sends `selectedStore: { id, name }` + `total: subtotal`, matching native's placeOrder.

### Reward was silently dropped
Customer was charged full price even with a reward applied. Now forwards `rewardId / rewardName / rewardPointsCost / rewardDiscountSen / voucherId`. Reward discount math was reading non-existent fields (`discount_sen`) — added shared `@/lib/reward-discount` (`calcRewardDiscount` + `formatRewardValue`, ported from native) keyed off the real `discount_type / discount_value`. Cart + checkout now show the reward line and correct grand total; tier earn-preview + Pay button use after-discount total.

### Order tracking
Relabelled the `discount_amount` line "Tier perk" → "Voucher" (that column is the voucher discount; tier perks live in `promo_discount`, already rendered as "Promo").

### Other parity rebuilds
- **account-delete** — PDPA policy page (espresso/primary, sections, typed-DELETE confirm modal, footnote) matching native; was a red-warning inline form.
- **wrapped** — full Spotify-style recap wired to `/api/loyalty/me/wrapped` (cups headline, BigCard stats, "The damage", Share); was a placeholder.
- **product add-to-cart** — returns to the menu (`router.back()`) instead of pushing `/cart`, matching native.

Bumps SW cache to v33.

## Test plan
- [ ] Place a web order end-to-end → order is created (no 400), lands on tracking.
- [ ] Apply a reward → cart + checkout show the discount; order total reflects it.
- [ ] Add to cart from menu → returns to menu.
- [ ] `/account-delete`, `/wrapped` render per native.