### PR TITLE
fix(ci): pos-native OTA — pass commit message via env, not inline shell

### DIFF
--- a/.github/workflows/pos-native-ota.yml
+++ b/.github/workflows/pos-native-ota.yml
@@ -42,8 +42,15 @@ jobs:
       - name: Publish OTA update (production channel)
         env:
           EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}
+          # Pass the commit message through the environment, NOT inline in the
+          # run script: a multi-line message with backticks / * / newlines would
+          # otherwise be parsed by the shell (command substitution + word
+          # splitting) and feed garbage args to eas. We then take just the first
+          # line as the update message.
+          COMMIT_MSG: ${{ github.event.head_commit.message || github.sha }}
         run: |
+          MSG="$(printf '%s' "$COMMIT_MSG" | head -n 1)"
           npx eas-cli@latest update \
             --channel production \
-            --message "${{ github.event.head_commit.message || github.sha }}" \
+            --message "$MSG" \
             --non-interactive


### PR DESCRIPTION
## Problem

The first `pos-native OTA` run (from the #234 merge) failed in 45s. The workflow inlined `github.event.head_commit.message` directly into the `run:` script, so the multi-line squash commit message was parsed by the shell:

- backticks in the message (`` `orders` ``, `` `eas build` ``) ran as command substitution → `orders: command not found`, `eas: command not found`
- the `*` and newlines word-split into bogus arguments → `eas-cli` reported `Unexpected arguments: Table, N in each row's meta line...` and exited 1

The `EXPO_TOKEN` secret itself was loaded correctly — this was purely a shell-quoting bug, so the registers never received the update.

## Fix

Pass the commit message through an env var (`COMMIT_MSG`) instead of interpolating it into the script, and use only its first line as the `--message`. GitHub sets env vars as literal values, so the backticks / `*` / newlines are no longer shell-evaluated.

## After merge

The workflow only auto-runs on pushes touching `apps/pos-native`; this change only touches the workflow file, so the OTA will be dispatched manually (`workflow_dispatch`) to publish the already-merged #234 JS changes (Table # in History, 15-min serving alarm, 5-min repeat reminder) to the `production` channel.

https://claude.ai/code/session_01GjJgv2uzoBTm57fC3T3MgR

---
_Generated by [Claude Code](https://claude.ai/code/session_01GjJgv2uzoBTm57fC3T3MgR)_