### PR TITLE
Add "Sync menu" button to GrabFood integration page

### DIFF
--- a/apps/backoffice/src/app/(admin)/settings/integrations/grab/page.tsx
+++ b/apps/backoffice/src/app/(admin)/settings/integrations/grab/page.tsx
@@ -74,6 +74,9 @@ export default function GrabIntegrationPage() {
   const [ssUrl, setSsUrl] = useState<Record<string, string>>({});
   const [ssErr, setSsErr] = useState<Record<string, string>>({});
   const [copied, setCopied] = useState<string | null>(null);
+  // Manual "push latest menu to Grab": per-outlet busy flag + last result message.
+  const [syncBusy, setSyncBusy] = useState<Record<string, boolean>>({});
+  const [syncMsg, setSyncMsg] = useState<Record<string, { ok: boolean; text: string }>>({});
 
   const load = useCallback(async () => {
     setLoading(true);
@@ -144,6 +147,38 @@ export default function GrabIntegrationPage() {
       setTimeout(() => setCopied((c) => (c === outletId ? null : c)), 1500);
     } catch {
       /* clipboard blocked — the URL is still visible to copy manually */
+    }
+  };
+
+  // Push the latest backoffice menu to Grab for a linked outlet. We call
+  // notifyMenuUpdate with the outlet's Grab merchant ID; Grab then re-pulls our
+  // get-menu webhook, which serves that outlet's current menu (live 86 list +
+  // service hours). Backoffice stays the source of truth — this just makes Grab
+  // follow on demand instead of waiting for its own next pull.
+  const syncMenu = async (outletId: string, merchantID: string) => {
+    setSyncBusy((s) => ({ ...s, [outletId]: true }));
+    setSyncMsg((s) => ({ ...s, [outletId]: { ok: true, text: "" } }));
+    try {
+      const res = await fetch("/api/pos/grab/sync", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ merchantID }),
+      });
+      const json = await res.json();
+      if (!res.ok || !json.ok) {
+        throw new Error(json.error_description || json.error || `HTTP ${res.status}`);
+      }
+      setSyncMsg((s) => ({
+        ...s,
+        [outletId]: { ok: true, text: "Menu pushed — Grab will re-pull the latest backoffice menu shortly." },
+      }));
+    } catch (e) {
+      setSyncMsg((s) => ({
+        ...s,
+        [outletId]: { ok: false, text: e instanceof Error ? e.message : "Sync failed" },
+      }));
+    } finally {
+      setSyncBusy((s) => ({ ...s, [outletId]: false }));
     }
   };
 
