### PR TITLE
fix(pos-native): stop serving alarm from sounding with no live orders

### DIFF
--- a/apps/pos-native/app/register.tsx
+++ b/apps/pos-native/app/register.tsx
@@ -257,7 +257,7 @@ export default function Register() {
   // hook is mounted persistently (catch-up + Realtime subscribe) instead
   // of being torn down each time the modal closes.
   const tableZonesInput = useMemo(() => tableZones(settings), [settings]);
-  const tableSlots = useTablesPanel(outletId, tableZonesInput);
+  const { slots: tableSlots, reload: reloadTables } = useTablesPanel(outletId, tableZonesInput);
   // Staff-side mirror of the customer display's mystery-bag moment (paid screen).
   const mysteryMirror = useDisplay((s) => s.mystery);
   const mysteryPrize = useDisplay((s) => s.mysteryPrize);
@@ -396,14 +396,19 @@ export default function Register() {
     try {
       await apiPost("/api/pos/order-status", { source: "qr", id: order.id, status: "completed" });
       Haptics.notificationAsync(Haptics.NotificationFeedbackType.Success);
-      // useTablesPanel's Realtime sub re-buckets the slot automatically.
+      // Force an immediate refetch rather than waiting on the Realtime round-trip
+      // (same as the pickup/Grab path). The serving-time alarm is derived from
+      // these slots, so the done order must drop off locally at once — otherwise
+      // a lagging/dropped Realtime event leaves it lingering and the alarm keeps
+      // sounding even though the order is already completed.
+      await reloadTables();
     } catch (e) {
       alert(`Couldn't mark ${order.orderNumber} done.\n${e instanceof Error ? e.message : "Check the connection and try again."}`);
     } finally {
       setBumpingUid(null);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [shift, shiftLoading]);
+  }, [reloadTables, shift, shiftLoading]);
 
   // Reprint a past order's customer receipt from the History tab. The history
   // row only carries a summary, so we re-fetch the full order + items (with

--- a/apps/pos-native/lib/use-orders-panel.ts
+++ b/apps/pos-native/lib/use-orders-panel.ts
@@ -26,6 +26,7 @@ import { supabase } from "./supabase";
 // cashier still needs to act on. completed / cancelled / failed drop off.
 const PICKUP_LIVE = ["paid", "sent_to_kitchen", "preparing", "ready"];
 const GRAB_LIVE = ["sent_to_kitchen", "preparing", "ready"];
+const SAFETY_REFRESH_MS = 60 * 1000; // backstop refetch if a Realtime event is dropped
 
 export type KdsSource = "pickup" | "grab";
 
@@ -174,9 +175,15 @@ export function useOrdersPanel(outletId: string | null | undefined) {
       .on("postgres_changes", { event: "*", schema: "public", table: "pos_orders", filter: `outlet_id=eq.${outletId}` }, scheduleReload)
       .subscribe();
 
+    // Safety-net refetch in case a Realtime event is dropped (flaky venue
+    // Wi-Fi): an order completed elsewhere would otherwise linger in this
+    // live list and keep the serving-time alarm sounding with no live orders.
+    const poll = setInterval(() => { if (!cancelled) void load(); }, SAFETY_REFRESH_MS);
+
     return () => {
       cancelled = true;
       if (reloadTimer.current) clearTimeout(reloadTimer.current);
+      clearInterval(poll);
       void supabase.removeChannel(ch);
     };
   }, [storeId, outletId, load]);

