### PR TITLE
feat(pos-native): edit a cart line's modifiers from the line editor

### DIFF
--- a/apps/pos-native/app/register.tsx
+++ b/apps/pos-native/app/register.tsx
@@ -168,6 +168,8 @@ export default function Register() {
   const [paying, setPaying] = useState(false);
   const [paid, setPaid] = useState<{ orderNumber: string; total: number; beansEarned: number; beansBalance: number } | null>(null);
   const [modProduct, setModProduct] = useState<Product | null>(null);
+  // Cart line whose modifiers are being edited (opens the picker pre-selected).
+  const [modEditKey, setModEditKey] = useState<string | null>(null);
 
   // Cashier-applied manual discount (sen) — stacks on top of loyalty/promo.
   const [manualDiscount, setManualDiscount] = useState(0);
@@ -633,6 +635,7 @@ export default function Register() {
   const dec = useCart((s) => s.dec);
   const remove = useCart((s) => s.remove);
   const setLineDiscount = useCart((s) => s.setLineDiscount);
+  const setLineModifiers = useCart((s) => s.setLineModifiers);
   const setLineNote = useCart((s) => s.setLineNote);
   const setLineTakeaway = useCart((s) => s.setLineTakeaway);
   const replaceLines = useCart((s) => s.replaceLines);
@@ -2562,6 +2565,23 @@ export default function Register() {
         )}
       </Modal>
 
+      {/* ── Edit a cart line's modifiers — same picker, pre-selected ── */}
+      <Modal visible={!!modEditKey} transparent animationType="fade" onRequestClose={() => setModEditKey(null)}>
+        {(() => {
+          const line = lines.find((l) => l.key === modEditKey);
+          if (!line) return null;
+          return (
+            <ModifierSheet
+              product={line.product}
+              initial={line.modifiers}
+              confirmVerb="Save"
+              onClose={() => setModEditKey(null)}
+              onConfirm={(opts) => { setLineModifiers(line.key, opts); Haptics.selectionAsync(); setModEditKey(null); }}
+            />
+          );
+        })()}
+      </Modal>
+
       {/* ── Manual discount ── */}
       <Modal visible={showDiscount} transparent animationType="fade" onRequestClose={() => setShowDiscount(false)}>
         <DiscountSheet
@@ -2587,6 +2607,7 @@ export default function Register() {
               onSetDiscount={(sen) => { setLineDiscount(line.key, sen); }}
               onSetNote={(note) => { setLineNote(line.key, note); }}
               onToggleTakeaway={(takeaway) => { setLineTakeaway(line.key, takeaway); }}
+              onEditOptions={line.product.modifiers.length > 0 ? () => { setEditLineKey(null); setModEditKey(line.key); } : undefined}
             />
           );
         })()}
@@ -2847,8 +2868,19 @@ function RegisterRedeemCard({ shop, onRedeem }: { shop: ShopCard; onRedeem: () =
   );
 }
 
