### PR TITLE
Pulse: Telegram data advisor bot (read-only SQL agent)

### DIFF
--- a/apps/backoffice/src/app/api/telegram/advisor/route.ts
+++ b/apps/backoffice/src/app/api/telegram/advisor/route.ts
@@ -1,0 +1,48 @@
+import { NextRequest, NextResponse } from "next/server";
+import { after } from "next/server";
+import { handleQuestion, WELCOME_MESSAGE } from "@/lib/pulse/advisor";
+import { sendMessage, type PulseUpdate } from "@/lib/pulse/telegram";
+
+export const maxDuration = 300;
+
+function allowedChatIds(): Set<number> {
+  return new Set(
+    (process.env.TELEGRAM_PULSE_ALLOWED_CHAT_IDS ?? "")
+      .split(",")
+      .map((id) => Number(id.trim()))
+      .filter((id) => Number.isFinite(id) && id !== 0),
+  );
+}
+
+export async function POST(request: NextRequest) {
+  const secret = request.headers.get("x-telegram-bot-api-secret-token");
+  if (secret !== process.env.TELEGRAM_PULSE_WEBHOOK_SECRET) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  let update: PulseUpdate;
+  try {
+    update = await request.json();
+  } catch {
+    return NextResponse.json({ ok: true });
+  }
+
+  const message = update.message;
+  const text = message?.text?.trim();
+  if (!message || !text) return NextResponse.json({ ok: true });
+
+  const chatId = message.chat.id;
+  if (!allowedChatIds().has(chatId)) {
+    // Silent drop — log the chat id so legitimate users can be allowlisted.
+    console.warn(`[pulse] ignored message from non-allowlisted chat ${chatId}`);
+    return NextResponse.json({ ok: true });
+  }
+
+  if (text === "/start" || text === "/help") {
+    after(() => sendMessage(chatId, WELCOME_MESSAGE));
+    return NextResponse.json({ ok: true });
+  }
+
+  after(() => handleQuestion(chatId, text));
+  return NextResponse.json({ ok: true });
+}

