### PR TITLE
fix(staff-native): restore dark mode (theme vars at root)

### DIFF
--- a/apps/staff-native/app/_layout.tsx
+++ b/apps/staff-native/app/_layout.tsx
@@ -27,6 +27,8 @@ import {
 import { API_BASE_URL } from "../lib/env";
 import { useStaff } from "../lib/store";
 import { registerForPush } from "../lib/push";
+import { useColorScheme } from "nativewind";
+import { themes, loadColorSchemePref } from "../lib/theme";
 
 SplashScreen.preventAutoHideAsync().catch(() => {});
 initSentry();
@@ -67,6 +69,19 @@ function RootLayout() {
 
   const setSession = useStaff((s) => s.setSession);
   const [sessionHydrated, setSessionHydrated] = useState(false);
+
+  // Apply the saved appearance preference on launch. The theme vars
+  // (lib/theme.ts) are applied at the root via `<View style={themes[scheme]} />`
+  // below; without this the Profile toggle shows "Dark" but the chosen scheme
+  // is never applied, so every screen renders with the light variables.
+  const { colorScheme, setColorScheme } = useColorScheme();
+  useEffect(() => {
+    loadColorSchemePref()
+      .then((pref) => setColorScheme(pref))
+      .catch(() => {});
+  }, [setColorScheme]);
+  const scheme = colorScheme === "dark" ? "dark" : "light";
+  const themeBg = scheme === "dark" ? "#0A0A0A" : "#FFFFFF";
 
   useEffect(() => {
     SplashScreen.hideAsync().catch(() => {});
@@ -139,11 +154,12 @@ function RootLayout() {
   }, [setSession]);
 
   useEffect(() => {
-    if (loaded) {
-      applyDefaultFont();
-      SystemUI.setBackgroundColorAsync("#FFFFFF").catch(() => {});
-    }
+    if (loaded) applyDefaultFont();
   }, [loaded]);
+
+  useEffect(() => {
+    SystemUI.setBackgroundColorAsync(themeBg).catch(() => {});
+  }, [themeBg]);
 
   const sessionUserId = useStaff((s) => s.session?.userId ?? null);
   useEffect(() => {
@@ -178,18 +194,23 @@ function RootLayout() {
 
   return (
     <GestureHandlerRootView style={{ flex: 1 }}>
-      <SafeAreaProvider>
-        <QueryClientProvider client={queryClient}>
-          <StatusBar style="dark" />
-          <Stack
-            screenOptions={{
-              headerShown: false,
-              contentStyle: { backgroundColor: "#FFFFFF" },
-              animation: "slide_from_right",
-            }}
-          />
-        </QueryClientProvider>
-      </SafeAreaProvider>
+      {/* Root theme scope: applies the light/dark CSS variables so every
+          screen using var(--color-*) tokens resolves against the chosen
+          scheme. */}
+      <View style={[{ flex: 1 }, themes[scheme]]}>
+        <SafeAreaProvider>
+          <QueryClientProvider client={queryClient}>
+            <StatusBar style={scheme === "dark" ? "light" : "dark"} />
+            <Stack
+              screenOptions={{
+                headerShown: false,
+                contentStyle: { backgroundColor: themeBg },
+                animation: "slide_from_right",
+              }}
+            />
+          </QueryClientProvider>
+        </SafeAreaProvider>
+      </View>
     </GestureHandlerRootView>
   );
 }

--- a/apps/staff-native/tailwind.config.js
+++ b/apps/staff-native/tailwind.config.js
@@ -5,20 +5,29 @@ module.exports = {
   theme: {
     extend: {
       colors: {
-        background: "#FFFFFF",
-        surface: "#FFFFFF",
-        espresso: "#1A0200",
+        // Themeable neutral / terracotta-tint tokens resolve against the CSS
+        // variables applied at the root in app/_layout.tsx (see lib/theme.ts
+        // for the light/dark values). Pure brand + accent colors stay static
+        // since they read well in both modes.
+        background: "var(--color-background)",
+        surface: "var(--color-surface)",
+        espresso: "var(--color-espresso)",
         primary: {
           DEFAULT: "#A2492C",
-          50: "#F6E8E2",
-          100: "#EBD0C2",
+          50: "var(--color-primary-50)",
+          100: "var(--color-primary-100)",
           900: "#4E1F12",
         },
         muted: {
-          DEFAULT: "#6B6B6B",
-          fg: "#4A4A4A",
+          DEFAULT: "var(--color-muted)",
+          fg: "var(--color-muted-fg)",
         },
-        border: "rgba(26, 2, 0, 0.10)",
+        border: "var(--color-border)",
+        gray: {
+          50: "var(--color-gray-50)",
+          100: "var(--color-gray-100)",
+          200: "var(--color-gray-200)",
+        },
         amber: {
           400: "#FBBF24",
           500: "#F59E0B",


### PR DESCRIPTION
## What broke
After the staff-native OTA, dark mode stopped applying — the Profile toggle showed **Dark** but every screen rendered **light** (and the login keypad surfaces looked off). Root cause: the theming had **three layers that must agree**, and two had regressed on `main`:

1. **`tailwind.config.js`** colors were **hardcoded hex** (`background`/`surface`/`espresso`/`muted`/`border`/`primary-50/100`/`gray`) instead of `var(--color-*)` — so the themeable tokens could never flip, no matter what scheme was set.
2. **`app/_layout.tsx`** never applied the saved scheme: it didn't load the preference on launch, never wrapped the tree in `<View style={themes[scheme]}>`, and hardcoded light (`contentStyle: #FFFFFF`, `StatusBar "dark"`, `SystemUI #FFFFFF`).

`lib/theme.ts` (the var spec — light/dark values) was **intact**, so it's the source of truth I reconstructed against.

## Fix
- Config tokens → `var(--color-*)`.
- `_layout` loads `loadColorSchemePref()` → `setColorScheme()` on mount, wraps the app in the themed root `View`, and drives StatusBar / nav background / system UI off the resolved scheme.
- Static brand/accent colors (primary DEFAULT, amber, success, danger) deliberately stay fixed.

## Notes
- **staff-native only → ships via OTA.** No backend/Vercel change.
- Login keypad is unaffected (static `COLORS`, already correct on `main`) — it'll render correctly on the fresh bundle.
- `staff-native` `tsc --noEmit` ✅. This is a **reconstruction** of lost wiring, so please verify on-device once the OTA lands; rollback-to-embedded is the safety net if anything's off.

https://claude.ai/code/session_01LiL5ppx4k5n85qVfQHu24K

---
_Generated by [Claude Code](https://claude.ai/code/session_01LiL5ppx4k5n85qVfQHu24K)_