### PR TITLE
fix(observability): boot env-check only pages Sentry for missing REQUIRED vars

### DIFF
--- a/apps/backoffice/src/instrumentation.ts
+++ b/apps/backoffice/src/instrumentation.ts
@@ -5,7 +5,7 @@ export function register() {
   // Env check first. Development: throws on missing REQUIRED vars
   // (fail fast on a bad .env). Production: logs one loud block and the
   // report is forwarded to Sentry below — never fatal at runtime.
-  const envReport = checkEnvAtBoot("backoffice", {
+  const envCheck = checkEnvAtBoot("backoffice", {
     required: [
       "DATABASE_URL",
       "JWT_SECRET",
@@ -46,7 +46,10 @@ export function register() {
     beforeBreadcrumb: (breadcrumb) => scrubSentryEvent(breadcrumb),
   });
 
-  if (envReport) Sentry.captureMessage(envReport, "error");
+  // Only escalate to Sentry when a REQUIRED var is missing. Recommended
+  // gaps are non-fatal and already logged to the runtime logs — paging
+  // them at error level on every cold start just buries real errors.
+  if (envCheck.hasRequiredProblems) Sentry.captureMessage(envCheck.report, "error");
 }
 
 export const onRequestError = Sentry.captureRequestError;

--- a/apps/loyalty/src/instrumentation.ts
+++ b/apps/loyalty/src/instrumentation.ts
@@ -5,7 +5,7 @@ export function register() {
   // Env check first. Development: throws on missing REQUIRED vars
   // (fail fast on a bad .env). Production: logs one loud block and the
   // report is forwarded to Sentry below — never fatal at runtime.
-  const envReport = checkEnvAtBoot("loyalty", {
+  const envCheck = checkEnvAtBoot("loyalty", {
     required: [
       "NEXT_PUBLIC_SUPABASE_URL",
       "NEXT_PUBLIC_SUPABASE_ANON_KEY",
@@ -42,7 +42,10 @@ export function register() {
     beforeBreadcrumb: (breadcrumb) => scrubSentryEvent(breadcrumb),
   });
 
-  if (envReport) Sentry.captureMessage(envReport, "error");
+  // Only escalate to Sentry when a REQUIRED var is missing. Recommended
+  // gaps are non-fatal and already logged to the runtime logs — paging
+  // them at error level on every cold start just buries real errors.
+  if (envCheck.hasRequiredProblems) Sentry.captureMessage(envCheck.report, "error");
 }
 
 export const onRequestError = Sentry.captureRequestError;

--- a/apps/order/src/instrumentation.ts
+++ b/apps/order/src/instrumentation.ts
@@ -5,7 +5,7 @@ export function register() {
   // Env check first. Development: throws on missing REQUIRED vars
   // (fail fast on a bad .env). Production: logs one loud block and the
   // report is forwarded to Sentry below — never fatal at runtime.
-  const envReport = checkEnvAtBoot("order", {
+  const envCheck = checkEnvAtBoot("order", {
     required: [
       "NEXT_PUBLIC_SUPABASE_URL",
       "NEXT_PUBLIC_SUPABASE_ANON_KEY",
@@ -45,7 +45,10 @@ export function register() {
     beforeBreadcrumb: (breadcrumb) => scrubSentryEvent(breadcrumb),
   });
 
-  if (envReport) Sentry.captureMessage(envReport, "error");
+  // Only escalate to Sentry when a REQUIRED var is missing. Recommended
+  // gaps are non-fatal and already logged to the runtime logs — paging
+  // them at error level on every cold start just buries real errors.
+  if (envCheck.hasRequiredProblems) Sentry.captureMessage(envCheck.report, "error");
 }
 
 export const onRequestError = Sentry.captureRequestError;

--- a/apps/staff/src/instrumentation.ts
+++ b/apps/staff/src/instrumentation.ts
@@ -5,7 +5,7 @@ export function register() {
   // Env check first. Development: throws on missing REQUIRED vars
   // (fail fast on a bad .env). Production: logs one loud block and the
   // report is forwarded to Sentry below — never fatal at runtime.
-  const envReport = checkEnvAtBoot("staff", {
+  const envCheck = checkEnvAtBoot("staff", {
     required: [
       "DATABASE_URL",
       "JWT_SECRET",
@@ -43,7 +43,10 @@ export function register() {
     beforeBreadcrumb: (breadcrumb) => scrubSentryEvent(breadcrumb),
   });
 
-  if (envReport) Sentry.captureMessage(envReport, "error");
+  // Only escalate to Sentry when a REQUIRED var is missing. Recommended
+  // gaps are non-fatal and already logged to the runtime logs — paging
+  // them at error level on every cold start just buries real errors.
+  if (envCheck.hasRequiredProblems) Sentry.captureMessage(envCheck.report, "error");
 }
 
 export const onRequestError = Sentry.captureRequestError;

--- a/packages/shared/src/__tests__/env.test.ts
+++ b/packages/shared/src/__tests__/env.test.ts
@@ -53,26 +53,32 @@ describe("checkEnvAtBoot", () => {
     );
   });
 
-  it("logs but never throws in production", () => {
+  it("logs but never throws in production, and flags required problems", () => {
     process.env.NODE_ENV = "production";
     const err = vi.spyOn(console, "error").mockImplementation(() => {});
-    const report = checkEnvAtBoot("order", { required: ["TEST_REQUIRED_A"] });
-    expect(report).toContain("TEST_REQUIRED_A");
+    const res = checkEnvAtBoot("order", { required: ["TEST_REQUIRED_A"] });
+    expect(res.report).toContain("TEST_REQUIRED_A");
+    expect(res.hasRequiredProblems).toBe(true);
     expect(err).toHaveBeenCalledOnce();
   });
 
-  it("recommended-only gaps warn without throwing, even in dev", () => {
+  it("recommended-only gaps warn without throwing and are NOT flagged as required", () => {
     process.env.NODE_ENV = "test";
     const err = vi.spyOn(console, "error").mockImplementation(() => {});
-    const report = checkEnvAtBoot("order", { required: [], recommended: ["TEST_RECOMMENDED"] });
-    expect(report).toContain("TEST_RECOMMENDED");
+    const res = checkEnvAtBoot("order", { required: [], recommended: ["TEST_RECOMMENDED"] });
+    expect(res.report).toContain("TEST_RECOMMENDED");
+    // The whole point of the fix: a recommended-only gap must not be
+    // flagged as a required problem (so it never pages Sentry at error).
+    expect(res.hasRequiredProblems).toBe(false);
     expect(err).toHaveBeenCalledOnce();
   });
 
-  it("returns empty string and stays silent when clean", () => {
+  it("returns empty report and stays silent when clean", () => {
     process.env.TEST_REQUIRED_A = "set";
     const err = vi.spyOn(console, "error").mockImplementation(() => {});
-    expect(checkEnvAtBoot("order", { required: ["TEST_REQUIRED_A"] })).toBe("");
+    const res = checkEnvAtBoot("order", { required: ["TEST_REQUIRED_A"] });
+    expect(res.report).toBe("");
+    expect(res.hasRequiredProblems).toBe(false);
     expect(err).not.toHaveBeenCalled();
   });
 });

--- a/packages/shared/src/env.ts
+++ b/packages/shared/src/env.ts
@@ -42,15 +42,30 @@ export function formatEnvReport(appName: string, p: EnvProblems): string {
   return lines.join("\n");
 }
 
-/** One-call helper for instrumentation.ts. Returns the report string
- *  ("" when clean) so the caller can also forward it to Sentry. */
-export function checkEnvAtBoot(appName: string, spec: EnvSpec): string {
+export type EnvCheckResult = {
+  /** Human-readable report; "" when nothing is missing. */
+  report: string;
+  /** True when at least one REQUIRED var is missing. This is the only
+   *  case that warrants a dev-boot throw or an error-level Sentry
+   *  capture — a missing *recommended* var is non-fatal (it just
+   *  disables a feature) and must NOT raise an error on every
+   *  serverless cold start, which only buries real errors. */
+  hasRequiredProblems: boolean;
+};
+
+/** One-call helper for instrumentation.ts. Returns the report ("" when
+ *  clean) plus whether any REQUIRED var is missing, so the caller can
+ *  forward only genuine problems to Sentry at error severity. */
+export function checkEnvAtBoot(appName: string, spec: EnvSpec): EnvCheckResult {
   const problems = validateEnv(spec);
   const report = formatEnvReport(appName, problems);
-  if (!report) return "";
-  if (process.env.NODE_ENV !== "production" && problems.missingRequired.length) {
+  const hasRequiredProblems = problems.missingRequired.length > 0;
+  if (!report) return { report: "", hasRequiredProblems: false };
+  if (process.env.NODE_ENV !== "production" && hasRequiredProblems) {
     throw new Error(report);
   }
+  // Always log the full block to the runtime logs (Vercel) — recommended
+  // gaps stay discoverable there without paging Sentry.
   console.error(report);
-  return report;
+  return { report, hasRequiredProblems };
 }

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -193,4 +193,4 @@ export function getStockUrgency(
 export { scrubSecrets, scrubSentryEvent } from "./sentry-scrub";
 
 // ─── Startup env validation ─────────────────────────
-export { validateEnv, formatEnvReport, checkEnvAtBoot, type EnvSpec, type EnvProblems } from "./env";
+export { validateEnv, formatEnvReport, checkEnvAtBoot, type EnvSpec, type EnvProblems, type EnvCheckResult } from "./env";


### PR DESCRIPTION
## Stops two escalating Sentry error-issues

Two issues have been escalating for ~2 days, both with "(No error message)":
- `[env] order: environment problems detected` — 831 events / 346 users
- `[env] staff: environment problems detected` — 204 events / 71 users

### Root cause
The startup env validation added in `b294fdbe` (part of #294) captured the combined report (required **and** recommended misses) via `Sentry.captureMessage(..., "error")` on **every serverless cold start**. With a recommended var unset in prod, every cold start raised an error-level issue — escalating with traffic and tagging each triggering request's user (the inflated user counts). The apps are healthy: orders are completing and staff are clocking in, so all *required* vars are present. This was error-level noise burying real errors.

This also contradicted the module's own policy: recommended vars are "worth a warning, never fatal."

### Fix
- `checkEnvAtBoot` now returns `{ report, hasRequiredProblems }` instead of a bare string.
- `instrumentation.ts` in all four web apps (order / staff / backoffice / loyalty) only `captureMessage(..., "error")` when `hasRequiredProblems` is true.
- Recommended gaps still `console.error` the full block to the Vercel runtime logs, so they stay discoverable without paging Sentry.
- A genuinely-missing **required** var still raises a loud error and throws at dev boot, exactly as before.

### Verification
- `packages/shared` env tests: 7/7 pass (added coverage asserting a recommended-only gap is NOT flagged as a required problem).
- `tsc --noEmit` on the shared package: clean.

### Note (separate, ops-side)
A recommended var IS unset in prod (that's what was firing). This PR stops the *noise*; it does not set the var. Candidates — order: `STRIPE_WEBHOOK_SECRET`, `CRON_SECRET`, VAPID keys; staff: `ANTHROPIC_API_KEY`, `BACKOFFICE_INTERNAL_URL`. Worth confirming in Vercel which are intentionally unset vs. should be set.

https://claude.ai/code/session_01Ec7qFc39nizzLgnxhw1WKn

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ec7qFc39nizzLgnxhw1WKn)_