### PR TITLE
feat(web/rewards): wire reward-apply + clear cart after order

### DIFF
--- a/apps/order/public/sw.js
+++ b/apps/order/public/sw.js
@@ -1,7 +1,7 @@
 // Mirror of apps/pickup-native/public/sw.js — overwritten on each
 // build-pwa run. v3 bumps over v2 to flush customers off the broken
 // CSS shipped in #157/#158 before this revert deployed.
-const CACHE = "celsius-v34";
+const CACHE = "celsius-v35";
 const SHELL = ["/", "/index.html", "/manifest.json"];
 
 self.addEventListener("install", (e) => {

--- a/apps/order/src/app/checkout/_CheckoutView.tsx
+++ b/apps/order/src/app/checkout/_CheckoutView.tsx
@@ -174,6 +174,21 @@ export function CheckoutView() {
       if (!res.ok) {
         throw new Error(data.error ?? "Failed to start payment");
       }
+      // Order now exists server-side (pending). Clear the cart + applied
+      // reward so a back-nav or re-open of checkout can't re-submit the
+      // same basket — any retry happens from the order page via the
+      // existing orderId. Mirrors native's clearCart() after placeOrder.
+      try {
+        const raw = window.localStorage.getItem("celsius-pickup");
+        const parsed = raw ? JSON.parse(raw) : { state: {} };
+        const s = parsed.state ?? {};
+        s.cart = [];
+        s.appliedReward = null;
+        s.reservedVoucher = null;
+        window.localStorage.setItem("celsius-pickup", JSON.stringify({ ...parsed, state: s }));
+      } catch {
+        /* ignore */
+      }
       // Stripe path → confirm via PaymentIntent (TODO: integrate Stripe.js).
       // RM path / hosted-page path → redirect.
       if (data.paymentUrl) {

--- a/apps/order/src/app/rewards/_RewardsView.tsx
+++ b/apps/order/src/app/rewards/_RewardsView.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState } from "react";
 import Link from "next/link";
+import { useRouter } from "next/navigation";
 import { Gift, Sparkles, Coffee, Tag, Cookie, Ticket } from "lucide-react";
 import { BeansHero } from "./_BeansHero";
 import { ActiveChallenges } from "./_ActiveChallenges";
@@ -18,8 +19,51 @@ type Reward = {
   id: string;
   name: string;
   description?: string;
-  beans_cost?: number;
+  points_required?: number;
+  discount_type?:
+    | "flat" | "percent" | "free_item" | "bogo" | "fixed_amount" | "percentage" | "none" | null;
+  discount_value?: number | null;
+  min_order_value?: number | null;
+  applicable_products?: string[] | null;
+  applicable_categories?: string[] | null;
+  free_product_name?: string | null;
+  bogo_buy_qty?: number;
+  bogo_free_qty?: number;
 };
+
+// Write the chosen catalog reward into the SPA's persisted state as the
+// applied reward + reserved-voucher banner, then send the customer to
+// the menu — same flow as apps/pickup-native/app/rewards.tsx useCatalog.
+function applyCatalogReward(r: Reward) {
+  try {
+    const raw = window.localStorage.getItem("celsius-pickup");
+    const parsed = raw ? JSON.parse(raw) : { state: {} };
+    const state = parsed.state ?? {};
+    state.appliedReward = {
+      id: r.id,
+      name: r.name,
+      points_required: r.points_required ?? 0,
+      discount_type: r.discount_type ?? null,
+      discount_value: r.discount_value ?? null,
+      applicable_categories: r.applicable_categories ?? null,
+      applicable_products: r.applicable_products ?? null,
+      free_product_name: r.free_product_name ?? null,
+      min_order_value: r.min_order_value ?? null,
+      bogo_buy_qty: r.bogo_buy_qty,
+      bogo_free_qty: r.bogo_free_qty,
+    };
+    state.reservedVoucher = {
+      id: r.id,
+      title: r.name,
+      category: "bean",
+      icon: "ticket",
+      expires_at: null,
+    };
+    window.localStorage.setItem("celsius-pickup", JSON.stringify({ ...parsed, state }));
+  } catch {
+    /* ignore */
+  }
+}
 
 export function RewardsView() {
   const [phone, setPhone] = useState<string | null>(null);
@@ -189,7 +233,8 @@ function themeFor(reward: Reward): {
 }
 
 function CatalogCard({ reward, balance }: { reward: Reward; balance: number }) {
-  const required = reward.beans_cost ?? 0;
+  const router = useRouter();
+  const required = reward.points_required ?? 0;
   const canUse = balance >= required;
   const theme = themeFor(reward);
   const Icon = theme.Icon;
@@ -244,8 +289,15 @@ function CatalogCard({ reward, balance }: { reward: Reward; balance: number }) {
               : `${(required - balance).toLocaleString()} beans to go`}
           </p>
         </div>
-        <span
-          className="rounded-full flex items-center justify-center flex-shrink-0"
+        <button
+          type="button"
+          disabled={!canUse}
+          onClick={() => {
+            if (!canUse) return;
+            applyCatalogReward(reward);
+            router.push("/menu");
+          }}
+          className="rounded-full flex items-center justify-center flex-shrink-0 active:opacity-80"
           style={{
             backgroundColor: canUse ? theme.accent : "rgba(0,0,0,0.10)",
             color: canUse ? "#FFFFFF" : theme.fgDim,
@@ -259,7 +311,7 @@ function CatalogCard({ reward, balance }: { reward: Reward; balance: number }) {
           }}
         >
           {canUse ? "Use" : `${required}`}
-        </span>
+        </button>
       </div>
     </li>
   );

--- a/apps/pickup-native/public/sw.js
+++ b/apps/pickup-native/public/sw.js
@@ -6,7 +6,7 @@
 //
 // Future rule of thumb: bump this on ANY production-affecting bundle
 // regression so customers don't get stuck on a bad build.
-const CACHE = "celsius-v34";
+const CACHE = "celsius-v35";
 const SHELL = ["/", "/index.html", "/manifest.json"];
 
 self.addEventListener("install", (e) => {


### PR DESCRIPTION
## Summary
Closes the reward-apply gap flagged in the wiring audit, plus a cart-clear bug.

- **Reward-apply was missing entirely** — the catalog "Use" control was a static label; nothing wrote `state.appliedReward`, so the cart/checkout discount path (added last PR) could never fire. The "Use" control is now a button that writes the full `appliedReward` shape + the `reservedVoucher` locked-in banner and routes to `/menu`, matching `apps/pickup-native/app/rewards.tsx` `useCatalog`. Disabled when unaffordable.
- **Wrong cost field** — `/api/loyalty/rewards` returns the full reward shape (`points_required`, `discount_type`, `discount_value`, `min_order_value`, `applicable_*`, `free_product_name`, `bogo_*`), but the web type only declared `beans_cost` (which doesn't exist → cost rendered blank). Fixed the type and read `points_required`.
- **Cart not cleared after order** — web left the basket + applied reward in localStorage after a successful order (native clears it). Checkout now clears `cart` + `appliedReward` + `reservedVoucher` once the order is created server-side, so a back-nav can't re-submit the basket.

Bumps SW cache to v35.

## Test plan
- [ ] `/rewards` → affordable reward shows its bean cost; tap "Use" → lands on `/menu` with the "{reward} locked in" banner.
- [ ] Add items → cart + checkout show the reward discount and reduced total.
- [ ] Place the order → cart empties; reopening checkout shows the empty-cart state.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xd1aERynqUbdCqXNboKWBe)_