### PR TITLE
order home: QR-table scan instruction, drop pickup outlet picker

### DIFF
--- a/apps/order/src/app/_OutletRow.tsx
+++ b/apps/order/src/app/_OutletRow.tsx
@@ -2,127 +2,83 @@
 
 import { useEffect, useState } from "react";
 import Link from "next/link";
-import { MapPin, ChevronRight } from "lucide-react";
+import { QrCode, UtensilsCrossed } from "lucide-react";
 
 /**
- * Outlet picker chip below the hero. Resolves the chosen outlet from the
- * SPA's localStorage (key 'celsius-pickup'). Shows the name + status of the
- * outlet matching the stored outletId — NOT the stored outletName string,
- * which can lag behind outletId (e.g. after a table-QR scan) and make the
- * tile claim one outlet while orders actually route to another. Mirrors the
- * native home's reconcile (apps/pickup-native/app/index.tsx).
+ * Home order-entry line below the hero. This app is QR-table ordering: a
+ * customer starts by scanning the physical table QR (their phone camera opens
+ * order.celsiuscoffee.com/table/{outletId}/{tableId}, which _TableEntry turns
+ * into a dine-in session). So the home no longer offers a pickup outlet picker
+ * — instead it tells the customer to scan.
+ *
+ * Two states, both read from the persisted "celsius-pickup" blob:
+ *   dine-in already set (came back to home after scanning) → "Table N · Outlet",
+ *     tappable straight back to the menu.
+ *   otherwise → a plain "Scan the QR on your table to order" instruction. The
+ *     scan happens with the phone camera on the physical table code, so this
+ *     line is guidance, not a button.
  */
 type Persisted = {
   state?: {
-    outletId?: string | null;
     outletName?: string | null;
-    outletIsOpen?: boolean;
-    outletIsBusy?: boolean;
-    outletPickupTimeMins?: number | null;
+    orderType?: "pickup" | "dine_in" | null;
+    tableNumber?: string | null;
   };
 };
 
-type Store = { id: string; name: string; isOpen: boolean; isBusy: boolean; pickupTime: string };
-
 export function OutletRow() {
+  const [dineIn, setDineIn] = useState(false);
+  const [table, setTable] = useState<string | null>(null);
   const [name, setName] = useState<string | null>(null);
-  const [isOpen, setIsOpen] = useState<boolean | null>(null);
-  const [isBusy, setIsBusy] = useState<boolean | null>(null);
-  const [pickupLabel, setPickupLabel] = useState<string | null>(null);
 
   useEffect(() => {
-    let outletId: string | null = null;
     try {
       const raw = window.localStorage.getItem("celsius-pickup");
       if (raw) {
         const parsed = JSON.parse(raw) as Persisted;
-        outletId = parsed.state?.outletId ?? null;
-        // Instant paint from the stored values; reconciled below against the
-        // authoritative outlet for outletId.
+        setDineIn(parsed.state?.orderType === "dine_in");
+        setTable(parsed.state?.tableNumber ?? null);
         setName(parsed.state?.outletName ?? null);
-        setIsOpen(parsed.state?.outletIsOpen ?? null);
-        setIsBusy(parsed.state?.outletIsBusy ?? null);
-        const mins = parsed.state?.outletPickupTimeMins ?? null;
-        setPickupLabel(mins ? `~${mins} min` : null);
       }
     } catch {
       /* ignore */
     }
-    if (!outletId) return;
-
-    let cancelled = false;
-    fetch("/api/stores")
-      .then((r) => (r.ok ? r.json() : []))
-      .then((stores: Store[]) => {
-        if (cancelled) return;
-        const match = Array.isArray(stores) ? stores.find((s) => s.id === outletId) : null;
-        if (!match) return;
-        // Truthful to outletId — the outlet the order will actually go to.
-        setName(match.name);
-        setIsOpen(match.isOpen);
-        setIsBusy(match.isBusy);
-        setPickupLabel(match.pickupTime && !match.pickupTime.includes("null") ? match.pickupTime : null);
-        // Self-heal the stored name so every other reader converges too.
-        try {
-          const raw = window.localStorage.getItem("celsius-pickup");
-          if (raw) {
-            const parsed = JSON.parse(raw) as Persisted;
-            if (parsed.state && parsed.state.outletName !== match.name) {
-              parsed.state.outletName = match.name;
-              window.localStorage.setItem("celsius-pickup", JSON.stringify(parsed));
-            }
-          }
-        } catch {
-          /* ignore */
-        }
-      })
-      .catch(() => {
-        /* keep the stored fallback */
-      });
-    return () => {
-      cancelled = true;
-    };
   }, []);
 
-  const dot =
-    isOpen === false
-      ? { bg: "#EF4444", label: "Closed" }
-      : isBusy
-      ? { bg: "#F59E0B", label: "Busy" }
-      : isOpen === true
-      ? { bg: "#22C55E", label: pickupLabel ?? "Open" }
-      : null;
+  // Returning to home mid-session — show the locked table + a tap back to the
+  // menu, never a pickup picker.
+  if (dineIn && table) {
+    return (
+      <Link
+        href="/menu"
+        className="flex items-center self-start active:opacity-75"
+        style={{ marginLeft: 20, marginTop: 14, marginBottom: 4, gap: 6 }}
+      >
+        <UtensilsCrossed size={14} color="#8E8E93" />
+        <span
+          className="font-peachi font-bold truncate"
+          style={{ color: "#160800", fontSize: 14 }}
+        >
+          Table {table}
+          {name ? ` · ${name}` : ""}
+        </span>
+      </Link>
+    );
+  }
 
+  // Default — no pickup. Tell them to scan the table QR to order.
   return (
-    <Link
-      href="/store"
-      className="flex items-center self-start active:opacity-75"
+    <div
+      className="flex items-center self-start"
       style={{ marginLeft: 20, marginTop: 14, marginBottom: 4, gap: 6 }}
     >
-      <MapPin size={14} color="#8E8E93" />
+      <QrCode size={14} color="#8E8E93" />
       <span
-        className="font-peachi font-bold truncate"
+        className="font-peachi font-bold"
         style={{ color: "#160800", fontSize: 14 }}
       >
-        {name ?? "Select pickup outlet"}
+        Scan the QR on your table to order
       </span>
-      {dot ? (
-        <>
-          <span
-            style={{
-              width: 6,
-              height: 6,
-              borderRadius: 3,
-              backgroundColor: dot.bg,
-              marginLeft: 4,
-            }}
-          />
-          <span style={{ color: "#8E8E93", fontSize: 12, fontWeight: 500 }}>
-            {dot.label}
-          </span>
-        </>
-      ) : null}
-      <ChevronRight size={13} color="#8E8E93" />
-    </Link>
+    </div>
   );
 }

