### PR TITLE
refactor(backoffice): single source of truth for grantable modules (housekeeping 1/4)

### DIFF
--- a/apps/backoffice/src/app/(admin)/layout.tsx
+++ b/apps/backoffice/src/app/(admin)/layout.tsx
@@ -92,6 +92,7 @@ import {
   DialogTrigger,
 } from "@/components/ui/dialog";
 import { useFetch } from "@/lib/use-fetch";
+import { GRANTABLE_MODULE_KEYS } from "@/lib/modules";
 
 // ─── Types ──────────────────────────────────────────────────────────────
 
@@ -457,6 +458,27 @@ const NAV_SECTIONS: NavSection[] = [
     ],
   },
 ];
+
+// Dev-time guard against nav <-> permission-registry drift. If a nav item
+// gates on a module that isn't grantable in the Staff & Access editor (or a
+// grantable module has no nav destination), managers silently lose access —
+// the exact failure that hid Reviews/Ads/POS settings. finance:* is OWNER-only
+// and intentionally not grantable, so it's skipped.
+if (process.env.NODE_ENV !== "production") {
+  const navKeys = new Set<string>();
+  for (const section of NAV_SECTIONS) {
+    const items = [...(section.items ?? []), ...(section.subgroups?.flatMap((sg) => sg.items) ?? [])];
+    for (const item of items) if (item.moduleKey) navKeys.add(item.moduleKey);
+  }
+  const missingFromRegistry = [...navKeys].filter((k) => !k.startsWith("finance:") && !GRANTABLE_MODULE_KEYS.has(k));
+  const missingFromNav = [...GRANTABLE_MODULE_KEYS].filter((k) => !navKeys.has(k));
+  if (missingFromRegistry.length) {
+    console.warn("[perms] nav moduleKeys not grantable in Staff & Access (add to lib/modules.ts):", missingFromRegistry);
+  }
+  if (missingFromNav.length) {
+    console.warn("[perms] grantable modules with no nav destination (remove from lib/modules.ts or add to nav):", missingFromNav);
+  }
+}
 
 // ─── RBAC helper ────────────────────────────────────────────────────────
 

--- a/apps/backoffice/src/app/(admin)/settings/staff/page.tsx
+++ b/apps/backoffice/src/app/(admin)/settings/staff/page.tsx
@@ -7,6 +7,7 @@ import { Badge } from "@/components/ui/badge";
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter } from "@/components/ui/dialog";
 import { useConfirm, toast } from "@celsius/ui";
 import { Plus, Loader2, Eye, EyeOff, Key, Lock, Hash, Check, X, Search, Trash2, RotateCcw } from "lucide-react";
+import { APP_MODULES, MODULE_GROUPS, BACKOFFICE_SUB_APPS } from "@/lib/modules";
 
 type ModuleAccess = Record<string, string[]>;
 