--- a/apps/backoffice/src/lib/pulse/advisor.ts
+++ b/apps/backoffice/src/lib/pulse/advisor.ts
@@ -1,0 +1,256 @@
+/**
+ * Celsius Pulse — "ask the business anything" agent.
+ *
+ * Answers plain-language questions by running read-only SQL against the
+ * production database, then replies on Telegram. SQL executes through a
+ * dedicated Prisma client connected as the `advisor_readonly` Postgres role
+ * (SELECT-only grants + default read-only transactions + 10s statement
+ * timeout), never the app's admin connection.
+ */
+
+import Anthropic from "@anthropic-ai/sdk";
+import { PrismaClient } from "@prisma/client";
+import { prisma } from "@/lib/prisma";
+import { sendMessage, sendChatAction } from "./telegram";
+
+const anthropic = new Anthropic({ apiKey: process.env.ANTHROPIC_API_KEY });
+
+const MODEL = process.env.PULSE_MODEL || "claude-opus-4-8";
+const MAX_TOOL_ITERATIONS = 15;
+const MAX_RESULT_ROWS = 200;
+const MAX_RESULT_CHARS = 12000;
+const HISTORY_LIMIT = 16;
+
+// ─── Read-only DB client ────────────────────────────────────
+
+const globalForPulse = globalThis as unknown as { pulseAdvisorDb?: PrismaClient };
+
+function advisorDb(): PrismaClient {
+  if (!globalForPulse.pulseAdvisorDb) {
+    globalForPulse.pulseAdvisorDb = new PrismaClient({
+      datasources: { db: { url: process.env.PULSE_ADVISOR_DATABASE_URL } },
+    });
+  }
+  return globalForPulse.pulseAdvisorDb;
+}
+
+// ─── System prompt ──────────────────────────────────────────
+
+const SYSTEM_PROMPT = `You are Celsius Pulse, the private data advisor for Celsius Coffee — a specialty coffee chain in Malaysia. You chat with Ammar (the founder) on Telegram and answer questions about the business by querying the production Postgres database (read-only).
+
+BUSINESS CONTEXT
+- 4 outlets: Shah Alam, Conezion (Putrajaya), Tamarind (Cyberjaya), Nilai.
+- Operating companies: Conezion → Celsius Coffee CONEZION SB; Tamarind → Celsius Coffee Tamarind SB; Shah Alam & Nilai → Celsius Coffee SB.
+- Per-outlet targets: RM120k revenue/month at ~25% profit; COGS target 35% of sales; people cost 15%; AOV target RM40.
+- "Rounds" = day-part segments (Breakfast, Brunch, Lunch, Midday, Evening, Dinner, Supper) with per-outlet daily targets (see "SalesTarget").
+- Not SST-registered yet, so SST = 0 on POS receipts is correct.
+- GrabFood sales are booked gross; Grab commission is a separate expense.
+
+DATA MAP (Postgres / Supabase, schema public)
+Naming: tables created via Prisma are PascalCase and MUST be double-quoted in SQL ("Order", "Invoice", "Outlet"); operational tables are snake_case.
+- Native POS sales (live): pos_orders, pos_order_items, pos_order_payments, pos_shifts. Putrajaya (Conezion) cut over to native POS on 2026-06-08; Shah Alam and Tamarind cut over 2026-06-15.
+- StoreHub archive (full sales history before cutover): storehub_sales, storehub_sale_items, storehub_products. Don't double-count: per outlet, use StoreHub before its cutover date and pos_orders after.
+- Customer app orders (pickup / table QR): orders, order_items. Menu catalog: products, categories.
+- Procurement & inventory (PascalCase): "Order" = supplier purchase orders (NOT customer sales), "OrderItem", "Invoice", "Receiving", "ReceivingItem", "StockBalance", "StockCount", "Supplier", "Product" (= ingredients/supplies), "ParLevel".
+- Outlets & users: "Outlet" (incl. per-outlet POS cutover timestamp), "User".
+- HR: hr_employee_profiles, hr_attendance_logs, hr_schedules, hr_schedule_shifts, hr_payroll_runs, hr_payroll_items, hr_leave_requests, hr_overtime_requests. Overtime hours always floor to whole numbers.
+- Finance: "BankStatement", "BankStatementLine" (real bank lines; ledger classification still partly draft — caveat balance-sheet/cashflow answers), fin_* tables (accounts, transactions, journal_lines, periods, ...).
+- Loyalty: members, member_brands, point_transactions, tiers, redemptions, voucher_templates, reward_missions. Tier qualification = real RM spend (net of SST), not points.
+- Marketing/ads: ads_* (Google Ads), indeed_* (job ads), splash_posters, promotions.
+- Ops/QA: "Checklist", "ChecklistItem", "AuditReport", qa_alerts.
+- Ignore tables ending in _backup or stamped _20260606 (frozen snapshots).
+
+SQL RULES
+- Read-only role: only SELECT / WITH / EXPLAIN execute; one statement per call; 10s timeout.
+- Timestamps are stored in UTC. Malaysia is UTC+8: for daily/round groupings convert with (col AT TIME ZONE 'Asia/Kuala_Lumpur').
+- Introspect when unsure: query information_schema.columns / information_schema.tables instead of guessing column names.
+- Always aggregate in SQL and LIMIT — result sets are truncated to ${MAX_RESULT_ROWS} rows. Never SELECT * from large tables (BankStatementLine ~51k rows, storehub_sale_items ~127k).
+
+ANSWER STYLE (Telegram)
+- Plain text only — no markdown (#, **, tables); messages render literally.
+- Lead with the answer/number, then 1-3 short supporting lines. Format amounts like RM12,345.
+- Briefly state the data source/period when relevant; add a one-line caveat if data may be incomplete (POS cutover, draft ledger).
+- If a question is ambiguous, take the most sensible interpretation and say which one you took instead of asking back.
+- You may run several queries before answering. Sanity-check surprising numbers with a second query.`;
+
+const RUN_SQL_TOOL: Anthropic.Tool = {
+  name: "run_sql",
+  description:
+    "Run one read-only SQL statement (SELECT / WITH / EXPLAIN) against the Celsius Coffee production Postgres database and get the rows back as JSON. Call this whenever answering requires actual data — including information_schema lookups to discover table/column names.",
+  input_schema: {
+    type: "object",
+    properties: {
+      sql: { type: "string", description: "A single read-only SQL statement. No semicolons." },
+      purpose: { type: "string", description: "One line: what this query is for." },
+    },
+    required: ["sql"],
+  },
+};
+
+// ─── SQL tool execution ─────────────────────────────────────
+
+const READ_ONLY_PATTERN = /^\s*(select|with|explain|show)\b/i;
+
+function jsonSafe(_key: string, value: unknown): unknown {
+  if (typeof value === "bigint") {
+    return value >= Number.MIN_SAFE_INTEGER && value <= Number.MAX_SAFE_INTEGER
+      ? Number(value)
+      : value.toString();
+  }
+  return value;
+}
+
+async function runSql(rawSql: string): Promise<{ ok: boolean; result: string }> {
+  let sql = rawSql.trim();
+  while (sql.endsWith(";")) sql = sql.slice(0, -1).trimEnd();
+
+  if (sql.includes(";")) {
+    return { ok: false, result: "Rejected: multiple statements are not allowed. Send one statement, no semicolons." };
+  }
+  if (!READ_ONLY_PATTERN.test(sql)) {
+    return { ok: false, result: "Rejected: only SELECT / WITH / EXPLAIN statements are allowed." };
+  }
+
+  try {
+    const rows = (await advisorDb().$queryRawUnsafe(sql)) as unknown[];
+    if (!Array.isArray(rows)) {
+      return { ok: true, result: JSON.stringify(rows, jsonSafe) };
+    }
+    const truncated = rows.length > MAX_RESULT_ROWS;
+    let payload = JSON.stringify(truncated ? rows.slice(0, MAX_RESULT_ROWS) : rows, jsonSafe);
+    if (payload.length > MAX_RESULT_CHARS) {
+      payload = payload.slice(0, MAX_RESULT_CHARS) + `… [output cut at ${MAX_RESULT_CHARS} chars — aggregate more in SQL]`;
+    }
+    const meta = truncated ? ` (showing ${MAX_RESULT_ROWS} of ${rows.length} rows — aggregate in SQL instead)` : "";
+    return { ok: true, result: `${rows.length} row(s)${meta}:\n${payload}` };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return { ok: false, result: `Query failed: ${message.slice(0, 600)}` };
+  }
+}
+
+// ─── Conversation memory ────────────────────────────────────
+
+type StoredMessage = { role: "user" | "assistant"; content: string };
+
+async function loadHistory(chatId: number): Promise<StoredMessage[]> {
+  try {
+    const rows = await prisma.$queryRawUnsafe<StoredMessage[]>(
+      `select role, content from advisor_messages
+       where chat_id = $1 and created_at > now() - interval '48 hours'
+       order by created_at desc limit ${HISTORY_LIMIT}`,
+      chatId,
+    );
+    const history = rows.reverse();
+    while (history.length && history[0].role !== "user") history.shift();
+    return history;
+  } catch (err) {
+    console.error("[pulse] loadHistory failed:", err);
+    return [];
+  }
+}
+
+async function saveMessage(chatId: number, role: "user" | "assistant", content: string): Promise<void> {
+  try {
+    await prisma.$executeRawUnsafe(
+      `insert into advisor_messages (chat_id, role, content) values ($1, $2, $3)`,
+      chatId,
+      role,
+      content,
+    );
+  } catch (err) {
+    console.error("[pulse] saveMessage failed:", err);
+  }
+}
+
+// ─── Agent loop ─────────────────────────────────────────────
+
+async function runAgent(chatId: number, question: string, history: StoredMessage[]): Promise<string> {
+  const todayKL = new Date().toLocaleDateString("en-MY", {
+    timeZone: "Asia/Kuala_Lumpur",
+    weekday: "short",
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+  });
+
+  const messages: Anthropic.MessageParam[] = [
+    ...history.map((m) => ({ role: m.role, content: m.content }) as Anthropic.MessageParam),
+    { role: "user", content: question },
+  ];
+
+  let finalText = "";
+
+  for (let i = 0; i < MAX_TOOL_ITERATIONS; i++) {
+    await sendChatAction(chatId);
+
+    const response = await anthropic.messages.create({
+      model: MODEL,
+      max_tokens: 4096,
+      thinking: { type: "adaptive" },
+      system: `${SYSTEM_PROMPT}\n\nToday is ${todayKL} (Asia/Kuala_Lumpur).`,
+      tools: [RUN_SQL_TOOL],
+      messages,
+    });
+
+    const toolUses = response.content.filter(
+      (block): block is Anthropic.ToolUseBlock => block.type === "tool_use",
+    );
+    const text = response.content
+      .filter((block): block is Anthropic.TextBlock => block.type === "text")
+      .map((block) => block.text)
+      .join("\n")
+      .trim();
+
+    if (toolUses.length === 0) {
+      finalText = text;
+      break;
+    }
+
+    messages.push({ role: "assistant", content: response.content });
+
+    const results: Anthropic.ToolResultBlockParam[] = [];
+    for (const toolUse of toolUses) {
+      const input = toolUse.input as { sql?: string };
+      const { ok, result } = await runSql(input.sql ?? "");
+      console.log(`[pulse] sql ${ok ? "ok" : "err"}: ${(input.sql ?? "").slice(0, 200)}`);
+      results.push({
+        type: "tool_result",
+        tool_use_id: toolUse.id,
+        content: result,
+        is_error: !ok,
+      });
+    }
+    messages.push({ role: "user", content: results });
+  }
+
+  return finalText || "I ran out of query attempts before reaching an answer — try narrowing the question.";
+}
+
+// ─── Entry point (called from the webhook via after()) ──────
+
+export async function handleQuestion(chatId: number, question: string): Promise<void> {
+  const history = await loadHistory(chatId);
+  await saveMessage(chatId, "user", question);
+
+  try {
+    const answer = await runAgent(chatId, question, history);
+    await sendMessage(chatId, answer);
+    await saveMessage(chatId, "assistant", answer);
+  } catch (err) {
+    console.error("[pulse] agent error:", err);
+    const message = err instanceof Error ? err.message : "unknown error";
+    await sendMessage(chatId, `⚠️ Couldn't answer that: ${message.slice(0, 300)}`);
+  }
+}
+
+export const WELCOME_MESSAGE = `Celsius Pulse here ☕ — ask me anything about the business.
+
+Examples:
+• sales semalam ikut outlet?
+• AOV Conezion this week vs target?
+• top 10 products by revenue this month
+• siapa belum clock out hari ini?
+• how much did we pay suppliers in May?
+
+I answer from the live database (read-only).`;

