### PR TITLE
feat(web/checkout): accurate price preview — promo discounts + SST

### DIFF
--- a/apps/order/public/sw.js
+++ b/apps/order/public/sw.js
@@ -1,7 +1,7 @@
 // Mirror of apps/pickup-native/public/sw.js — overwritten on each
 // build-pwa run. v3 bumps over v2 to flush customers off the broken
 // CSS shipped in #157/#158 before this revert deployed.
-const CACHE = "celsius-v43";
+const CACHE = "celsius-v44";
 const SHELL = ["/", "/index.html", "/manifest.json"];
 
 self.addEventListener("install", (e) => {

--- a/apps/order/src/app/api/checkout/quote/route.ts
+++ b/apps/order/src/app/api/checkout/quote/route.ts
@@ -1,0 +1,181 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getSupabaseAdmin } from "@/lib/supabase/server";
+import { getTierMultiplier } from "@/lib/loyalty/points";
+import { evaluatePromotions, type CartLine } from "@/lib/loyalty/promotions";
+
+// POST /api/checkout/quote
+//
+// Read-only price preview for the cart + checkout screens. Mirrors the
+// total computation in /api/checkout/initiate (same settings keys,
+// same promotion engine, same SST formula, same discount-layering
+// order) so the breakdown the customer sees BEFORE paying matches the
+// amount the order is actually created + charged for. Creates no
+// order and has no side effects.
+//
+// Body: { items: [{ product:{id}, quantity }], storeId, loyaltyPhone,
+//   loyaltyId, rewardDiscountSen?, voucherDiscountSen? }
+// Returns sen: { subtotalSen, promoDiscountSen, promoLines[],
+//   rewardDiscountSen, firstOrderDiscountSen, sstSen, sstRate,
+//   totalSen, pointsToEarn }
+
+export async function POST(request: NextRequest) {
+  try {
+    const body = await request.json();
+    const {
+      items,
+      storeId,
+      loyaltyPhone,
+      loyaltyId,
+      rewardDiscountSen = 0,
+      voucherDiscountSen = 0,
+    } = body as {
+      items?: Array<{ product?: { id?: string }; product_id?: string; quantity?: number }>;
+      storeId?: string | null;
+      loyaltyPhone?: string | null;
+      loyaltyId?: string | null;
+      rewardDiscountSen?: number;
+      voucherDiscountSen?: number;
+    };
+
+    if (!items?.length) {
+      return NextResponse.json({ error: "No items" }, { status: 400 });
+    }
+
+    const supabase = getSupabaseAdmin();
+
+    // Product prices (RM) — authoritative, same as initiate.
+    const productIds = items
+      .map((i) => i.product?.id ?? i.product_id)
+      .filter(Boolean) as string[];
+    const { data: dbProducts } = await supabase
+      .from("products")
+      .select("id, price, category")
+      .in("id", productIds);
+    const priceMap = new Map<string, number>();
+    const catMap = new Map<string, string | null>();
+    for (const p of (dbProducts ?? []) as Array<{ id: string; price: number; category: string | null }>) {
+      priceMap.set(p.id, p.price);
+      catMap.set(p.id, p.category);
+    }
+
+    // Subtotal in sen — base price × qty. (Modifier deltas are already
+    // baked into the client total but for the quote we mirror initiate's
+    // base-price subtotal; the reward/promo engines operate on line
+    // unit_price too.)
+    let subtotalSen = 0;
+    const cartLines: CartLine[] = [];
+    for (const it of items) {
+      const pid = (it.product?.id ?? it.product_id) as string;
+      const price = priceMap.get(pid) ?? 0;
+      const qty = Number(it.quantity) || 1;
+      subtotalSen += Math.round(price * 100) * qty;
+      cartLines.push({
+        product_id: pid,
+        quantity: qty,
+        unit_price: price,
+        category: catMap.get(pid) ?? undefined,
+      });
+    }
+
+    // Settings — SST + points rate.
+    const { data: settings } = await supabase
+      .from("app_settings")
+      .select("key, value")
+      .in("key", ["points_per_rm", "sst"]);
+    const settingsMap = new Map<string, unknown>();
+    for (const s of (settings ?? []) as Array<{ key: string; value: unknown }>) {
+      settingsMap.set(s.key, s.value);
+    }
+    const sstVal = settingsMap.get("sst") as { enabled?: boolean; rate?: number } | undefined;
+    const sstEnabled = sstVal?.enabled !== false;
+    const sstRate = sstVal?.rate ?? 0.06;
+    const pointsPerRm = Number((settingsMap.get("points_per_rm") as { rate?: number } | undefined)?.rate ?? 1);
+
+    // First-order discount — lives on the promotions table (same lookup
+    // as initiate / orders): most recent active trigger_type=first_order.
+    const { data: fodRow } = await supabase
+      .from("promotions")
+      .select("discount_type, discount_value")
+      .eq("brand_id", "brand-celsius")
+      .eq("trigger_type", "first_order")
+      .eq("is_active", true)
+      .order("priority", { ascending: false })
+      .limit(1)
+      .maybeSingle();
+    const fodConfig = fodRow
+      ? {
+          type: (fodRow.discount_type as string) === "percentage_off" ? "percent" : "fixed",
+          amount: Number((fodRow as { discount_value?: number }).discount_value ?? 0),
+        }
+      : null;
+
+    // First-order discount — first qualifying order on this phone.
+    let fodDiscountSen = 0;
+    if (fodConfig && loyaltyPhone) {
+      const { count } = await supabase
+        .from("orders")
+        .select("id", { count: "exact", head: true })
+        .eq("loyalty_phone", loyaltyPhone)
+        .in("status", ["completed", "preparing", "ready", "paid"]);
+      if ((count ?? 0) === 0) {
+        fodDiscountSen =
+          fodConfig.type === "percent"
+            ? Math.round(subtotalSen * (fodConfig.amount / 100))
+            : Math.round(fodConfig.amount * 100);
+      }
+    }
+
+    // Member tier → promo eligibility + points multiplier.
+    let memberTierId: string | null = null;
+    if (loyaltyId) {
+      const { data: mb } = await supabase
+        .from("member_brands")
+        .select("current_tier_id")
+        .eq("member_id", loyaltyId)
+        .eq("brand_id", "brand-celsius")
+        .maybeSingle();
+      memberTierId = (mb as { current_tier_id?: string | null } | null)?.current_tier_id ?? null;
+    }
+
+    const evaluated = await evaluatePromotions({
+      lines: cartLines,
+      member_id: loyaltyId ?? null,
+      outlet_id: storeId ?? null,
+      member_tier_id: memberTierId,
+    });
+    const promoDiscountSen = Math.round(evaluated.total_discount * 100);
+    const promoLines = evaluated.discounts.map((d) => ({
+      name: d.promotion_name,
+      amountSen: Math.round(d.discount_amount * 100),
+    }));
+
+    const afterDiscount = Math.max(
+      0,
+      subtotalSen -
+        Math.round(voucherDiscountSen) -
+        Math.round(rewardDiscountSen) -
+        fodDiscountSen -
+        promoDiscountSen,
+    );
+    const sstSen = sstEnabled ? Math.round(afterDiscount * sstRate) : 0;
+    const totalSen = afterDiscount + sstSen;
+    const basePoints = loyaltyId ? Math.floor((afterDiscount / 100) * pointsPerRm) : 0;
+    const tierMul = loyaltyId ? await getTierMultiplier(loyaltyId) : 1;
+    const pointsToEarn = Math.round(basePoints * tierMul);
+
+    return NextResponse.json({
+      subtotalSen,
+      promoDiscountSen,
+      promoLines,
+      rewardDiscountSen: Math.round(rewardDiscountSen),
+      firstOrderDiscountSen: fodDiscountSen,
+      sstSen,
+      sstRate,
+      totalSen,
+      pointsToEarn,
+    });
+  } catch (err) {
+    console.error("checkout quote error:", err);
+    return NextResponse.json({ error: "Failed to quote" }, { status: 500 });
+  }
+}

--- a/apps/order/src/app/checkout/_CheckoutView.tsx
+++ b/apps/order/src/app/checkout/_CheckoutView.tsx
@@ -118,7 +118,51 @@ export function CheckoutView() {
       ),
     [reward, state, subtotal],
   );
