### PR TITLE
fix(cron): restore dropped pos-loyalty-reconcile schedule

### DIFF
--- a/apps/backoffice/vercel.json
+++ b/apps/backoffice/vercel.json
@@ -57,6 +57,10 @@
     {
       "path": "/api/cron/music-alerts",
       "schedule": "*/5 * * * *"
+    },
+    {
+      "path": "/api/cron/pos-loyalty-reconcile",
+      "schedule": "*/5 * * * *"
     }
   ]
 }


### PR DESCRIPTION
## What
A later `vercel.json` edit (adding `storehub-sync`) accidentally dropped the **`pos-loyalty-reconcile`** cron entry added in #251 — so the in-store-loyalty **safety net stopped running**. The route (`/api/cron/pos-loyalty-reconcile`) and the DB function (`reconcile_pos_loyalty`) still exist; only the every-5-min trigger was gone.

Re-adds the cron entry next to `storehub-sync`. Takes effect when backoffice redeploys (Vercel reads `vercel.json` at deploy time). Config-only — no code change.

https://claude.ai/code/session_01GjJgv2uzoBTm57fC3T3MgR

---
_Generated by [Claude Code](https://claude.ai/code/session_01GjJgv2uzoBTm57fC3T3MgR)_