### PR TITLE
revert(staff-native): remove crash-looping dark-mode rewrite

### DIFF
--- a/apps/staff-native/app/_layout.tsx
+++ b/apps/staff-native/app/_layout.tsx
@@ -27,8 +27,6 @@ import {
 import { API_BASE_URL } from "../lib/env";
 import { useStaff } from "../lib/store";
 import { registerForPush } from "../lib/push";
-import { useColorScheme } from "nativewind";
-import { themes, loadColorSchemePref } from "../lib/theme";
 
 SplashScreen.preventAutoHideAsync().catch(() => {});
 initSentry();
@@ -69,19 +67,6 @@ function RootLayout() {
 
   const setSession = useStaff((s) => s.setSession);
   const [sessionHydrated, setSessionHydrated] = useState(false);
-
-  // Apply the saved appearance preference on launch. The theme vars
-  // (lib/theme.ts) are applied at the root via `<View style={themes[scheme]} />`
-  // below; without this the Profile toggle shows "Dark" but the chosen scheme
-  // is never applied, so every screen renders with the light variables.
-  const { colorScheme, setColorScheme } = useColorScheme();
-  useEffect(() => {
-    loadColorSchemePref()
-      .then((pref) => setColorScheme(pref))
-      .catch(() => {});
-  }, [setColorScheme]);
-  const scheme = colorScheme === "dark" ? "dark" : "light";
-  const themeBg = scheme === "dark" ? "#0A0A0A" : "#FFFFFF";
 
   useEffect(() => {
     SplashScreen.hideAsync().catch(() => {});
@@ -154,12 +139,11 @@ function RootLayout() {
   }, [setSession]);
 
   useEffect(() => {
-    if (loaded) applyDefaultFont();
+    if (loaded) {
+      applyDefaultFont();
+      SystemUI.setBackgroundColorAsync("#FFFFFF").catch(() => {});
+    }
   }, [loaded]);
-
-  useEffect(() => {
-    SystemUI.setBackgroundColorAsync(themeBg).catch(() => {});
-  }, [themeBg]);
 
   const sessionUserId = useStaff((s) => s.session?.userId ?? null);
   useEffect(() => {
@@ -194,23 +178,18 @@ function RootLayout() {
 
   return (
     <GestureHandlerRootView style={{ flex: 1 }}>
-      {/* Root theme scope: applies the light/dark CSS variables so every
-          screen using var(--color-*) tokens resolves against the chosen
-          scheme. */}
-      <View style={[{ flex: 1 }, themes[scheme]]}>
-        <SafeAreaProvider>
-          <QueryClientProvider client={queryClient}>
-            <StatusBar style={scheme === "dark" ? "light" : "dark"} />
-            <Stack
-              screenOptions={{
-                headerShown: false,
-                contentStyle: { backgroundColor: themeBg },
-                animation: "slide_from_right",
-              }}
-            />
-          </QueryClientProvider>
-        </SafeAreaProvider>
-      </View>
+      <SafeAreaProvider>
+        <QueryClientProvider client={queryClient}>
+          <StatusBar style="dark" />
+          <Stack
+            screenOptions={{
+              headerShown: false,
+              contentStyle: { backgroundColor: "#FFFFFF" },
+              animation: "slide_from_right",
+            }}
+          />
+        </QueryClientProvider>
+      </SafeAreaProvider>
     </GestureHandlerRootView>
   );
 }

--- a/apps/staff-native/tailwind.config.js
+++ b/apps/staff-native/tailwind.config.js
@@ -5,29 +5,20 @@ module.exports = {
   theme: {
     extend: {
       colors: {
-        // Themeable neutral / terracotta-tint tokens resolve against the CSS
-        // variables applied at the root in app/_layout.tsx (see lib/theme.ts
-        // for the light/dark values). Pure brand + accent colors stay static
-        // since they read well in both modes.
-        background: "var(--color-background)",
-        surface: "var(--color-surface)",
-        espresso: "var(--color-espresso)",
+        background: "#FFFFFF",
+        surface: "#FFFFFF",
+        espresso: "#1A0200",
         primary: {
           DEFAULT: "#A2492C",
-          50: "var(--color-primary-50)",
-          100: "var(--color-primary-100)",
+          50: "#F6E8E2",
+          100: "#EBD0C2",
           900: "#4E1F12",
         },
         muted: {
-          DEFAULT: "var(--color-muted)",
-          fg: "var(--color-muted-fg)",
+          DEFAULT: "#6B6B6B",
+          fg: "#4A4A4A",
         },
-        border: "var(--color-border)",
-        gray: {
-          50: "var(--color-gray-50)",
-          100: "var(--color-gray-100)",
-          200: "var(--color-gray-200)",
-        },
+        border: "rgba(26, 2, 0, 0.10)",
         amber: {
           400: "#FBBF24",
           500: "#F59E0B",


### PR DESCRIPTION
## The actual root cause
Every fact now fits one explanation: the dark-mode rewrite I added in #261 (`_layout.tsx` root theme wiring + `tailwind.config.js` `var(--color-*)` tokens) **crashes on launch**, so `expo-updates` **auto-rolled-back** every subsequent OTA to the last good update (#2). Devices were permanently stuck on an old bundle — broken keypad, overflowing tooltip — no matter how many times they pulled updates. That's why "Check for updates" + reload changed nothing.

## Fix
Revert `_layout.tsx` and `tailwind.config.js` to their pre-dark-mode state (commit `847966d`). The keypad fix (`login.tsx`) and tooltip fix (`AccumChart.tsx`) are safe inline changes that remain — once the crashing root code is gone, this bundle launches cleanly and those fixes finally land.

- Dark mode returns to its prior (already non-working) state — I'll redo it properly with on-device verification, not blind OTAs.
- staff-native only → OTA. `tsc` clean.

https://claude.ai/code/session_01LiL5ppx4k5n85qVfQHu24K

---
_Generated by [Claude Code](https://claude.ai/code/session_01LiL5ppx4k5n85qVfQHu24K)_