### PR TITLE
fix(web): polish pass — tier centring, fonts, stray button, reorder

### DIFF
--- a/apps/order/public/sw.js
+++ b/apps/order/public/sw.js
@@ -1,7 +1,7 @@
 // Mirror of apps/pickup-native/public/sw.js — overwritten on each
 // build-pwa run. v3 bumps over v2 to flush customers off the broken
 // CSS shipped in #157/#158 before this revert deployed.
-const CACHE = "celsius-v37";
+const CACHE = "celsius-v38";
 const SHELL = ["/", "/index.html", "/manifest.json"];
 
 self.addEventListener("install", (e) => {

--- a/apps/order/src/app/account/_AccountView.tsx
+++ b/apps/order/src/app/account/_AccountView.tsx
@@ -4,7 +4,7 @@ import { useEffect, useState } from "react";
 import Link from "next/link";
 import {
   User, ChevronRight, LogOut, Phone, ShoppingBag, Sparkles,
-  Settings as SettingsIcon, CircleHelp, Shield,
+  Settings as SettingsIcon, CircleHelp, Shield, Pencil,
 } from "lucide-react";
 import { TierCarousel } from "./_TierCarousel";
 
@@ -445,10 +445,22 @@ function EditProfileRow({
       <button
         type="button"
         onClick={() => setOpen(true)}
-        className="flex items-center gap-3 bg-white border border-[#EBE5DE] rounded-2xl px-4 py-3 active:opacity-80 text-left"
+        className="flex items-center bg-white active:opacity-80 text-left"
+        style={{
+          border: "1px solid rgba(26,2,0,0.10)",
+          borderRadius: 14,
+          paddingLeft: 14,
+          paddingRight: 14,
+          paddingTop: 12,
+          paddingBottom: 12,
+          gap: 12,
+        }}
       >
-        <span className="text-sm font-bold flex-1">Edit profile</span>
-        <ChevronRight size={14} color="#8E8E93" />
+        <Pencil size={18} color="#6B6B6B" strokeWidth={1.75} />
+        <span className="font-peachi font-bold flex-1" style={{ color: "#1A0200", fontSize: 15 }}>
+          Edit profile
+        </span>
+        <ChevronRight size={16} color="#8E8E93" />
       </button>
     );
   }
@@ -515,11 +527,22 @@ function SignOutRow({ onConfirm }: { onConfirm: () => void }) {
       <button
         type="button"
         onClick={() => setConfirming(true)}
-        className="flex items-center gap-3 bg-white border border-[#EBE5DE] rounded-2xl px-4 py-3 active:opacity-80 text-left"
+        className="flex items-center bg-white active:opacity-80 text-left"
+        style={{
+          border: "1px solid rgba(26,2,0,0.10)",
+          borderRadius: 14,
+          paddingLeft: 14,
+          paddingRight: 14,
+          paddingTop: 12,
+          paddingBottom: 12,
+          gap: 12,
+        }}
       >
-        <LogOut size={18} color="#8E8E93" />
-        <span className="text-sm font-bold flex-1">Sign out</span>
-        <ChevronRight size={14} color="#8E8E93" />
+        <LogOut size={18} color="#6B6B6B" strokeWidth={1.75} />
+        <span className="font-peachi font-bold flex-1" style={{ color: "#1A0200", fontSize: 15 }}>
+          Sign out
+        </span>
+        <ChevronRight size={16} color="#8E8E93" />
       </button>
     );
   }

--- a/apps/order/src/app/account/_TierCarousel.tsx
+++ b/apps/order/src/app/account/_TierCarousel.tsx
@@ -172,6 +172,11 @@ export function TierCarousel() {
           gap: GAP,
           paddingLeft: 16,
           paddingRight: 16,
+          // scroll-padding makes each snapped card respect the 16px
+          // gutter so it sits centred (16px each side) instead of
+          // flush-left — otherwise scroll-snap-align:start ignores the
+          // container padding for cards past the first.
+          scrollPaddingLeft: 16,
           scrollSnapType: "x mandatory",
           WebkitOverflowScrolling: "touch",
         }}

--- a/apps/order/src/app/cart/_CartView.tsx
+++ b/apps/order/src/app/cart/_CartView.tsx
@@ -389,12 +389,11 @@ export function CartView({ bestSellers = [] }: { bestSellers?: BestSeller[] }) {
               +{Math.floor(grandTotal)} pts
             </span>
           </div>
-        ) : (
-          <div style={{ marginBottom: 12 }} />
-        )}
+        ) : null}
         <Link
           href="/checkout"
-          className="block w-full rounded-full bg-[#A2492C] text-white text-center py-4 font-bold active:opacity-80"
+          className="block w-full rounded-full bg-[#A2492C] text-white text-center py-4 font-peachi font-bold active:opacity-80"
+          style={{ marginTop: 12 }}
         >
           Continue to checkout
         </Link>

