### PR TITLE
fix(order): route web payments through the same gateways as native

### DIFF
--- a/apps/order/src/app/api/checkout/initiate/route.ts
+++ b/apps/order/src/app/api/checkout/initiate/route.ts
@@ -9,10 +9,7 @@ import {
   type CartLine,
 } from "@/lib/loyalty/promotions";
 import type { OrderRow } from "@/lib/supabase/types";
-
-// All active payment methods route through Stripe (live keys, MYR).
-const DEFAULT_STRIPE_METHODS = new Set(["card", "apple_pay", "google_pay", "fpx", "grabpay"]);
-const DEFAULT_RM_METHODS     = new Set<string>();
+import { defaultMethodSets } from "@/lib/payments/gateway-methods";
 
 function generateOrderNumber(): string {
   return `C-${Date.now().toString(36).slice(-4).toUpperCase()}${Math.floor(Math.random() * 100).toString().padStart(2, '0')}`;
@@ -135,8 +132,9 @@ export async function POST(request: NextRequest) {
         pgRows.filter((r) => r.enabled && r.provider === "revenue_monster").map((r) => r.method_id as string)
       );
     } else {
-      STRIPE_METHODS = DEFAULT_STRIPE_METHODS;
-      RM_METHODS     = DEFAULT_RM_METHODS;
+      const defaults = defaultMethodSets();
+      STRIPE_METHODS = defaults.stripe;
+      RM_METHODS     = defaults.rm;
     }
 
     // Per-method routing is now authoritative: whatever provider the

--- a/apps/order/src/app/api/payments/gateway-config/route.ts
+++ b/apps/order/src/app/api/payments/gateway-config/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from "next/server";
 import { getSupabaseAdmin } from "@/lib/supabase/server";
+import { DEFAULT_GATEWAY_METHODS, METHOD_ORDER, type GatewayProvider } from "@/lib/payments/gateway-methods";
 
 /**
  * GET /api/payments/gateway-config
@@ -25,30 +26,6 @@ import { getSupabaseAdmin } from "@/lib/supabase/server";
  * split that initiate/route.ts also falls back to.
  */
 
