### PR TITLE
Staff StoreHub bridge: net total (close remaining sales-dashboard gap)

### DIFF
--- a/apps/staff/src/app/api/sales/_lib/storehub-bridge.ts
+++ b/apps/staff/src/app/api/sales/_lib/storehub-bridge.ts
@@ -36,7 +36,7 @@ export type ShContrib = {
 type ShRow = {
   outlet_id: string;
   transaction_time: Date | string;
-  sub_total: number | string | null;
+  total: number | string | null;
   channel: string | null;
   order_type: string | null;
   is_cancelled: boolean | null;
@@ -86,7 +86,7 @@ export async function getStorehubFromDB(opts: {
   let data: ShRow[] = [];
   try {
     data = await prisma.$queryRaw<ShRow[]>`
-      SELECT outlet_id, transaction_time, sub_total, channel, order_type, is_cancelled
+      SELECT outlet_id, transaction_time, total, channel, order_type, is_cancelled
       FROM storehub_sales
       WHERE outlet_id IN (${Prisma.join(ids)})
         AND transaction_time >= ${new Date(winStart)}
@@ -111,7 +111,10 @@ export async function getStorehubFromDB(opts: {
     }
     const d = getMYTDateStr(ts);
     const h = getMYTHour(ts);
-    const rev = sen(Number(r.sub_total ?? 0) || 0);
+    // Revenue = `total` (net of discounts), matching the backoffice unified
+    // reader. `sub_total` is the pre-discount gross and over-counts — the same
+    // basis fix applied to the native pos/orders loops in the route.
+    const rev = sen(Number(r.total ?? 0) || 0);
     const ch = classifyShChannel(r.channel, r.order_type);
     if (inCur(d)) {
       out.curRevSen += rev; out.curOrd++;


### PR DESCRIPTION
Follow-up to #290. After aligning the native pos/orders loops, the staff sales dashboard still read slightly higher than backoffice — traced to the **StoreHub bridge** summing `sub_total` (pre-discount gross) while backoffice uses `total` (net).

Today that was **+RM23.67** of StoreHub discounts over-counted. This swaps the bridge to `total`.

## Result
- Past/completed periods now reconcile **to the cent** with backoffice.
- "Today" still differs only by the StoreHub **archive sync lag** (≤1h): backoffice live-pulls StoreHub, the staff app reads the cron-synced archive (it has no live StoreHub client). By design, self-correcting — documented in the bridge header.

## Verification
- Staff app typechecks clean.
- Quantified against today's `storehub_sales`: `sum(sub_total) − sum(total)` = +10.92 + 12.75 + 0.00 = RM 23.67.
- Server-side — native staff app picks it up on staff API redeploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)