### PR TITLE
fix(backoffice): managers can only grant Staff access they hold themselves

### DIFF
--- a/apps/backoffice/src/app/(admin)/settings/staff/page.tsx
+++ b/apps/backoffice/src/app/(admin)/settings/staff/page.tsx
@@ -53,7 +53,7 @@ export default function StaffPage() {
   const [editingStaff, setEditingStaff] = useState<Staff | null>(null);
   const [form, setForm] = useState<StaffForm>(emptyForm);
   const [outlets, setOutlets] = useState<OutletOption[]>([]);
-  const [me, setMe] = useState<{ role: string; outletId: string | null } | null>(null);
+  const [me, setMe] = useState<{ role: string; outletId: string | null; appAccess: string[]; moduleAccess: string[] } | null>(null);
   const [saving, setSaving] = useState(false);
   const [saveError, setSaveError] = useState("");
   const [showPassword, setShowPassword] = useState(false);
@@ -73,11 +73,20 @@ export default function StaffPage() {
     loadStaff();
     fetch("/api/settings/outlets").then((r) => r.json()).then(setOutlets);
     fetch("/api/auth/me").then((r) => r.ok ? r.json() : null).then((d) => {
-      if (d) setMe({ role: d.role, outletId: d.outletId ?? null });
+      if (d) setMe({ role: d.role, outletId: d.outletId ?? null, appAccess: d.appAccess ?? [], moduleAccess: d.moduleAccess ?? [] });
     });
   }, []);
 
   const isManagerOnly = me?.role === "MANAGER";