-  const grandTotal = Math.max(0, subtotal - rewardDiscount);
+  const rewardDiscountSen = Math.round(rewardDiscount * 100);
+
+  // Server price preview — promo-engine discounts + SST + final total,
+  // computed by /api/checkout/quote with the SAME math the order is
+  // created with, so the breakdown matches the amount charged.
+  const [quote, setQuote] = useState<{
+    promoLines: Array<{ name: string; amountSen: number }>;
+    promoDiscountSen: number;
+    firstOrderDiscountSen: number;
+    sstSen: number;
+    totalSen: number;
+    pointsToEarn: number;
+  } | null>(null);
+
+  useEffect(() => {
+    const cartItems = state?.cart ?? [];
+    if (cartItems.length === 0) {
+      setQuote(null);
+      return;
+    }
+    let cancelled = false;
+    fetch("/api/checkout/quote", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        items: cartItems.map((i) => ({ product: { id: i.productId }, quantity: i.quantity })),
+        storeId: state?.outletId ?? null,
+        loyaltyPhone: state?.phone ?? null,
+        loyaltyId: state?.loyaltyId ?? null,
+        rewardDiscountSen,
+      }),
+    })
+      .then((r) => (r.ok ? r.json() : null))
+      .then((d) => {
+        if (!cancelled) setQuote(d);
+      })
+      .catch(() => !cancelled && setQuote(null));
+    return () => {
+      cancelled = true;
+    };
+  }, [state, rewardDiscountSen]);
+
+  // Use the server quote's total when present; fall back to the
+  // client subtotal-minus-reward while it loads.
+  const grandTotal = quote ? quote.totalSen / 100 : Math.max(0, subtotal - rewardDiscount);
 
   if (!state) {
     return <div className="p-8 text-center text-[#8E8E93]">Loading…</div>;
@@ -410,6 +454,32 @@ export function CheckoutView() {
             </span>
           </div>
         ) : null}
