### PR TITLE
fix(order): web honors hidden_modifier_ids — hidden modifiers hidden everywhere

### DIFF
--- a/apps/order/src/lib/menu-data.ts
+++ b/apps/order/src/lib/menu-data.ts
@@ -8,7 +8,7 @@
 import { getSupabaseAdmin } from "@/lib/supabase/server";
 import { products as mockProducts, categories as mockCategories } from "@/data/mock";
 import type { Product, Category } from "@/lib/types";
-import { filterModifiersForChannel } from "@celsius/shared";
+import { filterModifiersForChannel, filterHiddenModifiers } from "@celsius/shared";
 
 export interface MenuData {
   products: Product[];
@@ -70,7 +70,7 @@ export async function getMenuData(): Promise<MenuData> {
     const [{ data: dbProducts, error: prodError }, { data: dbCategories, error: catError }] = await Promise.all([
       supabase
         .from("products")
-        .select("id, name, category, description, price, image_url, is_available, is_featured, modifiers, featured_position, schedule_start_date, schedule_end_date, schedule_days_of_week, schedule_time_from, schedule_time_to")
+        .select("id, name, category, description, price, image_url, is_available, is_featured, modifiers, hidden_modifier_ids, featured_position, schedule_start_date, schedule_end_date, schedule_days_of_week, schedule_time_from, schedule_time_to")
         .eq("brand_id", "brand-celsius")
         .order("position")
         .order("name"),
@@ -96,9 +96,17 @@ export async function getMenuData(): Promise<MenuData> {
         isPopular:      (p.is_featured as boolean) ?? false,
         isNew:          false,
         variants:       [],
-        modifierGroups: filterModifiersForChannel(
-          Array.isArray(p.modifiers) ? (p.modifiers as Product["modifierGroups"]) : [],
-          "pickup",
+        // Apply BOTH catalog filters the native app does: per-channel
+        // visibility AND the hidden_modifier_ids soft-blacklist. Web had been
+        // skipping the blacklist, so modifiers hidden in the catalog (e.g.
+        // "Extra Sambal") still showed — and were forced as a required pick —
+        // on the website while correctly absent in the native apps.
+        modifierGroups: filterHiddenModifiers(
+          filterModifiersForChannel(
+            Array.isArray(p.modifiers) ? (p.modifiers as Product["modifierGroups"]) : [],
+            "pickup",
+          ),
+          Array.isArray(p.hidden_modifier_ids) ? (p.hidden_modifier_ids as string[]) : [],
         ) as Product["modifierGroups"],
         featuredPosition: (p.featured_position as number) ?? 9999,
       }));

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -47,7 +47,7 @@ export {
 } from "./format";
 export { sendSMS, getSMSProvider } from "./sms";
 export type { SMSProvider } from "./sms";
-export { filterModifiersForChannel } from "./modifier-channels";
+export { filterModifiersForChannel, filterHiddenModifiers } from "./modifier-channels";
 export type { ModifierChannel, ModifierGroupLike, ModifierOptionLike } from "./modifier-channels";
 // OTP is intentionally NOT re-exported here — it imports node:crypto,
 // which Turbopack pulls into every consumer of this barrel (including

--- a/packages/shared/src/modifier-channels.ts
+++ b/packages/shared/src/modifier-channels.ts
@@ -75,3 +75,25 @@ export function filterModifiersForChannel<T extends ModifierGroupLike>(
         : g.options,
     }));
 }
+
+// Drop modifier groups / options whose id is in the soft-blacklist
+// (products.hidden_modifier_ids). Originally a StoreHub-sync compat layer —
+// hide noisy/undesirable synced modifiers without the next sync undoing it —
+// but it's the catalog's source of truth for "hidden", so EVERY customer
+// surface (web order app + pickup-native + Grab/FoodPanda sync) must apply it.
+// A group left with no visible options is dropped (an empty selector is a bug).
+export function filterHiddenModifiers<T extends ModifierGroupLike>(
+  groups: T[] | null | undefined,
+  hiddenIds: string[] | null | undefined,
+): T[] {
+  if (!Array.isArray(groups)) return [];
+  const hidden = new Set(Array.isArray(hiddenIds) ? hiddenIds : []);
+  if (hidden.size === 0) return groups;
+  return groups
+    .filter((g) => !(g.id && hidden.has(g.id)))
+    .map((g) => ({
+      ...g,
+      options: Array.isArray(g.options) ? g.options.filter((o) => !(o.id && hidden.has(o.id))) : g.options,
+    }))
+    .filter((g) => !Array.isArray(g.options) || g.options.length > 0);
+}


### PR DESCRIPTION
## Problem

`products.hidden_modifier_ids` is the catalog's source of truth for "this modifier is hidden from customers" (originally a StoreHub-sync compatibility layer — soft-hide noisy/undesirable synced modifiers without the next sync undoing it). **pickup-native and the Grab/FoodPanda menu sync apply it — but the web order app never did.**

Result, as QA'd on **Nasi Lemak 2 Sambal + Ayam Crispy** (`hidden_modifier_ids` contains the `Extra Sambal` group):
- **Native:** Extra Sambal correctly hidden → no modifier shown.
- **Web:** Extra Sambal still shown — *and* force-rendered as a required "PICK ONE / Pick required options," making an optional add-on mandatory.

This affected **every product with hidden modifiers**, not just this one.

## Fix
- **`packages/shared`** — add `filterHiddenModifiers()`: one shared rule (drop blacklisted group ids + option ids; drop a group left with no options), so web, native, and the delivery-menu syncs all hide the same things.
- **`apps/order` menu-data** — select `hidden_modifier_ids` and apply it after the existing per-channel filter. The product detail page + menu both load via `getMenuData()`, so all customer-facing web surfaces are covered.

**Net:** a modifier hidden in the catalog is now hidden on web too — consistent with native. Extra Sambal will no longer appear (or block checkout) on the website.

## Notes / follow-ups
- This is the **read-side** fix matching "hidden modifiers should not be available now." The deeper "wire to our catalog directly / decouple from StoreHub" (so modifiers are managed natively rather than soft-blacklisted over a sync) is a separate, larger effort — happy to scope it.
- Separate latent issue surfaced during QA: web treats **any single-select group as required** ("Pick required options") since there's no `required` flag in the modifier data. Not triggered for this product once Extra Sambal is hidden, but worth a real `required` flag if you want genuine required choices. Left out of this PR.

https://claude.ai/code/session_01GjJgv2uzoBTm57fC3T3MgR

---
_Generated by [Claude Code](https://claude.ai/code/session_01GjJgv2uzoBTm57fC3T3MgR)_