### PR TITLE
feat(grab): auto-accept orders on receipt

### DIFF
--- a/apps/backoffice/src/app/api/pos/grab/webhook/route.ts
+++ b/apps/backoffice/src/app/api/pos/grab/webhook/route.ts
@@ -12,7 +12,7 @@
 
 import { NextRequest, NextResponse } from "next/server";
 import { randomUUID } from "crypto";
-import { verifyWebhookSignature } from "@/lib/grab";
+import { acceptRejectOrder, verifyWebhookSignature } from "@/lib/grab";
 import { verifyGrabPartnerToken } from "@/lib/grab-partner";
 import { createClient } from "@/lib/supabase-server";
 
@@ -317,12 +317,34 @@ export async function POST(request: NextRequest) {
     });
     if (payErr) console.error("[grab:webhook] payment insert failed:", payErr);
 
-    console.log(`[grab:webhook] CREATED order=${order.id} external=${orderID} outlet=${outletId} total=${total}`);
+    // 8. Auto-accept the order on Grab so it leaves PENDING and the lifecycle
+    //    advances via the API — otherwise it sits "open" until someone accepts in
+    //    the GrabMerchant app. The order is already recorded + printing locally,
+    //    so this is best-effort: a failed or duplicate accept never fails the
+    //    webhook. Uses the OUTBOUND OAuth pair (us → Grab).
+    let grabAccepted = false;
+    if (process.env.GRAB_CLIENT_ID && process.env.GRAB_CLIENT_SECRET) {
+      try {
+        await acceptRejectOrder(orderID, "ACCEPTED");
+        grabAccepted = true;
+        console.log(`[grab:webhook] auto-accepted orderID=${orderID}`);
+      } catch (e) {
+        console.warn(
+          `[grab:webhook] auto-accept failed orderID=${orderID}:`,
+          e instanceof Error ? e.message : e,
+        );
+      }
+    }
+
+    console.log(
+      `[grab:webhook] CREATED order=${order.id} external=${orderID} outlet=${outletId} total=${total} accepted=${grabAccepted}`,
+    );
     return NextResponse.json({
       success: true,
       action: "created",
       orderId: order.id,
       orderNumber: `GF-${payload.shortOrderNumber}`,
+      grabAccepted,
     });
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);


### PR DESCRIPTION
## Why
Your Grab orders arrive (100% order sync) but were **never accepted via the API** — nothing in the UI or webhook called `acceptRejectOrder`. So orders sat **PENDING/"open"** until someone accepted them in the GrabMerchant app, and Grab scored *accept* as un-integrated (a big chunk of the **40% feature-integration** gap).

## What
The order webhook now auto-accepts each new order the moment it's recorded:
- Calls `acceptRejectOrder(orderID, "ACCEPTED")` after the Submit Order is stored + printed.
- **Best-effort + gated** on the outbound OAuth pair (`GRAB_CLIENT_ID`/`SECRET`): a failed or duplicate accept is logged (`auto-accept failed …`) and **never fails the webhook** — the order is already saved + on the kitchen docket.
- Fires **only on order CREATE** — not on status pushes, not on duplicate re-deliveries.
- Surfaces `accepted=<bool>` in the `CREATED` log + the response.

## Impact
- Orders stop sitting "open" — they advance to ACCEPTED on Grab immediately.
- Exercises the Accept feature → moves the feature-integration score up.
- Backend-only → ships via Vercel, **no APK**.

## Test
- `tsc --noEmit` clean (only the 3 known pre-existing `@celsius/*` errors, untouched).
- Verify post-deploy: next live order's `[grab:webhook]` log shows `accepted=true`, and the order no longer flips to "open" in the integration panel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)