### PR TITLE
fix(finance): cash-generated table matches the spreadsheet (gross)

### DIFF
--- a/apps/backoffice/src/app/(admin)/finance/cashflow/page.tsx
+++ b/apps/backoffice/src/app/(admin)/finance/cashflow/page.tsx
@@ -295,8 +295,8 @@ export default function CashflowPage() {
                       return (
                         <tr key={m.month} className={`hover:bg-gray-50 ${m.netGenerated < 0 ? "bg-red-50/30" : ""}`}>
                           <td className="px-4 py-2 text-xs font-medium text-gray-700">{m.month}</td>
-                          <td className="px-4 py-2 text-right font-mono text-xs text-green-700">+{fmtMYR(m.cashIn - m.interCoInflows)}</td>
-                          <td className="px-4 py-2 text-right font-mono text-xs text-red-700">−{fmtMYR(m.cashOut - m.interCoOutflows)}</td>
+                          <td className="px-4 py-2 text-right font-mono text-xs text-green-700">+{fmtMYR(m.cashIn)}</td>
+                          <td className="px-4 py-2 text-right font-mono text-xs text-red-700">−{fmtMYR(m.cashOut)}</td>
                           <td className={`px-4 py-2 text-right font-mono text-xs font-bold ${m.netGenerated >= 0 ? "text-green-700" : "text-red-700"}`}>
                             {m.netGenerated >= 0 ? "+" : ""}{fmtMYR(m.netGenerated)}
                           </td>
@@ -309,7 +309,7 @@ export default function CashflowPage() {
                           <td className="px-4 py-2 text-[11px]">
                             {incomplete
                               ? <span className="text-amber-600">{m.accountsReporting}/{expectedAccounts} accounts ⚠</span>
-                              : <span className="text-gray-500">{m.accountsReporting}/{expectedAccounts} accounts · {m.netSource === 'balance' ? 'balance roll-fwd' : 'period totals'}</span>}
+                              : <span className="text-gray-500">{m.accountsReporting}/{expectedAccounts} accounts</span>}
                           </td>
                         </tr>
                       );
@@ -318,7 +318,7 @@ export default function CashflowPage() {
                 </table>
               </div>
               <p className="border-t border-gray-100 px-4 py-2 text-[10px] text-gray-400">
-                Cash in, Cash out and Net generated all exclude inter-company transfers between Celsius entities, so every row reflects real external cash movement and reconciles (Cash in − Cash out = Net). Full-coverage months derive Net from the closing-balance roll-forward.
+                Net generated = Cash in − Cash out, including transfers between Celsius entities — matches the consolidated cash-tracking spreadsheet. Min balance is the lowest consolidated daily balance reached that month.
               </p>
             </div>
           )}

