### PR TITLE
chore(backoffice): align Vercel ignoreCommand with other apps (housekeeping 4/4)

### DIFF
--- a/apps/backoffice/vercel.json
+++ b/apps/backoffice/vercel.json
@@ -1,6 +1,6 @@
 {
   "regions": ["sin1"],
-  "ignoreCommand": "git diff HEAD~3 HEAD --quiet -- . ../../packages/",
+  "ignoreCommand": "git diff HEAD^ HEAD --quiet -- . ../../packages/",
   "crons": [
     {
       "path": "/api/ai-agent/celsius-overview",


### PR DESCRIPTION
## Summary
Housekeeping track #4 of 4 — deploy config consistency.

`apps/backoffice/vercel.json` was the lone outlier using `git diff HEAD~3 HEAD` for its Vercel "ignored build step". The other apps (`loyalty`, `pos`, `staff`, `pickup`) all use `git diff HEAD^ HEAD`. Aligned backoffice to `HEAD^`.

For this repo's squash-merge-per-PR → one-commit-per-push flow, `HEAD^ HEAD` is the correct choice: it rebuilds exactly when the merged commit touches `apps/backoffice/` or `packages/`, with **no missed builds**. The `HEAD~3` window only caused redundant backoffice rebuilds whenever a nearby PR (touching some other app) landed within 3 commits.

## Findings I did NOT change (flagging for your call)
- **`apps/order/vercel.json` has no `ignoreCommand`** — the order PWA rebuilds on every push to main regardless of whether `apps/order` changed. Adding one would save build minutes but changes deploy behavior, so I left it. Want me to add `git diff HEAD^ HEAD --quiet -- . ../../packages/` there too?
- **Two Vercel projects build `apps/backoffice`** (`celsius-backoffice` + `celsius-inventory`) — every backoffice change builds twice. This is a Vercel **dashboard** setting, not in the repo, so I can't change it here. Recommend deleting/repurposing one project in the Vercel dashboard.
- **SW cache names** (`celsius-v45`, `celsius-backoffice-v2`, `celsius-staff-v1`, `celsius-loyalty-v1`) — deliberately left distinct. They're per-app on purpose (renaming would force-flush every user's cache), so this isn't redundancy to "fix".

## Test plan
- [ ] `vercel.json` is valid JSON (verified)
- [ ] On the next merge that touches only a non-backoffice app, the backoffice Vercel build is skipped; on a backoffice-touching merge, it builds

https://claude.ai/code/session_01Xd1aERynqUbdCqXNboKWBe

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xd1aERynqUbdCqXNboKWBe)_