### PR TITLE
Auto-approve zero-discrepancy stock counts

### DIFF
--- a/apps/backoffice/src/app/(admin)/inventory/stock-count/page.tsx
+++ b/apps/backoffice/src/app/(admin)/inventory/stock-count/page.tsx
@@ -72,6 +72,15 @@ function formatTime(iso: string) {
   return new Date(iso).toLocaleTimeString("en-MY", { hour: "2-digit", minute: "2-digit" });
 }
 
+// A count was auto-approved (no discrepancies) when it went straight to
+// REVIEWED at submit time — reviewedAt within a few seconds of submittedAt.
+// A manual review happens minutes/hours later, so the gap reliably tells
+// them apart without needing a dedicated DB column.
+function isAutoApproved(sc: { status: string; submittedAt: string | null; reviewedAt: string | null }) {
+  if (sc.status !== "REVIEWED" || !sc.submittedAt || !sc.reviewedAt) return false;
+  return Math.abs(new Date(sc.reviewedAt).getTime() - new Date(sc.submittedAt).getTime()) < 3000;
+}
+
 export default function StockCountPage() {
   const [data, setData] = useState<StockCount[]>([]);
   const [loading, setLoading] = useState(true);
@@ -81,6 +90,8 @@ export default function StockCountPage() {
   const [reviewing, setReviewing] = useState(false);
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  // Review dialog defaults to discrepancies only; manager can expand to all items.
+  const [showAllItems, setShowAllItems] = useState(false);
 
   // Editable variance reasons (per item id)
   const [editReasons, setEditReasons] = useState<Record<string, string>>({});
@@ -101,6 +112,7 @@ export default function StockCountPage() {
         if (item.varianceReason) reasons[item.id] = item.varianceReason;
       });
       setEditReasons(reasons);
+      setShowAllItems(false);
     }
   }, [selected]);
 
@@ -295,10 +307,17 @@ export default function StockCountPage() {
                     )}
                   </td>
                   <td className="px-4 py-3">
-                    <Badge variant="outline" className={`text-[10px] ${STATUS_STYLES[sc.status] ?? ""}`}>
-                      <StatusIcon className="h-3 w-3 mr-1" />
-                      {sc.status === "SUBMITTED" ? "Pending" : sc.status.toLowerCase()}
-                    </Badge>
+                    <div className="flex items-center gap-1.5">
+                      <Badge variant="outline" className={`text-[10px] ${STATUS_STYLES[sc.status] ?? ""}`}>
+                        <StatusIcon className="h-3 w-3 mr-1" />
+                        {sc.status === "SUBMITTED" ? "Pending" : sc.status.toLowerCase()}
+                      </Badge>
+                      {isAutoApproved(sc) && (
+                        <span className="text-[9px] uppercase tracking-wide text-gray-400" title="Auto-approved — no discrepancies">
+                          auto
+                        </span>
+                      )}
+                    </div>
                   </td>
                   <td className="px-4 py-3 text-right">
                     <Button size="sm" variant="outline" className="h-7 text-xs" onClick={() => setSelected(sc)}>
@@ -334,6 +353,13 @@ export default function StockCountPage() {
               const v = getVariance(i);
               return v !== null && v !== 0 && !(editReasons[i.id] || i.varianceReason);
             }).length;