--- a/apps/backoffice/src/lib/pulse/telegram.ts
+++ b/apps/backoffice/src/lib/pulse/telegram.ts
@@ -1,0 +1,52 @@
+/**
+ * Telegram Bot API helper for the Celsius Pulse advisor bot (@celsiuspulsebot).
+ * Separate from lib/telegram.ts, which is bound to the inventory POP bot token.
+ */
+
+const API = () => `https://api.telegram.org/bot${process.env.TELEGRAM_PULSE_BOT_TOKEN}`;
+
+export type PulseMessage = {
+  message_id: number;
+  chat: { id: number; type: string };
+  from?: { id: number; first_name?: string; username?: string };
+  text?: string;
+  date: number;
+};
+
+export type PulseUpdate = {
+  update_id: number;
+  message?: PulseMessage;
+  edited_message?: PulseMessage;
+};
+
+const TELEGRAM_MAX_CHARS = 4000;
+
+export async function sendMessage(chatId: number, text: string): Promise<void> {
+  // No parse_mode — answers are plain text so model output renders literally.
+  const chunks: string[] = [];
+  let remaining = text;
+  while (remaining.length > TELEGRAM_MAX_CHARS) {
+    const slice = remaining.slice(0, TELEGRAM_MAX_CHARS);
+    const cut = Math.max(slice.lastIndexOf("\n"), TELEGRAM_MAX_CHARS - 400);
+    chunks.push(remaining.slice(0, cut));
+    remaining = remaining.slice(cut);
+  }
+  chunks.push(remaining);
+
+  for (const chunk of chunks) {
+    if (!chunk.trim()) continue;
+    await fetch(`${API()}/sendMessage`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ chat_id: chatId, text: chunk }),
+    }).catch((err) => console.error("[pulse] sendMessage failed:", err));
+  }
+}
+
+export async function sendChatAction(chatId: number, action = "typing"): Promise<void> {
+  await fetch(`${API()}/sendChatAction`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ chat_id: chatId, action }),
+  }).catch(() => {});
+}

