### PR TITLE
fix(pos-native): auto-clear thank-you/claim-points screen after idle

### DIFF
--- a/apps/pos-native/app/customer-display.tsx
+++ b/apps/pos-native/app/customer-display.tsx
@@ -206,6 +206,20 @@ export default function CustomerDisplay() {
     return () => { cancelled = true; };
   }, [status, member?.id, snapshot]);
 
+  // Auto-clear the thank-you / "claim your points" screen back to idle when the
+  // customer walks off without doing anything — otherwise the previous order's
+  // prompt (esp. a guest's "don't miss your Points") stays up until staff start
+  // a new sale, greeting the next customer with the last one's screen. The
+  // window restarts if a guest signs in (member changes) so an active claimer
+  // gets a fresh minute to reveal; a member who taps reveal dismisses sooner
+  // via "Got it". The register's own New Order still resets everything; this is
+  // just a safety timeout on the customer-facing screen.
+  useEffect(() => {
+    if (status !== "complete") return;
+    const t = setTimeout(() => useDisplay.getState().setStatus("idle"), 60000);
+    return () => clearTimeout(t);
+  }, [status, member?.id]);
+
   function openRedeem() {
     if (!member) return;
     setRedeemOpen(true);


### PR DESCRIPTION
## Problem
After a sale, the customer display's **complete** screen — especially a guest's **"Don't miss your Points"** claim prompt — stayed up until staff pressed **New Order**. So if the customer walked off without claiming, the next customer was greeted by the previous order's screen.

## Fix
Add a **60s no-interaction timeout** on the complete screen that reverts the customer display to **idle** (the guest claim prompt lives inside the `status === "complete"` block, so flipping status clears it). The window **restarts if a guest signs in** (so an active claimer keeps a full minute to reveal), and a member who taps reveal still dismisses sooner via "Got it". The register's New Order continues to reset everything — this is just a safety auto-clear on the customer-facing screen. The cart is already cleared at completion, so idle renders the welcome poster cleanly.

pos-native-only → ships via OTA.

https://claude.ai/code/session_01GjJgv2uzoBTm57fC3T3MgR

---
_Generated by [Claude Code](https://claude.ai/code/session_01GjJgv2uzoBTm57fC3T3MgR)_