### PR TITLE
fix(order): settle payments that land on already-failed orders (RM + Stripe) and add failed-order audit sweep

### DIFF
--- a/apps/order/src/app/api/cron/reconcile-failed/route.ts
+++ b/apps/order/src/app/api/cron/reconcile-failed/route.ts
@@ -1,0 +1,203 @@
+export const dynamic = "force-dynamic";
+// One RM/Stripe round-trip per failed order — same budget discipline as
+// expire-orders: batch, and stop issuing work before the deadline.
+export const maxDuration = 60;
+
+import { NextRequest, NextResponse } from "next/server";
+import Stripe from "stripe";
+import { getSupabaseAdmin } from "@/lib/supabase/server";
+import { checkCronAuth } from "@celsius/shared";
+import { queryCheckoutStatus } from "@/lib/revenue-monster/client";
+import { markRmOrderPaid } from "@/lib/revenue-monster/order-status";
+import { earnLoyaltyPoints, deductLoyaltyPoints } from "@/lib/loyalty/points";
+
+/**
+ * Audit/backfill sweep for the "paid but failed" class of incident
+ * (C-9782): a payment that succeeds AFTER the order was flipped to
+ * failed used to have no path into the system, so the money sat at the
+ * gateway while the order showed "failed".
+ *
+ * This endpoint asks the gateway about every failed order in the window
+ * and reports the ones that were actually PAID. It is NOT on a cron
+ * schedule — it's an operator tool for incident QA:
+ *
+ *   GET /api/cron/reconcile-failed?days=30             → dry-run report
+ *   GET /api/cron/reconcile-failed?days=30&apply=true  → settle them too
+ *
+ * Dry-run is the default on purpose: a historical paid-but-failed order
+ * may have been handled out-of-band (refunded at the portal, re-rung on
+ * POS), so settling it blindly could double-fulfil. Review the dry-run
+ * list, refund or settle each case deliberately, then use apply=true
+ * only if every remaining row should be honoured as paid.
+ *
+ * apply=true settles through the same paths the live flows use
+ * (markRmOrderPaid / the Stripe-succeeded update + loyalty earn), so
+ * points and vouchers behave exactly like a normal payment.
+ */
+
+type FailedOrder = {
+  id: string;
+  order_number: string;
+  store_id: string;
+  status: string;
+  total: number;
+  payment_method: string | null;
+  payment_checkout_id: string | null;
+  payment_failure_reason: string | null;
+  loyalty_id: string | null;
+  loyalty_points_earned: number | null;
+  reward_id: string | null;
+  customer_phone: string | null;
+  created_at: string;
+};
+
+type PaidButFailed = {
+  orderNumber: string;
+  orderId: string;
+  storeId: string;
+  totalSen: number;
+  method: string | null;
+  gateway: "revenue_monster" | "stripe";
+  transactionId: string | null;
+  failureReason: string | null;
+  createdAt: string;
+  applied: boolean;
+};
+
+function getStripe() {
+  const key = process.env.STRIPE_SECRET_KEY?.trim();
+  if (!key) return null;
+  return new Stripe(key, { apiVersion: "2026-03-25.dahlia" });
+}
+
+export async function GET(request: NextRequest) {
+  const cronAuth = checkCronAuth(request.headers);
+  if (!cronAuth.ok) return NextResponse.json({ error: cronAuth.error }, { status: cronAuth.status });
+
+  const params = request.nextUrl.searchParams;
+  const days   = Math.min(Math.max(Number(params.get("days") ?? 30) || 30, 1), 90);
+  const apply  = params.get("apply") === "true";
+
+  const supabase = getSupabaseAdmin();
+  const since    = new Date(Date.now() - days * 24 * 60 * 60 * 1000).toISOString();
+
+  const { data, error } = await supabase
+    .from("orders")
+    .select("id, order_number, store_id, status, total, payment_method, payment_checkout_id, payment_failure_reason, loyalty_id, loyalty_points_earned, reward_id, customer_phone, created_at")
+    .eq("status", "failed")
+    .gt("created_at", since)
+    .order("created_at", { ascending: false })
+    .limit(300);
+
+  if (error) {
+    return NextResponse.json({ error: error.message }, { status: 500 });
+  }
+
+  const orders = (data ?? []) as FailedOrder[];
+  const stripe = getStripe();
+
+  const paidButFailed: PaidButFailed[] = [];
+  let checked = 0, deferred = 0;
+  const errors: string[] = [];
+
+  async function audit(order: FailedOrder): Promise<void> {
+    // RM-routed: the checkout id is the authoritative handle. Orders
+    // that never reached a checkout can't have taken money.
+    if (order.payment_checkout_id) {
+      const rm = await queryCheckoutStatus(order.payment_checkout_id);
+      checked += 1;
+      if (rm.status !== "SUCCESS") return;
+      let applied = false;
+      if (apply) {
+        applied = (await markRmOrderPaid({ orderId: order.id }, rm.transactionId)) != null;
+      }
+      paidButFailed.push({
+        orderNumber: order.order_number,
+        orderId: order.id,
+        storeId: order.store_id,
+        totalSen: order.total,
+        method: order.payment_method,
+        gateway: "revenue_monster",
+        transactionId: rm.transactionId,
+        failureReason: order.payment_failure_reason,
+        createdAt: order.created_at,
+        applied,
+      });
+      return;
+    }
+
+    // No RM checkout — check Stripe by the intent's orderId metadata.
+    // Covers the declined-then-retried-successfully intent case.
+    if (!stripe) { deferred += 1; return; }
+    const search = await stripe.paymentIntents.search({
+      query: `metadata['orderId']:'${order.id}'`,
+      limit: 1,
+    });
+    checked += 1;
+    const intent = search.data[0];
+    if (!intent || intent.status !== "succeeded") return;
+    let applied = false;
+    if (apply) {
+      const { data: updated } = await supabase
+        .from("orders")
+        .update({
+          status: "preparing",
+          payment_provider_ref: intent.id,
+          payment_failure_reason: null,
+        } as Record<string, unknown>)
+        .eq("id", order.id)
+        .eq("status", "failed")
+        .select("id")
+        .maybeSingle();
+      applied = updated != null;
+      if (applied && order.loyalty_id) {
+        if ((order.loyalty_points_earned ?? 0) > 0) {
+          await earnLoyaltyPoints(order.loyalty_id, order.id, order.loyalty_points_earned ?? 0, order.store_id);
+        }
+        if (order.reward_id) {
+          await deductLoyaltyPoints(order.loyalty_id, order.reward_id, order.store_id);
+        }
+      }
+    }
+    paidButFailed.push({
+      orderNumber: order.order_number,
+      orderId: order.id,
+      storeId: order.store_id,
+      totalSen: order.total,
+      method: order.payment_method,
+      gateway: "stripe",
+      transactionId: intent.id,
+      failureReason: order.payment_failure_reason,
+      createdAt: order.created_at,
+      applied,
+    });
+  }
+
+  const CONCURRENCY = 6;
+  const DEADLINE_MS = 50_000;
+  const startedAt = Date.now();
+  for (let i = 0; i < orders.length; i += CONCURRENCY) {
+    if (Date.now() - startedAt > DEADLINE_MS) {
+      deferred += orders.length - i;
+      break;
+    }
+    await Promise.all(
+      orders.slice(i, i + CONCURRENCY).map((o) =>
+        audit(o).catch((e) => {
+          deferred += 1;
+          errors.push(`${o.order_number}: ${e instanceof Error ? e.message : String(e)}`);
+        }),
+      ),
+    );
+  }
+
+  return NextResponse.json({
+    mode: apply ? "apply" : "dry-run",
+    windowDays: days,
+    failedOrdersInWindow: orders.length,
+    checked,
+    deferred,
+    paidButFailed,
+    errors: errors.slice(0, 20),
+  });
+}