--- a/apps/backoffice/supabase/migrations/018_pulse_advisor.sql
+++ b/apps/backoffice/supabase/migrations/018_pulse_advisor.sql
@@ -1,0 +1,29 @@
+-- Celsius Pulse (Telegram data advisor) — conversation memory.
+-- Applied to kqdcdhpnyuwrxqhbuyfl on 2026-06-12 via MCP (pulse_advisor_messages).
+--
+-- Companion (run out-of-band, NOT in migration history — contains a password):
+--   create role advisor_readonly login password '...' nosuperuser nocreatedb nocreaterole connection limit 8;
+--   alter role advisor_readonly set statement_timeout = '10s';
+--   alter role advisor_readonly set default_transaction_read_only = on;
+--   alter role advisor_readonly set idle_in_transaction_session_timeout = '15s';
+--   alter role advisor_readonly bypassrls;
+--   grant usage on schema public to advisor_readonly;
+--   grant select on all tables in schema public to advisor_readonly;
+--   alter default privileges in schema public grant select on tables to advisor_readonly;
+
+create table if not exists public.advisor_messages (
+  id uuid primary key default gen_random_uuid(),
+  chat_id bigint not null,
+  role text not null check (role in ('user','assistant')),
+  content text not null,
+  created_at timestamptz not null default now()
+);
+
+create index if not exists advisor_messages_chat_created_idx
+  on public.advisor_messages (chat_id, created_at desc);
+
+-- Written by the backoffice route via Prisma (postgres role); RLS on with no
+-- policies so anon/authenticated cannot read chat history.
+alter table public.advisor_messages enable row level security;
+
+grant select on public.advisor_messages to advisor_readonly;

