### PR TITLE
Add "bought product ≥ N units" frequency segment filter

### DIFF
--- a/apps/backoffice/src/app/(admin)/loyalty/members/page.tsx
+++ b/apps/backoffice/src/app/(admin)/loyalty/members/page.tsx
@@ -30,13 +30,16 @@ function isEligibleToRedeem(pointsBalance: number, lowestRewardPoints: number) {
 }
 
 // ─── Advanced filter types ──────────────────────────────
-type FilterField = "total_spent" | "last_visit" | "points_balance" | "total_visits" | "joined_date" | "tag" | "sms_received" | "purchased_product" | "order_channel";
+type FilterField = "total_spent" | "last_visit" | "points_balance" | "total_visits" | "joined_date" | "tag" | "sms_received" | "purchased_product" | "purchased_product_count" | "order_channel";
 type FilterOp = ">" | "<" | "=" | ">=" | "<=" | "!=";
 
 interface MemberFilter {
   field: FilterField;
   op: FilterOp;
   value: string;
+  // Only set for purchased_product_count: which product the count threshold
+  // applies to (value holds the numeric threshold, op the comparator).
+  productId?: string;
 }
 
 const filterFieldLabels: Record<FilterField, string> = {
@@ -48,6 +51,7 @@ const filterFieldLabels: Record<FilterField, string> = {
   tag: "Tag",
   sms_received: "SMS received",
   purchased_product: "Purchased product",
+  purchased_product_count: "Bought product (× units)",
   order_channel: "Order channel",
 };
 
@@ -143,7 +147,7 @@ function DetailRow({ left, sub, right, rightCls, time }: { left: string; sub?: s
   );
 }
 
-type MappedMember = { id: string; phone: string; name: string | null; email: string | null; birthday: string | null; preferred_outlet_id: string | null; created_at: string; updated_at: string; points_balance: number; total_visits: number; total_spent: number; joined_at: string; last_visit_at: string | null; tags: string[]; current_tier_id: string | null; purchased_product_ids: string[]; order_channels: string[] };
+type MappedMember = { id: string; phone: string; name: string | null; email: string | null; birthday: string | null; preferred_outlet_id: string | null; created_at: string; updated_at: string; points_balance: number; total_visits: number; total_spent: number; joined_at: string; last_visit_at: string | null; tags: string[]; current_tier_id: string | null; purchased_product_ids: string[]; purchased_product_counts: Record<string, number>; order_channels: string[] };
 
 function mapMember(m: MemberWithBrand): MappedMember {
   return {
@@ -165,6 +169,7 @@ function mapMember(m: MemberWithBrand): MappedMember {
     // Only the all=true load populates these; default to empty so paginated
     // rows (which don't carry aggregates) simply don't match item/channel filters.
     purchased_product_ids: m.purchased_product_ids ?? [],
+    purchased_product_counts: m.purchased_product_counts ?? {},
     order_channels: m.order_channels ?? [],
   };
 }
@@ -517,6 +522,16 @@ export default function MembersPage() {
         if (f.field === "purchased_product" && f.value) {
           const bought = m.purchased_product_ids.includes(f.value);
           if (f.op === "!=" ? bought : !bought) return false;
+        }
+        // Bought a specific product ≥/>/=/</≤ N units (frequency threshold).
+        if (f.field === "purchased_product_count" && f.productId && f.value) {
+          const count = m.purchased_product_counts[f.productId] ?? 0;
+          if (f.op === ">" && !(count > num)) return false;
+          if (f.op === "<" && !(count < num)) return false;
+          if (f.op === "=" && !(count === num)) return false;
+          if (f.op === ">=" && !(count >= num)) return false;
+          if (f.op === "<=" && !(count <= num)) return false;
+          if (f.op === "!=" && !(count !== num)) return false;
         }
         // Ordered via a specific channel (= used it, != never used it).
         // "app" is the lever for app-adoption marketing; "!= app" = the
@@ -924,6 +939,15 @@ export default function MembersPage() {
             const bought = m.purchased_product_ids.includes(f.value);
             if (f.op === "!=" ? bought : !bought) return false;
           }
+          if (f.field === "purchased_product_count" && f.productId && f.value) {
+            const count = m.purchased_product_counts[f.productId] ?? 0;
+            if (f.op === ">" && !(count > num)) return false;
+            if (f.op === "<" && !(count < num)) return false;
+            if (f.op === "=" && !(count === num)) return false;
+            if (f.op === ">=" && !(count >= num)) return false;
+            if (f.op === "<=" && !(count <= num)) return false;
+            if (f.op === "!=" && !(count !== num)) return false;
+          }
           if (f.field === "order_channel" && f.value) {
             const used = m.order_channels.includes(f.value);
             if (f.op === "!=" ? used : !used) return false;
@@ -1160,7 +1184,9 @@ export default function MembersPage() {
               key={i}
               className="inline-flex items-center gap-1 rounded-full border border-[#C2452D]/30 bg-[#C2452D]/5 px-3 py-1.5 text-xs font-medium text-[#C2452D]"
             >
-              {filterFieldLabels[f.field]} {f.op === "!=" && (f.field === "purchased_product" || f.field === "order_channel") ? "not" : f.op} {f.field === "tag" ? `"${f.value}"` : f.field === "sms_received" ? `"${(smsMessages.find((s) => s.message === f.value)?.display || f.value).slice(0, 30)}..."` : f.field === "purchased_product" ? `"${purchasedProducts.find((p) => p.id === f.value)?.name || f.value}"` : f.field === "order_channel" ? `"${channelLabel(f.value)}"` : f.value}
+              {f.field === "purchased_product_count"
+                ? `Bought "${purchasedProducts.find((p) => p.id === f.productId)?.name || f.productId || "—"}" ${f.op} ${f.value || "?"}× units`
+                : <>{filterFieldLabels[f.field]} {f.op === "!=" && (f.field === "purchased_product" || f.field === "order_channel") ? "not" : f.op} {f.field === "tag" ? `"${f.value}"` : f.field === "sms_received" ? `"${(smsMessages.find((s) => s.message === f.value)?.display || f.value).slice(0, 30)}..."` : f.field === "purchased_product" ? `"${purchasedProducts.find((p) => p.id === f.value)?.name || f.value}"` : f.field === "order_channel" ? `"${channelLabel(f.value)}"` : f.value}</>}
               <button onClick={() => removeFilter(i)} className="ml-0.5 hover:text-red-700"><X className="h-3 w-3" /></button>
             </span>
           ))}
@@ -1351,6 +1377,27 @@ export default function MembersPage() {
                       <option key={c.value} value={c.value}>{c.label}</option>
                     ))}
                   </select>
