### PR TITLE
feat(sales): RM delta in comparison, scrubbable chart, split QR Table channel

### DIFF
--- a/apps/staff-native/app/(staff)/sales/index.tsx
+++ b/apps/staff-native/app/(staff)/sales/index.tsx
@@ -29,13 +29,17 @@ function rmF(n: number): string {
   return "RM " + i.replace(/\B(?=(\d{3})+(?!\d))/g, ",") + "." + d;
 }
 function numF(n: number): string { return Math.round(n).toString().replace(/\B(?=(\d{3})+(?!\d))/g, ","); }
+function rmDeltaF(n: number): string {
+  const v = Math.round(Math.abs(n)).toString().replace(/\B(?=(\d{3})+(?!\d))/g, ",");
+  return `${n >= 0 ? "+" : "−"}RM ${v}`;
+}
 function deltaStr(d: number | null): string { return d == null ? "New" : `${d >= 0 ? "+" : ""}${d}%`; }
 function deltaUp(d: number | null): boolean { return d == null ? true : d >= 0; }
 
 const PAY_ICON: Record<string, any> = { cash: Banknote, card: CreditCard, duitnow_qr: QrCode, tng: Smartphone, grabpay: Bike, shopeepay: ShoppingBag, fpx: Landmark, wallet: Wallet };
 const PAY_COLOR: Record<string, string> = { cash: "#34d399", card: "#8FB3F0", duitnow_qr: "#FBBF24", tng: "#a78bfa", grabpay: "#34d399", shopeepay: "#fb923c", fpx: "#60a5fa", wallet: "#a78bfa" };
