### PR TITLE
fix(web/menu): freeze the outlet picker with the header

### DIFF
--- a/apps/order/public/sw.js
+++ b/apps/order/public/sw.js
@@ -1,7 +1,7 @@
 // Mirror of apps/pickup-native/public/sw.js — overwritten on each
 // build-pwa run. v3 bumps over v2 to flush customers off the broken
 // CSS shipped in #157/#158 before this revert deployed.
-const CACHE = "celsius-v39";
+const CACHE = "celsius-v40";
 const SHELL = ["/", "/index.html", "/manifest.json"];
 
 self.addEventListener("install", (e) => {

--- a/apps/order/public/sw.js
+++ b/apps/order/public/sw.js
@@ -1,7 +1,7 @@
 // Mirror of apps/pickup-native/public/sw.js — overwritten on each
 // build-pwa run. v3 bumps over v2 to flush customers off the broken
 // CSS shipped in #157/#158 before this revert deployed.
-const CACHE = "celsius-v40";
+const CACHE = "celsius-v41";
 const SHELL = ["/", "/index.html", "/manifest.json"];
 
 self.addEventListener("install", (e) => {

--- a/apps/order/src/app/menu/_MenuColumns.tsx
+++ b/apps/order/src/app/menu/_MenuColumns.tsx
@@ -163,12 +163,16 @@ export function MenuColumns({
 
   return (
     <>
-      {/* Sticky espresso header. Search is a toggle (matching
+      {/* Chrome block — header + outlet picker (+ reserved-voucher
+          banner) freeze together at the top so the outlet stays in view
+          while the product list scrolls under it. */}
+      <div className="sticky top-0 z-10">
+      {/* Espresso header. Search is a toggle (matching
           apps/pickup-native/app/menu.tsx:375-430): the title row shows
           a Search icon + Cart; tapping Search swaps the whole bar into
           an inline white-tinted field with a Cancel button. */}
       <header
-        className="bg-[#160800] text-white px-4 pb-3 sticky top-0 z-10"
+        className="bg-[#160800] text-white px-4 pb-3"
         style={{ paddingTop: "calc(env(safe-area-inset-top, 0px) + 12px)" }}
       >
         {searchOpen ? (
@@ -231,6 +235,7 @@ export function MenuColumns({
       </header>
 
       {children}
+      </div>
 
       {searchResults ? (
         <div className="px-3 pt-4">

--- a/apps/order/src/app/order/[id]/_OrderTrackingView.tsx
+++ b/apps/order/src/app/order/[id]/_OrderTrackingView.tsx
@@ -28,6 +28,8 @@ type Order = {
   store_id?: string | null;
   store_name?: string | null;
   store_address?: string | null;
+  order_type?: string | null;
+  table_number?: string | null;
   reward_discount_amount?: number | null;
   reward_name?: string | null;
   discount_amount?: number | null;
@@ -42,15 +44,17 @@ function rm(cents: number | null | undefined): string {
 }
 
 // Horizontal 3-step pipeline matching apps/pickup-native/components
-// /OrderStepper.tsx. Web order status → stepper index:
-//   pending/paid           → 0 (Received)
-//   preparing              → 1 (Brewing)
-//   ready/completed        → 2 (Ready)
-const STEPPER: Array<{ title: string; sub: string; Icon: typeof ShoppingBag }> = [
-  { title: "Received",  sub: "Order placed",   Icon: ShoppingBag },
-  { title: "Brewing",   sub: "Being prepared", Icon: Coffee },
-  { title: "Ready",     sub: "Pick up now",    Icon: CheckCircle2 },
-];
+// /OrderStepper.tsx. The final step reads "Ready / Pick up now" for
+// pickup and "Served / Enjoy!" for dine-in (table orders).
+function stepperSteps(dineIn: boolean): Array<{ title: string; sub: string; Icon: typeof ShoppingBag }> {
+  return [
+    { title: "Received", sub: "Order placed", Icon: ShoppingBag },
+    { title: "Brewing", sub: "Being prepared", Icon: Coffee },
+    dineIn
+      ? { title: "Served", sub: "Enjoy!", Icon: CheckCircle2 }
+      : { title: "Ready", sub: "Pick up now", Icon: CheckCircle2 },
+  ];
+}
 
 function stepperIndex(status: string): number {
   const s = status.toLowerCase();
@@ -95,6 +99,8 @@ export function OrderTrackingView({ orderId }: { orderId: string }) {
   }
 
   const stepIdx = stepperIndex(order.status);
+  const isDineIn = order.order_type === "dine_in";
+  const STEPPER = stepperSteps(isDineIn);
 
   return (
     <>
@@ -107,8 +113,14 @@ export function OrderTrackingView({ orderId }: { orderId: string }) {
 
       {order.store_name ? (
         <section className="px-4 pt-5">
-          <h2 className="font-peachi font-bold text-[16px] mb-1">Pickup from</h2>
-          <p className="text-sm font-peachi font-bold">{order.store_name}</p>
+          <h2 className="font-peachi font-bold text-[16px] mb-1">
+            {isDineIn ? "Dine-in" : "Pickup from"}
+          </h2>
+          <p className="text-sm font-peachi font-bold">
+            {isDineIn && order.table_number
+              ? `Table ${order.table_number} · ${order.store_name}`
+              : order.store_name}
+          </p>
           {order.store_address ? (
             <p className="text-[12px] text-[#6E6E73] mt-0.5">{order.store_address}</p>
           ) : null}

--- a/apps/pickup-native/public/sw.js
+++ b/apps/pickup-native/public/sw.js
@@ -6,7 +6,7 @@
 //
 // Future rule of thumb: bump this on ANY production-affecting bundle
 // regression so customers don't get stuck on a bad build.
-const CACHE = "celsius-v40";
+const CACHE = "celsius-v41";
 const SHELL = ["/", "/index.html", "/manifest.json"];
 
 self.addEventListener("install", (e) => {

--- a/apps/pickup-native/public/sw.js
+++ b/apps/pickup-native/public/sw.js
@@ -6,7 +6,7 @@
 //
 // Future rule of thumb: bump this on ANY production-affecting bundle
 // regression so customers don't get stuck on a bad build.
-const CACHE = "celsius-v39";
+const CACHE = "celsius-v40";
 const SHELL = ["/", "/index.html", "/manifest.json"];
 
 self.addEventListener("install", (e) => {


### PR DESCRIPTION
## Summary
On `/menu` only the espresso header was sticky, so the outlet picker row scrolled away. Wrapped the header + outlet picker (+ reserved-voucher banner) in a single `sticky top-0` chrome block so the outlet stays frozen at the top while the product list scrolls under it.

Bumps SW cache to v41.

## Test plan
- [ ] Open `/menu`, scroll the product list → header **and** outlet picker stay pinned at top.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xd1aERynqUbdCqXNboKWBe)_