### PR TITLE
diag(pos): log why in-store loyalty /complete returns 403

### DIFF
--- a/apps/backoffice/src/app/api/pos/loyalty/complete/route.ts
+++ b/apps/backoffice/src/app/api/pos/loyalty/complete/route.ts
@@ -220,6 +220,9 @@ async function spawnMysteryDrop(
 export async function POST(req: NextRequest) {
   try {
     const { member_id, order_id } = await req.json();
+    // TEMP diagnostic (loyalty 403 hunt): if this line shows in the logs, CSRF
+    // middleware let the request through and any 403 is the gate below.
+    console.log(`[complete-diag] HIT member_id="${member_id}" order_id="${order_id}"`);
     if (!member_id || !order_id) {
       return NextResponse.json({ error: "member_id and order_id required" }, { status: 400 });
     }
@@ -281,6 +284,12 @@ export async function POST(req: NextRequest) {
     const orderPhoneNsn = phoneNsn((order as { loyalty_phone?: string | null }).loyalty_phone);
     const memberPhoneNsn = phoneNsn((memberRow as { phone?: string | null } | null)?.phone);
     if (!orderPhoneNsn || !memberPhoneNsn || orderPhoneNsn !== memberPhoneNsn) {
+      // TEMP diagnostic (loyalty 403 hunt): show why the gate rejected — null
+      // member row, empty order phone, or a genuine NSN mismatch.
+      console.warn(
+        `[complete-diag] GATE 403 member_id="${member_id}" memberRowFound=${!!memberRow} ` +
+        `orderNsn="${orderPhoneNsn}" memberNsn="${memberPhoneNsn}"`,
+      );
       return NextResponse.json({ ok: false, reason: "order does not belong to this member" }, { status: 403 });
     }
 

--- a/apps/backoffice/src/middleware.ts
+++ b/apps/backoffice/src/middleware.ts
@@ -40,6 +40,15 @@ export async function middleware(request: NextRequest) {
     ],
   });
   if (csrfFail) {
+    // TEMP diagnostic (loyalty 403 hunt): the native POS register hits
+    // /api/pos/* without a browser Origin. Log what we actually received so
+    // we can tell a CSRF block apart from the route's own ownership gate.
+    if (pathname.startsWith("/api/pos/")) {
+      console.warn(
+        `[csrf-diag] BLOCKED ${request.method} ${pathname} reason="${csrfFail.reason}" ` +
+        `origin="${request.headers.get("origin") ?? ""}" referer="${request.headers.get("referer") ?? ""}"`,
+      );
+    }
     return NextResponse.json(
       { error: `CSRF check failed: ${csrfFail.reason}` },
       { status: 403 },


### PR DESCRIPTION
## Why

In-store native POS sales earn no Beans and spawn no mystery drop. Confirmed from prod data + logs: `POST /api/pos/loyalty/complete` returns **403 on every in-store member sale** (that one call does both the points award and the mystery-drop spawn, so both are skipped → the customer display has no drop to reveal → falls back to plain Thank You). Other outlets looked fine only because they still run StoreHub, which posts its own earns.

The 403 has two possible sources and the body isn't visible remotely:
1. CSRF middleware rejecting before the route runs (native register sends no browser Origin / no Bearer), or
2. the route's phone-ownership gate.

For the test order the phones are identical and the Origin is correctly formed + allowlisted, so *both* should pass — meaning something in the runtime differs from the source. This adds **logging only** (no behavior change) to settle it on the next sale.

## What

- **middleware**: on a CSRF block to `/api/pos/*`, log method/path/reason + the actual `origin`/`referer` received.
- **complete route**: log on entry (proves the request got past middleware) and log the gate inputs (`memberRowFound` / order NSN / member NSN) before the 403.

Read once: if `[complete-diag] HIT` appears for a 403 sale → it's the gate (with values). If only `[csrf-diag] BLOCKED` appears → it's CSRF (with the origin it saw). Then I revert this and ship the precise fix.

https://claude.ai/code/session_01GjJgv2uzoBTm57fC3T3MgR

---
_Generated by [Claude Code](https://claude.ai/code/session_01GjJgv2uzoBTm57fC3T3MgR)_