### PR TITLE
chore(backoffice): dedupe format helpers into @celsius/shared (housekeeping 3/4)

### DIFF
--- a/apps/backoffice/src/lib/loyalty/utils.ts
+++ b/apps/backoffice/src/lib/loyalty/utils.ts
@@ -1,77 +1,13 @@
-export function formatPoints(points: number): string {
-  return points.toLocaleString("en-MY");
-}
-
-export function formatCurrency(amount: number, currency = "MYR"): string {
-  return new Intl.NumberFormat("en-MY", {
-    style: "currency",
-    currency,
-    minimumFractionDigits: 2,
-  }).format(amount);
-}
-
-// ─── Phone number utilities ──────────────────────────────
-// Database/CRM stores: +60123456789 (for SMS delivery)
-// Customer display:    012-3456 789 (local Malaysian format)
-// Admin/CRM display:   +60 12-3456 789
-
-/** Format phone for display: +60123456789 → 012-345 6789 */
-export function formatPhone(phone: string): string {
-  const digits = phone.replace(/\D/g, "");
-  const local = digits.startsWith("60") ? "0" + digits.slice(2) : digits;
-  if (local.length === 11) {
-    // 011 numbers: 011-234 56789
-    return `${local.slice(0, 3)}-${local.slice(3, 6)} ${local.slice(6)}`;
-  }
-  if (local.length === 10) {
-    // Standard: 012-345 6789
-    return `${local.slice(0, 3)}-${local.slice(3, 6)} ${local.slice(6)}`;
-  }
-  if (local.length >= 4) {
-    return `${local.slice(0, 3)}-${local.slice(3)}`;
-  }
-  return local;
-}
-
-/** Convert customer input (0123456789) to storage format (+60123456789) */
-export function toStoragePhone(input: string): string {
-  const digits = input.replace(/\D/g, "");
-  if (digits.startsWith("60")) return `+${digits}`;
-  if (digits.startsWith("0")) return `+6${digits}`;
-  return `+60${digits}`;
-}
-
-/** Convert storage format (+60123456789) to local input (0123456789) */
-export function toLocalPhone(stored: string): string {
-  const digits = stored.replace(/\D/g, "");
-  if (digits.startsWith("60")) return "0" + digits.slice(2);
-  return digits;
-}
-
-export function generateRedemptionCode(): string {
-  const chars = "ABCDEFGHJKLMNPQRSTUVWXYZ23456789";
-  let code = "";
-  const randomBytes = new Uint8Array(8);
-  globalThis.crypto.getRandomValues(randomBytes);
-  for (let i = 0; i < 8; i++) {
-    code += chars.charAt(randomBytes[i] % chars.length);
-  }
-  return code;
-}
-
-export function getProgressPercentage(current: number, target: number): number {
-  if (target <= 0) return 100;
-  return Math.min(Math.round((current / target) * 100), 100);
-}
-
-export function getTimeAgo(date: string): string {
-  const seconds = Math.floor((Date.now() - new Date(date).getTime()) / 1000);
-  if (seconds < 60) return "just now";
-  if (seconds < 3600) return `${Math.floor(seconds / 60)}m ago`;
-  if (seconds < 86400) return `${Math.floor(seconds / 3600)}h ago`;
-  if (seconds < 2592000) return `${Math.floor(seconds / 86400)}d ago`;
-  const months = Math.floor(seconds / 2592000);
-  if (months < 12) return `${months} month${months === 1 ? "" : "s"} ago`;
-  const years = Math.floor(months / 12);
-  return `${years} year${years === 1 ? "" : "s"} ago`;
-}
+// Format helpers live in @celsius/shared (single source of truth). These
+// bodies used to be copy-pasted here and could drift from the canonical
+// versions; re-export instead, matching apps/loyalty/src/lib/utils.ts.
+export {
+  formatPoints,
+  formatCurrency,
+  formatPhone,
+  toStoragePhone,
+  toLocalPhone,
+  generateRedemptionCode,
+  getProgressPercentage,
+  getTimeAgo,
+} from "@celsius/shared";


### PR DESCRIPTION
## Summary
Housekeeping track #3 of 4 — de-duplication.

`apps/backoffice/src/lib/loyalty/utils.ts` re-implemented 8 helpers (`formatPoints`, `formatCurrency`, `formatPhone`, `toStoragePhone`, `toLocalPhone`, `generateRedemptionCode`, `getProgressPercentage`, `getTimeAgo`) **byte-identical** to `@celsius/shared`. Backoffice already depends on `@celsius/shared`, and the loyalty app already re-exports these from it — backoffice was the odd one out, free to silently drift (e.g. a phone-format fix in shared wouldn't reach backoffice).

Replaced the bodies with a re-export, mirroring `apps/loyalty/src/lib/utils.ts`. Identical export surface — the four consumers (`loyalty/members`, `engage`, `points-log`, `redemptions`) are untouched. −77/+13 lines.

### Why this is the only dedupe in this PR
I audited the rest of the apparent duplication and deliberately left it alone — it isn't safe to mechanically merge:
- **Web vs React-Native components** (order vs pickup-native) look similar but can't share code.
- **`formatRM`/`timeAgo` variants** across apps produce *different* output (sen-vs-RM input, "K" abbreviation, "Just now" vs "just now") — merging would change behavior.
- **Service workers** (order vs pickup-native) are build-generated mirrors.
- **`EmptyState`/`StatCard` look-alikes** differ per call site — consolidating is a parameterizing refactor, not a behavior-preserving merge.
- **`cn()` in packages/shared vs packages/ui** is identical, but deduping needs a new cross-package dependency for a 5-line util — not worth the coupling.

## Test plan
- [ ] Backoffice loyalty pages (members, engage, points-log, redemptions) render currency/points/phone/time-ago exactly as before
- [ ] Typecheck/lint pass (verified locally)

https://claude.ai/code/session_01Xd1aERynqUbdCqXNboKWBe

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xd1aERynqUbdCqXNboKWBe)_