### PR TITLE
fix(web): headers in Peachi + font/UI parity with native

### DIFF
--- a/apps/order/public/sw.js
+++ b/apps/order/public/sw.js
@@ -1,7 +1,7 @@
 // Mirror of apps/pickup-native/public/sw.js — overwritten on each
 // build-pwa run. v3 bumps over v2 to flush customers off the broken
 // CSS shipped in #157/#158 before this revert deployed.
-const CACHE = "celsius-v42";
+const CACHE = "celsius-v43";
 const SHELL = ["/", "/index.html", "/manifest.json"];
 
 self.addEventListener("install", (e) => {

--- a/apps/order/src/app/_ActiveOrderTracker.tsx
+++ b/apps/order/src/app/_ActiveOrderTracker.tsx
@@ -24,7 +24,7 @@ function statusLabel(status: string): string {
   const s = (status ?? "").toLowerCase();
   if (s === "pending") return "Awaiting payment";
   if (s === "paid") return "Payment confirmed";
-  if (s === "preparing") return "Brewing";
+  if (s === "preparing") return "Being prepared";
   if (s === "ready") return "Ready for pickup";
   return s;
 }

--- a/apps/order/src/app/_VoucherRail.tsx
+++ b/apps/order/src/app/_VoucherRail.tsx
@@ -189,7 +189,7 @@ function RewardTicket({ voucher }: { voucher: Voucher }) {
                 paddingTop: 2,
                 paddingBottom: 2,
                 borderRadius: 999,
-                fontFamily: "Peachi-Bold, serif",
+                fontFamily: "var(--font-display)",
                 fontWeight: 700,
                 fontSize: 9,
               }}

--- a/apps/order/src/app/account/_AccountView.tsx
+++ b/apps/order/src/app/account/_AccountView.tsx
@@ -57,7 +57,7 @@ export function AccountView() {
       >
         <h1
           className="text-[22px]"
-          style={{ fontFamily: "Peachi-Bold, serif", letterSpacing: -0.3, fontWeight: 700 }}
+          style={{ fontFamily: "var(--font-display)", letterSpacing: -0.3, fontWeight: 700 }}
         >
           Account
         </h1>
@@ -457,7 +457,7 @@ function EditProfileRow({
         }}
       >
         <Pencil size={18} color="#6B6B6B" strokeWidth={1.75} />
-        <span className="font-peachi font-bold flex-1" style={{ color: "#1A0200", fontSize: 15 }}>
+        <span className="flex-1" style={{ color: "#1A0200", fontSize: 15, fontWeight: 500 }}>
           Edit profile
         </span>
         <ChevronRight size={16} color="#8E8E93" />
@@ -539,7 +539,7 @@ function SignOutRow({ onConfirm }: { onConfirm: () => void }) {
         }}
       >
         <LogOut size={18} color="#6B6B6B" strokeWidth={1.75} />
-        <span className="font-peachi font-bold flex-1" style={{ color: "#1A0200", fontSize: 15 }}>
+        <span className="flex-1" style={{ color: "#1A0200", fontSize: 15, fontWeight: 500 }}>
           Sign out
         </span>
         <ChevronRight size={16} color="#8E8E93" />
@@ -597,8 +597,8 @@ function Row({
     >
       {Icon ? <Icon size={18} color="#6B6B6B" strokeWidth={1.75} /> : null}
       <span
-        className="font-peachi font-bold flex-1"
-        style={{ color: "#1A0200", fontSize: 15 }}
+        className="flex-1"
+        style={{ color: "#1A0200", fontSize: 15, fontWeight: 500 }}
       >
         {label}
       </span>

--- a/apps/order/src/app/cart/_CartView.tsx
+++ b/apps/order/src/app/cart/_CartView.tsx
@@ -22,6 +22,7 @@ type CartItem = {
   quantity: number;
   totalPrice: number;
   modifiers?: Array<{ groupName?: string; label?: string; priceDelta?: number }>;
+  specialInstructions?: string;
 };
 
 type Persisted = {
@@ -278,7 +279,7 @@ export function CartView({ bestSellers = [] }: { bestSellers?: BestSeller[] }) {
                 </Link>
                 <span
                   className="font-peachi font-bold flex-shrink-0"
-                  style={{ color: "#A2492C", fontSize: 14 }}
+                  style={{ color: "#B91C1C", fontSize: 14 }}
                 >
                   RM{item.totalPrice.toFixed(2)}
                 </span>
@@ -288,7 +289,15 @@ export function CartView({ bestSellers = [] }: { bestSellers?: BestSeller[] }) {
                   className="line-clamp-1"
                   style={{ color: "#6B6B6B", fontSize: 12, marginTop: 2, fontWeight: 500 }}
                 >
-                  {item.modifiers.map((m) => m.label).filter(Boolean).join(", ")}
+                  {item.modifiers.map((m) => m.label).filter(Boolean).join(" · ")}
+                </p>
+              ) : null}
+              {item.specialInstructions ? (
+                <p
+                  className="line-clamp-1 italic"
+                  style={{ color: "#6B6B6B", fontSize: 12, marginTop: 1 }}
+                >
+                  &ldquo;{item.specialInstructions}&rdquo;
                 </p>
               ) : null}
               <div className="mt-auto pt-2 flex items-center gap-3">
@@ -426,7 +435,7 @@ function CartShell({
           ) : null}
           <h1
             className="text-[22px] truncate"
-            style={{ fontFamily: "Peachi-Bold, serif", letterSpacing: -0.3, fontWeight: 700 }}
+            style={{ fontFamily: "var(--font-display)", letterSpacing: -0.3, fontWeight: 700 }}
           >
             Your cart
           </h1>

--- a/apps/order/src/app/orders/_OrdersView.tsx
+++ b/apps/order/src/app/orders/_OrdersView.tsx
@@ -130,7 +130,7 @@ export function OrdersView() {
       >
         <h1
           className="text-[22px]"
-          style={{ fontFamily: "Peachi-Bold, serif", letterSpacing: -0.3, fontWeight: 700 }}
+          style={{ fontFamily: "var(--font-display)", letterSpacing: -0.3, fontWeight: 700 }}
         >
           Orders
         </h1>
@@ -138,8 +138,8 @@ export function OrdersView() {
 
       {phone ? (
         <div className="flex border-b border-[#EBE5DE] px-4">
-          <TabButton on={tab === "active"} onClick={() => setTab("active")} label="Active" />
-          <TabButton on={tab === "past"} onClick={() => setTab("past")} label="Past" />
+          <TabButton on={tab === "active"} onClick={() => setTab("active")} label="In progress" />
+          <TabButton on={tab === "past"} onClick={() => setTab("past")} label="Past orders" />
         </div>
       ) : null}
 
@@ -330,7 +330,7 @@ function EmptyCTA({
       {icon}
       <p
         className="mt-4 text-base"
-        style={{ fontFamily: "Peachi-Bold, serif", fontWeight: 700 }}
+        style={{ fontFamily: "var(--font-display)", fontWeight: 700 }}
       >
         {title}
       </p>
@@ -361,9 +361,9 @@ function TabButton({
       className="flex-1 py-3 active:opacity-60"
       aria-current={on ? "true" : undefined}
       style={{
-        color: on ? "#160800" : "#8E8E93",
+        color: on ? "#A2492C" : "#8E8E93",
         fontWeight: on ? 700 : 600,
-        borderBottom: on ? "2px solid #160800" : "2px solid transparent",
+        borderBottom: on ? "2px solid #A2492C" : "2px solid transparent",
         marginBottom: -1,
       }}
     >

--- a/apps/order/src/app/rewards/_RewardsView.tsx
+++ b/apps/order/src/app/rewards/_RewardsView.tsx
@@ -101,7 +101,7 @@ export function RewardsView() {
       >
         <h1
           className="text-[22px]"
-          style={{ fontFamily: "Peachi-Bold, serif", letterSpacing: -0.3, fontWeight: 700 }}
+          style={{ fontFamily: "var(--font-display)", letterSpacing: -0.3, fontWeight: 700 }}
         >
           Rewards
         </h1>
@@ -124,7 +124,7 @@ export function RewardsView() {
           <Gift size={48} color="#8E8E93" strokeWidth={1.25} />
           <p
             className="mt-4 text-base"
-            style={{ fontFamily: "Peachi-Bold, serif", fontWeight: 700 }}
+            style={{ fontFamily: "var(--font-display)", fontWeight: 700 }}
           >
             Sign in to claim rewards
           </p>
@@ -145,7 +145,7 @@ export function RewardsView() {
           <Sparkles size={48} color="#8E8E93" strokeWidth={1.25} />
           <p
             className="mt-4 text-base"
-            style={{ fontFamily: "Peachi-Bold, serif", fontWeight: 700 }}
+            style={{ fontFamily: "var(--font-display)", fontWeight: 700 }}
           >
             No rewards available yet
           </p>

--- a/apps/pickup-native/public/sw.js
+++ b/apps/pickup-native/public/sw.js
@@ -6,7 +6,7 @@
 //
 // Future rule of thumb: bump this on ANY production-affecting bundle
 // regression so customers don't get stuck on a bad build.
-const CACHE = "celsius-v42";
+const CACHE = "celsius-v43";
 const SHELL = ["/", "/index.html", "/manifest.json"];
 
 self.addEventListener("install", (e) => {


### PR DESCRIPTION
## Summary
Fixes the "headers not Peachi" report + several font/UI parity diffs from the side-by-side QA.

**Root cause of non-Peachi headers:** screen titles used inline `fontFamily: "Peachi-Bold, serif"`, but the web `@font-face` family is `"Peachi"` (next/font exposes `--font-peachi` / `--font-display`). `"Peachi-Bold"` isn't a registered web family, so the browser fell back to serif. Swapped every `"Peachi-Bold, serif"` → `"var(--font-display)"` (orders / rewards / account / cart / voucher-rail headers).

Other parity fixes:
- **Account rows** → SpaceGrotesk medium (native uses the body face for functional menu rows, not the display face).
- **Cart line** → price colour to alert-red `#B91C1C`, modifier separator `,` → ` · `, added the italic special-instructions note.
- **Orders tabs** → "In progress / Past orders" + terracotta active underline (was espresso).
- **Active-order banner** → "Brewing" → "Being prepared".

Bumps SW cache to v43.

## Test plan
- [ ] Orders/Rewards/Account/Cart headers render in Peachi (not serif).
- [ ] Account menu rows in SpaceGrotesk; cart line price red + note shown; orders tabs renamed + terracotta underline.

---
The larger correctness items from the QA (checkout SST + promotion-engine discounts, min-order/closed gating, sale pricing, wallet-voucher list, inline add-to-cart) are bigger features — I'll stage those next.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xd1aERynqUbdCqXNboKWBe)_