### PR TITLE
feat(grab): per-outlet connection-status badge on the GrabFood admin page

### DIFF
--- a/apps/backoffice/src/app/(admin)/settings/integrations/grab/page.tsx
+++ b/apps/backoffice/src/app/(admin)/settings/integrations/grab/page.tsx
@@ -34,6 +34,10 @@ type Outlet = {
   storehubId: string | null;
   grabMerchantId: string | null;
   isActive: boolean;
+  // Grab integration status, pushed by Grab to /api/pos/grab/status during/after
+  // self-serve activation: ACTIVE / SYNCING / FAILED / INACTIVE (null = never linked).
+  integrationStatus: string | null;
+  integrationStatusAt: string | null;
 };
 
 type RecentOrder = {
@@ -272,7 +276,10 @@ export default function GrabIntegrationPage() {
               <div key={o.id} className="px-5 py-3">
                 <div className="flex items-center gap-3">
                   <div className="min-w-0 flex-1">
-                    <div className="text-sm font-medium text-neutral-900">{o.name}</div>
+                    <div className="flex items-center gap-2 text-sm font-medium text-neutral-900">
+                      {o.name}
+                      <ConnectionBadge status={o.integrationStatus} at={o.integrationStatusAt} />
+                    </div>
                     <div className="text-xs text-neutral-500">
                       Partner store ID: <code>{o.id}</code>
                     </div>
@@ -434,6 +441,27 @@ function StatusPill({ status }: { status: string | null }) {
   return (
     <span className={`inline-block rounded px-1.5 py-0.5 text-xs font-medium ${cls}`}>
       {status || "—"}
+    </span>
+  );
+}
+
+// Grab integration connection state per outlet, from Grab's /status webhook
+// pushes (ACTIVE / SYNCING / FAILED / INACTIVE; null = never linked).
+function ConnectionBadge({ status, at }: { status: string | null; at: string | null }) {
+  const s = (status || "").toUpperCase();
+  const map: Record<string, { label: string; cls: string }> = {
+    ACTIVE: { label: "● Connected", cls: "bg-emerald-100 text-emerald-700" },
+    SYNCING: { label: "● Syncing", cls: "bg-blue-100 text-blue-700" },
+    FAILED: { label: "● Failed", cls: "bg-red-100 text-red-700" },
+    INACTIVE: { label: "● Inactive", cls: "bg-neutral-100 text-neutral-600" },
+  };
+  const m = map[s] ?? { label: "○ Not linked", cls: "bg-neutral-100 text-neutral-500" };
+  const title = at
+    ? `Grab reported "${s}" at ${new Date(at).toLocaleString("en-MY", { dateStyle: "short", timeStyle: "short" })}`
+    : "No integration status received from Grab yet";
+  return (
+    <span title={title} className={`inline-block whitespace-nowrap rounded-full px-2 py-0.5 text-xs font-medium ${m.cls}`}>
+      {m.label}
     </span>
   );
 }

--- a/apps/backoffice/src/app/api/integrations/grab/route.ts
+++ b/apps/backoffice/src/app/api/integrations/grab/route.ts
@@ -27,6 +27,8 @@ type OutletLinkRow = {
   storehubId: string | null;
   grabMerchantId: string | null;
   is_active: boolean;
+  grab_integration_status: string | null;
+  grab_integration_status_at: Date | null;
 };
 
 type RecentOrderRow = {
@@ -53,7 +55,9 @@ export async function GET(req: NextRequest) {
            city,
            "storehubId",
            "grabMerchantId",
-           (status = 'ACTIVE'::"OutletStatus") AS is_active
+           (status = 'ACTIVE'::"OutletStatus") AS is_active,
+           "grabIntegrationStatus"   AS grab_integration_status,
+           "grabIntegrationStatusAt" AS grab_integration_status_at
     FROM "Outlet"
     WHERE "loyaltyOutletId" IS NOT NULL
     ORDER BY name ASC
@@ -110,6 +114,8 @@ export async function GET(req: NextRequest) {
       storehubId: o.storehubId,
       grabMerchantId: o.grabMerchantId,
       isActive: o.is_active,
+      integrationStatus: o.grab_integration_status,
+      integrationStatusAt: o.grab_integration_status_at,
     })),
     recentOrders: recentOrders.map((o) => ({
       id: o.id,

--- a/apps/backoffice/src/app/api/pos/grab/status/route.ts
+++ b/apps/backoffice/src/app/api/pos/grab/status/route.ts
@@ -4,9 +4,9 @@
  * POST /api/grab/status
  *
  * GrabFood pushes the store's integration status during/after the self-serve
- * store-activation journey. Status is one of INACTIVE / ACTIVE / SYNCING /
- * FAILED. For now we log + acknowledge (the POS doesn't yet surface Grab's
- * integration state in BackOffice — that's a separate task with its own column).
+ * store-activation journey (INACTIVE / ACTIVE / SYNCING / FAILED). We persist it
+ * onto the outlet so BackOffice can surface "connected / syncing / failed" per
+ * store (see /settings/integrations/grab), then acknowledge.
  *
  * Authenticated with the partner Bearer token Grab obtained from our
  * /api/grab/oauth/token endpoint. Register this URL in the portal
@@ -15,6 +15,8 @@
 
 import { NextRequest, NextResponse } from "next/server";
 import { verifyGrabPartnerToken } from "@/lib/grab-partner";
+import { prisma } from "@/lib/prisma";
+import { Prisma } from "@prisma/client";
 
 type IntegrationStatus = "INACTIVE" | "ACTIVE" | "SYNCING" | "FAILED";
 
@@ -30,12 +32,30 @@ export async function POST(request: NextRequest) {
     /* tolerate empty / non-JSON body */
   }
 
-  const merchantID = (body.merchantID || body.merchantId || "") as string;
+  // Spec field is `grabMerchantID` (+ `partnerMerchantID` + `integrationStatus`);
+  // tolerate the older `merchantID` / `status` aliases too.
+  const grabMerchantID = (body.grabMerchantID || body.merchantID || body.merchantId || "") as string;
   const partnerMerchantID = (body.partnerMerchantID || body.partnerMerchantId || "") as string;
-  const status = (body.status || body.integrationStatus || "") as IntegrationStatus | "";
+  const status = (body.integrationStatus || body.status || "") as IntegrationStatus | "";
   console.log(
-    `[grab:integration-status] merchant=${merchantID} partnerMerchant=${partnerMerchantID} status=${status}`,
+    `[grab:integration-status] grabMerchant=${grabMerchantID} partnerMerchant=${partnerMerchantID} status=${status}`,
   );
+
+  // Persist onto the outlet. Resolve by the partner store id (= Outlet.loyaltyOutletId,
+  // what we send on self-serve) or the Grab store id. Best-effort — never fail the
+  // ack on a write error (Grab retries on any non-2xx).
+  if (status && (partnerMerchantID || grabMerchantID)) {
+    try {
+      await prisma.$executeRaw(Prisma.sql`
+        UPDATE "Outlet"
+        SET "grabIntegrationStatus" = ${status}, "grabIntegrationStatusAt" = NOW()
+        WHERE "loyaltyOutletId" = ${partnerMerchantID || null}
+           OR "grabMerchantId"  = ${grabMerchantID || null}
+      `);
+    } catch (err) {
+      console.warn("[grab:integration-status] persist skipped:", err);
+    }
+  }
 
   // Ack — Grab retries on any non-2xx, so we only return non-200 on auth failure.
   return NextResponse.json({ success: true });

--- a/supabase/migrations/025_grab_integration_status.sql
+++ b/supabase/migrations/025_grab_integration_status.sql
@@ -1,0 +1,13 @@
+-- Grab integration status per outlet — surfaced as a "connected" badge in the
+-- BackOffice GrabFood admin (/settings/integrations/grab). GrabFood pushes the
+-- store's integration status (ACTIVE / SYNCING / FAILED / INACTIVE) to our
+-- /api/pos/grab/status webhook during/after self-serve activation; that route
+-- persists it onto "Outlet" (resolved by loyaltyOutletId = the partner store id,
+-- or by grabMerchantId). Read back in /api/integrations/grab GET.
+ALTER TABLE "Outlet"
+  ADD COLUMN IF NOT EXISTS "grabIntegrationStatus" text,
+  ADD COLUMN IF NOT EXISTS "grabIntegrationStatusAt" timestamptz;
+
+-- Backfill Putrajaya/Conezion: confirmed ACTIVE (self-serve activation succeeded 2026-06-16).
+UPDATE "Outlet" SET "grabIntegrationStatus" = 'ACTIVE', "grabIntegrationStatusAt" = now()
+  WHERE "loyaltyOutletId" = 'outlet-con';


### PR DESCRIPTION
## Why
"How can we know if an outlet is connected to GrabFood or not?" — the page only generated activation links, with no status indicator.

Grab actually reports it: it pushes the store integration status (`ACTIVE` / `SYNCING` / `FAILED` / `INACTIVE`) to our `/api/pos/grab/status` webhook during/after self-serve activation (confirmed in prod logs — it fired twice during the Putrajaya activation). We were only logging it.

## What
- **Migration 025** — `"Outlet".grabIntegrationStatus` + `grabIntegrationStatusAt` (backfilled Putrajaya/Conezion = `ACTIVE`, already verified live).
- **`/api/pos/grab/status`** — persists the pushed status onto the outlet (resolved by `loyaltyOutletId` = the partner store id we send, or by `grabMerchantId`). Best-effort write, never fails the ack. Also reads the spec field `grabMerchantID` (was reading `merchantID`).
- **`/api/integrations/grab` GET** — returns `integrationStatus` + `integrationStatusAt` per outlet.
- **Settings page** — a badge per outlet in the self-serve section: **● Connected / ● Syncing / ● Failed / ● Inactive / ○ Not linked**, last-seen time on hover.

Typechecks clean. Putrajaya shows **● Connected** immediately (backfill); the others show **○ Not linked** until activated, then update automatically from Grab's pushes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)