### PR TITLE
fix(order): enlarge menu category sidebar

### DIFF
--- a/apps/order/src/app/menu/_MenuColumns.tsx
+++ b/apps/order/src/app/menu/_MenuColumns.tsx
@@ -257,7 +257,7 @@ export function MenuColumns({
 
     <div className="flex" style={{ minHeight: "calc(100dvh - 200px)" }}>
       <aside
-        className="flex-shrink-0 bg-white overflow-y-auto w-[60px] min-[420px]:w-20"
+        className="flex-shrink-0 bg-white overflow-y-auto w-[76px] min-[420px]:w-24"
         style={{
           position: "sticky",
           top: "calc(env(safe-area-inset-top, 0px) + 100px)",
@@ -279,9 +279,9 @@ export function MenuColumns({
                 <button
                   type="button"
                   onClick={() => onPickPill(s.id)}
-                  className="flex flex-col items-center justify-center gap-1 rounded-2xl active:opacity-70 w-[52px] min-[420px]:w-[72px]"
+                  className="flex flex-col items-center justify-center gap-1 rounded-2xl active:opacity-70 w-[68px] min-[420px]:w-[88px]"
                   style={{
-                    height: 64,
+                    height: 78,
                     paddingLeft: 4,
                     paddingRight: 4,
                     backgroundColor: on ? "#160800" : "transparent",
@@ -289,13 +289,13 @@ export function MenuColumns({
                   aria-current={on ? "true" : undefined}
                 >
                   <Icon
-                    size={16}
+                    size={22}
                     color={on ? "#FFFFFF" : "#6E6E73"}
                     strokeWidth={1.75}
                     fill={on && s.icon === "star" ? "#FFFFFF" : "transparent"}
                   />
                   <span
-                    className="text-[9px] text-center leading-[11px]"
+                    className="text-[11px] text-center leading-[13px]"
                     style={{ color: on ? "#FFFFFF" : "#160800", fontWeight: 600 }}
                   >
                     {s.label}


### PR DESCRIPTION
## Summary
Issue #3 — the menu category sidebar was too small. Enlarged the vertical rail in `apps/order/src/app/menu/_MenuColumns.tsx`:

| Element | Before | After |
| --- | --- | --- |
| `aside` width | 60px / 80px (≥420px) | 76px / 96px |
| button width | 52px / 72px | 68px / 88px |
| button height | 64 | 78 |
| icon size | 16 | 22 |
| label text | 9px | 11px |

Proportional bump so the rail is easier to tap and read. Values are easy to tune if you want it bigger/smaller still.

⚠️ I can't render the UI in this environment, so this isn't visually verified — please eyeball it on the preview and tell me if the amount of "bigger" is right (or if you meant something specific like just the icons/labels vs the whole column width).

## Test plan
- [ ] CI: order lint / typecheck / build green
- [ ] Visual: category rail on the menu page looks appropriately larger on mobile + ≥420px widths

https://claude.ai/code/session_01Xd1aERynqUbdCqXNboKWBe

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xd1aERynqUbdCqXNboKWBe)_