### PR TITLE
fix(grab): sync menu via record push (price + availability); fix field bug

### DIFF
--- a/apps/backoffice/src/app/(admin)/settings/integrations/grab/page.tsx
+++ b/apps/backoffice/src/app/(admin)/settings/integrations/grab/page.tsx
@@ -153,10 +153,9 @@ export default function GrabIntegrationPage() {
     }
   };
 
-  // Push the latest backoffice menu to Grab for a linked outlet. The endpoint
-  // builds that outlet's menu (live 86 list + service hours) and PUTs it straight
-  // to GrabFood. Backoffice stays the source of truth — this makes GrabFood match
-  // it on demand instead of waiting on Grab.
+  // Push current prices + availability for this outlet's Grab-visible items to
+  // GrabFood (the on-demand record sync). Note: photos / item structure are NOT
+  // pushable via the API — those refresh only when Grab re-pulls our menu.
   const syncMenu = async (outletId: string, merchantID: string) => {
     setSyncBusy((s) => ({ ...s, [outletId]: true }));
     setSyncMsg((s) => ({ ...s, [outletId]: { ok: true, text: "" } }));
@@ -172,7 +171,7 @@ export default function GrabIntegrationPage() {
       }
       setSyncMsg((s) => ({
         ...s,
-        [outletId]: { ok: true, text: "Menu pushed to GrabFood — the storefront will reflect it shortly." },
+        [outletId]: { ok: true, text: "Prices & availability synced to GrabFood. (Photos refresh only on Grab's re-pull.)" },
       }));
     } catch (e) {
       setSyncMsg((s) => ({
@@ -186,7 +185,7 @@ export default function GrabIntegrationPage() {
 
   // Push the latest menu to every connected outlet at once (mirrors StoreHub's
   // top-bar "Sync Menu"). Fans out to the same per-outlet endpoint so each store
-  // gets its own menu pushed (live 86 list + hours).
+  // gets its prices + availability pushed.
   const syncAllMenus = async () => {
     const linked = (data?.outlets ?? []).filter((o) => o.grabMerchantId);
     if (linked.length === 0) return;
@@ -210,7 +209,7 @@ export default function GrabIntegrationPage() {
       ok: failed === 0,
       text:
         failed === 0
-          ? `Pushed menu to all ${ok} connected outlet${ok === 1 ? "" : "s"} — GrabFood will reflect it shortly.`
+          ? `Synced prices & availability to all ${ok} connected outlet${ok === 1 ? "" : "s"}.`
           : `${ok} synced, ${failed} failed. Use the per-outlet button below to retry the failures.`,
     });
     setSyncAllBusy(false);
@@ -250,7 +249,7 @@ export default function GrabIntegrationPage() {
             <button
               onClick={syncAllMenus}
               disabled={syncAllBusy}
-              title="Push the latest backoffice menu to every connected outlet"
+              title="Sync prices & availability to every connected outlet"
               className="inline-flex items-center gap-2 rounded bg-emerald-600 px-3 py-1.5 text-sm font-medium text-white hover:bg-emerald-700 disabled:cursor-not-allowed disabled:opacity-50"
             >
               {syncAllBusy ? <Loader2 className="h-4 w-4 animate-spin" /> : <RefreshCw className="h-4 w-4" />} Sync all menus
@@ -382,7 +381,7 @@ export default function GrabIntegrationPage() {
                     <button
                       onClick={() => syncMenu(o.id, o.grabMerchantId!)}
                       disabled={syncBusy[o.id]}
-                      title="Push the latest backoffice menu to Grab for this outlet"
+                      title="Sync prices & availability to GrabFood for this outlet"
                       className="inline-flex items-center gap-1.5 rounded border border-emerald-300 bg-emerald-50 px-2.5 py-1 text-sm font-medium text-emerald-700 hover:bg-emerald-100 disabled:cursor-not-allowed disabled:opacity-50"
                     >
                       {syncBusy[o.id] ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <RefreshCw className="h-3.5 w-3.5" />}

--- a/apps/backoffice/src/app/api/pos/availability/route.ts
+++ b/apps/backoffice/src/app/api/pos/availability/route.ts
@@ -85,8 +85,12 @@ export async function POST(req: NextRequest) {
     } else if (!isGrabConfigured()) {
       grab = "grab-not-configured";
     } else {
-      await batchUpdateMenu(merchantId, "availableStatus", [
-        { id: product_id, availableStatus: is_available ? "AVAILABLE" : "UNAVAILABLE" },
+      // field is the record TYPE ("ITEM"), attributes go in the entity. To set
+      // UNAVAILABLE Grab requires maxStock:0 alongside the status.
+      await batchUpdateMenu(merchantId, "ITEM", [
+        is_available
+          ? { id: product_id, availableStatus: "AVAILABLE" }
+          : { id: product_id, availableStatus: "UNAVAILABLE", maxStock: 0 },
       ]);
       grab = "pushed";
     }

--- a/apps/backoffice/src/app/api/pos/grab/menu/availability/route.ts
+++ b/apps/backoffice/src/app/api/pos/grab/menu/availability/route.ts
@@ -33,15 +33,16 @@ export async function PATCH(request: NextRequest) {
 
   const merchantId = process.env.GRAB_MERCHANT_ID!;
 
-  const menuEntities = items.map((item) => ({
-    id: item.id,
-    availableStatus: item.available
-      ? ("AVAILABLE" as const)
-      : ("UNAVAILABLE" as const),
-  }));
+  // field is the record TYPE ("ITEM"); attributes go in the entity. UNAVAILABLE
+  // requires maxStock:0 alongside the status.
+  const menuEntities = items.map((item) =>
+    item.available
+      ? { id: item.id, availableStatus: "AVAILABLE" as const }
+      : { id: item.id, availableStatus: "UNAVAILABLE" as const, maxStock: 0 },
+  );
 
   try {
-    const result = await batchUpdateMenu(merchantId, "availableStatus", menuEntities);
+    const result = await batchUpdateMenu(merchantId, "ITEM", menuEntities);
     return NextResponse.json({
       success: true,
       updated: items.length,

--- a/apps/backoffice/src/app/api/pos/grab/sync/route.ts
+++ b/apps/backoffice/src/app/api/pos/grab/sync/route.ts
@@ -1,23 +1,27 @@
 /**
- * Manual "Sync menu to Grab" — outbound push (us → Grab).
+ * Manual "Sync menu to Grab" — outbound record push (us → Grab).
  *
  * POST /api/pos/grab/sync   { merchantID }    (staff-auth)
  *
- * Builds the per-outlet menu (the SAME builder the get-menu webhook serves) and
- * PUTs it straight to Grab via updateMenu. We PUSH rather than notify: these
- * self-serve stores reject the notify→pull trigger — POST .../menu/notification
- * returns {"target":"UnsupportedMenuSync","reason":"invalid_argument"}. Pushing
- * makes GrabFood match backoffice on demand (corrected photos, hidden items,
- * price changes) instead of waiting on Grab.
+ * Pushes current PRICE + AVAILABILITY for every Grab-visible item to GrabFood via
+ * the Update Menu Record API (PUT /partner/v1/batch/menu, field "ITEM"). This is
+ * the only on-demand push GrabFood supports for self-serve-linked stores:
+ *   - notify→pull (.../menu/notification) → "UnsupportedMenuSync" (disabled here)
+ *   - full-menu upload                    → does not exist in the API
+ * So a sync keeps Grab's prices in line with backoffice and applies the per-outlet
+ * 86 list (sold-out items → UNAVAILABLE). It CANNOT change photos / item names /
+ * add-remove items — that menu *content* only refreshes when Grab re-pulls our
+ * get-menu webhook (i.e. at activation). Backoffice stays the source of truth.
  *
- * Per-outlet data (hours, 86 list) is read with the service-role key, same as the
- * inbound webhook; the route itself is staff-gated by requireAuth.
+ * Entities are taken straight off the shared per-outlet builder, so the ids,
+ * prices and availability we push are byte-for-byte what the get-menu webhook
+ * would serve. Service-role read for per-outlet data; route is staff-gated.
  */
 
 import { NextRequest, NextResponse } from "next/server";
 import { createClient } from "@supabase/supabase-js";
 import { requireAuth } from "@/lib/auth";
-import { updateMenu } from "@/lib/grab";
+import { batchUpdateMenu } from "@/lib/grab";
 import { buildOutletGrabMenu } from "@/lib/grab-menu-outlet";
 
 function serviceClient() {
@@ -62,10 +66,27 @@ export async function POST(request: NextRequest) {
     );
   }
 
+  // Flatten the menu's items into price/availability records. Same item ids the
+  // menu declares (= products.id), so they match what Grab pulled.
+  const entities = menu.categories
+    .flatMap((c) => c.items)
+    .map((it) => ({
+      id: it.id,
+      price: it.price,
+      availableStatus: it.availableStatus,
+      ...(it.maxStock != null ? { maxStock: it.maxStock } : {}),
+    }));
+
+  if (entities.length === 0) {
+    return NextResponse.json(
+      { ok: false, error: "empty_menu", error_description: "No Grab-visible items to sync for this outlet." },
+      { status: 400 },
+    );
+  }
+
   try {
-    const result = await updateMenu(menu);
-    const items = menu.categories.reduce((n, c) => n + c.items.length, 0);
-    return NextResponse.json({ ok: true, merchantID, categories: menu.categories.length, items, result });
+    const result = await batchUpdateMenu(merchantID, "ITEM", entities);
+    return NextResponse.json({ ok: true, merchantID, items: entities.length, result });
   } catch (err) {
     return NextResponse.json(
       { ok: false, error: "sync_failed", error_description: err instanceof Error ? err.message : "Unknown error" },

--- a/apps/backoffice/src/lib/grab.ts
+++ b/apps/backoffice/src/lib/grab.ts
@@ -204,16 +204,25 @@ export async function updateMenu(menu: GrabMenuPayload) {
 }
 
 /**
- * Batch update specific menu items (e.g. availability, price).
- * Field can be: "availableStatus", "price", "maxStock", etc.
+ * Batch update menu RECORDS — price / availability / stock for existing items.
+ * (Update Menu Record API: PUT /partner/v1/batch/menu.)
+ *
+ * IMPORTANT: `field` is the record TYPE — "ITEM" | "MODIFIER" | "CATEGORY" — NOT
+ * the attribute. The attributes (price, availableStatus, maxStock) live inside
+ * each menuEntity. Passing an attribute name here (e.g. "availableStatus") is
+ * malformed and Grab rejects it with `invalid_argument`.
+ *
+ * Note: to set an item UNAVAILABLE you must send BOTH availableStatus:"UNAVAILABLE"
+ * AND maxStock:0 (Grab treats maxStock>0 as AVAILABLE).
  */
 export async function batchUpdateMenu(
   merchantId: string,
-  field: string,
+  field: "ITEM" | "MODIFIER" | "CATEGORY",
   menuEntities: Array<{
     id: string;
     price?: number;
     availableStatus?: "AVAILABLE" | "UNAVAILABLE" | "HIDE";
+    maxStock?: number;
   }>,
 ) {
   return grabRequest("/partner/v1/batch/menu", {


### PR DESCRIPTION
## Problem

The Sync button errored — `PUT /partner/v1/menu → 400 "Invalid parameters!"`. Root cause: that endpoint is GrabFood's **Update Menu Record** (per-record), not a full-menu upload. Confirmed against the Go SDK source — there is **no full-menu push endpoint**. Menu *content* (photos, item names, add/remove) only refreshes when Grab **pulls** our get-menu webhook (at activation).

A second, deeper bug: `batchUpdateMenu` callers passed `field: "availableStatus"`, but `field` is the **record type** (`"ITEM"`/`"MODIFIER"`/`"CATEGORY"`) — the attributes belong inside each `MenuEntity`. So even the existing 86/availability push was malformed; it just never surfaced because its errors are swallowed and no one had 86'd a Grab item.

## Fix

What the API *can* push on demand is **price + availability** per record. So:

- **`/api/pos/grab/sync`** now flattens the per-outlet menu (shared `buildOutletGrabMenu`) into `ITEM` records and pushes them via `batchUpdateMenu` (`PUT /partner/v1/batch/menu`). Item ids are `products.id` — exactly what the get-menu builder declares, so they match what Grab pulled. This syncs prices and applies the 86 list (sold-out → `UNAVAILABLE` + `maxStock:0`), which also **hides the half-boiled-egg items** on Grab.
- **`batchUpdateMenu`**: `field` typed to `"ITEM" | "MODIFIER" | "CATEGORY"` (not a free string), `maxStock` added to the entity. The tighter type **caught a second buggy caller** at compile time.
- **Fixed both latent callers** (`api/pos/availability`, `api/pos/grab/menu/availability`) — now `field: "ITEM"` with `maxStock:0` on `UNAVAILABLE`.
- Page copy/tooltips updated: "prices & availability", and a note that **photos refresh only on Grab's re-pull**.

## Scope / honesty

This makes the button do the **only on-demand sync GrabFood allows** for self-serve stores. It deliberately does **not** claim to push photos/structure — those are a re-pull (re-activation) concern, tracked separately. `notify→pull` stays off for these stores (`UnsupportedMenuSync`).

## Test

- `tsc --noEmit` clean for all 5 changed files (3 unrelated pre-existing `@celsius/*` errors on main, untouched).
- Entity ids/prices verified against `convertProductToGrabItem` (`id: products.id`, `price: resolveGrabPriceRM × 100`).
- The live push round-trips against Grab + a staff session, so final proof is one click on the deployed page (and the button now surfaces Grab's exact response).

🤖 Generated with [Claude Code](https://claude.com/claude-code)