### PR TITLE
menu: reflect POS out-of-stock (86) on web + live updates on both apps

### DIFF
--- a/apps/order/src/app/menu/_MenuColumns.tsx
+++ b/apps/order/src/app/menu/_MenuColumns.tsx
@@ -8,6 +8,7 @@ import {
   Sparkles, Croissant, Wheat, UtensilsCrossed, Utensils, FlaskConical, Plus,
   Search, X, Heart, ArrowLeft, ShoppingCart,
 } from "lucide-react";
+import { useOosProductIds } from "./_useOosProductIds";
 
 /**
  * Two-column menu — sidebar pills (icon + label) on the left, product
@@ -102,12 +103,24 @@ export function MenuColumns({
       });
   }, [allProducts]);
 
-  // Prepend the Usual section above Best Sellers + categories when
-  // the customer has resolved recent items.
-  const sections: Section[] =
-    usual.length > 0
-      ? [{ id: USUAL_ID, label: "Your usual", products: usual, icon: "heart" }, ...baseSections]
-      : baseSections;
+  // Per-outlet out-of-stock (POS "86") product ids, kept live via realtime.
+  // The web menu had ignored these entirely — now it drops them like the
+  // native app does.
+  const oos = useOosProductIds();
+
+  // Prepend the Usual section above Best Sellers + categories when the customer
+  // has resolved recent items, and strip any item that's 86'd at their outlet
+  // (a category emptied by 86s disappears too).
+  const sections: Section[] = useMemo(() => {
+    const strip = (ps: Product[]) => (oos.size === 0 ? ps : ps.filter((p) => !oos.has(p.id)));
+    const base = baseSections
+      .map((s) => ({ ...s, products: strip(s.products) }))
+      .filter((s) => s.products.length > 0);
+    const u = strip(usual);
+    return u.length > 0
+      ? [{ id: USUAL_ID, label: "Your usual", products: u, icon: "heart" }, ...base]
+      : base;
+  }, [baseSections, usual, oos]);
 
   const [active, setActive] = useState(sections[0]?.id ?? "");
 

--- a/apps/order/src/app/menu/_useOosProductIds.ts
+++ b/apps/order/src/app/menu/_useOosProductIds.ts
@@ -1,0 +1,79 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import type { SupabaseClient } from "@supabase/supabase-js";
+import { getSupabaseClient } from "@/lib/supabase/client";
+
+/** The customer's selected pickup outlet (store slug), read from the persisted
+ *  SPA store — the same key + shape OutletRow / OutletPickerRow read. */
+function readOutletId(): string | null {
+  try {
+    const raw = window.localStorage.getItem("celsius-pickup");
+    if (!raw) return null;
+    const parsed = JSON.parse(raw) as { state?: { outletId?: string | null } };
+    return parsed.state?.outletId ?? null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Per-outlet out-of-stock product ids — the POS "86" overrides — kept live.
+ *
+ * Mirrors apps/pickup-native/lib/menu.ts: reads `outlet_product_availability`
+ * for the customer's selected outlet (the SAME table + store-slug key the POS
+ * register writes via /api/pos/availability and the backoffice Availability
+ * matrix edits) and subscribes to realtime, so a counter 86 drops the item off
+ * the website within seconds. The web menu had been ignoring this table
+ * entirely, so a POS 86 never reached the site.
+ *
+ * Empty set when no outlet is selected — the menu then shows everything,
+ * governed only by the product's global is_available.
+ */
+export function useOosProductIds(): Set<string> {
+  const [oos, setOos] = useState<Set<string>>(() => new Set());
+
+  useEffect(() => {
+    const outletId = readOutletId();
+    if (!outletId) {
+      setOos(new Set());
+      return;
+    }
+    // The browser client is typed to the generated Database, which doesn't
+    // include this sparse override table — use the untyped client for it.
+    const supabase = getSupabaseClient() as unknown as SupabaseClient;
+    let cancelled = false;
+
+    const load = async () => {
+      const { data } = await supabase
+        .from("outlet_product_availability")
+        .select("product_id")
+        .eq("outlet_id", outletId)
+        .eq("is_available", false);
+      if (cancelled) return;
+      setOos(new Set((data ?? []).map((r: { product_id: string }) => r.product_id)));
+    };
+    void load();
+
+    const channel = supabase
+      .channel(`web-oos-${outletId}`)
+      .on(
+        "postgres_changes",
+        {
+          event: "*",
+          schema: "public",
+          table: "outlet_product_availability",
+          filter: `outlet_id=eq.${outletId}`,
+        },
+        () => void load(),
+      )
+      .subscribe();
+
+    return () => {
+      cancelled = true;
+      void supabase.removeChannel(channel);
+    };
+  }, []);
+
+  return oos;
+}

--- a/apps/pickup-native/app/menu.tsx
+++ b/apps/pickup-native/app/menu.tsx
@@ -45,6 +45,7 @@ import {
 } from "lucide-react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { fetchMenu, type Product } from "../lib/menu";
+import { supabase } from "../lib/supabase";
 import { useApp, cartCount, cartTotal } from "../lib/store";
 import { formatPrice } from "../lib/api";
 import { EspressoHeader } from "../components/EspressoHeader";
@@ -118,6 +119,32 @@ export default function Menu() {
   });
   const addToCart = useApp((s) => s.addToCart);
   const phone = useApp((s) => s.phone);
