### PR TITLE
chore: consolidate identical domain types into @celsius/shared

### DIFF
--- a/apps/loyalty/src/types/index.ts
+++ b/apps/loyalty/src/types/index.ts
@@ -1,51 +1,28 @@
 // ==========================================
 // Celsius Loyalty — Core Types
 // Multi-tenant: supports multiple brands
+//
+// Canonical entities shared with apps/order live in @celsius/shared and
+// are re-exported below. Loyalty-specific supersets (tier-aware
+// MemberBrand, combo/override Reward) plus the tier and product types
+// stay here.
 // ==========================================
 
-export interface Brand {
-  id: string;
-  name: string;
-  slug: string; // e.g. "celsius-coffee", "berbuka-celsius"
-  logo_url: string | null;
-  primary_color: string; // hex
-  secondary_color: string; // hex
-  points_per_rm: number; // e.g. 1 = RM1 = 1 point
-  currency: string; // "MYR"
-  is_active: boolean;
-  points_expiry_months: number; // 0 = no expiry
-  points_expiry_enabled: boolean;
-  daily_earning_limit: number; // 0 = unlimited
-  sms_credits_balance?: number;
-  created_at: string;
-  updated_at: string;
-}
+export type {
+  Brand,
+  Outlet,
+  Member,
+  PointTransaction,
+  Redemption,
+  Campaign,
+  SMSLog,
+  StaffUser,
+  TopSpender,
+  DashboardStats,
+  IssuedReward,
+} from "@celsius/shared";
 
