### PR TITLE
fix(finance): source e-invoice SST line rate from app_settings.sst

### DIFF
--- a/apps/backoffice/src/lib/finance/agents/compliance.ts
+++ b/apps/backoffice/src/lib/finance/agents/compliance.ts
@@ -76,6 +76,20 @@ async function buildConsolidatedDoc(opts: {
 }): Promise<EinvoiceDocument | null> {
   const client = getFinanceClient();
   const { companyId, yearMonth, outletId } = opts;
+
+  // SST rate for the line-level rate label, sourced from app_settings.sst —
+  // the same config the order app charges customers with — so the rate we
+  // report to LHDN tracks the rate we collect. enabled=false ⇒ 0, matching
+  // the checkout path. The submitted sstAmount/taxTotal still come from the
+  // recorded fin_invoices amounts, not this rate.
+  const { data: sstSetting } = await client
+    .from("app_settings")
+    .select("value")
+    .eq("key", "sst")
+    .maybeSingle();
+  const sstConfig = (sstSetting?.value as { rate?: number; enabled?: boolean } | undefined) ?? {};
+  const sstRate = sstConfig.enabled === false ? 0 : Number(sstConfig.rate ?? 0.06);
+
   const [yearStr, monthStr] = yearMonth.split("-");
   const year = Number(yearStr);
   const month = Number(monthStr);
@@ -130,7 +144,7 @@ async function buildConsolidatedDoc(opts: {
     unitPrice: round2(agg.subtotal / Math.max(agg.count, 1)),
     classification: "022",       // F&B service classification
     subtotal: round2(agg.subtotal),
-    sstRate: 0.06,
+    sstRate,
     sstAmount: round2(agg.sst),
   }));
 


### PR DESCRIPTION
## Summary
The consolidated MyInvois B2C e-invoice builder (`buildConsolidatedDoc` in `lib/finance/agents/compliance.ts`) hardcoded the line-level `sstRate` at `0.06`. The submitted `sstAmount`/`taxTotal` already come from the recorded `fin_invoices.sst_amount` (the SST actually collected, which the order app computes from `app_settings.sst.rate`), so the **rate label was a second copy of a value owned elsewhere**. If Malaysia's SST rate changes again (it was 8% in 2024), the order app would charge the new rate but the e-invoice would keep reporting 6% to LHDN — rate × subtotal would no longer reconcile with the submitted amount.

This sources the line rate from `app_settings.sst` — the same config the checkout path charges with — and honours `enabled=false` (rate → 0, matching `orders`/`checkout`). Submitted amounts and `taxTotal` are unchanged; only the rate **label** now tracks the configured rate.

## Note / known caveat
The consolidated doc is built for a past `yearMonth`, so it reads the **current** `app_settings.sst.rate`. During a rate-transition month (invoices charged at the old rate while config already holds the new rate) the rate label could disagree with the per-invoice amounts. This matches the approach explicitly chosen for the consolidation; the deriving-from-amounts alternative was considered and set aside.

## Test plan
- [ ] Backoffice typecheck clean for `compliance.ts` (verified locally; repo-wide `tsc` has pre-existing unrelated errors in `scripts/`, `ads/`, `ops/compliance`).
- [ ] With `app_settings.sst = { rate: 0.06, enabled: true }`, run a consolidated submission and confirm line `sstRate` = 0.06 and amounts unchanged.
- [ ] Set `app_settings.sst.enabled = false` and confirm line `sstRate` = 0.
- [ ] (Optional) Set `rate: 0.08` and confirm the line label reflects 0.08.

https://claude.ai/code/session_01Xd1aERynqUbdCqXNboKWBe

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xd1aERynqUbdCqXNboKWBe)_