### PR TITLE
hotfix: restore maybank-terminal stub deleted by #281

### DIFF
--- a/apps/pos-native/lib/maybank-terminal.ts
+++ b/apps/pos-native/lib/maybank-terminal.ts
@@ -1,0 +1,48 @@
+/**
+ * Maybank terminal payment integration (STUB).
+ *
+ * Until the real Maybank MAPI / DTMC terminal SDK is wired up, this
+ * module shape lets the checkout flow drive a card payment via a
+ * single Promise — UI doesn't change when we swap the implementation.
+ *
+ * The real integration would either:
+ *   - Bluetooth-pair an external Maybank EDC and exchange APDUs, OR
+ *   - Call Maybank's online card-not-present API with tokenised cards
+ *
+ * For now this resolves after a short delay with a synthetic "approved"
+ * response so the cashier flow can be tested end-to-end before the real
+ * device or API key arrives. The downstream sale persists with
+ * payment_method='card' and provider_ref=approval code, just like a
+ * real Maybank EDC would supply.
+ */
+export type MaybankTerminalResult =
+  | {
+      status: "approved";
+      approvalCode: string;
+      cardBrand: "VISA" | "MASTERCARD" | "AMEX" | "MYDEBIT";
+      maskedPan: string;
+      txnRef: string;
+    }
+  | { status: "declined"; reason: string }
+  | { status: "cancelled" };
+
+/** Prompt the terminal for a card payment of the given amount (sen).
+ *  Returns the terminal's verdict. Cashier UI should show "Insert card
+ *  on terminal" while this is pending. */
+export async function chargeMaybankCard(amountSen: number): Promise<MaybankTerminalResult> {
+  // TODO: replace with real Maybank terminal SDK call. Expected wiring:
+  //   1. Pair / connect to the EDC over Bluetooth (one-time, in Settings)
+  //   2. Send SALE command with amountSen + invoice ref
+  //   3. Stream status updates (idle → prompt → reading → online → result)
+  //   4. Receive approval/decline + capture the receipt-printable fields
+  await new Promise((r) => setTimeout(r, 2500));
+  // Stub: always approves with a synthetic ref so cashiers can rehearse
+  // the flow. Swap to a real call when Maybank credentials land.
+  return {
+    status: "approved",
+    approvalCode: `APR-${Math.floor(Math.random() * 900000 + 100000)}`,
+    cardBrand: "VISA",
+    maskedPan: "**** **** **** 4242",
+    txnRef: `MBB-${Date.now().toString().slice(-10)}`,
+  };
+}


### PR DESCRIPTION
## Hotfix
#281 accidentally included a pre-staged deletion of `apps/pos-native/lib/maybank-terminal.ts`. Main's committed `apps/pos-native/app/register.tsx` still imports `chargeMaybankCard` / `MaybankTerminalResult` from it (line 23), so the pos-native build is left with a **dangling import**.

This restores the file verbatim (pre-#281 content) to un-break main. Nothing else included.

The in-progress `maybank-terminal` → `card-terminal` rename is uncommitted local WIP and should land separately as one atomic change (add `card-terminal.ts` + update `register.tsx` + delete `maybank-terminal.ts`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)