### PR TITLE
fix(pos-native): OTA export bundled web — pin app to Android

### DIFF
--- a/.github/workflows/pos-native-ota.yml
+++ b/.github/workflows/pos-native-ota.yml
@@ -42,6 +42,10 @@ jobs:
       - name: Publish OTA update (production channel)
         env:
           EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}
+          # eas update shells out to `expo export`, whose interactive prompts
+          # must be suppressed via CI=1 (the --non-interactive flag is not
+          # honoured by the export sub-step).
+          CI: "1"
           # Pass the commit message through the environment, NOT inline in the
           # run script: a multi-line message with backticks / * / newlines would
           # otherwise be parsed by the shell (command substitution + word
@@ -50,7 +54,12 @@ jobs:
           COMMIT_MSG: ${{ github.event.head_commit.message || github.sha }}
         run: |
           MSG="$(printf '%s' "$COMMIT_MSG" | head -n 1)"
+          # --platform android: this is an Android-only SUNMI register app, and
+          # the default (all) makes expo export bundle web too, which fails
+          # (react-native-web isn't a dependency). app.json also pins
+          # platforms:["android"]; this keeps the intent explicit.
           npx eas-cli@latest update \
             --channel production \
+            --platform android \
             --message "$MSG" \
             --non-interactive

--- a/apps/pos-native/app.json
+++ b/apps/pos-native/app.json
@@ -8,6 +8,7 @@
     "icon": "./assets/icon.png",
     "userInterfaceStyle": "dark",
     "newArchEnabled": true,
+    "platforms": ["android"],
     "splash": {
       "image": "./assets/splash-icon.png",
       "resizeMode": "contain",


### PR DESCRIPTION
## Problem

OTA run #2 (the #238 merge) got past the earlier shell-injection bug but failed at the real `eas update`:

```
[expo-cli] CommandError: It looks like you're trying to use web support but
don't have the required dependencies installed.
Install react-native-web@^0.21.0 ...
✖ Export failed
```

`eas update` runs `expo export --platform=all`. `app.json` had **no `platforms` key**, so the export defaulted to ios + android + **web** and choked on the missing `react-native-web` (this is an Android-only SUNMI register app — web is irrelevant).

## Fix

- **`app.json`**: pin `"platforms": ["android"]`.
- **workflow**: pass `--platform android` to `eas update` and set `CI=1` (the export sub-step ignores `--non-interactive` and warns to use `CI` instead).

The `app.json` change also touches `apps/pos-native/`, so merging re-triggers the OTA — this time it should publish cleanly to the `production` channel (Table # in History, 15-min alarm, 5-min repeat, centered mystery card).

https://claude.ai/code/session_01GjJgv2uzoBTm57fC3T3MgR

---
_Generated by [Claude Code](https://claude.ai/code/session_01GjJgv2uzoBTm57fC3T3MgR)_