--- a/apps/pos-native/lib/use-tables-panel.ts
+++ b/apps/pos-native/lib/use-tables-panel.ts
@@ -142,7 +142,7 @@ export function useTablesPanel(outletId: string | null | undefined, zones: { nam
   // 4. Compose flat slots from the configured zones (each slot tagged with its
   //    zone), orders matched by normalised table key. Any order whose table
   //    isn't in a zone is surfaced under "Other" so it's never lost.
-  return useMemo<TableSlot[]>(() => {
+  const slots = useMemo<TableSlot[]>(() => {
     const byKey = new Map<string, TableOrderRef[]>();
     for (const o of qr) {
       const arr = byKey.get(o.tableKey) ?? [];
@@ -172,4 +172,10 @@ export function useTablesPanel(outletId: string | null | undefined, zones: { nam
     });
     return slots;
   }, [qr, zones]);
+
+  // Expose `reload` so a write (e.g. marking a QR order Done) can force an
+  // immediate refetch instead of waiting on the Realtime round-trip — the
+  // serving-time alarm is derived from these slots, so an order that's been
+  // actioned must drop off locally at once even if Realtime is lagging/dropped.
+  return { slots, reload };
 }

--- a/apps/pos-native/lib/use-tables-panel.ts
+++ b/apps/pos-native/lib/use-tables-panel.ts
@@ -16,6 +16,7 @@ import { supabase } from "./supabase";
  */
 
 const WINDOW_MS = 6 * 60 * 60 * 1000; // map the last 6h of table activity
+const SAFETY_REFRESH_MS = 60 * 1000;  // backstop refetch if a Realtime event is dropped
 // Drop dead orders so a cancelled/failed attempt doesn't linger on a table.
 const DEAD = new Set(["cancelled", "failed", "refunded", "voided"]);
 // Finished orders fall off the ACTIVE view too — once served/collected the
@@ -126,6 +127,11 @@ export function useTablesPanel(outletId: string | null | undefined, zones: { nam
   }, [storeId]);
 
   // 3. Initial load + keep live (any change to either feed → debounced refetch).
+  //    A periodic safety-net refetch backs up Realtime: if a websocket event is
+  //    dropped (flaky venue Wi-Fi), an order that was completed elsewhere — the
+  //    guest's app, another till, a server-side auto-close — would otherwise
+  //    linger here forever and keep the serving-time alarm sounding even though
+  //    there are no live orders. The poll heals that within one interval.
   useEffect(() => {
     if (!outletId) return;
     void reload();
@@ -136,7 +142,8 @@ export function useTablesPanel(outletId: string | null | undefined, zones: { nam
       ch.on("postgres_changes", { event: "*", schema: "public", table: "orders", filter: `store_id=eq.${storeId}` }, bump);
     }
     ch.subscribe();
-    return () => { if (t) clearTimeout(t); void supabase.removeChannel(ch); };
+    const poll = setInterval(() => void reload(), SAFETY_REFRESH_MS);
+    return () => { if (t) clearTimeout(t); clearInterval(poll); void supabase.removeChannel(ch); };
   }, [outletId, storeId, reload]);
 
   // 4. Compose flat slots from the configured zones (each slot tagged with its


### PR DESCRIPTION
## Problem

The serving-time alarm at Conezion (Putrajaya) kept sounding even after orders were done — and even when there were no live orders at all. Querying production confirmed the alarm was firing on a **stale order held in the till's local state**, not on real data (the DB showed nothing live/overdue across any outlet).

## Root cause

The alarm list is derived from two live feeds — `useTablesPanel` and `useOrdersPanel` — which learned that an order had *left* the live set **only via Supabase Realtime**, with no refresh fallback. When a websocket event is dropped (flaky venue Wi-Fi) and an order is completed elsewhere (the guest's app, another till, a server-side auto-close), the finished order lingered in this till's local list forever and the alarm re-sounded every 5 min.

## Changes

1. **`markTableOrderDone` force-reloads** the tables feed after the write (mirroring the pickup/Grab `advanceOrderStatus` path) so the QR "Done" action drops the order locally at once instead of waiting on Realtime. `useTablesPanel` now exposes `reload`.
2. **60s safety-net poll** added to both `useTablesPanel` and `useOrdersPanel` so a dropped Realtime event self-heals within one interval — closing the gap for orders completed on another device/path.

## Notes

- `node_modules` isn't installed in the web container, so no typecheck/app run was possible; changes are small and localized.
- Separately noted (not changed here): the pickup feed has no time-window bound, so a genuinely abandoned pickup order in `paid`/`preparing` would alarm indefinitely.

https://claude.ai/code/session_01KXDwTLUTLY4myQYBTfkBLU

---
_Generated by [Claude Code](https://claude.ai/code/session_01KXDwTLUTLY4myQYBTfkBLU)_