### PR TITLE
feat(pos-native): keep chime/alarm on the SUNMI speaker (alarm-class audio)

### DIFF
--- a/.github/workflows/pos-native-build-apk.yml
+++ b/.github/workflows/pos-native-build-apk.yml
@@ -1,0 +1,33 @@
+name: pos-native build APK
+
+# Builds a fresh production APK for the SUNMI registers via EAS (cloud build).
+# Use this for NATIVE changes that can't ship over the OTA channel — e.g. the
+# device-alarm module (keeps the chime/alarm on the SUNMI speaker). Trigger it
+# manually from the Actions tab; the build runs on EAS and the installable APK
+# appears on expo.dev (project 3ea8d8f6-…) to download + `adb install -r`.
+#
+# Requires the EXPO_TOKEN repo secret (same one the OTA workflow uses).
+
+on:
+  workflow_dispatch: {}
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: apps/pos-native
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - name: Install dependencies
+        run: npm install --no-audit --no-fund
+      - name: Build production APK (EAS)
+        env:
+          EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}
+          CI: "1"
+        # --no-wait: submit to EAS and return; the APK is produced on EAS
+        # servers and downloadable from expo.dev when the build finishes.
+        run: npx eas-cli@latest build --platform android --profile production-apk --non-interactive --no-wait

--- a/apps/pos-native/lib/chime.ts
+++ b/apps/pos-native/lib/chime.ts
@@ -10,6 +10,7 @@
  * to break the order / print flow.
  */
 import { createAudioPlayer, type AudioPlayer } from "expo-audio";
+import DeviceAlarm from "device-alarm";
 
 type Sound = "chime" | "alarm";
 
@@ -35,6 +36,20 @@ function getPlayer(sound: Sound): AudioPlayer | null {
 }
 
 function play(sound: Sound): void {
+  // Prefer the native ALARM-class player: it keeps the alert on the SUNMI's
+  // built-in speaker even when a Bluetooth speaker is connected (so cafe music
+  // can play to BT while order alerts stay at the till). Falls through to the
+  // expo-audio media player below where the native module isn't present
+  // (Expo Go / an APK that predates it) — media routes to BT as before.
+  if (DeviceAlarm) {
+    try {
+      if (sound === "chime") DeviceAlarm.playChime();
+      else DeviceAlarm.playAlarm();
+      return;
+    } catch (e) {
+      console.warn(`[sound] native ${sound} failed, falling back`, e);
+    }
+  }
   const p = getPlayer(sound);
   if (!p) return;
   try {

--- a/apps/pos-native/modules/device-alarm/expo-module.config.json
+++ b/apps/pos-native/modules/device-alarm/expo-module.config.json
@@ -1,0 +1,6 @@
+{
+  "platforms": ["android"],
+  "android": {
+    "modules": ["com.celsiuscoffee.devicealarm.DeviceAlarmModule"]
+  }
+}

--- a/apps/pos-native/modules/device-alarm/index.ts
+++ b/apps/pos-native/modules/device-alarm/index.ts
@@ -1,0 +1,22 @@
+import { requireOptionalNativeModule } from "expo-modules-core";
+
+/**
+ * Native handle for the on-device alert player. Plays the chime/alarm as
+ * ALARM-class audio (AudioAttributes.USAGE_ALARM) so Android keeps them on the
+ * SUNMI's built-in speaker even while a Bluetooth speaker is connected for
+ * music (media audio still routes to BT; alarm audio stays on the device).
+ *
+ * Optional: where the native module isn't compiled in (Expo Go / dev / an
+ * older APK that predates it) this is null and callers fall back to the
+ * expo-audio media player (lib/chime.ts).
+ */
+export type DeviceAlarmModule = {
+  /** Soft new-order bell, on the device alarm stream. */
+  playChime(): void;
+  /** Urgent serving-overdue alert, on the device alarm stream. */
+  playAlarm(): void;
+};
+
+const DeviceAlarm = requireOptionalNativeModule<DeviceAlarmModule>("DeviceAlarm");
+
+export default DeviceAlarm;

--- a/apps/pos-native/modules/device-alarm/package.json
+++ b/apps/pos-native/modules/device-alarm/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "device-alarm",
+  "version": "0.1.0",
+  "description": "Local Expo module — plays the POS chime/alarm as ALARM-class audio so they stay on the SUNMI's built-in speaker even when a Bluetooth (A2DP) speaker is connected for music.",
+  "main": "index.ts",
+  "private": true
+}

--- a/apps/pos-native/package.json
+++ b/apps/pos-native/package.json
@@ -19,6 +19,7 @@
     "@supabase/supabase-js": "^2.45.4",
     "@tanstack/react-query": "^5.59.0",
     "customer-display": "file:./modules/customer-display",
+    "device-alarm": "file:./modules/device-alarm",
     "expo": "~54.0.33",
     "expo-audio": "~1.1.1",
     "expo-build-properties": "~1.0.9",


### PR DESCRIPTION
## What
When the SUNMI D3 is paired to a Bluetooth speaker (e.g. for café music), **all** the app's media audio — including the order chime + serving alarm — routes to the BT speaker, so the till alert leaves the counter. This makes the alerts **alarm-class** (`AudioAttributes.USAGE_ALARM`): Android keeps alarm-class audio on the device's **built-in speaker** while ordinary media (the music app) keeps going to Bluetooth. So: **music → BT, order alerts → SUNMI.**

## How
- **`modules/device-alarm`** — a local Expo module (mirrors `modules/customer-display`) that plays `chime.wav`/`alarm.wav` via `SoundPool` with `USAGE_ALARM`, from `res/raw`, on the device speaker.
- **`lib/chime.ts`** — prefers the native player; **falls back to expo-audio** media playback where the module isn't present (Expo Go / an APK that predates it), so it's a **safe no-op until the new APK is installed**.
- **`pos-native-build-apk` workflow** — manual `eas build --profile production-apk` to produce the installable APK.

## ⚠️ Rollout (not OTA)
This is a **native** change → needs a fresh **production APK**, installed on each SUNMI via **adb (wireless debugging)**. Alarm-stream routing can vary by device, so **test on one register first**. Note: alarm-class audio uses the device's **Alarm volume** (separate from Media volume).

https://claude.ai/code/session_01GjJgv2uzoBTm57fC3T3MgR

---
_Generated by [Claude Code](https://claude.ai/code/session_01GjJgv2uzoBTm57fC3T3MgR)_