### PR TITLE
fix(backoffice): Settings tab unclickable for managers lacking settings:outlets

### DIFF
--- a/apps/backoffice/src/app/(admin)/layout.tsx
+++ b/apps/backoffice/src/app/(admin)/layout.tsx
@@ -1060,7 +1060,13 @@ export default function AdminLayout({ children }: { children: React.ReactNode })
     // Empty moduleAccess = full access (legacy behavior)
     if (!user.moduleAccess || user.moduleAccess.length === 0) return;
 
-    // Find the moduleKey for the current path
+    // Match the current path to the MOST SPECIFIC (longest-href) nav item,
+    // then gate on that item's module. A first-match loop let a broad parent
+    // like the Settings "Hub" (/settings) shadow more specific siblings such
+    // as /settings/staff — so a manager who has settings:staff but not the
+    // Hub's settings:outlets got bounced to /dashboard the instant they
+    // opened Settings. Longest-match mirrors the sidebar's active-link logic.
+    let best: NavItem | undefined;
     for (const section of NAV_SECTIONS) {
       const allItems = [
         ...(section.items ?? []),
@@ -1068,13 +1074,12 @@ export default function AdminLayout({ children }: { children: React.ReactNode })
       ];
       for (const item of allItems) {
         if (pathname === item.href || pathname.startsWith(item.href + "/")) {
-          if (item.moduleKey && !canAccess(user, item.moduleKey)) {
-            router.replace("/dashboard");
-            return;
-          }
-          return; // Found matching route, access OK
+          if (!best || item.href.length > best.href.length) best = item;
         }
       }
+    }
+    if (best?.moduleKey && !canAccess(user, best.moduleKey)) {
+      router.replace("/dashboard");
     }
   }, [user, pathname, router]);
 


### PR DESCRIPTION
## Summary
Fixes the reported bug: **Ariff (a MANAGER) can't click into the Settings tab.**

### Root cause
Ariff has `moduleAccess.settings = ["staff", "rules"]` (→ `settings:staff`, `settings:rules`) but **not** `settings:outlets`.

The admin layout's URL-access guard matched the current path to the **first** nav item whose href was a prefix:

```js
if (pathname === item.href || pathname.startsWith(item.href + "/")) { ...check item.moduleKey... }
```

The Settings **Hub** item (`href: "/settings"`, `moduleKey: "settings:outlets"`) is listed before "Staff & Access" (`/settings/staff`). Since `"/settings/staff".startsWith("/settings/")` is true, the guard matched the **Hub** first, checked `settings:outlets`, found Ariff lacked it, and `router.replace("/dashboard")` — bouncing him the instant he opened Settings. The rail navigates to the first granted page (`/settings/staff`), so clicking Settings just flashed back to the dashboard → "tab won't click."

### Fix
Match the **longest (most specific)** href instead of the first, then gate on *that* item's module — same longest-match logic the sidebar already uses for active-link highlighting. Now `/settings/staff` resolves to the Staff & Access item (`settings:staff`, which Ariff has) and is allowed. It also closes the inverse hole where the broad `/settings` match let a user through to a subpage they didn't actually have (e.g. `/settings/system`).

No permissions data changed — Ariff keeps exactly the access he was granted (Staff & Access + Approval Rules). ADMIN/OWNER behaviour is unchanged (they bypass the guard).

## Test plan
- [ ] As a MANAGER with `settings:staff` but not `settings:outlets`: click **Settings** → lands on **Staff & Access**, sub-nav shows Staff & Access + Approval Rules (no bounce to dashboard)
- [ ] Same manager visiting `/settings/system` directly (not granted) → still redirected to dashboard
- [ ] ADMIN/OWNER: full Settings access unchanged
- [ ] A manager with `settings:outlets` can still open the Hub `/settings`

Note: this ships in the backoffice app, so merging triggers a backoffice redeploy (the production build is also being refreshed by #200).

https://claude.ai/code/session_01Xd1aERynqUbdCqXNboKWBe

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xd1aERynqUbdCqXNboKWBe)_