### PR TITLE
feat(finance): Maybank PDF ingestion, monthly cashflow page, AR posting fix

### DIFF
--- a/apps/backoffice/package.json
+++ b/apps/backoffice/package.json
@@ -44,6 +44,7 @@
     "swr": "^2.4.1",
     "tailwind-merge": "^3.5.0",
     "tw-animate-css": "^1.4.0",
+    "unpdf": "^1.6.2",
     "xlsx": "^0.18.5",
     "zod": "^4.3.6"
   },

--- a/apps/backoffice/scripts/maybank-backfill.ts
+++ b/apps/backoffice/scripts/maybank-backfill.ts
@@ -1,0 +1,62 @@
+// One-off backfill: parse every Maybank PDF in the local folder and persist it
+// (idempotently) into BankStatement + BankStatementLine on the live DB.
+//
+//   node --import tsx apps/backoffice/scripts/maybank-backfill.ts ["<folder>"]
+//
+// Loads apps/backoffice/.env.local for DATABASE_URL, then uses the @celsius/db
+// Prisma singleton + the shared persist layer (same code path as the ingest API).
+import { execFileSync } from "node:child_process";
+import { readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const here = fileURLToPath(new URL(".", import.meta.url));
+for (const line of readFileSync(join(here, "..", ".env.local"), "utf8").split("\n")) {
+  const m = line.match(/^\s*([A-Z0-9_]+)\s*=\s*(.*?)\s*$/);
+  if (m && process.env[m[1]] === undefined) process.env[m[1]] = m[2].replace(/^["']|["']$/g, "");
+}
+
+const ROOT = process.argv[2] ?? "/Users/ammarshahrin/Desktop/Celsius/Maybank Bank Statement";
+const UPLOADER = "213c5fb5-06ab-47c5-aa5f-a737dadaedf8"; // admin user (hanismsalleh+1)
+const ACCOUNTS = ["2644", "4384", "9345"];
+
+async function main() {
+  const { prisma } = await import("@celsius/db");
+  const { parseMaybankStatementText } = await import("../src/lib/finance/maybank-statement-parser");
+  const { persistMaybankStatement } = await import("../src/lib/finance/persist-bank-statement");
+
+  let files = 0;
+  let reconciled = 0;
+  let lines = 0;
+  for (const acc of ACCOUNTS) {
+    const dir = join(ROOT, acc);
+    for (const f of readdirSync(dir).filter((x) => x.toLowerCase().endsWith(".pdf")).sort()) {
+      files++;
+      try {
+        const m = f.match(/_(\d{12})_(\d{4}-\d{2}-\d{2})\.pdf$/i);
+        const text = execFileSync("pdftotext", ["-layout", join(dir, f), "-"], {
+          encoding: "utf8",
+          maxBuffer: 128 * 1024 * 1024,
+        });
+        const parsed = parseMaybankStatementText(text, { accountNumber: m?.[1], statementDate: m?.[2] });
+        const r = await persistMaybankStatement(prisma, parsed, { uploadedById: UPLOADER, sourceFileName: f });
+        lines += r.linesCreated;
+        if (r.reconciled) reconciled++;
+        console.log(
+          `${r.reconciled ? "OK " : "BAD"} ${r.created ? "new " : "repl"} ${r.accountName} ${r.statementDate} ` +
+            `lines=${String(r.linesCreated).padStart(4)} in=${String(r.totalInflows).padStart(11)} out=${String(r.totalOutflows).padStart(11)} ` +
+            `interco=${r.interCoInflows}/${r.interCoOutflows} close=${r.closingBalance}`
+        );
+      } catch (e) {
+        console.log(`ERR ${acc}/${f}: ${e instanceof Error ? e.message : String(e)}`);
+      }
+    }
+  }
+  console.log(`\n${reconciled}/${files} reconciled · ${lines} lines persisted`);
+  await prisma.$disconnect();
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/apps/backoffice/scripts/maybank-extract-check.ts
+++ b/apps/backoffice/scripts/maybank-extract-check.ts
@@ -1,0 +1,27 @@
+// Verifies the server-side (unpdf) extraction path reconciles, by comparing it
+// to the parser on one real PDF. Run: npx tsx apps/backoffice/scripts/maybank-extract-check.ts
+import { readFileSync } from "node:fs";
+
+async function main() {
+  const { extractMaybankText } = await import("../src/lib/finance/maybank-pdf-extract");
+  const { parseMaybankStatementText } = await import("../src/lib/finance/maybank-statement-parser");
+
+  const files = [
+    "/Users/ammarshahrin/Desktop/Celsius/Maybank Bank Statement/9345/MBBcurrent_562263659345_2026-05-31.pdf",
+    "/Users/ammarshahrin/Desktop/Celsius/Maybank Bank Statement/4384/MBBcurrent_562263574384_2026-04-30.pdf",
+  ];
+  for (const f of files) {
+    const data = new Uint8Array(readFileSync(f));
+    const text = await extractMaybankText(data);
+    const r = parseMaybankStatementText(text, { statementDate: f.match(/(\d{4}-\d{2}-\d{2})/)?.[1] });
+    console.log(
+      `${r.reconciled ? "OK " : "BAD"} ${f.split("/").pop()} rows=${r.rowsParsed} ` +
+        `beg=${r.beginningBalance} end=${r.endingBalance} in=${r.totalInflows} out=${r.totalOutflows}` +
+        (r.warnings.length ? `  WARN: ${r.warnings[0]}` : "")
+    );
+  }
+}
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/apps/backoffice/scripts/maybank-validate.ts
+++ b/apps/backoffice/scripts/maybank-validate.ts
@@ -1,0 +1,35 @@
+// One-off: parse every real Maybank PDF in the local folder and report whether
+// it reconciles against its own running-balance column. Run: npx tsx <thisfile>
+import { execFileSync } from "node:child_process";
+import { readdirSync } from "node:fs";
+import { join } from "node:path";
+import { parseMaybankStatementText } from "../src/lib/finance/maybank-statement-parser";
+
+const ROOT = process.argv[2] ?? "/Users/ammarshahrin/Desktop/Celsius/Maybank Bank Statement";
+const accounts = ["2644", "4384", "9345"];
+let ok = 0;
+let total = 0;
+
+for (const acc of accounts) {
+  const dir = join(ROOT, acc);
+  const pdfs = readdirSync(dir).filter((f) => f.toLowerCase().endsWith(".pdf")).sort();
+  for (const f of pdfs) {
+    total++;
+    const m = f.match(/_(\d{12})_(\d{4}-\d{2}-\d{2})\.pdf$/i);
+    const text = execFileSync("pdftotext", ["-layout", join(dir, f), "-"], {
+      encoding: "utf8",
+      maxBuffer: 128 * 1024 * 1024,
+    });
+    const r = parseMaybankStatementText(text, { accountNumber: m?.[1], statementDate: m?.[2] });
+    if (r.reconciled) ok++;
+    const tag = r.reconciled ? "OK " : "BAD";
+    const date = f.match(/(\d{4}-\d{2}-\d{2})/)?.[1] ?? "?";
+    console.log(
+      `${tag} ${acc} ${date} rows=${String(r.rowsParsed).padStart(4)} ` +
+        `beg=${String(r.beginningBalance).padStart(12)} end=${String(r.endingBalance).padStart(12)} ` +
+        `in=${String(r.totalInflows).padStart(12)} out=${String(r.totalOutflows).padStart(12)}` +
+        (r.warnings.length ? `  WARN: ${r.warnings[0]}` : "")
+    );
+  }
+}
+console.log(`\n${ok}/${total} statements reconciled`);

--- a/apps/backoffice/scripts/maybank-watcher.mjs
+++ b/apps/backoffice/scripts/maybank-watcher.mjs
@@ -1,0 +1,86 @@
+#!/usr/bin/env node
+// Local Maybank statement watcher. Runs under launchd: on a folder change (or
+// hourly fallback) it finds new/changed statement PDFs, extracts text with
+// pdftotext, and POSTs to the backoffice ingest endpoint. Idempotent on the
+// server, plus a local manifest so we only upload what's new.
+//
+// Config via env (set in the launchd plist):
+//   CELSIUS_INGEST_URL     full URL of /api/finance/bank-statements/ingest
+//   CELSIUS_INGEST_SECRET  bearer token (= FINANCE_INGEST_SECRET on the server)
+//   CELSIUS_MBB_FOLDER     statements root (default: the Desktop folder)
+//   CELSIUS_PDFTOTEXT      pdftotext path (default: /opt/homebrew/bin/pdftotext)
+//
+// Flags: --seed marks all current files processed WITHOUT uploading (used once
+// after the historical backfill so the watcher only picks up new statements).
+
+import { execFileSync } from "node:child_process";
+import { readdirSync, readFileSync, writeFileSync, mkdirSync, existsSync, statSync, appendFileSync } from "node:fs";
+import { join, basename } from "node:path";
+import { homedir } from "node:os";
+
+const FOLDER = process.env.CELSIUS_MBB_FOLDER || "/Users/ammarshahrin/Desktop/Celsius/Maybank Bank Statement";
+const INGEST_URL = process.env.CELSIUS_INGEST_URL || "";
+const SECRET = process.env.CELSIUS_INGEST_SECRET || "";
+const PDFTOTEXT = process.env.CELSIUS_PDFTOTEXT || "/opt/homebrew/bin/pdftotext";
+const STATE_DIR = join(homedir(), ".celsius-maybank-watcher");
+const MANIFEST = join(STATE_DIR, "processed.json");
+const LOG = join(STATE_DIR, "watcher.log");
+const SEED = process.argv.includes("--seed");
+
+mkdirSync(STATE_DIR, { recursive: true });
+function log(msg) {
+  const line = `${new Date().toISOString()} ${msg}\n`;
+  try { appendFileSync(LOG, line); } catch {}
+  process.stdout.write(line);
+}
+
+const processed = existsSync(MANIFEST) ? JSON.parse(readFileSync(MANIFEST, "utf8")) : {};
+
+function listPdfs() {
+  const out = [];
+  let subs = [];
+  try { subs = readdirSync(FOLDER); } catch (e) { log(`cannot read folder ${FOLDER}: ${e.message}`); return out; }
+  for (const sub of subs) {
+    const dir = join(FOLDER, sub);
+    let st;
+    try { st = statSync(dir); } catch { continue; }
+    if (!st.isDirectory()) continue;
+    for (const f of readdirSync(dir)) if (f.toLowerCase().endsWith(".pdf")) out.push(join(dir, f));
+  }
+  return out;
+}
+
+async function main() {
+  const pdfs = listPdfs();
+  let done = 0, failed = 0, skipped = 0;
+  for (const pdf of pdfs) {
+    const key = basename(pdf);
+    const mtime = statSync(pdf).mtimeMs;
+    if (processed[key] && processed[key] >= mtime) { skipped++; continue; }
+    if (SEED) { processed[key] = Date.now(); done++; continue; }
+    if (!INGEST_URL || !SECRET) { log(`missing CELSIUS_INGEST_URL / CELSIUS_INGEST_SECRET — skipping ${key}`); failed++; continue; }
+    try {
+      const text = execFileSync(PDFTOTEXT, ["-layout", pdf, "-"], { encoding: "utf8", maxBuffer: 128 * 1024 * 1024 });
+      const res = await fetch(INGEST_URL, {
+        method: "POST",
+        headers: { "content-type": "application/json", authorization: `Bearer ${SECRET}` },
+        body: JSON.stringify({ text, fileName: key }),
+      });
+      if (res.ok) {
+        processed[key] = mtime;
+        done++;
+        log(`OK ${key} -> ${res.status}`);
+      } else {
+        failed++;
+        log(`FAIL ${key} -> ${res.status} ${(await res.text().catch(() => "")).slice(0, 200)}`);
+      }
+    } catch (e) {
+      failed++;
+      log(`ERR ${key}: ${e?.message || e}`);
+    }
+  }
+  writeFileSync(MANIFEST, JSON.stringify(processed, null, 2));
+  log(`run complete: ${done} ${SEED ? "seeded" : "uploaded"}, ${failed} failed, ${skipped} unchanged`);
+}
+
+main().catch((e) => { log(`fatal: ${e?.message || e}`); process.exit(1); });

--- a/apps/backoffice/src/app/(admin)/finance/bank-statements/page.tsx
+++ b/apps/backoffice/src/app/(admin)/finance/bank-statements/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState } from "react";
+import Link from "next/link";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Loader2, Plus, Trash2, X, Upload, FileDown, FileSpreadsheet, AlertTriangle, Pencil } from "lucide-react";
@@ -66,6 +67,7 @@ export default function BankStatementsPage() {
   const [parseResult, setParseResult] = useState<ParseResult | null>(null);
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState("");
+  const [notice, setNotice] = useState("");
 
   const items = data ?? [];
 
@@ -113,7 +115,35 @@ export default function BankStatementsPage() {
 
   const processFile = async (file: File) => {
     setError("");
+    setNotice("");
+    const isPdf = /\.pdf$/i.test(file.name);
     const isSheet = /\.(csv|xlsx|xls)$/i.test(file.name);
+
+    // Maybank PDF → server parses, classifies and persists the statement
+    // (auto-creates it, idempotent). No manual totals entry needed.
+    if (isPdf) {
+      setParsing(true);
+      try {
+        const fd = new FormData();
+        fd.append("file", file);
+        const res = await fetch("/api/finance/bank-statements/ingest", { method: "POST", body: fd });
+        const d = await res.json().catch(() => null);
+        if (!res.ok) {
+          setError(d?.error || "PDF ingest failed");
+        } else {
+          await mutate();
+          reset();
+          setNotice(
+            `✓ Ingested ${d.accountName} — ${d.statementDate}: ${d.linesCreated} lines` +
+              (d.reconciled ? ", reconciled." : " — ⚠️ did NOT reconcile, please review.")
+          );
+        }
+      } catch {
+        setError("PDF ingest failed");
+      }
+      setParsing(false);
+      return;
+    }
 
     if (isSheet) {
       setParsing(true);
@@ -219,11 +249,18 @@ export default function BankStatementsPage() {
           <p className="mt-0.5 text-xs sm:text-sm text-gray-500">
             Upload weekly statement (CSV/Excel/PDF). The latest closing balance is the cashflow opening balance, and the period inflows/outflows feed the &ldquo;Other (from bank)&rdquo; column on the projection.
           </p>
+          <Link href="/finance/monthly-cashflow" className="mt-1 inline-flex items-center gap-1 text-xs font-medium text-terracotta hover:underline">
+            View Monthly Cash Flow →
+          </Link>
         </div>
         <Button onClick={() => setAdding(true)} className="bg-terracotta hover:bg-terracotta-dark w-full sm:w-auto">
           <Plus className="mr-1.5 h-4 w-4" /> New Statement
         </Button>
       </div>
+
+      {notice && (
+        <div className="mt-4 rounded-lg border border-green-200 bg-green-50 px-3 py-2 text-sm text-green-800">{notice}</div>
+      )}
 
       {latest && (
         <div className="mt-4 rounded-xl border border-blue-200 bg-blue-50/50 px-4 py-3">

--- a/apps/backoffice/src/app/(admin)/finance/cashflow/page.tsx
+++ b/apps/backoffice/src/app/(admin)/finance/cashflow/page.tsx
@@ -295,8 +295,8 @@ export default function CashflowPage() {
                       return (
                         <tr key={m.month} className={`hover:bg-gray-50 ${m.netGenerated < 0 ? "bg-red-50/30" : ""}`}>
                           <td className="px-4 py-2 text-xs font-medium text-gray-700">{m.month}</td>
-                          <td className="px-4 py-2 text-right font-mono text-xs text-green-700">+{fmtMYR(m.cashIn)}</td>
-                          <td className="px-4 py-2 text-right font-mono text-xs text-red-700">−{fmtMYR(m.cashOut)}</td>
+                          <td className="px-4 py-2 text-right font-mono text-xs text-green-700">+{fmtMYR(m.cashIn - m.interCoInflows)}</td>
+                          <td className="px-4 py-2 text-right font-mono text-xs text-red-700">−{fmtMYR(m.cashOut - m.interCoOutflows)}</td>
                           <td className={`px-4 py-2 text-right font-mono text-xs font-bold ${m.netGenerated >= 0 ? "text-green-700" : "text-red-700"}`}>
                             {m.netGenerated >= 0 ? "+" : ""}{fmtMYR(m.netGenerated)}
                           </td>
@@ -318,7 +318,7 @@ export default function CashflowPage() {
                 </table>
               </div>
               <p className="border-t border-gray-100 px-4 py-2 text-[10px] text-gray-400">
-                Net generated = (closing balance change across accounts) + (InterCo out − InterCo in). Excludes internal transfers between Celsius entities so the headline reflects real cash movement only.
+                Cash in, Cash out and Net generated all exclude inter-company transfers between Celsius entities, so every row reflects real external cash movement and reconciles (Cash in − Cash out = Net). Full-coverage months derive Net from the closing-balance roll-forward.
               </p>
             </div>
           )}

--- a/apps/backoffice/src/app/(admin)/finance/monthly-cashflow/page.tsx
+++ b/apps/backoffice/src/app/(admin)/finance/monthly-cashflow/page.tsx
@@ -1,0 +1,260 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import Link from "next/link";
+import { useFetch } from "@/lib/use-fetch";
+import { Loader2, ChevronLeft, TrendingUp, TrendingDown, ArrowRightLeft, Wallet } from "lucide-react";
+
+type MonthRow = { month: string; inflow: number; outflow: number; net: number; closingBalance: number };
+type CatRow = { category: string; amount: number; count: number };
+type Resp = {
+  from: string;
+  to: string;
+  monthly: MonthRow[];
+  totals: { inflow: number; outflow: number; net: number; closingBalance: number };
+  topInflow: CatRow[];
+  topOutflow: CatRow[];
+  accounts: { code: string; name: string }[];
+};
+
+const PRESETS: Record<string, number> = { "6m": 6, "12m": 12, "24m": 24, All: 60 };
+
+const CAT_OVERRIDES: Record<string, string> = {
+  QR: "QR (DuitNow)",
+  CARD: "Card",
+  STOREHUB: "StoreHub",
+  GASTROHUB: "GastroHub",
+  GRAB: "Grab",
+  FOODPANDA: "Foodpanda",
+  OTHER_INFLOW: "Other inflow",
+  OTHER_OUTFLOW: "Other outflow",
+  RAW_MATERIALS: "Raw materials",
+  EMPLOYEE_SALARY: "Employee salary",
+  STATUTORY_PAYMENT: "Statutory (EPF/SOCSO)",
+  DIRECTORS_ALLOWANCE: "Directors' allowance",
+  INTERCO_PEOPLE: "InterCo (people)",
+  DIGITAL_ADS: "Digital ads",
+};
+function catLabel(c: string): string {
+  if (CAT_OVERRIDES[c]) return CAT_OVERRIDES[c];
+  return c.charAt(0) + c.slice(1).toLowerCase().replace(/_/g, " ");
+}
+function fmtMYR(n: number, opts?: { sign?: boolean }): string {
+  const s = new Intl.NumberFormat("en-MY", { maximumFractionDigits: 0 }).format(Math.abs(n));
+  const prefix = n < 0 ? "−" : opts?.sign ? "+" : "";
+  return `${prefix}RM ${s}`;
+}
+function monthLabel(m: string): string {
+  const [y, mo] = m.split("-").map((x) => parseInt(x, 10));
+  return new Date(y, mo - 1, 1).toLocaleString("en-MY", { month: "short", year: "2-digit" });
+}
+function isoMonthsAgo(months: number): string {
+  const d = new Date();
+  d.setUTCMonth(d.getUTCMonth() - months);
+  return d.toISOString().slice(0, 10);
+}
+
+export default function MonthlyCashflowPage() {
+  const [preset, setPreset] = useState<keyof typeof PRESETS>("12m");
+  const [account, setAccount] = useState<string | null>(null); // last4 or null = all
+  const [compare, setCompare] = useState(false);
+
+  const months = PRESETS[preset];
+  const from = isoMonthsAgo(months);
+  const to = isoMonthsAgo(0);
+  const prevFrom = isoMonthsAgo(months * 2);
+  const prevTo = from;
+
+  const q = (f: string, t: string) => {
+    const p = new URLSearchParams({ from: f, to: t });
+    if (account) p.set("account", account);
+    return `/api/finance/cashflow/monthly?${p.toString()}`;
+  };
+
+  const { data, isLoading } = useFetch<Resp>(q(from, to));
+  const { data: prev } = useFetch<Resp>(compare ? q(prevFrom, prevTo) : null);
+
+  const maxIn = useMemo(() => Math.max(1, ...(data?.topInflow ?? []).map((c) => c.amount)), [data]);
+  const maxOut = useMemo(() => Math.max(1, ...(data?.topOutflow ?? []).map((c) => c.amount)), [data]);
+  const maxBar = useMemo(
+    () => Math.max(1, ...(data?.monthly ?? []).flatMap((m) => [m.inflow, m.outflow])),
+    [data]
+  );
+
+  return (
+    <div className="p-3 sm:p-6">
+      <div className="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
+        <div>
+          <Link href="/finance/cashflow" className="inline-flex items-center gap-1 text-xs text-gray-500 hover:text-gray-700">
+            <ChevronLeft className="h-3 w-3" /> Cashflow
+          </Link>
+          <h2 className="mt-1 text-lg sm:text-xl font-semibold text-gray-900">Monthly Cash Flow</h2>
+          <p className="mt-0.5 text-xs sm:text-sm text-gray-500">
+            Consolidated net cash flow from Maybank statements, net of inter-company transfers. Group bank balance is the sum of each entity&rsquo;s month-end balance.
+          </p>
+        </div>
+        <div className="flex flex-wrap items-center gap-2">
+          <button
+            onClick={() => setCompare((v) => !v)}
+            className={`inline-flex items-center gap-1 rounded-lg border px-2.5 py-1.5 text-xs font-medium transition-colors ${compare ? "border-terracotta bg-terracotta text-white" : "border-gray-200 bg-white text-gray-700 hover:bg-gray-50"}`}
+          >
+            <ArrowRightLeft className="h-3.5 w-3.5" /> Compare vs prev
+          </button>
+          <div className="flex rounded-lg border border-gray-200 bg-white p-0.5">
+            {Object.keys(PRESETS).map((p) => (
+              <button
+                key={p}
+                onClick={() => setPreset(p as keyof typeof PRESETS)}
+                className={`rounded-md px-2.5 py-1 text-xs font-medium transition-colors ${preset === p ? "bg-terracotta text-white" : "text-gray-600 hover:bg-gray-50"}`}
+              >
+                {p}
+              </button>
+            ))}
+          </div>
+        </div>
+      </div>
+
+      {/* Account / entity filter */}
+      {data && data.accounts.length > 0 && (
+        <div className="mt-4 flex flex-wrap gap-1.5">
+          <button
+            onClick={() => setAccount(null)}
+            className={`rounded-md border px-3 py-1.5 text-xs font-medium transition-colors ${account === null ? "border-terracotta bg-terracotta text-white" : "border-gray-200 bg-white text-gray-700 hover:bg-gray-50"}`}
+          >
+            All entities
+          </button>
+          {data.accounts.map((a) => (
+            <button
+              key={a.code}
+              onClick={() => setAccount(a.code)}
+              className={`rounded-md border px-3 py-1.5 text-xs font-medium transition-colors ${account === a.code ? "border-terracotta bg-terracotta text-white" : "border-gray-200 bg-white text-gray-700 hover:bg-gray-50"}`}
+            >
+              {a.name} ··{a.code}
+            </button>
+          ))}
+        </div>
+      )}
+
+      {isLoading || !data ? (
+        <div className="mt-6 flex justify-center py-12"><Loader2 className="h-5 w-5 animate-spin text-gray-400" /></div>
+      ) : data.monthly.length === 0 ? (
+        <div className="mt-6 rounded-lg border border-dashed border-gray-300 bg-gray-50 px-4 py-8 text-center">
+          <p className="text-sm text-gray-500">No bank statements in this period.</p>
+          <p className="mt-1 text-xs text-gray-400">
+            Drop a Maybank PDF on the <Link href="/finance/bank-statements" className="text-terracotta hover:underline">Bank Statements</Link> page, or let the watcher pick up new files.
+          </p>
+        </div>
+      ) : (
+        <>
+          {/* Summary cards */}
+          <div className="mt-4 grid grid-cols-2 gap-3 lg:grid-cols-4">
+            <SummaryCard icon={<TrendingUp className="h-4 w-4" />} tone="in" label="Total inflow" value={data.totals.inflow} prev={prev?.totals.inflow} compare={compare} />
+            <SummaryCard icon={<TrendingDown className="h-4 w-4" />} tone="out" label="Total outflow" value={data.totals.outflow} prev={prev?.totals.outflow} compare={compare} invertDelta />
+            <SummaryCard icon={<ArrowRightLeft className="h-4 w-4" />} tone="net" label="Net cash flow" value={data.totals.net} prev={prev?.totals.net} compare={compare} />
+            <SummaryCard icon={<Wallet className="h-4 w-4" />} tone="bal" label="Group bank balance" value={data.totals.closingBalance} prev={prev?.totals.closingBalance} compare={compare} />
+          </div>
+
+          {/* Monthly table */}
+          <div className="mt-4 overflow-x-auto rounded-lg border border-gray-200 bg-white">
+            <table className="min-w-full text-xs sm:text-sm">
+              <thead className="bg-gray-50 text-gray-600">
+                <tr>
+                  <th className="px-3 py-2 text-left font-medium">Month</th>
+                  <th className="px-3 py-2 text-right font-medium">Inflow</th>
+                  <th className="px-3 py-2 text-right font-medium">Outflow</th>
+                  <th className="px-3 py-2 text-right font-medium">Net</th>
+                  <th className="px-3 py-2 text-right font-medium">Group bank balance</th>
+                  <th className="hidden px-3 py-2 text-left font-medium sm:table-cell">In vs out</th>
+                </tr>
+              </thead>
+              <tbody>
+                {data.monthly.map((m) => (
+                  <tr key={m.month} className="border-t border-gray-100 hover:bg-gray-50">
+                    <td className="px-3 py-2 font-medium text-gray-900">{monthLabel(m.month)}</td>
+                    <td className="px-3 py-2 text-right tabular-nums text-green-700">{fmtMYR(m.inflow)}</td>
+                    <td className="px-3 py-2 text-right tabular-nums text-red-700">{fmtMYR(m.outflow)}</td>
+                    <td className={`px-3 py-2 text-right font-semibold tabular-nums ${m.net >= 0 ? "text-green-700" : "text-red-700"}`}>{fmtMYR(m.net)}</td>
+                    <td className="px-3 py-2 text-right tabular-nums text-gray-900">{fmtMYR(m.closingBalance)}</td>
+                    <td className="hidden px-3 py-2 sm:table-cell">
+                      <div className="flex h-3 w-40 overflow-hidden rounded-sm bg-gray-100">
+                        <div className="bg-green-400" style={{ width: `${(m.inflow / maxBar) * 50}%` }} />
+                        <div className="bg-red-400" style={{ width: `${(m.outflow / maxBar) * 50}%` }} />
+                      </div>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+              <tfoot>
+                <tr className="border-t-2 border-gray-300 bg-gray-50 font-semibold">
+                  <td className="px-3 py-2 text-gray-900">Total</td>
+                  <td className="px-3 py-2 text-right tabular-nums text-green-700">{fmtMYR(data.totals.inflow)}</td>
+                  <td className="px-3 py-2 text-right tabular-nums text-red-700">{fmtMYR(data.totals.outflow)}</td>
+                  <td className={`px-3 py-2 text-right tabular-nums ${data.totals.net >= 0 ? "text-green-700" : "text-red-700"}`}>{fmtMYR(data.totals.net)}</td>
+                  <td className="px-3 py-2 text-right tabular-nums text-gray-900">{fmtMYR(data.totals.closingBalance)}</td>
+                  <td className="hidden sm:table-cell" />
+                </tr>
+              </tfoot>
+            </table>
+          </div>
+
+          {/* Category rankings */}
+          <div className="mt-4 grid gap-3 lg:grid-cols-2">
+            <CategoryPanel title="Top inflow categories" rows={data.topInflow} max={maxIn} tone="in" />
+            <CategoryPanel title="Top outflow categories" rows={data.topOutflow} max={maxOut} tone="out" />
+          </div>
+
+          <p className="mt-2 text-[11px] text-gray-400">
+            Inflow/outflow are net of inter-company transfers. Where an account-month has both an early spreadsheet upload and the PDF import, the richer (PDF) statement is used so totals never double-count.
+          </p>
+        </>
+      )}
+    </div>
+  );
+}
+
+function SummaryCard({
+  icon, label, value, prev, compare, tone, invertDelta,
+}: {
+  icon: React.ReactNode;
+  label: string;
+  value: number;
+  prev?: number;
+  compare: boolean;
+  tone: "in" | "out" | "net" | "bal";
+  invertDelta?: boolean;
+}) {
+  const color = tone === "in" ? "text-green-700" : tone === "out" ? "text-red-700" : tone === "net" ? (value >= 0 ? "text-green-700" : "text-red-700") : "text-gray-900";
+  const delta = compare && prev != null && prev !== 0 ? ((value - prev) / Math.abs(prev)) * 100 : null;
+  const good = delta == null ? false : invertDelta ? delta < 0 : delta > 0;
+  return (
+    <div className="rounded-lg border border-gray-200 bg-white p-3">
+      <div className="flex items-center gap-1.5 text-xs text-gray-500">{icon}{label}</div>
+      <div className={`mt-1 text-lg font-semibold tabular-nums ${color}`}>{fmtMYR(value)}</div>
+      {delta != null && (
+        <div className={`mt-0.5 text-[11px] font-medium ${good ? "text-green-600" : "text-red-600"}`}>
+          {delta >= 0 ? "▲" : "▼"} {Math.abs(delta).toFixed(0)}% vs prev
+        </div>
+      )}
+    </div>
+  );
+}
+
+function CategoryPanel({ title, rows, max, tone }: { title: string; rows: CatRow[]; max: number; tone: "in" | "out" }) {
+  return (
+    <div className="rounded-lg border border-gray-200 bg-white p-3">
+      <h3 className="text-xs font-semibold uppercase tracking-wide text-gray-500">{title}</h3>
+      <div className="mt-2 space-y-1.5">
+        {rows.slice(0, 10).map((r) => (
+          <div key={r.category} className="flex items-center gap-2">
+            <div className="w-32 shrink-0 truncate text-xs text-gray-700" title={catLabel(r.category)}>{catLabel(r.category)}</div>
+            <div className="relative h-4 flex-1 overflow-hidden rounded-sm bg-gray-100">
+              <div className={`h-full ${tone === "in" ? "bg-green-300" : "bg-red-300"}`} style={{ width: `${(r.amount / max) * 100}%` }} />
+            </div>
+            <div className="w-24 shrink-0 text-right text-xs tabular-nums text-gray-900">{fmtMYR(r.amount)}</div>
+          </div>
+        ))}
+        {rows.length === 0 && <p className="text-xs text-gray-400">No data.</p>}
+      </div>
+    </div>
+  );
+}

--- a/apps/backoffice/src/app/api/finance/bank-statements/ingest/route.ts
+++ b/apps/backoffice/src/app/api/finance/bank-statements/ingest/route.ts
@@ -1,0 +1,86 @@
+import { NextRequest, NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+import { requireRole, AuthError } from "@/lib/auth";
+import { parseMaybankStatementText } from "@/lib/finance/maybank-statement-parser";
+import { extractMaybankText } from "@/lib/finance/maybank-pdf-extract";
+import { persistMaybankStatement } from "@/lib/finance/persist-bank-statement";
+
+// Ingests a Maybank PDF statement: extract → parse → classify → persist
+// (idempotent). Two callers:
+//   • In-app drag-drop  → multipart `file` (PDF), authed by ADMIN session.
+//   • Local watcher      → JSON { text, fileName } (pdftotext output), authed
+//                          by `Bearer ${CRON_SECRET}`.
+// The watcher pre-extracts text locally (pdftotext) so the server doesn't have
+// to run pdfjs on every upload; the UI path extracts server-side via unpdf.
+
+export const runtime = "nodejs";
+export const maxDuration = 300;
+
+const MAX_BYTES = 25 * 1024 * 1024;
+// Attribution for headless (watcher) ingests — overridable via env.
+const SYSTEM_UPLOADER = process.env.FINANCE_SYSTEM_USER_ID ?? "213c5fb5-06ab-47c5-aa5f-a737dadaedf8";
+
+function metaFromName(name?: string | null): { accountNumber?: string; statementDate?: string } {
+  const m = (name ?? "").match(/_(\d{12})_(\d{4}-\d{2}-\d{2})\./);
+  return { accountNumber: m?.[1], statementDate: m?.[2] };
+}
+
+export async function POST(req: NextRequest) {
+  // Headless watcher (Bearer FINANCE_INGEST_SECRET) or ADMIN session (UI).
+  let uploaderId = SYSTEM_UPLOADER;
+  const secret = process.env.FINANCE_INGEST_SECRET;
+  const authed = !!secret && (req.headers.get("authorization") ?? "") === `Bearer ${secret}`;
+  if (!authed) {
+    try {
+      const user = await requireRole(req.headers, "ADMIN");
+      uploaderId = user.id;
+    } catch (e) {
+      if (e instanceof AuthError) return NextResponse.json({ error: e.message }, { status: e.status });
+      return NextResponse.json({ error: "Auth error" }, { status: 500 });
+    }
+  }
+
+  const ctype = req.headers.get("content-type") ?? "";
+  let text: string;
+  let fileName: string | null = null;
+
+  try {
+    if (ctype.includes("multipart/form-data")) {
+      const fd = await req.formData();
+      const file = fd.get("file");
+      if (!(file instanceof File)) return NextResponse.json({ error: "Missing 'file' field" }, { status: 400 });
+      if (file.size > MAX_BYTES) {
+        return NextResponse.json({ error: `File too large (max ${MAX_BYTES / 1024 / 1024} MB)` }, { status: 413 });
+      }
+      if (!/\.pdf$/i.test(file.name) && file.type !== "application/pdf") {
+        return NextResponse.json(
+          { error: "This endpoint takes Maybank PDFs. For CSV/XLSX use the spreadsheet upload." },
+          { status: 415 }
+        );
+      }
+      fileName = file.name;
+      text = await extractMaybankText(new Uint8Array(await file.arrayBuffer()));
+    } else {
+      const body = (await req.json().catch(() => null)) as { text?: string; fileName?: string } | null;
+      if (!body?.text) return NextResponse.json({ error: "Provide a PDF file or JSON { text }" }, { status: 400 });
+      text = body.text;
+      fileName = body.fileName ?? null;
+    }
+  } catch (e) {
+    return NextResponse.json({ error: `Could not read upload: ${e instanceof Error ? e.message : "error"}` }, { status: 400 });
+  }
+
+  const parsed = parseMaybankStatementText(text, metaFromName(fileName));
+  if (parsed.rowsParsed === 0) {
+    return NextResponse.json(
+      { error: "No transactions found — is this a Maybank current-account statement?", warnings: parsed.warnings },
+      { status: 422 }
+    );
+  }
+
+  const result = await persistMaybankStatement(prisma, parsed, {
+    uploadedById: uploaderId,
+    sourceFileName: fileName,
+  });
+  return NextResponse.json(result, { status: result.created ? 201 : 200 });
+}

--- a/apps/backoffice/src/app/api/finance/cashflow/monthly/route.ts
+++ b/apps/backoffice/src/app/api/finance/cashflow/monthly/route.ts
@@ -1,0 +1,126 @@
+import { NextRequest, NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+import { requireRole, AuthError } from "@/lib/auth";
+
+// Consolidated monthly net cash flow from classified bank statements.
+// Monthly Inflow/Outflow/Net + Group Bank Balance come from BankStatement
+// HEADER totals (fast, already net of InterCo at ingest); the category
+// ranking comes from the classified lines of the same (deduped) statements.
+//
+// Dedupe: a given (account, month) can have more than one statement row
+// (e.g. an early CSV upload + the later PDF backfill). We keep the richest
+// one (most lines) per (account-last4, month) so totals never double-count.
+
+function last4(accountName: string | null): string {
+  return accountName?.match(/(\d{4})\)?\s*$/)?.[1] ?? (accountName ?? "????");
+}
+function ym(d: Date): string {
+  return `${d.getUTCFullYear()}-${String(d.getUTCMonth() + 1).padStart(2, "0")}`;
+}
+function round2(n: number): number {
+  return Math.round(n * 100) / 100;
+}
+
+export async function GET(req: NextRequest) {
+  try {
+    await requireRole(req.headers, "ADMIN");
+  } catch (e) {
+    if (e instanceof AuthError) return NextResponse.json({ error: e.message }, { status: e.status });
+    return NextResponse.json({ error: "Auth error" }, { status: 500 });
+  }
+
+  const sp = req.nextUrl.searchParams;
+  const to = sp.get("to") ? new Date(`${sp.get("to")}T23:59:59Z`) : new Date();
+  const from = sp.get("from")
+    ? new Date(`${sp.get("from")}T00:00:00Z`)
+    : new Date(Date.UTC(to.getUTCFullYear() - 1, to.getUTCMonth(), 1));
+  const accountFilter = sp.getAll("account").filter(Boolean); // list of last4
+
+  const statements = await prisma.bankStatement.findMany({
+    where: { statementDate: { gte: from, lte: to } },
+    select: {
+      id: true,
+      accountName: true,
+      statementDate: true,
+      closingBalance: true,
+      totalInflows: true,
+      totalOutflows: true,
+      interCoInflows: true,
+      interCoOutflows: true,
+      _count: { select: { lines: true } },
+    },
+    orderBy: { statementDate: "asc" },
+  });
+
+  // Dedupe per (last4, month): keep the statement with the most lines.
+  const best = new Map<string, (typeof statements)[number]>();
+  for (const s of statements) {
+    const code = last4(s.accountName);
+    if (accountFilter.length && !accountFilter.includes(code)) continue;
+    const key = `${code}|${ym(s.statementDate)}`;
+    const prev = best.get(key);
+    if (!prev || s._count.lines > prev._count.lines) best.set(key, s);
+  }
+  const kept = [...best.values()];
+  const keptIds = kept.map((s) => s.id);
+
+  // Monthly rollup from headers (already net of InterCo at ingest).
+  const months = new Map<string, { inflow: number; outflow: number; closing: number }>();
+  const accountSet = new Map<string, string>(); // last4 -> display name
+  for (const s of kept) {
+    const m = ym(s.statementDate);
+    const row = months.get(m) ?? { inflow: 0, outflow: 0, closing: 0 };
+    const inflow = Number(s.totalInflows ?? 0) - Number(s.interCoInflows ?? 0);
+    const outflow = Number(s.totalOutflows ?? 0) - Number(s.interCoOutflows ?? 0);
+    row.inflow += inflow;
+    row.outflow += outflow;
+    row.closing += Number(s.closingBalance); // group bank balance = Σ account closing balances
+    months.set(m, row);
+    accountSet.set(last4(s.accountName), (s.accountName ?? "").replace(/\s*\(\d{4}\)\s*$/, "").trim() || s.accountName || "Account");
+  }
+
+  const monthly = [...months.entries()]
+    .sort(([a], [b]) => a.localeCompare(b))
+    .map(([month, r]) => ({
+      month,
+      inflow: round2(r.inflow),
+      outflow: round2(r.outflow),
+      net: round2(r.inflow - r.outflow),
+      closingBalance: round2(r.closing),
+    }));
+
+  // Category ranking from the kept statements' lines (exclude InterCo).
+  const grouped = keptIds.length
+    ? await prisma.bankStatementLine.groupBy({
+        by: ["category", "direction"],
+        where: { statementId: { in: keptIds }, isInterCo: false },
+        _sum: { amount: true },
+        _count: { _all: true },
+      })
+    : [];
+  const cat = (dir: "CR" | "DR") =>
+    grouped
+      .filter((g) => g.direction === dir)
+      .map((g) => ({ category: g.category ?? "UNCLASSIFIED", amount: round2(Number(g._sum.amount ?? 0)), count: g._count._all }))
+      .sort((a, b) => b.amount - a.amount);
+
+  const totals = monthly.reduce(
+    (acc, m) => ({ inflow: acc.inflow + m.inflow, outflow: acc.outflow + m.outflow }),
+    { inflow: 0, outflow: 0 }
+  );
+
+  return NextResponse.json({
+    from: from.toISOString().slice(0, 10),
+    to: to.toISOString().slice(0, 10),
+    monthly,
+    totals: {
+      inflow: round2(totals.inflow),
+      outflow: round2(totals.outflow),
+      net: round2(totals.inflow - totals.outflow),
+      closingBalance: monthly.length ? monthly[monthly.length - 1].closingBalance : 0,
+    },
+    topInflow: cat("CR"),
+    topOutflow: cat("DR"),
+    accounts: [...accountSet.entries()].map(([code, name]) => ({ code, name })),
+  });
+}

--- a/apps/backoffice/src/lib/finance/agents/ar.ts
+++ b/apps/backoffice/src/lib/finance/agents/ar.ts
@@ -8,10 +8,17 @@
 // returns transaction id. Does not fetch from StoreHub directly — that's the
 // ingestor's job.
 
+import { randomUUID } from "crypto";
 import { postJournal } from "../ledger";
+import { getFinanceClient } from "../supabase";
 import type { JournalLineInput, PostJournalResult } from "../types";
 
 export const AR_AGENT_VERSION = "ar-v1";
+
+// Spec threshold: ≥0.95 auto-posts; below it the journal is held as a draft AND
+// an exception is raised so a human classifies the unrecognized tender. Keeping
+// these in lock-step is the whole point — a draft with no exception is invisible.
+export const AR_CONFIDENCE_THRESHOLD = 0.95;
 
 // Tender → revenue/debtor account mapping. Keep this aligned with the COA seed.
 //
@@ -132,6 +139,7 @@ export async function postDailyAr(summary: EodSummary): Promise<ArAgentResult> {
   // Confidence: drop if any "other" bucket has material amount.
   const otherShare = channels.other / Math.max(summary.netSales, 1);
   const confidence = otherShare > 0.05 ? 0.6 : 0.95;
+  const lowConfidence = confidence < AR_CONFIDENCE_THRESHOLD;
 
   const result: PostJournalResult = await postJournal({
     companyId: summary.companyId,
@@ -144,8 +152,15 @@ export async function postDailyAr(summary: EodSummary): Promise<ArAgentResult> {
     agentVersion: AR_AGENT_VERSION,
     confidence,
     lines,
-    draft: confidence < 0.85,  // low-confidence days held for human review
+    draft: lowConfidence,  // low-confidence days held for human review
   });
+
+  // A low-confidence draft is invisible unless we also raise an exception —
+  // that's the only human surface. Without this, mis-classified days pile up
+  // as silent drafts that never post (the exact failure we just fixed).
+  if (lowConfidence) {
+    await raiseClassificationException(summary, result.transactionId);
+  }
 
   return {
     transactionId: result.transactionId,
@@ -153,6 +168,40 @@ export async function postDailyAr(summary: EodSummary): Promise<ArAgentResult> {
     outletId: summary.outletId,
     date: summary.date,
   };
+}
+
+// Surfaces an unclassified-tender day to the exception inbox. Idempotent in
+// practice because the ingestor's per-day guard means postDailyAr runs at most
+// once per outlet/day; we also de-dupe on the related transaction id.
+async function raiseClassificationException(
+  summary: EodSummary,
+  transactionId: string
+): Promise<void> {
+  const client = getFinanceClient();
+  const otherAmount = round2(summary.channels.other);
+
+  const { data: existing } = await client
+    .from("fin_exceptions")
+    .select("id")
+    .eq("related_type", "transaction")
+    .eq("related_id", transactionId)
+    .maybeSingle();
+  if (existing?.id) return;
+
+  await client.from("fin_exceptions").insert({
+    id: randomUUID(),
+    type: "categorization",
+    related_type: "transaction",
+    related_id: transactionId,
+    agent: "ar",
+    reason:
+      `Unrecognized tender on ${summary.outletName} ${summary.date}: ` +
+      `RM${otherAmount.toFixed(2)} of RM${summary.netSales.toFixed(2)} fell to "other". ` +
+      `Journal held as draft pending channel review.`,
+    proposed_action: { channels: summary.channels, netSales: summary.netSales },
+    priority: "high",
+    status: "open",
+  });
 }
 
 function round2(n: number): number {

--- a/apps/backoffice/src/lib/finance/bank-statement-parser.ts
+++ b/apps/backoffice/src/lib/finance/bank-statement-parser.ts
@@ -28,6 +28,7 @@ export type ParsedLine = {
   reference: string | null;
   amount: number;             // always positive
   direction: "CR" | "DR";
+  balance?: number;           // running statement balance, when the source provides it (PDF)
 };
 
 export type ParsedStatement = {

--- a/apps/backoffice/src/lib/finance/ingestors/storehub-eod.ts
+++ b/apps/backoffice/src/lib/finance/ingestors/storehub-eod.ts
@@ -2,14 +2,20 @@
 // payment types into our channel buckets, persists the raw blob to fin_documents,
 // then hands a structured EodSummary to the AR agent.
 //
-// Tender classification (StoreHub `payments[].type` → our channel):
+// Tender classification (StoreHub `payments[].paymentMethod` → our channel).
+// Labels are normalized (uppercase, strip non-alphanumerics) before matching,
+// so "QR Code" / "Touch'n Go eWallet" / "Card Payment (International)" resolve
+// cleanly. The value sets below are enumerated from the live StoreHub payload:
 //
-//  Cash, QR, TouchnGo, GrabPay, Boost, Maybank QR        → cashQr
-//  Card, Visa, Mastercard, Debit, AMEX                    → card
-//  Voucher, Mulah, Member, Freeflow, Redeem               → voucher
-//  GrabFood, FoodPanda, ShopeeFood                        → grabfood
-//  GastroHub, Vendor                                      → gastrohub
-//  Anything else                                          → other  (drops AR confidence)
+//  Cash, QR Code, Online Banking, Touch'n Go eWallet, GrabPay, Boost  → cashQr
+//  DebitCard, CreditCard, Card Payment, Apple Pay, Visa, Mastercard   → card
+//  Voucher, Mulah, Member, Freeflow, Redeem                           → voucher
+//  GrabFood, FoodPanda, ShopeeFood                                    → grabfood
+//  GastroHub, Vendor                                                  → gastrohub
+//  Anything unrecognized                                              → other  (drops AR confidence → exception)
+//
+// NOTE: StoreHub uses `paymentMethod`, not `type` — reading the wrong field
+// silently buckets every card/e-wallet sale to "other"/cash.
 //
 // `channel` field on the StoreHub transaction wins over tender mapping when
 // it indicates a delivery aggregator — e.g. a card-paid Grab order should
@@ -25,19 +31,37 @@ import type { StoreHubTransaction } from "@/lib/storehub";
 
 type ChannelKey = keyof EodChannelSplit;
 
-const CASH_QR_TYPES = new Set(["CASH", "QR", "TOUCHNGO", "TNG", "GRABPAY", "BOOST", "MAYBANK QR", "MAE", "DUITNOW"]);
-const CARD_TYPES = new Set(["CARD", "VISA", "MASTERCARD", "MASTER", "DEBIT", "DEBIT CARD", "CREDIT CARD", "AMEX"]);
-const VOUCHER_TYPES = new Set(["VOUCHER", "MULAH", "MEMBER", "FREEFLOW", "REDEEM", "GIFT CARD"]);
-const GRAB_TYPES = new Set(["GRABFOOD", "GRAB", "GRAB FOOD"]);
-const PANDA_TYPES = new Set(["FOODPANDA", "FOOD PANDA"]);
-const SHOPEE_TYPES = new Set(["SHOPEEFOOD", "SHOPEE FOOD"]);
+// Normalize a tender label for robust matching: uppercase, strip everything
+// that isn't A-Z/0-9 ("Touch'n Go eWallet" → "TOUCHNGOEWALLET").
+function normTender(s: string): string {
+  return s.trim().toUpperCase().replace(/[^A-Z0-9]/g, "");
+}
 
-function classifyTender(type: string): ChannelKey {
-  const t = type.trim().toUpperCase();
-  if (CASH_QR_TYPES.has(t)) return "cashQr";
-  if (CARD_TYPES.has(t)) return "card";
-  if (VOUCHER_TYPES.has(t)) return "voucher";
-  if (GRAB_TYPES.has(t) || PANDA_TYPES.has(t) || SHOPEE_TYPES.has(t)) return "grabfood";
+const CASH_QR_TENDERS = new Set([
+  "CASH",
+  "QRCODE", "QR", "DUITNOW", "DUITNOWQR", "MAYBANKQR", "MAE",
+  "ONLINEBANKING", "FPX",
+  "TOUCHNGOEWALLET", "TOUCHNGOEWALLETMINIPROGRAM", "TNG", "TNGEWALLET",
+  "GRABPAY", "BOOST", "SHOPEEPAY",
+]);
+const CARD_TENDERS = new Set([
+  "DEBITCARD", "CREDITCARD", "CARD", "CARDPAYMENT", "CARDPAYMENTINTERNATIONAL",
+  "VISA", "MASTERCARD", "MASTER", "AMEX", "APPLEPAY", "GOOGLEPAY", "SAMSUNGPAY",
+]);
+const VOUCHER_TENDERS = new Set([
+  "VOUCHER", "MULAH", "MEMBER", "FREEFLOW", "REDEEM", "GIFTCARD", "STORECREDIT",
+]);
+// Delivery aggregators — paid out NET of commission. Distinct from GRABPAY,
+// which is Grab's in-store e-wallet and settles like cash/QR.
+const DELIVERY_TENDERS = new Set(["GRABFOOD", "FOODPANDA", "SHOPEEFOOD"]);
+
+function classifyTender(method: string): ChannelKey {
+  const t = normTender(method);
+  if (!t) return "other";
+  if (CASH_QR_TENDERS.has(t)) return "cashQr";
+  if (CARD_TENDERS.has(t)) return "card";
+  if (VOUCHER_TENDERS.has(t)) return "voucher";
+  if (DELIVERY_TENDERS.has(t)) return "grabfood";
   if (t.includes("GASTRO") || t.includes("VENDOR")) return "gastrohub";
   return "other";
 }
@@ -99,9 +123,10 @@ export function aggregateEod(
     const txnAggregator = classifyChannel((txn.channel as string | undefined) ?? undefined);
 
     const rawPayments = (txn as unknown as { payments?: unknown }).payments;
-    const payments: Array<{ type: string; amount: number }> = Array.isArray(rawPayments)
-      ? (rawPayments as Array<{ type: string; amount: number }>)
-      : [];
+    const payments: Array<{ paymentMethod?: string; type?: string; amount: number }> =
+      Array.isArray(rawPayments)
+        ? (rawPayments as Array<{ paymentMethod?: string; type?: string; amount: number }>)
+        : [];
 
     if (payments.length === 0) {
       // Fallback: assume cash/QR
@@ -120,7 +145,7 @@ export function aggregateEod(
       const amount = Number(p.amount ?? 0);
       if (amount === 0) continue;
       const netAmount = round2(amount * (1 - sstPortion));
-      const bucket: ChannelKey = txnAggregator ?? classifyTender(p.type ?? "");
+      const bucket: ChannelKey = txnAggregator ?? classifyTender(p.paymentMethod ?? p.type ?? "");
       channels[bucket] += netAmount;
       netSales += netAmount;
     }

--- a/apps/backoffice/src/lib/finance/maybank-pdf-extract.ts
+++ b/apps/backoffice/src/lib/finance/maybank-pdf-extract.ts
@@ -1,0 +1,45 @@
+// Server-side (serverless-safe) PDF text extraction for the in-app upload path.
+// The local watcher uses `pdftotext -layout`; this reproduces that row-major
+// layout from pdfjs (via unpdf) by grouping text items into rows by their
+// y-coordinate and sorting each row left-to-right. The output is fed to the
+// same parseMaybankStatementText() as the watcher path.
+
+import { getDocumentProxy } from "unpdf";
+
+type TextItem = { str: string; transform: number[] };
+
+export async function extractMaybankText(data: Uint8Array): Promise<string> {
+  const pdf = await getDocumentProxy(data);
+  const lines: string[] = [];
+
+  for (let p = 1; p <= pdf.numPages; p++) {
+    const page = await pdf.getPage(p);
+    const content = await page.getTextContent();
+    const items = (content.items as TextItem[]).filter((it) => typeof it.str === "string" && it.str.trim() !== "");
+
+    // Bucket items into rows by y (pdfjs y grows upward). Tolerate ~2px jitter.
+    const rows: { y: number; items: TextItem[] }[] = [];
+    for (const it of items) {
+      const y = it.transform[5];
+      let row = rows.find((r) => Math.abs(r.y - y) <= 2);
+      if (!row) {
+        row = { y, items: [] };
+        rows.push(row);
+      }
+      row.items.push(it);
+    }
+
+    rows.sort((a, b) => b.y - a.y); // top to bottom
+    for (const row of rows) {
+      const line = row.items
+        .sort((a, b) => a.transform[4] - b.transform[4])
+        .map((it) => it.str)
+        .join(" ")
+        .replace(/\s+/g, " ")
+        .trim();
+      if (line) lines.push(line);
+    }
+  }
+
+  return lines.join("\n");
+}

--- a/apps/backoffice/src/lib/finance/maybank-statement-parser.test.ts
+++ b/apps/backoffice/src/lib/finance/maybank-statement-parser.test.ts
@@ -1,0 +1,131 @@
+import { describe, it, expect } from "vitest";
+import { parseMaybankStatementText } from "./maybank-statement-parser";
+
+// Mimics `pdftotext -layout` output: repeated page chrome, a transaction whose
+// description continues AFTER a page break, trailing +/- sign convention.
+const STATEMENT = `
+                    Maybank Islamic Berhad (787435-M)
+       IBS BANDAR BARU BANGI
+                              STATEMENT DATE  :  31/05/26
+       CELSIUS COFFEE SDN. BHD.
+       NO. 12-1, JALAN PPS 2
+                              ACCOUNT NUMBER  :  562263574384
+ ENTRY DATE   VALUE DATE      TRANSACTION DESCRIPTION      TRANSACTION AMOUNT      STATEMENT BALANCE
+                    BEGINNING BALANCE                                                  1,000.00
+       01/05         TRANSFER FR A/C                              100.00-               900.00
+                       SUPPLIER A *
+                       INV-001
+       02/05         TRANSFER TO A/C                              250.50+             1,150.50
+                       CUSTOMER QR *
+ BAKI LEGAR          LEDGER BALANCE
+                    Maybank Islamic Berhad (787435-M)
+       IBS BANDAR BARU BANGI
+       CELSIUS COFFEE SDN. BHD.
+ ENTRY DATE   VALUE DATE      TRANSACTION DESCRIPTION      TRANSACTION AMOUNT      STATEMENT BALANCE
+                       DUITNOW QR-
+       03/05         CMS - CR PYMT MARS                            49.50+             1,200.00
+ BAKI LEGAR          LEDGER BALANCE
+`;
+
+describe("parseMaybankStatementText", () => {
+  const r = parseMaybankStatementText(STATEMENT);
+
+  it("extracts header fields", () => {
+    expect(r.accountNumber).toBe("562263574384");
+    expect(r.statementDate).toBe("2026-05-31");
+    expect(r.accountName).toBe("CELSIUS COFFEE SDN. BHD.");
+  });
+
+  it("parses every transaction with the trailing sign as the source of truth", () => {
+    expect(r.rowsParsed).toBe(3);
+    expect(r.lines[0]).toMatchObject({ txnDate: "2026-05-01", direction: "DR", amount: 100.0 });
+    expect(r.lines[1]).toMatchObject({ txnDate: "2026-05-02", direction: "CR", amount: 250.5 });
+    expect(r.lines[2]).toMatchObject({ txnDate: "2026-05-03", direction: "CR", amount: 49.5 });
+  });
+
+  it("stitches a description that continues across a page break", () => {
+    expect(r.lines[1].description).toBe("TRANSFER TO A/C CUSTOMER QR DUITNOW QR-");
+  });
+
+  it("computes balances and totals and reconciles against the running-balance column", () => {
+    expect(r.beginningBalance).toBe(1000.0);
+    expect(r.endingBalance).toBe(1200.0);
+    expect(r.totalInflows).toBe(300.0);
+    expect(r.totalOutflows).toBe(100.0);
+    expect(r.periodStart).toBe("2026-05-01");
+    expect(r.periodEnd).toBe("2026-05-03");
+    expect(r.reconciled).toBe(true);
+    expect(r.warnings).toHaveLength(0);
+  });
+});
+
+describe("balance-walk integrity check", () => {
+  it("flags a tampered running balance even when totals still tie out", () => {
+    // Corrupt only line 1's balance (900.00 -> 950.00). Amounts/totals are
+    // unaffected, so beginning+Σ still equals ending — but the per-line walk
+    // must catch the drift.
+    const tampered = STATEMENT.replace("100.00-               900.00", "100.00-               950.00");
+    const r = parseMaybankStatementText(tampered);
+    expect(r.reconciled).toBe(false);
+    expect(r.warnings.some((w) => /Balance walk mismatch/.test(w))).toBe(true);
+  });
+});
+
+describe("real-statement edge cases (regression guards)", () => {
+  it("reads overdrawn balances marked with a trailing DR as negative", () => {
+    const s = `
+       Maybank Islamic Berhad (787435-M)
+                              STATEMENT DATE  :  30/04/26
+       CELSIUS COFFEE SDN. BHD.
+                              ACCOUNT NUMBER  :  562263574384
+ ENTRY DATE   VALUE DATE      TRANSACTION DESCRIPTION      TRANSACTION AMOUNT      STATEMENT BALANCE
+                    BEGINNING BALANCE                                                    100.00
+       10/04         TRANSFER FR A/C                              150.00-                 50.00DR
+       10/04         TRANSFER TO A/C                               80.00+                 30.00
+ BAKI LEGAR          LEDGER BALANCE
+`;
+    const r = parseMaybankStatementText(s);
+    expect(r.lines[0].balance).toBe(-50.0);
+    expect(r.endingBalance).toBe(30.0);
+    expect(r.totalOutflows).toBe(150.0);
+    expect(r.reconciled).toBe(true);
+  });
+
+  it("reads sub-RM1 amounts written without a leading zero (.95)", () => {
+    const s = `
+       Maybank Islamic Berhad (787435-M)
+                              STATEMENT DATE  :  31/05/26
+       CELSIUS COFFEE SDN. BHD.
+                              ACCOUNT NUMBER  :  562263659345
+ ENTRY DATE   VALUE DATE      TRANSACTION DESCRIPTION      TRANSACTION AMOUNT      STATEMENT BALANCE
+                    BEGINNING BALANCE                                                     10.00
+       04/05         DR/CARD SALES M/N 1 D 5                         .95-                  9.05
+       05/05         DR/CARD SALES M/N 1 D 5                        1.50+                 10.55
+ BAKI LEGAR          LEDGER BALANCE
+`;
+    const r = parseMaybankStatementText(s);
+    expect(r.lines[0].amount).toBe(0.95);
+    expect(r.lines[0].direction).toBe("DR");
+    expect(r.reconciled).toBe(true);
+  });
+});
+
+describe("year resolution across the Dec->Jan boundary", () => {
+  it("assigns the prior calendar year to a December txn on a January statement", () => {
+    const s = `
+       Maybank Islamic Berhad (787435-M)
+                              STATEMENT DATE  :  31/01/26
+       CELSIUS COFFEE TAMARIND SDN. BHD.
+                              ACCOUNT NUMBER  :  562263659345
+ ENTRY DATE   VALUE DATE      TRANSACTION DESCRIPTION      TRANSACTION AMOUNT      STATEMENT BALANCE
+                    BEGINNING BALANCE                                                    500.00
+       31/12         TRANSFER FR A/C                               10.00-               490.00
+       02/01         TRANSFER TO A/C                               20.00+               510.00
+ BAKI LEGAR          LEDGER BALANCE
+`;
+    const r = parseMaybankStatementText(s);
+    expect(r.lines[0].txnDate).toBe("2025-12-31");
+    expect(r.lines[1].txnDate).toBe("2026-01-02");
+    expect(r.reconciled).toBe(true);
+  });
+});

--- a/apps/backoffice/src/lib/finance/maybank-statement-parser.ts
+++ b/apps/backoffice/src/lib/finance/maybank-statement-parser.ts
@@ -1,0 +1,259 @@
+// Maybank Islamic SME statement parser.
+//
+// Maybank only issues these as PDFs. We extract the page text (via `pdftotext
+// -layout` in the local watcher, or pdfjs row-reconstruction on the server —
+// see maybank-pdf-extract.ts) and parse it here. This function is PURE: text
+// in, structured statement out, no PDF/IO dependency, so it's fully unit
+// testable against captured fixtures.
+//
+// Layout (one transaction):
+//
+//   01/05            TRANSFER FR A/C                 50.50-        22,833.67
+//                      COLLECTIVE PROJECT *
+//                      IV-01990
+//                      CelsiusCoffee N
+//
+// - First line: ENTRY DATE (DD/MM), description, AMOUNT with a TRAILING sign
+//   (`-` = outflow/debit, `+` = inflow/credit), then the running STATEMENT
+//   BALANCE. The sign is authoritative — the "TRANSFER TO/FR" wording is not
+//   (a "TRANSFER TO A/C ... 31.80+" is an incoming DuitNow QR collection).
+// - Following indented lines (no date) are description continuations and may
+//   resume AFTER a page break (Maybank repeats a ~20-line header/footer on
+//   every page), so we track header/footer zones rather than flushing on gaps.
+// - The statement has no totals line; ending balance = last running balance,
+//   and we derive total in/out by summing. The running-balance column gives a
+//   per-line integrity check: prevBalance + signedAmount == thisBalance.
+
+import type { ParsedLine } from "./bank-statement-parser";
+
+export type MaybankParsedStatement = {
+  accountNumber: string | null;
+  accountName: string | null;
+  statementDate: string | null; // YYYY-MM-DD (statement end date)
+  beginningBalance: number | null;
+  endingBalance: number | null;
+  totalInflows: number;
+  totalOutflows: number;
+  periodStart: string | null;
+  periodEnd: string | null;
+  rowsParsed: number;
+  reconciled: boolean; // beginning + Σ signed == ending, and every line's balance walk ties
+  warnings: string[];
+  lines: ParsedLine[];
+};
+
+// Amounts/balances may omit the leading zero for sub-RM1 values (".95") and an
+// overdrawn balance carries a trailing "DR" (= negative). Both appear in real
+// statements; missing either silently dropped whole transactions.
+const MONEY = String.raw`[\d,]*\.\d{2}`;
+// A transaction's first line: leading DD/MM, description, amount+sign, then the
+// running balance with an optional DR/CR overdraft marker. The optional spaces
+// before the sign / DR marker tolerate PDF text extractors (pdfjs) that split
+// "50.50-" into separate "50.50" and "-" items; `pdftotext -layout` keeps them
+// joined, so this is a no-op there.
+const TXN_RE = new RegExp(
+  String.raw`^\s*(\d{2})/(\d{2})\s+(.*?)\s+(${MONEY})\s?([+-])\s+(${MONEY})\s?(DR|CR)?\s*$`
+);
+
+function toNum(s: string): number {
+  return Math.round(parseFloat(s.replace(/,/g, "")) * 100) / 100;
+}
+
+// Description fragments are Maybank-truncated (≤ ~20 chars, often ending "*").
+// Capping length cleanly excludes the end-of-statement announcement sentences
+// (stamp duty notices etc.) that share the transaction zone on the last pages.
+function cleanFragment(s: string): string {
+  const t = s.trim().replace(/\s+/g, " ").replace(/\*+$/, "").trim();
+  return t;
+}
+function isUsableFragment(t: string): boolean {
+  return t.length >= 2 && t.length <= 30 && /[A-Za-z0-9]/.test(t);
+}
+
+function isPageStart(line: string): boolean {
+  return /Maybank Islamic Berhad|Dataran Maybank/.test(line);
+}
+// The English column-header row marks the start of a page's transaction zone.
+function isColumnHeader(line: string): boolean {
+  return /ENTRY DATE|STATEMENT BALANCE|TRANSACTION DESCRIPTION/.test(line);
+}
+// Footer / notes block — ends the transaction zone for the page.
+function isFooterStart(line: string): boolean {
+  return /BAKI LEGAR|LEDGER BALANCE|Perhatian \/ Note/.test(line);
+}
+
+function ymd(year: number, month: number, day: number): string {
+  return `${year}-${String(month).padStart(2, "0")}-${String(day).padStart(2, "0")}`;
+}
+
+export function parseMaybankStatementText(
+  text: string,
+  opts: { accountNumber?: string; statementDate?: string } = {}
+): MaybankParsedStatement {
+  const lines = text.split(/\r?\n/);
+  const warnings: string[] = [];
+
+  // ── Header fields ──────────────────────────────────────────
+  // Statement date is the only DD/MM/YY (with year) in the doc; txn dates are DD/MM.
+  let statementDate = opts.statementDate ?? null;
+  if (!statementDate) {
+    const m = text.match(/\b(\d{2})\/(\d{2})\/(\d{2})\b/);
+    if (m) statementDate = ymd(2000 + parseInt(m[3], 10), parseInt(m[2], 10), parseInt(m[1], 10));
+  }
+  let accountNumber = opts.accountNumber ?? null;
+  if (!accountNumber) {
+    const m = text.match(/\b(\d{12})\b/);
+    if (m) accountNumber = m[1];
+  }
+  let accountName: string | null = null;
+  for (const raw of lines) {
+    if (/\bSDN\.?\s*BHD\b|\bENTERPRISE\b|\bRESOURCES\b|\bTRADING\b/i.test(raw) && !/MAYBANK/i.test(raw)) {
+      accountName = raw.trim().replace(/\s+/g, " ");
+      break;
+    }
+  }
+
+  const stmtYear = statementDate ? parseInt(statementDate.slice(0, 4), 10) : new Date().getUTCFullYear();
+  const stmtMonth = statementDate ? parseInt(statementDate.slice(5, 7), 10) : 12;
+  // Resolve a DD/MM transaction date's year: same-year normally; if the month
+  // is after the statement month, it belongs to the prior calendar year
+  // (statements that straddle Dec→Jan).
+  const resolveYear = (mm: number): number => (mm > stmtMonth ? stmtYear - 1 : stmtYear);
+
+  // ── Walk lines ─────────────────────────────────────────────
+  type Draft = { day: number; month: number; year: number; descParts: string[]; amount: number; direction: "CR" | "DR"; balance: number };
+  const drafts: Draft[] = [];
+  let beginningBalance: number | null = null;
+  let inTxnZone = false;
+  let cur: Draft | null = null;
+
+  const flush = () => {
+    if (cur) drafts.push(cur);
+    cur = null;
+  };
+
+  for (const raw of lines) {
+    if (isPageStart(raw)) {
+      inTxnZone = false;
+      continue;
+    }
+    if (isColumnHeader(raw)) {
+      inTxnZone = true;
+      continue;
+    }
+    if (isFooterStart(raw)) {
+      inTxnZone = false;
+      continue;
+    }
+    if (!inTxnZone) continue;
+
+    if (/BEGINNING BALANCE/i.test(raw)) {
+      const m = raw.match(new RegExp(`(${MONEY})(DR|CR)?\\s*$`));
+      if (m) beginningBalance = m[2] === "DR" ? -toNum(m[1]) : toNum(m[1]);
+      flush();
+      continue;
+    }
+
+    const m = raw.match(TXN_RE);
+    if (m) {
+      flush();
+      const day = parseInt(m[1], 10);
+      const month = parseInt(m[2], 10);
+      const descHead = cleanFragment(m[3]);
+      cur = {
+        day,
+        month,
+        year: resolveYear(month),
+        descParts: descHead ? [descHead] : [],
+        amount: toNum(m[4]),
+        direction: m[5] === "+" ? "CR" : "DR",
+        balance: m[7] === "DR" ? -toNum(m[6]) : toNum(m[6]),
+      };
+      continue;
+    }
+
+    // Continuation fragment for the current transaction.
+    if (cur && cur.descParts.length < 6) {
+      const frag = cleanFragment(raw);
+      if (isUsableFragment(frag)) cur.descParts.push(frag);
+    }
+  }
+  flush();
+
+  // ── Build lines + reconcile against the running-balance column ──
+  const parsed: ParsedLine[] = [];
+  let totalIn = 0;
+  let totalOut = 0;
+  let periodStart: string | null = null;
+  let periodEnd: string | null = null;
+  let running = beginningBalance;
+  let walkOk = beginningBalance !== null;
+
+  for (const d of drafts) {
+    const signed = d.direction === "CR" ? d.amount : -d.amount;
+    if (running !== null) {
+      const expected = Math.round((running + signed) * 100) / 100;
+      if (Math.abs(expected - d.balance) > 0.01) {
+        walkOk = false;
+        if (warnings.length < 5) {
+          warnings.push(
+            `Balance walk mismatch at ${ymd(d.year, d.month, d.day)} "${d.descParts.join(" ")}": ` +
+              `expected ${expected.toFixed(2)} but statement shows ${d.balance.toFixed(2)}`
+          );
+        }
+      }
+      running = d.balance; // trust the statement's column; resync after any drift
+    }
+
+    if (d.direction === "CR") totalIn += d.amount;
+    else totalOut += d.amount;
+
+    const date = ymd(d.year, d.month, d.day);
+    if (!periodStart || date < periodStart) periodStart = date;
+    if (!periodEnd || date > periodEnd) periodEnd = date;
+
+    parsed.push({
+      txnDate: date,
+      description: d.descParts.join(" ").trim(),
+      reference: null,
+      amount: d.amount,
+      direction: d.direction,
+      balance: d.balance,
+    });
+  }
+
+  const endingBalance = drafts.length ? drafts[drafts.length - 1].balance : beginningBalance;
+  const reconciled =
+    walkOk &&
+    beginningBalance !== null &&
+    endingBalance !== null &&
+    Math.abs(
+      Math.round((beginningBalance + totalIn - totalOut) * 100) / 100 - endingBalance
+    ) <= 0.01;
+
+  if (!reconciled && beginningBalance !== null && endingBalance !== null && warnings.length < 6) {
+    warnings.push(
+      `Statement does not reconcile: ${beginningBalance.toFixed(2)} + ${totalIn.toFixed(2)} in − ` +
+        `${totalOut.toFixed(2)} out = ${(beginningBalance + totalIn - totalOut).toFixed(2)}, ` +
+        `but ending balance is ${endingBalance.toFixed(2)}.`
+    );
+  }
+  if (beginningBalance === null) warnings.push("No BEGINNING BALANCE row found — cannot reconcile.");
+  if (drafts.length === 0) warnings.push("No transactions parsed — check the extracted text format.");
+
+  return {
+    accountNumber,
+    accountName,
+    statementDate,
+    beginningBalance,
+    endingBalance,
+    totalInflows: Math.round(totalIn * 100) / 100,
+    totalOutflows: Math.round(totalOut * 100) / 100,
+    periodStart,
+    periodEnd,
+    rowsParsed: parsed.length,
+    reconciled,
+    warnings,
+    lines: parsed,
+  };
+}

--- a/apps/backoffice/src/lib/finance/persist-bank-statement.ts
+++ b/apps/backoffice/src/lib/finance/persist-bank-statement.ts
@@ -1,0 +1,150 @@
+// Persists a parsed Maybank statement into BankStatement + BankStatementLine,
+// auto-classifying every line into a CashCategory. Shared by the ingest API
+// route (admin upload / watcher) and the one-off backfill script, so behaviour
+// is identical across both paths.
+//
+// Idempotent: keyed on (accountName label, statementDate). Re-ingesting the
+// same statement replaces its lines rather than duplicating — safe for cron
+// retries and re-runs.
+
+import { classifyBankLine } from "./bank-line-classifier";
+import type { MaybankParsedStatement } from "./maybank-statement-parser";
+import type { PrismaClient } from "@celsius/db";
+
+export type PersistOptions = {
+  uploadedById: string;
+  fileUrl?: string | null;
+  sourceFileName?: string | null;
+};
+
+export type PersistResult = {
+  statementId: string;
+  accountName: string;
+  statementDate: string;
+  created: boolean; // false => replaced an existing statement
+  linesCreated: number;
+  totalInflows: number;
+  totalOutflows: number;
+  interCoInflows: number;
+  interCoOutflows: number;
+  closingBalance: number;
+  reconciled: boolean;
+  warnings: string[];
+};
+
+function round2(n: number): number {
+  return Math.round(n * 100) / 100;
+}
+
+// Stable display + dedupe label, e.g. "CELSIUS COFFEE SDN. BHD. (4384)".
+export function accountLabel(parsed: MaybankParsedStatement): string {
+  const last4 = parsed.accountNumber ? parsed.accountNumber.slice(-4) : "????";
+  const name = (parsed.accountName ?? "Maybank").replace(/\s+/g, " ").trim();
+  return `${name} (${last4})`;
+}
+
+export async function persistMaybankStatement(
+  prisma: PrismaClient,
+  parsed: MaybankParsedStatement,
+  opts: PersistOptions
+): Promise<PersistResult> {
+  if (!parsed.statementDate) throw new Error("Cannot persist: statement date not found in PDF.");
+  const label = accountLabel(parsed);
+  const stmtDate = new Date(`${parsed.statementDate}T00:00:00.000Z`);
+  const closingBalance = parsed.endingBalance ?? parsed.beginningBalance ?? 0;
+
+  const outlets = await prisma.outlet.findMany({ select: { id: true, code: true } });
+  const codeToId = new Map(outlets.map((o) => [o.code, o.id]));
+
+  const lineData = parsed.lines
+    .filter((l) => l.amount > 0 && (l.direction === "CR" || l.direction === "DR"))
+    .map((l) => {
+      const cls = classifyBankLine({
+        description: l.description,
+        reference: l.reference ?? null,
+        amount: l.amount,
+        direction: l.direction,
+        accountKey: label,
+      });
+      return {
+        txnDate: new Date(`${l.txnDate}T00:00:00.000Z`),
+        description: l.description,
+        reference: l.reference ?? null,
+        amount: l.amount,
+        direction: l.direction,
+        category: cls.category,
+        outletId: cls.outletCode ? codeToId.get(cls.outletCode) ?? null : null,
+        isInterCo: cls.isInterCo,
+        classifiedBy: "rule",
+        ruleName: cls.ruleName,
+      };
+    });
+
+  const interCoInflows = round2(
+    lineData.filter((d) => d.isInterCo && d.direction === "CR").reduce((s, d) => s + d.amount, 0)
+  );
+  const interCoOutflows = round2(
+    lineData.filter((d) => d.isInterCo && d.direction === "DR").reduce((s, d) => s + d.amount, 0)
+  );
+
+  const notes =
+    (parsed.reconciled ? "Auto-ingested from Maybank PDF (reconciled)." : "⚠️ Auto-ingested but did NOT reconcile.") +
+    (opts.sourceFileName ? ` Source: ${opts.sourceFileName}.` : "") +
+    (parsed.warnings.length ? ` ${parsed.warnings.slice(0, 3).join(" | ")}` : "");
+
+  const header = {
+    closingBalance,
+    periodStart: parsed.periodStart ? new Date(`${parsed.periodStart}T00:00:00.000Z`) : null,
+    periodEnd: parsed.periodEnd ? new Date(`${parsed.periodEnd}T00:00:00.000Z`) : null,
+    totalInflows: parsed.totalInflows,
+    totalOutflows: parsed.totalOutflows,
+    interCoInflows,
+    interCoOutflows,
+    fileUrl: opts.fileUrl ?? null,
+    notes,
+  };
+
+  // Idempotent upsert keyed on (label, statementDate).
+  const existing = await prisma.bankStatement.findFirst({
+    where: { accountName: label, statementDate: stmtDate },
+    select: { id: true },
+  });
+
+  let statementId: string;
+  let created: boolean;
+  if (existing) {
+    await prisma.bankStatementLine.deleteMany({ where: { statementId: existing.id } });
+    await prisma.bankStatement.update({ where: { id: existing.id }, data: header });
+    statementId = existing.id;
+    created = false;
+  } else {
+    const c = await prisma.bankStatement.create({
+      data: { accountName: label, statementDate: stmtDate, uploadedById: opts.uploadedById, ...header },
+      select: { id: true },
+    });
+    statementId = c.id;
+    created = true;
+  }
+
+  let linesCreated = 0;
+  const rows = lineData.map((d) => ({ ...d, statementId }));
+  for (let i = 0; i < rows.length; i += 1000) {
+    const r = await prisma.bankStatementLine.createMany({ data: rows.slice(i, i + 1000), skipDuplicates: true });
+    linesCreated += r.count;
+  }
+
+  return {
+    statementId,
+    accountName: label,
+    statementDate: parsed.statementDate,
+    created,
+    linesCreated,
+    totalInflows: parsed.totalInflows,
+    totalOutflows: parsed.totalOutflows,
+    interCoInflows,
+    interCoOutflows,
+    closingBalance,
+    reconciled: parsed.reconciled,
+    warnings: parsed.warnings,
+  };
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,6 @@
         "apps/loyalty",
         "apps/order",
         "apps/pickup",
-        "apps/pos",
         "apps/staff",
         "packages/*"
       ],
@@ -65,6 +64,7 @@
         "swr": "^2.4.1",
         "tailwind-merge": "^3.5.0",
         "tw-animate-css": "^1.4.0",
+        "unpdf": "^1.6.2",
         "xlsx": "^0.18.5",
         "zod": "^4.3.6"
       },
@@ -1134,6 +1134,7 @@
     "apps/pos": {
       "name": "@celsius-ops/pos",
       "version": "0.1.0",
+      "extraneous": true,
       "hasInstallScript": true,
       "dependencies": {
         "@capacitor/android": "^8.3.0",
@@ -1170,25 +1171,6 @@
         "prisma": "^6.19.3",
         "tailwindcss": "^4.0.0",
         "typescript": "^5.7.0"
-      }
-    },
-    "apps/pos/node_modules/@types/node": {
-      "version": "22.19.17",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.17.tgz",
-      "integrity": "sha512-wGdMcf+vPYM6jikpS/qhg6WiqSV/OhG+jeeHT/KlVqxYfD40iYJf9/AE1uQxVWFvU7MipKRkRv8NSHiCGgPr8Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "undici-types": "~6.21.0"
-      }
-    },
-    "apps/pos/node_modules/zod": {
-      "version": "3.25.76",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
-      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "apps/staff": {
@@ -2578,10 +2560,6 @@
     },
     "node_modules/@celsius-ops/order": {
       "resolved": "apps/order",
-      "link": true
-    },
-    "node_modules/@celsius-ops/pos": {
-      "resolved": "apps/pos",
       "link": true
     },
     "node_modules/@celsius-ops/staff": {
@@ -20964,6 +20942,20 @@
       "license": "MIT",
       "engines": {
         "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/unpdf": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/unpdf/-/unpdf-1.6.2.tgz",
+      "integrity": "sha512-zQ80ySoPuPHOsvIoRp/nJyQt8TOUoTh1+WBCGcBvlddQNgKDLRwm0AY3x8Q35I7+kIiRSgqMx+Ma2pl9McIp7A==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@napi-rs/canvas": "^0.1.69"
+      },
+      "peerDependenciesMeta": {
+        "@napi-rs/canvas": {
+          "optional": true
+        }
       }
     },
     "node_modules/unpipe": {


### PR DESCRIPTION
## Summary
Improves the finance module across two fronts.

### AR posting fix (cutover blocker)
The AR autopilot read the wrong StoreHub field (`type` vs `paymentMethod`), so every card/e-wallet/QR sale bucketed to `other` → confidence pinned at 0.60 → journals stuck as **drafts, never posted**, and all reports read zero. Fixed classification against the real tender types; low-confidence days now raise a `fin_exception` instead of silently drafting.

⚠️ **Behavior change:** once deployed, the daily AR EOD cron will start **posting real journals** (status `posted`, not draft) on clean days. If you want to stay draft-only through the Bukku parallel-run, say so — it's a one-line change.

### Maybank statement ingestion + cashflow
- Deterministic Maybank PDF parser — reconciles every line against the running-balance column (handles `DR` overdraft balances, sub-RM1 amounts, page-break-spanning descriptions). **8 unit tests; 35/35 real statements reconcile.**
- Server-side (`unpdf`) + local (`pdftotext` watcher) extraction → one shared parse/classify/persist path, idempotent on (account, statement date).
- Ingest endpoint (ADMIN session **or** `FINANCE_INGEST_SECRET` bearer), in-app **PDF drag-drop**, and a **launchd watcher** for auto-upload.
- New **/finance/monthly-cashflow** page: inflow/outflow/net/group bank balance, entity + date filters, compare-vs-prev, category rankings.
- Existing cashflow page: Cash in/out columns now exclude inter-company transfers so each row reconciles (Cash in − Cash out = Net).

## Already done (live data)
- Backfilled 35 statements → 51,207 classified lines.
- Removed 9 superseded duplicate statements (was double-counting Jan–Mar 2026).

## Required to fully activate the watcher
Set **`FINANCE_INGEST_SECRET`** in Vercel (value on the Mac at `~/.celsius-maybank-watcher/ingest-secret.txt`).

## Verification
- `tsc --noEmit` clean · parser tests 8/8 · 35/35 statements reconcile · cashflow rows reconcile (verified in DB).

🤖 Generated with [Claude Code](https://claude.com/claude-code)