### PR TITLE
staff-native: rename Dayparts→Rounds + add OTA workflow

### DIFF
--- a/.github/workflows/staff-native-ota.yml
+++ b/.github/workflows/staff-native-ota.yml
@@ -1,0 +1,66 @@
+name: staff-native OTA
+
+# Ships JS-only changes in apps/staff-native to staff devices via EAS Update
+# (the `production` channel the App Store / Play builds subscribe to). No new
+# binary needed — expo-updates pulls the bundle on next app launch, as long as
+# the change is JS/asset-only and the runtimeVersion (appVersion, today 1.0.0)
+# is unchanged. A native/dependency change still needs a fresh `eas build` +
+# store submission, and a version bump won't be picked up by OTA.
+#
+# Triggers on a push to main that touches apps/staff-native, plus manual
+# dispatch so a release can be re-pushed on demand.
+#
+# Requires repo secret EXPO_TOKEN (Expo access token with update perms for the
+# celsiuscoffee org / staff-native project d57490c8-eb64-4f0e-8b5f-15190c8c4a57).
+#
+# Runtime config (Supabase / Sentry / EXPO_PUBLIC_* values) is deliberately NOT
+# hardcoded here. `--environment production` makes eas update load the same
+# server-side EAS environment variables the production build uses, so the OTA
+# bundle's config always matches the installed app.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "apps/staff-native/**"
+  workflow_dispatch: {}
+
+jobs:
+  ota:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: apps/staff-native
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - name: Install dependencies
+        run: npm install --no-audit --no-fund
+      - name: Publish OTA update (production channel)
+        env:
+          EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}
+          # eas update shells out to `expo export`, whose interactive prompts
+          # must be suppressed via CI=1 (the --non-interactive flag is not
+          # honoured by the export sub-step).
+          CI: "1"
+          # Pass the commit message through the environment, NOT inline in the
+          # run script: a multi-line message with backticks / * / newlines would
+          # otherwise be parsed by the shell (command substitution + word
+          # splitting) and feed garbage args to eas. We then take just the first
+          # line as the update message.
+          COMMIT_MSG: ${{ github.event.head_commit.message || github.sha }}
+        run: |
+          MSG="$(printf '%s' "$COMMIT_MSG" | head -n 1)"
+          # --platform all: ios + android (staff app ships on both).
+          # react-native-web + react-dom are deps, so the web export step the
+          # CLI runs under the hood succeeds. --environment production injects
+          # the EAS server-side prod env vars so the bundle config matches the
+          # installed build.
+          npx eas-cli@latest update \
+            --channel production \
+            --platform all \
+            --environment production \
+            --message "$MSG" \
+            --non-interactive

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,11 @@
+{
+  "mcpServers": {
+    "sentry": {
+      "command": "npx",
+      "args": ["-y", "@sentry/mcp-server@latest"],
+      "env": {
+        "SENTRY_ACCESS_TOKEN": "${SENTRY_ACCESS_TOKEN}"
+      }
+    }
+  }
+}

--- a/apps/staff-native/app/(staff)/sales/index.tsx
+++ b/apps/staff-native/app/(staff)/sales/index.tsx
@@ -186,13 +186,13 @@ export default function SalesScreen() {
                 ))}
             </View>
 
-            {/* Channels / Dayparts */}
+            {/* Channels / Rounds */}
             <View className="rounded-3xl border border-[#F5F3F01a] bg-[#2a1508] p-5">
               <Text className="font-display text-sm text-[#F5F3F0]">Sales breakdown</Text>
               <View className="mb-1 mt-3 flex-row gap-1.5 rounded-xl border border-[#F5F3F01a] bg-[#160800] p-1">
                 {(["channel", "round"] as const).map((d) => (
                   <Pressable key={d} onPress={() => setDim(d)} className={`flex-1 items-center rounded-lg py-2 ${dim === d ? "bg-[#A2492C40]" : ""}`}>
-                    <Text className={`text-xs ${dim === d ? "font-body-bold text-[#F5F3F0]" : "font-body-semi text-[#F5F3F08a]"}`}>{d === "channel" ? "Channels" : "Dayparts"}</Text>
+                    <Text className={`text-xs ${dim === d ? "font-body-bold text-[#F5F3F0]" : "font-body-semi text-[#F5F3F08a]"}`}>{d === "channel" ? "Channels" : "Rounds"}</Text>
                   </Pressable>
                 ))}
               </View>


### PR DESCRIPTION
## What
- Rename the Sales-breakdown dimension toggle label **Dayparts → Rounds** (internal key was already `round`; UI now matches).
- Add a **staff-native OTA workflow** mirroring pickup-native / pos-native, so this (and future JS-only staff-native changes) ship to staff devices via EAS Update on push to `main`.

## Shipping
Merging this push touches `apps/staff-native/**`, which triggers the new `staff-native OTA` workflow → publishes to the `production` channel. Staff get the relabel on next app launch (runtime 1.0.0, no new binary).

Requires repo secret `EXPO_TOKEN` to have update perms for staff-native project `d57490c8-eb64-4f0e-8b5f-15190c8c4a57` (same org token used by pickup/pos).

https://claude.ai/code/session_01LiL5ppx4k5n85qVfQHu24K

---
_Generated by [Claude Code](https://claude.ai/code/session_01LiL5ppx4k5n85qVfQHu24K)_