### PR TITLE
feat(finance): Ledger shows the real bank-statement ledger

### DIFF
--- a/apps/backoffice/src/app/(admin)/finance/transactions/page.tsx
+++ b/apps/backoffice/src/app/(admin)/finance/transactions/page.tsx
@@ -1,195 +1,58 @@
 "use client";
 
-// General Ledger view. Lists journals from fin_transactions with Excel-style
-// column sorting (asc/desc) + multi-dimension filtering (search, category/
-// account, type, status, outlet, date range, amount range), and a Sheet
-// drawer showing the journal lines + source document.
+// Ledger — the REAL cash ledger, sourced from classified bank-statement lines
+// (every actual deposit/payment across the entities). Excel-style column
+// sorting (asc/desc) + filtering: search, category, direction (in/out), entity,
+// outlet, date range, amount range. Date range is server-windowed; the rest is
+// client-side for instant feel. Row click opens a detail drawer.
 
 import { useState, useMemo } from "react";
 import { useFetch } from "@/lib/use-fetch";
-import { Button, Sheet, SheetContent, SheetHeader, SheetTitle, Badge } from "@celsius/ui";
-import {
-  Loader2, FileText, Bot, User as UserIcon,
-  ArrowUp, ArrowDown, ChevronsUpDown, Search, X,
-} from "lucide-react";
+import { Sheet, SheetContent, SheetHeader, SheetTitle, Badge, Button } from "@celsius/ui";
+import { Loader2, Search, X, ArrowUp, ArrowDown, ChevronsUpDown, Building2 } from "lucide-react";
 
