### PR TITLE
build(pos-native): rebuild verified APK to restore printer + customer-display modules

### DIFF
--- a/apps/pos-native/.apk-build-trigger
+++ b/apps/pos-native/.apk-build-trigger
@@ -1,1 +1,1 @@
-2026-06-10T07:06:15Z gradle build with device-speaker + all modules
+2026-06-14T17:46:04Z rebuild verified APK — restore printer + customer-display modules


### PR DESCRIPTION
**Urgent — restores the kitchen printer at the outlet.**

The installed POS app is missing its local native modules (sunmi-printer, customer-display) — the EAS-cloud build path silently drops them, so the SUNMI reports no printer / no customer display and prints nothing.

This bumps `apps/pos-native/.apk-build-trigger` to run `pos-native-build-apk.yml`, which prebuilds + gradle-assembles on a clean runner and **fails the run unless all 3 native modules are compiled in** — so a green run produces a trustworthy APK. Built from `main`, so it also carries the latest docket fixes (de-cramped items, time fix, header redesign).

After merge → the build runs → download the `pos-native-apk` artifact from the run and `adb install -r app-release.apk` on the register.

https://claude.ai/code/session_013ZZPXb2vvKGtiEogN3NEtr

---
_Generated by [Claude Code](https://claude.ai/code/session_013ZZPXb2vvKGtiEogN3NEtr)_