+
+  // A manager can only grant apps/modules they hold themselves (also enforced
+  // server-side). Empty moduleAccess = full access, so no module clamp then.
+  const managerApps = new Set(me?.appAccess ?? []);
+  const managerModuleKeys = new Set(me?.moduleAccess ?? []);
+  const managerFullModules = managerModuleKeys.size === 0;
+  const canGrantApp = (app: string) => !isManagerOnly || managerApps.has(app);
+  const canGrantModule = (app: string, key: string) =>
+    !isManagerOnly || managerFullModules || managerModuleKeys.has(`${app}:${key}`);
 
   const filtered = staff.filter((s) => {
     const matchStatus = filter === "all" || s.status === filter;
@@ -496,7 +505,7 @@ export default function StaffPage() {
                   {isOwnerOrAdmin ? "Owner and Admin roles have full access to all apps." : "Select which apps this user can access."}
                 </p>
                 <div className="grid grid-cols-2 gap-1.5">
-                  {availableApps.map((app) => {
+                  {availableApps.filter((app) => canGrantApp(app)).map((app) => {
                     const isSelected = isOwnerOrAdmin || form.appAccess.includes(app);
                     return (
                       <button
@@ -527,8 +536,10 @@ export default function StaffPage() {
                   <h3 className="text-sm font-semibold text-gray-900 mb-1">Module Access</h3>
                   <p className="text-xs text-gray-400 mb-3">Control which modules this user can see within each app. Empty = full access.</p>
                   <div className="space-y-4">
-                    {[...form.appAccess.filter((app) => APP_MODULES[app]), ...(form.appAccess.includes("backoffice") ? BACKOFFICE_SUB_APPS.filter((a) => APP_MODULES[a]) : [])].map((app) => {
-                      const modules = APP_MODULES[app];
+                    {[...form.appAccess.filter((app) => APP_MODULES[app]), ...(form.appAccess.includes("backoffice") ? BACKOFFICE_SUB_APPS.filter((a) => APP_MODULES[a]) : [])]
+                      .filter((app) => APP_MODULES[app].some((m) => canGrantModule(app, m.key)))
+                      .map((app) => {
+                      const modules = APP_MODULES[app].filter((m) => canGrantModule(app, m.key));
                       const selected = form.moduleAccess[app] || [];
                       const allSelected = modules.every((m) => selected.includes(m.key));
                       const noneSelected = selected.length === 0;

--- a/apps/backoffice/src/app/api/settings/staff/[id]/route.ts
+++ b/apps/backoffice/src/app/api/settings/staff/[id]/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse, NextRequest } from "next/server";
 import { prisma } from "@/lib/prisma";
 import { getUserFromHeaders, hasModulePermission, type SessionUser } from "@/lib/auth";
+import { clampGrantsToCaller } from "@/lib/staff-grants";
 import { hashPassword } from "@/lib/password";
 import { hashPin, verifyPin } from "@celsius/auth";
 import { logActivity, diffFields } from "@/lib/activity-log";
@@ -107,8 +108,10 @@ export async function PATCH(req: NextRequest, { params }: { params: Promise<{ id
   if (body.outletIds !== undefined) data.outletIds = body.outletIds;
   if (body.username !== undefined) data.username = body.username || null;
   if (body.status !== undefined) data.status = body.status;
-  if (body.appAccess !== undefined) data.appAccess = body.appAccess;
-  if (body.moduleAccess !== undefined) data.moduleAccess = body.moduleAccess;
+  // A manager can't grant a Staff member apps/modules they don't hold themselves.
+  const grants = await clampGrantsToCaller(caller, body.appAccess, body.moduleAccess);
+  if (grants.appAccess !== undefined) data.appAccess = grants.appAccess;
+  if (grants.moduleAccess !== undefined) data.moduleAccess = grants.moduleAccess;
 
   // Password — hash before saving
   if (body.password && body.password.length >= 8) {

--- a/apps/backoffice/src/app/api/settings/staff/route.ts
+++ b/apps/backoffice/src/app/api/settings/staff/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse, NextRequest } from "next/server";
 import { prisma } from "@/lib/prisma";
 import { getUserFromHeaders, hasModulePermission, AuthError } from "@/lib/auth";
+import { clampGrantsToCaller } from "@/lib/staff-grants";
 import { getAccessibleOutletIds } from "@/lib/hr/scope";
 import { hashPassword } from "@/lib/password";
 import { hashPin, verifyPin } from "@celsius/auth";
@@ -102,6 +103,9 @@ export async function POST(req: NextRequest) {
     return NextResponse.json({ error: "Forbidden" }, { status: 403 });
   }
 
+  // A manager can't grant a Staff member apps/modules they don't hold themselves.
+  const grants = await clampGrantsToCaller(caller, appAccess, moduleAccess);
+
   const data: Record<string, unknown> = {
     name,
     phone,
@@ -110,8 +114,8 @@ export async function POST(req: NextRequest) {
     outletId: outletId || (caller.role === "MANAGER" ? caller.outletId : null),
     outletIds: outletIds || [],
     username: username || null,
-    appAccess: appAccess || [],
-    moduleAccess: moduleAccess || {},
+    appAccess: grants.appAccess ?? [],
+    moduleAccess: grants.moduleAccess ?? {},
   };
 
   if (password && password.length >= 8) {

--- a/apps/backoffice/src/lib/staff-grants.ts
+++ b/apps/backoffice/src/lib/staff-grants.ts
@@ -1,0 +1,58 @@
+import { prisma } from "@/lib/prisma";
+import type { SessionUser } from "@/lib/auth";
+
+export type ModuleAccessMap = Record<string, string[]>;
+
+// Restrict the apps/modules a MANAGER may assign to a Staff member to a subset
+// of the manager's own grants — a manager can't hand out access they don't
+// themselves hold. OWNER/ADMIN are unrestricted.
+//
+// Mirrors the sidebar RBAC's "empty moduleAccess = full access" rule: a manager
+// with no module restrictions can still grant any module. appAccess is always
+// clamped to the manager's own apps (an admin provisions broader app access).
+//
+// Only the keys present in the request are returned, so callers can spread the
+// result over a partial update.
+export async function clampGrantsToCaller(
+  caller: SessionUser,
+  requestedAppAccess: string[] | undefined,
+  requestedModuleAccess: ModuleAccessMap | undefined,
+): Promise<{ appAccess?: string[]; moduleAccess?: ModuleAccessMap }> {
+  const out: { appAccess?: string[]; moduleAccess?: ModuleAccessMap } = {};
+  if (requestedAppAccess !== undefined) out.appAccess = requestedAppAccess;
+  if (requestedModuleAccess !== undefined) out.moduleAccess = requestedModuleAccess;
+
+  // Owners/admins grant freely.
+  if (caller.role === "OWNER" || caller.role === "ADMIN") return out;
+
+  const row = await prisma.user.findUnique({
+    where: { id: caller.id },
+    select: { appAccess: true, moduleAccess: true },
+  });
+  const callerApps = row?.appAccess ?? [];
+  const callerModules: ModuleAccessMap =
+    row?.moduleAccess && typeof row.moduleAccess === "object" && !Array.isArray(row.moduleAccess)
+      ? (row.moduleAccess as ModuleAccessMap)
+      : {};
+
+  if (requestedAppAccess !== undefined) {
+    out.appAccess = requestedAppAccess.filter((a) => callerApps.includes(a));
+  }
+
+  if (requestedModuleAccess !== undefined) {
+    // Empty moduleAccess on the manager = full access (sidebar RBAC rule) — no clamp.
+    if (Object.keys(callerModules).length === 0) {
+      out.moduleAccess = requestedModuleAccess;
+    } else {
+      const clamped: ModuleAccessMap = {};
+      for (const [app, keys] of Object.entries(requestedModuleAccess)) {
+        const allowed = callerModules[app];
+        if (!Array.isArray(allowed)) continue; // manager doesn't have this app at all
+        clamped[app] = (keys ?? []).filter((k) => allowed.includes(k));
+      }
+      out.moduleAccess = clamped;
+    }
+  }
+
+  return out;
+}


### PR DESCRIPTION
## Summary
Closes the privilege gap from your question #2: a manager with `settings:staff` could grant a Staff member **any** apps/modules — including ones the manager doesn't hold — because the create/update routes wrote `appAccess`/`moduleAccess` straight from the request with no clamp, and the editor UI showed every toggle.

**Fix:** new `clampGrantsToCaller()` helper. For a **MANAGER** caller it intersects:
- requested `appAccess` → with the manager's own apps
- requested `moduleAccess[app]` keys → with the manager's own keys for that app (drops apps the manager lacks entirely)

OWNER/ADMIN are unrestricted. A manager with empty `moduleAccess` (= full access, per the sidebar RBAC rule) can still grant anything. Enforced in **both** `POST /api/settings/staff` and `PATCH /api/settings/staff/[id]`. The Staff editor UI now also hides app/module toggles the manager can't grant (so nothing silently drops on save).

What's unchanged: a manager still can only create/manage **Staff** (not themselves, peers, or admins), within their outlet scope — so there was never self-escalation, only over-provisioning of Staff. This makes it least-privilege end to end.

## Test plan
- [ ] As a manager with `inventory:[products]` only: editing a Staff member, the Module picker shows only Inventory→Products (not other inventory modules or other apps); API drops any extra keys if forced
- [ ] As a manager, App Access shows only apps the manager has
- [ ] As OWNER/ADMIN: full grant ability unchanged
- [ ] Manager with empty moduleAccess (full access) can still grant any module

https://claude.ai/code/session_01Xd1aERynqUbdCqXNboKWBe

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xd1aERynqUbdCqXNboKWBe)_