--- a/docs/design/telegram-data-advisor.md
+++ b/docs/design/telegram-data-advisor.md
@@ -1,0 +1,97 @@
+# Telegram Data Advisor ("ask the business anything" bot)
+
+Scoped 2026-06-12 via office-hours. Decision: **full advisor vision, staged** — with usage-gated stages (stage N+1 only starts after stage N is in daily use).
+
+## Problem Statement
+
+Ammar's business questions fail in three recurring ways:
+1. **Away from Mac → interrupts staff.** WhatsApps/calls a manager to check something they have to dig up.
+2. **Away from Mac → question goes stale.** Waits until back at laptop; question forgotten or moment passed.
+3. **At Mac → backoffice can't answer.** Dashboards lack the specific cut; falls back to Claude Code / raw SQL.
+
+The third failure mode is the tell: the job is **ad-hoc questions dashboards were never going to pre-build**. That's an agent-with-SQL job, not another dashboard.
+
+## Demand Evidence
+
+Self-evident — the target user is the owner, and all three failure modes were confirmed from recent memory (last 3 failed questions). Risk is not demand; risk is scope (see Premises).
+
+## Status Quo (what happens now)
+
+- Backoffice at backoffice.celsiuscoffee.com (fixed dashboards; good for known questions).
+- Claude Code on the Mac with Supabase MCP (answers anything, but desk-bound).
+- WhatsApp/Telegram to managers (costs their time, gets approximate answers).
+- Giving up (question never answered).
+
+Cost: manager interruptions, stale decisions, and the owner being the only query engine for his own business.
+
+## Target User
+
+Ammar (owner). Promoted by: hitting Misi 2026 (4 new outlets, RM8M) and fixing the COGS overspend. Kept up at night by: cashflow squeeze, RM112k stuck POs, per-outlet profit. Later (stage-gated): ops managers — but that changes the data-access story (payroll!) and is explicitly out of v1.
+
+## Narrowest Wedge (= Stage 1, not a throwaway)
+
+A Telegram bot where Ammar asks plain-language questions and an agent answers by running **read-only SQL** on the single Supabase project (`kqdcdhpnyuwrxqhbuyfl`) with a business-context system prompt. Text answers only. No writes, no charts, no alerts. Same agent loop the full vision runs on — later stages add tools, not rewrites.
+
+Note: "all the databases" is in practice ONE database. Sales (pos_orders + archived storehub_*), HR (hr_*), inventory/procurement, finance (BankStatement, COA), loyalty — all already live in `kqdcdhpnyuwrxqhbuyfl`. Old project `akkwdrllvcpnkzgmclkk` is a frozen safety net: excluded.
+
+## Premises (explicit assumptions)
+
+- One Supabase project covers ≥90% of real questions; external sources (Sentry, GBP, ads) are rare-question territory.
+- Read-only is non-negotiable until trust is established. Write actions are a different risk class than the staff-app "warn+allow" philosophy.
+- A Telegram chat-ID allowlist (Ammar only) is the entire authz model for v1. Adding anyone else forces row/table-level scoping first.
+- Scope creep is the known failure pattern (HR 3→10 tables, Mujtama'OS). Usage gates between stages are the countermeasure.
+
+## Architecture (all stages share this)
+
+- **Bot**: new dedicated Telegram bot via BotFather (do NOT reuse the POP-ingestion bot — keep flows isolated). Webhook + secret token.
+- **Runtime**: API route in apps/backoffice (`/api/telegram/advisor`), Vercel `maxDuration: 300`, agent loop via Anthropic API tool-use (or Agent SDK). Zero new infra; secrets already on Vercel.
+- **DB access**: dedicated Postgres role `advisor_readonly` — `GRANT SELECT` only, `default_transaction_read_only = on`, `statement_timeout` ~10s, row-limit guard in the tool. Never the service-role key. (Respects the no-`prisma db push`, manual-SQL-migrations rule.)
+- **Tools (staged)**: `execute_sql` (stage 1) → digest cron (stage 2) → Sentry/Vercel/GBP/Google Ads/Indeed connectors (stage 3) → threshold watchers + advice (stage 4).
+- **Context**: system prompt = schema map + business rules (outlets & entities, rounds, COGS 35% target, AOV RM40, tier engine, Grab gross+commission, SST=0, OT flooring…). Much of this already exists as Claude memory — port it.
+- **Conversation memory**: `advisor_messages` table keyed by chat ID so follow-ups work ("ok now Tamarind").
+- **Authz**: hard chat-ID allowlist; unknown chat → silent drop + log.
+
+## Approaches Considered
+
+### Approach A — Wedge only (days)
+Stage 1 alone: bot + read-only SQL agent + context prompt + conversation memory. Daily value within a week. Risk: under-delivers on "advisor"; mitigated by the roadmap existing.
+
+### Approach B — Wedge + digest + first connectors (weeks)
+Stages 1–2 (+8am digest: yesterday by outlet/round vs targets, COGS flags, aging POs) and 1–2 external tools chosen by demand. Risk: digest design rabbit-hole; mitigate by shipping digest v1 as the answer to a fixed question.
+
+### Approach C — Full advisor, staged (months)
+All stages incl. proactive threshold alerts (COGS overspend, AWAITING_DELIVERY aging, round-target misses) and recommendation mode. Shares Telegram+agent infra with the planned Marketing AI Agent (docs/design/marketing-ai-agent.md) — build the bot plumbing once.
+
+## Recommended Approach
+
+**C as the committed roadmap, A as milestone 1, usage-gated.** Concretely:
+
+- **Stage 1 (week 1)**: read-only Q&A live, Ammar-only.
+  Gate: ≥5 real questions/week answered without opening the laptop, for 2 consecutive weeks.
+- **Stage 2**: morning digest cron.
+  Gate: digest read (not muted) 5 days straight.
+- **Stage 3**: external connectors — each added only when a real question failed for lack of it. Log every failed question; that log IS the stage-3 backlog.
+- **Stage 4**: proactive alerts + advice mode.
+  Gate: at least 3 alert thresholds Ammar has manually asked about repeatedly.
+
+Evidence that would flip this: if stage 1 logs show >30% of questions failing because they need non-DB sources, pull stage 3 forward.
+
+## Open Questions
+
+- Vercel 300s ceiling: enough for multi-query agent turns? If not, fallback = Supabase Edge Function or a small Fly worker.
+- Model: Fable/Sonnet per question (~cents) vs Haiku for cheap follow-ups. Decide after seeing real question complexity.
+- Chart images (QuickChart → PNG to Telegram): stage 2 nice-to-have or noise?
+- When managers join: per-role table grants (exclude hr_ payroll) — design before invite, not after.
+- e-Invoice/TIN data, bank lines still draft-only in finance ledger — answers from finance tables must caveat completeness (BS/CF incomplete).
+
+## Success Criteria (measurable)
+
+- ≥5 questions/week answered in Telegram, sustained 4 weeks.
+- Manager "can you check X for me" interruptions ↓ (self-reported).
+- Zero write incidents (role makes them impossible — verify with a canary attempt).
+- Failed-question log <20% of total by week 4.
+- Stage gates passed in order; no stage started early.
+
+## The Assignment (one concrete next step)
+
+**Before any code: 3 days of question logging.** Every business question that pops into your head — at an outlet, in bed, mid-meeting — type it into a Telegram "Saved Messages" note with where you were. Target 15–20 real questions. That log becomes (a) the v1 eval set, (b) the system-prompt scope, and (c) the proof of which external sources stage 3 actually needs. Then create the bot with BotFather and kick off stage 1.


### PR DESCRIPTION
Adds **Celsius Pulse** (@celsiuspulsebot) — ask-anything Telegram bot over the production DB.

- Webhook `/api/telegram/advisor`: Telegram secret-token auth + hard chat-ID allowlist (silent drop otherwise)
- Agent loop (claude-opus-4-8, adaptive thinking) with one tool: `run_sql`
- SQL runs as dedicated `advisor_readonly` Postgres role: SELECT-only grants, default read-only transactions (verified: INSERT/UPDATE/DELETE/DDL all rejected), 10s statement timeout, BYPASSRLS for full visibility
- Validator: single statement, must start with SELECT/WITH/EXPLAIN; 200-row / 12k-char result caps
- Conversation memory in `advisor_messages` (migration 018, RLS on with no policies)
- Env (already set in Vercel prod): TELEGRAM_PULSE_BOT_TOKEN, TELEGRAM_PULSE_WEBHOOK_SECRET, PULSE_ADVISOR_DATABASE_URL; TELEGRAM_PULSE_ALLOWED_CHAT_IDS pending chat-ID capture

Design doc: docs/design/telegram-data-advisor.md (stage 1 of the staged advisor plan)

🤖 Generated with [Claude Code](https://claude.com/claude-code)