### PR TITLE
catalog(backoffice): retire residual hidden_modifier_ids plumbing

### DIFF
--- a/apps/backoffice/src/app/(admin)/pickup/menu/_ModifierGroupsEditor.tsx
+++ b/apps/backoffice/src/app/(admin)/pickup/menu/_ModifierGroupsEditor.tsx
@@ -31,7 +31,7 @@ const CHANNELS: { value: ModifierChannel; label: string }[] = [
 
 // Local id generator — modifier groups/options live as jsonb on the product
 // row, so they don't have DB-generated ids. A short random suffix is enough
-// to keep React keys + hidden_modifier_ids stable across edits.
+// to keep React keys stable across edits.
 function uid(prefix: string) {
   return `${prefix}_${Math.random().toString(36).slice(2, 9)}`;
 }

--- a/apps/backoffice/src/app/(admin)/pickup/menu/_ProductForm.tsx
+++ b/apps/backoffice/src/app/(admin)/pickup/menu/_ProductForm.tsx
@@ -21,7 +21,6 @@ export interface DbProduct {
   is_new: boolean;
   variants: { id: string; name: string; price: number }[];
   modifiers: ModifierGroup[];
-  hidden_modifier_ids: string[];
   position: number;
   featured_position: number;
   print_additional_docket: boolean;

--- a/apps/backoffice/src/app/(admin)/pickup/menu/page.tsx
+++ b/apps/backoffice/src/app/(admin)/pickup/menu/page.tsx
@@ -31,7 +31,6 @@ interface DbProduct {
   is_new: boolean;
   variants: { id: string; name: string; price: number }[];
   modifiers: ModifierGroup[];
-  hidden_modifier_ids: string[];
   position: number;
   featured_position: number;
 }

--- a/apps/backoffice/src/app/api/pickup/products/[id]/route.ts
+++ b/apps/backoffice/src/app/api/pickup/products/[id]/route.ts
@@ -30,13 +30,6 @@ export async function PATCH(
     update.featured_position = Math.round(body.featured_position);
   }
 
-  // Soft-blacklist of modifier group IDs / option IDs the merchant wants to
-  // hide from customers. Stored as jsonb array; sync from StoreHub leaves
-  // this field alone, so deletions persist across re-syncs.
-  if (Array.isArray(body.hidden_modifier_ids)) {
-    update.hidden_modifier_ids = body.hidden_modifier_ids.filter((x): x is string => typeof x === "string");
-  }
-
   // Modifier groups — backoffice-owned (we no longer pull these from StoreHub
   // sync, so the merchant manages them directly here). Stored as jsonb on
   // products.modifiers. Shape mirrors StoreHub: group { id, name, multiSelect,

--- a/apps/backoffice/src/app/api/pickup/products/route.ts
+++ b/apps/backoffice/src/app/api/pickup/products/route.ts
@@ -10,7 +10,7 @@ export async function GET(request: NextRequest) {
   const supabase = getSupabaseAdmin();
   const { data, error } = await supabase
     .from("products")
-    .select("id, name, category, price, image_url, is_available, is_featured, modifiers, hidden_modifier_ids, track_stock, synced_at, position, featured_position, print_additional_docket, kitchen_station, e_invoice_classification_code, schedule_start_date, schedule_end_date, schedule_days_of_week, schedule_time_from, schedule_time_to, price_pickup, price_grab, price_foodpanda, price_dinein, tax_rate, tax_inclusive")
+    .select("id, name, category, price, image_url, is_available, is_featured, modifiers, track_stock, synced_at, position, featured_position, print_additional_docket, kitchen_station, e_invoice_classification_code, schedule_start_date, schedule_end_date, schedule_days_of_week, schedule_time_from, schedule_time_to, price_pickup, price_grab, price_foodpanda, price_dinein, tax_rate, tax_inclusive")
     .eq("brand_id", "brand-celsius")
     .order("category")
     .order("position")
@@ -31,7 +31,6 @@ export async function GET(request: NextRequest) {
     is_new:       false,
     variants:     [],
     modifiers:    Array.isArray(p.modifiers) ? p.modifiers : [],
-    hidden_modifier_ids: Array.isArray(p.hidden_modifier_ids) ? p.hidden_modifier_ids : [],
     position:     (p.position as number) ?? 9999,
     featured_position: (p.featured_position as number) ?? 9999,
     // StoreHub-parity fields.


### PR DESCRIPTION
## Why

While investigating a report that **Extra Sambal on Nasi Lemak doesn't appear in the pickup app** (modifiers not mirroring backoffice), the root cause was the legacy per-product `hidden_modifier_ids` blacklist still hiding the group — even though the backoffice "Show on" editor showed it as visible everywhere, with no UI to reconcile the two.

#243 already removed the **customer-facing reads** of that blacklist (channels are now the single source of truth), and the stale blacklist **data** has been cleared from the products table. But the **backoffice plumbing** was still alive: the pickup-products API kept selecting/returning/writing the column, and the menu form types still carried it — dead code with no editor surface.

This PR removes that residual plumbing.

## Changes

- `GET /api/pickup/products`: drop `hidden_modifier_ids` from the `select` and the mapped response.
- `PATCH /api/pickup/products/[id]`: drop the write block.
- `pickup/menu` page + `_ProductForm` `DbProduct` types: drop the field.
- `_ModifierGroupsEditor`: tidy a stale comment reference.

## Deliberately out of scope

The `products.hidden_modifier_ids` **column** is left in place (now inert and unreferenced). Dropping it now would break the **currently-deployed** backoffice, whose `SELECT` still names the column during rollout. It can be dropped in a follow-up migration once this ships. The stale per-product blacklist data was already cleared directly in the DB, so customer surfaces are already correct.

## Verification

- `grep` confirms only explanatory comments reference `hidden_modifier_ids` after this change.
- No type errors introduced by removing the field (nothing else constructs or reads it).

https://claude.ai/code/session_01LiL5ppx4k5n85qVfQHu24K

---
_Generated by [Claude Code](https://claude.ai/code/session_01LiL5ppx4k5n85qVfQHu24K)_