### PR TITLE
fix(grab): maxStock:0 for UNAVAILABLE menu items (unblocks menu push)

### DIFF
--- a/apps/backoffice/src/lib/grab-menu.ts
+++ b/apps/backoffice/src/lib/grab-menu.ts
@@ -103,15 +103,21 @@ export function convertProductToGrabItem(product: RawProduct, sequence = 1): Gra
     "grab",
   ) as unknown as RawProduct["modifiers"];
 
+  const availableStatus: GrabMenuItem["availableStatus"] =
+    product.is_available === false ? "UNAVAILABLE" : "AVAILABLE";
   return {
     id: product.id,
     name: product.name,
     sequence,
-    availableStatus: product.is_available === false ? "UNAVAILABLE" : "AVAILABLE",
+    availableStatus,
     description: product.description || undefined,
     price: Math.round(resolveGrabPriceRM(product) * 100), // RM → sen
     campaignInfo: null,
     photos: product.image_url ? [product.image_url] : undefined,
+    // Grab REQUIRES maxStock:0 whenever availableStatus is UNAVAILABLE — omitting it
+    // makes Grab reject the entire menu push ("failed to push your menu"). AVAILABLE
+    // items leave maxStock unset (Grab treats absent maxStock as in-stock).
+    ...(availableStatus === "UNAVAILABLE" ? { maxStock: 0 } : {}),
     modifierGroups: convertToGrabModifiers(product.id, visibleMods),
   };
 }
@@ -188,7 +194,11 @@ export function buildGrabMenuPayload(
       items: prods.map((product, iIdx) => {
         const item = convertProductToGrabItem(product, iIdx + 1);
         // Per-outlet 86 overrides the global flag → out of stock on Grab too.
-        if (opts.unavailableProductIds?.has(product.id)) item.availableStatus = "UNAVAILABLE";
+        // Grab requires maxStock:0 alongside UNAVAILABLE (see convertProductToGrabItem).
+        if (opts.unavailableProductIds?.has(product.id)) {
+          item.availableStatus = "UNAVAILABLE";
+          item.maxStock = 0;
+        }
         return item;
       }),
     }),


### PR DESCRIPTION
## Problem
GrabFood self-serve activation reaches the menu step and fails: *"Your POS failed to push your menu to GrabFood."* Grab authenticates fine and `GET /merchant/menu` returns **200** with all 86 products — but Grab rejects the **import**.

## Root cause
Grab's menu schema requires **`maxStock: 0`** on any item with `availableStatus: "UNAVAILABLE"` (spec: *"Item will be set to AVAILABLE if maxStock > 0"*). We send `UNAVAILABLE` **without** `maxStock`. Exactly **1 of 86** products is currently `is_available = false`, so that single item fails validation and Grab rejects the **entire** menu push.

## Fix
Set `maxStock: 0` whenever an item is `UNAVAILABLE`:
- `convertProductToGrabItem` — global `is_available = false`
- `buildGrabMenuPayload` — per-outlet 86 override

`AVAILABLE` items leave `maxStock` unset (Grab treats absent as in-stock). Two-line logic change, type already had `maxStock?`.

## After merge
Redeploy → in GrabMerchant hit **Try again** → menu import should succeed and activation completes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