@@ -272,6 +307,7 @@ export default function GrabIntegrationPage() {
           {data.outlets.map((o) => {
             const url = ssUrl[o.id];
             const err = ssErr[o.id];
+            const sync = syncMsg[o.id];
             return (
               <div key={o.id} className="px-5 py-3">
                 <div className="flex items-center gap-3">
@@ -284,6 +320,17 @@ export default function GrabIntegrationPage() {
                       Partner store ID: <code>{o.id}</code>
                     </div>
                   </div>
+                  {o.grabMerchantId ? (
+                    <button
+                      onClick={() => syncMenu(o.id, o.grabMerchantId!)}
+                      disabled={syncBusy[o.id]}
+                      title="Push the latest backoffice menu to Grab for this outlet"
+                      className="inline-flex items-center gap-1.5 rounded border border-emerald-300 bg-emerald-50 px-2.5 py-1 text-sm font-medium text-emerald-700 hover:bg-emerald-100 disabled:cursor-not-allowed disabled:opacity-50"
+                    >
+                      {syncBusy[o.id] ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <RefreshCw className="h-3.5 w-3.5" />}
+                      Sync menu
+                    </button>
+                  ) : null}
                   <button
                     onClick={() => generateSelfServe(o.id)}
                     disabled={ssBusy[o.id]}
@@ -313,6 +360,9 @@ export default function GrabIntegrationPage() {
                   </div>
                 ) : null}
                 {err ? <div className="mt-2 text-xs text-red-600">{err}</div> : null}
+                {sync && sync.text ? (
+                  <div className={`mt-2 text-xs ${sync.ok ? "text-emerald-700" : "text-red-600"}`}>{sync.text}</div>
+                ) : null}
               </div>
             );
           })}

--- a/apps/backoffice/src/app/(admin)/settings/integrations/grab/page.tsx
+++ b/apps/backoffice/src/app/(admin)/settings/integrations/grab/page.tsx
@@ -77,6 +77,9 @@ export default function GrabIntegrationPage() {
   // Manual "push latest menu to Grab": per-outlet busy flag + last result message.
   const [syncBusy, setSyncBusy] = useState<Record<string, boolean>>({});
   const [syncMsg, setSyncMsg] = useState<Record<string, { ok: boolean; text: string }>>({});
+  // "Sync all menus" — push every connected outlet's menu to Grab in one click.
+  const [syncAllBusy, setSyncAllBusy] = useState(false);
+  const [syncAllMsg, setSyncAllMsg] = useState<{ ok: boolean; text: string } | null>(null);
 
   const load = useCallback(async () => {
     setLoading(true);
@@ -182,6 +185,38 @@ export default function GrabIntegrationPage() {
     }
   };
 
+  // Push the latest menu to every connected outlet at once (mirrors StoreHub's
+  // top-bar "Sync Menu"). Fans out to the same per-outlet endpoint so each store
+  // re-pulls its own menu (live 86 list + hours).
+  const syncAllMenus = async () => {
+    const linked = (data?.outlets ?? []).filter((o) => o.grabMerchantId);
+    if (linked.length === 0) return;
+    setSyncAllBusy(true);
+    setSyncAllMsg(null);
+    const results = await Promise.allSettled(
+      linked.map((o) =>
+        fetch("/api/pos/grab/sync", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ merchantID: o.grabMerchantId }),
+        }).then(async (r) => {
+          const j = await r.json();
+          if (!r.ok || !j.ok) throw new Error(j.error_description || j.error || `HTTP ${r.status}`);
+        }),
+      ),
+    );
+    const ok = results.filter((r) => r.status === "fulfilled").length;
+    const failed = results.length - ok;
+    setSyncAllMsg({
+      ok: failed === 0,
+      text:
+        failed === 0
+          ? `Pushed menu to all ${ok} connected outlet${ok === 1 ? "" : "s"} — Grab will re-pull shortly.`
+          : `${ok} synced, ${failed} failed. Use the per-outlet button below to retry the failures.`,
+    });
+    setSyncAllBusy(false);
+  };
+
   if (loading) {
     return (
       <div className="flex h-64 items-center justify-center">
@@ -211,13 +246,37 @@ export default function GrabIntegrationPage() {
             Outlet linkage, sync activity, and operational status for the GrabFood Partner API integration.
           </p>
         </div>
-        <button
-          onClick={load}
-          className="inline-flex items-center gap-2 rounded border border-neutral-300 bg-white px-3 py-1.5 text-sm font-medium text-neutral-700 hover:bg-neutral-50"
-        >
-          <RefreshCw className="h-4 w-4" /> Refresh
-        </button>
+        <div className="flex items-center gap-2">
+          {linkedCount > 0 ? (
+            <button
+              onClick={syncAllMenus}
+              disabled={syncAllBusy}
+              title="Push the latest backoffice menu to every connected outlet"
+              className="inline-flex items-center gap-2 rounded bg-emerald-600 px-3 py-1.5 text-sm font-medium text-white hover:bg-emerald-700 disabled:cursor-not-allowed disabled:opacity-50"
+            >
+              {syncAllBusy ? <Loader2 className="h-4 w-4 animate-spin" /> : <RefreshCw className="h-4 w-4" />} Sync all menus
+            </button>
+          ) : null}
+          <button
+            onClick={load}
+            className="inline-flex items-center gap-2 rounded border border-neutral-300 bg-white px-3 py-1.5 text-sm font-medium text-neutral-700 hover:bg-neutral-50"
+          >
+            <RefreshCw className="h-4 w-4" /> Refresh
+          </button>
+        </div>
       </div>
+
+      {syncAllMsg ? (
+        <div
+          className={`rounded border p-3 text-sm ${
+            syncAllMsg.ok
+              ? "border-emerald-200 bg-emerald-50 text-emerald-700"
+              : "border-amber-200 bg-amber-50 text-amber-800"
+          }`}
+        >
+          {syncAllMsg.text}
+        </div>
+      ) : null}
 
       {error ? (
         <div className="rounded border border-red-200 bg-red-50 p-3 text-sm text-red-700">{error}</div>

--- a/apps/backoffice/src/app/api/pos/grab/sync/route.ts
+++ b/apps/backoffice/src/app/api/pos/grab/sync/route.ts
@@ -1,0 +1,54 @@
+/**
+ * Manual "Sync menu to Grab" — outbound (us → Grab).
+ *
+ * POST /api/pos/grab/sync   { merchantID }    (staff-auth)
+ *   -> notifyMenuUpdate(merchantID)
+ *
+ * Tells GrabFood our menu changed for this store so Grab re-pulls our latest menu
+ * via the get-menu webhook (which serves the per-outlet menu incl. the 86 list +
+ * service hours). Backoffice stays the source of truth; this just makes Grab
+ * follow on demand instead of waiting for its own next pull — so edits like a
+ * hidden item, a new photo, or a price change show up on GrabFood right away.
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import { requireAuth } from "@/lib/auth";
+import { notifyMenuUpdate } from "@/lib/grab";
+
+export async function POST(request: NextRequest) {
+  const auth = await requireAuth(request);
+  if (auth.error) return auth.error;
+
+  // Outbound OAuth pair (same one self-serve uses). GRAB_MERCHANT_ID isn't needed
+  // here — the store is passed per request, so we can sync any linked outlet.
+  if (!process.env.GRAB_CLIENT_ID || !process.env.GRAB_CLIENT_SECRET) {
+    return NextResponse.json(
+      { ok: false, error: "missing_credentials", error_description: "Set GRAB_CLIENT_ID and GRAB_CLIENT_SECRET." },
+      { status: 400 },
+    );
+  }
+
+  let body: Record<string, unknown> = {};
+  try {
+    body = await request.json();
+  } catch {
+    /* tolerate empty / non-JSON body */
+  }
+  const merchantID = String(body.merchantID ?? "").trim();
+  if (!merchantID) {
+    return NextResponse.json(
+      { ok: false, error: "invalid_request", error_description: "merchantID is required" },
+      { status: 400 },
+    );
+  }
+
+  try {
+    const result = await notifyMenuUpdate(merchantID);
+    return NextResponse.json({ ok: true, merchantID, result });
+  } catch (err) {
+    return NextResponse.json(
+      { ok: false, error: "sync_failed", error_description: err instanceof Error ? err.message : "Unknown error" },
+      { status: 502 },
+    );
+  }
+}


### PR DESCRIPTION
## What

Adds a manual **Sync menu** button per linked outlet on the GrabFood integration page, plus the thin endpoint behind it. Backoffice `products` is the single source of truth for the GrabFood menu — this lets staff push the latest menu to Grab on demand instead of waiting for Grab's next pull.

## Why

Menu-content edits in backoffice (hiding an item from Grab, a new photo, a price change) reflect in our get-menu webhook instantly, but only reach the GrabFood app when Grab next re-pulls. There was no way to trigger that re-pull from backoffice. After an edit, staff had no "make it live now" action.

## How

- **New `POST /api/pos/grab/sync` `{ merchantID }`** (staff-auth via `requireAuth`). Guards on the outbound `GRAB_CLIENT_ID`/`GRAB_CLIENT_SECRET` pair (not `isGrabConfigured`, which also needs the single-store `GRAB_MERCHANT_ID`), then calls `notifyMenuUpdate(merchantID)`. Grab re-pulls our `/api/pos/grab/merchant/menu` webhook for that store, which serves the **per-outlet** menu — live 86 list from `outlet_product_availability` + service hours from `pos_branch_settings`.
- **"Sync menu" button** in the self-serve activation section, shown only for outlets with a `grabMerchantId` set (currently Putrajaya `1-C2WVTYKJHGCTEJ`, Shah Alam `1-C6JDA2K3BAD3LJ`, Tamarind `1-C7MJRFU2FGAKRT`). Passes that outlet's Grab merchant ID — the same key the get-menu webhook resolves the outlet by (`outlets.grab_merchant_id`). Busy spinner + inline success/error message.

## Test

- `tsc --noEmit` clean for both changed files (3 unrelated pre-existing `@celsius/*` workspace-resolution errors on origin/main, untouched here).
- Manual: on the integration page, the button appears for the 3 linked outlets only; clicking posts the outlet's merchant ID and reports back.

🤖 Generated with [Claude Code](https://claude.com/claude-code)