--- a/apps/pickup-native/components/HomeOrderMode.tsx
+++ b/apps/pickup-native/components/HomeOrderMode.tsx
@@ -1,6 +1,6 @@
-import { Platform, View, Text, Pressable } from "react-native";
+import { View, Text, Pressable } from "react-native";
 import { router } from "expo-router";
-import { MapPin, ChevronRight, UtensilsCrossed, QrCode } from "lucide-react-native";
+import { MapPin, ChevronRight, UtensilsCrossed } from "lucide-react-native";
 import * as Haptics from "@/lib/haptics";
 import { useApp } from "@/lib/store";
 import { resolveOrderType, type OrderType } from "@/lib/order-type";
@@ -41,61 +41,6 @@ export function HomeOrderMode({
     }
     setOrderType(next, next === "dine_in" ? tableNumber ?? undefined : undefined);
   };
-
-  // ── Web PWA (order.celsiuscoffee.com): scan-to-order only ──
-  // The web surface is a dine-in / table-QR ordering page — pickup is NOT
-  // initiated from the home here, so we drop the Dine-In|Pickup toggle and the
-  // pickup-outlet picker entirely. The single home action is "Scan your table
-  // to order" (→ /scan). Once a table's been scanned, orderType flips to
-  // dine_in and we surface that table's context instead, continuing to the
-  // menu. Native (the installed app) keeps the full toggle below.
-  if (Platform.OS === "web") {
-    return (
-      <View style={{ marginHorizontal: 16, marginTop: 12, marginBottom: 2 }}>
-        <Pressable
-          onPress={() => {
-            Haptics.selectionAsync();
-            router.push((isDineIn ? "/menu" : "/scan") as never);
-          }}
-          accessibilityRole="button"
-          accessibilityLabel={
-            isDineIn
-              ? `Dine-in${tableNumber ? `, table ${tableNumber}` : ""}${
-                  outletName ? ` at ${outletName}` : ""
-                }. Tap for the menu.`
-              : "Scan your table QR to order"
-          }
-          className="active:opacity-80"
-          style={{
-            flexDirection: "row",
-            alignItems: "center",
-            gap: 11,
-            paddingHorizontal: 16,
-            paddingVertical: 15,
-            borderRadius: 14,
-            backgroundColor: "#160800",
-          }}
-        >
-          {isDineIn ? (
-            <UtensilsCrossed size={19} color="#FFFFFF" />
-          ) : (
-            <QrCode size={20} color="#FFFFFF" />
-          )}
-          <Text
-            style={{ flex: 1, fontFamily: "Peachi-Bold", fontSize: 15, color: "#FFFFFF" }}
-            numberOfLines={1}
-          >
-            {isDineIn
-              ? `${tableNumber ? `Table ${tableNumber}` : "Dine-in"}${
-                  outletName ? ` · ${outletName}` : ""
-                }`
-              : "Scan your table to order"}
-          </Text>
-          <ChevronRight size={16} color="rgba(255,255,255,0.85)" />
-        </Pressable>
-      </View>
-    );
-  }
 
   return (
     <View style={{ marginHorizontal: 16, marginTop: 12, marginBottom: 2, gap: 9 }}>

--- a/apps/pickup-native/components/HomeOrderMode.tsx
+++ b/apps/pickup-native/components/HomeOrderMode.tsx
@@ -1,6 +1,6 @@
-import { View, Text, Pressable } from "react-native";
+import { Platform, View, Text, Pressable } from "react-native";
 import { router } from "expo-router";
-import { MapPin, ChevronRight, UtensilsCrossed } from "lucide-react-native";
+import { MapPin, ChevronRight, UtensilsCrossed, QrCode } from "lucide-react-native";
 import * as Haptics from "@/lib/haptics";
 import { useApp } from "@/lib/store";
 import { resolveOrderType, type OrderType } from "@/lib/order-type";
@@ -41,6 +41,61 @@ export function HomeOrderMode({
     }
     setOrderType(next, next === "dine_in" ? tableNumber ?? undefined : undefined);
   };
+
+  // ── Web PWA (order.celsiuscoffee.com): scan-to-order only ──
+  // The web surface is a dine-in / table-QR ordering page — pickup is NOT
+  // initiated from the home here, so we drop the Dine-In|Pickup toggle and the
+  // pickup-outlet picker entirely. The single home action is "Scan your table
+  // to order" (→ /scan). Once a table's been scanned, orderType flips to
+  // dine_in and we surface that table's context instead, continuing to the
+  // menu. Native (the installed app) keeps the full toggle below.
+  if (Platform.OS === "web") {
+    return (
+      <View style={{ marginHorizontal: 16, marginTop: 12, marginBottom: 2 }}>
+        <Pressable
+          onPress={() => {
+            Haptics.selectionAsync();
+            router.push((isDineIn ? "/menu" : "/scan") as never);
+          }}
+          accessibilityRole="button"
+          accessibilityLabel={
+            isDineIn
+              ? `Dine-in${tableNumber ? `, table ${tableNumber}` : ""}${
+                  outletName ? ` at ${outletName}` : ""
+                }. Tap for the menu.`
+              : "Scan your table QR to order"
+          }
+          className="active:opacity-80"
+          style={{
+            flexDirection: "row",
+            alignItems: "center",
+            gap: 11,
+            paddingHorizontal: 16,
+            paddingVertical: 15,
+            borderRadius: 14,
+            backgroundColor: "#160800",
+          }}
+        >
+          {isDineIn ? (
+            <UtensilsCrossed size={19} color="#FFFFFF" />
+          ) : (
+            <QrCode size={20} color="#FFFFFF" />
+          )}
+          <Text
+            style={{ flex: 1, fontFamily: "Peachi-Bold", fontSize: 15, color: "#FFFFFF" }}
+            numberOfLines={1}
+          >
+            {isDineIn
+              ? `${tableNumber ? `Table ${tableNumber}` : "Dine-in"}${
+                  outletName ? ` · ${outletName}` : ""
+                }`
+              : "Scan your table to order"}
+          </Text>
+          <ChevronRight size={16} color="rgba(255,255,255,0.85)" />
+        </Pressable>
+      </View>
+    );
+  }
 
   return (
     <View style={{ marginHorizontal: 16, marginTop: 12, marginBottom: 2, gap: 9 }}>


### PR DESCRIPTION
## What

On `order.celsiuscoffee.com`, the home `📍 Outlet · ~15 min →` row (`apps/order/src/app/_OutletRow.tsx`) linked to the pickup outlet picker (`/store`). This app is QR-table ordering, so the home no longer offers pickup — it now shows a scan instruction.

## Behavior

- **No table scanned yet** → `Scan the QR on your table to order` (QR icon, instructional — the real scan is the phone camera on the physical table QR, which opens `/table/{outlet}/{table}` → dine-in session → menu).
- **Already in a dine-in session** (returning to home) → `Table N · Outlet`, tapping back to `/menu`. Read from the persisted `celsius-pickup` store, same source the menu's `_OutletPickerRow` already uses.

## Scope

Home screen only, per product decision. Pickup still exists in the menu outlet row (`_OutletPickerRow.tsx`) and cart/checkout for anyone reaching `/menu` via the bottom-nav Menu tab without scanning — that's a deliberate follow-up, not in this PR.

## Notes

- No new Next.js APIs; mirrors existing client-component patterns in `_OutletPickerRow.tsx`.
- Native app (`pickup-native`) untouched.

https://claude.ai/code/session_01QDNdybSVB2vJ39yEbQLECi

---
_Generated by [Claude Code](https://claude.ai/code/session_01QDNdybSVB2vJ39yEbQLECi)_