### PR TITLE
feat(web): QR table-pay dine-in flow

### DIFF
--- a/apps/order/public/sw.js
+++ b/apps/order/public/sw.js
@@ -1,7 +1,7 @@
 // Mirror of apps/pickup-native/public/sw.js — overwritten on each
 // build-pwa run. v3 bumps over v2 to flush customers off the broken
 // CSS shipped in #157/#158 before this revert deployed.
-const CACHE = "celsius-v38";
+const CACHE = "celsius-v39";
 const SHELL = ["/", "/index.html", "/manifest.json"];
 
 self.addEventListener("install", (e) => {

--- a/apps/order/src/app/checkout/_CheckoutView.tsx
+++ b/apps/order/src/app/checkout/_CheckoutView.tsx
@@ -25,6 +25,8 @@ type Persisted = {
     phone?: string | null;
     loyaltyId?: string | null;
     appliedReward?: AppliedReward | null;
+    orderType?: "pickup" | "dine_in" | null;
+    tableNumber?: string | null;
   };
 };
 
@@ -123,6 +125,7 @@ export function CheckoutView() {
   }
 
   const cart = state.cart ?? [];
+  const isDineIn = state.orderType === "dine_in";
   if (cart.length === 0) {
     return (
       <div className="p-8 text-center">
@@ -160,6 +163,8 @@ export function CheckoutView() {
           paymentMethod: method,
           loyaltyPhone: state.phone ?? null,
           loyaltyId:    state.loyaltyId ?? null,
+          orderType:    state.orderType === "dine_in" ? "dine_in" : "pickup",
+          tableNumber:  state.orderType === "dine_in" ? (state.tableNumber ?? null) : null,
           // Forward the applied reward so the server actually discounts
           // the order (otherwise the customer is charged full price).
           rewardId:          reward?.id ?? null,
@@ -167,7 +172,6 @@ export function CheckoutView() {
           rewardPointsCost:  reward?.points_required ?? 0,
           rewardDiscountSen: Math.round(rewardDiscount * 100),
           voucherId:         reward?.voucher_id ?? null,
-          orderType:    "pickup",
         }),
       });
       const data = await res.json();
@@ -239,13 +243,15 @@ export function CheckoutView() {
             className="uppercase"
             style={{ color: "#6B6B6B", fontSize: 10, fontWeight: 700, letterSpacing: 1.4 }}
           >
-            Pickup from
+            {isDineIn ? "Dine-in" : "Pickup from"}
           </p>
           <p
             className="font-peachi font-bold truncate"
             style={{ color: "#1A0200", fontSize: 15, marginTop: 4 }}
           >
-            {state.outletName ?? "Select an outlet"}
+            {isDineIn
+              ? `Table ${state.tableNumber ?? ""} · ${state.outletName ?? ""}`.trim()
+              : state.outletName ?? "Select an outlet"}
           </p>
         </div>
       </section>

--- a/apps/order/src/app/menu/_OutletPickerRow.tsx
+++ b/apps/order/src/app/menu/_OutletPickerRow.tsx
@@ -7,17 +7,23 @@ import { MapPin, ChevronDown } from "lucide-react";
 /**
  * Outlet picker row at the top of /menu. Shows the actual selected
  * outlet name from localStorage; same visual as apps/pickup-native
- * /app/menu.tsx:460-473 (MapPin terracotta + Peachi/sans bold name +
- * ChevronDown).
+ * /app/menu.tsx:460-473 (MapPin terracotta + bold name + ChevronDown).
+ *
+ * In dine-in (table-QR) mode it shows "Table N · {outlet}" and is not
+ * a link — the customer is seated, so there's no outlet to change.
  */
 type Persisted = {
   state?: {
     outletName?: string | null;
+    orderType?: "pickup" | "dine_in" | null;
+    tableNumber?: string | null;
   };
 };
 
 export function OutletPickerRow() {
   const [name, setName] = useState<string | null>(null);
+  const [dineIn, setDineIn] = useState(false);
+  const [table, setTable] = useState<string | null>(null);
 
   useEffect(() => {
     try {
@@ -25,11 +31,24 @@ export function OutletPickerRow() {
       if (raw) {
         const parsed = JSON.parse(raw) as Persisted;
         setName(parsed.state?.outletName ?? null);
+        setDineIn(parsed.state?.orderType === "dine_in");
+        setTable(parsed.state?.tableNumber ?? null);
       }
     } catch {
       /* ignore */
     }
   }, []);
+
+  if (dineIn) {
+    return (
+      <div className="flex items-center gap-2 bg-white border-b border-[rgba(26,2,0,0.10)] px-4 py-2">
+        <MapPin size={14} color="#A2492C" />
+        <span className="font-bold flex-1 truncate" style={{ color: "#1A0200", fontSize: 14 }}>
+          Table {table} · {name ?? "Dine-in"}
+        </span>
+      </div>
+    );
+  }
 
   return (
     <Link

--- a/apps/order/src/app/table/[outletId]/[tableId]/_TableEntry.tsx
+++ b/apps/order/src/app/table/[outletId]/[tableId]/_TableEntry.tsx
@@ -1,0 +1,90 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { MapPin } from "lucide-react";
+
+/**
+ * Writes the dine-in context into the persisted "celsius-pickup" store
+ * and redirects to the menu. Sets outletId/outletName so the menu's
+ * OutletGate passes without a picker, plus orderType "dine_in" +
+ * tableNumber so checkout creates a table order (not a pickup).
+ */
+type Persisted = {
+  state?: Record<string, unknown>;
+};
+
+export function TableEntry({
+  outletId,
+  outletName,
+  tableId,
+}: {
+  outletId: string;
+  outletName: string | null;
+  tableId: string;
+}) {
+  const router = useRouter();
+  const [ok] = useState(() => !!outletName);
+
+  useEffect(() => {
+    if (!outletName) return;
+    try {
+      const raw = window.localStorage.getItem("celsius-pickup");
+      const parsed = raw ? (JSON.parse(raw) as Persisted) : { state: {} };
+      const state = (parsed.state ?? {}) as Record<string, unknown>;
+      state.outletId = outletId;
+      state.outletName = outletName;
+      state.outletIsOpen = true;
+      state.orderType = "dine_in";
+      state.tableNumber = tableId;
+      // A fresh table session shouldn't inherit a previous pickup
+      // cart/reward — start the dine-in basket clean.
+      state.cart = [];
+      state.appliedReward = null;
+      state.reservedVoucher = null;
+      window.localStorage.setItem("celsius-pickup", JSON.stringify({ ...parsed, state }));
+    } catch {
+      /* ignore */
+    }
+    router.replace("/menu");
+  }, [outletId, outletName, tableId, router]);
+
+  if (!ok) {
+    return (
+      <div className="flex flex-col items-center justify-center px-8 text-center" style={{ minHeight: "70vh" }}>
+        <MapPin size={44} color="#A2492C" strokeWidth={1.5} />
+        <p className="font-peachi font-bold text-xl mt-4" style={{ color: "#1A0200" }}>
+          Table not found
+        </p>
+        <p className="text-sm mt-2" style={{ color: "#6B6B6B" }}>
+          This QR code doesn&apos;t match an active outlet. Ask a barista for help, or browse the menu
+          for pickup.
+        </p>
+        <Link
+          href="/"
+          className="mt-6 rounded-full bg-[#A2492C] text-white px-5 py-3 font-peachi font-bold active:opacity-80"
+        >
+          Go to home
+        </Link>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col items-center justify-center px-8 text-center" style={{ minHeight: "70vh" }}>
+      <span
+        className="flex items-center justify-center"
+        style={{ width: 56, height: 56, borderRadius: 16, backgroundColor: "rgba(162,73,44,0.10)" }}
+      >
+        <MapPin size={28} color="#A2492C" strokeWidth={1.5} />
+      </span>
+      <p className="font-peachi font-bold text-xl mt-4" style={{ color: "#1A0200" }}>
+        Table {tableId}
+      </p>
+      <p className="text-sm mt-1" style={{ color: "#6B6B6B" }}>
+        {outletName} · opening your menu…
+      </p>
+    </div>
+  );
+}

--- a/apps/order/src/app/table/[outletId]/[tableId]/page.tsx
+++ b/apps/order/src/app/table/[outletId]/[tableId]/page.tsx
@@ -1,0 +1,49 @@
+import { getSupabaseAdmin } from "@/lib/supabase/server";
+import { TableEntry } from "./_TableEntry";
+
+/**
+ * Table-QR landing — the URL encoded on the in-store QR codes is
+ * https://order.celsiuscoffee.com/table/{outletId}/{tableId}
+ * (see apps/backoffice/.../pos/table-qr/page.tsx buildTableUrl).
+ *
+ * Scanning the QR lands here: we resolve the outlet name server-side,
+ * then a tiny client component writes the dine-in context (outlet +
+ * orderType "dine_in" + tableNumber) into the persisted store and
+ * sends the customer straight to the menu — no outlet picker, no
+ * pickup gate.
+ */
+export const revalidate = 60;
+
+async function fetchOutletName(outletId: string): Promise<string | null> {
+  try {
+    const supabase = getSupabaseAdmin();
+    const { data } = await supabase
+      .from("outlet_settings")
+      .select("name, is_active")
+      .eq("store_id", outletId)
+      .maybeSingle();
+    if (!data || data.is_active === false) return null;
+    return (data.name as string) ?? null;
+  } catch {
+    return null;
+  }
+}
+
+export default async function TablePage({
+  params,
+}: {
+  params: Promise<{ outletId: string; tableId: string }>;
+}) {
+  const { outletId, tableId } = await params;
+  const outletName = await fetchOutletName(outletId);
+
+  return (
+    <main className="bg-white text-[#160800] min-h-screen">
+      <TableEntry
+        outletId={outletId}
+        outletName={outletName}
+        tableId={decodeURIComponent(tableId)}
+      />
+    </main>
+  );
+}

--- a/apps/order/src/middleware.ts
+++ b/apps/order/src/middleware.ts
@@ -80,7 +80,8 @@ export async function middleware(request: NextRequest) {
     pathname === "/account-delete" ||
     pathname.startsWith("/product/") ||
     pathname.startsWith("/order/") ||
-    pathname.startsWith("/challenge/");
+    pathname.startsWith("/challenge/") ||
+    pathname.startsWith("/table/");
 
   // Customer-facing UI lives in the Expo Web PWA shipped from
   // apps/pickup-native and copied into /public during build. For any

--- a/apps/pickup-native/public/sw.js
+++ b/apps/pickup-native/public/sw.js
@@ -6,7 +6,7 @@
 //
 // Future rule of thumb: bump this on ANY production-affecting bundle
 // regression so customers don't get stuck on a bad build.
-const CACHE = "celsius-v38";
+const CACHE = "celsius-v39";
 const SHELL = ["/", "/index.html", "/manifest.json"];
 
 self.addEventListener("install", (e) => {


### PR DESCRIPTION
## Summary
This wires up the **QR table-pay** flow — the actual target of this whole effort.

The in-store QR codes encode `order.celsiuscoffee.com/table/{outletId}/{tableId}` (`apps/backoffice/.../pos/table-qr`), but **no `/table/...` route existed** — scanning a table QR fell through to the SPA home with no table context, so table-pay never worked end-to-end. Built it:

- **New `/table/[outletId]/[tableId]` route** — server resolves the outlet name from `outlet_settings`; a client entry component writes the dine-in context into the persisted store (`outletId`, `outletName`, `orderType: "dine_in"`, `tableNumber`) with a fresh cart, then redirects to `/menu` (no outlet picker, no pickup gate). Shows a "Table not found" state for an inactive/unknown outlet.
- **Middleware** — `/table/*` is now Next-owned (was rewriting to the SPA).
- **Checkout** — reads `orderType` + `tableNumber` from state and sends them to `/api/checkout/initiate` (was hardcoded `"pickup"`); the route already persists `order_type` + `table_number`. The "Pickup from" card flips to "Dine-in · Table N · {outlet}".
- **Menu** — outlet row shows "Table N · {outlet}" (non-interactive) in dine-in mode.

POS already renders `order_type === "dine_in"` as "TABLE {table_number}" on open-orders + KDS, so table orders surface correctly there.

Bumps SW cache to v39.

## Test plan
- [ ] Scan/visit `/table/{outletId}/{tableId}` for an active outlet → "Table N" splash → lands on `/menu` with "Table N · {outlet}" row.
- [ ] Add items → checkout shows "Dine-in · Table N"; place order → order created with `order_type=dine_in`, `table_number=N`.
- [ ] POS open-orders/KDS shows "TABLE N".
- [ ] Unknown/inactive outlet → "Table not found".

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xd1aERynqUbdCqXNboKWBe)_