### PR TITLE
feat(web/cart): promo lines, min-order gate + outlet-closed banner

### DIFF
--- a/apps/order/public/sw.js
+++ b/apps/order/public/sw.js
@@ -1,7 +1,7 @@
 // Mirror of apps/pickup-native/public/sw.js — overwritten on each
 // build-pwa run. v3 bumps over v2 to flush customers off the broken
 // CSS shipped in #157/#158 before this revert deployed.
-const CACHE = "celsius-v44";
+const CACHE = "celsius-v45";
 const SHELL = ["/", "/index.html", "/manifest.json"];
 
 self.addEventListener("install", (e) => {

--- a/apps/order/src/app/api/checkout/quote/route.ts
+++ b/apps/order/src/app/api/checkout/quote/route.ts
@@ -81,7 +81,7 @@ export async function POST(request: NextRequest) {
     const { data: settings } = await supabase
       .from("app_settings")
       .select("key, value")
-      .in("key", ["points_per_rm", "sst"]);
+      .in("key", ["points_per_rm", "sst", "min_order_value"]);
     const settingsMap = new Map<string, unknown>();
     for (const s of (settings ?? []) as Array<{ key: string; value: unknown }>) {
       settingsMap.set(s.key, s.value);
@@ -90,6 +90,7 @@ export async function POST(request: NextRequest) {
     const sstEnabled = sstVal?.enabled !== false;
     const sstRate = sstVal?.rate ?? 0.06;
     const pointsPerRm = Number((settingsMap.get("points_per_rm") as { rate?: number } | undefined)?.rate ?? 1);
+    const minOrderRm = Number((settingsMap.get("min_order_value") as { rm?: number } | undefined)?.rm ?? 0);
 
     // First-order discount — lives on the promotions table (same lookup
     // as initiate / orders): most recent active trigger_type=first_order.
@@ -173,6 +174,7 @@ export async function POST(request: NextRequest) {
       sstRate,
       totalSen,
       pointsToEarn,
+      minOrderRm,
     });
   } catch (err) {
     console.error("checkout quote error:", err);

--- a/apps/order/src/app/cart/_CartView.tsx
+++ b/apps/order/src/app/cart/_CartView.tsx
@@ -28,9 +28,11 @@ type CartItem = {
 type Persisted = {
   state?: {
     cart?: CartItem[];
+    outletId?: string | null;
     outletName?: string | null;
     appliedReward?: AppliedReward | null;
     phone?: string | null;
+    loyaltyId?: string | null;
   };
 };
 
@@ -59,18 +61,35 @@ function clearReward() {
   }
 }
 
-function readCart(): { items: CartItem[]; outletName: string | null; phone: string | null } {
+type CartSnapshot = {
+  items: CartItem[];
+  outletId: string | null;
+  outletName: string | null;
+  phone: string | null;
+  loyaltyId: string | null;
+};
+
+function readCart(): CartSnapshot {
+  const empty: CartSnapshot = {
+    items: [],
+    outletId: null,
+    outletName: null,
+    phone: null,
+    loyaltyId: null,
+  };
   try {
     const raw = window.localStorage.getItem(KEY);
-    if (!raw) return { items: [], outletName: null, phone: null };
+    if (!raw) return empty;
     const parsed = JSON.parse(raw) as Persisted;
     return {
       items: parsed.state?.cart ?? [],
+      outletId: parsed.state?.outletId ?? null,
       outletName: parsed.state?.outletName ?? null,
       phone: parsed.state?.phone ?? null,
+      loyaltyId: parsed.state?.loyaltyId ?? null,
     };
   } catch {
-    return { items: [], outletName: null, phone: null };
+    return empty;
   }
 }
 
@@ -86,37 +105,111 @@ function writeCart(items: CartItem[]) {
   }
 }
 
+type Quote = {
+  promoLines: Array<{ name: string; amountSen: number }>;
+  promoDiscountSen: number;
+  minOrderRm: number;
+};
+
 export function CartView({ bestSellers = [] }: { bestSellers?: BestSeller[] }) {
   const [items, setItems] = useState<CartItem[]>([]);
+  const [outletId, setOutletId] = useState<string | null>(null);
   const [outletName, setOutletName] = useState<string | null>(null);
   const [phone, setPhone] = useState<string | null>(null);
+  const [loyaltyId, setLoyaltyId] = useState<string | null>(null);
   const [reward, setReward] = useState<AppliedReward | null>(null);
   const [hydrated, setHydrated] = useState(false);
+  const [quote, setQuote] = useState<Quote | null>(null);
+  const [outletClosed, setOutletClosed] = useState(false);
 
   useEffect(() => {
-    const { items, outletName, phone } = readCart();
+    const snap = readCart();
     setReward(readReward());
-    setItems(items);
-    setOutletName(outletName);
-    setPhone(phone);
+    setItems(snap.items);
+    setOutletId(snap.outletId);
+    setOutletName(snap.outletName);
+    setPhone(snap.phone);
+    setLoyaltyId(snap.loyaltyId);
     setHydrated(true);
   }, []);
 
   const subtotal = items.reduce((s, i) => s + i.totalPrice, 0);
+  const rewardLines = items.map((i) => ({
+    productId: i.productId,
+    basePrice: i.basePrice,
+    totalPrice: i.totalPrice,
+    quantity: i.quantity,
+  }));
+
+  // Promotion-engine preview (auto + tier-perk + combo + sale) and the
+  // min-order threshold, from the SAME endpoint checkout quotes against
+  // so the cart breakdown lines up with the final number. Re-fires when
+  // the cart, outlet, or member changes.
+  useEffect(() => {
+    if (items.length === 0) {
+      setQuote(null);
+      return;
+    }
+    let cancelled = false;
+    fetch("/api/checkout/quote", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        items: items.map((i) => ({ product: { id: i.productId }, quantity: i.quantity })),
+        storeId: outletId,
+        loyaltyPhone: phone,
+        loyaltyId,
+      }),
+    })
+      .then((r) => (r.ok ? r.json() : null))
+      .then((d) => {
+        if (!cancelled) setQuote(d);
+      })
+      .catch(() => !cancelled && setQuote(null));
+    return () => {
+      cancelled = true;
+    };
+  }, [items, outletId, phone, loyaltyId]);
+
+  // Re-check the chosen outlet's open state so a customer who flipped to
+  // closed mid-cart gets a banner here instead of a 422 at checkout.
+  // /api/stores carries a 30s server cache; poll on the same cadence.
+  useEffect(() => {
+    if (!outletId || items.length === 0) {
+      setOutletClosed(false);
+      return;
+    }
+    let cancelled = false;
+    const check = () => {
+      fetch("/api/stores")
+        .then((r) => (r.ok ? r.json() : []))
+        .then((stores: Array<{ id: string; isOpen: boolean }>) => {
+          if (cancelled) return;
+          const me = stores.find((s) => s.id === outletId);
+          setOutletClosed(!!me && me.isOpen === false);
+        })
+        .catch(() => {});
+    };
+    check();
+    const id = window.setInterval(check, 30_000);
+    return () => {
+      cancelled = true;
+      window.clearInterval(id);
+    };
+  }, [outletId, items.length]);
+
   const rewardDiscount = Math.min(
-    calcRewardDiscount(
-      reward,
-      items.map((i) => ({
-        productId: i.productId,
-        basePrice: i.basePrice,
-        totalPrice: i.totalPrice,
-        quantity: i.quantity,
-      })),
-      subtotal,
-    ),
+    calcRewardDiscount(reward, rewardLines, subtotal),
     subtotal,
   );
-  const grandTotal = Math.max(0, subtotal - rewardDiscount);
+  // Reward voucher comes off AFTER the promo engine, matching checkout's
+  // discount-layering order. No SST here — that's checkout-only.
+  const promoDiscount = quote ? quote.promoDiscountSen / 100 : 0;
+  const totalAfterPromo = Math.max(0, subtotal - promoDiscount);
+  const discount = Math.min(rewardDiscount, totalAfterPromo);
+  const grandTotal = Math.max(0, totalAfterPromo - discount);
+  const minOrder = quote?.minOrderRm ?? 0;
+  const belowMin = minOrder > 0 && subtotal < minOrder;
   const signedIn = typeof phone === "string" && phone.length > 0;
 
   const updateQty = (cartId: string, delta: number) => {
@@ -344,11 +437,11 @@ export function CartView({ bestSellers = [] }: { bestSellers?: BestSeller[] }) {
             <p className="font-peachi font-bold text-[13px]" style={{ color: "#B91C1C" }}>
               {reward.name ?? formatRewardValue(reward)}
             </p>
-            {rewardDiscount > 0 ? (
-              <p className="text-[11px]" style={{ color: "rgba(185,28,28,0.80)" }}>
-                {`−RM${rewardDiscount.toFixed(2)} off`}
-              </p>
-            ) : null}
+            <p className="text-[11px]" style={{ color: "rgba(185,28,28,0.80)" }}>
+              {discount > 0
+                ? `Reward applied · −RM${discount.toFixed(2)}`
+                : "Reward applied — discount at checkout"}
+            </p>
           </div>
           <button
             type="button"
@@ -371,13 +464,23 @@ export function CartView({ bestSellers = [] }: { bestSellers?: BestSeller[] }) {
             RM{subtotal.toFixed(2)}
           </span>
         </div>
-        {rewardDiscount > 0 ? (
+        {(quote?.promoLines ?? []).map((p, i) => (
+          <div key={i} className="flex items-center justify-between" style={{ marginBottom: 4 }}>
+            <span className="text-[13px] truncate" style={{ color: "#B91C1C", paddingRight: 8 }}>
+              {p.name}
+            </span>
+            <span className="text-[14px] flex-shrink-0" style={{ color: "#B91C1C", fontWeight: 500 }}>
+              −RM{(p.amountSen / 100).toFixed(2)}
+            </span>
+          </div>
+        ))}
+        {discount > 0 ? (
           <div className="flex items-center justify-between" style={{ marginBottom: 4 }}>
             <span className="text-[13px]" style={{ color: "#B91C1C" }}>
               Reward discount
             </span>
             <span className="text-[14px]" style={{ color: "#B91C1C", fontWeight: 500 }}>
-              −RM{rewardDiscount.toFixed(2)}
+              −RM{discount.toFixed(2)}
             </span>
           </div>
         ) : null}
@@ -399,13 +502,65 @@ export function CartView({ bestSellers = [] }: { bestSellers?: BestSeller[] }) {
             </span>
           </div>
         ) : null}
-        <Link
-          href="/checkout"
-          className="block w-full rounded-full bg-[#A2492C] text-white text-center py-4 font-peachi font-bold active:opacity-80"
-          style={{ marginTop: 12 }}
-        >
-          Continue to checkout
-        </Link>
+
+        {outletClosed ? (
+          <div
+            className="flex items-start gap-2.5 rounded-2xl px-3 py-3"
+            style={{
+              backgroundColor: "rgba(162, 73, 44, 0.10)",
+              border: "1px solid rgba(162, 73, 44, 0.25)",
+              marginTop: 12,
+              marginBottom: 12,
+            }}
+          >
+            <span
+              style={{ width: 6, height: 6, borderRadius: 3, backgroundColor: "#A2492C", marginTop: 6 }}
+              className="flex-shrink-0"
+            />
+            <div className="flex-1 min-w-0">
+              <p className="font-peachi font-bold text-[13px]" style={{ color: "#1A0200" }}>
+                {outletName ?? "This outlet"} just closed
+              </p>
+              <p className="text-[11px]" style={{ color: "#6B6B6B", fontWeight: 500, marginTop: 2 }}>
+                Pick another outlet to continue, or come back when we open.
+              </p>
+            </div>
+            <Link
+              href="/store"
+              className="flex-shrink-0 active:opacity-70 text-[12px] font-bold"
+              style={{ color: "#A2492C" }}
+            >
+              Switch
+            </Link>
+          </div>
+        ) : null}
+
+        {belowMin ? (
+          <p
+            className="text-center text-[12px]"
+            style={{ color: "#A2492C", fontWeight: 500, marginTop: 12, marginBottom: 8 }}
+          >
+            Add RM{(minOrder - subtotal).toFixed(2)} more to checkout (min RM{minOrder.toFixed(2)})
+          </p>
+        ) : null}
+
+        {belowMin || outletClosed ? (
+          <div
+            className="block w-full rounded-full text-white text-center py-4 font-peachi font-bold cursor-not-allowed"
+            style={{ marginTop: belowMin ? 0 : 12, backgroundColor: "rgba(162,73,44,0.40)" }}
+            aria-disabled="true"
+          >
+            {outletClosed ? "Outlet closed" : "Continue to checkout"}
+          </div>
+        ) : (
+          <Link
+            href="/checkout"
+            className="block w-full rounded-full bg-[#A2492C] text-white text-center py-4 font-peachi font-bold active:opacity-80"
+            style={{ marginTop: 12 }}
+          >
+            Continue to checkout
+          </Link>
+        )}
       </div>
     </CartShell>
   );

--- a/apps/pickup-native/public/sw.js
+++ b/apps/pickup-native/public/sw.js
@@ -6,7 +6,7 @@
 //
 // Future rule of thumb: bump this on ANY production-affecting bundle
 // regression so customers don't get stuck on a bad build.
-const CACHE = "celsius-v44";
+const CACHE = "celsius-v45";
 const SHELL = ["/", "/index.html", "/manifest.json"];
 
 self.addEventListener("install", (e) => {


### PR DESCRIPTION
## Summary
Brings the web cart (`apps/order`) to parity with the native cart (`apps/pickup-native/app/cart.tsx`), closing three QA gaps:

- **Promotion-engine discount lines** — the cart now calls `/api/checkout/quote` and renders each auto / tier-perk / combo / sale promotion as its own `−RMx` line, so the cart breakdown matches the final checkout number. Reward voucher layers *after* promos (same discount order as checkout). No SST line here — SST stays checkout-only, matching native.
- **Min-order gate** — when `subtotal < min_order_value`, the CTA is disabled and shows `Add RMx more to checkout (min RMy)`.
- **Outlet-closed banner** — polls `/api/stores` (30s server cache, 30s client interval) for the chosen outlet's `isOpen`; if it flipped closed mid-cart, shows a "just closed" banner with a *Switch* link to `/store` and disables checkout ("Outlet closed"), so customers no longer hit a 422 at checkout.

Supporting change: `/api/checkout/quote` now returns `minOrderRm` (reads the `min_order_value` setting). SW cache bumped v44 → v45 in both `apps/order` and `apps/pickup-native`.

## Test plan
- [ ] Cart with an active promotion shows the promo line(s) and a total of `subtotal − promo − reward`
- [ ] Cart below the min-order value disables checkout and shows the "Add RMx more" message
- [ ] Outlet toggled closed (backoffice) surfaces the banner + disables checkout within ~30s
- [ ] Reward voucher still applies and clamps to the post-promo total
- [ ] Signed-in points preview and the empty-cart hero are unchanged

https://claude.ai/code/session_01Xd1aERynqUbdCqXNboKWBe

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xd1aERynqUbdCqXNboKWBe)_