### PR TITLE
fix(grab): emit Selling-Time-Based menu so self-serve activation accepts the push

### DIFF
--- a/apps/backoffice/src/app/api/pos/grab/menu/route.ts
+++ b/apps/backoffice/src/app/api/pos/grab/menu/route.ts
@@ -52,8 +52,8 @@ export async function POST(request: NextRequest) {
     await notifyMenuUpdate(merchantId);
     return NextResponse.json({
       success: true,
-      sectionsCount: menuPayload.sections.length,
-      categoriesCount: menuPayload.sections.reduce((n, s) => n + s.categories.length, 0),
+      sellingTimesCount: menuPayload.sellingTimes.length,
+      categoriesCount: menuPayload.categories.length,
       itemsCount: productsRes.data.length,
       result,
     });

--- a/apps/backoffice/src/app/api/pos/grab/merchant/menu/route.ts
+++ b/apps/backoffice/src/app/api/pos/grab/merchant/menu/route.ts
@@ -105,9 +105,9 @@ export async function GET(request: NextRequest) {
     serviceHours,
     unavailableProductIds: unavailableIds,
   });
-  const catCount = menu.sections.reduce((n, s) => n + s.categories.length, 0);
+  const catCount = menu.categories.length;
   console.log(
-    `[grab:get-menu] served menu merchant=${merchantId} sections=${menu.sections.length} categories=${catCount} items=${grabProducts.length}`,
+    `[grab:get-menu] served menu merchant=${merchantId} sellingTimes=${menu.sellingTimes.length} categories=${catCount} items=${grabProducts.length}`,
   );
   return NextResponse.json(menu);
 }

--- a/apps/backoffice/src/lib/grab-menu.ts
+++ b/apps/backoffice/src/lib/grab-menu.ts
@@ -9,7 +9,6 @@
 import type {
   GrabMenuCategory,
   GrabMenuItem,
-  GrabMenuSection,
   GrabModifierGroup,
   GrabMenuPayload,
 } from "@/lib/grab";
@@ -204,12 +203,18 @@ export function buildGrabMenuPayload(
     if (!categoryMap.has(cat)) categoryMap.set(cat, []);
     categoryMap.get(cat)!.push(product);
   }
+  // GrabFood self-serve activation ONLY accepts the "Selling Time Based" menu —
+  // section-based payloads are rejected ("section-based menus will not be able to
+  // proceed with integration activation"). One all-day selling time; every
+  // category references it via sellingTimeID, all hung at the top level.
+  const SELLING_TIME_ID = "all-day";
   const categories: GrabMenuCategory[] = Array.from(categoryMap.entries()).map(
     ([slug, prods], cIdx) => ({
       id: `cat-${cIdx}`,
       name: opts.categoryNames?.[slug] || slug || "Uncategorized",
       sequence: cIdx + 1,
       availableStatus: "AVAILABLE" as const,
+      sellingTimeID: SELLING_TIME_ID,
       items: prods.map((product, iIdx) => {
         const item = convertProductToGrabItem(product, iIdx + 1);
         // Per-outlet 86 overrides the global flag → out of stock on Grab too.
@@ -222,17 +227,21 @@ export function buildGrabMenuPayload(
       }),
     }),
   );
-  const section: GrabMenuSection = {
-    id: "section-all-day",
-    name: "All Day",
-    sequence: 1,
-    serviceHours: opts.serviceHours ?? DEFAULT_SERVICE_HOURS,
-    categories,
-  };
   return {
     merchantID: merchantId,
     ...(opts.partnerMerchantId ? { partnerMerchantID: opts.partnerMerchantId } : {}),
     currency: opts.currency ?? { code: "MYR", symbol: "RM", exponent: 2 },
-    sections: [section],
+    sellingTimes: [
+      {
+        id: SELLING_TIME_ID,
+        name: "All Day",
+        // Date window must be present + wide so the selling time is always active;
+        // the per-day serviceHours carry the real open/close window.
+        startTime: "2020-01-01 00:00:00",
+        endTime: "2099-12-31 23:59:59",
+        serviceHours: opts.serviceHours ?? DEFAULT_SERVICE_HOURS,
+      },
+    ],
+    categories,
   };
 }

--- a/apps/backoffice/src/lib/grab.ts
+++ b/apps/backoffice/src/lib/grab.ts
@@ -158,6 +158,7 @@ export interface GrabMenuCategory {
   sequence?: number;
   nameTranslation?: Record<string, string>;
   availableStatus: "AVAILABLE" | "UNAVAILABLE";
+  sellingTimeID: string;
   items: GrabMenuItem[];
 }
 
@@ -171,21 +172,25 @@ type GrabServiceHours = {
   sun: { openPeriodType: string; periods: Array<{ startTime: string; endTime: string }> };
 };
 
-// GrabFood "Old Structure (Section Based Menu)": menu = list of sections;
-// each section has its own serviceHours + categories[] of items.
-export interface GrabMenuSection {
+// GrabFood "Selling Time Based" menu — the ONLY structure self-serve activation
+// accepts. Per the v1.1.3 docs, "section-based menus will not be able to proceed
+// with integration activation". Selling times are declared once at the top level
+// (each with a date window + per-day serviceHours); categories reference them by
+// sellingTimeID. This replaced the old section-based payload.
+export interface GrabSellingTime {
   id: string;
   name: string;
-  sequence?: number;
+  startTime: string; // "YYYY-MM-DD HH:mm:ss" (UTC)
+  endTime: string; //   "YYYY-MM-DD HH:mm:ss" (UTC)
   serviceHours: GrabServiceHours;
-  categories: GrabMenuCategory[];
 }
 
 export interface GrabMenuPayload {
   merchantID: string;
   partnerMerchantID?: string;
   currency: { code: string; symbol: string; exponent: number };
-  sections: GrabMenuSection[];
+  sellingTimes: GrabSellingTime[];
+  categories: GrabMenuCategory[];
 }
 
 /**


### PR DESCRIPTION
## Root cause (the real one)
GrabFood self-serve activation kept failing at **"Your POS failed to push your menu to GrabFood"** — through fixing inbound auth *and* capping oversized images *and* verifying the payload as 100% valid. It was valid against the **wrong schema**.

The v1.1.3 docs (self-serve activation intro) state:
> *"Only **selling-time-based menu** is supported; **section-based menus will not be able to proceed** with integration activation."*

We were emitting `GetMenuOldResponse` (**section-based**: `sections[]`, each with its own `serviceHours` + nested `categories[]`). Activation requires `GetMenuNewResponse` (**selling-time-based**).

## Fix
Rebuild `buildGrabMenuPayload` to selling-time format:
- one top-level `sellingTimes[]` entry (`all-day`, wide date window, the per-outlet `serviceHours`)
- `categories[]` hoisted to the **top level**, each carrying `sellingTimeID`
- drop the `sections[]` wrapper

Types updated (`GrabMenuSection`→`GrabSellingTime`; payload `.sections`→`.sellingTimes`+`.categories`; `GrabMenuCategory` gains `sellingTimeID`), plus the two log lines that read `.sections`. Applies to both the inbound get-menu webhook and outbound `updateMenu`. Typechecks clean.

After deploy I'll fetch the live menu to confirm it's `{ sellingTimes[], categories[] }` before the retry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)