--- a/apps/order/src/app/api/cron/reconcile-pending/route.ts
+++ b/apps/order/src/app/api/cron/reconcile-pending/route.ts
@@ -100,9 +100,10 @@ export async function GET(request: NextRequest) {
         continue;
       }
 
-      // Failed non-RM (Stripe) orders aren't retryable on the same order —
-      // only pending rows are reconciled against Stripe.
-      if (order.status !== "pending") continue;
+      // Failed Stripe orders are swept too: payment_failed fires on a
+      // declined first attempt while the customer can still retry the same
+      // intent, so a late success can land on a row already flipped to
+      // failed. Only the succeeded branch below may touch them.
 
       // Stripe indexes metadata for search within a few seconds of intent creation.
       const search = await stripe.paymentIntents.search({
@@ -122,9 +123,12 @@ export async function GET(request: NextRequest) {
           .update({
             status: "preparing",
             payment_provider_ref: intent.id,
+            payment_failure_reason: null,
           } as Record<string, unknown>)
           .eq("id", order.id)
-          .eq("status", "pending")
+          // failed → preparing rescue: money received always wins. No-op
+          // for already-settled rows so points can't double-earn.
+          .in("status", ["pending", "failed"])
           .select("id")
           .maybeSingle();
 

--- a/apps/order/src/app/api/cron/reconcile-pending/route.ts
+++ b/apps/order/src/app/api/cron/reconcile-pending/route.ts
@@ -25,6 +25,7 @@ function getStripe() {
 type OrderLite = {
   id: string;
   order_number: string;
+  status: string;
   store_id: string;
   loyalty_id: string | null;
   loyalty_points_earned: number | null;
@@ -49,10 +50,16 @@ export async function GET(request: NextRequest) {
   const olderThan  = new Date(now - 45 * 1000).toISOString();
   const youngerThan = new Date(now - 55 * 60 * 1000).toISOString();
 
+  // "failed" rows are swept too: a customer can retry payment on the same
+  // order after a failed attempt, so money can land on an order already
+  // flipped to failed (the C-9782 card→FPX case). reconcileRmOrder re-asks
+  // RM and markRmOrderPaid accepts failed → paid; the Stripe branch below
+  // still only transitions pending rows, so failed non-RM orders are
+  // skipped in the loop.
   const { data: pending, error } = await supabase
     .from("orders")
-    .select("id, order_number, store_id, loyalty_id, loyalty_points_earned, reward_id, payment_method, payment_checkout_id")
-    .eq("status", "pending")
+    .select("id, order_number, status, store_id, loyalty_id, loyalty_points_earned, reward_id, payment_method, payment_checkout_id")
+    .in("status", ["pending", "failed"])
     .lt("created_at", olderThan)
     .gt("created_at", youngerThan);
 
@@ -81,13 +88,21 @@ export async function GET(request: NextRequest) {
           if (paid) result.advanced += 1;
           else      result.unresolved += 1;
         } else if (rm.status === "FAILED" || rm.status === "CANCELLED" || rm.status === "EXPIRED") {
-          await markRmOrderFailed({ orderId: order.id }, `rm_${rm.status.toLowerCase()}`);
-          result.failed += 1;
+          // No-op for rows already failed (markRmOrderFailed is gated on
+          // status='pending'); only counts a fresh pending → failed flip.
+          if (order.status === "pending") {
+            await markRmOrderFailed({ orderId: order.id }, `rm_${rm.status.toLowerCase()}`);
+            result.failed += 1;
+          }
         } else {
           result.unresolved += 1;
         }
         continue;
       }
+
+      // Failed non-RM (Stripe) orders aren't retryable on the same order —
+      // only pending rows are reconciled against Stripe.
+      if (order.status !== "pending") continue;
 
       // Stripe indexes metadata for search within a few seconds of intent creation.
       const search = await stripe.paymentIntents.search({

--- a/apps/order/src/app/api/orders/[orderId]/confirm-stripe/route.ts
+++ b/apps/order/src/app/api/orders/[orderId]/confirm-stripe/route.ts
@@ -82,9 +82,14 @@ export async function POST(
       .update({
         status:               nextStatus,
         payment_provider_ref: intent.id,
+        payment_failure_reason: null,
       } as Record<string, unknown>)
       .eq("id", orderId)
-      .eq("status", "pending") // idempotent — only acts if still pending
+      // Idempotent — no-op for already-settled rows. "failed" is rescued:
+      // a declined first attempt flips the order to failed (webhook/cron)
+      // while the customer can still retry the same intent, and Stripe has
+      // verified `succeeded` above. Money received always wins.
+      .in("status", ["pending", "failed"])
       .select("loyalty_id, loyalty_points_earned, reward_id, wallet_voucher_id, store_id, order_number, customer_phone, created_at")
       .single();
 

--- a/apps/order/src/app/api/payments/stripe/webhook/route.ts
+++ b/apps/order/src/app/api/payments/stripe/webhook/route.ts
@@ -61,9 +61,16 @@ export async function POST(request: NextRequest) {
         .update({
           status:               nextStatus,
           payment_provider_ref: intent.id,
+          payment_failure_reason: null,
         } as Record<string, unknown>)
         .eq("id", orderId)
-        .eq("status", "pending")
+        // "failed" settles too: payment_failed fires on a declined FIRST
+        // attempt while the customer is still on the payment sheet, so a
+        // successful retry on the same intent lands after we've already
+        // flipped the order to failed. Money received always wins (same
+        // rule as markRmOrderPaid). Still a no-op for preparing/paid rows,
+        // so duplicate deliveries don't double-earn points.
+        .in("status", ["pending", "failed"])
         .select("loyalty_id, loyalty_points_earned, reward_id, wallet_voucher_id, store_id, order_number, customer_phone, created_at")
         .single();
 

--- a/apps/order/src/app/api/payments/webhook/route.ts
+++ b/apps/order/src/app/api/payments/webhook/route.ts
@@ -65,6 +65,7 @@ export async function POST(request: NextRequest) {
       data?: {
         referenceId: string;
         additionalData?: string;
+        transactionId?: string;
       };
     };
 
@@ -80,7 +81,14 @@ export async function POST(request: NextRequest) {
     // Authoritative settle: ignore the payload's claimed status and ask RM
     // directly. Awaited so the order flips (and the kitchen docket fires via
     // Realtime) before we ack; the loyalty push is deferred inside reconcile.
-    await reconcileRmOrder(target);
+    //
+    // The transactionId rides along as a HINT only: the stored checkout id
+    // is the latest attempt, but the paying attempt can be an earlier one
+    // (C-9782 — the FPX payment rode the first hosted session after a retry
+    // had overwritten payment_checkout_id). Reconcile re-verifies the
+    // transaction against RM and matches it to the order before settling,
+    // so a spoofed transactionId can't mark an unpaid order paid.
+    await reconcileRmOrder({ ...target, transactionId: data.transactionId });
 
     return NextResponse.json({ code: "SUCCESS" });
   } catch (err) {

--- a/apps/order/src/app/order/[id]/_OrderTrackingView.tsx
+++ b/apps/order/src/app/order/[id]/_OrderTrackingView.tsx
@@ -105,11 +105,17 @@ export function OrderTrackingView({ orderId }: { orderId: string }) {
   // paying), ask the server to query RM directly so it settles in seconds
   // instead of minutes. Mirrors the native backstop in
   // apps/pickup-native/app/order/[id].tsx. Keyed on status+method so it
-  // only runs while genuinely pending and tears down the moment it settles.
+  // only runs while unsettled and tears down the moment it settles.
+  //
+  // "failed" keeps polling too: a customer can retry payment on the same
+  // order after a failed attempt (C-9782 — card expired, FPX retry paid a
+  // minute later), so RM can flip a failed checkout to SUCCESS. Server-side
+  // reconcile accepts failed → paid, and this poll is what lets the customer
+  // watch their "Payment failed" screen heal into "Brewing now".
   const status = order?.status;
   const method = order?.payment_method;
   useEffect(() => {
-    if (status !== "pending" || !method || !RM_METHODS.has(method)) return;
+    if ((status !== "pending" && status !== "failed") || !method || !RM_METHODS.has(method)) return;
     let cancelled = false;
     const poll = async () => {
       try {
@@ -119,9 +125,10 @@ export function OrderTrackingView({ orderId }: { orderId: string }) {
           body: JSON.stringify({ orderId }),
         });
         const json = (await res.json().catch(() => null)) as { status?: string } | null;
-        // Reflect a settled status immediately rather than waiting for the
-        // next 5s DB tick.
-        if (!cancelled && json && (json.status === "preparing" || json.status === "paid" || json.status === "failed")) {
+        // Reflect a status change immediately rather than waiting for the
+        // next 5s DB tick. Compared against the current status so a failed
+        // order that stays failed doesn't refetch on every 3s tick.
+        if (!cancelled && json?.status && json.status !== status) {
           void fetchOrder();
         }
       } catch {

--- a/apps/order/src/lib/revenue-monster/client.ts
+++ b/apps/order/src/lib/revenue-monster/client.ts
@@ -446,6 +446,65 @@ export async function queryCheckoutStatus(checkoutId: string): Promise<QueryChec
   };
 }
 
+// ─── Query Payment Transaction ────────────────────────────────────────────────
+//
+// A checkout id identifies one ATTEMPT, but the money can ride a different
+// attempt than the one we stored (each retry overwrites payment_checkout_id,
+// and RM's hosted page keeps earlier sessions payable in other tabs — the
+// C-9782 case). RM's webhook carries the transactionId of the attempt that
+// actually settled, so this lets reconcile verify that exact transaction
+// against RM instead of trusting the payload or guessing the checkout.
+// Path per RM's own SDKs: GET /v3/payment/transaction/{transactionId}.
+
+export interface RmTransactionResult {
+  status:         string;        // SUCCESS | FAILED | ...
+  transactionId:  string | null;
+  /** RM-side order id — our `${orderNumber}-${base36 suffix}` */
+  rmOrderId:      string | null;
+  /** The order UUID we set as order.additionalData at checkout creation */
+  additionalData: string | null;
+  amountSen:      number | null;
+  raw:            unknown;
+}
+
+export async function queryTransaction(transactionId: string): Promise<RmTransactionResult> {
+  const token     = await getToken();
+  const url       = `${BASE_URL}/v3/payment/transaction/${encodeURIComponent(transactionId)}`;
+  const nonceStr  = nonce();
+  const timestamp = String(Math.floor(Date.now() / 1000));
+  const sig = buildSignature("GET", url, nonceStr, timestamp);
+  const res = await fetch(url, {
+    method: "GET",
+    headers: {
+      Authorization:  `Bearer ${token}`,
+      "X-Nonce-Str":  nonceStr,
+      "X-Timestamp":  timestamp,
+      "X-Signature":  sig,
+    },
+    signal: AbortSignal.timeout(RM_TIMEOUT_MS),
+  });
+  const data = (await res.json()) as {
+    code:  string;
+    item?: {
+      transactionId?: string;
+      status?: string;
+      order?: { id?: string; additionalData?: string; amount?: number };
+    };
+    error?: { code?: string; message?: string };
+  };
+  if (data.code !== "SUCCESS" || !data.item) {
+    throw new Error(`RM transaction query failed: ${JSON.stringify(data)}`);
+  }
+  return {
+    status:         data.item.status ?? "PENDING",
+    transactionId:  data.item.transactionId ?? null,
+    rmOrderId:      data.item.order?.id ?? null,
+    additionalData: data.item.order?.additionalData ?? null,
+    amountSen:      typeof data.item.order?.amount === "number" ? data.item.order.amount : null,
+    raw:            data,
+  };
+}
+
 // ─── Webhook validation ───────────────────────────────────────────────────────
 //
 // RM signs callback bodies with their server's private key. We verify

--- a/apps/order/src/lib/revenue-monster/order-status.ts
+++ b/apps/order/src/lib/revenue-monster/order-status.ts
@@ -91,6 +91,9 @@ export async function markRmOrderPaid(
     .update({
       status: nextStatus,
       payment_provider_ref: transactionId,
+      // A failed → paid rescue must clear the stale failure reason, or the
+      // backoffice shows "rm_expired" on an order that was actually paid.
+      payment_failure_reason: null,
     } as Record<string, unknown>)
     // A paid event must settle the order even if a stale/abandoned checkout
     // — or the expire-orders cron — already flipped it to "failed". Money

--- a/apps/order/src/lib/revenue-monster/reconcile.ts
+++ b/apps/order/src/lib/revenue-monster/reconcile.ts
@@ -1,6 +1,6 @@
 import { after } from "next/server";
 import { getSupabaseAdmin } from "@/lib/supabase/server";
-import { queryCheckoutStatus } from "./client";
+import { queryCheckoutStatus, queryTransaction } from "./client";
 import { markRmOrderPaid, markRmOrderFailed } from "./order-status";
 import { notifyOrderPreparing } from "@/lib/push/templates";
 
@@ -43,7 +43,18 @@ export interface ReconcileResult {
 const RM_METHODS = new Set(["fpx", "tng", "boost", "shopeepay", "grabpay", "duitnow", "card"]);
 
 export async function reconcileRmOrder(
-  target: { orderId?: string; orderNumber?: string },
+  target: {
+    orderId?: string;
+    orderNumber?: string;
+    /** RM transactionId from a webhook payload. The stored checkout id is
+     *  only the LATEST attempt — the money can ride an earlier attempt
+     *  (each retry overwrites payment_checkout_id while RM's hosted page
+     *  keeps prior sessions payable in other tabs). When the checkout
+     *  query doesn't confirm payment, this lets us verify the exact
+     *  transaction RM claims settled. NEVER trusted as-is — re-queried
+     *  against RM and matched to this order before settling. */
+    transactionId?: string;
+  },
 ): Promise<ReconcileResult> {
   if (!target.orderId && !target.orderNumber) return { status: "pending", source: "not_found" };
 
@@ -51,13 +62,15 @@ export async function reconcileRmOrder(
     const supabase = getSupabaseAdmin();
     const sel = supabase
       .from("orders")
-      .select("id, status, payment_checkout_id, payment_method");
+      .select("id, order_number, status, total, payment_checkout_id, payment_method");
     const { data } = target.orderId
       ? await sel.eq("id", target.orderId).maybeSingle()
       : await sel.eq("order_number", target.orderNumber!).maybeSingle();
     const row = data as {
       id: string;
+      order_number: string;
       status: string;
+      total: number | null;
       payment_checkout_id: string | null;
       payment_method: string | null;
     } | null;
@@ -78,12 +91,9 @@ export async function reconcileRmOrder(
     if (row.payment_method && !RM_METHODS.has(row.payment_method)) {
       return { status: row.status, source: "not_rm" };
     }
-    if (!row.payment_checkout_id) return { status: "pending", source: "no_checkout_id" };
 
-    const rm = await queryCheckoutStatus(row.payment_checkout_id);
-
-    if (rm.status === "SUCCESS") {
-      const paid = await markRmOrderPaid({ orderId: row.id }, rm.transactionId);
+    const settle = async (transactionId: string | null): Promise<ReconcileResult> => {
+      const paid = await markRmOrderPaid({ orderId: row.id }, transactionId);
       if (paid && !paid.scheduled) {
         // "Brewing now" push — suppressed for scheduled orders (the
         // promote-scheduled cron fires it at brew-window-open time).
@@ -95,7 +105,46 @@ export async function reconcileRmOrder(
           }).catch((e) => console.warn("[push] order_preparing reconcile", e));
         });
       }
-      return { status: paid?.scheduled ? "paid" : "preparing", source: "rm", rmStatus: rm.status };
+      return { status: paid?.scheduled ? "paid" : "preparing", source: "rm", rmStatus: "SUCCESS" };
+    };
+
+    const rm = row.payment_checkout_id
+      ? await queryCheckoutStatus(row.payment_checkout_id)
+      : null;
+    if (rm?.status === "SUCCESS") return settle(rm.transactionId);
+
+    // The stored checkout didn't confirm payment, but a webhook may have
+    // told us exactly which transaction settled (possibly an EARLIER
+    // attempt whose checkout id we overwrote). Verify it with RM and make
+    // sure it belongs to THIS order before settling — additionalData is
+    // the order UUID we set at checkout creation and RM echoes it back,
+    // so a spoofed/foreign transactionId can't be cross-applied; the
+    // amount check guards against settling on a mismatched charge.
+    if (target.transactionId) {
+      try {
+        const tx = await queryTransaction(target.transactionId);
+        const belongsToOrder =
+          (tx.additionalData != null && tx.additionalData === row.id) ||
+          (tx.rmOrderId != null && tx.rmOrderId.replace(/-[0-9a-z]{6,}$/, "") === row.order_number);
+        const amountMatches =
+          tx.amountSen == null || row.total == null || tx.amountSen === row.total;
+        if (tx.status === "SUCCESS" && belongsToOrder && amountMatches) {
+          return settle(tx.transactionId ?? target.transactionId);
+        }
+        if (tx.status === "SUCCESS") {
+          console.warn(
+            `[rm reconcile] tx ${target.transactionId} is SUCCESS but did not match order ${row.order_number} (belongs=${belongsToOrder} amount=${amountMatches}) — NOT settling, review manually`,
+          );
+        }
+      } catch (err) {
+        // Transaction lookup is best-effort on top of the checkout query —
+        // a failure here must not block the normal flow below.
+        console.warn("[rm reconcile] transaction verify failed:", err instanceof Error ? err.message : err);
+      }
+    }
+
+    if (!rm) {
+      return { status: row.status === "failed" ? "failed" : "pending", source: "no_checkout_id" };
     }
 
     if (rm.status === "FAILED" || rm.status === "CANCELLED" || rm.status === "EXPIRED") {
@@ -103,7 +152,7 @@ export async function reconcileRmOrder(
       return { status: "failed", source: "rm", rmStatus: rm.status };
     }
 
-    return { status: "pending", source: "rm", rmStatus: rm.status };
+    return { status: row.status === "failed" ? "failed" : "pending", source: "rm", rmStatus: rm.status };
   } catch (err) {
     // Gateway/network blip — leave the order pending; another trigger
     // (poll / cron / redirect) will settle it. Must never bubble.

--- a/apps/order/src/lib/revenue-monster/reconcile.ts
+++ b/apps/order/src/lib/revenue-monster/reconcile.ts
@@ -63,8 +63,18 @@ export async function reconcileRmOrder(
     } | null;
 
     if (!row) return { status: "pending", source: "not_found" };
-    // Already settled — nothing to do (idempotent fast path).
-    if (row.status !== "pending") return { status: row.status, source: "db" };
+    // Already settled — nothing to do (idempotent fast path). "failed" is
+    // NOT settled: the customer can retry payment on the same order after a
+    // failed attempt (/api/payments/create allows it), so money can land on
+    // an order we already flipped to failed. Treating failed as terminal
+    // here stranded C-9782: the card attempt expired → order failed → the
+    // FPX retry's SUCCESS webhook hit this early-return and the payment was
+    // never recorded. Fall through and re-ask RM — markRmOrderPaid accepts
+    // failed → paid (money received always wins) and markRmOrderFailed is a
+    // no-op on an already-failed row, so this stays idempotent.
+    if (row.status !== "pending" && row.status !== "failed") {
+      return { status: row.status, source: "db" };
+    }
     if (row.payment_method && !RM_METHODS.has(row.payment_method)) {
       return { status: row.status, source: "not_rm" };
     }

--- a/apps/pickup-native/app/order/[id].tsx
+++ b/apps/pickup-native/app/order/[id].tsx
@@ -216,8 +216,13 @@ export default function OrderStatus() {
   // on a pending RM-routed order, hit /api/payments/poll so the server
   // asks RM directly and reconciles. The /api/orders/[id] poll above
   // then sees the new status on the next 5s tick.
+  //
+  // "failed" polls too: the retry button below re-pays the SAME order, so
+  // money can land after the order was flipped to failed (C-9782). The
+  // server accepts failed → paid, and this poll is what lets the failed
+  // screen heal into preparing without the customer re-ordering.
   useEffect(() => {
-    if (!id || !data || data.status !== "pending") return;
+    if (!id || !data || (data.status !== "pending" && data.status !== "failed")) return;
     const rmMethods = new Set(["fpx", "tng", "boost", "shopeepay", "grabpay", "duitnow", "card"]);
     if (!data.payment_method || !rmMethods.has(data.payment_method)) return;
     let cancelled = false;
@@ -239,7 +244,7 @@ export default function OrderStatus() {
         const json = (await res.json().catch(() => null)) as
           | { status?: string; source?: string }
           | null;
-        if (json && (json.status === "preparing" || json.status === "failed")) {
+        if (json?.status && json.status !== data.status) {
           queryClient.invalidateQueries({ queryKey: ["order", id] });
         }
       } catch {


### PR DESCRIPTION
## Problem

A payment that succeeds **after** an order has been flipped to `failed` had no path into the system — every settle trigger was gated on `status='pending'`, so the money sat at the gateway while the order showed "failed". This is a supported flow being broken: both the web and native clients let a customer retry payment on the *same* order after a failed attempt.

**Real incident (12 Jun, order C-9782, Putrajaya):** card checkout expired at 3:35 pm → order flipped to failed → customer paid MYR 86.61 via FPX at 3:36 pm → RM's webhook arrived at 3:36:48 (twice) and was dropped by the pending-only gate. The customer watched the "Payment failed" screen for two minutes after paying.

Two distinct holes, both fixed here:

1. **Pending-only gating** — every settle trigger (RM webhook/poll/redirect/cron, Stripe webhook/confirm/cron) ignored `failed` orders. `markRmOrderPaid` already encoded the right rule ("money received always wins") but no trigger could reach it. The same hole existed on Stripe: `payment_intent.payment_failed` fires on a declined *first* attempt while the customer is still retrying on the payment sheet.
2. **Stored-checkout blind spot** — `payment_checkout_id` holds only the *latest* attempt (each retry overwrites it, and RM's hosted page keeps earlier sessions payable in other tabs). C-9782's FPX payment rode the *first* session, so even re-querying the stored checkout couldn't see the money. The webhook names the exact transaction that settled; we now verify that transaction directly against RM.

## Changes

**Revenue Monster path**
- `reconcileRmOrder`: re-query RM for `failed` orders too; `markRmOrderFailed` stays gated on `pending` (idempotent)
- `reconcileRmOrder`: when the stored checkout doesn't confirm payment and the trigger carried a `transactionId` (webhook), re-query that transaction at RM (`GET /v3/payment/transaction/{id}`) and settle only if RM says SUCCESS **and** the transaction's `additionalData`/order-id matches this order **and** the amount matches — spoofed/foreign ids can't cross-apply
- reconcile-pending cron: sweep failed RM-routed rows in the 45s–55min window
- `_OrderTrackingView` (web) + `order/[id]` (pickup-native): keep the reconcile poll alive on failed orders so the "Payment failed" screen heals into "Brewing now"
- `markRmOrderPaid`: clear `payment_failure_reason` on the failed → paid rescue

**Stripe path**
- `payment_intent.succeeded` webhook, `confirm-stripe` fallback, and the cron's Stripe branch now settle `failed` orders too, clearing the stale failure reason; still no-ops for already-settled rows so points can't double-earn

**Incident QA tool**
- New `GET /api/cron/reconcile-failed?days=N[&apply=true]` (cron-auth, **not** scheduled): sweeps failed orders in the window, asks RM/Stripe which were actually paid, and reports them. Dry-run by default — a historical paid-but-failed order may have been refunded or re-rung at the counter, so settling is an explicit operator decision. `apply=true` settles through the live code paths (loyalty included). Note: it checks the *stored* checkout id, so multi-attempt orders should additionally be cross-checked against the RM portal's transaction export.

## Verification

- `tsc --noEmit` and `eslint` clean for `apps/order`; `apps/pickup-native` typechecks with no new errors (one pre-existing unrelated error in `lib/maybank-qr.ts`)
- C-9782 timeline reconstructed from production Vercel logs + DB; webhook arrival at 07:36:48 UTC confirmed hitting the pending-only early return; RM's answer for the stored checkout confirmed the superseded-checkout blind spot
- `queryTransaction` path verified against RM's official Go SDK (`/payment/transaction/{id}`)

## Post-merge follow-up

Run the audit sweep to find any other customers hit by this:
```
curl -H "Authorization: Bearer $CRON_SECRET" "https://order.celsiuscoffee.com/api/cron/reconcile-failed?days=30"
```
Review the `paidButFailed` list — refund or settle each case deliberately, and cross-check multi-attempt candidates against the RM portal transaction export.

https://claude.ai/code/session_015vwBumEzu4WuVmMDqKZj1b