### PR TITLE
test(finance): vitest harness + classifier tests; tighten inter-co fallback

### DIFF
--- a/apps/backoffice/package.json
+++ b/apps/backoffice/package.json
@@ -8,7 +8,9 @@
     "build": "prisma generate --schema=../../packages/db/prisma/schema.prisma && next build",
     "start": "next start",
     "lint": "eslint",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run",
+    "test:watch": "vitest"
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.87.0",

--- a/apps/backoffice/src/lib/finance/bank-line-classifier.test.ts
+++ b/apps/backoffice/src/lib/finance/bank-line-classifier.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect } from "vitest";
+import { classifyBankLine } from "./bank-line-classifier";
+
+const cr = (description: string, amount = 100) =>
+  classifyBankLine({ description, amount, direction: "CR" });
+const dr = (description: string, amount = 100) =>
+  classifyBankLine({ description, amount, direction: "DR" });
+
+describe("bank-line-classifier", () => {
+  it("maps sales inflows to their channel", () => {
+    expect(cr("TRANSFER TO A/C JOHN DOE DUITNOW QR-").category).toBe("QR");
+    expect(cr("DR/CARD SALES M/N 2612988 D 5").category).toBe("CARD");
+    expect(cr("IBG GPAY NETWORK SDN BHD").category).toBe("GRAB");
+    expect(cr("TRANSFER FR A/C GYRO GASTRO SDN. BH vendor").category).toBe("GASTROHUB");
+    expect(cr("INTERBANK GIRO STOREHUB SDN BHD").category).toBe("STOREHUB");
+  });
+
+  it("flags ANY inter-entity transfer as inter-company, regardless of purpose", () => {
+    expect(dr("TRANSFER TO A/C CELSIUS COFFEE TAMA Loan").isInterCo).toBe(true);
+    expect(cr("TRANSFER FR A/C CELSIUS COFFEE SDN. Payback loan").isInterCo).toBe(true);
+    expect(dr("TRANSFER FR A/C CELSIUS COFFEE CONEZION Inventory").isInterCo).toBe(true);
+    // purpose category is still set even though it's inter-co
+    expect(dr("TRANSFER FR A/C CELSIUS COFFEE SDN. Digital Ads").category).toBe("DIGITAL_ADS");
+  });
+
+  it("does NOT flag a line that only mentions Celsius outside the counterparty slot", () => {
+    // account-holder / reference mention, not a transfer TO/FR a Celsius A/C
+    expect(dr("ESI PAYMENT DEBIT CELSIUS COFFEE SDN. WME00000").isInterCo).toBe(false);
+    expect(dr("TRANSFER FR A/C 365EAT FOOD SDN BHD INV CELSIUS").isInterCo).toBe(false);
+  });
+
+  it("classifies the reclassified OTHER_OUTFLOW vendors", () => {
+    expect(dr("TRANSFER FR A/C COUNTRY BREAD BAKER INV-001").category).toBe("RAW_MATERIALS");
+    expect(dr("TRANSFER FR A/C BEARD BROTHERS MEAT INV250").category).toBe("RAW_MATERIALS");
+    expect(dr("TRANSFER FR A/C UNIQUE PAPER SDN. B INU-25").category).toBe("RAW_MATERIALS");
+    expect(dr("TRANSFER FR A/C BESPOKE INTERIOR SD INV011").category).toBe("INVESTMENTS");
+    expect(dr("TRANSFER FR A/C KIAN CONTRACT SDN B Furniture").category).toBe("EQUIPMENTS");
+    expect(dr("TRANSFER FR A/C NURFARAH QURAISYA B SCC Week 36").category).toBe("EMPLOYEE_SALARY");
+  });
+
+  it("maps statutory + known opex vendors", () => {
+    expect(dr("M2UBEPF KWSP PAYMENT").category).toBe("STATUTORY_PAYMENT");
+    expect(dr("PAYMENT TO TNB TENAGA NASIONAL").category).toBe("UTILITIES");
+    expect(dr("TRANSFER FR A/C TUJUAN GEMILANG rent").category).toBe("RENT");
+  });
+
+  it("falls back to OTHER_* for genuinely unknown lines", () => {
+    expect(dr("TRANSFER FR A/C SOME UNKNOWN VENDOR XYZ").category).toBe("OTHER_OUTFLOW");
+    expect(cr("MISC CREDIT NO PATTERN").category).toBe("OTHER_INFLOW");
+    expect(dr("TRANSFER FR A/C SOME UNKNOWN VENDOR XYZ").isInterCo).toBe(false);
+  });
+});

--- a/apps/backoffice/src/lib/finance/bank-line-classifier.ts
+++ b/apps/backoffice/src/lib/finance/bank-line-classifier.ts
@@ -243,7 +243,7 @@ const OUTFLOW_RULES: Rule[] = [
   // exists. These are bona-fide internal transfers and net to zero
   // across consolidation, so flagging isInterCo=true keeps them out
   // of cash-burn totals.
-  { name: "interco_celsius_entity_fallback", match: /\bCELSIUS\s*COFFEE\s+(SDN|CONEZION|TAMARIND|CONE|TAMA)\b/i, direction: "DR", category: "INTERCO_PEOPLE" as CashCategory, isInterCo: true },
+  { name: "interco_celsius_entity_fallback", match: /TRANSFER (TO|FR) A\/C CELSIUS\s?COFFEE\s+(SDN|CONEZION|TAMARIND|CONE|TAMA)/i, direction: "DR", category: "INTERCO_PEOPLE" as CashCategory, isInterCo: true },
 ];
 
 // InterCo override: any transfer whose COUNTERPARTY (the name right after

--- a/apps/backoffice/vitest.config.ts
+++ b/apps/backoffice/vitest.config.ts
@@ -1,0 +1,18 @@
+import { defineConfig } from "vitest/config";
+import { fileURLToPath } from "node:url";
+import path from "node:path";
+
+const dir = path.dirname(fileURLToPath(import.meta.url));
+
+// Unit tests for pure finance logic (parsers, classifiers, report math).
+// Node environment; no Next/CSS pipeline needed. The `@/` alias mirrors
+// tsconfig so modules that use it resolve under test.
+export default defineConfig({
+  test: {
+    include: ["src/**/*.test.ts"],
+    environment: "node",
+  },
+  resolve: {
+    alias: { "@": path.resolve(dir, "src") },
+  },
+});


### PR DESCRIPTION
Stands up the **test safety net** flagged in the cutover audit (the backoffice had zero runnable tests on a financial system).

- Wires up vitest (config + `npm test`; vitest@4 already at the workspace root), so the existing **Maybank parser test (8 cases)** now actually runs.
- Adds **bank-line-classifier tests**: channel mapping, counterparty inter-co flagging, false-positive guard, the reclassified vendors, and fallbacks. **14 tests green.**

**A test caught a real bug:** the broad `interco_celsius_entity_fallback` rule flagged DR lines that merely reference "Celsius Coffee SDN" as the *account holder* (e.g. ESI statutory payments) as inter-company — wrongly hiding them from external-cash views. Tightened to the counterparty position (`TRANSFER TO/FR A/C …`).

**Data (already applied):** 34 such false-positive lines un-flagged + recategorized to OTHER_OUTFLOW; statement inter-co headers re-synced → inter-co is now **360 genuine lines** (was 394).

`tsc --noEmit` clean · `npm test` 14/14 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)