+                ) : filter.field === "purchased_product_count" ? (
+                  <div className="flex flex-1 items-center gap-2">
+                    <select
+                      value={filter.productId ?? ""}
+                      onChange={(e) => updateFilter(idx, "productId", e.target.value)}
+                      className="min-w-0 flex-1 rounded-lg border border-gray-300 dark:border-neutral-600 bg-white dark:bg-neutral-700 px-2 py-1.5 text-sm dark:text-neutral-200"
+                    >
+                      <option value="">Select product</option>
+                      {purchasedProducts.map((p) => (
+                        <option key={p.id} value={p.id}>{p.name}</option>
+                      ))}
+                    </select>
+                    <input
+                      type="number"
+                      min={1}
+                      value={filter.value}
+                      onChange={(e) => updateFilter(idx, "value", e.target.value)}
+                      placeholder="× units"
+                      className="w-20 shrink-0 rounded-lg border border-gray-300 dark:border-neutral-600 bg-white dark:bg-neutral-700 px-2 py-1.5 text-sm dark:text-neutral-200"
+                    />
+                  </div>
                 ) : (
                   <input
                     type="number"

--- a/apps/backoffice/src/app/api/loyalty/members/route.ts
+++ b/apps/backoffice/src/app/api/loyalty/members/route.ts
@@ -16,46 +16,59 @@ import { classifyOrderChannel, posChannel, type OrderChannel } from '@/lib/loyal
  * extra queries.
  */
 async function buildPurchaseAggregates(): Promise<
-  Map<string, { productIds: string[]; channels: OrderChannel[] }>
+  Map<string, { productIds: string[]; productCounts: Record<string, number>; channels: OrderChannel[] }>
 > {
   const [ordersRes, posOrdersRes, itemsRes, posItemsRes] = await Promise.all([
     supabaseAdmin.from('orders').select('id, loyalty_phone, source, order_type').not('loyalty_phone', 'is', null),
     supabaseAdmin.from('pos_orders').select('id, loyalty_phone, order_type').not('loyalty_phone', 'is', null),
-    supabaseAdmin.from('order_items').select('order_id, product_id'),
-    supabaseAdmin.from('pos_order_items').select('order_id, product_id'),
+    supabaseAdmin.from('order_items').select('order_id, product_id, quantity'),
+    supabaseAdmin.from('pos_order_items').select('order_id, product_id, quantity'),
   ]);
 
-  // order_id → product_ids
-  const itemsByOrder = new Map<string, string[]>();
-  for (const it of [...(itemsRes.data ?? []), ...(posItemsRes.data ?? [])] as { order_id: string | null; product_id: string | null }[]) {
+  // order_id → [{ product_id, qty }]. qty carries the per-line quantity so we
+  // can sum total units per product per member (for the "bought ≥ N times"
+  // frequency filter), not just distinct products.
+  const itemsByOrder = new Map<string, { pid: string; qty: number }[]>();
+  for (const it of [...(itemsRes.data ?? []), ...(posItemsRes.data ?? [])] as { order_id: string | null; product_id: string | null; quantity: number | null }[]) {
     if (!it.order_id || !it.product_id) continue;
     const arr = itemsByOrder.get(it.order_id) ?? [];
-    arr.push(it.product_id);
+    arr.push({ pid: it.product_id, qty: it.quantity ?? 0 });
     itemsByOrder.set(it.order_id, arr);
   }
 
-  const byPhone = new Map<string, { productIds: Set<string>; channels: Set<OrderChannel> }>();
+  const byPhone = new Map<string, { productCounts: Map<string, number>; channels: Set<OrderChannel> }>();
   const bucket = (phone: string) => {
     let b = byPhone.get(phone);
-    if (!b) { b = { productIds: new Set(), channels: new Set() }; byPhone.set(phone, b); }
+    if (!b) { b = { productCounts: new Map(), channels: new Set() }; byPhone.set(phone, b); }
     return b;
+  };
+  const addItems = (b: { productCounts: Map<string, number> }, orderId: string) => {
+    for (const { pid, qty } of itemsByOrder.get(orderId) ?? []) {
+      b.productCounts.set(pid, (b.productCounts.get(pid) ?? 0) + qty);
+    }
   };
 
   for (const o of (ordersRes.data ?? []) as { id: string; loyalty_phone: string | null; source: string | null; order_type: string | null }[]) {
     if (!o.loyalty_phone) continue;
     const b = bucket(o.loyalty_phone);
     b.channels.add(classifyOrderChannel(o.source, o.order_type));
-    for (const pid of itemsByOrder.get(o.id) ?? []) b.productIds.add(pid);
+    addItems(b, o.id);
   }
   for (const o of (posOrdersRes.data ?? []) as { id: string; loyalty_phone: string | null }[]) {
     if (!o.loyalty_phone) continue;
     const b = bucket(o.loyalty_phone);
     b.channels.add(posChannel());
-    for (const pid of itemsByOrder.get(o.id) ?? []) b.productIds.add(pid);
+    addItems(b, o.id);
   }
 
-  const out = new Map<string, { productIds: string[]; channels: OrderChannel[] }>();
-  for (const [phone, b] of byPhone) out.set(phone, { productIds: [...b.productIds], channels: [...b.channels] });
+  const out = new Map<string, { productIds: string[]; productCounts: Record<string, number>; channels: OrderChannel[] }>();
+  for (const [phone, b] of byPhone) {
+    out.set(phone, {
+      productIds: [...b.productCounts.keys()],
+      productCounts: Object.fromEntries(b.productCounts),
+      channels: [...b.channels],
+    });
+  }
   return out;
 }
 
@@ -135,6 +148,7 @@ export async function GET(request: NextRequest) {
             ? member.brand_data[0]
             : member.brand_data,
           purchased_product_ids: agg?.productIds ?? [],
+          purchased_product_counts: agg?.productCounts ?? {},
           order_channels: agg?.channels ?? [],
         };
       });

