### PR TITLE
fix(pos): in-store loyalty 403 — members SELECT used nonexistent brand_data column

### DIFF
--- a/apps/backoffice/src/app/api/pos/loyalty/complete/route.ts
+++ b/apps/backoffice/src/app/api/pos/loyalty/complete/route.ts
@@ -220,9 +220,6 @@ async function spawnMysteryDrop(
 export async function POST(req: NextRequest) {
   try {
     const { member_id, order_id } = await req.json();
-    // TEMP diagnostic (loyalty 403 hunt): if this line shows in the logs, CSRF
-    // middleware let the request through and any 403 is the gate below.
-    console.log(`[complete-diag] HIT member_id="${member_id}" order_id="${order_id}"`);
     if (!member_id || !order_id) {
       return NextResponse.json({ error: "member_id and order_id required" }, { status: 400 });
     }
@@ -250,12 +247,12 @@ export async function POST(req: NextRequest) {
         .eq("member_id", member_id)
         .eq("brand_id", BRAND_ID)
         .maybeSingle(),
-      supabase.from("members").select("phone, brand_data").eq("id", member_id).maybeSingle(),
+      supabase.from("members").select("phone, birthday").eq("id", member_id).maybeSingle(),
     ]);
     const tier = (mb as { tiers?: { slug?: string | null; multiplier?: number | null } | null } | null)?.tiers ?? null;
     const tierSlug = tier?.slug ?? null;
     const tierMul = Number(tier?.multiplier ?? 1) || 1;
-    const bdayIso = (memberRow?.brand_data as { birthday?: string | null } | null)?.birthday ?? null;
+    const bdayIso = (memberRow as { birthday?: string | null } | null)?.birthday ?? null;
     const birthdayMonth = bdayIso ? new Date(bdayIso).getMonth() + 1 : null;
 
     // ── Ownership gate ───────────────────────────────────────────────
@@ -284,12 +281,6 @@ export async function POST(req: NextRequest) {
     const orderPhoneNsn = phoneNsn((order as { loyalty_phone?: string | null }).loyalty_phone);
     const memberPhoneNsn = phoneNsn((memberRow as { phone?: string | null } | null)?.phone);
     if (!orderPhoneNsn || !memberPhoneNsn || orderPhoneNsn !== memberPhoneNsn) {
-      // TEMP diagnostic (loyalty 403 hunt): show why the gate rejected — null
-      // member row, empty order phone, or a genuine NSN mismatch.
-      console.warn(
-        `[complete-diag] GATE 403 member_id="${member_id}" memberRowFound=${!!memberRow} ` +
-        `orderNsn="${orderPhoneNsn}" memberNsn="${memberPhoneNsn}"`,
-      );
       return NextResponse.json({ ok: false, reason: "order does not belong to this member" }, { status: 403 });
     }
 

--- a/apps/backoffice/src/middleware.ts
+++ b/apps/backoffice/src/middleware.ts
@@ -40,15 +40,6 @@ export async function middleware(request: NextRequest) {
     ],
   });
   if (csrfFail) {
-    // TEMP diagnostic (loyalty 403 hunt): the native POS register hits
-    // /api/pos/* without a browser Origin. Log what we actually received so
-    // we can tell a CSRF block apart from the route's own ownership gate.
-    if (pathname.startsWith("/api/pos/")) {
-      console.warn(
-        `[csrf-diag] BLOCKED ${request.method} ${pathname} reason="${csrfFail.reason}" ` +
-        `origin="${request.headers.get("origin") ?? ""}" referer="${request.headers.get("referer") ?? ""}"`,
-      );
-    }
     return NextResponse.json(
       { error: `CSRF check failed: ${csrfFail.reason}` },
       { status: 403 },


### PR DESCRIPTION
## Root cause (proved, not guessed)

Every in-store native-POS member sale was 403'ing at `POST /api/pos/loyalty/complete`, so **Beans + tier + the mystery drop were all skipped** — and with no drop created, the customer display polled, found nothing, and fell back to the plain Thank You (the "loading → thank you, no reveal" you saw).

Diagnostics added in #241 proved the path:
- `csrf-diag` → **no match** (CSRF was fine; request reached the route)
- `complete-diag HIT` → matched (route ran)
- `memberRowFound=false` → matched **every** 403

The ownership gate read the member with `members.select("phone, brand_data")`, but **`members` has no `brand_data` column** (birthday lives in `members.birthday`; `brand_data` is only a PostgREST *embed alias* used in other routes). That SELECT errored → `memberRow` came back `null` → the member phone was empty → the gate rejected **every** sale with 403 "order does not belong to this member".

This is why #236 (phone NSN normalisation) didn't help — the member row was null regardless of phone format.

## Fix

- `members.select("phone, birthday")` (the real column) and read `birthday` off the row directly.
- Removes the temporary diagnostics from #241.

## After deploy

Next in-store member sale will earn points + spawn the drop → the reveal appears. I'll then backfill the ~19 orders (Jun 7-8) that missed their points.

https://claude.ai/code/session_01GjJgv2uzoBTm57fC3T3MgR

---
_Generated by [Claude Code](https://claude.ai/code/session_01GjJgv2uzoBTm57fC3T3MgR)_