### PR TITLE
fix(order): card/QR orders settle in seconds + show table number in backoffice

### DIFF
--- a/apps/backoffice/src/app/(admin)/pickup/orders/[id]/page.tsx
+++ b/apps/backoffice/src/app/(admin)/pickup/orders/[id]/page.tsx
@@ -149,6 +149,11 @@ export default function OrderDetailPage({ params }: { params: Promise<{ id: stri
       <div className="bg-white rounded-2xl p-4 space-y-2">
         <h2 className="font-bold text-sm mb-3">Pickup Details</h2>
         <Row label="Outlet"  value={order.store_id.replace(/-/g, " ").replace(/\b\w/g, (c) => c.toUpperCase())} />
+        {order.order_type === "dine_in" ? (
+          <Row label="Table" value={order.table_number ? `Dine-in · Table ${order.table_number}` : "Dine-in"} />
+        ) : order.order_type ? (
+          <Row label="Type" value={order.order_type.replace(/_/g, " ").replace(/\b\w/g, (c) => c.toUpperCase())} />
+        ) : null}
         <Row label="Payment" value={order.payment_method.replace(/_/g, " ").toUpperCase()} />
         {order.payment_provider_ref && (
           <Row label="Ref" value={order.payment_provider_ref} mono />

--- a/apps/backoffice/src/app/(admin)/pickup/orders/page.tsx
+++ b/apps/backoffice/src/app/(admin)/pickup/orders/page.tsx
@@ -235,7 +235,12 @@ export default function PickupOrders() {
                   "flex flex-col md:grid md:grid-cols-[1fr_1.1fr_0.9fr_0.7fr_0.9fr_0.7fr_0.8fr_40px] gap-1 md:gap-3 items-start md:items-center px-5 py-3.5 transition-colors hover:bg-muted/20";
                 const content = (
                   <>
-                    <span className="font-semibold text-sm">#{order.order_number}</span>
+                    <span className="font-semibold text-sm">
+                      #{order.order_number}
+                      {order.order_type === "dine_in" && order.table_number && (
+                        <span className="ml-2 text-[11px] font-medium text-teal-700">Table {order.table_number}</span>
+                      )}
+                    </span>
                     <span className="text-sm text-muted-foreground truncate">
                       {order.customer_name ?? "—"}{order.customer_phone ? ` · ${order.customer_phone}` : ""}
                     </span>

--- a/apps/backoffice/src/app/api/pickup/orders/[id]/route.ts
+++ b/apps/backoffice/src/app/api/pickup/orders/[id]/route.ts
@@ -42,6 +42,7 @@ export async function GET(
         .select("*")
         .eq("order_id", id);
       if (iErr) return NextResponse.json({ error: iErr.message }, { status: 500 });
+      // order is select("*") so order_type/table_number already ride along.
       return NextResponse.json({ order: { ...order, channel: "pickup" }, items: items ?? [] });
     }
 
@@ -49,7 +50,7 @@ export async function GET(
     const { data: pos, error: pErr } = await supabase
       .from("pos_orders")
       .select(
-        "id, order_number, outlet_id, source, order_type, status, customer_name, customer_phone, subtotal, discount_amount, sst_amount, service_charge, total, notes, created_at",
+        "id, order_number, outlet_id, source, order_type, table_number, status, customer_name, customer_phone, subtotal, discount_amount, sst_amount, service_charge, total, notes, created_at",
       )
       .eq("id", id)
       .maybeSingle();
@@ -68,6 +69,8 @@ export async function GET(
       order_number: pos.order_number,
       store_id: OUTLET_ID_TO_SLUG[pos.outlet_id as string] ?? pos.outlet_id,
       status: pos.status,
+      order_type: pos.order_type ?? null,
+      table_number: pos.table_number ?? null,
       payment_method: "",
       payment_provider_ref: null,
       subtotal: pos.subtotal ?? 0,

--- a/apps/backoffice/src/app/api/pickup/orders/route.ts
+++ b/apps/backoffice/src/app/api/pickup/orders/route.ts
@@ -106,7 +106,7 @@ export async function GET(request: NextRequest) {
           let q = supabase
             .from("pos_orders")
             .select(
-              "id, order_number, outlet_id, source, order_type, status, customer_name, customer_phone, subtotal, discount_amount, sst_amount, service_charge, total, notes, created_at, pos_order_items(product_name, quantity, item_total)",
+              "id, order_number, outlet_id, source, order_type, table_number, status, customer_name, customer_phone, subtotal, discount_amount, sst_amount, service_charge, total, notes, created_at, pos_order_items(product_name, quantity, item_total)",
             )
             .order("created_at", { ascending: false })
             .limit(limit);
@@ -128,6 +128,8 @@ export async function GET(request: NextRequest) {
               order_number: o.order_number,
               store_id: OUTLET_ID_TO_SLUG[oid] ?? oid,
               status: o.status,
+              order_type: o.order_type ?? null,
+              table_number: o.table_number ?? null,
               payment_method: "",
               payment_provider_ref: null,
               subtotal: o.subtotal ?? 0,

--- a/apps/backoffice/src/lib/pickup/types.ts
+++ b/apps/backoffice/src/lib/pickup/types.ts
@@ -26,6 +26,11 @@ export interface OrderRow {
   total: number;
   customer_name: string | null;
   customer_phone: string | null;
+  /** "dine_in" (QR table order) | "pickup" / "takeaway". Optional so older
+   *  reads stay valid; absence is treated as a non-dine-in order. */
+  order_type: string | null;
+  /** Set for dine_in orders — the table the QR was scanned at. */
+  table_number: string | null;
   loyalty_phone: string | null;
   loyalty_id: string | null;
   loyalty_points_earned: number;

--- a/apps/order/src/app/api/cron/reconcile-pending/route.ts
+++ b/apps/order/src/app/api/cron/reconcile-pending/route.ts
@@ -8,10 +8,13 @@ import { checkCronAuth } from "@celsius/shared";
 import { queryCheckoutStatus } from "@/lib/revenue-monster/client";
 import { markRmOrderPaid, markRmOrderFailed } from "@/lib/revenue-monster/order-status";
 
-// Runs every minute. Finds "pending" orders between 2 and 55 minutes old and
-// reconciles them against Stripe — covers wallet cancels where confirm-stripe
-// and the Stripe webhook both never fired. Older rows are left to
-// /api/cron/expire-orders, which fails them at the 60-minute mark.
+// Finds "pending" orders between 45s and 55 minutes old and reconciles them
+// against Stripe (and Revenue Monster) — covers wallet/card confirms where the
+// gateway webhook never fired. The 45s floor (was 2 min) is the safety net for
+// customers who close the app/browser before the on-screen poll
+// (_OrderTrackingView / pickup-native) settles the order; both the cron and the
+// poll are idempotent (gated on status=pending), so they can't double-process.
+// Older rows are left to /api/cron/expire-orders, which fails them at 60 min.
 
 function getStripe() {
   const key = process.env.STRIPE_SECRET_KEY?.trim();
@@ -43,7 +46,7 @@ export async function GET(request: NextRequest) {
 
   const supabase = getSupabaseAdmin();
   const now      = Date.now();
-  const olderThan  = new Date(now - 2  * 60 * 1000).toISOString();
+  const olderThan  = new Date(now - 45 * 1000).toISOString();
   const youngerThan = new Date(now - 55 * 60 * 1000).toISOString();
 
   const { data: pending, error } = await supabase

--- a/apps/order/src/app/api/payments/poll/route.ts
+++ b/apps/order/src/app/api/payments/poll/route.ts
@@ -1,84 +1,23 @@
 import { NextRequest, NextResponse } from "next/server";
-import { after } from "next/server";
-import { getSupabaseAdmin } from "@/lib/supabase/server";
-import { queryCheckoutStatus } from "@/lib/revenue-monster/client";
-import { markRmOrderPaid, markRmOrderFailed } from "@/lib/revenue-monster/order-status";
-import { notifyOrderPreparing } from "@/lib/push/templates";
+import { reconcileRmOrder } from "@/lib/revenue-monster/reconcile";
 
 /**
- * Poll RM's Query Payment Checkout for a given order and reconcile.
+ * Ask RM directly whether an order's checkout has settled, and reconcile.
  *
- * Why: in Direct Payment Checkout mode RM treats webhook delivery as
- * best-effort and explicitly tells integrators to poll. Right now the
- * native order detail screen has a 5s React Query poll on /api/orders/[id]
- * but if the webhook is dropped (or fails signature verification, which
- * has been happening) the order is stuck pending forever even though RM
- * has the money. This endpoint asks RM directly and updates the row when
- * RM says SUCCESS / FAILED.
+ * RM Direct mode treats webhook delivery as best-effort and tells
+ * integrators to poll. The order screens (web _OrderTrackingView +
+ * pickup-native) hit this every few seconds while a pending RM order is
+ * open, so a dropped/sig-failed webhook still settles in seconds.
  *
- * No-op if the order is already in a non-pending state (idempotent).
+ * Thin wrapper over the shared reconcileRmOrder() — the single source of
+ * truth used by the webhook, the ?payment=done redirect, this poll, and
+ * the cron. Idempotent + never throws.
  */
 export async function POST(request: NextRequest) {
-  try {
-    const { orderId } = (await request.json()) as { orderId?: string };
-    if (!orderId) {
-      return NextResponse.json({ error: "Missing orderId" }, { status: 400 });
-    }
-
-    const supabase = getSupabaseAdmin();
-    const { data: order, error } = await supabase
-      .from("orders")
-      .select("id, status, payment_checkout_id, payment_method")
-      .eq("id", orderId)
-      .single<{
-        id: string;
-        status: string;
-        payment_checkout_id: string | null;
-        payment_method: string | null;
-      }>();
-
-    if (error || !order) {
-      return NextResponse.json({ error: "Order not found" }, { status: 404 });
-    }
-    // Already settled — nothing to do.
-    if (order.status !== "pending") {
-      return NextResponse.json({ status: order.status, source: "db" });
-    }
-    if (!order.payment_checkout_id) {
-      // Pre-poll orders or non-RM orders don't have a checkoutId stashed.
-      // Caller can fall back to the standard order screen flow.
-      return NextResponse.json({ status: "pending", source: "no_checkout_id" });
-    }
-
-    const result = await queryCheckoutStatus(order.payment_checkout_id);
-    if (result.status === "SUCCESS") {
-      const paid = await markRmOrderPaid({ orderId: order.id }, result.transactionId);
-      if (paid && !paid.scheduled) {
-        // Suppress for scheduled orders — promote-scheduled fires
-        // the push at brew-window-open time. See the equivalent
-        // suppression in the RM webhook handler.
-        after(async () => {
-          await notifyOrderPreparing({
-            orderId:       paid.orderId,
-            orderNumber:   paid.orderNumber,
-            customerPhone: paid.customerPhone,
-          }).catch((e) => console.warn("[push] order_preparing rm poll", e));
-        });
-      }
-      return NextResponse.json({
-        status: paid?.scheduled ? "paid" : "preparing",
-        source: "rm",
-        transactionId: result.transactionId,
-      });
-    }
-    if (result.status === "FAILED" || result.status === "EXPIRED" || result.status === "CANCELLED") {
-      await markRmOrderFailed({ orderId: order.id });
-      return NextResponse.json({ status: "failed", source: "rm", rmStatus: result.status });
-    }
-    return NextResponse.json({ status: "pending", source: "rm", rmStatus: result.status });
-  } catch (err) {
-    const msg = err instanceof Error ? err.message : "Poll failed";
-    console.error("RM poll error:", err);
-    return NextResponse.json({ error: msg }, { status: 500 });
+  const { orderId } = (await request.json().catch(() => ({}))) as { orderId?: string };
+  if (!orderId) {
+    return NextResponse.json({ error: "Missing orderId" }, { status: 400 });
   }
+  const result = await reconcileRmOrder({ orderId });
+  return NextResponse.json(result);
 }

--- a/apps/order/src/app/api/payments/webhook/route.ts
+++ b/apps/order/src/app/api/payments/webhook/route.ts
@@ -1,26 +1,26 @@
 import { NextRequest, NextResponse } from "next/server";
-import { after } from "next/server";
 import { validateWebhookSignature } from "@/lib/revenue-monster/client";
-import { markRmOrderPaid, markRmOrderFailed } from "@/lib/revenue-monster/order-status";
-import { notifyOrderPreparing } from "@/lib/push/templates";
+import { reconcileRmOrder } from "@/lib/revenue-monster/reconcile";
 
 /**
  * Revenue Monster webhook (FPX, ewallet, card-via-RM).
  *
- * Mirrors the Stripe webhook at /api/payments/stripe/webhook. Both
- * endpoints land on confirmed-payment events and use the direct-
- * Supabase loyalty helpers in lib/loyalty/points.ts to:
- *   • earn points for the order (via earnLoyaltyPoints)
- *   • burn the redeemed reward, if any (via deductLoyaltyPoints)
+ * This handler treats the callback as a HINT, not as the source of truth.
+ * RM Direct-mode webhook delivery is best-effort and its signature has
+ * been bouncing legitimate callbacks — so trusting the payload's claimed
+ * `status` (and dropping the event when the signature won't verify) used
+ * to strand paid orders as `pending` until the 5-min reconcile cron.
  *
- * Idempotency: the orders update is gated on status="pending" so a
- * duplicate webhook delivery doesn't trigger the points calls again.
- *
- * Was: this file had a local fire-and-forget HTTP-fetch earnLoyalty
- * helper that POSTed to loyalty/api/transactions — an endpoint that
- * only accepts GET, so every RM-paid order was silently 405'ing the
- * earn call. No deduct call existed at all, so RM-paid reward
- * redemptions were never recorded.
+ * Instead we resolve the order and call reconcileRmOrder(), which asks
+ * RM's Query Payment Checkout endpoint directly and settles the order on
+ * RM's authoritative answer. Consequences:
+ *   • A dropped / signature-failed webhook no longer strands a payment —
+ *     any trigger (this, the ?payment=done redirect, the poll, the cron)
+ *     settles it from RM's truth.
+ *   • A spoofed webhook can't mark an order paid — RM still reports the
+ *     real status, so we never trust attacker-supplied "SUCCESS".
+ * Signature verification is kept for observability/anti-abuse only; it no
+ * longer gates settlement.
  */
 /** Map an RM callback's referenceId/additionalData to a markRm* target.
  *  additionalData is the order UUID we set in createPayment — unambiguous, so
@@ -51,50 +51,36 @@ export async function POST(request: NextRequest) {
     const signature = request.headers.get("x-signature")  || "";
     const url       = request.nextUrl.toString();
 
+    // Verify for observability/anti-abuse only — do NOT gate settlement on
+    // it. A bouncing signature must not strand a real payment; reconcile
+    // re-verifies against RM regardless, so an unverifiable (or spoofed)
+    // callback can never mark an unpaid order paid.
     const isValid = validateWebhookSignature("POST", url, nonce, timestamp, body, signature);
     if (!isValid) {
-      console.warn("Webhook signature mismatch");
-      return NextResponse.json({ code: "SIGNATURE_ERROR" });
+      console.warn("[rm webhook] signature did not verify — treating callback as a re-query trigger only");
     }
 
-    const { code, data } = body as {
+    const { data } = body as {
       code: string;
       data?: {
         referenceId: string;
-        transactionId: string;
-        status: string;
         additionalData?: string;
       };
     };
 
-    if (code !== "SUCCESS" || !data) {
+    if (!data?.referenceId && !data?.additionalData) {
       return NextResponse.json({ code: "OK" });
     }
 
     // Prefer the order UUID (additionalData) RM echoes back; fall back to a
     // suffix-safe order_number strip. Handles numeric AND alphanumeric order
     // numbers — see resolveOrderTarget.
-    const target = resolveOrderTarget(data.referenceId, data.additionalData);
+    const target = resolveOrderTarget(data.referenceId ?? "", data.additionalData);
 
-    if (data.status === "SUCCESS") {
-      const paid = await markRmOrderPaid(target, data.transactionId);
-      if (paid && !paid.scheduled) {
-        // Same "Brewing now" push the Stripe webhook fires. Suppressed
-        // when the order was held for scheduled pickup — promote-
-        // scheduled cron fires the push at brew-window-open time
-        // instead, so the customer doesn't get a "brewing now" ping
-        // 30 min before their drink is actually being made.
-        after(async () => {
-          await notifyOrderPreparing({
-            orderId:       paid.orderId,
-            orderNumber:   paid.orderNumber,
-            customerPhone: paid.customerPhone,
-          }).catch((e) => console.warn("[push] order_preparing rm webhook", e));
-        });
-      }
-    } else if (data.status === "FAILED") {
-      await markRmOrderFailed(target);
-    }
+    // Authoritative settle: ignore the payload's claimed status and ask RM
+    // directly. Awaited so the order flips (and the kitchen docket fires via
+    // Realtime) before we ack; the loyalty push is deferred inside reconcile.
+    await reconcileRmOrder(target);
 
     return NextResponse.json({ code: "SUCCESS" });
   } catch (err) {

--- a/apps/order/src/app/order/[id]/_OrderTrackingView.tsx
+++ b/apps/order/src/app/order/[id]/_OrderTrackingView.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Fragment, useEffect, useState } from "react";
+import { Fragment, useCallback, useEffect, useState } from "react";
 import Link from "next/link";
 import { ArrowLeft, ShoppingBag, Coffee, CheckCircle2, XCircle } from "lucide-react";
 import { MysteryReward } from "./_MysteryReward";
@@ -43,6 +43,11 @@ function rm(cents: number | null | undefined): string {
   return `RM${((cents ?? 0) / 100).toFixed(2)}`;
 }
 
+// RM Direct-mode payment methods whose confirmation rides on a best-effort
+// webhook. Kept in sync with the same set in /api/cron/reconcile-pending and
+// /api/payments/poll so the on-screen backstop covers exactly those methods.
+const RM_METHODS = new Set(["fpx", "tng", "boost", "shopeepay", "grabpay", "duitnow", "card"]);
+
 // Horizontal 3-step pipeline matching apps/pickup-native/components
 // /OrderStepper.tsx. The final step reads "Ready / Pick up now" for
 // pickup and "Served / Enjoy!" for dine-in (table orders).
@@ -67,25 +72,68 @@ export function OrderTrackingView({ orderId }: { orderId: string }) {
   const [order, setOrder] = useState<Order | null>(null);
   const [error, setError] = useState<string | null>(null);
 
+  const fetchOrder = useCallback(async () => {
+    try {
+      const r = await fetch(`/api/orders/${orderId}`);
+      const data = await r.json();
+      if (data?.order) setOrder(data.order as Order);
+      else if (data?.id) setOrder(data as Order);
+    } catch (err) {
+      setError(String(err));
+    }
+  }, [orderId]);
+
+  // DB status poll — reflects whatever flipped the order server-side.
   useEffect(() => {
     let cancelled = false;
-    const fetchOrder = () => {
-      fetch(`/api/orders/${orderId}`)
-        .then((r) => r.json())
-        .then((data) => {
-          if (cancelled) return;
-          if (data?.order) setOrder(data.order as Order);
-          else if (data?.id) setOrder(data as Order);
-        })
-        .catch((err) => !cancelled && setError(String(err)));
-    };
-    fetchOrder();
-    const id = window.setInterval(fetchOrder, 5000);
+    const tick = () => { if (!cancelled) void fetchOrder(); };
+    tick();
+    const id = window.setInterval(tick, 5000);
     return () => {
       cancelled = true;
       window.clearInterval(id);
     };
-  }, [orderId]);
+  }, [fetchOrder]);
+
+  // Active RM reconcile backstop. RM Direct-mode webhooks are best-effort
+  // (and signature validation has been bouncing valid callbacks), so a
+  // card / FPX / e-wallet order can sit `pending` until the 5-min
+  // reconcile-pending cron — the kitchen docket only prints once it flips
+  // to `preparing`. While the customer is on this screen with a pending RM
+  // order (they land here via the …?payment=done redirect right after
+  // paying), ask the server to query RM directly so it settles in seconds
+  // instead of minutes. Mirrors the native backstop in
+  // apps/pickup-native/app/order/[id].tsx. Keyed on status+method so it
+  // only runs while genuinely pending and tears down the moment it settles.
+  const status = order?.status;
+  const method = order?.payment_method;
+  useEffect(() => {
+    if (status !== "pending" || !method || !RM_METHODS.has(method)) return;
+    let cancelled = false;
+    const poll = async () => {
+      try {
+        const res = await fetch(`/api/payments/poll`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ orderId }),
+        });
+        const json = (await res.json().catch(() => null)) as { status?: string } | null;
+        // Reflect a settled status immediately rather than waiting for the
+        // next 5s DB tick.
+        if (!cancelled && json && (json.status === "preparing" || json.status === "paid" || json.status === "failed")) {
+          void fetchOrder();
+        }
+      } catch {
+        // Network blip — the next tick retries.
+      }
+    };
+    void poll();
+    const id = window.setInterval(poll, 3000);
+    return () => {
+      cancelled = true;
+      window.clearInterval(id);
+    };
+  }, [status, method, orderId, fetchOrder]);
 
   if (!order) {
     return (

--- a/apps/order/src/app/order/[id]/page.tsx
+++ b/apps/order/src/app/order/[id]/page.tsx
@@ -1,11 +1,27 @@
 import { OrderTrackingView } from "./_OrderTrackingView";
+import { reconcileRmOrder } from "@/lib/revenue-monster/reconcile";
 
 export default async function OrderDetailPage({
   params,
+  searchParams,
 }: {
   params: Promise<{ id: string }>;
+  searchParams: Promise<{ payment?: string }>;
 }) {
   const { id } = await params;
+  const { payment } = await searchParams;
+
+  // RM redirects the customer's browser back here right after they pay
+  // (…/order/[id]?payment=done). That return is a guaranteed signal that
+  // depends on neither webhook delivery nor the customer keeping the
+  // tracking screen open — so settle the order server-side, the moment the
+  // page is requested, by asking RM directly. Idempotent + never throws, so
+  // a non-RM/already-settled order is a cheap no-op and a gateway blip can't
+  // break the render (the on-screen poll + cron remain as backstops).
+  if (payment === "done") {
+    await reconcileRmOrder({ orderId: id });
+  }
+
   return (
     // No bottom tab bar — matches native (sub-screens opt out). Back via header.
     <main className="bg-white text-[#160800] min-h-screen pb-[calc(env(safe-area-inset-bottom,0px)+24px)]">

--- a/apps/order/src/lib/revenue-monster/reconcile.ts
+++ b/apps/order/src/lib/revenue-monster/reconcile.ts
@@ -1,0 +1,103 @@
+import { after } from "next/server";
+import { getSupabaseAdmin } from "@/lib/supabase/server";
+import { queryCheckoutStatus } from "./client";
+import { markRmOrderPaid, markRmOrderFailed } from "./order-status";
+import { notifyOrderPreparing } from "@/lib/push/templates";
+
+/**
+ * Single source of truth for settling a Revenue Monster order.
+ *
+ * Every trigger funnels through here: the RM webhook, the customer's
+ * redirect back to `…?payment=done`, the order-screen poll, and the
+ * reconcile-pending cron.
+ *
+ * The defining rule: we NEVER trust a webhook/redirect payload's claimed
+ * status. We resolve the order, then ask RM's Query Payment Checkout
+ * endpoint directly and act on its authoritative answer. That makes a
+ * dropped or signature-failed webhook a non-event (any other trigger
+ * settles the order), and a spoofed webhook harmless (RM still reports
+ * PENDING, so an unpaid order can't be marked paid).
+ *
+ * Idempotent: markRmOrderPaid/markRmOrderFailed are gated on the order's
+ * status, so concurrent triggers collapse to a single transition. Never
+ * throws — RM/query failures resolve to a "pending" result so no caller
+ * (page render, webhook ack) can be crashed by a flaky gateway.
+ */
+
+export type ReconcileSource =
+  | "db"            // already settled before we queried
+  | "rm"            // RM gave an authoritative answer
+  | "no_checkout_id"// pre-poll / non-RM order with nothing to query
+  | "not_rm"        // payment method isn't RM-routed
+  | "not_found"     // no such order
+  | "error";        // query/network failure — safe to retry on next trigger
+
+export interface ReconcileResult {
+  status: string;
+  source: ReconcileSource;
+  rmStatus?: string;
+}
+
+// RM Direct-mode methods whose confirmation rides on a best-effort webhook.
+// Kept in sync with the same set in the cron + the order tracking views.
+const RM_METHODS = new Set(["fpx", "tng", "boost", "shopeepay", "grabpay", "duitnow", "card"]);
+
+export async function reconcileRmOrder(
+  target: { orderId?: string; orderNumber?: string },
+): Promise<ReconcileResult> {
+  if (!target.orderId && !target.orderNumber) return { status: "pending", source: "not_found" };
+
+  try {
+    const supabase = getSupabaseAdmin();
+    const sel = supabase
+      .from("orders")
+      .select("id, status, payment_checkout_id, payment_method");
+    const { data } = target.orderId
+      ? await sel.eq("id", target.orderId).maybeSingle()
+      : await sel.eq("order_number", target.orderNumber!).maybeSingle();
+    const row = data as {
+      id: string;
+      status: string;
+      payment_checkout_id: string | null;
+      payment_method: string | null;
+    } | null;
+
+    if (!row) return { status: "pending", source: "not_found" };
+    // Already settled — nothing to do (idempotent fast path).
+    if (row.status !== "pending") return { status: row.status, source: "db" };
+    if (row.payment_method && !RM_METHODS.has(row.payment_method)) {
+      return { status: row.status, source: "not_rm" };
+    }
+    if (!row.payment_checkout_id) return { status: "pending", source: "no_checkout_id" };
+
+    const rm = await queryCheckoutStatus(row.payment_checkout_id);
+
+    if (rm.status === "SUCCESS") {
+      const paid = await markRmOrderPaid({ orderId: row.id }, rm.transactionId);
+      if (paid && !paid.scheduled) {
+        // "Brewing now" push — suppressed for scheduled orders (the
+        // promote-scheduled cron fires it at brew-window-open time).
+        after(async () => {
+          await notifyOrderPreparing({
+            orderId: paid.orderId,
+            orderNumber: paid.orderNumber,
+            customerPhone: paid.customerPhone,
+          }).catch((e) => console.warn("[push] order_preparing reconcile", e));
+        });
+      }
+      return { status: paid?.scheduled ? "paid" : "preparing", source: "rm", rmStatus: rm.status };
+    }
+
+    if (rm.status === "FAILED" || rm.status === "CANCELLED" || rm.status === "EXPIRED") {
+      await markRmOrderFailed({ orderId: row.id });
+      return { status: "failed", source: "rm", rmStatus: rm.status };
+    }
+
+    return { status: "pending", source: "rm", rmStatus: rm.status };
+  } catch (err) {
+    // Gateway/network blip — leave the order pending; another trigger
+    // (poll / cron / redirect) will settle it. Must never bubble.
+    console.warn("[rm reconcile] failed:", err instanceof Error ? err.message : err);
+    return { status: "pending", source: "error" };
+  }
+}


### PR DESCRIPTION
## Why

A dine-in QR / card order could sit `pending` for ~5 minutes before its kitchen docket printed (observed on Conezion table-3 order **C-0X2G77**: paid 08:54:51, docket 09:00:14). Root cause: Revenue Monster (Direct mode) confirmation rode on a **best-effort webhook whose signature has been bouncing valid callbacks**. Because the webhook handler trusted the payload's `status` to mark an order paid, signature verification was load-bearing for money correctness — so when it failed, the handler correctly dropped the event and the paid order wasn't settled until the 5-minute `reconcile-pending` cron. The kitchen docket only prints once the order flips to `preparing`, hence the lag.

## What changed

**Reframe confirmation around one rule: never trust a webhook/redirect payload for the money decision — re-query RM's authoritative Query Payment Checkout endpoint and act on that.**

- **`reconcileRmOrder()`** (new, `lib/revenue-monster/reconcile.ts`) — single source of truth: resolves the order, asks RM directly, settles via the idempotent `markRmOrderPaid/Failed`. Never throws.
- **Webhook** is now a *trigger, not the truth* — verifies the signature for observability/anti-abuse only (no longer drops on failure) and reconciles against RM. A dropped **or** spoofed callback can neither strand nor fake a payment.
- **Order page `?payment=done`** — settles **server-side** the instant the customer is redirected back from the bank/wallet. Works for *every* customer, independent of webhook delivery or keeping the tracking screen open. Highest-impact path.
- **Poll route** — thin wrapper over `reconcileRmOrder` (was duplicated logic).
- **On-screen poll** (web `_OrderTrackingView`, mirrors the native app) + **cron floor 2min→45s** — defense-in-depth.
- **Backoffice** — show the table number for dine-in QR orders (detail page + orders list).

All settlement paths are idempotent (gated on order status), so concurrent triggers collapse to a single transition — no double-charge / double-earn.

## Deploy / risk notes

- Touches the payment **confirmation** path (not the charge path, not the POS register, not the printing code). The order/KDS Capacitor shell loads live from Vercel, so this goes live on deploy — no app rebuild / OTA needed; the native register already reacts to the faster status flip via Realtime.
- Recommend a quick real card/QR run on the preview deploy (place → bank redirect → back to `?payment=done` → order flips to `preparing` → docket prints) before/after promoting.
- Follow-up (non-blocking): fix the RM webhook signature itself for the fast path + real auth — it now only logs (`[rm] webhook sig mismatch`) and no longer gates payments.

https://claude.ai/code/session_01GjJgv2uzoBTm57fC3T3MgR

---
_Generated by [Claude Code](https://claude.ai/code/session_01GjJgv2uzoBTm57fC3T3MgR)_