### PR TITLE
fix(web): rewards bean cost always shown + tier-themed BeansHero + drop home CTA

### DIFF
--- a/apps/order/public/sw.js
+++ b/apps/order/public/sw.js
@@ -1,7 +1,7 @@
 // Mirror of apps/pickup-native/public/sw.js — overwritten on each
 // build-pwa run. v3 bumps over v2 to flush customers off the broken
 // CSS shipped in #157/#158 before this revert deployed.
-const CACHE = "celsius-v41";
+const CACHE = "celsius-v42";
 const SHELL = ["/", "/index.html", "/manifest.json"];
 
 self.addEventListener("install", (e) => {

--- a/apps/order/src/app/page.tsx
+++ b/apps/order/src/app/page.tsx
@@ -193,16 +193,6 @@ export default async function HomePage() {
         </section>
       )}
 
-      {/* Primary CTA */}
-      <div className="mt-6 mx-4">
-        <Link
-          href="/menu"
-          className="block w-full rounded-full bg-[#A2492C] text-white text-center py-4 font-peachi font-bold active:opacity-80"
-        >
-          Open the menu →
-        </Link>
-      </div>
-
       <GlobalCartPill />
       <BottomNav active="home" />
     </main>

--- a/apps/order/src/app/rewards/_BeansHero.tsx
+++ b/apps/order/src/app/rewards/_BeansHero.tsx
@@ -3,23 +3,17 @@
 import { useEffect, useState } from "react";
 
 /**
- * Beans hero card for /rewards — port of the BeansHero function in
- * apps/pickup-native/app/rewards.tsx:447-680. Compact 110px-tall
- * horizontal card with the customer's bean balance as the protagonist
- * (Peachi-Bold 28px) and a progress line "Spend RMx in N days to
- * unlock NextTier" + thin progress bar on the right.
- *
- * Themed by tier_color at 8% / 18% alpha so each tier gets its own
- * colourway. Replaces the prior account-style TierCard on the rewards
- * screen — native uses BeansHero there, TierCard only on the Account
- * tab.
+ * Beans hero card for /rewards — port of the BeansHero in
+ * apps/pickup-native/app/rewards.tsx. Tier-themed gradient card (same
+ * gradient + brand "°c" watermark as the Account tier cards) with the
+ * bean balance as the protagonist and a "Spend RMx in N days to unlock
+ * {next}" progress line + thin bar.
  */
 type Tier = {
-  tier_id?: string | null;
+  tier_slug?: string | null;
   tier_name?: string | null;
   tier_color?: string | null;
   tier_multiplier?: number | null;
-  next_tier_id?: string | null;
   next_tier_name?: string | null;
   next_tier_min_spend?: number | null;
   spend_to_next_tier?: number | null;
@@ -34,14 +28,27 @@ type Persisted = {
   };
 };
 
-function hexWithAlpha(hex: string, alpha: number): string {
-  const m = /^#([0-9a-f]{6})$/i.exec((hex || "").trim());
-  if (!m) return `rgba(146, 64, 14, ${alpha})`;
-  const num = parseInt(m[1], 16);
-  const r = (num >> 16) & 0xff;
-  const g = (num >> 8) & 0xff;
-  const b = num & 0xff;
-  return `rgba(${r}, ${g}, ${b}, ${alpha})`;
+type Theme = {
+  gradTop: string;
+  gradBottom: string;
+  accent: string;
+  subtle: string;
+  watermark: string;
+  dark: boolean;
+};
+
+// Same TIER_THEMES table as apps/order/src/app/account/_TierCarousel.tsx
+const TIER_THEMES: Record<string, Theme> = {
+  bronze:       { gradTop: "#FFF6E2", gradBottom: "#E4CFA5", accent: "#7A4B16", subtle: "rgba(73,42,7,0.62)",    watermark: "rgba(122,75,22,0.10)",  dark: false },
+  silver:       { gradTop: "#F1F4F6", gradBottom: "#B6C3CC", accent: "#3F4A55", subtle: "rgba(31,38,46,0.58)",   watermark: "rgba(63,74,85,0.10)",   dark: false },
+  gold:         { gradTop: "#FFF1C2", gradBottom: "#D6A55A", accent: "#6B4A0F", subtle: "rgba(63,42,4,0.62)",    watermark: "rgba(107,74,15,0.10)",  dark: false },
+  elite:        { gradTop: "#241408", gradBottom: "#040201", accent: "#E8C766", subtle: "rgba(232,199,102,0.72)", watermark: "rgba(232,199,102,0.08)", dark: true },
+  "arba-staff": { gradTop: "#5A1F16", gradBottom: "#1A0200", accent: "#FBBF24", subtle: "rgba(251,191,36,0.72)", watermark: "rgba(251,191,36,0.08)",  dark: true },
+  "black-card": { gradTop: "#1F1916", gradBottom: "#000000", accent: "#D4B978", subtle: "rgba(212,185,120,0.70)", watermark: "rgba(212,185,120,0.08)", dark: true },
+};
+
+function themeForSlug(slug: string | null | undefined): Theme {
+  return TIER_THEMES[slug ?? "bronze"] ?? TIER_THEMES.bronze;
 }
 
 function daysUntil(iso: string | null | undefined): number | null {
@@ -76,10 +83,8 @@ export function BeansHero() {
       });
   }, []);
 