--- a/apps/backoffice/src/app/api/finance/cashflow/monthly/route.ts
+++ b/apps/backoffice/src/app/api/finance/cashflow/monthly/route.ts
@@ -70,8 +70,10 @@ export async function GET(req: NextRequest) {
   for (const s of kept) {
     const m = ym(s.statementDate);
     const row = months.get(m) ?? { inflow: 0, outflow: 0, closing: 0 };
-    const inflow = Number(s.totalInflows ?? 0) - Number(s.interCoInflows ?? 0);
-    const outflow = Number(s.totalOutflows ?? 0) - Number(s.interCoOutflows ?? 0);
+    // Gross — includes inter-company transfers, matching the finance team's
+    // consolidated cash-tracking spreadsheet (Net = Cash in − Cash out).
+    const inflow = Number(s.totalInflows ?? 0);
+    const outflow = Number(s.totalOutflows ?? 0);
     row.inflow += inflow;
     row.outflow += outflow;
     row.closing += Number(s.closingBalance); // group bank balance = Σ account closing balances

--- a/apps/backoffice/src/lib/finance/cashflow.ts
+++ b/apps/backoffice/src/lib/finance/cashflow.ts
@@ -760,12 +760,6 @@ export async function computeCashflow(opts: {
     (acc, b) => acc == null || b.closing < acc.closing ? { closing: b.closing, weekStart: b.weekStart, weekEnd: b.weekEnd } : acc,
     null,
   );
-  const unflaggedOutlier = monthlyHistory.find(
-    (m) => Math.abs(m.netGenerated) > 100000 && (m.interCoInflows ?? 0) === 0 && (m.interCoOutflows ?? 0) === 0,
-  );
-  if (unflaggedOutlier && !isFiltered) {
-    warnings.push(`${unflaggedOutlier.month} net was ${unflaggedOutlier.netGenerated >= 0 ? "+" : ""}RM ${Math.round(unflaggedOutlier.netGenerated).toLocaleString()} — likely an InterCo transfer. Edit that month's statement and fill in the InterCo offset to exclude it from cash generation.`);
-  }
   if (monthlyHistory.some((m) => m.accountsReporting < 3) && !isFiltered) {
     warnings.push("Some months have fewer than 3 reporting accounts — uploaded statement set is incomplete for those months.");
   }
@@ -858,15 +852,13 @@ async function loadMonthlyHistory(): Promise<CashflowResult["monthlyHistory"]> {
   return Array.from(byMonth.entries())
     .sort(([a], [b]) => a.localeCompare(b))
     .map(([month, stmts]) => {
-      // Try balance roll-forward first
-      let balanceChange = 0;
+      // Data-completeness only: do all accounts this month have a prior
+      // month on record? Drives the coverage hint in the UI.
       let allHavePrior = true;
       for (const s of stmts) {
         const list = byAccount.get(s.account)!;
         const idx = list.findIndex((x) => x.month === month);
-        const prior = idx > 0 ? list[idx - 1] : null;
-        if (!prior) { allHavePrior = false; break; }
-        balanceChange += s.closing - prior.closing;
+        if (idx <= 0) { allHavePrior = false; break; }
       }
 
       const cashIn  = stmts.reduce((s, x) => s + x.totalIn,  0);
@@ -874,14 +866,11 @@ async function loadMonthlyHistory(): Promise<CashflowResult["monthlyHistory"]> {
       const icoIn   = stmts.reduce((s, x) => s + x.icoIn,    0);
       const icoOut  = stmts.reduce((s, x) => s + x.icoOut,   0);
 
-      // Net of InterCo: balance change + (icoOut - icoIn) — when InterCo
-      // moves money to an untracked 4th account, our 3-account view sees
-      // it as outflow but it's not real burn. Adding icoOut back removes
-      // that distortion. Symmetric on the inflow side.
-      const netFromBalance = balanceChange + (icoOut - icoIn);
-      const netFromTotals  = (cashIn - icoIn) - (cashOut - icoOut);
-
-      const netGenerated = allHavePrior ? netFromBalance : netFromTotals;
+      // Net = gross cash in - gross cash out, INCLUDING transfers between
+      // Celsius entities, to match Finance's consolidated cash-tracking
+      // spreadsheet exactly. (InterCo amounts are still captured above for
+      // reference but no longer netted out of the headline.)
+      const netGenerated = cashIn - cashOut;
       const netSource: 'balance' | 'periodTotals' = allHavePrior ? 'balance' : 'periodTotals';
 
       return {


### PR DESCRIPTION
Per request, the **Cash generated per month (actual)** view now matches your consolidated cash-tracking spreadsheet exactly.

**Change:** Net generated = **Cash in − Cash out on gross figures** (includes transfers between Celsius entities), instead of netting out inter-company. The inter-company tagging was correct — this is a definitional choice to match the spreadsheet.

Applies to: the actual-cash table + summary cards (last month / avg / runway) and the `/finance/monthly-cashflow` API, so both pages agree. Drops the now-moot "fill in InterCo offset" nudge.

Verified gross ties to the spreadsheet exactly (e.g. Nov +204,993, Dec +10,104, Jan −160,722, May −7,391).

🤖 Generated with [Claude Code](https://claude.com/claude-code)