@@ -38,96 +39,6 @@ const emptyForm: StaffForm = {
   pin: "",
   appAccess: [],
   moduleAccess: {},
-};
-
-// Module definitions per app
-const APP_MODULES: Record<string, { label: string; key: string }[]> = {
-  pickup: [
-    { label: "Orders", key: "orders" },
-    { label: "Menu", key: "menu" },
-    { label: "Customers", key: "customers" },
-    { label: "Settings (Pickup + POS)", key: "settings" },
-  ],
-  inventory: [
-    { label: "Products", key: "products" },
-    { label: "Perishables", key: "perishables" },
-    { label: "Suppliers", key: "suppliers" },
-    { label: "Categories", key: "categories" },
-    { label: "Menu & BOM", key: "menus" },
-    { label: "Purchase Orders", key: "orders" },
-    { label: "Receivings", key: "receivings" },
-    { label: "Invoices", key: "invoices" },
-    { label: "Payment Requests", key: "pay-and-claim" },
-    { label: "Stock Count", key: "stock-count" },
-    { label: "Wastage", key: "wastage" },
-    { label: "Transfers", key: "transfers" },
-    { label: "Par Levels", key: "par-levels" },
-    { label: "Reports", key: "reports" },
-  ],
-  loyalty: [
-    { label: "Overview", key: "dashboard" },
-    { label: "Members", key: "members" },
-    { label: "Rewards", key: "rewards" },
-    { label: "Redemptions", key: "redemptions" },
-    { label: "Campaigns", key: "campaigns" },
-    { label: "Engage", key: "engage" },
-  ],
-  sales: [
-    { label: "Dashboard", key: "dashboard" },
-  ],
-  settings: [
-    { label: "Outlets", key: "outlets" },
-    { label: "Staff & Access", key: "staff" },
-    { label: "Approval Rules", key: "rules" },
-    { label: "Integrations", key: "integrations" },
-    { label: "Stock Count", key: "stock-count" },
-    { label: "System", key: "system" },
-  ],
-  ops: [
-    { label: "Dashboard & Performance", key: "performance" },
-    { label: "Audit", key: "audit" },
-    { label: "SOPs", key: "sops" },
-    { label: "Categories", key: "categories" },
-  ],
-  hr: [
-    { label: "Dashboard", key: "dashboard" },
-    { label: "Attendance", key: "attendance" },
-    { label: "Schedules", key: "schedules" },
-    { label: "Leave", key: "leave" },
-    { label: "Overtime", key: "overtime" },
-    { label: "Payroll", key: "payroll" },
-    { label: "Employees", key: "employees" },
-    { label: "Performance", key: "performance" },
-    { label: "Allowances", key: "allowances" },
-    { label: "Review Penalties", key: "review-penalties" },
-    { label: "Memos", key: "memos" },
-    { label: "Settings", key: "settings" },
-  ],
-  reviews: [
-    { label: "All Reviews", key: "list" },
-    { label: "Settings", key: "settings" },
-  ],
-  ads: [
-    { label: "Marketing (Google)", key: "overview" },
-    { label: "Campaigns", key: "campaigns" },
-    { label: "Invoices", key: "invoices" },
-    { label: "Ad Settings", key: "settings" },
-    { label: "Recruitment (Indeed)", key: "recruitment" },
-  ],
-};
-
-// Optional visual groupings for the module picker. Keys map to APP_MODULES keys.
-// When an app has an entry here, the picker renders grouped sections instead of a flat grid.
-const MODULE_GROUPS: Record<string, { label: string; keys: string[] }[]> = {
-  hr: [
-    { label: "People", keys: ["dashboard", "employees"] },
-    { label: "Time & Attendance", keys: ["attendance", "schedules", "overtime"] },
-    { label: "Leave", keys: ["leave"] },
-    { label: "Payroll & Compensation", keys: ["payroll", "allowances"] },
-    { label: "Performance", keys: ["performance", "review-penalties"] },
-    { label: "Communication", keys: ["memos"] },
-    { label: "Admin", keys: ["settings"] },
-  ],
 };
 
 export default function StaffPage() {
@@ -616,7 +527,7 @@ export default function StaffPage() {
                   <h3 className="text-sm font-semibold text-gray-900 mb-1">Module Access</h3>
                   <p className="text-xs text-gray-400 mb-3">Control which modules this user can see within each app. Empty = full access.</p>
                   <div className="space-y-4">
-                    {[...form.appAccess.filter((app) => APP_MODULES[app]), ...(form.appAccess.includes("backoffice") ? ["settings", "hr", "reviews", "ads"].filter((a) => APP_MODULES[a]) : [])].map((app) => {
+                    {[...form.appAccess.filter((app) => APP_MODULES[app]), ...(form.appAccess.includes("backoffice") ? BACKOFFICE_SUB_APPS.filter((a) => APP_MODULES[a]) : [])].map((app) => {
                       const modules = APP_MODULES[app];
                       const selected = form.moduleAccess[app] || [];
                       const allSelected = modules.every((m) => selected.includes(m.key));

--- a/apps/backoffice/src/lib/modules.ts
+++ b/apps/backoffice/src/lib/modules.ts
@@ -1,0 +1,113 @@
+// Canonical registry of grantable backoffice modules.
+//
+// SINGLE SOURCE OF TRUTH. The Staff & Access editor builds its permission
+// toggles from this, and the admin sidebar (app/(admin)/layout.tsx) gates
+// nav items on the same `${app}:${key}` keys. A dev-time check in the
+// layout warns if a nav moduleKey isn't represented here, so the two can't
+// silently drift (which is exactly what hid Reviews/Ads/POS settings from
+// the editor before).
+//
+// NOTE: finance:* is intentionally absent — Finance is OWNER/ADMIN-only and
+// cannot be granted to managers, so it's not a "grantable module".
+
+export type ModuleDef = { label: string; key: string };
+
+export const APP_MODULES: Record<string, ModuleDef[]> = {
+  pickup: [
+    { label: "Orders", key: "orders" },
+    { label: "Menu", key: "menu" },
+    { label: "Customers", key: "customers" },
+    { label: "Settings (Pickup + POS)", key: "settings" },
+  ],
+  inventory: [
+    { label: "Products", key: "products" },
+    { label: "Perishables", key: "perishables" },
+    { label: "Suppliers", key: "suppliers" },
+    { label: "Categories", key: "categories" },
+    { label: "Menu & BOM", key: "menus" },
+    { label: "Purchase Orders", key: "orders" },
+    { label: "Receivings", key: "receivings" },
+    { label: "Invoices", key: "invoices" },
+    { label: "Payment Requests", key: "pay-and-claim" },
+    { label: "Stock Count", key: "stock-count" },
+    { label: "Wastage", key: "wastage" },
+    { label: "Transfers", key: "transfers" },
+    { label: "Par Levels", key: "par-levels" },
+    { label: "Reports", key: "reports" },
+  ],
+  loyalty: [
+    { label: "Overview", key: "dashboard" },
+    { label: "Members", key: "members" },
+    { label: "Rewards", key: "rewards" },
+    { label: "Redemptions", key: "redemptions" },
+    { label: "Campaigns", key: "campaigns" },
+    { label: "Engage", key: "engage" },
+  ],
+  sales: [
+    { label: "Dashboard", key: "dashboard" },
+  ],
+  settings: [
+    { label: "Outlets", key: "outlets" },
+    { label: "Staff & Access", key: "staff" },
+    { label: "Approval Rules", key: "rules" },
+    { label: "Integrations", key: "integrations" },
+    { label: "Stock Count", key: "stock-count" },
+    { label: "System", key: "system" },
+  ],
+  ops: [
+    { label: "Dashboard & Performance", key: "performance" },
+    { label: "Audit", key: "audit" },
+    { label: "SOPs", key: "sops" },
+    { label: "Categories", key: "categories" },
+  ],
+  hr: [
+    { label: "Dashboard", key: "dashboard" },
+    { label: "Attendance", key: "attendance" },
+    { label: "Schedules", key: "schedules" },
+    { label: "Leave", key: "leave" },
+    { label: "Overtime", key: "overtime" },
+    { label: "Payroll", key: "payroll" },
+    { label: "Employees", key: "employees" },
+    { label: "Performance", key: "performance" },
+    { label: "Allowances", key: "allowances" },
+    { label: "Review Penalties", key: "review-penalties" },
+    { label: "Memos", key: "memos" },
+    { label: "Settings", key: "settings" },
+  ],
+  reviews: [
+    { label: "All Reviews", key: "list" },
+    { label: "Settings", key: "settings" },
+  ],
+  ads: [
+    { label: "Marketing (Google)", key: "overview" },
+    { label: "Campaigns", key: "campaigns" },
+    { label: "Invoices", key: "invoices" },
+    { label: "Ad Settings", key: "settings" },
+    { label: "Recruitment (Indeed)", key: "recruitment" },
+  ],
+};
+
+// Optional visual groupings for the module picker. Keys map to APP_MODULES
+// keys; an app with an entry here renders grouped sections instead of a flat
+// grid.
+export const MODULE_GROUPS: Record<string, { label: string; keys: string[] }[]> = {
+  hr: [
+    { label: "People", keys: ["dashboard", "employees"] },
+    { label: "Time & Attendance", keys: ["attendance", "schedules", "overtime"] },
+    { label: "Leave", keys: ["leave"] },
+    { label: "Payroll & Compensation", keys: ["payroll", "allowances"] },
+    { label: "Performance", keys: ["performance", "review-penalties"] },
+    { label: "Communication", keys: ["memos"] },
+    { label: "Admin", keys: ["settings"] },
+  ],
+};
+
+// Apps that live INSIDE the backoffice app (gated by their own modules, not a
+// separate login). The picker surfaces these whenever a user has "backoffice"
+// app access, in addition to the apps listed in their appAccess.
+export const BACKOFFICE_SUB_APPS = ["settings", "hr", "reviews", "ads"] as const;
+
+// Every grantable `${app}:${key}`. Used by the sidebar's dev-time drift check.
+export const GRANTABLE_MODULE_KEYS: ReadonlySet<string> = new Set(
+  Object.entries(APP_MODULES).flatMap(([app, mods]) => mods.map((m) => `${app}:${m.key}`)),
+);


### PR DESCRIPTION
## Summary
Housekeeping track #1 of 4 — kills the redundancy that caused the Ariff / missing-modules issues.

The grantable-module catalog was duplicated: the Staff & Access editor had `APP_MODULES`/`MODULE_GROUPS`, and the sidebar (`layout.tsx`) independently tagged each nav item with a `moduleKey`. They drifted — which is exactly how Reviews, Ads, and Pickup/POS settings ended up impossible to grant.

- New canonical `apps/backoffice/src/lib/modules.ts` — `APP_MODULES`, `MODULE_GROUPS`, `BACKOFFICE_SUB_APPS`, and a derived `GRANTABLE_MODULE_KEYS`.
- Staff & Access editor imports the catalog instead of redeclaring it (removed ~90 lines of duplication).
- The admin layout runs a **dev-time drift check**: it warns in the console if a nav `moduleKey` isn't grantable in the editor, or if a grantable module has no nav destination. `finance:*` is OWNER-only and intentionally excluded.

Pure refactor — no behavior or permissions change.

## Why dev-warn instead of a CI test
A hard CI assertion would need `NAV_SECTIONS` importable, but it lives inside a `"use client"` component full of JSX icons. Extracting the nav into pure data is a larger change — happy to do it as a follow-up if you want the check enforced in CI rather than at dev time.

## Still open (flagged earlier, not in this PR)
The "empty per-app = full access" mismatch: the editor implies an empty per-app selection means full access, but runtime `canAccess` requires explicit keys (only a globally-empty `moduleAccess` grants all). Fixing it is a behavior change to the permission model — wants your call before I touch it.

## Test plan
- [ ] Staff & Access editor renders identically (all apps + groups, Reviews/Ads/POS settings present)
- [ ] Granting/removing modules still saves correctly
- [ ] `npm run dev` backoffice console shows no `[perms]` drift warnings (confirms nav ↔ registry are in sync)

https://claude.ai/code/session_01Xd1aERynqUbdCqXNboKWBe

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xd1aERynqUbdCqXNboKWBe)_