### PR TITLE
fix(loyalty): stop syncing products from StoreHub — backoffice owns the catalog

### DIFF
--- a/apps/loyalty/src/lib/storehub-products.ts
+++ b/apps/loyalty/src/lib/storehub-products.ts
@@ -1,210 +1,23 @@
 // ==========================================
-// StoreHub Product Sync Service
-// Pulls product catalog from StoreHub API
-// and upserts into Supabase products tables.
-// This is the SINGLE source of sync — all apps
-// read from Supabase, not StoreHub directly.
+// StoreHub Product Sync — DISABLED
 // ==========================================
+// Products are backoffice-owned. The catalog (name, price, category,
+// image, channels, featured flag, and especially modifiers +
+// hidden_modifier_ids) is managed directly in the backoffice menu
+// editor and is the source of truth.
+//
+// This sync used to pull the catalog from StoreHub and upsert the
+// `products` table, which clobbered backoffice edits on every run —
+// most painfully the modifier groups (#144 made those backoffice-owned)
+// and the soft-hidden modifier list. It now does nothing.
+//
+// Kept as an exported no-op so the cron + manual sync endpoints that
+// import it still compile; remove those callers if/when the StoreHub
+// product pipeline is retired for good.
 
-import { supabaseAdmin } from './supabase';
-
-const API_URL = process.env.STOREHUB_API_URL || 'https://api.storehubhq.com';
-const USERNAME = process.env.STOREHUB_USERNAME || '';
-const API_KEY = process.env.STOREHUB_API_KEY || '';
-
-function getAuthHeader(): string {
-  const credentials = Buffer.from(`${USERNAME}:${API_KEY}`).toString('base64');
-  return `Basic ${credentials}`;
-}
-
-// Raw StoreHub product shape (from their API)
-interface StoreHubProduct {
-  _id: string;
-  name: string;
-  sku?: string;
-  category?: { _id?: string; name?: string };
-  tags?: string[];
-  description?: string;
-  imageUrl?: string;
-  images?: string[];
-  pricingType?: string;     // "fixed", "variable", "weight"
-  price?: number;
-  costPrice?: number;
-  onlinePrice?: number;
-  grabFoodPrice?: number;
-  taxCode?: string;
-  taxRate?: number;
-  modifiers?: Array<{
-    name?: string;
-    type?: string;            // "single", "multiple"
-    required?: boolean;
-    min?: number;
-    max?: number;
-    options?: Array<{
-      name?: string;
-      price?: number;
-      isDefault?: boolean;
-    }>;
-  }>;
-  isAvailable?: boolean;
-  onlineChannels?: string[];
-  isFeatured?: boolean;
-  isPreOrder?: boolean;
-  kitchenStation?: string;
-  trackStock?: boolean;
-  stockLevel?: number;
-  variants?: Array<{
-    _id?: string;
-    name?: string;
-    sku?: string;
-    barcode?: string;
-    price?: number;
-    costPrice?: number;
-    stockLevel?: number;
-    isAvailable?: boolean;
-  }>;
-  storeId?: string;
-  updatedAt?: string;
-}
-
-/**
- * Fetch all products from StoreHub for a given store
- */
-export async function fetchStoreHubProducts(storeId: string): Promise<StoreHubProduct[]> {
-  const url = `${API_URL}/products?storeId=${storeId}`;
-
-  try {
-    const response = await fetch(url, {
-      headers: {
-        Authorization: getAuthHeader(),
-        'Content-Type': 'application/json',
-      },
-      signal: AbortSignal.timeout(30000),
-    });
-
-    if (!response.ok) {
-      console.error(`StoreHub Products API error: ${response.status}`);
-      return [];
-    }
-
-    const data = await response.json();
-    return Array.isArray(data) ? data : data.products || [];
-  } catch (error) {
-    console.error('StoreHub Products fetch error:', error);
-    return [];
-  }
-}
-
-/**
- * Sync products from StoreHub into Supabase
- * Upserts based on storehub_product_id to avoid duplicates
- */
 export async function syncProducts(
-  brandId: string,
-  storeId: string
-): Promise<{ synced: number; errors: number }> {
-  const products = await fetchStoreHubProducts(storeId);
-  let synced = 0;
-  let errors = 0;
-
-  for (const p of products) {
-    try {
-      const productId = `prod-${p._id}`;
-      const now = new Date().toISOString();
-
-      // Upsert product
-      const { error } = await supabaseAdmin
-        .from('products')
-        .upsert({
-          id: productId,
-          brand_id: brandId,
-          storehub_product_id: p._id,
-          name: p.name,
-          sku: p.sku || null,
-          category: p.category?.name || null,
-          tags: p.tags || [],
-          description: p.description || null,
-          image_url: p.imageUrl || null,
-          image_urls: p.images || [],
-          pricing_type: p.pricingType || 'fixed',
-          price: p.price || 0,
-          cost: p.costPrice ?? null,
-          online_price: p.onlinePrice ?? null,
-          grabfood_price: p.grabFoodPrice ?? null,
-          tax_code: p.taxCode || null,
-          tax_rate: p.taxRate || 0,
-          modifiers: (p.modifiers || []).map(m => ({
-            group: m.name || 'Unnamed',
-            type: m.type === 'multiple' ? 'multiple' : 'single',
-            required: m.required ?? false,
-            min: m.min ?? 0,
-            max: m.max ?? 0,
-            options: (m.options || []).map(o => ({
-              name: o.name || '',
-              price: o.price || 0,
-              is_default: o.isDefault || false,
-            })),
-          })),
-          is_available: p.isAvailable !== false,
-          online_channels: p.onlineChannels || [],
-          is_featured: p.isFeatured || false,
-          is_preorder: p.isPreOrder || false,
-          kitchen_station: p.kitchenStation || null,
-          track_stock: p.trackStock || false,
-          stock_level: p.stockLevel ?? null,
-          synced_at: now,
-          storehub_updated_at: p.updatedAt || null,
-          updated_at: now,
-        }, { onConflict: 'storehub_product_id' });
-
-      if (error) {
-        console.error(`Failed to sync product ${p.name}:`, error.message);
-        errors++;
-        continue;
-      }
-
-      // Sync variants if present
-      if (p.variants && p.variants.length > 0) {
-        for (const v of p.variants) {
-          const variantId = `pv-${v._id || `${p._id}-${v.name}`}`;
-          await supabaseAdmin
-            .from('product_variants')
-            .upsert({
-              id: variantId,
-              product_id: productId,
-              name: v.name || 'Default',
-              sku: v.sku || null,
-              barcode: v.barcode || null,
-              price: v.price ?? null,
-              cost: v.costPrice ?? null,
-              stock_level: v.stockLevel ?? null,
-              storehub_variant_id: v._id || null,
-              is_available: v.isAvailable !== false,
-            }, { onConflict: 'id' });
-        }
-      }
-
-      // Sync category
-      if (p.category?.name) {
-        const catSlug = p.category.name.toLowerCase().replace(/\s+/g, '-');
-        await supabaseAdmin
-          .from('product_categories')
-          .upsert({
-            id: `cat-${brandId}-${catSlug}`,
-            brand_id: brandId,
-            name: p.category.name,
-            slug: catSlug,
-            storehub_category_id: p.category._id || null,
-            is_active: true,
-          }, { onConflict: 'id' });
-      }
-
-      synced++;
-    } catch (err) {
-      console.error(`Error syncing product ${p.name}:`, err);
-      errors++;
-    }
-  }
-
-  return { synced, errors };
+  _brandId: string,
+  _storeId: string,
+): Promise<{ synced: number; errors: number; disabled: true }> {
+  return { synced: 0, errors: 0, disabled: true };
 }