+            const discrepancyItems = itemsWithVariance.filter((i) => {
+              const v = getVariance(i);
+              return v !== null && v !== 0;
+            });
+            // Exception-only: show just the discrepancy rows unless the manager
+            // expands to the full list.
+            const visibleItems = showAllItems ? itemsWithVariance : discrepancyItems;
 
             return (
               <>
@@ -370,8 +396,37 @@ export default function StockCountPage() {
                   </div>
                 </div>
 
-                {/* Variance table */}
-                <div className="mt-3 rounded-lg border overflow-hidden overflow-x-auto">
+                {/* Exception-only review: discrepancies first, expandable to all */}
+                <div className="mt-3 flex items-center justify-between gap-2">
+                  <p className="text-xs text-gray-500">
+                    {discrepancyCount === 0
+                      ? "No discrepancies — nothing to review"
+                      : showAllItems
+                        ? `Showing all ${itemsWithVariance.length} items`
+                        : `Showing ${discrepancyCount} discrepanc${discrepancyCount === 1 ? "y" : "ies"} only`}
+                  </p>
+                  {itemsWithVariance.length > discrepancyItems.length && (
+                    <button
+                      onClick={() => setShowAllItems((v) => !v)}
+                      className="text-xs text-terracotta hover:underline whitespace-nowrap"
+                    >
+                      {showAllItems
+                        ? "Show discrepancies only"
+                        : `Show all ${itemsWithVariance.length} items`}
+                    </button>
+                  )}
+                </div>
+
+                {discrepancyCount === 0 && !showAllItems ? (
+                  <div className="mt-2 rounded-lg border border-green-200 bg-green-50 px-4 py-4 text-center">
+                    <CheckCircle2 className="h-5 w-5 text-green-600 mx-auto" />
+                    <p className="mt-1.5 text-sm font-medium text-green-700">No discrepancies found</p>
+                    <p className="text-xs text-green-600/80">
+                      All {itemsWithVariance.length} counted items are in line — nothing to action.
+                    </p>
+                  </div>
+                ) : (
+                <div className="mt-2 rounded-lg border overflow-hidden overflow-x-auto">
                   <table className="w-full text-xs min-w-[720px]">
                     <thead>
                       <tr className="bg-gray-50 border-b">
@@ -383,7 +438,7 @@ export default function StockCountPage() {
                       </tr>
                     </thead>
                     <tbody>
-                      {itemsWithVariance.map((item) => {
+                      {visibleItems.map((item) => {
                         const variance = getVariance(item);
                         const hasVariance = variance !== null && variance !== 0;
                         const cf = item.packageConversion || 1;
@@ -436,6 +491,7 @@ export default function StockCountPage() {
                     </tbody>
                   </table>
                 </div>
+                )}
 
                 {/* Actions */}
                 {selected.status === "SUBMITTED" && (
@@ -471,7 +527,7 @@ export default function StockCountPage() {
 
                 {selected.status === "REVIEWED" && selected.reviewedAt && (
                   <p className="mt-3 text-xs text-gray-400 text-right">
-                    Reviewed on {formatDate(selected.reviewedAt)} at {formatTime(selected.reviewedAt)}
+                    {isAutoApproved(selected) ? "Auto-approved" : "Reviewed"} on {formatDate(selected.reviewedAt)} at {formatTime(selected.reviewedAt)}
                   </p>
                 )}
               </>

--- a/apps/backoffice/src/app/api/inventory/stock-checks/route.ts
+++ b/apps/backoffice/src/app/api/inventory/stock-checks/route.ts
@@ -1,4 +1,5 @@
 import { NextResponse, NextRequest } from "next/server";
+import { isCleanCount } from "@celsius/db";
 import { prisma } from "@/lib/prisma";
 import { setStockBalance } from "@/lib/stock";
 import { getUserFromHeaders } from "@/lib/auth";
@@ -81,13 +82,24 @@ export async function POST(req: NextRequest) {
     balanceMap[b.productId] = Number(b.quantity);
   }
 
+  // Zero-variance counts auto-approve straight to REVIEWED; only counts with a
+  // real discrepancy against the snapshotted balance need a manager's review.
+  const now = new Date();
+  const autoApprove = isCleanCount(
+    (items as Array<{ productId: string; countedQty?: number | null }>).map((i) => ({
+      expectedQty: balanceMap[i.productId] ?? null,
+      countedQty: i.countedQty ?? null,
+    })),
+  );
+
   const stockCount = await prisma.stockCount.create({
     data: {
       outletId,
       countedById,
       frequency,
-      status: "SUBMITTED",
-      submittedAt: new Date(),
+      status: autoApprove ? "REVIEWED" : "SUBMITTED",
+      submittedAt: now,
+      ...(autoApprove ? { reviewedAt: now } : {}),
       notes: notes || null,
       items: {
         create: items.map((i: { productId: string; productPackageId?: string; countedQty?: number; isConfirmed?: boolean }) => ({

--- a/apps/staff/src/app/api/stock-checks/[id]/finalize/route.ts
+++ b/apps/staff/src/app/api/stock-checks/[id]/finalize/route.ts
@@ -1,4 +1,5 @@
 import { NextResponse, NextRequest } from "next/server";
+import { isCleanCount } from "@celsius/db";
 import { prisma } from "@/lib/prisma";
 import { setStockBalance } from "@/lib/stock";
 import { getSession } from "@/lib/auth";
@@ -28,6 +29,7 @@ export async function POST(req: NextRequest, { params }: { params: Promise<{ id:
         select: {
           productId: true,
           productPackageId: true,
+          expectedQty: true,
           countedQty: true,
         },
       },
@@ -65,14 +67,20 @@ export async function POST(req: NextRequest, { params }: { params: Promise<{ id:
 
   const now = new Date();
 
+  // Zero-variance counts auto-approve: there's nothing for a manager to action,
+  // so skip the review queue and stamp them REVIEWED on the spot. Only counts
+  // with a real discrepancy stay SUBMITTED (pending review).
+  const autoApprove = isCleanCount(count.items);
+
   // Flip status first so any concurrent finalize attempt sees the new state.
   const updated = await prisma.stockCount.updateMany({
     where: { id, status: "DRAFT" },
     data: {
-      status: "SUBMITTED",
+      status: autoApprove ? "REVIEWED" : "SUBMITTED",
       submittedAt: now,
       finalizedById: session.id,
       finalizedAt: now,
+      ...(autoApprove ? { reviewedAt: now } : {}),
     },
   });
   if (updated.count === 0) {
@@ -97,5 +105,5 @@ export async function POST(req: NextRequest, { params }: { params: Promise<{ id:
     );
   }
 
-  return NextResponse.json({ ok: true, finalizedAt: now }, { status: 200 });
+  return NextResponse.json({ ok: true, finalizedAt: now, autoApproved: autoApprove }, { status: 200 });
 }

--- a/apps/staff/src/app/api/stock-checks/route.ts
+++ b/apps/staff/src/app/api/stock-checks/route.ts
@@ -1,4 +1,5 @@
 import { NextResponse, NextRequest } from "next/server";
+import { isCleanCount } from "@celsius/db";
 import { prisma } from "@/lib/prisma";
 import { setStockBalance } from "@/lib/stock";
 import { getSession } from "@/lib/auth";
@@ -67,13 +68,24 @@ export async function POST(req: NextRequest) {
     return NextResponse.json({ error: "Cannot submit stock count for another outlet" }, { status: 403 });
   }
 
+  // Zero-variance counts auto-approve straight to REVIEWED; only counts with a
+  // real discrepancy land in the manager's review queue (SUBMITTED).
+  const now = new Date();
+  const autoApprove = isCleanCount(
+    (items as Array<{ expectedQty?: number | null; countedQty?: number | null }>).map((i) => ({
+      expectedQty: i.expectedQty ?? null,
+      countedQty: i.countedQty ?? null,
+    })),
+  );
+
   const stockCount = await prisma.stockCount.create({
     data: {
       outletId,
       countedById: session.id,
       frequency,
-      status: "SUBMITTED",
-      submittedAt: new Date(),
+      status: autoApprove ? "REVIEWED" : "SUBMITTED",
+      submittedAt: now,
+      ...(autoApprove ? { reviewedAt: now } : {}),
       notes: notes || null,
       items: {
         create: items.map((i: { productId: string; productPackageId?: string; expectedQty?: number; countedQty?: number; isConfirmed?: boolean; varianceReason?: string }) => ({

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -9,3 +9,4 @@ export const prisma = globalForPrisma.prisma ?? new PrismaClient();
 if (process.env.NODE_ENV !== "production") globalForPrisma.prisma = prisma;
 
 export * from "@prisma/client";
+export * from "./stock-count";

--- a/packages/db/src/stock-count.ts
+++ b/packages/db/src/stock-count.ts
@@ -1,0 +1,46 @@
+/**
+ * Stock-count review helpers — shared by the staff and backoffice apps so the
+ * single rule "what counts as a discrepancy" lives in exactly one place.
+ *
+ * A count auto-approves when it has zero discrepancies — i.e. it would show
+ * "All OK" in the backoffice review list. Only counts with a real variance
+ * land in the manager's review queue.
+ */
+
+type QtyLike = number | string | { toString(): string } | null | undefined;
+
+function toNum(v: QtyLike): number | null {
+  if (v === null || v === undefined) return null;
+  const n = typeof v === "number" ? v : Number(v.toString());
+  return Number.isFinite(n) ? n : null;
+}
+
+export interface VarianceItem {
+  expectedQty: QtyLike;
+  countedQty: QtyLike;
+}
+
+/**
+ * Number of items that were counted, have a known expected quantity, and
+ * differ from it. Mirrors the backoffice "Discrepancies" column exactly:
+ * an item with no expected baseline (expectedQty == null) cannot be flagged.
+ */
+export function countDiscrepancies(items: VarianceItem[]): number {
+  let n = 0;
+  for (const it of items) {
+    const expected = toNum(it.expectedQty);
+    const counted = toNum(it.countedQty);
+    if (expected === null || counted === null) continue; // no baseline → can't flag
+    if (counted !== expected) n++;
+  }
+  return n;
+}
+
+/**
+ * A count is "clean" — and therefore safe to auto-approve — when nothing flags
+ * as a discrepancy. A count with no expected baseline has zero discrepancies,
+ * so it auto-approves, matching today's "All OK" behaviour.
+ */
+export function isCleanCount(items: VarianceItem[]): boolean {
+  return countDiscrepancies(items) === 0;
+}


### PR DESCRIPTION
## What
Stock counts submitted with **zero discrepancies** now auto-approve — they skip the **Pending** review queue and are saved as **Reviewed** at submit time. Only counts with a real variance need a manager. This is what was asked: *"make the stock count auto approve, only review the discrepancy items."*

Workflow-only change — **stock balances already update at submit time, so no inventory numbers change.**

## How
- Shared rule `isCleanCount()` / `countDiscrepancies()` in `packages/db/src/stock-count.ts` (re-exported from `@celsius/db`), mirroring the existing **"All OK"** column exactly (item flagged only when expected & counted both present and differ).
- Applied at all three submit paths:
  - `apps/staff/.../stock-checks/[id]/finalize` (primary — staff PWA + native)
  - `apps/staff/.../stock-checks` (direct POST)
  - `apps/backoffice/.../inventory/stock-checks` (manager entry)
- Backoffice review dialog is now **exception-only**: opens to discrepancy rows with a *"Show all N items"* expander; clean counts show a no-discrepancy panel. Auto-approved rows carry an **"auto"** tag (derived from `reviewedAt ≈ submittedAt`; no schema change).

## Known limitation (not addressed here)
The staff counting flow never snapshots `expectedQty`, so staff-app counts have no baseline and will essentially all auto-approve (this is why everything shows "All OK" today). Real variance detection for staff counts needs reliable expected-stock tracking — a larger, separate piece tied to the COGS/receiving-loop problem.

## Verification
- `tsc --noEmit` clean on both `apps/backoffice` and `apps/staff` (0 errors).
- Helper logic unit-checked (7/7): all-match, mismatch, null baseline, uncounted-ignored, Decimal values, empty.

🤖 Generated with [Claude Code](https://claude.com/claude-code)