### PR TITLE
fix(grab): outbound API paths → GrabFood v1.1.3 official spec

### DIFF
--- a/apps/backoffice/.gitignore
+++ b/apps/backoffice/.gitignore
@@ -1,1 +1,4 @@
 .vercel
+
+# Grab production secrets (filled from .grab-prod.env.example)
+.grab-prod.env

--- a/apps/backoffice/.grab-prod.env.example
+++ b/apps/backoffice/.grab-prod.env.example
@@ -1,0 +1,25 @@
+# GrabFood PRODUCTION values — copy this file to `.grab-prod.env` (gitignored)
+# and fill in from the Grab Developer Portal's PRODUCTION project, then run
+# ./scripts/grab-go-live.sh. Never commit the filled file.
+
+# Flips the API base to https://partner-api.grab.com/grabfood (leave as-is).
+GRAB_ENV=production
+
+# Outbound (POS → Grab): production OAuth client + your primary merchant/store
+# ID. Portal → "API client" / "Credentials".
+GRAB_CLIENT_ID=
+GRAB_CLIENT_SECRET=
+GRAB_MERCHANT_ID=
+
+# Inbound (Grab → POS webhooks): the production "Partner configuration" client
+# ID/secret you registered in the portal — must match exactly.
+GRAB_PARTNER_CLIENT_ID=
+GRAB_PARTNER_CLIENT_SECRET=
+
+# Webhook signature key (HMAC-SHA256) from the portal's production webhook
+# config — Grab signs inbound order/state pushes with it.
+GRAB_HMAC_SECRET=
+
+# OURS, not Grab's: signs the Bearer tokens we issue to Grab. Leave blank to
+# auto-generate a stable random key, or paste your own (openssl rand -hex 32).
+GRAB_PARTNER_JWT_SECRET=

--- a/apps/backoffice/scripts/grab-go-live.sh
+++ b/apps/backoffice/scripts/grab-go-live.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+#
+# GrabFood production cutover for the celsius-backoffice Vercel project.
+#
+# Sets the production GrabFood env vars, then redeploys. Your secret values
+# stay LOCAL: fill apps/backoffice/.grab-prod.env (gitignored) from the Grab
+# Developer Portal, then run this. No secret is echoed or committed.
+#
+#   cd apps/backoffice && ./scripts/grab-go-live.sh            # do it
+#   cd apps/backoffice && ./scripts/grab-go-live.sh --dry-run  # preview only
+#
+set -euo pipefail
+cd "$(dirname "$0")/.."   # → apps/backoffice (where .vercel/ links the project)
+
+DRY=0; [ "${1:-}" = "--dry-run" ] && DRY=1
+ENVFILE=".grab-prod.env"
+
+if [ ! -f "$ENVFILE" ]; then
+  echo "Missing $ENVFILE — copy .grab-prod.env.example to it and fill in your"
+  echo "production values from the Grab Developer Portal, then re-run."
+  exit 1
+fi
+set -a; # shellcheck disable=SC1090
+source "$ENVFILE"; set +a
+
+# GRAB_PARTNER_JWT_SECRET is OURS (signs the tokens we hand Grab) — if you
+# didn't set one, mint a stable random key now so token signing is decoupled
+# from credential rotation.
+: "${GRAB_PARTNER_JWT_SECRET:=$(openssl rand -hex 32)}"
+
+VARS=(GRAB_ENV GRAB_CLIENT_ID GRAB_CLIENT_SECRET GRAB_MERCHANT_ID
+      GRAB_PARTNER_CLIENT_ID GRAB_PARTNER_CLIENT_SECRET
+      GRAB_HMAC_SECRET GRAB_PARTNER_JWT_SECRET)
+
+echo "Will set on celsius-backoffice [production]:"
+for v in "${VARS[@]}"; do
+  if [ -n "${!v:-}" ]; then echo "  ✓ $v"; else echo "  ✗ $v (empty — skipped)"; fi
+done
+
+if [ "$DRY" = "1" ]; then echo "(dry-run — nothing changed)"; exit 0; fi
+read -r -p "Apply to PRODUCTION now? [y/N] " ok; [ "$ok" = "y" ] || { echo "aborted"; exit 1; }
+
+setvar() {
+  local name="$1" val="${!1:-}"
+  [ -n "$val" ] || { echo "  skip $name"; return; }
+  vercel env rm "$name" production -y >/dev/null 2>&1 || true
+  printf '%s' "$val" | vercel env add "$name" production >/dev/null
+  echo "  set $name"
+}
+for v in "${VARS[@]}"; do setvar "$v"; done
+
+echo "Redeploying production so the new env vars take effect…"
+vercel deploy --prod --yes >/dev/null
+echo
+
+cat <<'EOF'
+Done. Next:
+  1. Verify (staff-auth):  https://backoffice.celsiuscoffee.com/api/pos/grab/health
+                           → expect { ok:true, env:"production", tokenAcquired:true }
+  2. Register these in the Grab Developer Portal → Partner configuration:
+       OAuth token        https://backoffice.celsiuscoffee.com/api/pos/grab/oauth/token
+       Submit order       https://backoffice.celsiuscoffee.com/api/pos/grab/webhook
+       Push order state   https://backoffice.celsiuscoffee.com/api/pos/grab/webhook
+       Get menu           https://backoffice.celsiuscoffee.com/api/pos/grab/merchant/menu
+       Integration status https://backoffice.celsiuscoffee.com/api/pos/grab/status
+       Menu sync          https://backoffice.celsiuscoffee.com/api/pos/grab/menu-sync
+       Push grab menu     https://backoffice.celsiuscoffee.com/api/pos/grab/menus
+  3. In BackOffice → Settings → Integrations → Grab: set each outlet's
+     PRODUCTION merchant ID, then generate the self-serve activation link.
+  4. Place a real GrabFood test order → confirm it lands in the order list.
+EOF

