### PR TITLE
Sales dashboard: realtime (like-for-like) headline comparison

### DIFF
--- a/apps/backoffice/src/app/(admin)/sales/dashboard/page.tsx
+++ b/apps/backoffice/src/app/(admin)/sales/dashboard/page.tsx
@@ -74,6 +74,9 @@ type PreviousPeriod = {
   pickupDeliveryOrders: number;
   periodFrom: string;
   periodTo: string;
+  // true when the previous period was capped to the same elapsed point (the
+  // current period is still running) — deltas are a like-for-like to-now read.
+  sameTime?: boolean;
 };
 
 type TargetsMeta = {
@@ -382,6 +385,9 @@ export default function SalesDashboard() {
               const revChange = pctChange(data.summary.revenue, prev.revenue);
               const ordChange = pctChange(data.summary.orders, prev.orders);
               const aovChange = pctChange(data.summary.aov, prev.aov);
+              // For an in-progress period the previous one is capped to the same
+              // elapsed point, so the delta is a like-for-like to-now read.
+              const vsLabel = prev.sameTime ? "vs same time, prev period" : "vs prev period";
               return (
                 <>
                   <div className="rounded-xl border border-gray-200 bg-white p-5 shadow-sm">
@@ -399,7 +405,7 @@ export default function SalesDashboard() {
                     <div className="flex items-center gap-2 mt-1">
                       <span className={cn("text-xs font-semibold", revChange.color)}>{revChange.label}</span>
                       {revChange.diffLabel && <span className={cn("text-xs", revChange.color)}>{revChange.diffLabel}</span>}
-                      <span className="text-[10px] text-gray-400">vs prev period</span>
+                      <span className="text-[10px] text-gray-400">{vsLabel}</span>
                     </div>
                     {data.deliveryQR && data.deliveryQR.orders > 0 && (
                       <p className="text-[10px] text-gray-400 mt-1.5">
@@ -424,7 +430,7 @@ export default function SalesDashboard() {
                     <div className="flex items-center gap-2 mt-1">
                       <span className={cn("text-xs font-semibold", ordChange.color)}>{ordChange.label}</span>
                       {ordChange.diff !== 0 && <span className={cn("text-xs", ordChange.color)}>{ordChange.diff > 0 ? "+" : ""}{ordChange.diff}</span>}
-                      <span className="text-[10px] text-gray-400">vs prev period</span>
+                      <span className="text-[10px] text-gray-400">{vsLabel}</span>
                     </div>
                   </div>
 
@@ -443,7 +449,7 @@ export default function SalesDashboard() {
                     <div className="flex items-center gap-2 mt-1">
                       <span className={cn("text-xs font-semibold", aovChange.color)}>{aovChange.label}</span>
                       {aovChange.diffLabel && <span className={cn("text-xs", aovChange.color)}>{aovChange.diffLabel}</span>}
-                      <span className="text-[10px] text-gray-400">vs prev period</span>
+                      <span className="text-[10px] text-gray-400">{vsLabel}</span>
                     </div>
                   </div>
                 </>

--- a/apps/backoffice/src/app/api/sales/dashboard/route.ts
+++ b/apps/backoffice/src/app/api/sales/dashboard/route.ts
@@ -94,6 +94,16 @@ export async function GET(request: NextRequest) {
     const prevFromDate = prevFromMYT.toISOString().split("T")[0];
     const prevToDate = prevToMYT.toISOString().split("T")[0];
 
+    // Like-for-like ("realtime") comparison: when the current period is still
+    // in progress (it runs up to today), the previous period must be measured
+    // to the SAME elapsed point — otherwise a partial day/week/month reads as a
+    // huge drop against the prior FULL one (e.g. today-so-far vs all of
+    // yesterday → "-70%"). Shifting `now` back exactly periodDays reproduces the
+    // same time-of-day / weekday offset the chart's running-total already uses,
+    // so the headline deltas match the Today-vs-Yesterday curve.
+    const inProgress = toDate === todayMYT;
+    const prevCutoffMs = now.getTime() - periodDays * 24 * 60 * 60 * 1000;
+
     // Fetch outlets
     const outletWhere = outletId
       ? { id: outletId, storehubId: { not: null } }
@@ -161,7 +171,12 @@ export async function GET(request: NextRequest) {
             deliveryQRRevenue += ev.total;
             deliveryQROrders++;
           }
-        } else if (dateStr >= prevFromDate && dateStr <= prevToDate) {
+        } else if (
+          dateStr >= prevFromDate && dateStr <= prevToDate &&
+          // Cap the previous period at the same elapsed point when the current
+          // one is still running, so the comparison is to-now vs to-now.
+          (!inProgress || new Date(ev.ts).getTime() <= prevCutoffMs)
+        ) {
           prevSales.push(ev);
           if (ev.isDeliveryQR) {
             prevDeliveryQRRevenue += ev.total;
@@ -354,6 +369,10 @@ export async function GET(request: NextRequest) {
         pickupDeliveryOrders: prevTakeawayOrd,
         periodFrom: prevFromDate,
         periodTo: prevToDate,
+        // true = previous period was capped to the same elapsed point (the
+        // current period is still running), so deltas are a like-for-like
+        // to-now comparison. The page labels it accordingly.
+        sameTime: inProgress,
       },
       rounds: roundsData,
       outsideRounds: {


### PR DESCRIPTION
## Problem
The Total Revenue / Orders / AOV cards compared **period-to-date** against the **previous period's full length**. So today-so-far (a partial morning) read as "-70%" against all of yesterday — even though the Today-vs-Yesterday chart shows today is actually *ahead* (RM 2,727 vs yesterday-at-11:00 RM 2,661).

## Fix
When the current period is still running (`toDate === today`), cap the previous period at the **same elapsed point**: `prevCutoff = now − periodDays days`. This reproduces the same time-of-day / weekday offset the chart's running total already uses, so the headline deltas match the curve.

- **Daily** → today-so-far vs yesterday up to the same clock time
- **This Week / Month / Last 7/30** → period-to-date vs prior period up to the same offset
- **Yesterday / completed custom** → unchanged (full vs full)

The API returns `previous.sameTime`; the page labels the cards **"vs same time, prev period"** while in progress.

For the reported screenshot, Total Revenue flips from **-70%** to ~**+2.5% (+RM 66)**, matching the chart tooltip.

## Verification
- Backoffice typechecks clean (the 2 changed files).
- UI not visually verified (behind login).

🤖 Generated with [Claude Code](https://claude.com/claude-code)