### PR TITLE
fix(backoffice): correct two broken Settings Hub links (404s)

### DIFF
--- a/apps/backoffice/src/app/(admin)/settings/page.tsx
+++ b/apps/backoffice/src/app/(admin)/settings/page.tsx
@@ -131,7 +131,7 @@ const GROUPS: Group[] = [
         blurb: "Bronze / Silver / Gold / Platinum / Staff / Black Card — discount %, stackable rule, qualifying thresholds.",
       },
       {
-        href: "/promotions",
+        href: "/loyalty/promotions",
         Icon: TicketPercent,
         title: "Promotions",
         blurb: "Auto-promos, first-order discount, combos, BOGO, time-window deals. Per-channel + per-outlet.",
@@ -143,7 +143,7 @@ const GROUPS: Group[] = [
         blurb: "RM50 Bill, Weekend Run, Make it a Meal — gamified goals that mint vouchers.",
       },
       {
-        href: "/loyalty/mystery-pool",
+        href: "/loyalty/mystery",
         Icon: Star,
         title: "Mystery Bean Pool",
         blurb: "Surprise reward outcomes shown on the customer-display after checkout.",


### PR DESCRIPTION
## Summary
Fixes the 404 you hit. The Settings Hub (`/settings`) had two tiles pointing at routes that don't exist:

| Tile | Was (404) | Now |
| --- | --- | --- |
| Mystery Bean Pool | `/loyalty/mystery-pool` | `/loyalty/mystery` |
| Promotions | `/promotions` | `/loyalty/promotions` |

Both target paths now match the real route directories and the sidebar nav links. I audited **every** other Hub tile href (POS, pickup, loyalty, reviews, ads, HR, finance, settings) — all 17 others resolve to real routes, so these two were the only breaks.

## Test plan
- [ ] Settings Hub → "Mystery Bean Pool" opens `/loyalty/mystery` (no 404)
- [ ] Settings Hub → "Promotions" opens `/loyalty/promotions` (no 404)

https://claude.ai/code/session_01Xd1aERynqUbdCqXNboKWBe

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xd1aERynqUbdCqXNboKWBe)_