+        {(quote?.promoLines ?? []).map((p, i) => (
+          <div key={i} className="flex items-center justify-between" style={{ marginBottom: 6 }}>
+            <span className="text-[13px] truncate pr-2" style={{ color: "#A2492C" }}>
+              {p.name}
+            </span>
+            <span className="text-[14px]" style={{ color: "#A2492C", fontWeight: 500 }}>
+              −RM{(p.amountSen / 100).toFixed(2)}
+            </span>
+          </div>
+        ))}
+        {quote && quote.firstOrderDiscountSen > 0 ? (
+          <div className="flex items-center justify-between" style={{ marginBottom: 6 }}>
+            <span className="text-[13px]" style={{ color: "#A2492C" }}>First-order discount</span>
+            <span className="text-[14px]" style={{ color: "#A2492C", fontWeight: 500 }}>
+              −RM{(quote.firstOrderDiscountSen / 100).toFixed(2)}
+            </span>
+          </div>
+        ) : null}
+        {quote && quote.sstSen > 0 ? (
+          <div className="flex items-center justify-between" style={{ marginBottom: 6 }}>
+            <span className="text-[13px]" style={{ color: "#6B6B6B" }}>SST</span>
+            <span className="text-[14px]" style={{ color: "#1A0200", fontWeight: 500 }}>
+              RM{(quote.sstSen / 100).toFixed(2)}
+            </span>
+          </div>
+        ) : null}
         <div className="flex items-center justify-between pt-3 border-t border-[rgba(26,2,0,0.10)]">
           <span className="font-peachi font-bold" style={{ color: "#1A0200", fontSize: 15 }}>
             Total
@@ -427,7 +497,7 @@ export function CheckoutView() {
               className="text-[12px] font-bold"
               style={{ color: tier.tier_color ?? "#92400e" }}
             >
-              +{Math.round(grandTotal * (tier.tier_multiplier ?? 1))} pts
+              +{quote ? quote.pointsToEarn : Math.round(grandTotal * (tier.tier_multiplier ?? 1))} pts
             </span>
           </div>
         ) : null}

--- a/apps/pickup-native/public/sw.js
+++ b/apps/pickup-native/public/sw.js
@@ -6,7 +6,7 @@
 //
 // Future rule of thumb: bump this on ANY production-affecting bundle
 // regression so customers don't get stuck on a bad build.
-const CACHE = "celsius-v43";
+const CACHE = "celsius-v44";
 const SHELL = ["/", "/index.html", "/manifest.json"];
 
 self.addEventListener("install", (e) => {


### PR DESCRIPTION
## Summary
Fixes the biggest QA correctness gap: the checkout preview showed only `subtotal − reward`, omitting promotion-engine discounts, first-order discount, and **SST** — so the preview understated the real charge. (The amount *charged* was always correct — Stripe/RM use the server-computed total — but the preview didn't match, which erodes trust.)

Added a read-only **`/api/checkout/quote`** endpoint that mirrors `initiate`'s exact math:
- same settings keys (`points_per_rm`, `sst`),
- same first-order-discount lookup (promotions table, `trigger_type=first_order`),
- same `evaluatePromotions` call,
- same discount layering (voucher → reward → first-order → promo, then SST on the remainder),
- same tier-multiplier points.

No order is created. Checkout now renders the full breakdown — subtotal, reward, each promo line, first-order discount, SST, and the **server-accurate Total** — and the tier earn-preview + Pay button use the quote's points/total, so what's shown equals what's charged.

Bumps SW cache to v44.

## Test plan
- [ ] Checkout with a member on a tier with an auto/tier promo → promo line(s) appear; total drops accordingly.
- [ ] SST line shows and is included in Total; Total matches the Stripe/RM charge.
- [ ] First order on a phone → "First-order discount" line.
- [ ] Earn-preview pts match the server's credited points.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xd1aERynqUbdCqXNboKWBe)_