+
+  // Live OOS: a POS "86" (or un-86) at this outlet flips
+  // outlet_product_availability; refetch so the item drops/returns within
+  // seconds instead of waiting for a manual refresh. Mirrors the register's
+  // own availability channel (apps/pos-native/app/register.tsx).
+  useEffect(() => {
+    if (!outletId) return;
+    const channel = supabase
+      .channel(`menu-oos-${outletId}`)
+      .on(
+        "postgres_changes",
+        {
+          event: "*",
+          schema: "public",
+          table: "outlet_product_availability",
+          filter: `outlet_id=eq.${outletId}`,
+        },
+        () => {
+          void refetchMenu();
+        },
+      )
+      .subscribe();
+    return () => {
+      void supabase.removeChannel(channel);
+    };
+  }, [outletId, refetchMenu]);
 
   // Force outlet pick before showing the menu. Without this, customers
   // could shop the whole menu, hit checkout, and only THEN learn they


### PR DESCRIPTION
## Problem

A POS "86" (out-of-stock) didn't reflect on the customer apps. Tracing the wiring:

**Write (✅ already correct):** register long-press → `POST /api/pos/availability` → upserts `outlet_product_availability(outlet_id = store slug, product_id, is_available)` and pushes to GrabFood.

**Read (broken):**
- **Web PWA (`apps/order`)** — `menu-data.ts` **never read `outlet_product_availability`** and isn't outlet-scoped, so a 86 *never* reached the website.
- **pickup-native** — *did* read the table (matching key), but neither customer surface updated **live** — only on a manual menu refetch.

## Fix (all surfaces)

- **`apps/order`** — new `useOosProductIds` hook reads `outlet_product_availability` for the customer's selected outlet (store slug from the persisted store) and subscribes to **realtime**. `_MenuColumns` strips 86'd items from every section (and a category emptied by 86s disappears) — mirroring pickup-native's hide rule. (The table isn't in the order app's generated `Database` types, so the query uses an untyped client cast.)
- **`apps/pickup-native`** — the menu now subscribes to the same table and **refetches on change**, so a 86 drops/returns the item within seconds instead of waiting for a manual refresh. Mirrors the register's own availability channel.

Same table + slug key the POS writes and the backoffice Availability matrix edits — all channels now agree, live.

## Notes / scope
- Items are **hidden** when 86'd (matches pickup-native). A greyed-out "Sold out" state could be a follow-up.
- No DB/schema change — `outlet_product_availability` already has realtime enabled (migration 015) and anon SELECT (pickup-native already reads it).
- Hardening the product-detail page / checkout to also block a 86'd item is a possible follow-up; this PR covers the menu reflection + live updates that were the reported gap.

https://claude.ai/code/session_01QDNdybSVB2vJ39yEbQLECi

---
_Generated by [Claude Code](https://claude.ai/code/session_01QDNdybSVB2vJ39yEbQLECi)_