-type GatewayProvider = "stripe" | "revenue_monster";
-
-// Defaults applied only when payment_gateway_config is empty (fresh DB).
-// Routing intent: keep Apple/Google Pay on Stripe (only Stripe supports
-// the native iOS/Android wallet sheets), keep GrabPay on Stripe (Stripe
-// MY has solid GrabPay support); push everything else through Revenue
-// Monster for direct settlement to the merchant's MY bank account.
-// Once a row exists for a method, the backoffice toggle is authoritative.
-const DEFAULT_METHODS: Array<{ method_id: string; enabled: boolean; provider: GatewayProvider }> = [
-  { method_id: "card",       enabled: true,  provider: "revenue_monster" },
-  { method_id: "apple_pay",  enabled: true,  provider: "stripe" },
-  { method_id: "google_pay", enabled: true,  provider: "stripe" },
-  { method_id: "fpx",        enabled: true,  provider: "revenue_monster" },
-  { method_id: "grabpay",    enabled: true,  provider: "stripe" },
-  { method_id: "tng",        enabled: true,  provider: "revenue_monster" },
-  { method_id: "boost",      enabled: true,  provider: "revenue_monster" },
-  { method_id: "shopeepay",  enabled: true,  provider: "revenue_monster" },
-  { method_id: "duitnow",    enabled: false, provider: "revenue_monster" },
-];
-
-// Matches the ZUS-style grouping the customer is familiar with:
-// Online Banking first, then e-wallets, then card, then platform wallets.
-const METHOD_ORDER = ["fpx", "tng", "boost", "shopeepay", "grabpay", "duitnow", "card", "apple_pay", "google_pay"];
-
 export async function GET() {
   const supabase = getSupabaseAdmin();
 
@@ -72,7 +49,7 @@ export async function GET() {
   const dbMethods =
     pgRows && pgRows.length > 0
       ? (pgRows as Array<{ method_id: string; enabled: boolean; provider: GatewayProvider }>)
-      : DEFAULT_METHODS;
+      : DEFAULT_GATEWAY_METHODS;
 
   // Stable, customer-facing order. Card first, wallets next, redirects last —
   // matches how most MY F&B apps present payment options.

--- a/apps/order/src/lib/payments/gateway-methods.ts
+++ b/apps/order/src/lib/payments/gateway-methods.ts
@@ -1,0 +1,55 @@
+export type GatewayProvider = "stripe" | "revenue_monster";
+
+export type GatewayMethod = {
+  method_id: string;
+  enabled: boolean;
+  provider: GatewayProvider;
+};
+
+/**
+ * Single source of truth for default per-method gateway routing, applied
+ * only when the `payment_gateway_config` table is empty (fresh DB). BOTH
+ * the customer-facing `/api/payments/gateway-config` (which the native and
+ * web clients render) and the server-side `/api/checkout/initiate` router
+ * read this, so the two can never disagree.
+ *
+ * Previously `initiate` had its own default that sent card + FPX to Stripe,
+ * while `gateway-config` sent them to Revenue Monster — so the web app's
+ * card/FPX payments hit Stripe (often unconfigured) and failed, while the
+ * native app correctly used Revenue Monster. Sharing this list keeps web
+ * and native gateway routing identical.
+ *
+ * Routing intent: Apple/Google Pay stay on Stripe (only Stripe drives the
+ * native iOS/Android wallet sheets) and GrabPay stays on Stripe (strong
+ * Stripe MY support); everything else routes through Revenue Monster for
+ * direct settlement to the merchant's MY bank account. Once a row exists
+ * for a method, the backoffice toggle in /pickup/settings is authoritative.
+ */
+export const DEFAULT_GATEWAY_METHODS: GatewayMethod[] = [
+  { method_id: "card",       enabled: true,  provider: "revenue_monster" },
+  { method_id: "apple_pay",  enabled: true,  provider: "stripe" },
+  { method_id: "google_pay", enabled: true,  provider: "stripe" },
+  { method_id: "fpx",        enabled: true,  provider: "revenue_monster" },
+  { method_id: "grabpay",    enabled: true,  provider: "stripe" },
+  { method_id: "tng",        enabled: true,  provider: "revenue_monster" },
+  { method_id: "boost",      enabled: true,  provider: "revenue_monster" },
+  { method_id: "shopeepay",  enabled: true,  provider: "revenue_monster" },
+  { method_id: "duitnow",    enabled: false, provider: "revenue_monster" },
+];
+
+/** Customer-facing order: Online Banking, e-wallets, card, platform wallets. */
+export const METHOD_ORDER = ["fpx", "tng", "boost", "shopeepay", "grabpay", "duitnow", "card", "apple_pay", "google_pay"];
+
+/**
+ * Default provider→method sets (enabled methods only) for server-side
+ * routing in `initiate`, derived from DEFAULT_GATEWAY_METHODS.
+ */
+export function defaultMethodSets(): { stripe: Set<string>; rm: Set<string> } {
+  const stripe = new Set<string>();
+  const rm = new Set<string>();
+  for (const m of DEFAULT_GATEWAY_METHODS) {
+    if (!m.enabled) continue;
+    (m.provider === "stripe" ? stripe : rm).add(m.method_id);
+  }
+  return { stripe, rm };
+}


### PR DESCRIPTION
## Summary
Wire the **web** order app's payment to use the **same gateway routing as the native app**.

### Root cause
There were **two disagreeing sources of truth** for per-method gateway routing:
- `/api/payments/gateway-config` (what **native** reads): defaults `card` and `fpx` → **Revenue Monster**.
- `/api/checkout/initiate` (what **web** uses), old lines 14-15: `DEFAULT_STRIPE_METHODS = {card, apple_pay, google_pay, fpx, grabpay}`, `DEFAULT_RM_METHODS = {}` — i.e. defaults card + FPX → **Stripe**.

So with an unconfigured `payment_gateway_config` table, **native** sent card/FPX to Revenue Monster (works) while **web** sent them to Stripe → `"Stripe not configured"` → payment failed. This is why "the payment gateway doesn't work" on web but works on native.

### Fix
- New single source of truth: `apps/order/src/lib/payments/gateway-methods.ts` (`DEFAULT_GATEWAY_METHODS`, `METHOD_ORDER`, `defaultMethodSets()`).
- `gateway-config` and `initiate` both consume it, so web and native can never diverge again.
- No behaviour change when the DB table is populated — both already read it; this only fixes the empty-DB default to match native (card/FPX/e-wallets → Revenue Monster; Apple/Google Pay + GrabPay → Stripe).

The web client already handles both gateway responses (`paymentUrl` → redirect, `clientSecret` → inline Stripe), so no client change is needed for routing.

### Bonus
This also fixes the **rewards "not deducting"** report: reward points are deducted *post-payment* (`confirm-stripe` / webhook / RM `order-status`). Payment never completing (this bug) meant the deduction never fired. With payment working, the existing deduction path runs.

## Not in this PR (offering as follow-up)
The web still renders a **hardcoded** 3-method picker (`card / fpx / grabpay`) instead of fetching `gateway-config` like native, so it doesn't surface TnG / Boost / ShopeePay. I can do that next as a separate client change — it's a bigger, visual change I'd want you to eyeball on preview.

## Verification
- `order`: `tsc --noEmit` ✓ clean.
- ⚠️ Can't exercise live payment here (no gateway creds in CI). Please test on preview. **Prerequisite:** Revenue Monster creds (`RM_*`) must be set on the order app's deploy — native proves they are. Stripe-routed methods (Apple/Google Pay, GrabPay) still need the Stripe keys.

## Test plan
- [ ] CI green
- [ ] On preview: pay with card + FPX → should open the Revenue Monster hosted page (same as native), order confirms, and a redeemed reward deducts points after payment

https://claude.ai/code/session_01Xd1aERynqUbdCqXNboKWBe

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xd1aERynqUbdCqXNboKWBe)_