-export interface Outlet {
-  id: string;
-  brand_id: string;
-  name: string;
-  address: string;
-  city: string;
-  state: string;
-  phone: string | null;
-  storehub_store_id?: string; // StoreHub POS store ID for auto-sync
-  is_active: boolean;
-  created_at: string;
-}
-
-export interface Member {
-  id: string;
-  phone: string; // Stored as +60XXXXXXXXX format for SMS delivery
-  name: string | null;
-  email: string | null;
-  birthday: string | null; // YYYY-MM-DD
-  preferred_outlet_id: string | null;
-  sms_opt_out?: boolean;
-  consent_at?: string | null;
-  created_at: string;
-  updated_at: string;
-}
+import type { Member } from "@celsius/shared";
 
 export interface MemberBrand {
   id: string;
@@ -103,21 +80,6 @@ export interface ActivePostPurchase {
   hours_remaining: number;
 }
 
-export interface PointTransaction {
-  id: string;
-  member_id: string;
-  brand_id: string;
-  outlet_id: string | null;
-  type: "earn" | "redeem" | "bonus" | "expire" | "adjust";
-  points: number; // positive for earn, negative for redeem
-  balance_after: number;
-  description: string;
-  reference_id: string | null; // POS transaction ID
-  multiplier: number; // 1x, 2x, 3x
-  created_at: string;
-  created_by: string | null; // staff user id
-}
-
 export interface Reward {
   id: string;
   brand_id: string;
@@ -153,122 +115,6 @@ export interface Reward {
   expiry_minutes: number | null; // pickup redemption validity (default 60)
   created_at: string;
   updated_at: string;
-}
-
-export interface Redemption {
-  id: string;
-  member_id: string;
-  reward_id: string;
-  brand_id: string;
-  outlet_id: string | null;
-  points_spent: number;
-  status: "pending" | "confirmed" | "collected" | "used" | "cancelled" | "expired";
-  code: string; // unique redemption code
-  confirmed_at: string | null;
-  confirmed_by: string | null; // staff
-  // ─── Pickup app fields ───
-  redemption_type: "in_store" | "pickup" | "delivery";
-  pickup_outlet_id: string | null;
-  expires_at: string | null;
-  collected_at: string | null;
-  source: "portal" | "web_app" | "pickup_app";
-  created_at: string;
-}
-
-export interface Campaign {
-  id: string;
-  brand_id: string;
-  name: string;
-  description: string | null;
-  type: "multiplier" | "bonus" | "broadcast";
-  multiplier: number | null; // for multiplier campaigns
-  bonus_points: number | null; // for bonus campaigns
-  message: string | null; // for broadcast
-  target_segment: "all" | "new" | "active" | "inactive";
-  start_date: string;
-  end_date: string;
-  is_active: boolean;
-  created_at: string;
-  sms_message?: string;
-  sms_sent_count?: number;
-  sms_sent_at?: string;
-}
-
-export interface SMSLog {
-  id: string;
-  brand_id: string;
-  campaign_id: string | null;
-  member_id: string | null;
-  phone: string;
-  message: string;
-  status: "sent" | "delivered" | "failed" | "pending";
-  provider: string;
-  provider_message_id: string | null;
-  error: string | null;
-  created_at: string;
-  created_by: string | null;
-}
-
-export interface StaffUser {
-  id: string;
-  brand_id: string;
-  outlet_id: string | null;
-  outlet_ids: string[];
-  name: string;
-  email: string;
-  role: "admin" | "manager" | "staff";
-  pin_hash: string | null; // bcrypt-hashed PIN (never plaintext)
-  is_active: boolean;
-  created_at: string;
-}
-
-// Dashboard analytics
-export interface DashboardStats {
-  total_members: number;
-  new_members_today: number;
-  new_members_this_month: number;
-  total_points_issued: number;
-  total_points_redeemed: number;
-  total_redemptions: number;
-  total_revenue_attributed: number;
-  active_campaigns: number;
-  // Enhanced insights
-  active_members_30d: number;
-  floating_points: number;
-  member_transaction_pct: number;
-  avg_lifetime_value_members: number;
-  avg_lifetime_value_nonmembers: number;
-  reward_redemption_rate: number;
-  top_spenders: TopSpender[];
-  new_members_by_month: { month: string; count: number }[];
-  redemptions_by_month: { month: string; count: number }[];
-  recent_activity?: { id: string; name: string; text: string; type: string; date: string }[];
-  returning_count?: number;
-  new_count?: number;
-  eligible_count?: number;
-}
-
-export interface TopSpender {
-  id: string;
-  name: string | null;
-  phone: string;
-  total_spent: number;
-  total_visits: number;
-  total_points_earned: number;
-  total_rewards_redeemed: number;
-  last_visit_at: string | null;
-}
-
-export interface IssuedReward {
-  id: string;
-  member_id: string;
-  reward_id: string;
-  brand_id: string;
-  issued_at: string;
-  expires_at: string | null;
-  status: "active" | "used" | "expired";
-  code: string;
-  year: number | null;
 }
 
 // Member with brand-specific data

--- a/apps/order/src/types/index.ts
+++ b/apps/order/src/types/index.ts
@@ -1,51 +1,27 @@
 // ==========================================
-// Celsius Loyalty — Core Types
-// Multi-tenant: supports multiple brands
+// Celsius Pickup (order) — Core Types
+//
+// Canonical entities live in @celsius/shared and are re-exported below.
+// MemberBrand and Reward are intentionally NARROWER than loyalty's — the
+// order/pickup surface has no tier system and no combo/override reward
+// mechanics — so they stay local here.
 // ==========================================
 
-export interface Brand {
-  id: string;
-  name: string;
-  slug: string; // e.g. "celsius-coffee", "berbuka-celsius"
-  logo_url: string | null;
-  primary_color: string; // hex
-  secondary_color: string; // hex
-  points_per_rm: number; // e.g. 1 = RM1 = 1 point
-  currency: string; // "MYR"
-  is_active: boolean;
-  points_expiry_months: number; // 0 = no expiry
-  points_expiry_enabled: boolean;
-  daily_earning_limit: number; // 0 = unlimited
-  sms_credits_balance?: number;
-  created_at: string;
-  updated_at: string;
-}
+export type {
+  Brand,
+  Outlet,
+  Member,
+  PointTransaction,
+  Redemption,
+  Campaign,
+  SMSLog,
+  StaffUser,
+  TopSpender,
+  DashboardStats,
+  IssuedReward,
+} from "@celsius/shared";
 
-export interface Outlet {
-  id: string;
-  brand_id: string;
-  name: string;
-  address: string;
-  city: string;
-  state: string;
-  phone: string | null;
-  storehub_store_id?: string; // StoreHub POS store ID for auto-sync
-  is_active: boolean;
-  created_at: string;
-}
-
-export interface Member {
-  id: string;
-  phone: string; // Stored as +60XXXXXXXXX format for SMS delivery
-  name: string | null;
-  email: string | null;
-  birthday: string | null; // YYYY-MM-DD
-  preferred_outlet_id: string | null;
-  sms_opt_out?: boolean;
-  consent_at?: string | null;
-  created_at: string;
-  updated_at: string;
-}
+import type { Member } from "@celsius/shared";
 
 export interface MemberBrand {
   id: string;
@@ -58,21 +34,6 @@ export interface MemberBrand {
   total_spent: number;
   joined_at: string;
   last_visit_at: string | null;
-}
-
-export interface PointTransaction {
-  id: string;
-  member_id: string;
-  brand_id: string;
-  outlet_id: string | null;
-  type: "earn" | "redeem" | "bonus" | "expire" | "adjust";
-  points: number; // positive for earn, negative for redeem
-  balance_after: number;
-  description: string;
-  reference_id: string | null; // POS transaction ID
-  multiplier: number; // 1x, 2x, 3x
-  created_at: string;
-  created_by: string | null; // staff user id
 }
 
 export interface Reward {
@@ -106,122 +67,6 @@ export interface Reward {
   expiry_minutes: number | null; // pickup redemption validity (default 60)
   created_at: string;
   updated_at: string;
-}
-
-export interface Redemption {
-  id: string;
-  member_id: string;
-  reward_id: string;
-  brand_id: string;
-  outlet_id: string | null;
-  points_spent: number;
-  status: "pending" | "confirmed" | "collected" | "used" | "cancelled" | "expired";
-  code: string; // unique redemption code
-  confirmed_at: string | null;
-  confirmed_by: string | null; // staff
-  // ─── Pickup app fields ───
-  redemption_type: "in_store" | "pickup" | "delivery";
-  pickup_outlet_id: string | null;
-  expires_at: string | null;
-  collected_at: string | null;
-  source: "portal" | "web_app" | "pickup_app";
-  created_at: string;
-}
-
-export interface Campaign {
-  id: string;
-  brand_id: string;
-  name: string;
-  description: string | null;
-  type: "multiplier" | "bonus" | "broadcast";
-  multiplier: number | null; // for multiplier campaigns
-  bonus_points: number | null; // for bonus campaigns
-  message: string | null; // for broadcast
-  target_segment: "all" | "new" | "active" | "inactive";
-  start_date: string;
-  end_date: string;
-  is_active: boolean;
-  created_at: string;
-  sms_message?: string;
-  sms_sent_count?: number;
-  sms_sent_at?: string;
-}
-
-export interface SMSLog {
-  id: string;
-  brand_id: string;
-  campaign_id: string | null;
-  member_id: string | null;
-  phone: string;
-  message: string;
-  status: "sent" | "delivered" | "failed" | "pending";
-  provider: string;
-  provider_message_id: string | null;
-  error: string | null;
-  created_at: string;
-  created_by: string | null;
-}
-
-export interface StaffUser {
-  id: string;
-  brand_id: string;
-  outlet_id: string | null;
-  outlet_ids: string[];
-  name: string;
-  email: string;
-  role: "admin" | "manager" | "staff";
-  pin_hash: string | null; // bcrypt-hashed PIN (never plaintext)
-  is_active: boolean;
-  created_at: string;
-}
-
-// Dashboard analytics
-export interface DashboardStats {
-  total_members: number;
-  new_members_today: number;
-  new_members_this_month: number;
-  total_points_issued: number;
-  total_points_redeemed: number;
-  total_redemptions: number;
-  total_revenue_attributed: number;
-  active_campaigns: number;
-  // Enhanced insights
-  active_members_30d: number;
-  floating_points: number;
-  member_transaction_pct: number;
-  avg_lifetime_value_members: number;
-  avg_lifetime_value_nonmembers: number;
-  reward_redemption_rate: number;
-  top_spenders: TopSpender[];
-  new_members_by_month: { month: string; count: number }[];
-  redemptions_by_month: { month: string; count: number }[];
-  recent_activity?: { id: string; name: string; text: string; type: string; date: string }[];
-  returning_count?: number;
-  new_count?: number;
-  eligible_count?: number;
-}
-
-export interface TopSpender {
-  id: string;
-  name: string | null;
-  phone: string;
-  total_spent: number;
-  total_visits: number;
-  total_points_earned: number;
-  total_rewards_redeemed: number;
-  last_visit_at: string | null;
-}
-
-export interface IssuedReward {
-  id: string;
-  member_id: string;
-  reward_id: string;
-  brand_id: string;
-  issued_at: string;
-  expires_at: string | null;
-  status: "active" | "used" | "expired";
-  code: string;
-  year: number | null;
 }
 
 // Member with brand-specific data

--- a/packages/shared/src/domain.ts
+++ b/packages/shared/src/domain.ts
@@ -1,0 +1,186 @@
+// ==========================================
+// Celsius — Canonical domain entities
+//
+// These mirror the Supabase schema and were defined identically in both
+// apps/order and apps/loyalty. Consolidated here as the single source of
+// truth so the two surfaces can't silently drift.
+//
+// App-specific supersets stay in each app's own types module: loyalty's
+// tier-aware MemberBrand and its combo/override Reward, plus the tier and
+// product types, are intentionally NOT here.
+// ==========================================
+
+export interface Brand {
+  id: string;
+  name: string;
+  slug: string; // e.g. "celsius-coffee", "berbuka-celsius"
+  logo_url: string | null;
+  primary_color: string; // hex
+  secondary_color: string; // hex
+  points_per_rm: number; // e.g. 1 = RM1 = 1 point
+  currency: string; // "MYR"
+  is_active: boolean;
+  points_expiry_months: number; // 0 = no expiry
+  points_expiry_enabled: boolean;
+  daily_earning_limit: number; // 0 = unlimited
+  sms_credits_balance?: number;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface Outlet {
+  id: string;
+  brand_id: string;
+  name: string;
+  address: string;
+  city: string;
+  state: string;
+  phone: string | null;
+  storehub_store_id?: string; // StoreHub POS store ID for auto-sync
+  is_active: boolean;
+  created_at: string;
+}
+
+export interface Member {
+  id: string;
+  phone: string; // Stored as +60XXXXXXXXX format for SMS delivery
+  name: string | null;
+  email: string | null;
+  birthday: string | null; // YYYY-MM-DD
+  preferred_outlet_id: string | null;
+  sms_opt_out?: boolean;
+  consent_at?: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface PointTransaction {
+  id: string;
+  member_id: string;
+  brand_id: string;
+  outlet_id: string | null;
+  type: "earn" | "redeem" | "bonus" | "expire" | "adjust";
+  points: number; // positive for earn, negative for redeem
+  balance_after: number;
+  description: string;
+  reference_id: string | null; // POS transaction ID
+  multiplier: number; // 1x, 2x, 3x
+  created_at: string;
+  created_by: string | null; // staff user id
+}
+
+export interface Redemption {
+  id: string;
+  member_id: string;
+  reward_id: string;
+  brand_id: string;
+  outlet_id: string | null;
+  points_spent: number;
+  status: "pending" | "confirmed" | "collected" | "used" | "cancelled" | "expired";
+  code: string; // unique redemption code
+  confirmed_at: string | null;
+  confirmed_by: string | null; // staff
+  // ─── Pickup app fields ───
+  redemption_type: "in_store" | "pickup" | "delivery";
+  pickup_outlet_id: string | null;
+  expires_at: string | null;
+  collected_at: string | null;
+  source: "portal" | "web_app" | "pickup_app";
+  created_at: string;
+}
+
+export interface Campaign {
+  id: string;
+  brand_id: string;
+  name: string;
+  description: string | null;
+  type: "multiplier" | "bonus" | "broadcast";
+  multiplier: number | null; // for multiplier campaigns
+  bonus_points: number | null; // for bonus campaigns
+  message: string | null; // for broadcast
+  target_segment: "all" | "new" | "active" | "inactive";
+  start_date: string;
+  end_date: string;
+  is_active: boolean;
+  created_at: string;
+  sms_message?: string;
+  sms_sent_count?: number;
+  sms_sent_at?: string;
+}
+
+export interface SMSLog {
+  id: string;
+  brand_id: string;
+  campaign_id: string | null;
+  member_id: string | null;
+  phone: string;
+  message: string;
+  status: "sent" | "delivered" | "failed" | "pending";
+  provider: string;
+  provider_message_id: string | null;
+  error: string | null;
+  created_at: string;
+  created_by: string | null;
+}
+
+export interface StaffUser {
+  id: string;
+  brand_id: string;
+  outlet_id: string | null;
+  outlet_ids: string[];
+  name: string;
+  email: string;
+  role: "admin" | "manager" | "staff";
+  pin_hash: string | null; // bcrypt-hashed PIN (never plaintext)
+  is_active: boolean;
+  created_at: string;
+}
+
+export interface TopSpender {
+  id: string;
+  name: string | null;
+  phone: string;
+  total_spent: number;
+  total_visits: number;
+  total_points_earned: number;
+  total_rewards_redeemed: number;
+  last_visit_at: string | null;
+}
+
+// Dashboard analytics
+export interface DashboardStats {
+  total_members: number;
+  new_members_today: number;
+  new_members_this_month: number;
+  total_points_issued: number;
+  total_points_redeemed: number;
+  total_redemptions: number;
+  total_revenue_attributed: number;
+  active_campaigns: number;
+  // Enhanced insights
+  active_members_30d: number;
+  floating_points: number;
+  member_transaction_pct: number;
+  avg_lifetime_value_members: number;
+  avg_lifetime_value_nonmembers: number;
+  reward_redemption_rate: number;
+  top_spenders: TopSpender[];
+  new_members_by_month: { month: string; count: number }[];
+  redemptions_by_month: { month: string; count: number }[];
+  recent_activity?: { id: string; name: string; text: string; type: string; date: string }[];
+  returning_count?: number;
+  new_count?: number;
+  eligible_count?: number;
+}
+
+export interface IssuedReward {
+  id: string;
+  member_id: string;
+  reward_id: string;
+  brand_id: string;
+  issued_at: string;
+  expires_at: string | null;
+  status: "active" | "used" | "expired";
+  code: string;
+  year: number | null;
+}

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -1,5 +1,19 @@
 // ─── Re-exports from submodules ─────────────────────────
 export { cn } from "./cn";
+// ─── Canonical domain entities (shared by order + loyalty) ───
+export type {
+  Brand,
+  Outlet,
+  Member,
+  PointTransaction,
+  Redemption,
+  Campaign,
+  SMSLog,
+  StaffUser,
+  TopSpender,
+  DashboardStats,
+  IssuedReward,
+} from "./domain";
 export {
   OUTLET_IDS,
   OUTLET_LABELS,


### PR DESCRIPTION
## Summary
Housekeeping — `order` and `loyalty` each defined the same entity types verbatim. Consolidate the identical ones into a new `packages/shared/src/domain.ts` (single source of truth), re-exported through the existing `@celsius/shared` barrel. Both apps re-export them from their `@/types` surface, so **no consumer import changes** and **no runtime change** (type-only, erased at build).

**Moved to shared (verified byte-identical across both apps):** `Brand`, `Outlet`, `Member`, `PointTransaction`, `Redemption`, `Campaign`, `SMSLog`, `StaffUser`, `TopSpender`, `DashboardStats`, `IssuedReward`.

**Deliberately left app-local (genuine, correct drift):**
- `Reward` — loyalty's is a superset: `override_price`, `combo_product_ids`, `combo_price`, `applicable_tags`, plus a wider `discount_type` union (`override_price | combo`). The order/pickup surface doesn't support those, so merging would wrongly widen order's type.
- `MemberBrand` — loyalty adds `current_tier_id` / `tier_evaluated_at` (tier system order lacks).
- Their dependents `MemberWithBrand` / `RewardWithProgress`, plus loyalty's `Tier` / `MemberTierStatus` / `Product*` types.

Net **−109 lines**.

## Verification
- `order`: `tsc --noEmit` ✓ clean
- `loyalty`: `tsc --noEmit` ✓ clean (after `prisma generate`)
- Type-only re-exports through the shared barrel — no `node:crypto`/runtime pulled in (unlike the OTP module the barrel deliberately avoids).

## Test plan
- [ ] CI: typecheck (order, loyalty, all apps) green
- [ ] CI: build (all apps) green
- [ ] CI: test green

https://claude.ai/code/session_01Xd1aERynqUbdCqXNboKWBe

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xd1aERynqUbdCqXNboKWBe)_