--- a/apps/backoffice/src/lib/loyalty/types.ts
+++ b/apps/backoffice/src/lib/loyalty/types.ts
@@ -244,6 +244,9 @@ export interface MemberWithBrand extends Member {
   // load (used for the client-side item/channel segment filters). Optional
   // because the paginated/phone-lookup responses don't compute them.
   purchased_product_ids?: string[];
+  // product_id → total units purchased (across pickup + counter), for the
+  // "bought ≥ N times" frequency filter.
+  purchased_product_counts?: Record<string, number>;
   order_channels?: string[];
 }
 


### PR DESCRIPTION
## Summary
Follow-up to #279. Adds a product-frequency threshold to the customer segmentation, on top of the existing has/hasn't-bought filter.

## What's new
- **"Bought product (× units)" filter** — pick a product, a comparator (≥ > = < ≤ ≠), and a unit threshold. E.g. "bought Latte ≥ 5×" (loyal repeat buyers) or "bought Cold Brew ≤ 1×" (one-time triers to re-engage).
- Per-member aggregate now tracks **per-product unit counts** (`purchased_product_counts`), summing `quantity` across pickup `order_items` + counter `pos_order_items`, attached in the `all=true` load.
- Wired into the filter logic, saved-segment counts, and the active-filter chip.

## Semantics
- **"Times" = total units purchased** (e.g. 5 lattes across any orders), not distinct visits. Switchable to distinct-order count if preferred.
- Subject to the same phone-format linkage quirk noted in #279 (counts can under-merge for un-normalized phones).

## Verification
- Backoffice typechecks clean.
- Validated against live data (members with 3+ units exist, e.g. one with 118× "Black").
- UI not visually verified (behind login).

Additive only — the has/hasn't "Purchased product" filter is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)