### PR TITLE
chore: wire up Sentry MCP for error triage (.mcp.json)

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,11 @@
+{
+  "mcpServers": {
+    "sentry": {
+      "command": "npx",
+      "args": ["-y", "@sentry/mcp-server@latest"],
+      "env": {
+        "SENTRY_ACCESS_TOKEN": "${SENTRY_ACCESS_TOKEN}"
+      }
+    }
+  }
+}


### PR DESCRIPTION
Wires the Sentry MCP server into the repo so Claude Code sessions (local + cloud) can read and triage Sentry issues directly — the foundation for an automated error-debug loop.

- Project `.mcp.json` carries into cloud sessions (per the Claude Code web docs).
- Uses the stdio `@sentry/mcp-server` with the token read from a `SENTRY_ACCESS_TOKEN` env var — **no secret is committed**.

### Activation (one manual step)
There's no secrets store in the web sandbox yet, so add the token as an **environment variable** in the environment settings:
- `SENTRY_ACCESS_TOKEN` = a Sentry **user auth token** with scopes: `org:read`, `project:read`, `project:write`, `team:read`, `team:write`, `event:write`.
- SaaS (sentry.io) needs no `SENTRY_HOST`. Org `celsius-coffee-sdn-bhd`, project `celsius-pickup-native`.

Takes effect on the next session start.

https://claude.ai/code/session_01LiL5ppx4k5n85qVfQHu24K

---
_Generated by [Claude Code](https://claude.ai/code/session_01LiL5ppx4k5n85qVfQHu24K)_