### PR TITLE
fix(sales): like-for-like "vs yesterday" comparison (time-aligned)

### DIFF
--- a/apps/staff/src/app/api/sales/dashboard/route.ts
+++ b/apps/staff/src/app/api/sales/dashboard/route.ts
@@ -110,6 +110,19 @@ export async function GET(req: NextRequest) {
   const prevDates = dateRange(prev.from, prev.to);
   const curIncludesToday = cur.to >= today;
 
+  // Like-for-like comparison: when the current period is still in progress
+  // (includes today), the previous period's *summary* total is counted only up
+  // to the same elapsed point — e.g. today-so-far vs yesterday up to the same
+  // time of day — so the headline delta isn't "partial day vs full day". For a
+  // fully past period the cutoff is open (full previous period). The comparison
+  // chart's previous line is intentionally left full (shows yesterday's finish
+  // as a target); only the summary deltas use this cutoff.
+  // NOTE: StoreHub-sourced previous totals (transitioning outlets) are not
+  // time-clipped — they still merge the full previous period below.
+  const prevCutoffMs = curIncludesToday
+    ? Date.parse(mytDayStartUTC(prev.from)) + (Date.now() - Date.parse(mytDayStartUTC(cur.from)))
+    : Number.POSITIVE_INFINITY;
+
   // ── Accumulators ──
   const acc = (n: number) => Array.from({ length: n }, () => 0);
   // series buckets (net sen)
@@ -148,7 +161,7 @@ export async function GET(req: NextRequest) {
       chanRev[classifyPosChannel(r.order_type, r.source)] += net;
       const rd = getRound(getMYTHour(r.created_at)); if (rd) roundRev[rd] += net;
     } else if (inPrev(d)) {
-      prevRev += net; prevOrd++; prevPosOrd++;
+      if (Date.parse(r.created_at) <= prevCutoffMs) { prevRev += net; prevOrd++; prevPosOrd++; }
       if (r.customer_phone) prevPhones.add(r.customer_phone);
       prevByDate[d] = (prevByDate[d] || 0) + net;
       prevHour[getMYTHour(r.created_at)] += net;
@@ -168,7 +181,7 @@ export async function GET(req: NextRequest) {
       const pk = normalizePayment(r.payment_method);
       payAmt[pk] = (payAmt[pk] || 0) + (r.total || 0);
     } else if (inPrev(d)) {
-      prevRev += net; prevOrd++; prevAppOrd++;
+      if (Date.parse(r.created_at) <= prevCutoffMs) { prevRev += net; prevOrd++; prevAppOrd++; }
       if (r.customer_phone) { prevPhones.add(r.customer_phone); prevAppPhones.add(r.customer_phone); }
       prevByDate[d] = (prevByDate[d] || 0) + net;
       prevHour[getMYTHour(r.created_at)] += net;


### PR DESCRIPTION
## Problem
The "vs yesterday" headline delta compared **today-so-far** against **yesterday's full day**, so any in-progress day looked alarming — e.g. `−71.55% · −RM 2,996` at 10:27am, purely because the day wasn't over.

## Fix
When the current period is still running, the previous period's **summary** total is counted only up to the **same elapsed point** (today→now vs yesterday→same time of day) — the like-for-like / "realtime" basis, matching the StoreHub same-window comparison (`00:00→10:00` vs `00:00→10:00`).

- Applies to the revenue, orders, AOV, and app-share deltas.
- The comparison **chart's** previous (blue) line is intentionally left **full** — it shows yesterday's finish as a target; only the summary deltas use the cutoff.
- Fully-past periods are unaffected (open cutoff).

## Caveat
StoreHub-sourced previous totals (transitioning outlets only) aren't time-clipped — they still merge the full previous period. Noted in a code comment. Native-POS outlets (the majority) are exact.

## Scope
Backend-only (`apps/staff` → Vercel). No native change — the hero already renders the RM delta + "vs yesterday"; the numbers just become fair. No OTA needed.

`apps/staff` `tsc --noEmit` ✅

https://claude.ai/code/session_01LiL5ppx4k5n85qVfQHu24K

---
_Generated by [Claude Code](https://claude.ai/code/session_01LiL5ppx4k5n85qVfQHu24K)_