### PR TITLE
fix(grab): inbound /oauth/token accepts outbound OAuth client creds (unblocks menu export)

### DIFF
--- a/apps/backoffice/src/app/api/pos/grab/oauth/token/route.ts
+++ b/apps/backoffice/src/app/api/pos/grab/oauth/token/route.ts
@@ -50,6 +50,12 @@ export async function POST(req: NextRequest) {
     );
   }
   if (!partnerCredsMatch(clientId, clientSecret)) {
+    // Diagnostic (no secrets): surfaces what Grab actually sends so an inbound 401
+    // can be pinned to a specific client_id / secret length in the runtime logs.
+    console.warn(
+      `[grab/oauth/token] invalid_client — incoming client_id="${String(clientId).slice(0, 12)}" ` +
+        `secret_len=${String(clientSecret).length}`,
+    );
     return NextResponse.json({ error: "invalid_client" }, { status: 401 });
   }
 

--- a/apps/backoffice/src/lib/grab-partner.ts
+++ b/apps/backoffice/src/lib/grab-partner.ts
@@ -41,16 +41,29 @@ function signingKey(): Uint8Array {
  *  vars", with nothing to remove or flip. */
 function partnerPairs(): Array<{ id: string; secret: string }> {
   const pairs: Array<{ id: string; secret: string }> = [];
-  const add = (id?: string, secret?: string) => { if (id && secret) pairs.push({ id, secret }); };
+  // Trim so a stray space/newline pasted into a Vercel env var can't break the
+  // exact-match compare in partnerCredsMatch.
+  const add = (id?: string, secret?: string) => {
+    const i = (id ?? "").trim();
+    const s = (secret ?? "").trim();
+    if (i && s) pairs.push({ id: i, secret: s });
+  };
   add(process.env.GRAB_PARTNER_CLIENT_ID, process.env.GRAB_PARTNER_CLIENT_SECRET);
   add(process.env.GRAB_PARTNER_CLIENT_ID_PROD, process.env.GRAB_PARTNER_CLIENT_SECRET_PROD);
+  // GrabFood's POS API uses ONE OAuth client credential in BOTH directions: Grab
+  // presents our outbound Client ID/secret (GRAB_CLIENT_ID/SECRET) on its inbound
+  // calls to this token endpoint. Accept it so inbound auth works off the already-
+  // verified outbound creds — no separate partner pair to configure or match.
+  add(process.env.GRAB_CLIENT_ID, process.env.GRAB_CLIENT_SECRET);
   return pairs;
 }
 
 /** True if the supplied client credentials match ANY configured partner pair. */
 export function partnerCredsMatch(clientId: unknown, clientSecret: unknown): boolean {
   if (typeof clientId !== "string" || typeof clientSecret !== "string") return false;
-  return partnerPairs().some((p) => p.id === clientId && p.secret === clientSecret);
+  const id = clientId.trim();
+  const secret = clientSecret.trim();
+  return partnerPairs().some((p) => p.id === id && p.secret === secret);
 }
 
 export function partnerConfigured(): boolean {


### PR DESCRIPTION
## Problem
GrabFood self-serve store activation fails at the **menu-export** step — *"We faced an issue with the export… no response from your POS partner."* Backoffice runtime logs show Grab repeatedly calling our inbound `POST /api/pos/grab/oauth/token` and getting **`401 invalid_client`**, so Grab can never obtain a Bearer token to fetch our menu.

Root cause: `partnerCredsMatch()` only accepted `GRAB_PARTNER_CLIENT_ID/SECRET`, and those didn't match what Grab actually sends. In the GrabFood POS API, Grab presents the **same OAuth client credential** on its inbound calls that we use for outbound — i.e. `GRAB_CLIENT_ID/GRAB_CLIENT_SECRET`, which are already verified working (`/api/pos/grab/health` → `tokenAcquired: true`).

## Fix
- `partnerPairs()` also accepts **`GRAB_CLIENT_ID` / `GRAB_CLIENT_SECRET`** → inbound `/oauth/token` authenticates off the proven outbound creds, with no separate partner pair to configure or keep in sync.
- **Trim** env + incoming creds — defends against a stray pasted space/newline breaking the exact-match compare.
- On mismatch, **log** the incoming `client_id` prefix + secret length (no secrets) so any future inbound 401 is diagnosable straight from the runtime logs.

Additive — existing valid `GRAB_PARTNER_*` pairs still work. No schema, no secrets. Typecheck clean on both files.

## After merge
Production redeploys → Grab's `/oauth/token` returns **200** → Grab pulls the menu → self-serve activation completes. Then hit **Try again** in GrabMerchant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
