### PR TITLE
fix(pickup-native): unique Maybank-QR realtime topic to stop subscribe() crash

### DIFF
--- a/apps/pickup-native/lib/maybank-qr.ts
+++ b/apps/pickup-native/lib/maybank-qr.ts
@@ -53,6 +53,15 @@ async function fetchMaybankQr(): Promise<MaybankQrConfig | null> {
 export function useMaybankQrConfig(): MaybankQrConfig | null {
   const [blob, setBlob] = useState<MaybankQrConfig | null>(null);
   const cancelledRef = useRef(false);
+  // Unique realtime topic PER hook instance. This hook is mounted by two
+  // screens that can be alive at once in the nav stack (checkout +
+  // order/[id]); a shared fixed topic made supabase-js attach the
+  // postgres_changes listener to an already-subscribed channel and throw
+  // "cannot add `postgres_changes` callbacks ... after `subscribe()`".
+  const topicRef = useRef<string>();
+  if (!topicRef.current) {
+    topicRef.current = `maybank-qr-customer-${Math.random().toString(36).slice(2, 10)}`;
+  }
 
   useEffect(() => {
     cancelledRef.current = false;
@@ -60,7 +69,7 @@ export function useMaybankQrConfig(): MaybankQrConfig | null {
       if (!cancelledRef.current) setBlob(b);
     });
     const ch = supabase
-      .channel("maybank-qr-customer")
+      .channel(topicRef.current!)
       .on(
         "postgres_changes",
         {


### PR DESCRIPTION
## Fix

A live Sentry error (prod iOS) — `cannot add `postgres_changes` callbacks for realtime:maybank-qr-customer after `subscribe()``.

`useMaybankQrConfig()` opened a Supabase realtime channel with a **hard-coded topic** (`"maybank-qr-customer"`). The hook is mounted by two screens that can be alive simultaneously in the expo-router stack — `checkout.tsx` and `order/[id].tsx`. Two subscriptions on the same topic made supabase-js attach the `postgres_changes` listener to an already-`subscribe()`d channel and throw.

(The `FpxBankPicker.tsx:18` frame in Sentry was just where it surfaced in the render tree — that component has no realtime code.)

**Change:** each hook instance now uses its own channel topic (random suffix, stable across renders via a ref), so the two subscriptions never collide. JS-only — ships through the `pickup-native` OTA pipeline.

https://claude.ai/code/session_01LiL5ppx4k5n85qVfQHu24K

---
_Generated by [Claude Code](https://claude.ai/code/session_01LiL5ppx4k5n85qVfQHu24K)_