### PR DESCRIPTION
## Summary
Products are backoffice-owned. The StoreHub product sync (`syncProducts` in `apps/loyalty/src/lib/storehub-products.ts`) was upserting the `products` table on every run (6-hourly cron + manual admin button + cron-key API), overwriting backoffice edits.

The worst symptom: it rewrote `products.modifiers` in StoreHub's **old** shape (`{ group, type, options:[{name, price, is_default}] }`), clobbering the **backoffice-owned** modifier groups introduced in #144 (`{ id, name, multiSelect, options:[{id, label, priceDelta, isDefault}] }`). So every sync "wired the modifiers back to StoreHub" and undid manual edits / the soft-hidden modifier list — despite the PATCH route's contract that sync "leaves this field alone."

This makes `syncProducts` a no-op so **nothing from StoreHub touches the product catalog anymore**. The cron (`/api/cron/sync-products`) and manual sync (`/api/products/sync`) endpoints still compile and respond, but perform no writes (they now return `disabled: true`, `synced: 0`).

## Notes / follow-ups
- New products must be created in the backoffice menu editor; they will no longer auto-import from StoreHub.
- The loyalty admin "Sync from StoreHub" button and the 6-hourly cron are now no-ops. I left them in place (harmless) rather than rip out the wiring — happy to remove the button + cron entry as a follow-up if you'd like them gone.
- Inventory's StoreHub sync (`/api/inventory/storehub/sync-products`, writes the `Menu`/recipe table) is a separate concern and is untouched.

## Test plan
- [ ] Edit a product's modifiers in backoffice, save, then trigger `/api/products/sync` (or wait for cron) → modifiers are unchanged
- [ ] Soft-hidden modifiers (`hidden_modifier_ids`) persist across a sync run
- [ ] Cron and manual sync endpoints return `{ success: true, disabled: true, synced: 0 }` without errors

https://claude.ai/code/session_01Xd1aERynqUbdCqXNboKWBe

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xd1aERynqUbdCqXNboKWBe)_