-const CHAN_ICON: Record<string, any> = { dine_in: Utensils, takeaway: ShoppingBag, pickup: Package, delivery: Bike };
-const CHAN_COLOR: Record<string, string> = { dine_in: "#E0875F", takeaway: "#FBBF24", pickup: "#a78bfa", delivery: "#34d399" };
+const CHAN_ICON: Record<string, any> = { dine_in: Utensils, takeaway: ShoppingBag, pickup: Package, delivery: Bike, qr_table: QrCode };
+const CHAN_COLOR: Record<string, string> = { dine_in: "#E0875F", takeaway: "#FBBF24", pickup: "#a78bfa", delivery: "#34d399", qr_table: "#2dd4bf" };
 const ROUND_ICON: Record<string, any> = { breakfast: Sunrise, brunch: Coffee, lunch: Sandwich, midday: Sun, evening: Sunset, dinner: UtensilsCrossed, supper: Moon };
 
 const TABS: { key: Mode; label: string }[] = [
@@ -142,6 +146,7 @@ export default function SalesScreen() {
               <View className={`mt-2 flex-row items-center gap-1 self-start rounded-full px-2.5 py-1 ${deltaUp(s.revenueDelta) ? "bg-[#34d39920]" : "bg-[#f8717120]"}`}>
                 {deltaUp(s.revenueDelta) ? <TrendingUp color="#34d399" size={13} /> : <TrendingDown color="#f87171" size={13} />}
                 <Text className={`font-body-bold text-xs ${deltaUp(s.revenueDelta) ? "text-[#34d399]" : "text-[#f87171]"}`}>{deltaStr(s.revenueDelta)}</Text>
+                <Text className={`font-body-semi text-xs ${deltaUp(s.revenueDelta) ? "text-[#34d399]" : "text-[#f87171]"}`}>· {rmDeltaF(s.revenue - s.prevRevenue)}</Text>
                 <Text className="font-body text-xs text-[#F5F3F08a]"> vs {data.prev.label.toLowerCase()}</Text>
               </View>
               <View className="mt-4 flex-row gap-3 border-t border-[#F5F3F00f] pt-4">
@@ -155,7 +160,7 @@ export default function SalesScreen() {
             <View className="rounded-3xl border border-[#F5F3F01a] bg-[#2a1508] p-5">
               <Text className="font-display text-sm text-[#F5F3F0]">Total Accumulative Sales <Text className="font-body text-[#F5F3F057]">(RM)</Text></Text>
               <Text className="mb-2 mt-0.5 font-body text-[11px] text-[#F5F3F08a]">{data.cur.label} vs {data.prev.label} · running total</Text>
-              <AccumChart series={data.series} />
+              <AccumChart series={data.series} curLabel={data.cur.label} prevLabel={data.prev.label} />
               <View className="mt-3 flex-row justify-center gap-4">
                 <Legend color="#FBBF24" label={data.cur.label} />
                 <Legend color="#8FB3F0" label={data.prev.label} />

--- a/apps/staff-native/components/sales/AccumChart.tsx
+++ b/apps/staff-native/components/sales/AccumChart.tsx
@@ -1,6 +1,6 @@
-import { useState } from "react";
-import { View } from "react-native";
-import Svg, { Path, Line, Circle, Text as SvgText } from "react-native-svg";
+import { useRef, useState } from "react";
+import { PanResponder, View } from "react-native";
+import Svg, { Path, Line, Circle, Rect, Text as SvgText } from "react-native-svg";
 import type { SeriesPoint } from "@/lib/sales/dashboard";
 
 const CUR = "#FBBF24"; // amber — current period
@@ -18,10 +18,26 @@ function niceMax(v: number): number {
 function kfmt(v: number): string {
   return v >= 1000 ? `${Math.round(v / 100) / 10}k` : `${Math.round(v)}`;
 }
+function rmTip(v: number): string {
+  return "RM " + Math.round(v).toString().replace(/\B(?=(\d{3})+(?!\d))/g, ",");
+}
 
-/** Cumulative ("running total") overlay: current (amber) vs previous (blue). */
-export function AccumChart({ series, height = 210 }: { series: SeriesPoint[]; height?: number }) {
+/** Cumulative ("running total") overlay: current (amber) vs previous (blue).
+ *  Tap or drag across the chart to scrub a tooltip showing both periods'
+ *  running totals at that point (like the StoreHub chart). */
+export function AccumChart({
+  series,
+  height = 210,
+  curLabel = "Today",
+  prevLabel = "Yesterday",
+}: {
+  series: SeriesPoint[];
+  height?: number;
+  curLabel?: string;
+  prevLabel?: string;
+}) {
   const [w, setW] = useState(0);
+  const [sel, setSel] = useState<number | null>(null);
 
   let p = 0;
   let c = 0;
@@ -36,6 +52,26 @@ export function AccumChart({ series, height = 210 }: { series: SeriesPoint[]; he
   const innerH = height - padT - padB;
   const x = (i: number) => padL + (n <= 1 ? innerW / 2 : (i / (n - 1)) * innerW);
   const y = (v: number) => padT + (1 - v / max) * innerH;
+
+  // Geometry the gesture handlers read — kept in a ref so the PanResponder
+  // (created once) always sees the current layout instead of a stale closure.
+  const geo = useRef({ padL, innerW, n });
+  geo.current = { padL, innerW, n };
+  const pan = useRef(
+    PanResponder.create({
+      onStartShouldSetPanResponder: () => true,
+      onMoveShouldSetPanResponder: (_, g) => Math.abs(g.dx) > Math.abs(g.dy),
+      onPanResponderTerminationRequest: () => false,
+      onPanResponderGrant: (e) => setSel(pick(e.nativeEvent.locationX)),
+      onPanResponderMove: (e) => setSel(pick(e.nativeEvent.locationX)),
+    }),
+  ).current;
+  function pick(lx: number): number {
+    const { padL, innerW, n } = geo.current;
+    if (n <= 1 || innerW <= 0) return 0;
+    const i = Math.round(((lx - padL) / innerW) * (n - 1));
+    return Math.max(0, Math.min(n - 1, i));
+  }
 
   const toPath = (arr: (number | null)[]) => {
     let d = "";
@@ -52,8 +88,16 @@ export function AccumChart({ series, height = 210 }: { series: SeriesPoint[]; he
   const step = Math.max(1, Math.ceil(n / 6));
   const lastCur = cumCur.reduce<number>((acc, v, i) => (v != null ? i : acc), -1);
 
+  // ── Tooltip geometry (when a point is selected) ──
+  const selPrev = sel != null ? cumPrev[sel] : 0;
+  const selCur = sel != null ? cumCur[sel] : null;
+  const boxW = 132, boxH = 58;
+  const selX = sel != null ? x(sel) : 0;
+  const bx = Math.max(padL, Math.min(w - padR - boxW, selX - boxW / 2));
+  const by = padT + 2;
+
   return (
-    <View onLayout={(e) => setW(e.nativeEvent.layout.width)}>
+    <View onLayout={(e) => setW(e.nativeEvent.layout.width)} {...pan.panHandlers}>
       {w > 0 ? (
         <Svg width={w} height={height}>
           {grid.map((g, i) => (
@@ -75,6 +119,21 @@ export function AccumChart({ series, height = 210 }: { series: SeriesPoint[]; he
           <Path d={toPath(cumCur)} stroke={CUR} strokeWidth={2.5} fill="none" />
           {n > 0 && cumPrev.length ? <Circle cx={x(n - 1)} cy={y(cumPrev[n - 1])} r={3} fill={PREV} /> : null}
           {lastCur >= 0 ? <Circle cx={x(lastCur)} cy={y(cumCur[lastCur] as number)} r={3.5} fill={CUR} /> : null}
+
+          {/* ── Scrub selection + tooltip ── */}
+          {sel != null ? (
+            <>
+              <Line x1={selX} y1={padT} x2={selX} y2={padT + innerH} stroke={AXIS} strokeWidth={1} strokeDasharray="3 3" />
+              <Circle cx={selX} cy={y(selPrev)} r={4} fill={PREV} stroke="#160800" strokeWidth={1.5} />
+              {selCur != null ? <Circle cx={selX} cy={y(selCur)} r={4} fill={CUR} stroke="#160800" strokeWidth={1.5} /> : null}
+              <Rect x={bx} y={by} width={boxW} height={boxH} rx={8} fill="#160800" stroke="rgba(245,243,240,0.18)" strokeWidth={1} opacity={0.97} />
+              <SvgText x={bx + 9} y={by + 16} fontSize={10} fill={AXIS}>{series[sel].label}</SvgText>
+              <Circle cx={bx + 12} cy={by + 31} r={3} fill={CUR} />
+              <SvgText x={bx + 20} y={by + 34} fontSize={11} fontWeight="600" fill="#F5F3F0">{`${curLabel}  ${selCur == null ? "—" : rmTip(selCur)}`}</SvgText>
+              <Circle cx={bx + 12} cy={by + 47} r={3} fill={PREV} />
+              <SvgText x={bx + 20} y={by + 50} fontSize={11} fontWeight="600" fill="#F5F3F0">{`${prevLabel}  ${rmTip(selPrev)}`}</SvgText>
+            </>
+          ) : null}
         </Svg>
       ) : (
         <View style={{ height }} />

--- a/apps/staff/src/app/api/sales/_lib/sales-helpers.ts
+++ b/apps/staff/src/app/api/sales/_lib/sales-helpers.ts
@@ -113,26 +113,37 @@ export function getRound(hour: number): RoundKey | null {
 }
 
 // ─── Channel classification ──────────────────────────────────────────────────
-export type ChannelKey = "dine_in" | "takeaway" | "pickup" | "delivery";
-/** Classify a POS counter order (pos_orders). */
+export type ChannelKey = "dine_in" | "takeaway" | "pickup" | "delivery" | "qr_table";
+/** Classify a POS counter order (pos_orders). Counter dine-in stays "dine_in";
+ *  the POS has no table/QR ordering, so qr_table never originates here. */
 export function classifyPosChannel(orderType?: string | null, source?: string | null): ChannelKey {
   const s = (source || "").toLowerCase();
   if (/grab|foodpanda|shopee|delivery/.test(s)) return "delivery";
   const t = (orderType || "").toLowerCase();
   if (/takeaway|take[\s-]?away|tapau|bungkus|ta\b/.test(t)) return "takeaway";
   if (/pickup/.test(t)) return "pickup";
-  return "dine_in"; // dine_in, qr_table, default
+  return "dine_in"; // counter dine_in / default
 }
-/** Classify an app order (orders). All app-originated; default pickup. */
-export function classifyAppChannel(orderType?: string | null): ChannelKey {
+/** Classify an app order (orders). App dine-in is always table-based ordering
+ *  — the customer scans a QR at the table, so every app dine_in row carries a
+ *  table_number (newer ones also source "web_qr"). It therefore maps to the
+ *  distinct "qr_table" channel instead of being merged into counter dine-in. */
+export function classifyAppChannel(
+  orderType?: string | null,
+  tableNumber?: string | null,
+  source?: string | null,
+): ChannelKey {
   const t = (orderType || "").toLowerCase();
-  if (/dine[\s-]?in|qr[\s-]?table|dinein/.test(t)) return "dine_in";
+  const s = (source || "").toLowerCase();
+  const hasTable = !!(tableNumber && tableNumber.trim());
+  if (s.includes("qr") || hasTable || /qr[\s-]?table/.test(t)) return "qr_table";
+  if (/dine[\s-]?in|dinein/.test(t)) return "qr_table";
   if (/takeaway|take[\s-]?away|tapau|bungkus/.test(t)) return "takeaway";
   if (/grab|delivery/.test(t)) return "delivery";
   return "pickup";
 }
 export const CHANNEL_LABELS: Record<ChannelKey, string> = {
-  dine_in: "Dine-in", takeaway: "Takeaway", pickup: "Pickup", delivery: "Grab",
+  dine_in: "Dine-in", takeaway: "Takeaway", pickup: "Pickup", delivery: "Grab", qr_table: "QR Table",
 };
 
 // ─── Payment-method normalisation ────────────────────────────────────────────

--- a/apps/staff/src/app/api/sales/dashboard/route.ts
+++ b/apps/staff/src/app/api/sales/dashboard/route.ts
@@ -81,7 +81,7 @@ export async function GET(req: NextRequest) {
     storeIds.length
       ? supabaseAdmin
           .from("orders")
-          .select("id, created_at, subtotal, total, status, order_type, customer_phone, payment_method")
+          .select("id, created_at, subtotal, total, status, order_type, customer_phone, payment_method, table_number, source")
           .in("store_id", storeIds)
           .gte("created_at", winStart).lte("created_at", winEnd)
           .limit(20000)
@@ -120,7 +120,7 @@ export async function GET(req: NextRequest) {
   // summary
   let curRev = 0, curOrd = 0, prevRev = 0, prevOrd = 0;
   // current-period breakdowns
-  const chanRev: Record<ChannelKey, number> = { dine_in: 0, takeaway: 0, pickup: 0, delivery: 0 };
+  const chanRev: Record<ChannelKey, number> = { dine_in: 0, takeaway: 0, pickup: 0, delivery: 0, qr_table: 0 };
   const roundRev: Record<string, number> = {};
   for (const r of ROUNDS) roundRev[r.key] = 0;
   const payAmt: Record<string, number> = {};
@@ -163,7 +163,7 @@ export async function GET(req: NextRequest) {
       if (r.customer_phone) { curPhones.add(r.customer_phone); curAppPhones.add(r.customer_phone); }
       curByDate[d] = (curByDate[d] || 0) + net;
       curHour[getMYTHour(r.created_at)] += net;
-      chanRev[classifyAppChannel(r.order_type)] += net;
+      chanRev[classifyAppChannel(r.order_type, r.table_number, r.source)] += net;
       const rd = getRound(getMYTHour(r.created_at)); if (rd) roundRev[rd] += net;
       const pk = normalizePayment(r.payment_method);
       payAmt[pk] = (payAmt[pk] || 0) + (r.total || 0);
@@ -291,7 +291,7 @@ export async function GET(req: NextRequest) {
 
 // ── local types + tiny helpers ──
 type PosRow = { id: string; outlet_id: string; created_at: string; subtotal: number | null; total: number | null; status: string | null; order_type: string | null; source: string | null; customer_phone: string | null; refund_of_order_id: string | null };
-type AppRow = { id: string; created_at: string; subtotal: number | null; total: number | null; status: string | null; order_type: string | null; customer_phone: string | null; payment_method: string | null };
+type AppRow = { id: string; created_at: string; subtotal: number | null; total: number | null; status: string | null; order_type: string | null; customer_phone: string | null; payment_method: string | null; table_number: string | null; source: string | null };
 type PayRow = { order_id: string; payment_method: string | null; amount: number | null; refund_amount: number | null };
 
 const WK = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];


### PR DESCRIPTION
Three changes to the staff Sales dashboard, from manager feedback on the live screen.

### 1. RM in the comparison
The "vs yesterday" pill showed only a percentage. Now it also shows the absolute money delta, e.g. `−80.23% · −RM 3,292 vs yesterday`. *(staff-native, OTA)*

### 2. Scrubbable accumulative-sales chart
Tap or drag across the **Total Accumulative Sales** chart to show a tooltip with both periods' running totals at that point — matching the StoreHub interaction. The PanResponder reads layout from a ref to avoid a stale-closure on the one-time responder. *(staff-native, OTA)*

### 3. Split "QR Table" out of "Dine-in"
App `dine_in` orders are always table-based QR ordering and were inflating counter Dine-in. Verified against live data (90d): **all 69 app `dine_in` rows carry a `table_number`** (31 explicitly `source=web_qr`), vs **234 `pickup` with none** — so Pickup and QR-table are genuinely distinct, and QR-table was hidden inside Dine-in.

`classifyAppChannel` now routes app dine-in (via `table_number` / `source=web_qr`) to a new **`qr_table`** channel; POS counter dine-in is unaffected. *(backend in apps/staff → Vercel; new icon/label/colour → OTA)*

### Verification
- `apps/staff` `tsc --noEmit` ✅ (in CI matrix)
- `apps/staff-native` `tsc --noEmit` ✅

### Deploy
Merging ships the backend via the `staff` Vercel project and the native bits (RM delta, chart tooltip, QR Table icon) via the `staff-native` OTA workflow.

https://claude.ai/code/session_01LiL5ppx4k5n85qVfQHu24K

---
_Generated by [Claude Code](https://claude.ai/code/session_01LiL5ppx4k5n85qVfQHu24K)_