### PR TITLE
fix(finance): home reads real data + honest BS/CF banner + cashflow footnotes

### DIFF
--- a/apps/backoffice/src/app/(admin)/finance/monthly-cashflow/page.tsx
+++ b/apps/backoffice/src/app/(admin)/finance/monthly-cashflow/page.tsx
@@ -90,7 +90,7 @@ export default function MonthlyCashflowPage() {
           </Link>
           <h2 className="mt-1 text-lg sm:text-xl font-semibold text-gray-900">Monthly Cash Flow</h2>
           <p className="mt-0.5 text-xs sm:text-sm text-gray-500">
-            Consolidated net cash flow from Maybank statements, net of inter-company transfers. Group bank balance is the sum of each entity&rsquo;s month-end balance.
+            Consolidated net cash flow from Maybank statements (gross — includes inter-company transfers between entities, matching the cash-tracking spreadsheet). Group bank balance is the sum of each entity&rsquo;s month-end balance.
           </p>
         </div>
         <div className="flex flex-wrap items-center gap-2">
@@ -204,7 +204,7 @@ export default function MonthlyCashflowPage() {
           </div>
 
           <p className="mt-2 text-[11px] text-gray-400">
-            Inflow/outflow are net of inter-company transfers. Where an account-month has both an early spreadsheet upload and the PDF import, the richer (PDF) statement is used so totals never double-count.
+            Inflow/outflow include inter-company transfers between entities (gross). Where an account-month has both an early spreadsheet upload and the PDF import, the richer (PDF) statement is used so totals never double-count.
           </p>
         </>
       )}

--- a/apps/backoffice/src/app/(admin)/finance/reports/page.tsx
+++ b/apps/backoffice/src/app/(admin)/finance/reports/page.tsx
@@ -533,7 +533,7 @@ export default function FinanceReportsPage() {
       <header>
         <h1 className="text-xl sm:text-2xl font-semibold">Reports</h1>
         <p className="mt-0.5 text-xs sm:text-sm text-muted-foreground">
-          P&L, Balance Sheet, and Cash Flow — generated live from the ledger.
+          P&L is source-driven (sales, procurement, ads, bank). Balance Sheet &amp; Cash Flow are ledger-based and fill in as journals post.
         </p>
       </header>
 
@@ -559,6 +559,13 @@ export default function FinanceReportsPage() {
           ))}
         </div>
       </nav>
+
+      {(tab === "bs" || tab === "cf") && (
+        <div className="rounded-lg border border-amber-500/40 bg-amber-500/5 p-3 text-xs sm:text-sm text-amber-700 dark:text-amber-400">
+          <span className="font-medium">Ledger-based — currently incomplete.</span>{" "}
+          This {tab === "bs" ? "Balance Sheet" : "Cash Flow"} is built from <em>posted</em> journals, but historical journals aren&rsquo;t fully posted yet (AR is still in draft). Treat it as indicative. For accurate figures use the <strong>P&amp;L</strong> (source-driven), the <strong>Cashflow</strong> page (bank actuals), and the <strong>Ledger</strong> (real bank lines).
+        </div>
+      )}
 
       {tab === "pnl" && <PnlTab />}
       {tab === "bs" && <BsTab />}

--- a/apps/backoffice/src/app/api/finance/home/route.ts
+++ b/apps/backoffice/src/app/api/finance/home/route.ts
@@ -7,6 +7,16 @@ import { NextRequest, NextResponse } from "next/server";
 import { requireAuth } from "@/lib/auth";
 import { getFinanceClient } from "@/lib/finance/supabase";
 import { getActiveCompanyId } from "@/lib/finance/companies";
+import { prisma } from "@/lib/prisma";
+
+// Each company's Maybank current account, identified by the 4-digit suffix in
+// BankStatement.accountName. Cash position reads the latest statement's closing
+// balance — the ledger's 1000-* balances are unreliable until journals post.
+const BANK_ACCOUNT_SUFFIX: Record<string, string> = {
+  celsius: "4384",
+  celsiusconezion: "2644",
+  celsiustamarind: "9345",
+};
 
 export const dynamic = "force-dynamic";
 