--- a/apps/order/src/app/order/[id]/_OrderTrackingView.tsx
+++ b/apps/order/src/app/order/[id]/_OrderTrackingView.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useState } from "react";
 import Link from "next/link";
-import { ArrowLeft, ShoppingBag, Coffee, CheckCircle2, XCircle, X } from "lucide-react";
+import { ArrowLeft, ShoppingBag, Coffee, CheckCircle2, XCircle } from "lucide-react";
 import { MysteryReward } from "./_MysteryReward";
 
 type OrderItem = {
@@ -62,28 +62,6 @@ function stepperIndex(status: string): number {
 export function OrderTrackingView({ orderId }: { orderId: string }) {
   const [order, setOrder] = useState<Order | null>(null);
   const [error, setError] = useState<string | null>(null);
-  const [cancelling, setCancelling] = useState(false);
-
-  const cancel = async () => {
-    setCancelling(true);
-    try {
-      const res = await fetch(`/api/orders/${orderId}/status`, {
-        method: "PATCH",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ status: "cancelled" }),
-      });
-      if (res.ok) {
-        setOrder((prev) => (prev ? { ...prev, status: "cancelled" } : prev));
-      } else {
-        const data = await res.json().catch(() => ({}));
-        setError(data.error ?? "Couldn't cancel the order");
-      }
-    } catch (e) {
-      setError(e instanceof Error ? e.message : String(e));
-    } finally {
-      setCancelling(false);
-    }
-  };
 
   useEffect(() => {
     let cancelled = false;
@@ -130,7 +108,7 @@ export function OrderTrackingView({ orderId }: { orderId: string }) {
       {order.store_name ? (
         <section className="px-4 pt-5">
           <h2 className="font-peachi font-bold text-[16px] mb-1">Pickup from</h2>
-          <p className="text-sm font-bold">{order.store_name}</p>
+          <p className="text-sm font-peachi font-bold">{order.store_name}</p>
           {order.store_address ? (
             <p className="text-[12px] text-[#6E6E73] mt-0.5">{order.store_address}</p>
           ) : null}
@@ -143,7 +121,7 @@ export function OrderTrackingView({ orderId }: { orderId: string }) {
           <div className="flex items-center gap-3 rounded-2xl bg-red-50 border border-red-200 p-3">
             <XCircle size={20} color="#B91C1C" />
             <div>
-              <p className="font-bold text-sm text-red-800">
+              <p className="font-peachi font-bold text-sm text-red-800">
                 {order.status === "failed" ? "Payment failed" : "Cancelled"}
               </p>
               <p className="text-[12px] text-red-700 mt-0.5">
@@ -255,20 +233,6 @@ export function OrderTrackingView({ orderId }: { orderId: string }) {
           </div>
         )}
       </section>
-
-      {order.status.toLowerCase() === "pending" ? (
-        <section className="px-4 pt-4">
-          <button
-            type="button"
-            disabled={cancelling}
-            onClick={cancel}
-            className="w-full flex items-center justify-center gap-2 rounded-full border border-red-200 bg-red-50 text-red-700 py-3 font-bold active:opacity-80"
-          >
-            <X size={16} />
-            {cancelling ? "Cancelling…" : "Cancel order"}
-          </button>
-        </section>
-      ) : null}
 
       {/* Mystery-bean reveal — only once payment is in (not pending /
           failed / cancelled). Renders nothing if the order has no drop. */}

--- a/apps/order/src/app/orders/_OrdersView.tsx
+++ b/apps/order/src/app/orders/_OrdersView.tsx
@@ -2,7 +2,20 @@
 
 import { useEffect, useState } from "react";
 import Link from "next/link";
-import { ClipboardList, ChevronRight, CheckCircle2, XCircle, Coffee, Clock, MapPin } from "lucide-react";
+import { useRouter } from "next/navigation";
+import { ClipboardList, ChevronRight, CheckCircle2, XCircle, Coffee, Clock, MapPin, RefreshCw } from "lucide-react";
+
+type OrderItem = {
+  product_id?: string;
+  product_name: string;
+  quantity: number;
+  unit_price?: number; // sen
+  item_total?: number; // sen
+  modifiers?: {
+    selections?: Array<{ groupId?: string; groupName?: string; optionId?: string; label?: string; priceDelta?: number }>;
+    specialInstructions?: string;
+  } | null;
+};
 
 type Order = {
   id: string;
@@ -10,9 +23,43 @@ type Order = {
   status: string;
   total: number;
   created_at: string;
-  order_items?: Array<{ product_name: string; quantity: number }>;
+  order_items?: OrderItem[];
   store_name?: string | null;
 };
+
+// Rebuild cart lines from a past order's items and drop them into the
+// persisted cart, then send the customer to the cart. order_items carry
+// product_id, unit_price + item_total (sen) and the modifiers jsonb, so
+// the line reconstructs faithfully. Mirrors native's "Order again".
+function reorder(order: Order): boolean {
+  const items = order.order_items ?? [];
+  if (items.length === 0) return false;
+  try {
+    const raw = window.localStorage.getItem("celsius-pickup");
+    const parsed = raw ? JSON.parse(raw) : { state: {} };
+    const state = parsed.state ?? {};
+    state.cart = items.map((it, i) => ({
+      cartId: `${Date.now()}-${i}-${Math.random().toString(36).slice(2, 6)}`,
+      productId: it.product_id ?? "",
+      name: it.product_name,
+      basePrice: (it.unit_price ?? 0) / 100,
+      quantity: it.quantity,
+      totalPrice: (it.item_total ?? 0) / 100,
+      modifiers: (it.modifiers?.selections ?? []).map((s) => ({
+        groupId: s.groupId ?? "",
+        groupName: s.groupName ?? "",
+        optionId: s.optionId ?? "",
+        label: s.label ?? "",
+        priceDelta: s.priceDelta ?? 0,
+      })),
+      specialInstructions: it.modifiers?.specialInstructions,
+    }));
+    window.localStorage.setItem("celsius-pickup", JSON.stringify({ ...parsed, state }));
+    return true;
+  } catch {
+    return false;
+  }
+}
 
 type Persisted = { state?: { phone?: string | null; sessionToken?: string | null } };
 
@@ -142,6 +189,7 @@ export function OrdersView() {
 }
 
 function OrderRow({ order }: { order: Order }) {
+  const router = useRouter();
   const status = order.status.toLowerCase();
   const StatusIcon =
     status === "completed" || status === "ready"
@@ -241,8 +289,12 @@ function OrderRow({ order }: { order: Order }) {
           </span>
           <ChevronRight size={14} color="#160800" />
         </Link>
-        <Link
-          href="/menu"
+        <button
+          type="button"
+          onClick={() => {
+            if (reorder(order)) router.push("/cart");
+            else router.push("/menu");
+          }}
           className="flex-1 flex items-center justify-center gap-1 rounded-full active:opacity-80"
           style={{
             backgroundColor: "#1A0200",
@@ -250,10 +302,11 @@ function OrderRow({ order }: { order: Order }) {
             paddingBottom: 10,
           }}
         >
+          <RefreshCw size={13} color="#FFFFFF" strokeWidth={2.5} />
           <span className="font-peachi font-bold" style={{ color: "#FFFFFF", fontSize: 13 }}>
             Order again
           </span>
-        </Link>
+        </button>
       </div>
     </li>
   );

--- a/apps/order/src/app/page.tsx
+++ b/apps/order/src/app/page.tsx
@@ -197,7 +197,7 @@ export default async function HomePage() {
       <div className="mt-6 mx-4">
         <Link
           href="/menu"
-          className="block w-full rounded-full bg-[#A2492C] text-white text-center py-4 font-bold active:opacity-80"
+          className="block w-full rounded-full bg-[#A2492C] text-white text-center py-4 font-peachi font-bold active:opacity-80"
         >
           Open the menu →
         </Link>

--- a/apps/pickup-native/public/sw.js
+++ b/apps/pickup-native/public/sw.js
@@ -6,7 +6,7 @@
 //
 // Future rule of thumb: bump this on ANY production-affecting bundle
 // regression so customers don't get stuck on a bad build.
-const CACHE = "celsius-v37";
+const CACHE = "celsius-v38";
 const SHELL = ["/", "/index.html", "/manifest.json"];
 
 self.addEventListener("install", (e) => {


### PR DESCRIPTION
## Summary
Visual-QA polish pass against native, fixing the classes you flagged (centering, fonts, stray buttons, gaps):

- **Tier card centering** — added `scroll-padding-left` so each snapped card sits centred in the 16px gutter (cards past the first were flush-left under `scroll-snap-align:start`).
- **Font misuse → Peachi-Bold** — home "Open the menu" CTA, cart "Continue to checkout", order "Pickup from" outlet name, failed/cancelled status title; account "Edit profile" + "Sign out" rows now use the same Peachi-Bold + icon-tile treatment as the other action rows.
- **Stray button** — removed the web-only "Cancel order" button on the order page (native has no customer-facing cancel) + its dead handler/state.
- **Gap** — removed the stray empty spacer `<div>` in cart; moved the 12px gap onto the checkout CTA.
- **Order again** — now actually reorders (rebuilds cart lines from the past order's items and routes to `/cart`) with the RefreshCw icon, instead of a bare `/menu` link.

Bumps SW cache to v38.

## Test plan
- [ ] `/account` tier carousel → every card centred when swiped.
- [ ] Peachi font on the listed CTAs/labels.
- [ ] Order page → no Cancel button; "Pickup from" name in Peachi.
- [ ] `/orders` "Order again" → cart fills with that order's items.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xd1aERynqUbdCqXNboKWBe)_