### PR TITLE
menu(web): fetch OOS via server route — fixes availability never wiring on the PWA

### DIFF
--- a/apps/order/src/app/api/menu/availability/route.ts
+++ b/apps/order/src/app/api/menu/availability/route.ts
@@ -1,0 +1,38 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getSupabaseAdmin } from "@/lib/supabase/server";
+
+/**
+ * Per-outlet out-of-stock (POS "86") product ids for the customer menu.
+ *
+ * Server-side (service role) on purpose: every other customer read in this app
+ * goes through an /api route, and the order app has no provisioned browser
+ * Supabase client — an earlier client-side version of this read silently
+ * returned nothing, so a 86 never reached the web menu. Reads the SAME table +
+ * store-slug key the POS register writes (/api/pos/availability) and the
+ * backoffice Availability matrix edits.
+ *
+ * GET /api/menu/availability?outlet={storeSlug} -> { oos: string[] }
+ */
+export const dynamic = "force-dynamic";
+
+export async function GET(req: NextRequest) {
+  const outlet = req.nextUrl.searchParams.get("outlet");
+  if (!outlet) return NextResponse.json({ oos: [] });
+
+  try {
+    const supabase = getSupabaseAdmin();
+    const { data, error } = await supabase
+      .from("outlet_product_availability")
+      .select("product_id")
+      .eq("outlet_id", outlet)
+      .eq("is_available", false);
+
+    if (error || !data) return NextResponse.json({ oos: [] });
+
+    const res = NextResponse.json({ oos: data.map((d) => d.product_id as string) });
+    res.headers.set("Cache-Control", "no-store");
+    return res;
+  } catch {
+    return NextResponse.json({ oos: [] });
+  }
+}

--- a/apps/order/src/app/menu/_useOosProductIds.ts
+++ b/apps/order/src/app/menu/_useOosProductIds.ts
@@ -1,11 +1,10 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import type { SupabaseClient } from "@supabase/supabase-js";
-import { getSupabaseClient } from "@/lib/supabase/client";
 
 /** The customer's selected pickup outlet (store slug), read from the persisted
- *  SPA store — the same key + shape OutletRow / OutletPickerRow read. */
+ *  store — the same key + shape OutletRow / OutletPickerRow / _TableEntry use.
+ *  In dine-in (table-QR) mode _TableEntry writes this to the scanned outlet. */
 function readOutletId(): string | null {
   try {
     const raw = window.localStorage.getItem("celsius-pickup");
@@ -18,17 +17,13 @@ function readOutletId(): string | null {
 }
 
 /**
- * Per-outlet out-of-stock product ids — the POS "86" overrides — kept live.
+ * Per-outlet out-of-stock product ids — the POS "86" overrides.
  *
- * Mirrors apps/pickup-native/lib/menu.ts: reads `outlet_product_availability`
- * for the customer's selected outlet (the SAME table + store-slug key the POS
- * register writes via /api/pos/availability and the backoffice Availability
- * matrix edits) and subscribes to realtime, so a counter 86 drops the item off
- * the website within seconds. The web menu had been ignoring this table
- * entirely, so a POS 86 never reached the site.
- *
- * Empty set when no outlet is selected — the menu then shows everything,
- * governed only by the product's global is_available.
+ * Fetches via the server /api/menu/availability route (service role), NOT a
+ * browser Supabase client: the order app provisions no anon browser client, so
+ * a client-side read silently returned nothing and a 86 never reached the web
+ * menu. Refetches on tab focus + every 30s so a counter 86 drops the item
+ * without a manual refresh. Empty set when no outlet is selected.
  */
 export function useOosProductIds(): Set<string> {
   const [oos, setOos] = useState<Set<string>>(() => new Set());
@@ -39,39 +34,33 @@ export function useOosProductIds(): Set<string> {
       setOos(new Set());
       return;
     }
-    // The browser client is typed to the generated Database, which doesn't
-    // include this sparse override table — use the untyped client for it.
-    const supabase = getSupabaseClient() as unknown as SupabaseClient;
     let cancelled = false;
 
     const load = async () => {
-      const { data } = await supabase
-        .from("outlet_product_availability")
-        .select("product_id")
-        .eq("outlet_id", outletId)
-        .eq("is_available", false);
-      if (cancelled) return;
-      setOos(new Set((data ?? []).map((r: { product_id: string }) => r.product_id)));
+      try {
+        const res = await fetch(
+          `/api/menu/availability?outlet=${encodeURIComponent(outletId)}`,
+          { cache: "no-store" },
+        );
+        if (!res.ok) return;
+        const json = (await res.json()) as { oos?: string[] };
+        if (!cancelled) setOos(new Set(json.oos ?? []));
+      } catch {
+        /* keep the last good set */
+      }
     };
-    void load();
 
-    const channel = supabase
-      .channel(`web-oos-${outletId}`)
-      .on(
-        "postgres_changes",
-        {
-          event: "*",
-          schema: "public",
-          table: "outlet_product_availability",
-          filter: `outlet_id=eq.${outletId}`,
-        },
-        () => void load(),
-      )
-      .subscribe();
+    void load();
+    const onFocus = () => void load();
+    window.addEventListener("focus", onFocus);
+    document.addEventListener("visibilitychange", onFocus);
+    const interval = setInterval(() => void load(), 30_000);
 
     return () => {
       cancelled = true;
-      void supabase.removeChannel(channel);
+      window.removeEventListener("focus", onFocus);
+      document.removeEventListener("visibilitychange", onFocus);
+      clearInterval(interval);
     };
   }, []);
 


### PR DESCRIPTION
## QA finding

You were right to push on this. I QA'd the full chain and it was all correct **except one fragile link**:

- ✅ `/menu` is Next-owned → renders the order app's `_MenuColumns` (where the filter lives).
- ✅ QR flow stores the **store slug** as `state.outletId` (`/table/{slug}/…` → `_TableEntry`), matching the availability key.
- ✅ `outlet_product_availability` keys + `product_id`s line up with `products.id` (verified: conezion has 12 real 86'd items).
- ✅ RLS lets `anon` read it; #271 was deployed to production.
- ❌ **The read used a *browser* Supabase client.** The order app provisions no anon browser client — every other customer read goes through a server `/api` route — so the client-side query **silently returned nothing**, and a POS 86 never reached the web menu (pickup *or* QR).

## Fix

- New `GET /api/menu/availability?outlet={slug}` — server-side **service-role** read (same client as the menu data itself, proven to work), returns the 86'd `product_id`s.
- `_useOosProductIds` now fetches that route and **refetches on tab focus + every 30s** for live-ish updates, instead of the browser client / realtime.

This removes the dependency on a browser anon client that the order app never had, so OOS now actually reflects on the PWA — including QR-table orders. `pickup-native` (its own working realtime) is unchanged.

## Verify after deploy
At a **conezion / Putrajaya** table, these should be **absent** from the QR menu: Classic Fries, Classic Croissant, Truffle/Korean/Loaded Fries, Chocolate Mudslide, Chocolate Cake Bars, Mini Pavlova, and the NYC cookies.

https://claude.ai/code/session_01QDNdybSVB2vJ39yEbQLECi

---
_Generated by [Claude Code](https://claude.ai/code/session_01QDNdybSVB2vJ39yEbQLECi)_