@@ -47,8 +57,8 @@ export async function GET(req: NextRequest) {
     .eq("company_id", companyId)
     .gte("txn_date", yesterday)
     .lte("txn_date", today)
-    .eq("status", "posted")
-    .order("posted_at", { ascending: false })
+    .in("status", ["posted", "draft"])
+    .order("txn_date", { ascending: false })
     .limit(20);
 
   // Open exceptions count by priority.
@@ -80,7 +90,7 @@ export async function GET(req: NextRequest) {
       .in("id", txnIds);
     const validTxnIds = new Set(
       (txns ?? [])
-        .filter((t) => t.status === "posted" && t.txn_date >= mtdStart && t.company_id === companyId)
+        .filter((t) => (t.status === "posted" || t.status === "draft") && t.txn_date >= mtdStart && t.company_id === companyId)
         .map((t) => t.id)
     );
     for (const l of mtdLines) {
@@ -89,37 +99,25 @@ export async function GET(req: NextRequest) {
     }
   }
 
-  // Cash position per bank account: sum of (debit - credit) on 1000-* codes.
-  const { data: bankLines } = await client
-    .from("fin_journal_lines")
-    .select("account_code, debit, credit, transaction_id")
-    .like("account_code", "1000%");
-
-  const cashByAccount: Record<string, number> = {};
-  if (bankLines && bankLines.length) {
-    const txnIds = Array.from(new Set(bankLines.map((l) => l.transaction_id)));
-    const { data: txns } = await client
-      .from("fin_transactions")
-      .select("id, status, company_id")
-      .in("id", txnIds);
-    const valid = new Set(
-      (txns ?? [])
-        .filter((t) => t.status === "posted" && t.company_id === companyId)
-        .map((t) => t.id)
-    );
-    for (const l of bankLines) {
-      if (!valid.has(l.transaction_id)) continue;
-      const code = l.account_code as string;
-      cashByAccount[code] = (cashByAccount[code] ?? 0) + Number(l.debit) - Number(l.credit);
+  // Cash position — latest bank-statement closing balance for this company's
+  // account. (Reads the bank directly; the ledger's 1000-* balances are
+  // unreliable until journals actually post.)
+  const suffix = BANK_ACCOUNT_SUFFIX[companyId];
+  const cashPosition: { code: string; name: string; balance: number }[] = [];
+  if (suffix) {
+    const stmt = await prisma.bankStatement.findFirst({
+      where: { accountName: { contains: suffix } },
+      orderBy: { statementDate: "desc" },
+      select: { accountName: true, closingBalance: true, statementDate: true },
+    });
+    if (stmt) {
+      cashPosition.push({
+        code: suffix,
+        name: `${stmt.accountName ?? "Bank"} · as of ${stmt.statementDate.toISOString().slice(0, 10)}`,
+        balance: Number(stmt.closingBalance),
+      });
     }
   }
-
-  // Account names for cash card display.
-  const codes = Object.keys(cashByAccount);
-  const { data: accounts } = codes.length
-    ? await client.from("fin_accounts").select("code, name").in("code", codes)
-    : { data: [] as { code: string; name: string }[] };
-  const accountNames = new Map((accounts ?? []).map((a) => [a.code, a.name]));
 
   // Today's agent activity counts for the activity feed header.
   const { data: agentActivity } = await client
@@ -128,7 +126,7 @@ export async function GET(req: NextRequest) {
     .eq("company_id", companyId)
     .gte("txn_date", yesterday)
     .lte("txn_date", today)
-    .eq("status", "posted");
+    .in("status", ["posted", "draft"]);
 
   const activityByAgent: Record<string, { count: number; amount: number }> = {};
   for (const r of agentActivity ?? []) {
@@ -142,13 +140,7 @@ export async function GET(req: NextRequest) {
     asOf: new Date().toISOString(),
     mtd: { start: mtdStart, revenue: Math.round(mtdRevenue * 100) / 100 },
     exceptions: exceptionCount,
-    cashPosition: codes
-      .map((code) => ({
-        code,
-        name: accountNames.get(code) ?? code,
-        balance: Math.round(cashByAccount[code] * 100) / 100,
-      }))
-      .sort((a, b) => b.balance - a.balance),
+    cashPosition,
     agentActivity: Object.entries(activityByAgent).map(([agent, v]) => ({
       agent,
       count: v.count,


### PR DESCRIPTION
Fixes the finance pages that were reading the near-empty `posted` ledger (same root cause as the P&L).

**Home (`/api/finance/home`)**
- **Revenue MTD** now includes **draft** AR (real net sales), not just posted journals.
- **Cash position** now reads the latest **BankStatement closing balance** for the company's account, not the ledger's 1000-* lines.
- Recent posts + agent activity include drafts (the real AR activity).

**Reports**
- Balance Sheet & Cash Flow stay ledger-based (a correctly-sourced Balance Sheet isn't possible until journals post) but now show a clear **"ledger-based — incomplete until journals post"** banner so they're not mistaken for accurate. Subtitle clarifies the P&L is source-driven.

**Monthly cashflow** — footnotes corrected: figures are **gross / include inter-company** (not net).

**Data (already applied, separate from this code):** re-synced 25 statements' `interCoInflows/Outflows` headers to the corrected line-level flags, fixing cash-tracking's inflated "Uncategorized" residual.

`tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)