### PR TITLE
fix(grab): link Grab item ids to POS products so dockets route to kitchen

### DIFF
--- a/apps/backoffice/src/app/(admin)/settings/integrations/grab/item-links/page.tsx
+++ b/apps/backoffice/src/app/(admin)/settings/integrations/grab/item-links/page.tsx
@@ -26,13 +26,15 @@ type LinkItem = {
 };
 type Unlinked = {
   grabItemId: string;
+  grabName: string | null;
   sampleName: string | null;
   lastPriceRM: number | null;
   basePriceRM: number | null;
   seen: number;
   lastSeen: string;
-  // Catalogue products at the same base price + the confident single match.
+  // Catalogue products matched by name/price + the confident single match.
   candidateIds: string[];
+  matchedByName: boolean;
   suggestedProductId: string | null;
 };
 type Data = { products: Product[]; links: LinkItem[]; unlinked: Unlinked[] };
@@ -243,7 +245,10 @@ export default function GrabItemLinksPage() {
               {data.unlinked.map((u) => (
                 <tr key={u.grabItemId} className="text-neutral-800">
                   <td className="px-5 py-2">
-                    <code className="text-xs">{u.grabItemId}</code>
+                    {u.grabName ? (
+                      <div className="text-sm font-medium text-neutral-900">{u.grabName}</div>
+                    ) : null}
+                    <code className="text-xs text-neutral-500">{u.grabItemId}</code>
                     <div className="text-xs text-neutral-400">
                       last seen {new Date(u.lastSeen).toLocaleString("en-MY", { dateStyle: "short", timeStyle: "short" })}
                     </div>
@@ -280,7 +285,7 @@ export default function GrabItemLinksPage() {
                           ))}
                         </optgroup>
                       </select>
-                      <MatchBadge count={u.candidateIds.length} />
+                      <MatchBadge count={u.candidateIds.length} byName={u.matchedByName} />
                     </div>
                   </td>
                   <td className="px-5 py-2 text-right">
@@ -353,7 +358,14 @@ export default function GrabItemLinksPage() {
 
 // Confidence hint next to each unlinked row's product picker, driven by how
 // many catalogue products share the item's base price.
-function MatchBadge({ count }: { count: number }) {
+function MatchBadge({ count, byName }: { count: number; byName?: boolean }) {
+  if (byName) {
+    return (
+      <span className="whitespace-nowrap rounded-full bg-emerald-100 px-2 py-0.5 text-xs font-medium text-emerald-700">
+        name match
+      </span>
+    );
+  }
   if (count === 1) {
     return (
       <span className="whitespace-nowrap rounded-full bg-emerald-100 px-2 py-0.5 text-xs font-medium text-emerald-700">

--- a/apps/backoffice/src/app/(admin)/settings/integrations/grab/item-links/page.tsx
+++ b/apps/backoffice/src/app/(admin)/settings/integrations/grab/item-links/page.tsx
@@ -1,0 +1,281 @@
+"use client";
+
+/**
+ * GrabFood item linking.
+ *
+ * Grab order webhooks carry Grab's OWN item id (e.g. "MYITE2026…"), which never
+ * matches our products.id — so unlinked lines reach the kitchen as
+ * "Item @ RM x [MYITE..]" with no station routing. This page lets staff map
+ * each Grab item id seen on recent orders to the real POS product. Linking
+ * backfills the recent orders and fixes every future one (see
+ * /api/integrations/grab/item-links + the order webhook).
+ */
+
+import { useCallback, useEffect, useMemo, useState } from "react";
+import Link from "next/link";
+import { Loader2, RefreshCw, Link2, Unlink, ArrowLeft, CheckCircle2 } from "lucide-react";
+
+type Product = { id: string; name: string; category: string | null; priceRM: number };
+type LinkItem = {
+  grabItemId: string;
+  productId: string;
+  productName: string | null;
+  label: string | null;
+  lastPriceRM: number | null;
+  updatedAt: string;
+};
+type Unlinked = {
+  grabItemId: string;
+  sampleName: string | null;
+  lastPriceRM: number | null;
+  seen: number;
+  lastSeen: string;
+};
+type Data = { products: Product[]; links: LinkItem[]; unlinked: Unlinked[] };
+
+export default function GrabItemLinksPage() {
+  const [data, setData] = useState<Data | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  // Per-row selected product id (keyed by grab item id) + busy flags.
+  const [picks, setPicks] = useState<Record<string, string>>({});
+  const [busy, setBusy] = useState<Record<string, boolean>>({});
+  const [flash, setFlash] = useState<string | null>(null);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await fetch("/api/integrations/grab/item-links", { cache: "no-store" });
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      setData((await res.json()) as Data);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Failed to load");
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  const productLabel = useCallback(
+    (p: Product) => `${p.name}${p.priceRM ? ` · RM ${p.priceRM.toFixed(2)}` : ""}${p.category ? ` (${p.category})` : ""}`,
+    [],
+  );
+
+  const sortedProducts = useMemo(
+    () => (data?.products ?? []).slice().sort((a, b) => a.name.localeCompare(b.name)),
+    [data?.products],
+  );
+
+  const link = async (grabItemId: string, lastPriceRM: number | null, sampleName: string | null) => {
+    const productId = picks[grabItemId];
+    if (!productId) return;
+    setBusy((s) => ({ ...s, [grabItemId]: true }));
+    try {
+      const res = await fetch("/api/integrations/grab/item-links", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          grabItemId,
+          productId,
+          label: sampleName,
+          lastPrice: lastPriceRM != null ? Math.round(lastPriceRM * 100) : null,
+        }),
+      });
+      const json = await res.json();
+      if (!res.ok || !json.success) throw new Error(json.error || `HTTP ${res.status}`);
+      setFlash(`Linked ${grabItemId} → ${json.productName}${json.backfilled ? ` · fixed ${json.backfilled} order line(s)` : ""}`);
+      setPicks((s) => {
+        const next = { ...s };
+        delete next[grabItemId];
+        return next;
+      });
+      await load();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Link failed");
+    } finally {
+      setBusy((s) => ({ ...s, [grabItemId]: false }));
+    }
+  };
+
+  const unlink = async (grabItemId: string) => {
+    setBusy((s) => ({ ...s, [grabItemId]: true }));
+    try {
+      const res = await fetch("/api/integrations/grab/item-links", {
+        method: "DELETE",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ grabItemId }),
+      });
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      await load();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Unlink failed");
+    } finally {
+      setBusy((s) => ({ ...s, [grabItemId]: false }));
+    }
+  };
+
+  if (loading) {
+    return (
+      <div className="flex h-64 items-center justify-center">
+        <Loader2 className="h-6 w-6 animate-spin text-neutral-400" />
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-6 p-6">
+      <div className="flex items-start justify-between gap-4">
+        <div>
+          <Link
+            href="/settings/integrations/grab"
+            className="mb-1 inline-flex items-center gap-1 text-xs text-neutral-500 hover:text-neutral-700"
+          >
+            <ArrowLeft className="h-3 w-3" /> Back to GrabFood integration
+          </Link>
+          <h1 className="text-2xl font-semibold text-neutral-900">GrabFood item linking</h1>
+          <p className="mt-1 max-w-2xl text-sm text-neutral-600">
+            Grab sends its own item ids on orders, which don&apos;t match our menu. Unlinked items reach the
+            kitchen as a bare &quot;Item&quot; with no station routing. Map each Grab item to the right product —
+            linking fixes recent orders and every future one.
+          </p>
+        </div>
+        <button
+          onClick={load}
+          className="inline-flex items-center gap-2 rounded border border-neutral-300 bg-white px-3 py-1.5 text-sm font-medium text-neutral-700 hover:bg-neutral-50"
+        >
+          <RefreshCw className="h-4 w-4" /> Refresh
+        </button>
+      </div>
+
+      {flash ? (
+        <div className="flex items-center gap-2 rounded border border-emerald-200 bg-emerald-50 p-3 text-sm text-emerald-700">
+          <CheckCircle2 className="h-4 w-4" /> {flash}
+        </div>
+      ) : null}
+      {error ? (
+        <div className="rounded border border-red-200 bg-red-50 p-3 text-sm text-red-700">{error}</div>
+      ) : null}
+
+      {/* Unlinked items */}
+      <section className="rounded-lg border border-neutral-200 bg-white">
+        <header className="border-b border-neutral-200 px-5 py-3">
+          <h2 className="text-base font-medium text-neutral-900">
+            Unlinked Grab items{data ? ` (${data.unlinked.length})` : ""}
+          </h2>
+          <p className="mt-0.5 text-sm text-neutral-600">
+            Distinct Grab item ids seen on orders in the last 45 days that aren&apos;t mapped to a product yet.
+          </p>
+        </header>
+        {!data || data.unlinked.length === 0 ? (
+          <div className="px-5 py-8 text-center text-sm text-neutral-500">
+            Nothing unlinked — every recent Grab item maps to a product. 🎉
+          </div>
+        ) : (
+          <table className="w-full text-sm">
+            <thead className="border-b border-neutral-100 text-left text-xs uppercase tracking-wide text-neutral-500">
+              <tr>
+                <th className="px-5 py-2">Grab item id</th>
+                <th className="px-5 py-2 text-right">Price</th>
+                <th className="px-5 py-2 text-right">Seen</th>
+                <th className="px-5 py-2">Link to product</th>
+                <th className="px-5 py-2" />
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-neutral-100">
+              {data.unlinked.map((u) => (
+                <tr key={u.grabItemId} className="text-neutral-800">
+                  <td className="px-5 py-2">
+                    <code className="text-xs">{u.grabItemId}</code>
+                    <div className="text-xs text-neutral-400">
+                      last seen {new Date(u.lastSeen).toLocaleString("en-MY", { dateStyle: "short", timeStyle: "short" })}
+                    </div>
+                  </td>
+                  <td className="px-5 py-2 text-right font-mono text-xs">
+                    {u.lastPriceRM != null ? `RM ${u.lastPriceRM.toFixed(2)}` : "—"}
+                  </td>
+                  <td className="px-5 py-2 text-right text-xs text-neutral-500">{u.seen}×</td>
+                  <td className="px-5 py-2">
+                    <select
+                      value={picks[u.grabItemId] ?? ""}
+                      onChange={(e) => setPicks((s) => ({ ...s, [u.grabItemId]: e.target.value }))}
+                      className="w-72 rounded border border-neutral-300 px-2 py-1 text-sm focus:border-neutral-500 focus:outline-none"
+                    >
+                      <option value="">Select product…</option>
+                      {sortedProducts.map((p) => (
+                        <option key={p.id} value={p.id}>
+                          {productLabel(p)}
+                        </option>
+                      ))}
+                    </select>
+                  </td>
+                  <td className="px-5 py-2 text-right">
+                    <button
+                      onClick={() => link(u.grabItemId, u.lastPriceRM, u.sampleName)}
+                      disabled={!picks[u.grabItemId] || busy[u.grabItemId]}
+                      className="inline-flex items-center gap-1.5 rounded bg-emerald-600 px-2.5 py-1 text-sm font-medium text-white hover:bg-emerald-700 disabled:cursor-not-allowed disabled:opacity-40"
+                    >
+                      {busy[u.grabItemId] ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <Link2 className="h-3.5 w-3.5" />}
+                      Link
+                    </button>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        )}
+      </section>
+
+      {/* Existing links */}
+      <section className="rounded-lg border border-neutral-200 bg-white">
+        <header className="border-b border-neutral-200 px-5 py-3">
+          <h2 className="text-base font-medium text-neutral-900">
+            Linked items{data ? ` (${data.links.length})` : ""}
+          </h2>
+        </header>
+        {!data || data.links.length === 0 ? (
+          <div className="px-5 py-8 text-center text-sm text-neutral-500">No links yet.</div>
+        ) : (
+          <table className="w-full text-sm">
+            <thead className="border-b border-neutral-100 text-left text-xs uppercase tracking-wide text-neutral-500">
+              <tr>
+                <th className="px-5 py-2">Grab item id</th>
+                <th className="px-5 py-2">Product</th>
+                <th className="px-5 py-2 text-right">Price seen</th>
+                <th className="px-5 py-2" />
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-neutral-100">
+              {data.links.map((l) => (
+                <tr key={l.grabItemId} className="text-neutral-800">
+                  <td className="px-5 py-2">
+                    <code className="text-xs">{l.grabItemId}</code>
+                  </td>
+                  <td className="px-5 py-2">
+                    {l.productName ?? <span className="text-red-600">missing ({l.productId})</span>}
+                  </td>
+                  <td className="px-5 py-2 text-right font-mono text-xs">
+                    {l.lastPriceRM != null ? `RM ${l.lastPriceRM.toFixed(2)}` : "—"}
+                  </td>
+                  <td className="px-5 py-2 text-right">
+                    <button
+                      onClick={() => unlink(l.grabItemId)}
+                      disabled={busy[l.grabItemId]}
+                      className="inline-flex items-center gap-1.5 rounded border border-neutral-300 bg-white px-2.5 py-1 text-sm font-medium text-neutral-700 hover:bg-neutral-50 disabled:opacity-40"
+                    >
+                      {busy[l.grabItemId] ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <Unlink className="h-3.5 w-3.5" />}
+                      Unlink
+                    </button>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        )}
+      </section>
+    </div>
+  );
+}

--- a/apps/backoffice/src/app/(admin)/settings/integrations/grab/item-links/page.tsx
+++ b/apps/backoffice/src/app/(admin)/settings/integrations/grab/item-links/page.tsx
@@ -28,8 +28,12 @@ type Unlinked = {
   grabItemId: string;
   sampleName: string | null;
   lastPriceRM: number | null;
+  basePriceRM: number | null;
   seen: number;
   lastSeen: string;
+  // Catalogue products at the same base price + the confident single match.
+  candidateIds: string[];
+  suggestedProductId: string | null;
 };
 type Data = { products: Product[]; links: LinkItem[]; unlinked: Unlinked[] };
 
@@ -48,7 +52,15 @@ export default function GrabItemLinksPage() {
     try {
       const res = await fetch("/api/integrations/grab/item-links", { cache: "no-store" });
       if (!res.ok) throw new Error(`HTTP ${res.status}`);
-      setData((await res.json()) as Data);
+      const json = (await res.json()) as Data;
+      setData(json);
+      // Pre-fill each row with its confident single-match suggestion so staff
+      // just confirm. Ambiguous rows stay blank for a manual pick.
+      setPicks(
+        Object.fromEntries(
+          json.unlinked.filter((u) => u.suggestedProductId).map((u) => [u.grabItemId, u.suggestedProductId!]),
+        ),
+      );
     } catch (e) {
       setError(e instanceof Error ? e.message : "Failed to load");
     } finally {
@@ -69,36 +81,62 @@ export default function GrabItemLinksPage() {
     () => (data?.products ?? []).slice().sort((a, b) => a.name.localeCompare(b.name)),
     [data?.products],
   );
+  const productById = useMemo(
+    () => new Map((data?.products ?? []).map((p) => [p.id, p] as const)),
+    [data?.products],
+  );
+  const uniqueMatchCount = useMemo(
+    () => (data?.unlinked ?? []).filter((u) => u.suggestedProductId).length,
+    [data?.unlinked],
+  );
+
+  // Single POST. Returns the linked product name on success (for the flash /
+  // bulk summary), or throws.
+  const postLink = async (grabItemId: string, productId: string, lastPriceRM: number | null, sampleName: string | null) => {
+    const res = await fetch("/api/integrations/grab/item-links", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        grabItemId,
+        productId,
+        label: sampleName,
+        lastPrice: lastPriceRM != null ? Math.round(lastPriceRM * 100) : null,
+      }),
+    });
+    const json = await res.json();
+    if (!res.ok || !json.success) throw new Error(json.error || `HTTP ${res.status}`);
+    return json as { productName: string; backfilled: number };
+  };
 
   const link = async (grabItemId: string, lastPriceRM: number | null, sampleName: string | null) => {
     const productId = picks[grabItemId];
     if (!productId) return;
     setBusy((s) => ({ ...s, [grabItemId]: true }));
     try {
-      const res = await fetch("/api/integrations/grab/item-links", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          grabItemId,
-          productId,
-          label: sampleName,
-          lastPrice: lastPriceRM != null ? Math.round(lastPriceRM * 100) : null,
-        }),
-      });
-      const json = await res.json();
-      if (!res.ok || !json.success) throw new Error(json.error || `HTTP ${res.status}`);
+      const json = await postLink(grabItemId, productId, lastPriceRM, sampleName);
       setFlash(`Linked ${grabItemId} → ${json.productName}${json.backfilled ? ` · fixed ${json.backfilled} order line(s)` : ""}`);
-      setPicks((s) => {
-        const next = { ...s };
-        delete next[grabItemId];
-        return next;
-      });
       await load();
     } catch (e) {
       setError(e instanceof Error ? e.message : "Link failed");
     } finally {
       setBusy((s) => ({ ...s, [grabItemId]: false }));
     }
+  };
+
+  // One-click link every row that has a confident single price match.
+  const autoLinkUnique = async () => {
+    const targets = (data?.unlinked ?? []).filter((u) => u.suggestedProductId);
+    if (targets.length === 0) return;
+    setBusy((s) => ({ ...s, __bulk: true }));
+    setError(null);
+    const results = await Promise.allSettled(
+      targets.map((u) => postLink(u.grabItemId, u.suggestedProductId!, u.lastPriceRM, u.sampleName)),
+    );
+    const ok = results.filter((r) => r.status === "fulfilled").length;
+    const failed = results.length - ok;
+    setFlash(`Auto-linked ${ok} unique match${ok === 1 ? "" : "es"}${failed ? ` · ${failed} failed` : ""}.`);
+    setBusy((s) => ({ ...s, __bulk: false }));
+    await load();
   };
 
   const unlink = async (grabItemId: string) => {
@@ -143,12 +181,25 @@ export default function GrabItemLinksPage() {
             linking fixes recent orders and every future one.
           </p>
         </div>
-        <button
-          onClick={load}
-          className="inline-flex items-center gap-2 rounded border border-neutral-300 bg-white px-3 py-1.5 text-sm font-medium text-neutral-700 hover:bg-neutral-50"
-        >
-          <RefreshCw className="h-4 w-4" /> Refresh
-        </button>
+        <div className="flex items-center gap-2">
+          {uniqueMatchCount > 0 ? (
+            <button
+              onClick={autoLinkUnique}
+              disabled={busy.__bulk}
+              title="Link every Grab item that matches exactly one product by price"
+              className="inline-flex items-center gap-2 rounded bg-emerald-600 px-3 py-1.5 text-sm font-medium text-white hover:bg-emerald-700 disabled:cursor-not-allowed disabled:opacity-50"
+            >
+              {busy.__bulk ? <Loader2 className="h-4 w-4 animate-spin" /> : <Link2 className="h-4 w-4" />}
+              Auto-link {uniqueMatchCount} unique match{uniqueMatchCount === 1 ? "" : "es"}
+            </button>
+          ) : null}
+          <button
+            onClick={load}
+            className="inline-flex items-center gap-2 rounded border border-neutral-300 bg-white px-3 py-1.5 text-sm font-medium text-neutral-700 hover:bg-neutral-50"
+          >
+            <RefreshCw className="h-4 w-4" /> Refresh
+          </button>
+        </div>
       </div>
 
       {flash ? (
@@ -168,6 +219,9 @@ export default function GrabItemLinksPage() {
           </h2>
           <p className="mt-0.5 text-sm text-neutral-600">
             Distinct Grab item ids seen on orders in the last 45 days that aren&apos;t mapped to a product yet.
+            We suggest catalogue products by base price (the item price minus add-ons). A single price match is
+            pre-selected — use <span className="font-medium">Auto-link</span> for those; pick from the shortlist
+            where several products share a price.
           </p>
         </header>
         {!data || data.unlinked.length === 0 ? (
@@ -199,18 +253,35 @@ export default function GrabItemLinksPage() {
                   </td>
                   <td className="px-5 py-2 text-right text-xs text-neutral-500">{u.seen}×</td>
                   <td className="px-5 py-2">
-                    <select
-                      value={picks[u.grabItemId] ?? ""}
-                      onChange={(e) => setPicks((s) => ({ ...s, [u.grabItemId]: e.target.value }))}
-                      className="w-72 rounded border border-neutral-300 px-2 py-1 text-sm focus:border-neutral-500 focus:outline-none"
-                    >
-                      <option value="">Select product…</option>
-                      {sortedProducts.map((p) => (
-                        <option key={p.id} value={p.id}>
-                          {productLabel(p)}
-                        </option>
-                      ))}
-                    </select>
+                    <div className="flex items-center gap-2">
+                      <select
+                        value={picks[u.grabItemId] ?? ""}
+                        onChange={(e) => setPicks((s) => ({ ...s, [u.grabItemId]: e.target.value }))}
+                        className="w-72 rounded border border-neutral-300 px-2 py-1 text-sm focus:border-neutral-500 focus:outline-none"
+                      >
+                        <option value="">Select product…</option>
+                        {u.candidateIds.length > 0 ? (
+                          <optgroup label={`Price match${u.basePriceRM != null ? ` · RM ${u.basePriceRM.toFixed(2)}` : ""}`}>
+                            {u.candidateIds.map((id) => {
+                              const p = productById.get(id);
+                              return p ? (
+                                <option key={id} value={id}>
+                                  {productLabel(p)}
+                                </option>
+                              ) : null;
+                            })}
+                          </optgroup>
+                        ) : null}
+                        <optgroup label="All products">
+                          {sortedProducts.map((p) => (
+                            <option key={p.id} value={p.id}>
+                              {productLabel(p)}
+                            </option>
+                          ))}
+                        </optgroup>
+                      </select>
+                      <MatchBadge count={u.candidateIds.length} />
+                    </div>
                   </td>
                   <td className="px-5 py-2 text-right">
                     <button
@@ -277,5 +348,29 @@ export default function GrabItemLinksPage() {
         )}
       </section>
     </div>
+  );
+}
+
+// Confidence hint next to each unlinked row's product picker, driven by how
+// many catalogue products share the item's base price.
+function MatchBadge({ count }: { count: number }) {
+  if (count === 1) {
+    return (
+      <span className="whitespace-nowrap rounded-full bg-emerald-100 px-2 py-0.5 text-xs font-medium text-emerald-700">
+        1 match
+      </span>
+    );
+  }
+  if (count > 1) {
+    return (
+      <span className="whitespace-nowrap rounded-full bg-amber-100 px-2 py-0.5 text-xs font-medium text-amber-700">
+        {count} matches
+      </span>
+    );
+  }
+  return (
+    <span className="whitespace-nowrap rounded-full bg-neutral-100 px-2 py-0.5 text-xs font-medium text-neutral-500">
+      no price match
+    </span>
   );
 }

--- a/apps/backoffice/src/app/(admin)/settings/integrations/grab/page.tsx
+++ b/apps/backoffice/src/app/(admin)/settings/integrations/grab/page.tsx
@@ -14,6 +14,7 @@
  */
 
 import { useEffect, useState, useCallback } from "react";
+import NextLink from "next/link";
 import {
   Loader2,
   CheckCircle2,
@@ -245,6 +246,13 @@ export default function GrabIntegrationPage() {
           </p>
         </div>
         <div className="flex items-center gap-2">
+          <NextLink
+            href="/settings/integrations/grab/item-links"
+            title="Map Grab item ids to POS products so order lines reach the kitchen with the right name + station"
+            className="inline-flex items-center gap-2 rounded border border-neutral-300 bg-white px-3 py-1.5 text-sm font-medium text-neutral-700 hover:bg-neutral-50"
+          >
+            <Link2 className="h-4 w-4" /> Item linking
+          </NextLink>
           {linkedCount > 0 ? (
             <button
               onClick={syncAllMenus}

--- a/apps/backoffice/src/app/api/integrations/grab/item-links/route.ts
+++ b/apps/backoffice/src/app/api/integrations/grab/item-links/route.ts
@@ -1,0 +1,177 @@
+/**
+ * GrabFood item-linking admin API (BackOffice side).
+ *
+ * Grab order webhooks carry Grab's OWN item id (item.id = "MYITE…"), which
+ * never matches products.id — so unlinked lines print as "Item @ RM x [MYITE..]"
+ * with no kitchen_station. This endpoint manages the grab_item_links mapping
+ * the order webhook consults to resolve the real product.
+ *
+ * GET    /api/integrations/grab/item-links → { products[], links[], unlinked[] }
+ * POST   /api/integrations/grab/item-links → { grabItemId, productId } → upsert + backfill
+ * DELETE /api/integrations/grab/item-links → { grabItemId } → remove link
+ *
+ * Raw SQL via Prisma: products / pos_order_items / grab_item_links are POS
+ * (Supabase-migration) tables not modelled in the Prisma schema — same pattern
+ * as the sibling /api/integrations/grab route.
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+import { getUserFromHeaders } from "@/lib/auth";
+import { Prisma } from "@prisma/client";
+
+type ProductRow = {
+  id: string;
+  name: string;
+  category: string | null;
+  price: number | null;
+  price_grab: number | null;
+  grabfood_price: number | null;
+};
+
+type LinkRow = {
+  grab_item_id: string;
+  product_id: string;
+  product_name: string | null;
+  label: string | null;
+  last_price: number | null;
+  updated_at: Date;
+};
+
+type UnlinkedRow = {
+  grab_item_id: string;
+  sample_name: string | null;
+  last_price: number | null;
+  seen: bigint;
+  last_seen: Date;
+};
+
+export async function GET(req: NextRequest) {
+  const caller = await getUserFromHeaders(req.headers);
+  if (!caller) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+
+  // Catalogue for the link dropdown — Grab-visible price first for the hint.
+  const products = await prisma.$queryRaw<ProductRow[]>(Prisma.sql`
+    SELECT id, name, category, price, price_grab, grabfood_price
+    FROM products
+    ORDER BY category NULLS LAST, name ASC
+  `);
+
+  // Existing links + the product name they resolve to.
+  const links = await prisma.$queryRaw<LinkRow[]>(Prisma.sql`
+    SELECT g.grab_item_id, g.product_id, p.name AS product_name,
+           g.label, g.last_price, g.updated_at
+    FROM grab_item_links g
+    LEFT JOIN products p ON p.id = g.product_id
+    ORDER BY g.updated_at DESC
+  `);
+
+  // Distinct Grab item ids seen on recent orders that are neither a known
+  // product nor already linked — i.e. the things still showing as "Item".
+  const unlinked = await prisma.$queryRaw<UnlinkedRow[]>(Prisma.sql`
+    SELECT i.product_id AS grab_item_id,
+           MAX(i.product_name) AS sample_name,
+           MAX(i.unit_price)   AS last_price,
+           COUNT(*)            AS seen,
+           MAX(o.created_at)   AS last_seen
+    FROM pos_order_items i
+    JOIN pos_orders o ON o.id = i.order_id
+    WHERE o.source = 'grabfood'
+      AND o.created_at > NOW() - INTERVAL '45 days'
+      AND NOT EXISTS (SELECT 1 FROM products p WHERE p.id = i.product_id)
+      AND NOT EXISTS (SELECT 1 FROM grab_item_links g WHERE g.grab_item_id = i.product_id)
+    GROUP BY i.product_id
+    ORDER BY last_seen DESC
+    LIMIT 200
+  `);
+
+  return NextResponse.json({
+    products: products.map((p) => ({
+      id: p.id,
+      name: p.name,
+      category: p.category,
+      priceRM: Number(p.price_grab ?? p.grabfood_price ?? p.price ?? 0),
+    })),
+    links: links.map((l) => ({
+      grabItemId: l.grab_item_id,
+      productId: l.product_id,
+      productName: l.product_name,
+      label: l.label,
+      lastPriceRM: l.last_price != null ? l.last_price / 100 : null,
+      updatedAt: l.updated_at,
+    })),
+    unlinked: unlinked.map((u) => ({
+      grabItemId: u.grab_item_id,
+      sampleName: u.sample_name,
+      lastPriceRM: u.last_price != null ? Number(u.last_price) / 100 : null,
+      seen: Number(u.seen),
+      lastSeen: u.last_seen,
+    })),
+  });
+}
+
+export async function POST(req: NextRequest) {
+  const caller = await getUserFromHeaders(req.headers);
+  if (!caller) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+
+  const body = (await req.json().catch(() => ({}))) as {
+    grabItemId?: string;
+    productId?: string;
+    label?: string | null;
+    lastPrice?: number | null;
+  };
+  const grabItemId = (body.grabItemId || "").trim();
+  const productId = (body.productId || "").trim();
+  if (!grabItemId || !productId) {
+    return NextResponse.json({ error: "grabItemId and productId are required" }, { status: 400 });
+  }
+
+  // Guard against a typo'd product id (FK would 500 with a raw error).
+  const prod = await prisma.$queryRaw<{ id: string; name: string }[]>(Prisma.sql`
+    SELECT id, name FROM products WHERE id = ${productId} LIMIT 1
+  `);
+  if (prod.length === 0) {
+    return NextResponse.json({ error: "Unknown productId" }, { status: 404 });
+  }
+  const productName = prod[0].name;
+  const label = body.label?.trim() || null;
+  const lastPrice = typeof body.lastPrice === "number" ? Math.round(body.lastPrice) : null;
+
+  await prisma.$executeRaw(Prisma.sql`
+    INSERT INTO grab_item_links (grab_item_id, product_id, label, last_price, updated_at)
+    VALUES (${grabItemId}, ${productId}, ${label}, ${lastPrice}, now())
+    ON CONFLICT (grab_item_id)
+    DO UPDATE SET product_id = EXCLUDED.product_id,
+                  label      = COALESCE(EXCLUDED.label, grab_item_links.label),
+                  last_price = COALESCE(EXCLUDED.last_price, grab_item_links.last_price),
+                  updated_at = now()
+  `);
+
+  // Backfill already-received Grab lines that still hold the raw Grab id, so
+  // in-progress/recent dockets, the order history, and reports show the real
+  // product — and the printer's kitchen_station lookup starts resolving.
+  const backfilled = await prisma.$executeRaw(Prisma.sql`
+    UPDATE pos_order_items
+    SET product_id = ${productId}, product_name = ${productName}
+    WHERE product_id = ${grabItemId}
+      AND order_id IN (SELECT id FROM pos_orders WHERE source = 'grabfood')
+  `);
+
+  return NextResponse.json({ success: true, grabItemId, productId, productName, backfilled });
+}
+
+export async function DELETE(req: NextRequest) {
+  const caller = await getUserFromHeaders(req.headers);
+  if (!caller) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+
+  const body = (await req.json().catch(() => ({}))) as { grabItemId?: string };
+  const grabItemId = (body.grabItemId || "").trim();
+  if (!grabItemId) return NextResponse.json({ error: "grabItemId required" }, { status: 400 });
+
+  // Remove the mapping only — past backfilled order lines are left intact.
+  const removed = await prisma.$executeRaw(Prisma.sql`
+    DELETE FROM grab_item_links WHERE grab_item_id = ${grabItemId}
+  `);
+  if (removed === 0) return NextResponse.json({ error: "link not found" }, { status: 404 });
+  return NextResponse.json({ success: true, grabItemId });
+}

--- a/apps/backoffice/src/app/api/integrations/grab/item-links/route.ts
+++ b/apps/backoffice/src/app/api/integrations/grab/item-links/route.ts
@@ -18,6 +18,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
 import { getUserFromHeaders } from "@/lib/auth";
+import { normalizeMenuName } from "@/lib/grab-menu";
 import { Prisma } from "@prisma/client";
 
 type ProductRow = {
@@ -45,6 +46,8 @@ type UnlinkedRow = {
   // Base price (sen) = unit_price − modifier_total. Grab bakes the chosen
   // add-ons into item.price, so the base is what matches a catalogue product.
   base_price: number | null;
+  // Grab's real item name, learned from the PushGrabMenu webhook (grab_menu_items).
+  grab_name: string | null;
   seen: bigint;
   last_seen: Date;
 };
@@ -76,10 +79,12 @@ export async function GET(req: NextRequest) {
            MAX(i.product_name) AS sample_name,
            MAX(i.unit_price)   AS last_price,
            MAX(i.unit_price - COALESCE(i.modifier_total, 0)) AS base_price,
+           MAX(gmi.name)       AS grab_name,
            COUNT(*)            AS seen,
            MAX(o.created_at)   AS last_seen
     FROM pos_order_items i
     JOIN pos_orders o ON o.id = i.order_id
+    LEFT JOIN grab_menu_items gmi ON gmi.grab_item_id = i.product_id
     WHERE o.source = 'grabfood'
       AND o.created_at > NOW() - INTERVAL '45 days'
       AND NOT EXISTS (SELECT 1 FROM products p WHERE p.id = i.product_id)
@@ -104,6 +109,14 @@ export async function GET(req: NextRequest) {
     const sen = Math.round(p.priceRM * 100);
     (byPriceSen.get(sen) ?? byPriceSen.set(sen, []).get(sen)!).push(p);
   }
+  // Name index for the strongest signal: when Grab's real item name (learned
+  // from the PushGrabMenu webhook) maps to exactly one product, that's a far
+  // more confident suggestion than price.
+  const byName = new Map<string, typeof productOut>();
+  for (const p of productOut) {
+    const key = normalizeMenuName(p.name);
+    (byName.get(key) ?? byName.set(key, []).get(key)!).push(p);
+  }
 
   return NextResponse.json({
     products: productOut,
@@ -117,18 +130,27 @@ export async function GET(req: NextRequest) {
     })),
     unlinked: unlinked.map((u) => {
       const baseSen = u.base_price != null ? Number(u.base_price) : null;
-      const candidates = baseSen != null ? byPriceSen.get(baseSen) ?? [] : [];
+      const priceCandidates = baseSen != null ? byPriceSen.get(baseSen) ?? [] : [];
+      const nameMatches = u.grab_name ? byName.get(normalizeMenuName(u.grab_name)) ?? [] : [];
+      // Prefer a unique name match; fall back to a unique price match.
+      const suggested =
+        nameMatches.length === 1 ? nameMatches[0].id : priceCandidates.length === 1 ? priceCandidates[0].id : null;
+      // Candidate shortlist = name matches first (best), then price matches.
+      const seen = new Set<string>();
+      const candidates = [...nameMatches, ...priceCandidates].filter((c) =>
+        seen.has(c.id) ? false : (seen.add(c.id), true),
+      );
       return {
         grabItemId: u.grab_item_id,
+        grabName: u.grab_name,
         sampleName: u.sample_name,
         lastPriceRM: u.last_price != null ? Number(u.last_price) / 100 : null,
         basePriceRM: baseSen != null ? baseSen / 100 : null,
         seen: Number(u.seen),
         lastSeen: u.last_seen,
-        // Catalogue products at the same base price, and a confident suggestion
-        // when there's exactly one.
         candidateIds: candidates.map((c) => c.id),
-        suggestedProductId: candidates.length === 1 ? candidates[0].id : null,
+        matchedByName: nameMatches.length === 1,
+        suggestedProductId: suggested,
       };
     }),
   });

--- a/apps/backoffice/src/app/api/integrations/grab/item-links/route.ts
+++ b/apps/backoffice/src/app/api/integrations/grab/item-links/route.ts
@@ -42,6 +42,9 @@ type UnlinkedRow = {
   grab_item_id: string;
   sample_name: string | null;
   last_price: number | null;
+  // Base price (sen) = unit_price − modifier_total. Grab bakes the chosen
+  // add-ons into item.price, so the base is what matches a catalogue product.
+  base_price: number | null;
   seen: bigint;
   last_seen: Date;
 };
@@ -72,6 +75,7 @@ export async function GET(req: NextRequest) {
     SELECT i.product_id AS grab_item_id,
            MAX(i.product_name) AS sample_name,
            MAX(i.unit_price)   AS last_price,
+           MAX(i.unit_price - COALESCE(i.modifier_total, 0)) AS base_price,
            COUNT(*)            AS seen,
            MAX(o.created_at)   AS last_seen
     FROM pos_order_items i
@@ -85,13 +89,24 @@ export async function GET(req: NextRequest) {
     LIMIT 200
   `);
 
+  // Catalogue match: index products by their Grab-facing price (sen). Grab gives
+  // us no item name on orders, so price is the only signal — we suggest the
+  // catalogue products at the item's base price. Exactly one ⇒ confident
+  // pre-fill; several ⇒ a shortlist the staff picks from.
+  const productOut = products.map((p) => ({
+    id: p.id,
+    name: p.name,
+    category: p.category,
+    priceRM: Number(p.price_grab ?? p.grabfood_price ?? p.price ?? 0),
+  }));
+  const byPriceSen = new Map<number, typeof productOut>();
+  for (const p of productOut) {
+    const sen = Math.round(p.priceRM * 100);
+    (byPriceSen.get(sen) ?? byPriceSen.set(sen, []).get(sen)!).push(p);
+  }
+
   return NextResponse.json({
-    products: products.map((p) => ({
-      id: p.id,
-      name: p.name,
-      category: p.category,
-      priceRM: Number(p.price_grab ?? p.grabfood_price ?? p.price ?? 0),
-    })),
+    products: productOut,
     links: links.map((l) => ({
       grabItemId: l.grab_item_id,
       productId: l.product_id,
@@ -100,13 +115,22 @@ export async function GET(req: NextRequest) {
       lastPriceRM: l.last_price != null ? l.last_price / 100 : null,
       updatedAt: l.updated_at,
     })),
-    unlinked: unlinked.map((u) => ({
-      grabItemId: u.grab_item_id,
-      sampleName: u.sample_name,
-      lastPriceRM: u.last_price != null ? Number(u.last_price) / 100 : null,
-      seen: Number(u.seen),
-      lastSeen: u.last_seen,
-    })),
+    unlinked: unlinked.map((u) => {
+      const baseSen = u.base_price != null ? Number(u.base_price) : null;
+      const candidates = baseSen != null ? byPriceSen.get(baseSen) ?? [] : [];
+      return {
+        grabItemId: u.grab_item_id,
+        sampleName: u.sample_name,
+        lastPriceRM: u.last_price != null ? Number(u.last_price) / 100 : null,
+        basePriceRM: baseSen != null ? baseSen / 100 : null,
+        seen: Number(u.seen),
+        lastSeen: u.last_seen,
+        // Catalogue products at the same base price, and a confident suggestion
+        // when there's exactly one.
+        candidateIds: candidates.map((c) => c.id),
+        suggestedProductId: candidates.length === 1 ? candidates[0].id : null,
+      };
+    }),
   });
 }
 

--- a/apps/backoffice/src/app/api/pos/grab/menus/route.ts
+++ b/apps/backoffice/src/app/api/pos/grab/menus/route.ts
@@ -3,10 +3,16 @@
  *
  * POST /api/grab/menus
  *
- * During the self-serve store-activation journey, GrabFood pushes the store's
- * canonical menu (as it exists on Grab's side) to the partner. We just need to
- * accept and acknowledge it — our POS is the menu source of truth, so there's
- * nothing to persist yet; we log the shape for debugging during staging.
+ * During/after self-serve activation (and on a Grab-side menu change) GrabFood
+ * pushes the store's canonical menu — the items as they exist ON GRAB, carrying
+ * Grab's own item id ("MYITE…"), the item NAME, and price.
+ *
+ * This is the ONE place we ever learn a Grab item's name: order webhooks carry
+ * no name, only the id. So we persist each item into grab_menu_items, then
+ * auto-link any item whose name maps to exactly one of our products
+ * (grab_item_links + backfill of already-received order lines). Items with no
+ * unique name match are left for a manual pick in BackOffice → Integrations →
+ * GrabFood → Item linking, where the stored name is now shown as the hint.
  *
  * Authenticated with the partner Bearer token Grab obtained from our
  * /api/grab/oauth/token endpoint. Register this URL in the portal
@@ -15,6 +21,27 @@
 
 import { NextRequest, NextResponse } from "next/server";
 import { verifyGrabPartnerToken } from "@/lib/grab-partner";
+import { createClient } from "@/lib/supabase-server";
+import { normalizeMenuName } from "@/lib/grab-menu";
+
+type IncomingItem = { id?: string; itemID?: string; grabItemID?: string; name?: string; price?: number };
+type IncomingCategory = { items?: IncomingItem[] };
+
+// Flatten Grab's menu payload (categories[].items[]) into {id, name, price}.
+// Tolerant of field aliases across API versions.
+function flattenItems(body: Record<string, unknown>): { id: string; name: string; price: number | null }[] {
+  const categories = (body.categories as IncomingCategory[] | undefined) ?? [];
+  const out: { id: string; name: string; price: number | null }[] = [];
+  for (const c of categories) {
+    for (const it of c.items ?? []) {
+      const id = (it.id || it.itemID || it.grabItemID || "").trim();
+      const name = (it.name || "").trim();
+      if (!id || !name) continue;
+      out.push({ id, name, price: typeof it.price === "number" ? it.price : null });
+    }
+  }
+  return out;
+}
 
 export async function POST(request: NextRequest) {
   if (!(await verifyGrabPartnerToken(request))) {
@@ -29,16 +56,75 @@ export async function POST(request: NextRequest) {
   }
 
   const merchantID = (body.merchantID || body.merchantId || "") as string;
-  const categories = Array.isArray((body as { categories?: unknown[] }).categories)
-    ? (body as { categories: unknown[] }).categories.length
-    : undefined;
-  console.log(
-    `[grab:push-menu] received merchant=${merchantID}` +
-      (categories !== undefined ? ` categories=${categories}` : ""),
-  );
+  const items = flattenItems(body);
+  console.log(`[grab:push-menu] received merchant=${merchantID} items=${items.length}`);
+
+  // Nothing to persist (URL-reachability ping or empty push) → just ack.
+  if (items.length === 0) return NextResponse.json({ success: true, items: 0 });
+
+  let autoLinked = 0;
+  try {
+    const supabase = await createClient();
+
+    // 1. Persist every item's name + price (idempotent upsert).
+    await supabase.from("grab_menu_items").upsert(
+      items.map((it) => ({
+        grab_item_id: it.id,
+        merchant_id: merchantID || null,
+        name: it.name,
+        price: it.price,
+        updated_at: new Date().toISOString(),
+      })),
+      { onConflict: "grab_item_id" },
+    );
+
+    // 2. Auto-link by name. Build a normalised-name → product index; only a
+    //    UNIQUE name match is safe to auto-link (ambiguous names stay manual).
+    const { data: prods } = await supabase.from("products").select("id, name");
+    const byName = new Map<string, string[]>();
+    for (const p of (prods ?? []) as { id: string; name: string }[]) {
+      const key = normalizeMenuName(p.name);
+      (byName.get(key) ?? byName.set(key, []).get(key)!).push(p.id);
+    }
+
+    // Skip ids already linked so we never override a manual decision.
+    const ids = items.map((it) => it.id);
+    const { data: existing } = await supabase
+      .from("grab_item_links").select("grab_item_id").in("grab_item_id", ids);
+    const linked = new Set((existing ?? []).map((r: { grab_item_id: string }) => r.grab_item_id));
+
+    const productNameById = new Map(
+      ((prods ?? []) as { id: string; name: string }[]).map((p) => [p.id, p.name] as const),
+    );
+    for (const it of items) {
+      if (linked.has(it.id)) continue;
+      const matches = byName.get(normalizeMenuName(it.name));
+      if (!matches || matches.length !== 1) continue;
+      const productId = matches[0];
+      const { error: linkErr } = await supabase.from("grab_item_links").insert({
+        grab_item_id: it.id,
+        product_id: productId,
+        label: it.name,
+        last_price: it.price,
+        updated_at: new Date().toISOString(),
+      });
+      if (linkErr) continue; // raced / FK miss — leave for manual.
+      // Backfill already-received Grab lines holding the raw Grab id.
+      await supabase
+        .from("pos_order_items")
+        .update({ product_id: productId, product_name: productNameById.get(productId) })
+        .eq("product_id", it.id);
+      autoLinked += 1;
+    }
+    console.log(`[grab:push-menu] persisted=${items.length} auto-linked=${autoLinked} merchant=${merchantID}`);
+  } catch (e) {
+    // Never fail the webhook on a persistence hiccup — Grab retries any non-2xx
+    // and the menu data isn't order-critical. Log and ack.
+    console.error("[grab:push-menu] persist/auto-link failed:", e instanceof Error ? e.message : e);
+  }
 
   // Ack — Grab retries on any non-2xx, so we only return non-200 on auth failure.
-  return NextResponse.json({ success: true });
+  return NextResponse.json({ success: true, items: items.length, autoLinked });
 }
 
 // Grab may GET to verify the URL is reachable before activation.

--- a/apps/backoffice/src/app/api/pos/grab/webhook/route.ts
+++ b/apps/backoffice/src/app/api/pos/grab/webhook/route.ts
@@ -266,8 +266,36 @@ export async function POST(request: NextRequest) {
       const { data: prods } = await supabase.from("products").select("id, name").in("id", candidateIds);
       for (const p of (prods ?? []) as ProductLookupRow[]) products.set(p.id, p);
     }
+
+    // Item linking: Grab's order ids (item.id = "MYITE…") are Grab's OWN item
+    // ids and never match products.id, so the direct lookup above misses every
+    // time. grab_item_links maps each Grab id → our product; resolving through
+    // it gives the real product name AND lets us store OUR product_id on the
+    // line (below), which is what the kitchen-docket printer keys on to find
+    // the kitchen_station. Without this, dockets print "Item" with no station.
+    const linkByGrabId = new Map<string, string>(); // grab_item_id → our product_id
+    if (candidateIds.length > 0) {
+      const { data: links } = await supabase
+        .from("grab_item_links").select("grab_item_id, product_id").in("grab_item_id", candidateIds);
+      for (const l of (links ?? []) as { grab_item_id: string; product_id: string }[]) {
+        linkByGrabId.set(l.grab_item_id, l.product_id);
+      }
+      // Pull the linked products we haven't already loaded by direct id.
+      const linkedIds = Array.from(new Set(linkByGrabId.values())).filter((id) => !products.has(id));
+      if (linkedIds.length > 0) {
+        const { data: lp } = await supabase.from("products").select("id, name").in("id", linkedIds);
+        for (const p of (lp ?? []) as ProductLookupRow[]) products.set(p.id, p);
+      }
+    }
+
     const orderItems = itemsArr.map((item) => {
-      const product = products.get(item.id) || (item.grabItemID ? products.get(item.grabItemID) : undefined);
+      // Resolve directly (item.id already = a products.id) or via the link
+      // table (Grab id → our product). Either way `product` carries OUR id+name.
+      const linkedId = linkByGrabId.get(item.id) || (item.grabItemID ? linkByGrabId.get(item.grabItemID) : undefined);
+      const product =
+        products.get(item.id) ||
+        (item.grabItemID ? products.get(item.grabItemID) : undefined) ||
+        (linkedId ? products.get(linkedId) : undefined);
       const qty = item.quantity ?? 1;
       const unitPrice = item.price ?? 0;
       const modTotal = (item.modifiers ?? []).reduce((n, m) => n + (m.price ?? 0) * (m.quantity ?? 1), 0);
@@ -279,7 +307,10 @@ export async function POST(request: NextRequest) {
       return {
         id: randomUUID(),
         order_id: order.id,
-        product_id: item.id || item.grabItemID || randomUUID(),
+        // Store OUR product id whenever resolved (direct or via grab_item_links)
+        // so the kitchen-docket printer can look up the kitchen_station. Only an
+        // unlinked Grab item keeps the raw Grab id.
+        product_id: product?.id || item.id || item.grabItemID || randomUUID(),
         product_name: product?.name || fallbackName,
         quantity: qty,
         unit_price: unitPrice,

--- a/apps/backoffice/src/lib/grab-menu.ts
+++ b/apps/backoffice/src/lib/grab-menu.ts
@@ -14,6 +14,22 @@ import type {
 } from "@/lib/grab";
 import { filterModifiersForChannel } from "@celsius/shared";
 
+/**
+ * Normalise a product / menu-item name for cross-system matching: lowercase,
+ * trim, collapse internal whitespace, drop punctuation. Used to auto-link a
+ * Grab menu item (from the PushGrabMenu webhook) to our product by name — Grab
+ * order webhooks never carry the item name, so the menu push is our one chance
+ * to learn it.
+ */
+export function normalizeMenuName(name: string): string {
+  return name
+    .toLowerCase()
+    .normalize("NFKD")
+    .replace(/[^a-z0-9]+/g, " ")
+    .trim();
+}
+
+
 export interface RawProduct {
   id: string;
   name: string;

--- a/supabase/migrations/026_grab_item_links.sql
+++ b/supabase/migrations/026_grab_item_links.sql
@@ -1,0 +1,30 @@
+-- GrabFood item linking — maps a Grab order item's id to our POS product.
+--
+-- Grab order webhooks carry Grab's OWN internal item id in item.id (e.g.
+-- "MYITE2026011703281674464"), which never matches products.id (our slugs /
+-- StoreHub ids). With no mapping, every Grab line falls back to
+-- "Item @ RM x [MYITE..]" AND, because pos_order_items.product_id then holds
+-- the unmatched Grab id, the kitchen-docket printer can't resolve a
+-- kitchen_station for it (products.get(product_id) misses) — so the docket
+-- never routes to the right station. This table is the missing link the order
+-- webhook consults to resolve the real product (name + station).
+--
+-- Managed in BackOffice → Settings → Integrations → GrabFood → Item linking.
+CREATE TABLE IF NOT EXISTS grab_item_links (
+  grab_item_id text PRIMARY KEY,
+  product_id   text NOT NULL REFERENCES products(id) ON DELETE CASCADE,
+  -- Human reference only: the fallback name / last item name seen for this
+  -- Grab id, and the last observed unit price (sen) — both shown in the
+  -- linking UI to help staff identify what to map an id to.
+  label        text,
+  last_price   integer,
+  created_at   timestamptz NOT NULL DEFAULT now(),
+  updated_at   timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS grab_item_links_product_id_idx ON grab_item_links(product_id);
+
+-- Server-only table: the order webhook reads it with the service-role client
+-- and BackOffice manages it over a privileged Prisma connection — both bypass
+-- RLS. Enable RLS with no policies so it's never exposed to anon/auth clients.
+ALTER TABLE grab_item_links ENABLE ROW LEVEL SECURITY;

--- a/supabase/migrations/027_grab_menu_items.sql
+++ b/supabase/migrations/027_grab_menu_items.sql
@@ -1,0 +1,18 @@
+-- GrabFood menu items (names) learned from the PushGrabMenu webhook.
+--
+-- Grab order webhooks carry NO item name — only Grab's own item id ("MYITE…")
+-- and a price. The PushGrabMenu webhook (/api/pos/grab/menus) is where Grab
+-- sends us its canonical menu, which DOES carry the item name. We persist that
+-- here so the item-linking screen can show the real name (not just a price) and
+-- so items can be auto-linked to our product by name.
+CREATE TABLE IF NOT EXISTS grab_menu_items (
+  grab_item_id text PRIMARY KEY,
+  merchant_id  text,
+  name         text,
+  price        integer,        -- sen, as Grab reports it
+  category     text,
+  updated_at   timestamptz NOT NULL DEFAULT now()
+);
+
+-- Server-only (service-role webhook + privileged Prisma); no anon/auth access.
+ALTER TABLE grab_menu_items ENABLE ROW LEVEL SECURITY;


### PR DESCRIPTION
## Problem

GrabFood order lines reached the kitchen as **`Item @ RM 15.90 [MYITE202]`** with no station routing — the docket was effectively useless.

Traced end-to-end against the live POS DB:

- Grab order webhooks send **Grab's own internal item id** in `item.id` (e.g. `MYITE2026011703281674464`) and **no item name**.
- Our `products.id` are slugs / StoreHub ids (`matcha-batik-cake`, `68ad6eab…`). None of the 86 products carry a `MYITE` id, sku, or `storehub_product_id`, so the webhook's product lookup missed every time → fallback name.
- Because the unmatched `MYITE…` id was then stored as `pos_order_items.product_id`, the kitchen-docket printer (`use-grab-printer.ts`) couldn't resolve a `kitchen_station` (`products.get(product_id)` missed) — so nothing routed to a station printer.

Root cause: this store's Grab menu was built with Grab-generated ids (not from our menu push), so orders never carry our product ids and there was **no mapping** between them.

## Fix

### 1. Item-linking layer
- **`grab_item_links` table** (migration `026`) mapping `grab_item_id → product_id`. *(Applied to the live POS DB.)*
- **Order webhook** resolves each line through the link table and stores **our** `product_id` + name whenever matched — restoring kitchen-station routing.
- **BackOffice → Settings → Integrations → GrabFood → Item linking**: lists unlinked Grab item ids from recent orders and maps each to a product. Linking **backfills recent order lines** and fixes all future ones.

### 2. Catalogue match by price
Grab orders carry no name, so the screen matches by base price (`unit_price − modifier_total`). Single price matches are pre-selected with one-click **"Auto-link N unique matches"**; ambiguous prices (e.g. 19 products at RM15.90) show a price shortlist rather than being guessed.

### 3. Learn names from PushGrabMenu + auto-link by name
- **`grab_menu_items` table** (migration `027`) persists Grab's `item id → name → price` from the **PushGrabMenu** webhook (`/api/pos/grab/menus`) — the one place Grab sends us names.
- That webhook now persists items and **auto-links any whose name uniquely matches a product** (normalised name), backfilling existing order lines.
- The linking screen shows Grab's **real item name** as the primary hint and prefers a unique **name match** over price (with a `name match` badge).

API: `GET/POST/DELETE /api/integrations/grab/item-links`.

## Not done — "re-push our menu so Grab adopts our ids"

Not possible from our side: per `sync/route.ts`, the full-menu upload "does not exist in the API" and notify→pull returns `UnsupportedMenuSync`. Grab only adopts our ids when it re-pulls our get-menu webhook at **(re)activation** — an operator action via the existing "Generate activation link", with an uncertain outcome. No production menu replace was fired.

Name-learning (3) is also **latent until Grab actually pushes its menu** (activation / menu change); price matching (2) and manual linking (1) work today.

## Test plan

- [x] `tsc --noEmit` + eslint clean on changed files
- [x] Migrations `026`/`027` applied; tables verified live
- [x] Unlinked-items + price-candidate queries verified against production data
- [ ] Link a `MYITE…` item in BackOffice → confirm recent order lines backfill and the next Grab docket prints the real name + routes to the station
- [ ] Trigger a Grab menu push → confirm `grab_menu_items` fills and unique-name items auto-link

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SXF3GNPYGpZzwMWy9AR9DV