--- a/apps/backoffice/src/lib/grab.ts
+++ b/apps/backoffice/src/lib/grab.ts
@@ -211,7 +211,7 @@ export async function batchUpdateMenu(
     availableStatus?: "AVAILABLE" | "UNAVAILABLE" | "HIDE";
   }>,
 ) {
-  return grabRequest("/partner/v1/menu/batch", {
+  return grabRequest("/partner/v1/batch/menu", {
     method: "PUT",
     body: { merchantID: merchantId, field, menuEntities },
   });
@@ -221,7 +221,7 @@ export async function batchUpdateMenu(
  * Notify GrabFood that the menu has been updated.
  */
 export async function notifyMenuUpdate(merchantId: string) {
-  return grabRequest("/partner/v1/menu/notification", {
+  return grabRequest("/partner/v1/merchant/menu/notification", {
     method: "POST",
     body: { merchantID: merchantId },
   });
@@ -231,7 +231,7 @@ export async function notifyMenuUpdate(merchantId: string) {
  * Check menu sync status.
  */
 export async function traceMenuSync(merchantId: string) {
-  return grabRequest("/partner/v1/menu/trace", {
+  return grabRequest("/partner/v1/merchant/menu/trace", {
     params: { merchantID: merchantId },
   });
 }
@@ -252,11 +252,13 @@ export type GrabOrderState =
 export async function acceptRejectOrder(
   orderID: string,
   state: "ACCEPTED" | "REJECTED",
-  rejectCode?: string,
+  _rejectCode?: string,
 ) {
-  return grabRequest("/partner/v1/order/accept", {
+  // GrabFood v1.1.3: POST /order/prepare with toState "Accepted" | "Rejected".
+  // (No reject-code field in the prepare payload; param kept for call-site compat.)
+  return grabRequest("/partner/v1/order/prepare", {
     method: "POST",
-    body: { orderID, state, ...(rejectCode ? { rejectCode } : {}) },
+    body: { orderID, toState: state === "ACCEPTED" ? "Accepted" : "Rejected" },
   });
 }
 
@@ -264,9 +266,10 @@ export async function acceptRejectOrder(
  * Mark an order as ready for pickup by the driver.
  */
 export async function markOrderReady(orderID: string) {
-  return grabRequest("/partner/v1/order/ready", {
+  // GrabFood v1.1.3: POST /orders/mark with markStatus 1 = ready (2 = completed/dine-in).
+  return grabRequest("/partner/v1/orders/mark", {
     method: "POST",
-    body: { orderID },
+    body: { orderID, markStatus: 1 },
   });
 }
 
@@ -352,14 +355,14 @@ export async function getStoreStatus(merchantID: string) {
     isActive: boolean;
     isPause: boolean;
     closedReason?: string;
-  }>(`/partner/v1/merchant/${merchantID}/store/status`);
+  }>(`/partner/v1/merchants/${merchantID}/store/status`);
 }
 
 /**
  * Get store operating hours.
  */
 export async function getStoreHours(merchantID: string) {
-  return grabRequest(`/partner/v1/merchant/${merchantID}/store/hour`);
+  return grabRequest(`/partner/v1/merchants/${merchantID}/store/opening-hours`);
 }
 
 /**


### PR DESCRIPTION
Reconciles `lib/grab.ts` outbound paths against Grab's official OpenAPI spec (grabfood-api-sdk). Our integration was on an older spec — fixes menu notify/trace/batch, order accept→prepare `{toState}`, mark-ready→`orders/mark {markStatus:1}`, store status/hours (`merchants/…`). **No GrabFood traffic yet → no live impact.** Adds grab-go-live.sh + .grab-prod.env.example. tsc clean (the one repo error is unrelated untracked music WIP).

⚠️ Merging triggers a backoffice production deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)