### PR TITLE
fix(pos): loyalty-complete gate 403'd in-store sales — restores Points + mystery reveal

### DIFF
--- a/apps/backoffice/src/app/api/pos/loyalty/complete/route.ts
+++ b/apps/backoffice/src/app/api/pos/loyalty/complete/route.ts
@@ -261,11 +261,26 @@ export async function POST(req: NextRequest) {
     // loyaltyPhone + memberId from the same member object), so it must match
     // member_id's phone. Without this, anyone could POST a stranger's completed
     // order_id + their own member_id to farm Beans / mystery drops / reward
-    // burns — the /api/pos transport is Origin-spoofable (task #186). Digits-only
-    // compare since both are stored E.164.
-    const orderPhoneDigits = String((order as { loyalty_phone?: string | null }).loyalty_phone ?? "").replace(/\D/g, "");
-    const memberPhoneDigits = String((memberRow as { phone?: string | null } | null)?.phone ?? "").replace(/\D/g, "");
-    if (!orderPhoneDigits || !memberPhoneDigits || orderPhoneDigits !== memberPhoneDigits) {
+    // burns — the /api/pos transport is Origin-spoofable (task #186).
+    //
+    // Compare the national significant number, NOT raw digits: Malaysian phones
+    // are stored inconsistently (+60.., 60.., 0..), so "+60124013766" (order)
+    // and "0124013766" (member row) are the SAME number but differ as raw
+    // digits. The original digits-only compare 403'd every legitimate in-store
+    // completion (regression from the gate's introduction), silently killing
+    // Beans + mystery drops + the till reveal for all members. Reducing to the
+    // NSN (drop a leading 60 or 0) fixes the false reject while keeping the
+    // anti-farming guarantee (the credited member must still own the order's
+    // phone).
+    const phoneNsn = (p: string | null | undefined): string => {
+      let d = String(p ?? "").replace(/\D/g, "");
+      if (d.startsWith("60")) d = d.slice(2);
+      else if (d.startsWith("0")) d = d.slice(1);
+      return d;
+    };
+    const orderPhoneNsn = phoneNsn((order as { loyalty_phone?: string | null }).loyalty_phone);
+    const memberPhoneNsn = phoneNsn((memberRow as { phone?: string | null } | null)?.phone);
+    if (!orderPhoneNsn || !memberPhoneNsn || orderPhoneNsn !== memberPhoneNsn) {
       return NextResponse.json({ ok: false, reason: "order does not belong to this member" }, { status: 403 });
     }
 


### PR DESCRIPTION
## Root cause (confirmed from production logs)
In-store members have earned **0 Points and no mystery bag since ~06-07** — and the mystery **reveal** on the customer display breaks (shows "wait a moment" then collapses to plain Thank You).

It's **not** the display and **not** the register. Production runtime logs show the register correctly calls `POST /api/pos/loyalty/complete` on every member sale — and the **ownership gate returns 403 on all of them** (14× today alone):
```
POST /api/pos/loyalty/complete → 403   (00:05 … 05:16 today)
```
The 403 returns *before* Beans, tier re-eval, and the mystery-drop spawn, so all three are skipped. With no `mystery_drops` row, the display's post-payment poll finds nothing → "wait a moment" → falls back to Thank You.

Data confirms it: after the gate shipped, **16 in-store member sales → 14 earned 0 Points / no drop**; before, they worked.

## Why the gate falsely rejects
It compared **raw phone digits**. Malaysian numbers are stored inconsistently (`+60…` / `60…` / `0…`), so the order's `loyalty_phone` (`+60124013766`) and the member row's `phone` (`0124013766`) are the **same** number but differ as raw digits → false 403.

## Fix
Compare the **national significant number** (strip a leading `60` or `0`) on both sides. Legitimate completions pass again; the anti-farming guarantee (task #186) is unchanged — the credited member must still own the order's phone.

- **Backoffice-only.** Deploys via Vercel; **no register change / no Expo OTA** needed (the register was already calling the endpoint correctly).
- Restores **Beans + tier + mystery drop + the live till reveal** in one go.

## Verify after deploy
A member sale at the till should: earn Points (`pos_orders.loyalty_points_earned > 0`), create a `mystery_drops` row, and show the tappable Mystery Bag on the 2nd screen instead of "wait a moment → Thank You".

Audit query:
```sql
select order_number, loyalty_points_earned,
  exists(select 1 from mystery_drops d where d.order_id::text = pos_orders.id::text) as got_drop
from pos_orders where status='completed' and loyalty_phone is not null
order by created_at desc limit 10;  -- expect points>0 and got_drop=true after deploy
```

## Notes
- I couldn't test from the sandbox (the backoffice host isn't in the egress allowlist), so please confirm on the preview/after merge. If any residual 403s remain, they'd be members whose stored phone is genuinely different/empty — a smaller follow-up (resolve the member from the order's phone).
- Separate, still-open: the mystery **card text centering** is a `pos-native` cosmetic issue that needs the (currently blocked) Expo OTA; the "wait a moment → Thank You" symptom itself is fixed by this PR.

https://claude.ai/code/session_01GjJgv2uzoBTm57fC3T3MgR

---
_Generated by [Claude Code](https://claude.ai/code/session_01GjJgv2uzoBTm57fC3T3MgR)_