### PR TITLE
fix(backoffice): exclude vitest.config.ts from Next build type-check (#231 hotfix)

### DIFF
--- a/apps/backoffice/tsconfig.json
+++ b/apps/backoffice/tsconfig.json
@@ -24,5 +24,5 @@
     ".next/dev/types/**/*.ts",
     "**/*.mts"
   ],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules", "vitest.config.ts"]
 }


### PR DESCRIPTION
## What

One-line `tsconfig.json` change: add `vitest.config.ts` to `exclude` so the Next production build doesn't type-check it.

## Why — main's HEAD currently fails to build

PR #231 added `apps/backoffice/vitest.config.ts`, which imports `"vitest/config"`. That subpath **resolves locally but not in Vercel's production build env** (it pulls `vite` types that aren't resolvable there). Next runs TypeScript type-checking on **every `.ts` in the project**, in a phase that runs *after* compile + Sentry source-map upload — so the production build for `aa3ff426` failed late with:

```
  Running TypeScript ...
./vitest.config.ts:1:30
Type error: Cannot find module 'vitest/config' or its corresponding type declarations.
Next.js build worker exited with code: 1
```

`main`'s HEAD (`aa3ff426`) errored as a result. **Production was never affected** — it kept serving the prior good build `761a749d` (#251).

## The fix

Exclude `vitest.config.ts` from `tsconfig.json`. Notes:
- **Vitest still works** — it loads its config via its own loader, not tsconfig (`vitest run` → 14/14 tests pass).
- **`.test.ts` files stay type-checked** for coverage. They import `"vitest"` (the main entry), which *does* resolve on Vercel — proven by the maybank parser test passing in the known-good `761a749d` build. Only the `"vitest/config"` subpath was the problem.

## Verification (at `aa3ff426` + this change, isolated worktree)
- `tsc --noEmit` → **clean, 0 errors**
- `tsc --listFiles` → `vitest.config.ts` **no longer in the program**; `.test.ts` files still in it
- `vitest run` → **14/14 pass**

## Note on the preview check
The preview/branch deploy will likely show red at the **Sentry source-map upload** step (no upload token on non-production deploys) — that's a pre-existing, preview-only limitation, **not** this change. The type-check phase (which this PR fixes) only runs on the production build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)