### PR TITLE
fix(pos-native): reset display store on New Order (stale mystery reveal)

### DIFF
--- a/apps/pos-native/app/register.tsx
+++ b/apps/pos-native/app/register.tsx
@@ -1276,8 +1276,12 @@ export default function Register() {
     setCoTouched(false);
     setDisplayStatus("idle");
     useDisplay.getState().setMember(null);
-    useDisplay.getState().setExtraDiscount(null);
-    useDisplay.getState().setManualDiscount(null);
+    // Clear all cart-scoped display state between orders (mystery reveal +
+    // prize, beans, pay total, reward, redeem req…). Without this the paid
+    // screen kept mirroring the PREVIOUS order's "REVEALED" card while the
+    // customer hadn't revealed the new one. reset() keeps member, so the
+    // setMember(null) above still does the fresh-order logout.
+    useDisplay.getState().reset();
     // Surface any performance nudge queued at the last checkout.
     if (pendingNudgeRef.current) { setPerfNudge(pendingNudgeRef.current); pendingNudgeRef.current = null; }
   }


### PR DESCRIPTION
The register's `newOrder()` cleared its local state but never called the shared display store's `useDisplay.reset()`, so the previous order's `mystery: revealed` + prize (and other cart-scoped display state) persisted. The staff paid screen kept showing the PREVIOUS order's "REVEALED" card while the customer hadn't revealed the new one. One-line fix: call `reset()` (keeps member; `setMember(null)` above still logs out for a fresh order). tsc clean.

⚠️ Merging triggers a **pos-native production OTA** to the tills (via pos-native-ota.yml).

🤖 Generated with [Claude Code](https://claude.com/claude-code)