-  const color = tier?.tier_color || "#92400e";
-  const bgFill = hexWithAlpha(color, 0.08);
-  const borderFill = hexWithAlpha(color, 0.18);
-  const subtle = hexWithAlpha(color, 0.7);
+  const theme = themeForSlug(tier?.tier_slug);
+  const numberColor = theme.dark ? theme.accent : "#1A0200";
 
   const nextName = tier?.next_tier_name ?? null;
   const spendToNext = Math.max(0, tier?.spend_to_next_tier ?? 0);
@@ -92,55 +97,79 @@ export function BeansHero() {
   if (nextName && spendToNext > 0 && nextMin > 0) {
     progressRatio = Math.max(0, Math.min(1, spent / nextMin));
     const window =
-      daysLeft != null && daysLeft > 0
-        ? ` in ${daysLeft} day${daysLeft === 1 ? "" : "s"}`
-        : "";
+      daysLeft != null && daysLeft > 0 ? ` in ${daysLeft} day${daysLeft === 1 ? "" : "s"}` : "";
     progressText = `Spend RM${Math.round(spendToNext)}${window} to unlock ${nextName}`;
   }
+
+  const markSize = 110 * 1.15;
 
   return (
     <section className="px-4 pt-4">
       <div
-        className="flex items-center"
+        className="flex items-center relative overflow-hidden"
         style={{
           height: 110,
           borderRadius: 18,
-          backgroundColor: bgFill,
-          border: `1px solid ${borderFill}`,
+          background: `linear-gradient(160deg, ${theme.gradTop}, ${theme.gradBottom})`,
           paddingLeft: 14,
           paddingRight: 14,
           paddingTop: 14,
           paddingBottom: 14,
           gap: 14,
-          boxShadow: "0 4px 10px rgba(0,0,0,0.06)",
+          boxShadow: "0 4px 10px rgba(0,0,0,0.10)",
         }}
       >
-        <div className="flex-shrink-0">
+        {/* "°c" brand watermark */}
+        <span
+          aria-hidden
+          style={{ position: "absolute", left: -markSize * 0.04, top: -markSize * 0.04, width: markSize, height: markSize, pointerEvents: "none", zIndex: 0 }}
+        >
+          <span
+            style={{
+              position: "absolute",
+              left: markSize * 0.18,
+              top: markSize * 0.18,
+              width: markSize * 0.1,
+              height: markSize * 0.1,
+              borderRadius: markSize * 0.05,
+              border: `${Math.max(2, markSize * 0.015)}px solid ${theme.watermark}`,
+            }}
+          />
+          <span
+            className="font-peachi font-bold"
+            style={{
+              position: "absolute",
+              left: markSize * 0.2,
+              top: markSize * 0.05,
+              fontSize: markSize * 0.95,
+              lineHeight: `${markSize * 0.95}px`,
+              color: theme.watermark,
+            }}
+          >
+            c
+          </span>
+        </span>
+
+        <div className="flex-shrink-0" style={{ position: "relative", zIndex: 1 }}>
           <p
             className="uppercase"
-            style={{ color: subtle, fontSize: 9.5, fontWeight: 700, letterSpacing: 1.4 }}
+            style={{ color: theme.subtle, fontSize: 9.5, fontWeight: 700, letterSpacing: 1.4 }}
           >
             Beans
           </p>
           <p
             className="font-peachi font-bold"
-            style={{
-              color: "#1A0200",
-              fontSize: 28,
-              letterSpacing: -0.6,
-              lineHeight: "32px",
-              marginTop: 2,
-            }}
+            style={{ color: numberColor, fontSize: 28, letterSpacing: -0.6, lineHeight: "32px", marginTop: 2 }}
           >
             {balance.toLocaleString()}
           </p>
         </div>
 
         {progressText ? (
-          <div className="flex-1 min-w-0">
+          <div className="flex-1 min-w-0" style={{ position: "relative", zIndex: 1 }}>
             <p
               className="line-clamp-2"
-              style={{ color: subtle, fontSize: 12, lineHeight: "16px", fontWeight: 500 }}
+              style={{ color: theme.subtle, fontSize: 12, lineHeight: "16px", fontWeight: 500 }}
             >
               {progressText}
             </p>
@@ -150,7 +179,7 @@ export function BeansHero() {
                   marginTop: 6,
                   height: 4,
                   borderRadius: 2,
-                  backgroundColor: "rgba(0,0,0,0.10)",
+                  backgroundColor: theme.dark ? "rgba(232,199,102,0.22)" : "rgba(0,0,0,0.10)",
                   overflow: "hidden",
                 }}
               >
@@ -158,7 +187,7 @@ export function BeansHero() {
                   style={{
                     width: `${Math.round(progressRatio * 100)}%`,
                     height: "100%",
-                    backgroundColor: color,
+                    backgroundColor: theme.accent,
                     borderRadius: 2,
                   }}
                 />

--- a/apps/order/src/app/rewards/_RewardsView.tsx
+++ b/apps/order/src/app/rewards/_RewardsView.tsx
@@ -310,7 +310,7 @@ function CatalogCard({ reward, balance }: { reward: Reward; balance: number }) {
             fontSize: 12,
           }}
         >
-          {canUse ? "Use" : `${required}`}
+          {canUse ? `Use · ${required.toLocaleString()}` : `${required.toLocaleString()}`}
         </button>
       </div>
     </li>

--- a/apps/pickup-native/public/sw.js
+++ b/apps/pickup-native/public/sw.js
@@ -6,7 +6,7 @@
 //
 // Future rule of thumb: bump this on ANY production-affecting bundle
 // regression so customers don't get stuck on a bad build.
-const CACHE = "celsius-v41";
+const CACHE = "celsius-v42";
 const SHELL = ["/", "/index.html", "/manifest.json"];
 
 self.addEventListener("install", (e) => {


### PR DESCRIPTION
## Summary
Three customer-requested tweaks on the rewards + home screens:

1. **Rewards bean cost always visible** — the catalog "Use" pill now shows the bean cost whether or not you can afford it: "Use · 150" when affordable, "150" when locked (was just "Use" / a bare number). Matches native's `CatalogCard`.
2. **Rewards tier card follows native** — rebuilt `BeansHero` as the tier-themed gradient card (same per-tier gradient + "°c" brand watermark as the Account tier cards), with the bean number in the tier accent on dark tiers / espresso on light. Was a flat tinted card.
3. **Home** — removed the "Open the menu →" primary CTA (bottom-nav Menu puck + global cart pill already cover it).

Bumps SW cache to v42.

## Test plan
- [ ] `/rewards` → every catalog card shows its bean cost (affordable + locked).
- [ ] BeansHero shows the tier gradient + watermark; bean number legible on each tier.
- [ ] `/` → no "Open the menu" button.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xd1aERynqUbdCqXNboKWBe)_