### PR TITLE
order: /get-app smart redirect so the receipt QR actually downloads the app

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -34,6 +34,13 @@
       "runtimeArgs": ["next", "dev", "--port", "3005"],
       "cwd": "apps/pos",
       "port": 3005
+    },
+    {
+      "name": "order",
+      "runtimeExecutable": "npx",
+      "runtimeArgs": ["next", "dev", "--port", "3007"],
+      "cwd": "apps/order",
+      "port": 3007
     }
   ]
 }

--- a/apps/order/src/app/get-app/route.ts
+++ b/apps/order/src/app/get-app/route.ts
@@ -1,0 +1,40 @@
+/**
+ * GET /get-app — smart app-download redirect.
+ *
+ * This is the URL behind the "Scan to download our app" QR printed on POS
+ * receipts (pos_branch_settings.receipt_app_url). A single QR can't carry
+ * two store links, so we sniff the platform and 302 to the right listing:
+ *   iPhone/iPad  → App Store  (Celsius Coffee, id6766792077)
+ *   Android      → Play Store (com.celsiuscoffee.pickup.next)
+ *   anything else→ the web ordering app
+ *
+ * iPadOS Safari masquerades as macOS ("Macintosh") by default, so those
+ * scans fall through to the web app — acceptable; receipt scans are
+ * overwhelmingly phones. Kept uncached so store URLs can change freely.
+ */
+
+const APP_STORE_URL =
+  "https://apps.apple.com/my/app/celsius-coffee/id6766792077";
+const PLAY_STORE_URL =
+  "https://play.google.com/store/apps/details?id=com.celsiuscoffee.pickup.next";
+const WEB_FALLBACK_URL = "https://order.celsiuscoffee.com";
+
+export function GET(request: Request) {
+  const ua = request.headers.get("user-agent") ?? "";
+
+  let target = WEB_FALLBACK_URL;
+  if (/iPhone|iPad|iPod/i.test(ua)) {
+    target = APP_STORE_URL;
+  } else if (/Android/i.test(ua)) {
+    target = PLAY_STORE_URL;
+  }
+
+  return new Response(null, {
+    status: 302,
+    headers: {
+      Location: target,
+      "Cache-Control": "no-store",
+      Vary: "User-Agent",
+    },
+  });
+}

--- a/apps/order/src/middleware.ts
+++ b/apps/order/src/middleware.ts
@@ -86,6 +86,7 @@ export async function middleware(request: NextRequest) {
     pathname === "/tier-benefits" ||
     pathname === "/wrapped" ||
     pathname === "/account-delete" ||
+    pathname === "/get-app" ||
     pathname.startsWith("/product/") ||
     pathname.startsWith("/order/") ||
     pathname.startsWith("/challenge/") ||


### PR DESCRIPTION
The receipt 'Scan to download our app' QR encoded the bare PWA URL (https://order.celsiuscoffee.com), so it opened the web app instead of a store listing.

- New `/get-app` route: UA-sniffing 302 — iPhone → App Store (id6766792077), Android → Play Store (com.celsiuscoffee.pickup.next), else → web app.
- Middleware: whitelist `/get-app` in isNextOwned so the SPA rewrite doesn't swallow it.
- Verified locally: all three user agents redirect to the right destination; `tsc --noEmit` clean.

After deploy, `pos_branch_settings.receipt_app_url` flips to `https://order.celsiuscoffee.com/get-app` (DB change, tills refresh automatically).

🤖 Generated with [Claude Code](https://claude.com/claude-code)