### PR TITLE
catalog: retire hidden_modifier_ids — channels are the single source of truth

### DIFF
--- a/apps/order/src/lib/menu-data.ts
+++ b/apps/order/src/lib/menu-data.ts
@@ -8,7 +8,7 @@
 import { getSupabaseAdmin } from "@/lib/supabase/server";
 import { products as mockProducts, categories as mockCategories } from "@/data/mock";
 import type { Product, Category } from "@/lib/types";
-import { filterModifiersForChannel, filterHiddenModifiers } from "@celsius/shared";
+import { filterModifiersForChannel } from "@celsius/shared";
 
 export interface MenuData {
   products: Product[];
@@ -70,7 +70,7 @@ export async function getMenuData(): Promise<MenuData> {
     const [{ data: dbProducts, error: prodError }, { data: dbCategories, error: catError }] = await Promise.all([
       supabase
         .from("products")
-        .select("id, name, category, description, price, image_url, is_available, is_featured, modifiers, hidden_modifier_ids, featured_position, schedule_start_date, schedule_end_date, schedule_days_of_week, schedule_time_from, schedule_time_to")
+        .select("id, name, category, description, price, image_url, is_available, is_featured, modifiers, featured_position, schedule_start_date, schedule_end_date, schedule_days_of_week, schedule_time_from, schedule_time_to")
         .eq("brand_id", "brand-celsius")
         .order("position")
         .order("name"),
@@ -96,17 +96,13 @@ export async function getMenuData(): Promise<MenuData> {
         isPopular:      (p.is_featured as boolean) ?? false,
         isNew:          false,
         variants:       [],
-        // Apply BOTH catalog filters the native app does: per-channel
-        // visibility AND the hidden_modifier_ids soft-blacklist. Web had been
-        // skipping the blacklist, so modifiers hidden in the catalog (e.g.
-        // "Extra Sambal") still showed — and were forced as a required pick —
-        // on the website while correctly absent in the native apps.
-        modifierGroups: filterHiddenModifiers(
-          filterModifiersForChannel(
-            Array.isArray(p.modifiers) ? (p.modifiers as Product["modifierGroups"]) : [],
-            "pickup",
-          ),
-          Array.isArray(p.hidden_modifier_ids) ? (p.hidden_modifier_ids as string[]) : [],
+        // Per-channel modifier visibility is the single source of truth for
+        // what shows where. (The legacy hidden_modifier_ids soft-blacklist —
+        // a StoreHub-sync compat layer — has been retired now that channels
+        // express the same intent; see packages/shared/modifier-channels.ts.)
+        modifierGroups: filterModifiersForChannel(
+          Array.isArray(p.modifiers) ? (p.modifiers as Product["modifierGroups"]) : [],
+          "pickup",
         ) as Product["modifierGroups"],
         featuredPosition: (p.featured_position as number) ?? 9999,
       }));

--- a/apps/pickup-native/lib/menu.ts
+++ b/apps/pickup-native/lib/menu.ts
@@ -38,7 +38,7 @@ export type Product = {
   featured_position?: number;
 };
 
-type RawProduct = Product & { hidden_modifier_ids?: string[]; visible_channels?: string[] };
+type RawProduct = Product & { visible_channels?: string[] };
 
 /** "Show on" placement: empty/missing visible_channels = everywhere; otherwise
  *  the product must list "pickup" to appear in the customer pickup app. */
@@ -52,7 +52,7 @@ export async function fetchMenu(
 ): Promise<{ categories: Category[]; products: Product[] }> {
   const productsQuery = supabase
     .from("products")
-    .select("id,name,category,description,price,image_url,is_available,is_featured,modifiers,hidden_modifier_ids,visible_channels,featured_position")
+    .select("id,name,category,description,price,image_url,is_available,is_featured,modifiers,visible_channels,featured_position")
     .eq("brand_id", "brand-celsius")
     .order("position")
     .order("name");
@@ -85,30 +85,23 @@ export async function fetchMenu(
 
   return {
     categories: (cats ?? []) as Category[],
-    // Backoffice can soft-hide noisy modifier groups or specific options
-    // (think "ice level: cold", "cup type", etc) without losing the StoreHub
-    // source data. Customers shouldn't see them — strip both at read time.
+    // Per-channel modifier visibility is the single source of truth for what
+    // shows where. (The legacy hidden_modifier_ids soft-blacklist — a
+    // StoreHub-sync compat layer — has been retired now that channels express
+    // the same intent.)
     products: ((prods ?? []) as RawProduct[])
       .filter((p) => !oosAtOutlet.has(p.id) && visibleOnPickup(p.visible_channels))
       .map((p) => {
-        const hidden = new Set(Array.isArray(p.hidden_modifier_ids) ? p.hidden_modifier_ids : []);
         const modifiers = Array.isArray(p.modifiers) ? p.modifiers : [];
         return {
           ...p,
           modifiers: modifiers
-            // Honor per-channel modifier visibility: drop any group/option
-            // restricted to other channels — e.g. a Grab-only "Packaging
-            // +RM0.90" must not show or charge on pickup. Mirrors the web
-            // app's filterModifiersForChannel; the native reader had been
-            // missing this, leaking grab-only modifiers (and their default
-            // price deltas) into the pickup menu, product page, and the
-            // Pair-with-a-bite price.
-            .filter((g) => !hidden.has(g.id) && visibleOnPickup(g.channels))
+            // Drop any group/option restricted to other channels — e.g. a
+            // Grab-only "Packaging +RM0.90" must not show or charge on pickup.
+            .filter((g) => visibleOnPickup(g.channels))
             .map((g) => ({
               ...g,
-              options: g.options.filter(
-                (opt) => !hidden.has(opt.id) && visibleOnPickup(opt.channels),
-              ),
+              options: g.options.filter((opt) => visibleOnPickup(opt.channels)),
             }))
             // Drop a group entirely if every option got hidden — empty
             // selectors confuse the product detail screen.

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -47,7 +47,7 @@ export {
 } from "./format";
 export { sendSMS, getSMSProvider } from "./sms";
 export type { SMSProvider } from "./sms";
-export { filterModifiersForChannel, filterHiddenModifiers } from "./modifier-channels";
+export { filterModifiersForChannel } from "./modifier-channels";
 export type { ModifierChannel, ModifierGroupLike, ModifierOptionLike } from "./modifier-channels";
 // OTP is intentionally NOT re-exported here — it imports node:crypto,
 // which Turbopack pulls into every consumer of this barrel (including

--- a/packages/shared/src/modifier-channels.ts
+++ b/packages/shared/src/modifier-channels.ts
@@ -75,25 +75,3 @@ export function filterModifiersForChannel<T extends ModifierGroupLike>(
         : g.options,
     }));
 }
-
-// Drop modifier groups / options whose id is in the soft-blacklist
-// (products.hidden_modifier_ids). Originally a StoreHub-sync compat layer —
-// hide noisy/undesirable synced modifiers without the next sync undoing it —
-// but it's the catalog's source of truth for "hidden", so EVERY customer
-// surface (web order app + pickup-native + Grab/FoodPanda sync) must apply it.
-// A group left with no visible options is dropped (an empty selector is a bug).
-export function filterHiddenModifiers<T extends ModifierGroupLike>(
-  groups: T[] | null | undefined,
-  hiddenIds: string[] | null | undefined,
-): T[] {
-  if (!Array.isArray(groups)) return [];
-  const hidden = new Set(Array.isArray(hiddenIds) ? hiddenIds : []);
-  if (hidden.size === 0) return groups;
-  return groups
-    .filter((g) => !(g.id && hidden.has(g.id)))
-    .map((g) => ({
-      ...g,
-      options: Array.isArray(g.options) ? g.options.filter((o) => !(o.id && hidden.has(o.id))) : g.options,
-    }))
-    .filter((g) => !Array.isArray(g.options) || g.options.length > 0);
-}


### PR DESCRIPTION
## What

Retire the `hidden_modifier_ids` soft-blacklist. It was a StoreHub-sync compatibility layer; now that per-channel modifier visibility (`modifiers[].channels` / the backoffice "SHOW ON" toggles) exists, the blacklist is redundant **and** conflicting — a modifier shown on all channels in the editor could still be silently removed by the blacklist, with no UI to see or clear it.

## Why (the bug it caused)

On `order.celsiuscoffee.com`, **Nasi Lemak 2 Sambal** showed **no modifiers**: "Extra Sambal" was enabled on all channels in the catalog but its group id sat in the product's `hidden_modifier_ids`, so both web and native dropped it. POS already filtered by channel only, so the customer apps were the odd ones out.

## Change

- `apps/order` menu-data: drop `filterHiddenModifiers`; per-channel filter only.
- `apps/pickup-native` menu: drop the inline `hidden.has(...)` checks; per-channel filter only.
- `packages/shared`: remove the now-unused `filterHiddenModifiers` helper + export.
- Stop selecting `hidden_modifier_ids` in both readers.

`channels` is now the single source of truth across POS, web, and native.

## Effect (audited against prod catalog)

11 products carried a blacklist (16 ids); 7 are stale ids matching nothing. **9 real add-ons reappear** on the customer channel (all have no channel restriction = show everywhere), which is the intended outcome:

- **Extra Shot** (option) — Buttercream Chocolate, Chocolate, Matcha, Mint Matcha, Strawberry Matcha
- **Extra Sambal** (group) — Nasi Lemak 2 Sambal ×3 variants
- **Add Celsius Secret Sauce** (group) — Smoked Pulled Lamb

To hide any modifier from customers going forward, restrict its `channels` (un-tick Pickup/Dine-in) instead of using the retired blacklist.

## Notes / follow-ups

- The `hidden_modifier_ids` column is left in place but **inert** (no longer read). Clearing the data and dropping the column (plus the backoffice passthrough) can be a follow-up.
- Pre-existing separate issue: customer apps filter by the `pickup` channel only, so the "Dine-in" SHOW ON toggle has no effect on QR/dine-in orders — not addressed here.

https://claude.ai/code/session_01QDNdybSVB2vJ39yEbQLECi

---
_Generated by [Claude Code](https://claude.ai/code/session_01QDNdybSVB2vJ39yEbQLECi)_