### PR TITLE
feat(pos-native): sleep/lock idle tills so online orders keep printing

### DIFF
--- a/apps/pos-native/app/register.tsx
+++ b/apps/pos-native/app/register.tsx
@@ -19,6 +19,7 @@ import { apiPost } from "@/lib/api";
 import { supabase } from "@/lib/supabase";
 import { usePickupPrinter } from "@/lib/use-pickup-printer";
 import { useGrabPrinter } from "@/lib/use-grab-printer";
+import LockScreen from "@/components/lock-screen";
 import { chargeMaybankCard, type MaybankTerminalResult } from "@/lib/maybank-terminal";
 import { fetchCategories, fetchProducts, type Product, type ModifierOption } from "@/lib/menu";
 import { useCart, cartSubtotal, type CartLine } from "@/lib/cart";
@@ -125,7 +126,7 @@ type AppliedReward = { redemptionId: string | null; rewardId: string | null; nam
 type Panel = "none" | "customer" | "table";
 
 export default function Register() {
-  const { staff, outletId, signOut, loggedInAt, shiftEndsAt } = usePos();
+  const { staff, outletId, signOut, loggedInAt, shiftEndsAt, locked, lock } = usePos();
   const [activeCat, setActiveCat] = useState<string>("all");
   // One "Orders" command center — four tabs: QR Tables (dine-in floor + QR
   // self-orders) · Pickup · Grab · History (today, all channels, filterable).
@@ -551,7 +552,7 @@ export default function Register() {
   // no checkout/paid screen). A rostered end also closes the store (Z-roll-up)
   // on the way out. Re-checked on every cart change plus a slow idle poll.
   useEffect(() => {
-    if (!staff) return;
+    if (!staff || locked) return; // already asleep → nothing to re-check
     const maybeLogout = () => {
       if (!shiftSessionExpired(loggedInAt, shiftEndsAt)) { setShiftEnded(false); return; }
       // The session's clock is up. Never yank the cashier mid-task: hold for an
@@ -559,17 +560,28 @@ export default function Register() {
       // are still waiting on those).
       if (lines.length > 0 || showCheckout || paid) return;
       if (openLiveCount > 0) { setShiftEnded(true); return; } // keep them in to finish + hand over
-      // Safe gap, nothing outstanding → close the rostered shift + sign out.
-      if (shiftEndsAt != null && shift) { void closeShift(shift, staff.staffId); }
       setShiftEnded(false);
-      signOut();
-      router.replace("/");
+      if (shiftEndsAt != null) {
+        // Rostered shift END = a real financial close → close the store
+        // (Z-roll-up) and fully sign out, exactly as before. The next rostered
+        // cashier logs in fresh and auto-opens; no shift-lifecycle ambiguity.
+        if (shift) void closeShift(shift, staff.staffId);
+        signOut();
+        router.replace("/");
+      } else {
+        // Off-schedule / manager session hit the 2h idle TTL → SLEEP/LOCK rather
+        // than sign out + leave the register. No shift is closed here, so the
+        // same (manually-opened) shift simply continues on resume. The register
+        // stays mounted, so its online-order auto-printers + chime keep firing
+        // while the till is asleep; a staff PIN on the overlay resumes it.
+        lock();
+      }
     };
     maybeLogout();
     const id = setInterval(maybeLogout, 20000);
     return () => clearInterval(id);
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [staff, loggedInAt, shiftEndsAt, lines.length, showCheckout, paid, shift, openLiveCount]);
+  }, [staff, locked, loggedInAt, shiftEndsAt, lines.length, showCheckout, paid, shift, openLiveCount]);
 
   // ── Open Store on scheduled login ────────────────────────────────────
   // A rostered session (shiftEndsAt set) auto-opens the store the first time
@@ -2540,6 +2552,11 @@ export default function Register() {
           </View>
         </View>
       </Modal>
+
+      {/* Sleep/lock overlay — covers the till behind a PIN when the shift/idle
+          timer fires, WITHOUT unmounting the register (so the online-order
+          auto-printers + chime above keep running while it's asleep). */}
+      {locked && <LockScreen />}
     </View>
   );
 }

--- a/apps/pos-native/components/lock-screen.tsx
+++ b/apps/pos-native/components/lock-screen.tsx
@@ -1,0 +1,182 @@
+import { useCallback, useEffect, useState } from "react";
+import { View, Text, Pressable, Image, useWindowDimensions } from "react-native";
+import * as Haptics from "expo-haptics";
+import { Delete } from "lucide-react-native";
+import { apiPost } from "@/lib/api";
+import { usePos } from "@/lib/store";
+
+/**
+ * Sleep/lock overlay for the register.
+ *
+ * The auto-logout timer flips usePos().locked instead of signing out and
+ * leaving the register, so the register stays mounted and its online-order
+ * auto-printers + chime (usePickupPrinter / useGrabPrinter / useOrderChime —
+ * all keyed on outletId, not staff) keep firing while the till is idle. This
+ * overlay sits on top, blocks all interaction, and requires a staff PIN to
+ * resume — same auth as the login screen (incl. manager override), so sales
+ * still can't happen without a PIN and attribution is preserved.
+ *
+ * On a successful PIN, setStaff() also clears `locked`, so this unmounts.
+ * Deliberately self-contained (no outlet picker, no navigation) so it can be
+ * dropped over the register without touching the login flow.
+ */
+
+const SURFACE_RAISED = "rgba(245,243,240,0.06)";
+const BRAND = "#A2492C";
+const DANGER = "#E5484D";
+
+function clockLabel(d: Date): string {
+  let h = d.getHours();
+  const m = d.getMinutes().toString().padStart(2, "0");
+  const ampm = h >= 12 ? "PM" : "AM";
+  h = h % 12 || 12;
+  return `${h}:${m} ${ampm}`;
+}
+
+export default function LockScreen() {
+  const { outletId, setStaff } = usePos();
+  const [pin, setPin] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [busy, setBusy] = useState(false);
+  // Manager-override mode: rostered staff signing in outside their shift get a
+  // 403 NOT_SCHEDULED; the keypad then collects a MANAGER pin to authorise.
+  const [override, setOverride] = useState<{ staffPin: string } | null>(null);
+  const [now, setNow] = useState(() => new Date());
+
+  // Live clock for the "asleep" framing — cheap 30s tick.
+  useEffect(() => {
+    const id = setInterval(() => setNow(new Date()), 30000);
+    return () => clearInterval(id);
+  }, []);
+
+  const submit = useCallback(
+    async (fullPin: string) => {
+      if (!outletId) { setError("No outlet set"); return; }
+      setBusy(true);
+      setError(null);
+      const isOverride = !!override;
+      const payload = isOverride
+        ? { pin: override!.staffPin, outletId, overridePin: fullPin }
+        : { pin: fullPin, outletId };
+      try {
+        const u = await apiPost<{ id: string; name: string; role: string; shiftEnd?: string | null }>(
+          "/api/pos/auth/pin", payload,
+        );
+        const shiftEndsAt = u.shiftEnd ? Date.parse(u.shiftEnd) : null;
+        // setStaff stamps a fresh session AND clears `locked` → this unmounts.
+        setStaff({ staffId: u.id, staffName: u.name, role: u.role }, shiftEndsAt);
+        setOverride(null);
+        Haptics.notificationAsync(Haptics.NotificationFeedbackType.Success);
+      } catch (e: any) {
+        const msg = String(e?.message ?? "");
+        if (!isOverride && msg.includes("NOT_SCHEDULED")) {
+          setOverride({ staffPin: fullPin });
+          setPin("");
+          Haptics.notificationAsync(Haptics.NotificationFeedbackType.Warning);
+          setBusy(false);
+          return;
+        }
+        setError(
+          msg.includes("OVERRIDE_FAILED") ? "Manager PIN not recognised" :
+          msg.includes("NOT_SCHEDULED") ? "Not scheduled — ask a manager" :
+          msg.includes("401") ? "Invalid PIN" :
+          msg.includes("409") ? "Duplicate PIN — see manager" :
+          "Login error",
+        );
+        Haptics.notificationAsync(Haptics.NotificationFeedbackType.Error);
+        setTimeout(() => { setPin(""); setError(null); }, 1100);
+      } finally {
+        setBusy(false);
+      }
+    },
+    [outletId, override, setStaff],
+  );
+
+  function digit(d: string) {
+    if (busy || pin.length >= 6) return;
+    Haptics.selectionAsync();
+    const next = pin + d;
+    setPin(next);
+    setError(null);
+    if (next.length === 6) submit(next);
+  }
+  const del = () => { if (!busy) { Haptics.selectionAsync(); setPin((p) => p.slice(0, -1)); setError(null); } };
+  const clear = () => { if (!busy) { Haptics.selectionAsync(); setPin(""); setError(null); setOverride(null); } };
+
+  const { width: winW, height: winH } = useWindowDimensions();
+  const scale = Math.min(1, (winW - 56) / 644, (winH - 56) / 400);
+
+  return (
+    <View
+      // Absolute full-screen cover — blocks every touch on the register beneath.
+      style={{ position: "absolute", top: 0, left: 0, right: 0, bottom: 0, backgroundColor: "#0B0402", alignItems: "center", justifyContent: "center" }}
+    >
+      <View className="flex-row items-center" style={{ gap: 72, transform: [{ scale }] }}>
+        {/* Left: asleep identity + clock + PIN dots */}
+        <View className="items-center" style={{ gap: 20, width: 300 }}>
+          <Image source={require("@/assets/icon.png")} style={{ width: 96, height: 96, borderRadius: 24, opacity: 0.92 }} resizeMode="contain" />
+          <Text style={{ fontFamily: "Peachi-Bold", fontSize: 46, color: "rgba(245,243,240,0.92)", lineHeight: 50 }}>{clockLabel(now)}</Text>
+          <Text style={{ fontFamily: "SpaceGrotesk_500Medium", fontSize: 15, color: override ? "#FBBF24" : "rgba(245,243,240,0.55)" }}>
+            {override ? "Manager PIN to authorise" : "Till asleep — enter PIN to resume"}
+          </Text>
+
+          {/* PIN dots */}
+          <View className="flex-row" style={{ gap: 16, marginTop: 4 }}>
+            {[0, 1, 2, 3, 4, 5].map((i) => {
+              const filled = i < pin.length;
+              return (
+                <View
+                  key={i}
+                  className="h-5 w-5 rounded-full"
+                  style={{ backgroundColor: filled ? (error ? DANGER : BRAND) : "#3A2A22", transform: [{ scale: filled ? 1.25 : 1 }] }}
+                />
+              );
+            })}
+          </View>
+
+          {/* Status line */}
+          <View className="h-6 justify-center">
+            {busy ? (
+              <Text style={{ fontFamily: "SpaceGrotesk_500Medium", fontSize: 17, color: "rgba(245,243,240,0.55)" }}>Verifying…</Text>
+            ) : error ? (
+              <Text style={{ fontFamily: "SpaceGrotesk_600SemiBold", fontSize: 17, color: DANGER }}>{error}</Text>
+            ) : override ? (
+              <Text style={{ fontFamily: "SpaceGrotesk_500Medium", fontSize: 13, color: "#FBBF24" }}>Not scheduled — manager PIN, or Clear to cancel</Text>
+            ) : null}
+          </View>
+        </View>
+
+        {/* Right: keypad — 1-9, Clear · 0 · ⌫ */}
+        <View style={{ gap: 16 }}>
+          {[["1", "2", "3"], ["4", "5", "6"], ["7", "8", "9"]].map((row, ri) => (
+            <View key={ri} className="flex-row" style={{ gap: 16 }}>
+              {row.map((d) => <DigitKey key={d} label={d} onPress={() => digit(d)} disabled={busy} />)}
+            </View>
+          ))}
+          <View className="flex-row" style={{ gap: 16 }}>
+            <Pressable onPress={clear} className="h-20 w-20 rounded-2xl items-center justify-center active:opacity-60" style={{ backgroundColor: "rgba(229,72,77,0.18)" }}>
+              <Text style={{ fontFamily: "SpaceGrotesk_600SemiBold", fontSize: 16, color: DANGER }}>Clear</Text>
+            </Pressable>
+            <DigitKey label="0" onPress={() => digit("0")} disabled={busy} />
+            <Pressable onPress={del} className="h-20 w-20 rounded-2xl items-center justify-center active:opacity-60" style={{ backgroundColor: SURFACE_RAISED }}>
+              <Delete size={28} color="#F5F3F0" />
+            </Pressable>
+          </View>
+        </View>
+      </View>
+    </View>
+  );
+}
+
+function DigitKey({ label, onPress, disabled }: { label: string; onPress: () => void; disabled?: boolean }) {
+  return (
+    <Pressable
+      onPress={onPress}
+      disabled={disabled}
+      className="h-20 w-20 rounded-2xl items-center justify-center active:opacity-60"
+      style={{ backgroundColor: SURFACE_RAISED, opacity: disabled ? 0.5 : 1 }}
+    >
+      <Text style={{ fontFamily: "SpaceGrotesk_500Medium", fontSize: 30, color: "#F5F3F0" }}>{label}</Text>
+    </Pressable>
+  );
+}

--- a/apps/pos-native/lib/store.ts
+++ b/apps/pos-native/lib/store.ts
@@ -50,9 +50,16 @@ type PosState = {
    *  null when the login wasn't schedule-bound (manager / override / no roster),
    *  in which case the 2h TTL applies instead. */
   shiftEndsAt: number | null;
+  /** "Sleep/lock" mode: the auto-logout timer locks the till behind a PIN
+   *  overlay INSTEAD of signing out + leaving the register, so the screen's
+   *  online-order auto-printers + chime keep running while the till is idle.
+   *  Not persisted — a relaunch goes through the normal login. */
+  locked: boolean;
   setOutlet: (id: string) => void;
   setStaff: (s: StaffSession, shiftEndsAt?: number | null) => void;
   signOut: () => void;
+  lock: () => void;
+  unlock: () => void;
 };
 
 export const usePos = create<PosState>()(
@@ -62,11 +69,15 @@ export const usePos = create<PosState>()(
       staff: null,
       loggedInAt: null,
       shiftEndsAt: null,
+      locked: false,
       setOutlet: (id) => set({ outletId: id }),
       // Stamp the sign-in time + (optional) rostered shift end so the session
       // can auto-expire at shift end, or after SESSION_TTL_MS as a fallback.
-      setStaff: (s, shiftEndsAt = null) => set({ staff: s, loggedInAt: Date.now(), shiftEndsAt }),
-      signOut: () => set({ staff: null, loggedInAt: null, shiftEndsAt: null }),
+      // A fresh sign-in always clears the lock.
+      setStaff: (s, shiftEndsAt = null) => set({ staff: s, loggedInAt: Date.now(), shiftEndsAt, locked: false }),
+      signOut: () => set({ staff: null, loggedInAt: null, shiftEndsAt: null, locked: false }),
+      lock: () => set({ locked: true }),
+      unlock: () => set({ locked: false }),
     }),
     {
       name: "celsius-pos-session",


### PR DESCRIPTION
## Problem
The online-order auto-printers (`usePickupPrinter`, `useGrabPrinter`) and the new-order chime are mounted on the **register screen**, keyed on `outletId`. The idle auto-logout does `signOut()` + `router.replace("/")`, which **unmounts the register** → those Realtime listeners tear down → web/QR/Grab kitchen dockets stop printing in real time until someone logs back in (they only catch up on next login). A customer waiting on a just-placed online order gets a late docket.

## Fix
When an **off-schedule / manager session hits the 2h idle TTL**, drop a **PIN-locked "sleep" overlay** over the register instead of logging out. The register stays mounted, so the printers + chime keep firing while the till is asleep; a staff PIN (same auth as login, incl. manager override) resumes it. Keep-awake is already global (`_layout`), so the WebSocket stays alive.

## Scope (deliberately conservative)
Only the **idle-TTL path (`shiftEndsAt == null`)** sleeps — no shift is closed there, so the same manually-opened shift just continues on resume. A **rostered shift END** is a real financial close (Z-roll-up) and keeps the existing full close + sign-out, **untouched** — zero change to shift accounting.

- `store`: add `locked` + `lock()`/`unlock()`; `setStaff`/`signOut` clear it; not persisted.
- `register`: idle path → `lock()`; rostered end → unchanged logout; render `<LockScreen/>` over the root when locked; the idle effect skips while locked.
- new `components/lock-screen.tsx`: dimmed clock + PIN keypad overlay; valid PIN → `setStaff()` resumes (and clears `locked`). Handover = any valid staff (per your choice).

## Open question for reviewer
This only triggers for **non-rostered / manager** logins (those are what hit the 2h idle TTL). If your tills log in via **rostered "Open Store"**, they only auto-logout at scheduled shift end, not from idling — so we may want to extend "sleep" to the rostered handover too (slightly more involved because of the Z-roll-up + reopen). Holding merge to confirm.

https://claude.ai/code/session_01GjJgv2uzoBTm57fC3T3MgR

---
_Generated by [Claude Code](https://claude.ai/code/session_01GjJgv2uzoBTm57fC3T3MgR)_