### PR TITLE
fix(order): payment reconciliation hardening from paid-but-failed QA

### DIFF
--- a/apps/order/src/app/api/cron/reconcile-failed/route.ts
+++ b/apps/order/src/app/api/cron/reconcile-failed/route.ts
@@ -132,10 +132,19 @@ export async function GET(request: NextRequest) {
     const search = await stripe.paymentIntents.search({
       query: `metadata['orderId']:'${order.id}'`,
       limit: 1,
+      expand: ["data.latest_charge"],
     });
     checked += 1;
     const intent = search.data[0];
     if (!intent || intent.status !== "succeeded") return;
+    // A refunded intent still reads "succeeded" — without this guard a
+    // paid-but-failed order we refunded out-of-band would be re-flagged on
+    // every sweep, and ?apply=true would settle (and earn points on) money
+    // we already gave back.
+    const charge = intent.latest_charge;
+    if (charge && typeof charge !== "string" && (charge.refunded || charge.amount_refunded > 0)) {
+      return;
+    }
     let applied = false;
     if (apply) {
       const { data: updated } = await supabase

--- a/apps/order/src/app/api/cron/reconcile-pending/route.ts
+++ b/apps/order/src/app/api/cron/reconcile-pending/route.ts
@@ -143,9 +143,18 @@ export async function GET(request: NextRequest) {
           }
           result.advanced += 1;
         }
-      } else if (intent.status === "canceled" || intent.status === "requires_payment_method") {
-        // requires_payment_method after a failed attempt means the wallet /
-        // card rejected — treat as failed so the KDS stops seeing a ghost row.
+      } else if (
+        intent.status === "canceled" ||
+        (intent.status === "requires_payment_method" && intent.last_payment_error != null)
+      ) {
+        // requires_payment_method ALONE doesn't mean rejected — it's also the
+        // state of an intent the customer simply hasn't attempted yet (still
+        // typing card details on the sheet). This cron sweeps orders as young
+        // as 45s, so failing on bare requires_payment_method flipped live
+        // checkouts to "failed" mid-payment (the C-HDLZ57 / C-VNXC42 class —
+        // the success then landed on a failed row). Only treat it as failed
+        // when Stripe records an actual declined attempt; otherwise fall
+        // through to unresolved and let the next sweep look again.
         const reason = intent.status === "canceled"
           ? `cancelled${intent.cancellation_reason ? `: ${intent.cancellation_reason}` : ""}`
           : (intent.last_payment_error?.code

--- a/apps/order/src/app/api/orders/[orderId]/confirm-maybank-qr/route.ts
+++ b/apps/order/src/app/api/orders/[orderId]/confirm-maybank-qr/route.ts
@@ -75,19 +75,24 @@ export async function POST(
 
     // Idempotent update: only flips if the order is still pending +
     // payment_method=maybank_qr. Same select shape confirm-stripe uses
-    // so the loyalty handoff below matches its parity.
-    const { data: updated } = await supabase
+    // so the loyalty handoff below matches its parity. orders has no
+    // paid_at column — writing one here used to make this update error
+    // silently and the route report alreadyReleased without releasing.
+    const { data: updated, error: updateError } = await supabase
       .from("orders")
-      .update({
-        status: nextStatus,
-        paid_at: new Date().toISOString(),
-      } as Record<string, unknown>)
+      .update({ status: nextStatus } as Record<string, unknown>)
       .eq("id", orderId)
       .eq("status", "pending")
       .eq("payment_method", "maybank_qr")
       .select("loyalty_id, loyalty_points_earned, reward_id, wallet_voucher_id, store_id, order_number, customer_phone, created_at")
       .maybeSingle();
 
+    if (updateError) {
+      // A DB error is NOT "already released" — surface it so the staff
+      // member retries instead of walking away from an unreleased order.
+      console.error("confirm-maybank-qr update failed:", updateError);
+      return NextResponse.json({ error: "Failed to release order" }, { status: 500 });
+    }
     if (!updated) {
       // Raced with another release; nothing to do.
       return NextResponse.json({ confirmed: true, alreadyReleased: true });


### PR DESCRIPTION
Three follow-ups from the 2026-06-12 payment QA (full two-way reconciliation of orders vs RM merchant portal Jun 8–12, plus Stripe intent checks).

## Changes

**1. `confirm-maybank-qr` — silent no-op release**
The update wrote `paid_at`, a column that doesn't exist in `orders`. Supabase returned an error the code discarded, `updated` was null, and the route answered `alreadyReleased: true` without releasing the order. Latent today (zero `maybank_qr` orders) but would break the Maybank QR launch on day one. `paid_at` write removed; DB errors now return 500 so the staff member retries instead of walking away.

**2. `reconcile-pending` — stop failing orders mid-checkout**
The cron treated `requires_payment_method` as "declined", but that's also the state of an intent the customer simply hasn't attempted yet — and the sweep picks up orders as young as 45s. Slow customers got their order flipped to `failed` while still typing card details; when their payment then succeeded it landed on a failed row (the C-HDLZ57 / C-VNXC42 / C-OMTX17 / C-NMIF84 class — RM91.30 in refunds pending). Now only fails when `last_payment_error` is present. Genuine abandons are still cleaned up by `expire-orders` at 10 min via the no-checkout-id branch.

**3. `reconcile-failed` — refund-aware audit sweep**
A refunded Stripe intent still reads `succeeded`, so once the 4 pending refunds are issued, every sweep would re-flag those orders as paid-but-failed — and `?apply=true` would settle them (and earn points) on money already given back. The sweep now expands `latest_charge` and skips refunded charges.

## Verification
- `tsc --noEmit` clean on apps/order
- Rigorous review critical pass: no P0/P1; abandoned-sheet cleanup path verified against expire-orders

🤖 Generated with [Claude Code](https://claude.com/claude-code)