### PR TITLE
fix(staff-native): make login keypad keys clearly visible

### DIFF
--- a/apps/staff-native/app/(auth)/login.tsx
+++ b/apps/staff-native/app/(auth)/login.tsx
@@ -31,8 +31,9 @@ const LAST_OUTLET_KEY = "celsius_staff_last_outlet_v1";
 // the dark background.
 const COLORS = {
   bg: "#1A0200", // espresso
-  surface: "#5C3A30", // keypad button + outlet picker bg (visible on espresso)
-  surfaceHi: "#7A4D40", // pressed/hover
+  surface: "#6E4434", // keypad button + outlet picker bg (visible on espresso)
+  surfaceHi: "#8A5544", // pressed/hover
+  keyBorder: "rgba(245,243,240,0.20)", // outline so keys read as distinct cards
   text: "#FAFAFA",
   textMuted: "#C8B8B3",
   brand: "#C2452D", // primary
@@ -385,6 +386,8 @@ function NumPad({
                   borderRadius: 20,
                   alignItems: "center",
                   justifyContent: "center",
+                  borderWidth: 1,
+                  borderColor: isDanger ? COLORS.danger + "55" : COLORS.keyBorder,
                   backgroundColor: pressed
                     ? isDanger
                       ? COLORS.danger + "33"


### PR DESCRIPTION
The login keypad keys (inline `#5C3A30` brown on `#1A0200` espresso) were too low-contrast to read as cards on-device — they looked like bare digits. This brightens the fill (`#6E4434`, pressed `#8A5544`) and adds a soft cream outline (`rgba(245,243,240,0.20)`) so each key is an unmistakable rounded card; the Clear key gets a tinted danger border.

staff-native only → ships via OTA. `tsc` clean.

https://claude.ai/code/session_01LiL5ppx4k5n85qVfQHu24K

---
_Generated by [Claude Code](https://claude.ai/code/session_01LiL5ppx4k5n85qVfQHu24K)_