### PR TITLE
Fix tier downgrade/reset in customer list + allow granting any tier

### DIFF
--- a/apps/backoffice/src/app/(admin)/loyalty/members/page.tsx
+++ b/apps/backoffice/src/app/(admin)/loyalty/members/page.tsx
@@ -81,6 +81,10 @@ const TIER_OPTIONS: { id: string; label: string; cls: string }[] = [
 const tierMeta = (id: string | null) => TIER_OPTIONS.find((t) => t.id === (id ?? "tier-celsius-bronze")) ?? TIER_OPTIONS[0];
 // Only invitation-only tiers can be granted by hand (earned tiers come from spend).
 const GRANTABLE_TIERS = TIER_OPTIONS.filter((t) => t.id === "tier-celsius-arba-staff" || t.id === "tier-celsius-black-card");
+// Sentinel for the "Reset to auto" radio option. Kept distinct from "" (the
+// "nothing selected yet" state) so the Apply button can tell them apart —
+// otherwise picking Reset leaves Apply disabled and the tier can't be cleared.
+const RESET_TIER_OPTION = "__reset__";
 
 // Customer-360 drawer payload (from /api/loyalty/members/[id]/detail).
 type DetailData = {
@@ -1766,7 +1770,7 @@ export default function MembersPage() {
               {[
                 { id: "tier-celsius-arba-staff", name: "Staff",      desc: "30% off · for Celsius staff" },
                 { id: "tier-celsius-black-card", name: "Black Card", desc: "50% off · for investors / owners" },
-                { id: "",                          name: "Reset to auto", desc: "Re-evaluate from quarterly spend (clears any invitation grant)" },
+                { id: RESET_TIER_OPTION,           name: "Reset to auto", desc: "Re-evaluate from quarterly spend (clears any invitation grant)" },
               ].map((opt) => {
                 const selected = grantTierId === opt.id;
                 return (
@@ -1814,6 +1818,7 @@ export default function MembersPage() {
                 disabled={grantSaving || grantTierId === ""}
                 onClick={async () => {
                   if (!grantingMember || grantTierId === "") return;
+                  // (grantTierId === "" means no radio is selected yet.)
                   setGrantSaving(true);
                   try {
                     const res = await fetch(
@@ -1822,8 +1827,8 @@ export default function MembersPage() {
                         method: "POST",
                         headers: { "Content-Type": "application/json" },
                         body: JSON.stringify({
-                          // Empty string in UI → null in API = reset path.
-                          tier_id: grantTierId === "" ? null : grantTierId,
+                          // "Reset to auto" in UI → null in API = reset path.
+                          tier_id: grantTierId === RESET_TIER_OPTION ? null : grantTierId,
                         }),
                       },
                     );

--- a/apps/backoffice/src/app/(admin)/loyalty/members/page.tsx
+++ b/apps/backoffice/src/app/(admin)/loyalty/members/page.tsx
@@ -79,8 +79,19 @@ const TIER_OPTIONS: { id: string; label: string; cls: string }[] = [
 ];
 // A null tier = effectively Member (the engine defaults null → bronze).
 const tierMeta = (id: string | null) => TIER_OPTIONS.find((t) => t.id === (id ?? "tier-celsius-bronze")) ?? TIER_OPTIONS[0];
-// Only invitation-only tiers can be granted by hand (earned tiers come from spend).
-const GRANTABLE_TIERS = TIER_OPTIONS.filter((t) => t.id === "tier-celsius-arba-staff" || t.id === "tier-celsius-black-card");
+// Any tier can be granted by hand. Invitation tiers (Staff, Black Card)
+// stick until reset; earned tiers (Member/Silver/Gold/Platinum) are pinned
+// by the grant route until the quarter rolls over, then re-evaluate from spend.
+const GRANTABLE_TIERS = TIER_OPTIONS;
+// Short blurbs for the grant-tier dialog radio list.
+const TIER_GRANT_DESC: Record<string, string> = {
+  "tier-celsius-bronze": "Base tier · 0% off · earned from spend",
+  "tier-celsius-silver": "3% off · earned from spend",
+  "tier-celsius-gold": "5% off · earned from spend",
+  "tier-celsius-elite": "10% off · earned from spend",
+  "tier-celsius-arba-staff": "30% off · for Celsius staff",
+  "tier-celsius-black-card": "50% off · for investors / owners",
+};
 // Sentinel for the "Reset to auto" radio option. Kept distinct from "" (the
 // "nothing selected yet" state) so the Apply button can tell them apart —
 // otherwise picking Reset leaves Apply disabled and the tier can't be cleared.
@@ -1415,7 +1426,7 @@ export default function MembersPage() {
               >
                 Remove tier (auto)
               </button>
-              <span className="text-[11px] text-gray-400 dark:text-neutral-500">Earned tiers (Silver/Gold/Platinum) come from spend.</span>
+              <span className="text-[11px] text-gray-400 dark:text-neutral-500">Earned tiers (Silver/Gold/Platinum) hold until quarter-end, then re-evaluate from spend.</span>
               {bulkTierSaving && <Loader2 className="h-3.5 w-3.5 animate-spin text-gray-400" />}
             </div>
           )}
@@ -1762,15 +1773,15 @@ export default function MembersPage() {
             </div>
 
             <p className="text-xs text-gray-500 dark:text-neutral-400 mb-3">
-              Only invitation-only tiers can be granted manually. Earned tiers
-              (Member/Silver/Gold/Platinum) come from quarterly spend.
+              Invitation tiers (Staff, Black Card) stay until you reset. Earned
+              tiers (Member/Silver/Gold/Platinum) hold until the quarter ends,
+              then re-evaluate from spend.
             </p>
 
             <div className="space-y-2 mb-4">
               {[
-                { id: "tier-celsius-arba-staff", name: "Staff",      desc: "30% off · for Celsius staff" },
-                { id: "tier-celsius-black-card", name: "Black Card", desc: "50% off · for investors / owners" },
-                { id: RESET_TIER_OPTION,           name: "Reset to auto", desc: "Re-evaluate from quarterly spend (clears any invitation grant)" },
+                ...TIER_OPTIONS.map((t) => ({ id: t.id, name: t.label, desc: TIER_GRANT_DESC[t.id] ?? "" })),
+                { id: RESET_TIER_OPTION, name: "Reset to auto", desc: "Re-evaluate from quarterly spend (clears any grant)" },
               ].map((opt) => {
                 const selected = grantTierId === opt.id;
                 return (

--- a/apps/backoffice/src/app/api/loyalty/members/[id]/grant-tier/route.ts
+++ b/apps/backoffice/src/app/api/loyalty/members/[id]/grant-tier/route.ts
@@ -8,19 +8,33 @@ const BRAND_ID = "brand-celsius";
  * POST /api/loyalty/members/[id]/grant-tier
  * Body: { tier_id: string | null }
  *
- * Grant a customer an invitation-only tier (Arba & Staff, Black Card),
- * or pass `tier_id: null` to revert them to auto-evaluation.
+ * Grant a customer any active tier, or pass `tier_id: null` to revert
+ * them to auto-evaluation.
  *
- * Earned tiers (Member / Silver / Gold / Platinum) are intentionally
- * NOT grantable here — those come from quarterly spend via the
- * evaluate_member_tier RPC. Forcing one would be a comp/perk override
- * better expressed by directly editing tier_locked_until via SQL.
+ * How the grant persists depends on the tier kind — driven by the
+ * evaluate_member_tier RPC that runs on every purchase:
  *
- * After grant: the RPC's first branch keeps invitation-only tiers
- * untouched on every subsequent evaluation, so the assignment sticks
- * until an admin explicitly revokes (tier_id: null) or grants a
- * different invitation tier.
+ *  • Invitation-only tiers (Staff, Black Card): the RPC's first branch
+ *    never auto-overwrites an invitation tier, so we leave
+ *    tier_locked_until null and the grant sticks until an admin
+ *    explicitly resets (tier_id: null) or grants a different tier.
+ *
+ *  • Earned tiers (Member / Silver / Gold / Platinum): the RPC
+ *    re-evaluates these from quarterly spend. We pin the grant by
+ *    setting tier_locked_until to the current quarter end — the RPC
+ *    honours an active lock and won't demote mid-quarter (only spend
+ *    upgrades land). When the quarter rolls over the lock expires and
+ *    the member re-evaluates from real spend, same as a naturally
+ *    earned tier.
  */
+
+/** First instant of the next calendar quarter (UTC), matching the
+ *  RPC's `date_trunc('quarter', now()) + interval '3 months'`. */
+function currentQuarterEndIso(): string {
+  const now = new Date();
+  const q = Math.floor(now.getUTCMonth() / 3); // 0..3
+  return new Date(Date.UTC(now.getUTCFullYear(), q * 3 + 3, 1)).toISOString();
+}
 export async function POST(
   request: NextRequest,
   { params }: { params: Promise<{ id: string }> },
@@ -72,7 +86,7 @@ export async function POST(
     return NextResponse.json({ ok: true, action: "reset", granted_by: callerLabel });
   }
 
-  // Grant path — validate tier exists + is invitation-only.
+  // Grant path — validate the tier exists and is active.
   const { data: tier, error: tierErr } = await supabaseAdmin
     .from("tiers")
     .select("id, name, slug, is_active, invitation_only")
@@ -94,24 +108,16 @@ export async function POST(
       { status: 400 },
     );
   }
-  if (!tier.invitation_only) {
-    return NextResponse.json(
-      {
-        error:
-          "Only invitation-only tiers can be granted manually. Earned tiers (Member/Silver/Gold/Platinum) come from quarterly spend.",
-      },
-      { status: 400 },
-    );
-  }
 
-  // Apply the grant. Lock-until is cleared because the RPC's first
-  // branch always preserves invitation tiers — a lock would be
-  // redundant and confusing in the UI.
+  // Apply the grant. Invitation tiers need no lock (the RPC preserves
+  // them); earned tiers are pinned to the quarter end so the RPC's
+  // lock-honouring branch holds them until the quarter rolls over.
+  const lockedUntil = tier.invitation_only ? null : currentQuarterEndIso();
   const { error: updErr } = await supabaseAdmin
     .from("member_brands")
     .update({
       current_tier_id: tier.id,
-      tier_locked_until: null,
+      tier_locked_until: lockedUntil,
       tier_evaluated_at: nowIso,
     })
     .eq("member_id", memberId)
@@ -125,12 +131,13 @@ export async function POST(
   }
 
   console.warn(
-    `[tier-grant] member=${memberId} → tier=${tier.slug} by=${callerLabel}`,
+    `[tier-grant] member=${memberId} → tier=${tier.slug} lock=${lockedUntil ?? "none"} by=${callerLabel}`,
   );
 
   return NextResponse.json({
     ok: true,
     action: "granted",
+    locked_until: lockedUntil,
     tier_id: tier.id,
     tier_slug: tier.slug,
     tier_name: tier.name,


### PR DESCRIPTION
## Summary

Two fixes to the **Grant tier** flow in the customer list (Loyalty → Members):

1. **Fix: "Reset to auto" could never be applied (couldn't downgrade/clear a tier).**
   The "Reset to auto" radio shared the empty-string sentinel (`""`) used for the "nothing selected yet" state, so the Apply button's `grantTierId === ""` disabled-guard kept it disabled even after picking Reset. Result: an admin could never clear an invitation tier (e.g. revert a Black Card customer to auto-evaluation) — exactly the reported "cannot downgrade tier" bug. Gave Reset its own distinct sentinel (`RESET_TIER_OPTION`) so the button can tell "nothing selected" apart from "Reset selected".

2. **Feature: grant any tier, not just invitation tiers.**
   The dialog previously only exposed Staff and Black Card, and the API rejected earned tiers outright. Both the single-customer dialog and the bulk **Set tier** menu now list all six tiers (Member / Silver / Gold / Platinum / Staff / Black Card) for comps and corrections.

## How persistence works

Verified against the live `evaluate_member_tier` RPC (runs on every purchase):

| Grant | Lock set | Behavior |
|-------|----------|----------|
| **Invitation** (Staff, Black Card) | none | Sticks until Reset — the RPC's `invitation_only` branch never overwrites |
| **Earned** (Member/Silver/Gold/Platinum) | quarter-end | Holds for the rest of the current quarter, then re-evaluates from real spend |
| **Reset to auto** | cleared | Re-evaluates immediately from quarterly spend |

The earned-tier grant sets `tier_locked_until` to the current quarter end. Without it, an earned-tier grant would be silently wiped on the customer's next purchase (the RPC recomputes earned tiers from spend); the RPC honors an active lock and won't demote mid-quarter, so the grant holds for the quarter — matching how naturally earned tiers behave.

### Known limitation
Spend **upgrades** still land mid-quarter, so granting a tier *below* a customer's earned level won't hold (a heavy spender comped to Silver re-upgrades to Gold on next purchase). Granting up, or to inactive customers, holds for the quarter as expected.

## Changes
- `apps/backoffice/src/app/(admin)/loyalty/members/page.tsx` — distinct Reset sentinel; grant dialog + bulk menu list all tiers; updated helper copy.
- `apps/backoffice/src/app/api/loyalty/members/[id]/grant-tier/route.ts` — accept any active tier; pin earned grants to quarter end via `tier_locked_until`; invitation tiers keep null lock.

## Testing
- Manually traced the disabled-button logic and the live RPC's lock-handling branches.
- Note: a full `tsc` typecheck couldn't run in this environment (dependencies not installed — `react` unresolved); changes are type-consistent with surrounding code.

https://claude.ai/code/session_016W3Th6Bvvju4zTADNQJzVg

---
_Generated by [Claude Code](https://claude.ai/code/session_016W3Th6Bvvju4zTADNQJzVg)_