-type Outlet = { id: string; name: string; code: string };
-
-type Transaction = {
+type BankLine = {
   id: string;
-  txn_date: string;
+  txnDate: string;
   description: string;
-  outlet_id: string | null;
+  reference: string | null;
   amount: number;
-  currency: string;
-  txn_type: string;
-  posted_by_agent: string | null;
-  agent_version: string | null;
-  confidence: number | null;
-  status: "draft" | "posted" | "exception" | "reversed";
-  posted_at: string | null;
-  period: string;
-  source_doc_id: string | null;
-  accounts: string[];
-  outlet: Outlet | null;
-};
-
-type Account = { code: string; name: string; type: string };
-
-type JournalLine = {
-  id: string;
-  account_code: string;
-  account_name: string | null;
-  outlet_id: string | null;
-  debit: number;
-  credit: number;
-  memo: string | null;
-  line_order: number;
-};
-
-type SourceDoc = {
-  id: string;
-  source: string;
-  source_ref: string;
-  doc_type: string;
-  raw_url: string | null;
-  received_at: string;
+  direction: "CR" | "DR";
+  category: string | null;
+  isInterCo: boolean;
+  classifiedBy: string | null;
+  ruleName: string | null;
+  outlet: string | null;
+  account: string | null;
 };
 
 const RM = (n: number) =>
   new Intl.NumberFormat("en-MY", { style: "currency", currency: "MYR" }).format(n);
 
-function StatusBadge({ status }: { status: Transaction["status"] }) {
-  const variant: Record<Transaction["status"], "default" | "secondary" | "destructive" | "outline"> = {
-    posted: "default",
-    draft: "outline",
-    exception: "destructive",
-    reversed: "secondary",
-  };
-  return <Badge variant={variant[status]}>{status}</Badge>;
+function humanCat(c: string | null): string {
+  if (!c) return "Unclassified";
+  return c.toLowerCase().replace(/_/g, " ").replace(/\b\w/g, (m) => m.toUpperCase());
 }
 
-function DrawerContent({ id }: { id: string }) {
-  const { data, error } = useFetch<{
-    transaction: Transaction;
-    lines: JournalLine[];
-    document: SourceDoc | null;
-  }>(`/api/finance/transactions/${id}`);
-
-  if (!data && !error) {
-    return <div className="p-6"><Loader2 className="h-5 w-5 animate-spin" /></div>;
-  }
-  if (error) {
-    return <div className="p-6 text-sm text-destructive">Failed to load.</div>;
-  }
-  if (!data) return null;
-
-  return (
-    <div className="space-y-5 overflow-y-auto p-6">
-      <section className="space-y-1">
-        <div className="text-xs uppercase tracking-wide text-muted-foreground">Description</div>
-        <div className="break-words">{data.transaction.description}</div>
-      </section>
-
-      <section className="grid grid-cols-2 gap-3 text-sm">
-        <div className="min-w-0">
-          <div className="text-xs uppercase tracking-wide text-muted-foreground">Date</div>
-          <div className="tabular-nums">{data.transaction.txn_date}</div>
-        </div>
-        <div className="min-w-0">
-          <div className="text-xs uppercase tracking-wide text-muted-foreground">Status</div>
-          <StatusBadge status={data.transaction.status} />
-        </div>
-        <div className="min-w-0">
-          <div className="text-xs uppercase tracking-wide text-muted-foreground">Amount</div>
-          <div className="truncate font-medium tabular-nums">{RM(Number(data.transaction.amount))}</div>
-        </div>
-        <div className="min-w-0">
-          <div className="text-xs uppercase tracking-wide text-muted-foreground">Posted by</div>
-          <div className="flex items-center gap-1 truncate">
-            {data.transaction.posted_by_agent === "manual" ? (
-              <UserIcon className="h-3.5 w-3.5 shrink-0" />
-            ) : (
-              <Bot className="h-3.5 w-3.5 shrink-0" />
-            )}
-            <span className="truncate">{data.transaction.posted_by_agent ?? "—"}</span>
-            {data.transaction.confidence !== null && (
-              <span className="shrink-0 text-muted-foreground">
-                ({Math.round(Number(data.transaction.confidence) * 100)}%)
-              </span>
-            )}
-          </div>
-        </div>
-      </section>
-
-      <section>
-        <div className="mb-2 text-xs uppercase tracking-wide text-muted-foreground">
-          Journal lines
-        </div>
-        <div className="overflow-x-auto rounded-md border">
-          <table className="w-full text-sm">
-            <thead className="bg-muted/40 text-xs text-muted-foreground">
-              <tr>
-                <th className="px-2 py-1.5 text-left">Account</th>
-                <th className="px-2 py-1.5 text-right">Debit</th>
-                <th className="px-2 py-1.5 text-right">Credit</th>
-              </tr>
-            </thead>
-            <tbody>
-              {data.lines.map((l) => (
-                <tr key={l.id} className="border-t align-top">
-                  <td className="min-w-0 px-2 py-1.5">
-                    <div className="font-medium tabular-nums">{l.account_code}</div>
-                    {l.account_name && (
-                      <div className="text-xs text-muted-foreground">{l.account_name}</div>
-                    )}
-                    {l.memo && (
-                      <div className="break-words text-xs text-muted-foreground">{l.memo}</div>
-                    )}
-                  </td>
-                  <td className="whitespace-nowrap px-2 py-1.5 text-right tabular-nums">
-                    {Number(l.debit) ? RM(Number(l.debit)) : ""}
-                  </td>
-                  <td className="whitespace-nowrap px-2 py-1.5 text-right tabular-nums">
-                    {Number(l.credit) ? RM(Number(l.credit)) : ""}
-                  </td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
-        </div>
-      </section>
-
-      {data.document && (
-        <section className="rounded-md border bg-muted/20 p-3 text-sm">
-          <div className="mb-1 flex items-center gap-1.5 text-xs uppercase tracking-wide text-muted-foreground">
-            <FileText className="h-3.5 w-3.5" /> Source document
-          </div>
-          <div className="truncate">
-            {data.document.source} · {data.document.doc_type}
-          </div>
-          <div className="break-all text-xs text-muted-foreground">{data.document.source_ref}</div>
-        </section>
-      )}
-    </div>
-  );
+// Long bank account names → short entity label via the 4-digit suffix.
+function entityShort(account: string | null): string {
+  if (!account) return "—";
+  const m = account.match(/\((\d{3,4})\)/);
+  const suffix = m ? m[1] : "";
+  const up = account.toUpperCase();
+  const base = up.includes("CONEZION") ? "Conezion" : up.includes("TAMARIND") ? "Tamarind" : "Celsius SB";
+  return suffix ? `${base} · ${suffix}` : base;
 }
 
-type SortKey = "txn_date" | "description" | "outlet" | "txn_type" | "amount" | "status";
+type SortKey = "txnDate" | "description" | "category" | "account" | "amount";
 
-const SELECT_CLASS =
-  "h-8 rounded-md border bg-background px-2 text-xs sm:text-sm shrink-0 max-w-[40vw]";
+const SELECT_CLASS = "h-8 rounded-md border bg-background px-2 text-xs sm:text-sm shrink-0 max-w-[40vw]";
 
 function SortTh({
   label, sortField, sortKey, sortDir, onSort, className = "", align = "left",
 }: {
-  label: string;
-  sortField: SortKey;
-  sortKey: SortKey;
-  sortDir: "asc" | "desc";
-  onSort: (k: SortKey) => void;
-  className?: string;
-  align?: "left" | "right";
+  label: string; sortField: SortKey; sortKey: SortKey; sortDir: "asc" | "desc";
+  onSort: (k: SortKey) => void; className?: string; align?: "left" | "right";
 }) {
   const active = sortKey === sortField;
   return (
@@ -211,115 +74,107 @@ function SortTh({
 }
 
 export default function FinanceLedgerPage() {
-  const [openId, setOpenId] = useState<string | null>(null);
+  const [openLine, setOpenLine] = useState<BankLine | null>(null);
 
-  // Filters (all client-side over the fetched window — instant, Excel-like)
-  const [search, setSearch] = useState("");
-  const [typeF, setTypeF] = useState("");
-  const [statusF, setStatusF] = useState("");
-  const [outletF, setOutletF] = useState("");
-  const [catF, setCatF] = useState("");
+  // Server-windowed date range (blank → API default = last 6 months).
   const [dateFrom, setDateFrom] = useState("");
   const [dateTo, setDateTo] = useState("");
+
+  // Client-side filters.
+  const [search, setSearch] = useState("");
+  const [catF, setCatF] = useState("");
+  const [dirF, setDirF] = useState("");
+  const [entityF, setEntityF] = useState("");
+  const [outletF, setOutletF] = useState("");
   const [amountMin, setAmountMin] = useState("");
   const [amountMax, setAmountMax] = useState("");
 
-  const [sortKey, setSortKey] = useState<SortKey>("txn_date");
+  const [sortKey, setSortKey] = useState<SortKey>("txnDate");
   const [sortDir, setSortDir] = useState<"asc" | "desc">("desc");
 
-  const { data, error, isLoading } = useFetch<{ transactions: Transaction[] }>(
-    "/api/finance/transactions?limit=2000"
-  );
-  const { data: coa } = useFetch<{ accounts: Account[] }>("/api/finance/accounts");
+  const qs = useMemo(() => {
+    const p = new URLSearchParams();
+    if (dateFrom) p.set("from", dateFrom);
+    if (dateTo) p.set("to", dateTo);
+    return p.toString();
+  }, [dateFrom, dateTo]);
 
-  const txns = useMemo(() => data?.transactions ?? [], [data]);
-  const acctName = useMemo(() => {
-    const m = new Map<string, string>();
-    for (const a of coa?.accounts ?? []) m.set(a.code, a.name);
-    return m;
-  }, [coa]);
-  const acctLabel = (code: string) => (acctName.get(code) ? `${code} — ${acctName.get(code)}` : code);
-
-  // Distinct dropdown options derived from the data
-  const typeOptions = useMemo(
-    () => Array.from(new Set(txns.map((t) => t.txn_type))).sort(),
-    [txns]
+  const { data, error, isLoading } = useFetch<{ from: string; to: string | null; lines: BankLine[] }>(
+    `/api/finance/bank-ledger${qs ? `?${qs}` : ""}`
   );
-  const outletOptions = useMemo(() => {
-    const m = new Map<string, string>();
-    for (const t of txns) if (t.outlet) m.set(t.outlet.id, t.outlet.name);
-    return Array.from(m, ([id, name]) => ({ id, name })).sort((a, b) => a.name.localeCompare(b.name));
-  }, [txns]);
-  const hasNoOutlet = useMemo(() => txns.some((t) => !t.outlet_id), [txns]);
+  const lines = useMemo(() => data?.lines ?? [], [data]);
+
   const categoryOptions = useMemo(
-    () => Array.from(new Set(txns.flatMap((t) => t.accounts))).sort(),
-    [txns]
+    () => Array.from(new Set(lines.map((l) => l.category ?? "__null__"))).sort(),
+    [lines]
+  );
+  const entityOptions = useMemo(
+    () => Array.from(new Set(lines.map((l) => entityShort(l.account)))).sort(),
+    [lines]
+  );
+  const outletOptions = useMemo(
+    () => Array.from(new Set(lines.map((l) => l.outlet).filter(Boolean) as string[])).sort(),
+    [lines]
   );
 
   function onSort(k: SortKey) {
     if (sortKey === k) setSortDir((d) => (d === "asc" ? "desc" : "asc"));
-    else { setSortKey(k); setSortDir(k === "amount" || k === "txn_date" ? "desc" : "asc"); }
+    else { setSortKey(k); setSortDir(k === "amount" || k === "txnDate" ? "desc" : "asc"); }
   }
 
   const filtered = useMemo(() => {
     const s = search.trim().toLowerCase();
     const min = parseFloat(amountMin);
     const max = parseFloat(amountMax);
-    let rows = txns.filter((t) => {
+    let rows = lines.filter((l) => {
       if (s) {
-        const hay =
-          t.description.toLowerCase() + " " +
-          t.txn_type.toLowerCase() + " " +
-          (t.outlet?.name?.toLowerCase() ?? "") + " " +
-          (t.posted_by_agent?.toLowerCase() ?? "") + " " +
-          t.accounts.join(" ").toLowerCase() + " " +
-          t.accounts.map((c) => acctName.get(c)?.toLowerCase() ?? "").join(" ");
+        const hay = `${l.description} ${l.reference ?? ""} ${humanCat(l.category)} ${entityShort(l.account)} ${l.outlet ?? ""}`.toLowerCase();
         if (!hay.includes(s)) return false;
       }
-      if (typeF && t.txn_type !== typeF) return false;
-      if (statusF && t.status !== statusF) return false;
-      if (outletF) {
-        if (outletF === "__none__" ? !!t.outlet_id : t.outlet_id !== outletF) return false;
+      if (catF) {
+        if (catF === "__null__" ? l.category != null : l.category !== catF) return false;
       }
-      if (catF && !t.accounts.includes(catF)) return false;
-      if (dateFrom && t.txn_date < dateFrom) return false;
-      if (dateTo && t.txn_date > dateTo) return false;
-      if (!isNaN(min) && Number(t.amount) < min) return false;
-      if (!isNaN(max) && Number(t.amount) > max) return false;
+      if (dirF && l.direction !== dirF) return false;
+      if (entityF && entityShort(l.account) !== entityF) return false;
+      if (outletF) {
+        if (outletF === "__none__" ? !!l.outlet : l.outlet !== outletF) return false;
+      }
+      if (!isNaN(min) && l.amount < min) return false;
+      if (!isNaN(max) && l.amount > max) return false;
       return true;
     });
 
+    const signed = (l: BankLine) => (l.direction === "CR" ? l.amount : -l.amount);
     const dir = sortDir === "asc" ? 1 : -1;
     rows = [...rows].sort((a, b) => {
       let av: string | number;
       let bv: string | number;
       switch (sortKey) {
-        case "amount": av = Number(a.amount); bv = Number(b.amount); break;
-        case "outlet": av = a.outlet?.name ?? ""; bv = b.outlet?.name ?? ""; break;
-        case "txn_date": av = a.txn_date; bv = b.txn_date; break;
-        case "txn_type": av = a.txn_type; bv = b.txn_type; break;
-        case "status": av = a.status; bv = b.status; break;
+        case "amount": av = signed(a); bv = signed(b); break;
+        case "category": av = humanCat(a.category); bv = humanCat(b.category); break;
+        case "account": av = entityShort(a.account); bv = entityShort(b.account); break;
+        case "txnDate": av = a.txnDate; bv = b.txnDate; break;
         default: av = a.description.toLowerCase(); bv = b.description.toLowerCase();
       }
       if (av < bv) return -1 * dir;
       if (av > bv) return 1 * dir;
-      // tiebreak by date desc for stability
-      return a.txn_date < b.txn_date ? 1 : a.txn_date > b.txn_date ? -1 : 0;
+      return a.txnDate < b.txnDate ? 1 : a.txnDate > b.txnDate ? -1 : 0;
     });
     return rows;
-  }, [txns, search, typeF, statusF, outletF, catF, dateFrom, dateTo, amountMin, amountMax, sortKey, sortDir, acctName]);
+  }, [lines, search, catF, dirF, entityF, outletF, amountMin, amountMax, sortKey, sortDir]);
 
-  const filteredTotal = useMemo(
-    () => filtered.reduce((s, t) => s + Number(t.amount), 0),
-    [filtered]
-  );
+  const totals = useMemo(() => {
+    let inn = 0, out = 0;
+    for (const l of filtered) (l.direction === "CR" ? (inn += l.amount) : (out += l.amount));
+    return { inn, out, net: inn - out };
+  }, [filtered]);
 
-  const anyFilter =
-    !!(search || typeF || statusF || outletF || catF || dateFrom || dateTo || amountMin || amountMax);
+  const MAX_RENDER = 500;
+  const rendered = filtered.slice(0, MAX_RENDER);
 
+  const anyFilter = !!(search || catF || dirF || entityF || outletF || amountMin || amountMax);
   function clearFilters() {
-    setSearch(""); setTypeF(""); setStatusF(""); setOutletF(""); setCatF("");
-    setDateFrom(""); setDateTo(""); setAmountMin(""); setAmountMax("");
+    setSearch(""); setCatF(""); setDirF(""); setEntityF(""); setOutletF(""); setAmountMin(""); setAmountMax("");
   }
 
   return (
@@ -327,7 +182,8 @@ export default function FinanceLedgerPage() {
       <header className="min-w-0">
         <h1 className="text-xl sm:text-2xl font-semibold">Ledger</h1>
         <p className="mt-0.5 text-xs sm:text-sm text-muted-foreground">
-          Every journal posted to the ledger by agents and humans. Sort any column; filter like a spreadsheet.
+          Real cash ledger from the bank statements — every deposit and payment, classified. Sort any column; filter like a spreadsheet.
+          {data && <span className="ml-1">Showing from {data.from}{data.to ? ` to ${data.to}` : ""}.</span>}
         </p>
       </header>
 
@@ -339,40 +195,40 @@ export default function FinanceLedgerPage() {
             <input
               value={search}
               onChange={(e) => setSearch(e.target.value)}
-              placeholder="Search description, account, agent…"
+              placeholder="Search description, reference, category…"
               className="h-8 w-full rounded-md border bg-background pl-7 pr-2 text-sm"
             />
           </div>
 
-          <select value={catF} onChange={(e) => setCatF(e.target.value)} className={SELECT_CLASS} title="Category (account)">
+          <select value={catF} onChange={(e) => setCatF(e.target.value)} className={SELECT_CLASS} title="Category">
             <option value="">All categories</option>
             {categoryOptions.map((c) => (
-              <option key={c} value={c}>{acctLabel(c)}</option>
+              <option key={c} value={c}>{c === "__null__" ? "Unclassified" : humanCat(c)}</option>
             ))}
           </select>
 
-          <select value={typeF} onChange={(e) => setTypeF(e.target.value)} className={SELECT_CLASS} title="Type">
-            <option value="">All types</option>
-            {typeOptions.map((t) => (
-              <option key={t} value={t}>{t}</option>
+          <select value={dirF} onChange={(e) => setDirF(e.target.value)} className={SELECT_CLASS} title="Direction">
+            <option value="">In &amp; Out</option>
+            <option value="CR">In (money received)</option>
+            <option value="DR">Out (money paid)</option>
+          </select>
+
+          <select value={entityF} onChange={(e) => setEntityF(e.target.value)} className={SELECT_CLASS} title="Entity (bank account)">
+            <option value="">All entities</option>
+            {entityOptions.map((e) => (
+              <option key={e} value={e}>{e}</option>
             ))}
           </select>
 
-          <select value={statusF} onChange={(e) => setStatusF(e.target.value)} className={SELECT_CLASS} title="Status">
-            <option value="">All statuses</option>
-            <option value="posted">Posted</option>
-            <option value="draft">Draft</option>
-            <option value="exception">Exception</option>
-            <option value="reversed">Reversed</option>
-          </select>
-
-          <select value={outletF} onChange={(e) => setOutletF(e.target.value)} className={SELECT_CLASS} title="Outlet">
-            <option value="">All outlets</option>
-            {outletOptions.map((o) => (
-              <option key={o.id} value={o.id}>{o.name}</option>
-            ))}
-            {hasNoOutlet && <option value="__none__">No outlet</option>}
-          </select>
+          {outletOptions.length > 0 && (
+            <select value={outletF} onChange={(e) => setOutletF(e.target.value)} className={SELECT_CLASS} title="Outlet">
+              <option value="">All outlets</option>
+              {outletOptions.map((o) => (
+                <option key={o} value={o}>{o}</option>
+              ))}
+              <option value="__none__">No outlet</option>
+            </select>
+          )}
         </div>
 
         <div className="flex flex-wrap items-center gap-2 text-xs text-muted-foreground">
@@ -393,8 +249,13 @@ export default function FinanceLedgerPage() {
               <X className="mr-1 h-3 w-3" /> Clear
             </Button>
           )}
-          <span className="ml-auto tabular-nums">
-            {filtered.length} {filtered.length === 1 ? "entry" : "entries"} · {RM(filteredTotal)}
+          <span className="ml-auto flex flex-wrap items-center gap-x-3 tabular-nums">
+            <span>{filtered.length} {filtered.length === 1 ? "line" : "lines"}</span>
+            <span className="text-green-700">In {RM(totals.inn)}</span>
+            <span className="text-red-700">Out {RM(totals.out)}</span>
+            <span className={totals.net >= 0 ? "font-semibold text-green-700" : "font-semibold text-red-700"}>
+              Net {totals.net >= 0 ? "+" : ""}{RM(totals.net)}
+            </span>
           </span>
         </div>
       </div>
@@ -406,71 +267,62 @@ export default function FinanceLedgerPage() {
         </div>
       )}
 
-      {data && txns.length === 0 && (
+      {data && lines.length === 0 && (
         <div className="rounded-lg border border-dashed p-12 text-center text-sm text-muted-foreground">
-          No journals yet. Run the StoreHub EOD ingest to backfill.
+          No bank-statement lines in this range. Upload statements on the Bank Statements page, or widen the date range.
         </div>
       )}
 
-      {data && txns.length > 0 && (
+      {data && lines.length > 0 && (
         <div className="overflow-x-auto rounded-lg border bg-card">
           <table className="w-full text-sm">
             <thead className="bg-muted/40 text-left text-xs uppercase tracking-wide text-muted-foreground">
               <tr>
-                <SortTh label="Date" sortField="txn_date" sortKey={sortKey} sortDir={sortDir} onSort={onSort} className="whitespace-nowrap" />
+                <SortTh label="Date" sortField="txnDate" sortKey={sortKey} sortDir={sortDir} onSort={onSort} className="whitespace-nowrap" />
                 <SortTh label="Description" sortField="description" sortKey={sortKey} sortDir={sortDir} onSort={onSort} />
-                <SortTh label="Outlet" sortField="outlet" sortKey={sortKey} sortDir={sortDir} onSort={onSort} className="whitespace-nowrap hidden md:table-cell" />
-                <SortTh label="Type" sortField="txn_type" sortKey={sortKey} sortDir={sortDir} onSort={onSort} className="whitespace-nowrap hidden lg:table-cell" />
-                <th className="px-3 py-2 whitespace-nowrap hidden lg:table-cell">Agent</th>
+                <SortTh label="Category" sortField="category" sortKey={sortKey} sortDir={sortDir} onSort={onSort} className="whitespace-nowrap hidden sm:table-cell" />
+                <SortTh label="Entity" sortField="account" sortKey={sortKey} sortDir={sortDir} onSort={onSort} className="whitespace-nowrap hidden md:table-cell" />
                 <SortTh label="Amount" sortField="amount" sortKey={sortKey} sortDir={sortDir} onSort={onSort} className="whitespace-nowrap text-right" align="right" />
-                <SortTh label="Status" sortField="status" sortKey={sortKey} sortDir={sortDir} onSort={onSort} className="whitespace-nowrap" />
               </tr>
             </thead>
             <tbody>
-              {filtered.map((t) => (
+              {rendered.map((l) => (
                 <tr
-                  key={t.id}
+                  key={l.id}
                   className="cursor-pointer border-t transition hover:bg-muted/30"
-                  onClick={() => setOpenId(t.id)}
+                  onClick={() => setOpenLine(l)}
                 >
-                  <td className="whitespace-nowrap px-3 py-2 tabular-nums align-top">{t.txn_date}</td>
-                  <td className="max-w-[320px] px-3 py-2">
-                    <div className="truncate">{t.description}</div>
-                    {t.accounts.length > 0 && (
-                      <div
-                        className="truncate text-[11px] text-muted-foreground"
-                        title={t.accounts.map((c) => acctLabel(c)).join(", ")}
-                      >
-                        {t.accounts.join(" · ")}
-                      </div>
-                    )}
+                  <td className="whitespace-nowrap px-3 py-2 tabular-nums align-top">{l.txnDate}</td>
+                  <td className="max-w-[340px] px-3 py-2">
+                    <div className="truncate">{l.description}</div>
+                    <div className="flex items-center gap-1 text-[11px] text-muted-foreground">
+                      {l.reference && <span className="truncate">{l.reference}</span>}
+                      <span className="sm:hidden">· {humanCat(l.category)}</span>
+                      {l.isInterCo && <span className="rounded bg-amber-500/15 px-1 text-amber-700">inter-co</span>}
+                    </div>
                   </td>
-                  <td className="whitespace-nowrap px-3 py-2 hidden md:table-cell align-top">
-                    {t.outlet?.name ?? "—"}
+                  <td className="whitespace-nowrap px-3 py-2 hidden sm:table-cell align-top">
+                    <Badge variant="outline" className="font-normal">{humanCat(l.category)}</Badge>
                   </td>
-                  <td className="whitespace-nowrap px-3 py-2 hidden lg:table-cell text-xs text-muted-foreground align-top">
-                    {t.txn_type}
+                  <td className="whitespace-nowrap px-3 py-2 hidden md:table-cell align-top text-xs text-muted-foreground">
+                    {entityShort(l.account)}
                   </td>
-                  <td className="whitespace-nowrap px-3 py-2 hidden lg:table-cell text-xs align-top">
-                    {t.posted_by_agent}
-                    {t.confidence !== null && (
-                      <span className="ml-1 text-muted-foreground">
-                        ({Math.round(Number(t.confidence) * 100)}%)
-                      </span>
-                    )}
-                  </td>
-                  <td className="whitespace-nowrap px-3 py-2 text-right tabular-nums align-top">
-                    {RM(Number(t.amount))}
-                  </td>
-                  <td className="whitespace-nowrap px-3 py-2 align-top">
-                    <StatusBadge status={t.status} />
+                  <td className={`whitespace-nowrap px-3 py-2 text-right tabular-nums align-top font-medium ${l.direction === "CR" ? "text-green-700" : "text-red-700"}`}>
+                    {l.direction === "CR" ? "+" : "−"}{RM(l.amount)}
                   </td>
                 </tr>
               ))}
+              {filtered.length > MAX_RENDER && (
+                <tr>
+                  <td colSpan={5} className="px-3 py-3 text-center text-xs text-muted-foreground">
+                    Showing first {MAX_RENDER} of {filtered.length.toLocaleString()} lines — narrow with filters or the date range. Totals above reflect all {filtered.length.toLocaleString()}.
+                  </td>
+                </tr>
+              )}
               {filtered.length === 0 && (
                 <tr>
-                  <td colSpan={7} className="px-3 py-10 text-center text-sm text-muted-foreground">
-                    No entries match your filters.
+                  <td colSpan={5} className="px-3 py-10 text-center text-sm text-muted-foreground">
+                    No lines match your filters.
                   </td>
                 </tr>
               )}
@@ -479,12 +331,60 @@ export default function FinanceLedgerPage() {
         </div>
       )}
 
-      <Sheet open={!!openId} onOpenChange={(o) => !o && setOpenId(null)}>
-        <SheetContent side="right" className="w-full sm:max-w-xl overflow-hidden flex flex-col gap-0 p-0">
+      <Sheet open={!!openLine} onOpenChange={(o) => !o && setOpenLine(null)}>
+        <SheetContent side="right" className="w-full sm:max-w-md overflow-hidden flex flex-col gap-0 p-0">
           <SheetHeader className="border-b px-6 py-4">
-            <SheetTitle>Transaction</SheetTitle>
+            <SheetTitle>Bank transaction</SheetTitle>
           </SheetHeader>
-          {openId && <DrawerContent id={openId} />}
+          {openLine && (
+            <div className="space-y-5 overflow-y-auto p-6 text-sm">
+              <section className="space-y-1">
+                <div className="text-xs uppercase tracking-wide text-muted-foreground">Description</div>
+                <div className="break-words">{openLine.description}</div>
+                {openLine.reference && (
+                  <div className="break-all text-xs text-muted-foreground">Ref: {openLine.reference}</div>
+                )}
+              </section>
+              <section className="grid grid-cols-2 gap-3">
+                <div>
+                  <div className="text-xs uppercase tracking-wide text-muted-foreground">Date</div>
+                  <div className="tabular-nums">{openLine.txnDate}</div>
+                </div>
+                <div>
+                  <div className="text-xs uppercase tracking-wide text-muted-foreground">Amount</div>
+                  <div className={`font-medium tabular-nums ${openLine.direction === "CR" ? "text-green-700" : "text-red-700"}`}>
+                    {openLine.direction === "CR" ? "+" : "−"}{RM(openLine.amount)} ({openLine.direction === "CR" ? "in" : "out"})
+                  </div>
+                </div>
+                <div>
+                  <div className="text-xs uppercase tracking-wide text-muted-foreground">Category</div>
+                  <Badge variant="outline" className="font-normal">{humanCat(openLine.category)}</Badge>
+                </div>
+                <div>
+                  <div className="text-xs uppercase tracking-wide text-muted-foreground">Entity</div>
+                  <div className="flex items-center gap-1"><Building2 className="h-3.5 w-3.5 shrink-0" />{entityShort(openLine.account)}</div>
+                </div>
+                {openLine.outlet && (
+                  <div>
+                    <div className="text-xs uppercase tracking-wide text-muted-foreground">Outlet</div>
+                    <div>{openLine.outlet}</div>
+                  </div>
+                )}
+                {openLine.isInterCo && (
+                  <div>
+                    <div className="text-xs uppercase tracking-wide text-muted-foreground">Inter-company</div>
+                    <div className="text-amber-700">Yes</div>
+                  </div>
+                )}
+              </section>
+              {(openLine.classifiedBy || openLine.ruleName) && (
+                <section className="rounded-md border bg-muted/20 p-3 text-xs text-muted-foreground">
+                  Classified by {openLine.classifiedBy ?? "—"}
+                  {openLine.ruleName && <> · rule <span className="font-mono">{openLine.ruleName}</span></>}
+                </section>
+              )}
+            </div>
+          )}
         </SheetContent>
       </Sheet>
     </div>

--- a/apps/backoffice/src/app/api/finance/bank-ledger/route.ts
+++ b/apps/backoffice/src/app/api/finance/bank-ledger/route.ts
@@ -1,0 +1,68 @@
+// GET /api/finance/bank-ledger?from=YYYY-MM-DD&to=YYYY-MM-DD
+// The REAL cash ledger — individual classified bank-statement lines across all
+// entities. Powers the /finance Ledger page. Date-windowed server-side (default
+// last 6 months); everything else is filtered/sorted client-side.
+
+import { NextRequest, NextResponse } from "next/server";
+import { requireAuth } from "@/lib/auth";
+import { prisma } from "@/lib/prisma";
+
+export const dynamic = "force-dynamic";
+export const maxDuration = 30;
+
+export async function GET(req: NextRequest) {
+  const auth = await requireAuth(req);
+  if (auth.error) return auth.error;
+  if (!["OWNER", "ADMIN"].includes(auth.user.role)) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+
+  const url = new URL(req.url);
+  const from = url.searchParams.get("from");
+  const to = url.searchParams.get("to");
+
+  // Default window: last 3 months (keeps the payload sane; widen via from/to).
+  const defFrom = new Date();
+  defFrom.setMonth(defFrom.getMonth() - 3);
+  const gte = from ? new Date(`${from}T00:00:00.000Z`) : defFrom;
+  const lte = to ? new Date(`${to}T23:59:59.999Z`) : undefined;
+
+  const rows = await prisma.bankStatementLine.findMany({
+    where: { txnDate: lte ? { gte, lte } : { gte } },
+    select: {
+      id: true,
+      txnDate: true,
+      description: true,
+      reference: true,
+      amount: true,
+      direction: true,
+      category: true,
+      isInterCo: true,
+      classifiedBy: true,
+      ruleName: true,
+      outlet: { select: { name: true } },
+      statement: { select: { accountName: true, statementDate: true } },
+    },
+    orderBy: [{ txnDate: "desc" }, { id: "desc" }],
+    take: 20000,
+  });
+
+  return NextResponse.json({
+    from: (from ? gte : defFrom).toISOString().slice(0, 10),
+    to: to ?? null,
+    lines: rows.map((l) => ({
+      id: l.id,
+      txnDate: l.txnDate.toISOString().slice(0, 10),
+      description: l.description,
+      reference: l.reference,
+      amount: Number(l.amount),
+      direction: l.direction, // CR (in) | DR (out)
+      category: l.category,   // CashCategory | null
+      isInterCo: l.isInterCo,
+      classifiedBy: l.classifiedBy,
+      ruleName: l.ruleName,
+      outlet: l.outlet?.name ?? null,
+      account: l.statement?.accountName ?? null,
+    })),
+  });
+}


### PR DESCRIPTION
The **Ledger** tab now shows the real cash ledger — actual classified **bank-statement lines** (every deposit/payment across the entities) — instead of the synthetic AR EOD sales journals.

- New `/api/finance/bank-ledger`: flat `BankStatementLine` feed, date-windowed server-side (default last 3 months), joined to entity (account) + outlet.
- Excel-style UX fitted to bank data: search; **Category** filter (the CashCategory classification); **Direction** (in/out); **Entity**; **Outlet**; date range; amount range; sortable columns (date/description/category/entity/amount).
- Live **In / Out / Net** totals over the full filtered set; first 500 rows rendered for performance (note shown when truncated; ~18k lines exist over 6 months).
- Per-line detail drawer (description, reference, category, entity, outlet, inter-co flag, classification rule).

Verified against live data (e.g. 2026-05-31 QR/Card sales in, per entity). `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)