-function ModifierSheet({ product, onClose, onConfirm }: { product: Product; onClose: () => void; onConfirm: (opts: ModifierOption[]) => void }) {
-  const [sel, setSel] = useState<Record<string, string[]>>({});
+function ModifierSheet({ product, onClose, onConfirm, initial, confirmVerb = "Add" }: { product: Product; onClose: () => void; onConfirm: (opts: ModifierOption[]) => void; initial?: ModifierOption[]; confirmVerb?: string }) {
+  // Seed the selection from `initial` (editing an existing cart line) so the
+  // picker opens pre-ticked; empty for a fresh add.
+  const [sel, setSel] = useState<Record<string, string[]>>(() => {
+    const seed: Record<string, string[]> = {};
+    if (initial?.length) {
+      for (const g of product.modifiers) {
+        const ids = g.options.filter((o) => initial.some((m) => m.id === o.id)).map((o) => o.id);
+        if (ids.length) seed[g.id] = ids;
+      }
+    }
+    return seed;
+  });
   function toggle(groupId: string, optId: string, multi: boolean) {
     Haptics.selectionAsync();
     setSel((cur) => {
@@ -2897,7 +2929,7 @@ function ModifierSheet({ product, onClose, onConfirm }: { product: Product; onCl
           ))}
         </ScrollView>
         <Pressable disabled={missingRequired} onPress={() => onConfirm(chosen)} className={`h-14 rounded-2xl items-center justify-center mt-3 ${missingRequired ? "bg-primary/30" : "bg-primary active:opacity-80"}`}>
-          <Text className="text-cream text-base" style={{ fontFamily: "SpaceGrotesk_700Bold" }}>{missingRequired ? "Select required options" : `Add — ${rm(product.price_sen + addOn)}`}</Text>
+          <Text className="text-cream text-base" style={{ fontFamily: "SpaceGrotesk_700Bold" }}>{missingRequired ? "Select required options" : `${confirmVerb} — ${rm(product.price_sen + addOn)}`}</Text>
         </Pressable>
       </View>
     </View>
@@ -3273,6 +3305,7 @@ function LineEditorSheet({
   onSetDiscount,
   onSetNote,
   onToggleTakeaway,
+  onEditOptions,
 }: {
   line: CartLine;
   onClose: () => void;
@@ -3282,6 +3315,8 @@ function LineEditorSheet({
   onSetDiscount: (sen: number) => void;
   onSetNote: (note: string) => void;
   onToggleTakeaway: (takeaway: boolean) => void;
+  /** Present only when the product has modifier groups — opens the picker. */
+  onEditOptions?: () => void;
 }) {
   const lineGross = line.unit_sen * line.qty;
   const currentDisc = line.line_discount_sen ?? 0;
@@ -3328,6 +3363,21 @@ function LineEditorSheet({
           </View>
           <Pressable onPress={onClose} className="active:opacity-60"><X size={22} color="rgba(245,243,240,0.7)" /></Pressable>
         </View>
+
+        {/* Edit options — reopen the modifier picker pre-selected (only when the
+            product actually has modifier groups). */}
+        {onEditOptions && (
+          <Pressable
+            onPress={() => { Haptics.selectionAsync(); onEditOptions(); }}
+            className="flex-row items-center justify-between rounded-2xl px-4 py-3 active:opacity-80"
+            style={{ backgroundColor: "rgba(251,191,36,0.10)", borderWidth: 1, borderColor: "rgba(251,191,36,0.40)" }}
+          >
+            <Text className="text-cream/60 text-xs uppercase tracking-widest" style={{ fontFamily: "SpaceGrotesk_700Bold" }}>Options</Text>
+            <Text className="text-amber-400 text-sm" style={{ fontFamily: "SpaceGrotesk_700Bold" }}>
+              {line.modifiers.length > 0 ? "Change ›" : "Add ›"}
+            </Text>
+          </Pressable>
+        )}
 
         {/* Quantity stepper */}
         <View className="flex-row items-center justify-between rounded-2xl px-4 py-3" style={{ backgroundColor: "rgba(245,243,240,0.04)", borderWidth: 1, borderColor: "rgba(245,243,240,0.10)" }}>

--- a/apps/pos-native/lib/cart.ts
+++ b/apps/pos-native/lib/cart.ts
@@ -46,6 +46,11 @@ type CartState = {
   setLineNote: (key: string, note: string) => void;
   /** Flip a line's fulfilment override (true = pack to-go on a dine-in order). */
   setLineTakeaway: (key: string, takeaway: boolean) => void;
+  /** Change an existing line's modifier selection. Recomputes the line key +
+   *  unit price (product + new modifier prices) while keeping its qty,
+   *  discount, note and takeaway. If the new product+modifier combo already
+   *  exists as another line, the two merge (qty added), mirroring add(). */
+  setLineModifiers: (key: string, modifiers: ModifierOption[]) => void;
   /** Replace the whole basket at once — used to restore a recovered draft order
    *  on relaunch (lib/draft-order.ts). */
   replaceLines: (lines: CartLine[]) => void;
@@ -94,6 +99,25 @@ export const useCart = create<CartState>((set) => ({
     })),
   setLineTakeaway: (key, takeaway) =>
     set((s) => ({ lines: s.lines.map((l) => (l.key === key ? { ...l, takeaway } : l)) })),
+  setLineModifiers: (key, modifiers) =>
+    set((s) => {
+      const idx = s.lines.findIndex((l) => l.key === key);
+      if (idx < 0) return s;
+      const l = s.lines[idx];
+      const newKey = lineKey(l.product.id, modifiers);
+      if (newKey === key) return s; // nothing changed
+      const unit_sen = l.product.price_sen + modifiers.reduce((sum, m) => sum + m.price_sen, 0);
+      const dupIdx = s.lines.findIndex((x, i) => i !== idx && x.key === newKey);
+      const lines = s.lines.slice();
+      if (dupIdx >= 0) {
+        // The edited combo already exists → merge quantities, drop this line.
+        lines[dupIdx] = { ...lines[dupIdx], qty: lines[dupIdx].qty + l.qty };
+        lines.splice(idx, 1);
+      } else {
+        lines[idx] = { ...l, key: newKey, modifiers, unit_sen };
+      }
+      return { lines };
+    }),
   replaceLines: (lines) => set({ lines }),
   clear: () => set({ lines: [] }),
 }));


### PR DESCRIPTION
## What
In the register's **cart-line editor** (tap a line → the sheet with Quantity / Takeaway / Discount / Item Note), you couldn't change the drink's **options/modifiers** — to fix a wrong choice you had to remove and re-add the item. This adds an **Options** row that reopens the modifier picker **pre-selected** with the line's current choices.

## How
- **cart store:** `setLineModifiers(key, modifiers)` — swaps a line's modifiers, recomputing its key + unit price while keeping qty / discount / note / takeaway; merges into an existing line if the edited combo already exists (mirrors `add`).
- **ModifierSheet:** optional `initial` selection + `confirmVerb` (so the same picker is reused for "Add" and "Save"), with the same required-option validation.
- **LineEditorSheet:** an "Options · Change ›" button, shown only when the product has modifier groups.

pos-native-only → ships via OTA.

https://claude.ai/code/session_01GjJgv2uzoBTm57fC3T3MgR

---
_Generated by [Claude Code](https://claude.ai/code/session_01GjJgv2uzoBTm57fC3T3MgR)_