### PR TITLE
fix(grab): push the menu to GrabFood instead of notify (UnsupportedMenuSync)

### DIFF
--- a/apps/backoffice/src/app/(admin)/settings/integrations/grab/page.tsx
+++ b/apps/backoffice/src/app/(admin)/settings/integrations/grab/page.tsx
@@ -153,11 +153,10 @@ export default function GrabIntegrationPage() {
     }
   };
 
-  // Push the latest backoffice menu to Grab for a linked outlet. We call
-  // notifyMenuUpdate with the outlet's Grab merchant ID; Grab then re-pulls our
-  // get-menu webhook, which serves that outlet's current menu (live 86 list +
-  // service hours). Backoffice stays the source of truth — this just makes Grab
-  // follow on demand instead of waiting for its own next pull.
+  // Push the latest backoffice menu to Grab for a linked outlet. The endpoint
+  // builds that outlet's menu (live 86 list + service hours) and PUTs it straight
+  // to GrabFood. Backoffice stays the source of truth — this makes GrabFood match
+  // it on demand instead of waiting on Grab.
   const syncMenu = async (outletId: string, merchantID: string) => {
     setSyncBusy((s) => ({ ...s, [outletId]: true }));
     setSyncMsg((s) => ({ ...s, [outletId]: { ok: true, text: "" } }));
@@ -173,7 +172,7 @@ export default function GrabIntegrationPage() {
       }
       setSyncMsg((s) => ({
         ...s,
-        [outletId]: { ok: true, text: "Menu pushed — Grab will re-pull the latest backoffice menu shortly." },
+        [outletId]: { ok: true, text: "Menu pushed to GrabFood — the storefront will reflect it shortly." },
       }));
     } catch (e) {
       setSyncMsg((s) => ({
@@ -187,7 +186,7 @@ export default function GrabIntegrationPage() {
 
   // Push the latest menu to every connected outlet at once (mirrors StoreHub's
   // top-bar "Sync Menu"). Fans out to the same per-outlet endpoint so each store
-  // re-pulls its own menu (live 86 list + hours).
+  // gets its own menu pushed (live 86 list + hours).
   const syncAllMenus = async () => {
     const linked = (data?.outlets ?? []).filter((o) => o.grabMerchantId);
     if (linked.length === 0) return;
@@ -211,7 +210,7 @@ export default function GrabIntegrationPage() {
       ok: failed === 0,
       text:
         failed === 0
-          ? `Pushed menu to all ${ok} connected outlet${ok === 1 ? "" : "s"} — Grab will re-pull shortly.`
+          ? `Pushed menu to all ${ok} connected outlet${ok === 1 ? "" : "s"} — GrabFood will reflect it shortly.`
           : `${ok} synced, ${failed} failed. Use the per-outlet button below to retry the failures.`,
     });
     setSyncAllBusy(false);

--- a/apps/backoffice/src/app/api/pos/grab/merchant/menu/route.ts
+++ b/apps/backoffice/src/app/api/pos/grab/merchant/menu/route.ts
@@ -3,22 +3,23 @@
  *
  * GET /api/grab/merchant/menu
  *
- * GrabFood calls this to pull our latest menu. Per the API deck this is only
- * triggered AFTER we call the outbound "Update menu notification" (lib/grab.ts
- * notifyMenuUpdate). Grab presents the partner Bearer token it obtained from our
+ * GrabFood calls this to pull our latest menu (e.g. during self-serve store
+ * activation). Grab presents the partner Bearer token it obtained from our
  * /api/grab/oauth/token endpoint, so we gate on verifyGrabPartnerToken (NOT the
  * staff requireAuth used by the outbound routes).
  *
- * Register this URL in the GrabFood portal "Partner configuration → Get menu".
+ * The per-outlet menu is built by lib/grab-menu-outlet (shared with the outbound
+ * "sync menu" push at api/pos/grab/sync), so a pull and a push serve identical
+ * menus. We read with the service-role key (products are behind RLS) since an
+ * inbound webhook has no user session — mirrors lib/loyalty-snapshot.
  *
- * There's no user session on an inbound webhook, so we read products with the
- * service-role key (the products table is behind RLS) — mirrors lib/loyalty-snapshot.
+ * Register this URL in the GrabFood portal "Partner configuration → Get menu".
  */
 
 import { NextRequest, NextResponse } from "next/server";
 import { createClient } from "@supabase/supabase-js";
 import { verifyGrabPartnerToken } from "@/lib/grab-partner";
-import { buildGrabMenuPayload, buildGrabServiceHours, grabMenuOptionsFromEnv, type RawProduct } from "@/lib/grab-menu";
+import { buildOutletGrabMenu } from "@/lib/grab-menu-outlet";
 
 function serviceClient() {
   return createClient(
@@ -40,74 +41,13 @@ export async function GET(request: NextRequest) {
     process.env.GRAB_MERCHANT_ID ||
     "";
 
-  const supabase = serviceClient();
-  const [productsRes, categoriesRes] = await Promise.all([
-    supabase.from("products").select("*").order("category").order("name"),
-    supabase.from("categories").select("id, slug, name").order("position", { ascending: true }),
-  ]);
-
-  if (productsRes.error || !productsRes.data) {
-    console.error("[grab:get-menu] product fetch failed:", productsRes.error);
+  const menu = await buildOutletGrabMenu(serviceClient(), merchantId);
+  if (!menu) {
     return NextResponse.json({ error: "Failed to fetch products" }, { status: 500 });
   }
 
-  // Per-outlet open hours: merchantID → outlets.grab_merchant_id → outlet id →
-  // pos_branch_settings.grab_open_time/close/24h. Falls back to 08:00–22:00.
-  let serviceHours: ReturnType<typeof buildGrabServiceHours> | undefined;
-  // Product ids 86'd at this merchant's outlet (per-outlet stock-outs) → forced
-  // UNAVAILABLE in the payload so a full re-sync respects the same overrides
-  // the live availability push sends.
-  let unavailableIds: Set<string> | undefined;
-  if (merchantId) {
-    const { data: outlet } = await supabase
-      .from("outlets").select("id").eq("grab_merchant_id", merchantId).maybeSingle();
-    if (outlet?.id) {
-      const { data: bs } = await supabase
-        .from("pos_branch_settings")
-        .select("grab_open_time, grab_close_time, grab_open_24h")
-        .eq("outlet_id", outlet.id)
-        .maybeSingle();
-      if (bs) {
-        serviceHours = buildGrabServiceHours({
-          open: bs.grab_open_time, close: bs.grab_close_time, open24h: bs.grab_open_24h,
-        });
-        console.log(`[grab:get-menu] hours outlet=${outlet.id} 24h=${bs.grab_open_24h} ${bs.grab_open_time}-${bs.grab_close_time}`);
-      }
-      // Per-outlet 86 list (outlet_product_availability keyed by store slug).
-      const { data: os } = await supabase
-        .from("outlet_settings").select("store_id").eq("loyalty_outlet_id", outlet.id).maybeSingle();
-      const storeId = (os as { store_id?: string } | null)?.store_id;
-      if (storeId) {
-        const { data: oos } = await supabase
-          .from("outlet_product_availability").select("product_id")
-          .eq("outlet_id", storeId).eq("is_available", false);
-        unavailableIds = new Set((oos ?? []).map((r: { product_id: string }) => r.product_id));
-      }
-    }
-  }
-
-  // Build slug→displayName map so Grab sees "Artisan Choc" instead of "artisan-choc".
-  const categoryNames: Record<string, string> = {};
-  for (const c of categoriesRes.data || []) {
-    if (c.slug && c.name) categoryNames[c.slug] = c.name;
-    if (c.id && c.name) categoryNames[c.id] = c.name; // products.category might store id too
-  }
-
-  // "Show on" placement: only products visible on the Grab channel ship (empty
-  // visible_channels = everywhere — same allow-list rule as modifiers).
-  const grabProducts = (productsRes.data as RawProduct[]).filter((p) => {
-    const vc = (p as { visible_channels?: string[] }).visible_channels;
-    return !Array.isArray(vc) || vc.length === 0 || vc.includes("grab");
-  });
-  const menu = buildGrabMenuPayload(grabProducts, merchantId, {
-    ...grabMenuOptionsFromEnv(),
-    categoryNames,
-    serviceHours,
-    unavailableProductIds: unavailableIds,
-  });
-  const catCount = menu.categories.length;
   console.log(
-    `[grab:get-menu] served menu merchant=${merchantId} sellingTimes=${menu.sellingTimes.length} categories=${catCount} items=${grabProducts.length}`,
+    `[grab:get-menu] served menu merchant=${merchantId} sellingTimes=${menu.sellingTimes.length} categories=${menu.categories.length}`,
   );
   return NextResponse.json(menu);
 }

--- a/apps/backoffice/src/app/api/pos/grab/sync/route.ts
+++ b/apps/backoffice/src/app/api/pos/grab/sync/route.ts
@@ -1,19 +1,31 @@
 /**
- * Manual "Sync menu to Grab" — outbound (us → Grab).
+ * Manual "Sync menu to Grab" — outbound push (us → Grab).
  *
  * POST /api/pos/grab/sync   { merchantID }    (staff-auth)
- *   -> notifyMenuUpdate(merchantID)
  *
- * Tells GrabFood our menu changed for this store so Grab re-pulls our latest menu
- * via the get-menu webhook (which serves the per-outlet menu incl. the 86 list +
- * service hours). Backoffice stays the source of truth; this just makes Grab
- * follow on demand instead of waiting for its own next pull — so edits like a
- * hidden item, a new photo, or a price change show up on GrabFood right away.
+ * Builds the per-outlet menu (the SAME builder the get-menu webhook serves) and
+ * PUTs it straight to Grab via updateMenu. We PUSH rather than notify: these
+ * self-serve stores reject the notify→pull trigger — POST .../menu/notification
+ * returns {"target":"UnsupportedMenuSync","reason":"invalid_argument"}. Pushing
+ * makes GrabFood match backoffice on demand (corrected photos, hidden items,
+ * price changes) instead of waiting on Grab.
+ *
+ * Per-outlet data (hours, 86 list) is read with the service-role key, same as the
+ * inbound webhook; the route itself is staff-gated by requireAuth.
  */
 
 import { NextRequest, NextResponse } from "next/server";
+import { createClient } from "@supabase/supabase-js";
 import { requireAuth } from "@/lib/auth";
-import { notifyMenuUpdate } from "@/lib/grab";
+import { updateMenu } from "@/lib/grab";
+import { buildOutletGrabMenu } from "@/lib/grab-menu-outlet";
+
+function serviceClient() {
+  return createClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.SUPABASE_SERVICE_ROLE_KEY || process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+  );
+}
 
 export async function POST(request: NextRequest) {
   const auth = await requireAuth(request);
@@ -42,9 +54,18 @@ export async function POST(request: NextRequest) {
     );
   }
 
+  const menu = await buildOutletGrabMenu(serviceClient(), merchantID);
+  if (!menu) {
+    return NextResponse.json(
+      { ok: false, error: "build_failed", error_description: "Could not build the menu for this outlet." },
+      { status: 500 },
+    );
+  }
+
   try {
-    const result = await notifyMenuUpdate(merchantID);
-    return NextResponse.json({ ok: true, merchantID, result });
+    const result = await updateMenu(menu);
+    const items = menu.categories.reduce((n, c) => n + c.items.length, 0);
+    return NextResponse.json({ ok: true, merchantID, categories: menu.categories.length, items, result });
   } catch (err) {
     return NextResponse.json(
       { ok: false, error: "sync_failed", error_description: err instanceof Error ? err.message : "Unknown error" },

--- a/apps/backoffice/src/lib/grab-menu-outlet.ts
+++ b/apps/backoffice/src/lib/grab-menu-outlet.ts
@@ -1,0 +1,89 @@
+/**
+ * Per-outlet GrabFood menu builder — the SINGLE source for both menu directions:
+ *   - inbound  "get menu" webhook  (Grab pulls our menu)        — api/pos/grab/merchant/menu
+ *   - outbound "sync menu" push     (we PUT our menu to Grab)    — api/pos/grab/sync
+ *
+ * Building it in one place guarantees what we PUSH is byte-for-byte what we'd
+ * SERVE on a pull: same channel-visible products, per-outlet service hours, and
+ * per-outlet 86 (stock-out) list. Backoffice stays the single source of truth.
+ */
+
+import type { SupabaseClient } from "@supabase/supabase-js";
+import {
+  buildGrabMenuPayload,
+  buildGrabServiceHours,
+  grabMenuOptionsFromEnv,
+  type RawProduct,
+} from "@/lib/grab-menu";
+
+/**
+ * Resolve a GrabFood merchant ID to the full per-outlet menu payload.
+ * Returns null only on a hard product-fetch failure (caller decides the HTTP code).
+ */
+export async function buildOutletGrabMenu(
+  supabase: SupabaseClient,
+  merchantId: string,
+): Promise<ReturnType<typeof buildGrabMenuPayload> | null> {
+  const [productsRes, categoriesRes] = await Promise.all([
+    supabase.from("products").select("*").order("category").order("name"),
+    supabase.from("categories").select("id, slug, name").order("position", { ascending: true }),
+  ]);
+
+  if (productsRes.error || !productsRes.data) {
+    console.error("[grab:build-menu] product fetch failed:", productsRes.error);
+    return null;
+  }
+
+  // Per-outlet open hours: merchantID → outlets.grab_merchant_id → outlet id →
+  // pos_branch_settings.grab_open_time/close/24h. Falls back to the env default.
+  let serviceHours: ReturnType<typeof buildGrabServiceHours> | undefined;
+  // Product ids 86'd at this merchant's outlet (per-outlet stock-outs) → forced
+  // UNAVAILABLE so a full sync respects the same overrides the live 86 push sends.
+  let unavailableIds: Set<string> | undefined;
+  if (merchantId) {
+    const { data: outlet } = await supabase
+      .from("outlets").select("id").eq("grab_merchant_id", merchantId).maybeSingle();
+    if (outlet?.id) {
+      const { data: bs } = await supabase
+        .from("pos_branch_settings")
+        .select("grab_open_time, grab_close_time, grab_open_24h")
+        .eq("outlet_id", outlet.id)
+        .maybeSingle();
+      if (bs) {
+        serviceHours = buildGrabServiceHours({
+          open: bs.grab_open_time, close: bs.grab_close_time, open24h: bs.grab_open_24h,
+        });
+      }
+      const { data: os } = await supabase
+        .from("outlet_settings").select("store_id").eq("loyalty_outlet_id", outlet.id).maybeSingle();
+      const storeId = (os as { store_id?: string } | null)?.store_id;
+      if (storeId) {
+        const { data: oos } = await supabase
+          .from("outlet_product_availability").select("product_id")
+          .eq("outlet_id", storeId).eq("is_available", false);
+        unavailableIds = new Set((oos ?? []).map((r: { product_id: string }) => r.product_id));
+      }
+    }
+  }
+
+  // Build slug→displayName map so Grab sees "Artisan Choc" instead of "artisan-choc".
+  const categoryNames: Record<string, string> = {};
+  for (const c of categoriesRes.data || []) {
+    if (c.slug && c.name) categoryNames[c.slug] = c.name;
+    if (c.id && c.name) categoryNames[c.id] = c.name; // products.category might store id too
+  }
+
+  // "Show on" placement: only products visible on the Grab channel ship (empty
+  // visible_channels = everywhere — same allow-list rule as modifiers).
+  const grabProducts = (productsRes.data as RawProduct[]).filter((p) => {
+    const vc = (p as { visible_channels?: string[] }).visible_channels;
+    return !Array.isArray(vc) || vc.length === 0 || vc.includes("grab");
+  });
+
+  return buildGrabMenuPayload(grabProducts, merchantId, {
+    ...grabMenuOptionsFromEnv(),
+    categoryNames,
+    serviceHours,
+    unavailableProductIds: unavailableIds,
+  });
+}


### PR DESCRIPTION
## Problem

Clicking **Sync menu** failed on both live stores with a Grab API error:

```
POST /partner/v1/merchant/menu/notification → 400
{"target":"UnsupportedMenuSync","reason":"invalid_argument","message":"Unsupported menu sync"}
```

The call reaches Grab and authenticates fine — but `notifyMenuUpdate` asks Grab to **re-pull** our menu, and our self-serve-activated stores aren't on the notify→pull model. They're on the **push** model: the partner PUTs the menu to Grab (the same family as our live 86/availability push, which already works).

## Fix

- **New `lib/grab-menu-outlet.buildOutletGrabMenu()`** — the single per-outlet menu builder (channel-visible products + per-outlet service hours + 86/stock-out list). Shared by both menu directions so a **push is byte-for-byte what a pull would serve**.
- **`/api/pos/grab/sync`** now builds that per-outlet menu and **PUTs it via `updateMenu` (`PUT /partner/v1/menu`)** instead of `notifyMenuUpdate`. On failure it surfaces Grab's exact message so any remaining issue is diagnosable from one click. Reads per-outlet data with the service-role key (like the webhook); the route stays staff-gated by `requireAuth`.
- **get-menu webhook** refactored onto the shared builder — **no behaviour change**, and it preserves the pull path that Tamarind's self-serve activation will use.
- Page copy updated: "pushed to GrabFood" instead of "Grab will re-pull".

## Why push is the right call

`UnsupportedMenuSync` on the notify endpoint is the direct signal these merchants don't accept the pull trigger; `updateMenu` is its push complement and is what the old outbound route already used. Pushing the full per-outlet menu (photos, prices, hidden items, hours, 86) is exactly "GrabFood follows backoffice."

## Test

- `tsc --noEmit` clean for all 4 changed files (3 unrelated pre-existing `@celsius/*` workspace-resolution errors on main, untouched).
- Builder reuse verified against the live get-menu webhook logic (same queries, same `buildGrabMenuPayload` call).
- Runtime push round-trip happens against live Grab OAuth + a staff session, so final verification is one click on the deployed integration page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)