### PR TITLE
ux(order): acknowledge retried payments instead of silently flipping failed → preparing

### DIFF
--- a/apps/order/src/app/order/[id]/_OrderTrackingView.tsx
+++ b/apps/order/src/app/order/[id]/_OrderTrackingView.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Fragment, useCallback, useEffect, useState } from "react";
+import { Fragment, useCallback, useEffect, useRef, useState } from "react";
 import Link from "next/link";
 import { ArrowLeft, ShoppingBag, Coffee, CheckCircle2, XCircle } from "lucide-react";
 import { MysteryReward } from "./_MysteryReward";
@@ -69,16 +69,57 @@ function stepperIndex(status: string): number {
   return 0;
 }
 
-export function OrderTrackingView({ orderId }: { orderId: string }) {
+export function OrderTrackingView({
+  orderId,
+  justPaid = false,
+}: {
+  orderId: string;
+  /** True when the customer landed via the gateway's …?payment=done
+   *  redirect — i.e. they JUST completed payment, even if the order row
+   *  still reads pending or failed (FPX settlement lag, or a failed-then-
+   *  repaid order the reconcile is about to heal). Drives the amber
+   *  "Confirming payment" treatment instead of a red failed card. */
+  justPaid?: boolean;
+}) {
   const [order, setOrder] = useState<Order | null>(null);
   const [error, setError] = useState<string | null>(null);
+  // Confirming window: opens when the customer arrives with payment=done
+  // and the order isn't settled yet; closes after 90s so a genuinely
+  // failed payment can't hide behind "confirming" forever. The RM poll
+  // below keeps running either way.
+  const [confirmWindow, setConfirmWindow] = useState(justPaid);
+  useEffect(() => {
+    if (!confirmWindow) return;
+    const t = window.setTimeout(() => setConfirmWindow(false), 90_000);
+    return () => window.clearTimeout(t);
+  }, [confirmWindow]);
+  // "Payment confirmed ✓" acknowledgement — shown briefly when we watch
+  // the order settle (pending/failed → preparing/paid/ready) so the flip
+  // to Brewing reads as a response to the customer's payment instead of
+  // the screen silently swapping (the C-5760 complaint). Transition
+  // detection lives in the fetch callback (where new server state lands),
+  // not an effect, so it can't cascade renders.
+  const prevStatusRef = useRef<string | null>(null);
+  const [showPaymentConfirmed, setShowPaymentConfirmed] = useState(false);
 
   const fetchOrder = useCallback(async () => {
     try {
       const r = await fetch(`/api/orders/${orderId}`);
       const data = await r.json();
-      if (data?.order) setOrder(data.order as Order);
-      else if (data?.id) setOrder(data as Order);
+      const next: Order | null = data?.order ?? (data?.id ? (data as Order) : null);
+      if (!next) return;
+      const cur = next.status?.toLowerCase() ?? null;
+      const prev = prevStatusRef.current;
+      if (
+        prev && cur && prev !== cur &&
+        (prev === "pending" || prev === "failed") &&
+        ["preparing", "paid", "ready"].includes(cur)
+      ) {
+        setShowPaymentConfirmed(true);
+        window.setTimeout(() => setShowPaymentConfirmed(false), 5000);
+      }
+      prevStatusRef.current = cur;
+      setOrder(next);
     } catch (err) {
       setError(String(err));
     }
@@ -196,7 +237,41 @@ export function OrderTrackingView({ orderId }: { orderId: string }) {
 
       <section className="px-4 pt-5">
         <h2 className="font-peachi font-bold text-[16px] mb-3">Status</h2>
-        {order.status.toLowerCase() === "failed" || order.status.toLowerCase() === "cancelled" ? (
+        {showPaymentConfirmed ? (
+          <div className="flex items-center gap-3 rounded-2xl bg-green-50 border border-green-200 p-3 mb-3">
+            <CheckCircle2 size={20} color="#15803D" />
+            <div>
+              <p className="font-peachi font-bold text-sm text-green-800">Payment confirmed</p>
+              <p className="text-[12px] text-green-700 mt-0.5">
+                We&rsquo;ve started on your order.
+              </p>
+            </div>
+          </div>
+        ) : null}
+        {(order.status.toLowerCase() === "failed" || order.status.toLowerCase() === "pending") &&
+        confirmWindow &&
+        RM_METHODS.has(order.payment_method) ? (
+          // The customer just came back from the gateway (?payment=done)
+          // but the row hasn't settled yet — FPX settlement lag, or a
+          // failed-then-repaid order reconcile is healing. Showing the
+          // red "Payment failed" card here right after their bank said
+          // "paid" is alarming and invites a double payment; show the
+          // checking state instead. The poll flips this the moment the
+          // server confirms (or the 90s window lapses back to truth).
+          <div className="flex items-center gap-3 rounded-2xl bg-amber-50 border border-amber-200 p-3">
+            <span
+              className="inline-block flex-shrink-0 rounded-full border-2 border-amber-600 border-t-transparent animate-spin"
+              style={{ width: 20, height: 20 }}
+            />
+            <div>
+              <p className="font-peachi font-bold text-sm text-amber-800">Confirming payment…</p>
+              <p className="text-[12px] text-amber-700 mt-0.5">
+                We&rsquo;re checking with your bank — usually a few seconds. Please
+                don&rsquo;t pay again; this page updates automatically.
+              </p>
+            </div>
+          </div>
+        ) : order.status.toLowerCase() === "failed" || order.status.toLowerCase() === "cancelled" ? (
           <div className="flex items-center gap-3 rounded-2xl bg-red-50 border border-red-200 p-3">
             <XCircle size={20} color="#B91C1C" />
             <div>
@@ -208,6 +283,12 @@ export function OrderTrackingView({ orderId }: { orderId: string }) {
                   ? "Place the order again to retry."
                   : "This order was cancelled."}
               </p>
+              {order.status === "failed" && RM_METHODS.has(order.payment_method) ? (
+                <p className="text-[12px] text-red-700 mt-1">
+                  Just paid? Hang tight — we re-check with the bank automatically
+                  and this page will update.
+                </p>
+              ) : null}
             </div>
           </div>
         ) : (

--- a/apps/order/src/app/order/[id]/page.tsx
+++ b/apps/order/src/app/order/[id]/page.tsx
@@ -25,7 +25,7 @@ export default async function OrderDetailPage({
   return (
     // No bottom tab bar — matches native (sub-screens opt out). Back via header.
     <main className="bg-white text-[#160800] min-h-screen pb-[calc(env(safe-area-inset-bottom,0px)+24px)]">
-      <OrderTrackingView orderId={id} />
+      <OrderTrackingView orderId={id} justPaid={payment === "done"} />
     </main>
   );
 }

--- a/apps/pickup-native/app/order/[id].tsx
+++ b/apps/pickup-native/app/order/[id].tsx
@@ -124,6 +124,14 @@ export default function OrderStatus() {
   // "failed" instead, the overlay dismisses without celebrating.
   const prevStatusRef = useRef<string | null>(null);
   const [overlay, setOverlay] = useState<null | "confirming" | "success">(null);
+  // Set when a retry launched FROM THIS SCREEN comes back from RM's page
+  // with the payment completed (or the server answers "already paid").
+  // The order row may still read pending OR failed at that moment — the
+  // failed case is the C-9782 flow: first attempt flipped the order to
+  // failed, the retry's money is in, and reconcile is about to heal it.
+  // Without this flag the customer stares at the red "Payment failed"
+  // card for the gap and then it "suddenly" turns into Brewing now.
+  const [retryConfirming, setRetryConfirming] = useState(false);
   const overlayOpacity = useRef(new Animated.Value(0)).current;
   const overlayScale   = useRef(new Animated.Value(0.7)).current;
 
@@ -133,11 +141,16 @@ export default function OrderStatus() {
   useEffect(() => {
     const cur = data?.status ?? null;
     const prev = prevStatusRef.current;
-    const isRmPendingNow =
-      cur === "pending" &&
+    const isRmUnsettledNow =
+      (cur === "pending" || cur === "failed") &&
       !!data?.payment_method &&
       new Set(["fpx", "tng", "boost", "shopeepay", "grabpay", "duitnow", "card"]).has(data.payment_method);
-    const shouldShowConfirming = isRmPendingNow && justPaid === "1";
+    // justPaid covers arrivals from checkout; retryConfirming covers
+    // retries from this screen. Both can apply to a failed row — the
+    // order page poll re-checks RM for failed orders and the server
+    // accepts failed → paid, so "failed + payment just completed" is a
+    // confirming state, not a dead end.
+    const shouldShowConfirming = isRmUnsettledNow && (justPaid === "1" || retryConfirming);
 
     // First mount or pure confirming state → show confirming overlay.
     if (shouldShowConfirming && overlay !== "confirming" && overlay !== "success") {
@@ -161,22 +174,42 @@ export default function OrderStatus() {
     }
 
     // Transition into preparing/ready while the customer is here →
-    // morph to success.
+    // morph to success. "failed" is in the prev-list on purpose: a
+    // successful re-payment heals a failed order (failed → preparing),
+    // and that flip deserves the same acknowledgement moment instead
+    // of the screen silently swapping under the customer.
     if (prev && cur && prev !== cur) {
       const becamePreparingOrReady =
-        (prev === "pending" || prev === "paid") && (cur === "preparing" || cur === "ready");
+        (prev === "pending" || prev === "paid" || prev === "failed") &&
+        (cur === "preparing" || cur === "ready");
       if (becamePreparingOrReady) {
+        setRetryConfirming(false);
         Haptics.notificationAsync(Haptics.NotificationFeedbackType.Success);
         setOverlay("success");
       }
-      // Failed → dismiss overlay so the customer sees the retry UI
-      // underneath.
+      // Settled into failed (pending → failed: the retried attempt
+      // genuinely didn't go through) → drop the confirming state so
+      // the customer sees the retry UI underneath.
       if (cur === "failed") {
+        setRetryConfirming(false);
         setOverlay(null);
       }
     }
     prevStatusRef.current = cur;
-  }, [data?.status, data?.payment_method, justPaid, overlay]);
+  }, [data?.status, data?.payment_method, justPaid, retryConfirming, overlay]);
+
+  // Confirming is a promise that reconcile lands "in seconds" — don't
+  // hold the screen hostage if it doesn't (bank-side FPX can sit in
+  // limbo). After 90s fall back to the retry UI; the poll keeps running,
+  // so a late settle still flips the status and celebrates.
+  useEffect(() => {
+    if (!retryConfirming) return;
+    const t = setTimeout(() => {
+      setRetryConfirming(false);
+      setOverlay((o) => (o === "confirming" ? null : o));
+    }, 90_000);
+    return () => clearTimeout(t);
+  }, [retryConfirming]);
 
   // Fade + scale the circle whenever the overlay mode changes. On
   // "success" we also schedule the auto-dismiss after 1.4s.
@@ -437,12 +470,16 @@ export default function OrderStatus() {
           },
         );
         const rmJson = (await rmRes.json()) as { paymentUrl?: string; error?: string; alreadyPaid?: boolean };
-        // Already paid/settled — the server blocked a second charge. We're
-        // already on the order screen, so just close the picker and let the 5s
-        // poll render the real (paid) state instead of a "Couldn't retry" alert.
+        // Already paid/settled — the server blocked a second charge AND
+        // settled the order during the pre-check (this is C-5760: an
+        // earlier attempt's money was found the moment the customer
+        // tapped retry). Show the confirming → success overlay instead
+        // of an alert, so the flip to Brewing now reads as an
+        // acknowledgement rather than a surprise.
         if (rmRes.status === 409 && rmJson.alreadyPaid) {
           setMethodPickerOpen(false);
-          Alert.alert("Already paid", "This order is already paid — refreshing its status.");
+          setRetryConfirming(true);
+          queryClient.invalidateQueries({ queryKey: ["order", id] });
           return;
         }
         if (!rmRes.ok || !rmJson.paymentUrl) {
@@ -453,9 +490,16 @@ export default function OrderStatus() {
         // formatPrice (see the order-summary block below). Missed that
         // here originally — produced RM445.00 for a RM4.45 order.
         const amount = typeof data?.total === "number" ? formatPrice(data.total / 100) : "";
-        await openRmCheckout(rmJson.paymentUrl, label, amount, methodId);
-        // Webhook is authoritative for status — we don't mutate locally.
-        // The 5s React Query poll will pick up the new status.
+        const rmResult = await openRmCheckout(rmJson.paymentUrl, label, amount, methodId);
+        // Webhook/reconcile is authoritative for status — we don't mutate
+        // locally. But the RM page signalling success means the money is
+        // (very likely) in while the row still reads pending/failed, so
+        // bridge the gap with the confirming overlay and refetch now
+        // instead of waiting out the 5s poll tick.
+        if (rmResult === "success") {
+          setRetryConfirming(true);
+          queryClient.invalidateQueries({ queryKey: ["order", id] });
+        }
       } else {
         await reopenStripeInner(methodId);
       }
@@ -567,8 +611,11 @@ export default function OrderStatus() {
   // through to the existing retry UI so a genuinely stuck order can be
   // recovered.
   const rmConfirmMethods = new Set(["fpx", "tng", "boost", "shopeepay", "grabpay", "duitnow", "card"]);
-  const isRmPending =
-    data?.status === "pending" &&
+  // failed counts as confirmable too: a failed order re-paid from this
+  // screen heals into preparing (server accepts failed → paid), so while
+  // we KNOW a payment just completed the red failed card is misleading.
+  const isRmUnsettled =
+    (data?.status === "pending" || data?.status === "failed") &&
     !!data?.payment_method &&
     rmConfirmMethods.has(data.payment_method);
   // Maybank static QR: order sits as pending until staff release it.
@@ -581,11 +628,13 @@ export default function OrderStatus() {
   const maybankPayload = showMaybankWaiting
     ? maybankQrPayloadFor(maybankConfig, data?.store_id ?? null)
     : null;
-  // Only show "Confirming payment…" when the checkout screen explicitly
-  // signals a successful RM return via justPaid=1. The previous 90s
+  // Only show "Confirming payment…" when something explicitly signalled a
+  // completed payment: the checkout screen's justPaid=1 on arrival, or a
+  // retry from this screen coming back from RM with success / the server
+  // answering "already paid" (retryConfirming). The previous 90s
   // creation-time fallback ran for cancelled orders too, making the
   // customer think the payment went through when it didn't.
-  const confirmingPayment = isRmPending && justPaid === "1";
+  const confirmingPayment = isRmUnsettled && (justPaid === "1" || retryConfirming);
 
   return (
     <View className="flex-1 bg-background">


### PR DESCRIPTION
Follow-up to #288, prompted by order **C-5760** (12 Jun, 7:53 pm): first FPX attempt expired, the retry's money went through at 7:54:32, but the customer stared at the red "Payment failed" card until the order "suddenly" became preparing at 7:57:01 — zero acknowledgement anywhere.

(That order itself raced the #288 deploy by two minutes, so the old code dropped the webhook; the settle was finally triggered by the customer's second retry tap hitting the `409 already-paid` pre-check. New code settles via webhook in seconds — but the UX gap below applied to the new flow too.)

The confirming/success overlay machinery already existed, but was only wired to checkout arrivals (`justPaid=1`) and only for `status=pending`. The retry-on-failed flow bypassed all of it.

## Native order screen (ships with next Expo release)
- New `retryConfirming` state: set when a retry launched from this screen returns from RM's hosted page with success, **or** the server answers `409 already-paid` (which settles the order during the pre-check — exactly how C-5760 flipped). Both now show the amber "Confirming payment" overlay + immediate refetch, instead of an `Alert` / nothing.
- Confirming treatment now covers `status=failed` too — a failed order being healed by reconcile is a confirming state, not a dead end.
- `failed → preparing/ready` now fires the same green success overlay + haptic as `pending → preparing`. No more silent swap.
- 90s fallback returns to the retry UI so confirming can't mask a genuinely failed payment; the poll keeps running, so a late settle still celebrates.

## Web order page (live on merge)
- `?payment=done` arrivals on a not-yet-settled (pending/failed) RM order show an amber "Confirming payment… please don't pay again" card for up to 90s instead of the red failed card.
- Watching the order settle shows a green "Payment confirmed" banner for 5s, so the flip to Brewing reads as a response rather than a surprise.
- The red failed card gains a "Just paid? We re-check automatically" hint.

`tsc` + `eslint` clean on both apps.

https://claude.ai/code/session_015vwBumEzu4WuVmMDqKZj1b

---
_Generated by [Claude Code](https://claude.ai/code/session_015vwBumEzu4WuVmMDqKZj1b)_