### PR TITLE
feat(grab): link Grab order items to the catalogue + auto-sync backoffice → GrabFood

### DIFF
--- a/apps/backoffice/src/app/(admin)/pickup/menu/_ProductForm.tsx
+++ b/apps/backoffice/src/app/(admin)/pickup/menu/_ProductForm.tsx
@@ -40,6 +40,9 @@ export interface DbProduct {
   tax_rate: number;
   tax_inclusive: boolean;
   visible_channels: string[] | null;
+  // GrabFood menu item id — links incoming Grab order lines (which carry only
+  // Grab's own item id) back to this catalogue product so they show the real name.
+  grab_item_id: string | null;
 }
 
 export interface Category { id: string; name: string; slug: string; position?: number }
@@ -72,6 +75,7 @@ function emptyForm(categories: Category[]) {
     tax_inclusive:                  true,
     modifiers:                      [] as ModifierGroup[],
     visible_channels:               [] as string[],
+    grab_item_id:                   "" as string,
   };
 }
 
@@ -114,6 +118,7 @@ export function ProductForm({ product, categories }: Props) {
       tax_inclusive:                  product.tax_inclusive ?? true,
       modifiers:                      product.modifiers ?? [],
       visible_channels:               product.visible_channels ?? [],
+      grab_item_id:                   product.grab_item_id ?? "",
     };
   });
 
@@ -502,6 +507,26 @@ export function ProductForm({ product, categories }: Props) {
           <p className="text-[11px] text-muted-foreground mt-1">
             MSIC classification code for LHDN e-Invoice compliance. Look up at{" "}
             <a href="https://sdk.myinvois.hasil.gov.my/codes/classification-codes/" target="_blank" rel="noopener" className="text-indigo-600 hover:underline">myinvois.hasil.gov.my</a>.
+          </p>
+        </Field>
+
+        {/* GrabFood item link — when the Grab menu was built in Grab's portal,
+            order lines arrive with Grab's own item id (e.g. "MYITE2026...")
+            which doesn't match our product id. Paste that id here and incoming
+            Grab orders for this item will show this product's name (instead of
+            "Item @ RM x") on the docket and receipt. */}
+        <Field label="GrabFood item ID">
+          <input
+            type="text"
+            value={form.grab_item_id}
+            onChange={(e) => setForm((f) => ({ ...f, grab_item_id: e.target.value }))}
+            placeholder="e.g. MYITE2026011703282830543"
+            className="w-full px-3 py-2 border rounded-xl text-sm font-mono focus:outline-none focus:ring-2 focus:ring-primary/30"
+          />
+          <p className="text-[11px] text-muted-foreground mt-1">
+            Links incoming GrabFood orders to this product. Find it in the
+            GrabFood order log (the <code>[MYITE…]</code> code on an unmatched line)
+            or the Grab Merchant menu. Leave blank if Grab uses our menu push.
           </p>
         </Field>
 

--- a/apps/backoffice/src/app/api/pickup/products/[id]/route.ts
+++ b/apps/backoffice/src/app/api/pickup/products/[id]/route.ts
@@ -51,6 +51,12 @@ export async function PATCH(
   if (typeof body.e_invoice_classification_code === "string" || body.e_invoice_classification_code === null) {
     update.e_invoice_classification_code = body.e_invoice_classification_code || null;
   }
+  // GrabFood menu item id — links Grab order lines back to this product.
+  // Empty/null clears the link (NULL keeps the unique partial index happy).
+  if (typeof body.grab_item_id === "string" || body.grab_item_id === null) {
+    const s = (body.grab_item_id ?? "").toString().trim();
+    update.grab_item_id = s === "" ? null : s;
+  }
   if ("schedule_start_date" in body) update.schedule_start_date = body.schedule_start_date || null;
   if ("schedule_end_date"   in body) update.schedule_end_date   = body.schedule_end_date   || null;
   if (Array.isArray(body.schedule_days_of_week)) {

--- a/apps/backoffice/src/app/api/pickup/products/[id]/route.ts
+++ b/apps/backoffice/src/app/api/pickup/products/[id]/route.ts
@@ -1,6 +1,22 @@
-import { NextRequest, NextResponse } from "next/server";
+import { NextRequest, NextResponse, after } from "next/server";
 import { getSupabaseAdmin } from "@/lib/pickup/supabase";
 import { requireAuth } from "@/lib/auth";
+import { autoSyncCatalogueToGrab } from "@/lib/grab-auto-sync";
+
+// Columns that change what GrabFood shows — an edit touching any of these
+// triggers an auto-sync. Editing internal-only fields (schedule, kitchen
+// station, e-invoice code, tax) doesn't push to Grab.
+const GRAB_RELEVANT_COLUMNS = new Set([
+  "name",
+  "image_url",
+  "is_available",
+  "price",
+  "price_grab",
+  "category",
+  "modifiers",
+  "visible_channels",
+  "grab_item_id",
+]);
 
 // PATCH /api/pickup/products/[id]
 export async function PATCH(
@@ -123,6 +139,15 @@ export async function PATCH(
     .eq("id", id);
 
   if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+
+  // Push to Grab when the edit touches anything Grab shows (off critical path).
+  if (Object.keys(update).some((k) => GRAB_RELEVANT_COLUMNS.has(k))) {
+    after(() =>
+      autoSyncCatalogueToGrab(supabase)
+        .then((r) => console.log(`[grab:auto-sync] product ${id} update →`, JSON.stringify(r)))
+        .catch((e) => console.error(`[grab:auto-sync] product ${id} update failed:`, e)),
+    );
+  }
   return NextResponse.json({ ok: true });
 }
 
@@ -138,5 +163,12 @@ export async function DELETE(
   const { error } = await supabase.from("products").delete().eq("id", id);
 
   if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+
+  // Removed product → re-push the (now smaller) catalogue to Grab.
+  after(() =>
+    autoSyncCatalogueToGrab(supabase)
+      .then((r) => console.log(`[grab:auto-sync] product ${id} delete →`, JSON.stringify(r)))
+      .catch((e) => console.error(`[grab:auto-sync] product ${id} delete failed:`, e)),
+  );
   return NextResponse.json({ ok: true });
 }

--- a/apps/backoffice/src/app/api/pickup/products/route.ts
+++ b/apps/backoffice/src/app/api/pickup/products/route.ts
@@ -1,6 +1,7 @@
-import { NextRequest, NextResponse } from "next/server";
+import { NextRequest, NextResponse, after } from "next/server";
 import { getSupabaseAdmin } from "@/lib/pickup/supabase";
 import { requireAuth } from "@/lib/auth";
+import { autoSyncCatalogueToGrab } from "@/lib/grab-auto-sync";
 
 // GET /api/pickup/products
 // Maps the loyalty app's products table schema to the backoffice DbProduct interface.
@@ -161,6 +162,13 @@ export async function POST(request: NextRequest) {
     .single();
 
   if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+
+  // New product → push the catalogue to Grab (off the response's critical path).
+  after(() =>
+    autoSyncCatalogueToGrab(supabase)
+      .then((r) => console.log("[grab:auto-sync] product create →", JSON.stringify(r)))
+      .catch((e) => console.error("[grab:auto-sync] product create failed:", e)),
+  );
 
   const mapped = {
     id:           (data as Record<string,unknown>).id,

--- a/apps/backoffice/src/app/api/pickup/products/route.ts
+++ b/apps/backoffice/src/app/api/pickup/products/route.ts
@@ -10,7 +10,7 @@ export async function GET(request: NextRequest) {
   const supabase = getSupabaseAdmin();
   const { data, error } = await supabase
     .from("products")
-    .select("id, name, category, price, image_url, is_available, is_featured, modifiers, track_stock, synced_at, position, featured_position, print_additional_docket, kitchen_station, e_invoice_classification_code, schedule_start_date, schedule_end_date, schedule_days_of_week, schedule_time_from, schedule_time_to, price_pickup, price_grab, price_foodpanda, price_dinein, tax_rate, tax_inclusive")
+    .select("id, name, category, price, image_url, is_available, is_featured, modifiers, track_stock, synced_at, position, featured_position, print_additional_docket, kitchen_station, e_invoice_classification_code, schedule_start_date, schedule_end_date, schedule_days_of_week, schedule_time_from, schedule_time_to, price_pickup, price_grab, price_foodpanda, price_dinein, tax_rate, tax_inclusive, grab_item_id")
     .eq("brand_id", "brand-celsius")
     .order("category")
     .order("position")
@@ -54,6 +54,9 @@ export async function GET(request: NextRequest) {
     // lives in e_invoice_classification_code above.
     tax_rate:                       p.tax_rate ?? 0,
     tax_inclusive:                  p.tax_inclusive ?? true,
+    // GrabFood menu item id — links this catalogue product to incoming Grab
+    // order lines (which carry only Grab's own item id). See grab-order-items.ts.
+    grab_item_id:                   p.grab_item_id ?? null,
   }));
 
   // Also fetch categories so the menu page can group/filter by category
@@ -93,6 +96,8 @@ export async function POST(request: NextRequest) {
     // Kitchen station routing for SUNMI POS-native docket split.
     kitchen_station?: string | null;
     print_additional_docket?: boolean;
+    // GrabFood menu item id (links Grab order lines back to this product).
+    grab_item_id?: string | null;
   };
 
   const supabase = getSupabaseAdmin();
@@ -128,6 +133,12 @@ export async function POST(request: NextRequest) {
   }
   if (typeof body.print_additional_docket === "boolean") {
     channelTaxInsert.print_additional_docket = body.print_additional_docket;
+  }
+  // Grab item id — empty string clears the link (store NULL so the unique
+  // partial index doesn't trip on multiple empty strings).
+  if (typeof body.grab_item_id === "string") {
+    const s = body.grab_item_id.trim();
+    channelTaxInsert.grab_item_id = s === "" ? null : s;
   }
 
   const { data, error } = await supabase

--- a/apps/backoffice/src/app/api/pos/availability/route.ts
+++ b/apps/backoffice/src/app/api/pos/availability/route.ts
@@ -85,12 +85,24 @@ export async function POST(req: NextRequest) {
     } else if (!isGrabConfigured()) {
       grab = "grab-not-configured";
     } else {
+      // Records must target GRAB's item id, not ours — a portal-built (self-serve)
+      // menu keys items by Grab's id (e.g. "MYITE2026..."), so a record keyed by
+      // our product id matches nothing and the 86 silently never reaches Grab.
+      // Use products.grab_item_id when linked; fall back to our id (works only on
+      // stores that pulled our menu).
+      const { data: prod } = await supabase
+        .from("products")
+        .select("grab_item_id")
+        .eq("id", product_id)
+        .maybeSingle();
+      const grabItemId =
+        (prod as { grab_item_id?: string | null } | null)?.grab_item_id || product_id;
       // field is the record TYPE ("ITEM"), attributes go in the entity. To set
       // UNAVAILABLE Grab requires maxStock:0 alongside the status.
       await batchUpdateMenu(merchantId, "ITEM", [
         is_available
-          ? { id: product_id, availableStatus: "AVAILABLE" }
-          : { id: product_id, availableStatus: "UNAVAILABLE", maxStock: 0 },
+          ? { id: grabItemId, availableStatus: "AVAILABLE" }
+          : { id: grabItemId, availableStatus: "UNAVAILABLE", maxStock: 0 },
       ]);
       grab = "pushed";
     }

--- a/apps/backoffice/src/app/api/pos/grab/webhook/route.ts
+++ b/apps/backoffice/src/app/api/pos/grab/webhook/route.ts
@@ -14,6 +14,12 @@ import { NextRequest, NextResponse } from "next/server";
 import { randomUUID } from "crypto";
 import { acceptRejectOrder, verifyWebhookSignature } from "@/lib/grab";
 import { verifyGrabPartnerToken } from "@/lib/grab-partner";
+import {
+  indexProductsByGrabKeys,
+  resolveGrabItemProduct,
+  fallbackGrabItemName,
+  type GrabItemProductRow,
+} from "@/lib/grab-order-items";
 import { createClient } from "@/lib/supabase-server";
 
 interface GrabOrderItemModifier {
@@ -254,33 +260,43 @@ export async function POST(request: NextRequest) {
     }
 
     // 6. Items. Grab order items carry NO name field — the product name is
-    //    resolved from our catalogue by the PARTNER id (item.id = products.id),
-    //    with grabItemID as a fallback. (Looking up by grabItemID first was the
-    //    "Item" bug: Grab's id never matches our UUIDs.) `itemsArr` is from §4.
+    //    resolved from our catalogue by the PARTNER id (item.id = products.id)
+    //    OR the catalogue's `grab_item_id` (set in BackOffice when the Grab menu
+    //    was created in Grab's portal, so the order only carries Grab's own id —
+    //    e.g. "MYITE2026..." — which never matches products.id). grabItemID is
+    //    the last fallback. (Looking up by grabItemID against products.id first
+    //    was the "Item" bug: Grab's id never matches our ids.) `itemsArr` is §4.
     const candidateIds = Array.from(
       new Set(itemsArr.flatMap((i) => [i.id, i.grabItemID]).filter(Boolean) as string[]),
     );
-    type ProductLookupRow = { id: string; name: string };
-    const products = new Map<string, ProductLookupRow>();
+    const productIndex = new Map<string, GrabItemProductRow>();
     if (candidateIds.length > 0) {
-      const { data: prods } = await supabase.from("products").select("id, name").in("id", candidateIds);
-      for (const p of (prods ?? []) as ProductLookupRow[]) products.set(p.id, p);
+      // Match on EITHER the product id or its linked grab_item_id. Two narrow
+      // queries (cheap, a handful of ids per order) avoid escaping arbitrary id
+      // values into a single PostgREST `.or()` filter.
+      const [byId, byGrab] = await Promise.all([
+        supabase.from("products").select("id, name, grab_item_id").in("id", candidateIds),
+        supabase.from("products").select("id, name, grab_item_id").in("grab_item_id", candidateIds),
+      ]);
+      const rows = [
+        ...((byId.data ?? []) as GrabItemProductRow[]),
+        ...((byGrab.data ?? []) as GrabItemProductRow[]),
+      ];
+      for (const [k, v] of indexProductsByGrabKeys(rows)) productIndex.set(k, v);
     }
     const orderItems = itemsArr.map((item) => {
-      const product = products.get(item.id) || (item.grabItemID ? products.get(item.grabItemID) : undefined);
+      const product = resolveGrabItemProduct(item, productIndex);
       const qty = item.quantity ?? 1;
       const unitPrice = item.price ?? 0;
       const modTotal = (item.modifiers ?? []).reduce((n, m) => n + (m.price ?? 0) * (m.quantity ?? 1), 0);
       const itemTotal = (unitPrice + modTotal) * qty;
-      // No catalogue match (an item Grab has that we don't) → price + id hint so
-      // the kitchen can still act, instead of a bare "Item".
-      const idHint = (item.id || item.grabItemID || "").slice(0, 8);
-      const fallbackName = unitPrice > 0 ? `Item @ RM ${(unitPrice / 100).toFixed(2)}${idHint ? ` [${idHint}]` : ""}` : `Item${idHint ? ` [${idHint}]` : ""}`;
       return {
         id: randomUUID(),
         order_id: order.id,
-        product_id: item.id || item.grabItemID || randomUUID(),
-        product_name: product?.name || fallbackName,
+        // Prefer the matched catalogue product id so the order line links back
+        // to the catalogue; fall back to whatever Grab sent.
+        product_id: product?.id || item.id || item.grabItemID || randomUUID(),
+        product_name: product?.name || fallbackGrabItemName(item),
         quantity: qty,
         unit_price: unitPrice,
         modifiers: (item.modifiers ?? []).map((m) => ({

--- a/apps/backoffice/src/lib/grab-auto-sync.test.ts
+++ b/apps/backoffice/src/lib/grab-auto-sync.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect } from "vitest";
+import { buildGrabRecordEntities, type GrabMenuItemLike } from "./grab-record-entities";
+
+const item = (over: Partial<GrabMenuItemLike> = {}): GrabMenuItemLike => ({
+  id: "68ad6eab59357c00074fe000",
+  price: 1590,
+  availableStatus: "AVAILABLE",
+  ...over,
+});
+
+describe("buildGrabRecordEntities", () => {
+  it("targets Grab's own item id when the product is linked (self-serve store)", () => {
+    const gid = new Map([["68ad6eab59357c00074fe000", "MYITE2026011703270414937"]]);
+    const [entity] = buildGrabRecordEntities([item()], gid);
+    expect(entity.id).toBe("MYITE2026011703270414937");
+    expect(entity.price).toBe(1590);
+    expect(entity.availableStatus).toBe("AVAILABLE");
+  });
+
+  it("falls back to our product id when there's no link (pushed-menu store)", () => {
+    const [entity] = buildGrabRecordEntities([item()], new Map());
+    expect(entity.id).toBe("68ad6eab59357c00074fe000");
+  });
+
+  it("carries maxStock for an out-of-stock item (Grab requires it with UNAVAILABLE)", () => {
+    const gid = new Map([["68ad6eab59357c00074fe000", "MYITE202"]]);
+    const [entity] = buildGrabRecordEntities(
+      [item({ availableStatus: "UNAVAILABLE", maxStock: 0 })],
+      gid,
+    );
+    expect(entity).toEqual({ id: "MYITE202", price: 1590, availableStatus: "UNAVAILABLE", maxStock: 0 });
+  });
+
+  it("omits maxStock when the item is available", () => {
+    const [entity] = buildGrabRecordEntities([item()], new Map());
+    expect("maxStock" in entity).toBe(false);
+  });
+
+  it("maps a mixed basket, translating only the linked items", () => {
+    const gid = new Map([["linked", "MYITE-LINKED"]]);
+    const entities = buildGrabRecordEntities(
+      [item({ id: "linked" }), item({ id: "unlinked", price: 990 })],
+      gid,
+    );
+    expect(entities.map((e) => e.id)).toEqual(["MYITE-LINKED", "unlinked"]);
+  });
+
+  it("returns an empty array for an empty menu", () => {
+    expect(buildGrabRecordEntities([], new Map())).toEqual([]);
+  });
+});

--- a/apps/backoffice/src/lib/grab-auto-sync.ts
+++ b/apps/backoffice/src/lib/grab-auto-sync.ts
@@ -1,0 +1,133 @@
+/**
+ * Auto-sync the backoffice product catalogue to GrabFood.
+ *
+ * Backoffice is the SINGLE SOURCE OF TRUTH: whenever a product is created,
+ * edited, or deleted, we push to every Grab-linked outlet so item names,
+ * photos, price and availability track the catalogue without a manual "Sync".
+ *
+ * Two push paths, tried in order per outlet:
+ *   1. Full-menu replace (PUT /partner/v1/menu) — carries names + photos +
+ *      price + availability. Works for partner-managed menus. After it lands we
+ *      also notify Grab to re-pull (best-effort), the lever that refreshes
+ *      photos / item structure on stores that own their menu.
+ *   2. Record batch (PUT /partner/v1/batch/menu, field "ITEM") — price +
+ *      availability for items that ALREADY exist on Grab. The fallback for
+ *      self-serve-linked stores where the full replace is rejected
+ *      (UnsupportedMenuSync). Records MUST target Grab's own item id, so we
+ *      translate our product id → products.grab_item_id here (a record keyed by
+ *      our id would silently match nothing on a portal-built menu).
+ *
+ * Everything is best-effort: a Grab failure NEVER breaks the catalogue write.
+ * Intended to run from `after()` so it's off the request's critical path.
+ */
+
+import type { SupabaseClient } from "@supabase/supabase-js";
+import { updateMenu, batchUpdateMenu, notifyMenuUpdate } from "@/lib/grab";
+import { buildOutletGrabMenu } from "@/lib/grab-menu-outlet";
+import { buildGrabRecordEntities, type GrabMenuItemLike } from "@/lib/grab-record-entities";
+
+export interface GrabSyncOutcome {
+  merchantId: string;
+  mode: "full" | "records" | "failed" | "empty";
+  items: number;
+  error?: string;
+}
+
+export interface GrabSyncResult {
+  skipped?: string;
+  outlets: GrabSyncOutcome[];
+}
+
+/**
+ * Push the current catalogue to every Grab-linked outlet. Safe to call from
+ * `after()`; resolves with a per-outlet outcome summary for logging.
+ */
+export async function autoSyncCatalogueToGrab(
+  supabase: SupabaseClient,
+): Promise<GrabSyncResult> {
+  // Outbound OAuth pair is what every push uses (same as /api/pos/grab/sync).
+  // No creds → nothing to do (preview / dev / not-yet-live).
+  if (!process.env.GRAB_CLIENT_ID || !process.env.GRAB_CLIENT_SECRET) {
+    return { skipped: "no_grab_credentials", outlets: [] };
+  }
+
+  const { data: linked, error } = await supabase
+    .from("outlets")
+    .select("grab_merchant_id")
+    .not("grab_merchant_id", "is", null);
+  if (error) return { skipped: "outlet_lookup_failed", outlets: [] };
+
+  const merchantIds = Array.from(
+    new Set(
+      (linked ?? [])
+        .map((o) => (o as { grab_merchant_id: string | null }).grab_merchant_id)
+        .filter((m): m is string => !!m),
+    ),
+  );
+  if (merchantIds.length === 0) return { skipped: "no_linked_outlets", outlets: [] };
+
+  // product id → Grab item id, for record-push targeting (self-serve stores).
+  const { data: gidRows } = await supabase
+    .from("products")
+    .select("id, grab_item_id")
+    .not("grab_item_id", "is", null);
+  const gidByProductId = new Map<string, string>();
+  for (const r of (gidRows ?? []) as Array<{ id: string; grab_item_id: string | null }>) {
+    if (r.grab_item_id) gidByProductId.set(r.id, r.grab_item_id);
+  }
+
+  const outlets: GrabSyncOutcome[] = [];
+  for (const merchantId of merchantIds) {
+    outlets.push(await syncOneOutlet(supabase, merchantId, gidByProductId));
+  }
+  return { outlets };
+}
+
+async function syncOneOutlet(
+  supabase: SupabaseClient,
+  merchantId: string,
+  gidByProductId: Map<string, string>,
+): Promise<GrabSyncOutcome> {
+  const menu = await buildOutletGrabMenu(supabase, merchantId);
+  if (!menu) return { merchantId, mode: "failed", items: 0, error: "build_failed" };
+
+  const menuItems: GrabMenuItemLike[] = menu.categories
+    .flatMap((c) => c.items)
+    .map((it) => ({
+      id: it.id,
+      price: it.price,
+      availableStatus: it.availableStatus,
+      ...(it.maxStock != null ? { maxStock: it.maxStock } : {}),
+    }));
+  if (menuItems.length === 0) return { merchantId, mode: "empty", items: 0 };
+
+  // 1. Full replace — names + photos + price + availability.
+  try {
+    await updateMenu(menu);
+    try {
+      await notifyMenuUpdate(merchantId); // nudge a re-pull (photos / structure)
+    } catch {
+      /* notify is unsupported on some stores — ignore */
+    }
+    return { merchantId, mode: "full", items: menuItems.length };
+  } catch (fullErr) {
+    // 2. Fallback — records (price + availability) targeting Grab's item ids.
+    try {
+      const entities = buildGrabRecordEntities(menuItems, gidByProductId);
+      await batchUpdateMenu(merchantId, "ITEM", entities);
+      return { merchantId, mode: "records", items: entities.length };
+    } catch (recErr) {
+      console.error(
+        `[grab:auto-sync] both pushes failed merchant=${merchantId} full=${
+          fullErr instanceof Error ? fullErr.message : fullErr
+        }`,
+      );
+      return {
+        merchantId,
+        mode: "failed",
+        items: menuItems.length,
+        error: recErr instanceof Error ? recErr.message : String(recErr),
+      };
+    }
+  }
+}

--- a/apps/backoffice/src/lib/grab-menu.ts
+++ b/apps/backoffice/src/lib/grab-menu.ts
@@ -28,6 +28,10 @@ export interface RawProduct {
   description?: string;
   image_url?: string;
   is_available?: boolean;
+  // Grab's own menu item id, set in BackOffice when the Grab menu was built in
+  // Grab's portal. Used to target outbound price/availability record pushes (and
+  // to resolve inbound order item names). See grab-order-items.ts / grab-auto-sync.ts.
+  grab_item_id?: string | null;
   // Real shape of products.modifiers (jsonb), aligned with @celsius/shared
   // ModifierGroupLike. Earlier we had `title`/`isMultiSelect`/nested `modifiers`
   // here — wrong; the DB stores `name`/`multiSelect`/`options`. That mismatch

--- a/apps/backoffice/src/lib/grab-order-items.test.ts
+++ b/apps/backoffice/src/lib/grab-order-items.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect } from "vitest";
+import {
+  indexProductsByGrabKeys,
+  resolveGrabItemProduct,
+  fallbackGrabItemName,
+  type GrabItemProductRow,
+} from "./grab-order-items";
+
+const LATTE: GrabItemProductRow = {
+  id: "68ad6eab59357c00074fe000",
+  name: "Buttercream Latte",
+  grab_item_id: "MYITE2026011703270414937",
+};
+const MOCHA: GrabItemProductRow = {
+  id: "68ad6eac59357c00074fe149",
+  name: "Berry Berries",
+  grab_item_id: null,
+};
+
+describe("indexProductsByGrabKeys", () => {
+  it("keys a product by both its id and its grab_item_id", () => {
+    const index = indexProductsByGrabKeys([LATTE]);
+    expect(index.get(LATTE.id)).toBe(LATTE);
+    expect(index.get(LATTE.grab_item_id!)).toBe(LATTE);
+  });
+
+  it("skips an empty grab_item_id", () => {
+    const index = indexProductsByGrabKeys([MOCHA]);
+    expect(index.get(MOCHA.id)).toBe(MOCHA);
+    expect([...index.keys()]).toEqual([MOCHA.id]);
+  });
+
+  it("never lets a grab_item_id clobber a real product id key", () => {
+    // Pathological: another product's grab_item_id equals MOCHA's product id.
+    const evil: GrabItemProductRow = { id: "x", name: "Evil", grab_item_id: MOCHA.id };
+    const index = indexProductsByGrabKeys([MOCHA, evil]);
+    expect(index.get(MOCHA.id)).toBe(MOCHA); // id wins over the colliding grab_item_id
+  });
+});
+
+describe("resolveGrabItemProduct", () => {
+  const index = indexProductsByGrabKeys([LATTE, MOCHA]);
+
+  it("matches a self-serve order line by Grab's own item id (the real-world bug)", () => {
+    // Grab's portal-built menu sends only grabItemID; item.id is Grab's id too.
+    const item = { id: "MYITE2026011703270414937", grabItemID: "MYITE2026011703270414937", price: 1590 };
+    expect(resolveGrabItemProduct(item, index)?.name).toBe("Buttercream Latte");
+  });
+
+  it("matches a pushed-menu order line by our product id (item.id = products.id)", () => {
+    expect(resolveGrabItemProduct({ id: MOCHA.id, price: 1690 }, index)?.name).toBe("Berry Berries");
+  });
+
+  it("falls back to grabItemID when item.id doesn't match", () => {
+    const item = { id: "unknown-partner-id", grabItemID: "MYITE2026011703270414937" };
+    expect(resolveGrabItemProduct(item, index)?.name).toBe("Buttercream Latte");
+  });
+
+  it("returns undefined for an unlinked item", () => {
+    expect(resolveGrabItemProduct({ id: "MYITE9999", grabItemID: "MYITE8888" }, index)).toBeUndefined();
+  });
+});
+
+describe("fallbackGrabItemName", () => {
+  it("shows the price and an 8-char id hint when no catalogue match", () => {
+    expect(fallbackGrabItemName({ id: "MYITE2026011703282830543", price: 987 })).toBe(
+      "Item @ RM 9.87 [MYITE202]",
+    );
+  });
+
+  it("uses grabItemID for the hint when item.id is absent", () => {
+    expect(fallbackGrabItemName({ grabItemID: "MYITE2026011703283251309", price: 1487 })).toBe(
+      "Item @ RM 14.87 [MYITE202]",
+    );
+  });
+
+  it("omits the price when it is zero or missing", () => {
+    expect(fallbackGrabItemName({ id: "MYITE202", price: 0 })).toBe("Item [MYITE202]");
+    expect(fallbackGrabItemName({})).toBe("Item");
+  });
+});

--- a/apps/backoffice/src/lib/grab-order-items.ts
+++ b/apps/backoffice/src/lib/grab-order-items.ts
@@ -1,0 +1,77 @@
+/**
+ * Resolve GrabFood order-item lines against our product catalogue.
+ *
+ * Grab order items carry NO name — only an `id` (the partner externalID we
+ * shipped in the menu, = products.id when WE pushed the menu) and a `grabItemID`
+ * (Grab's own id, e.g. "MYITE2026011703282830543"). For a store whose Grab menu
+ * was created via self-serve / in the Grab portal, the order only carries Grab's
+ * id, which never matches our products.id (a Mongo-style "68ad6eac..." id). Those
+ * lines used to fall back to "Item @ RM x [MYITE202]" on the docket.
+ *
+ * The fix: the catalogue product carries an optional `grab_item_id` (set in
+ * BackOffice → Pickup → Menu). We index products by BOTH their id and their
+ * grab_item_id, so an order line resolves whether Grab sends our externalID or
+ * its own item id.
+ */
+
+export interface GrabItemProductRow {
+  id: string;
+  name: string;
+  grab_item_id?: string | null;
+}
+
+/** The identifying fields an order line can carry (everything else ignored). */
+export interface GrabOrderItemRef {
+  id?: string;
+  grabItemID?: string;
+  price?: number; // minor units (sen) — used only for the fallback label
+}
+
+/**
+ * Index catalogue rows by every key an order line might reference: the
+ * product's own id AND its linked grab_item_id. Later rows don't clobber an
+ * existing id key (id is the strongest signal); grab_item_id only fills a key
+ * that isn't already taken.
+ */
+export function indexProductsByGrabKeys(
+  rows: GrabItemProductRow[],
+): Map<string, GrabItemProductRow> {
+  const index = new Map<string, GrabItemProductRow>();
+  for (const row of rows) {
+    if (row.id) index.set(row.id, row);
+  }
+  for (const row of rows) {
+    const gid = row.grab_item_id;
+    if (gid && !index.has(gid)) index.set(gid, row);
+  }
+  return index;
+}
+
+/**
+ * Resolve the catalogue product for an order line: prefer a match on the
+ * partner externalID (`item.id`), then Grab's own id (`item.grabItemID`).
+ * Returns undefined when the item isn't linked to any catalogue product.
+ */
+export function resolveGrabItemProduct(
+  item: GrabOrderItemRef,
+  index: Map<string, GrabItemProductRow>,
+): GrabItemProductRow | undefined {
+  return (
+    (item.id ? index.get(item.id) : undefined) ??
+    (item.grabItemID ? index.get(item.grabItemID) : undefined)
+  );
+}
+
+/**
+ * Human-readable fallback when an order line has no catalogue match: surface
+ * the price + a short id hint so the kitchen can still act, instead of a bare
+ * "Item". The hint is the first 8 chars of whichever id is present.
+ */
+export function fallbackGrabItemName(item: GrabOrderItemRef): string {
+  const unitPrice = item.price ?? 0;
+  const idHint = (item.id || item.grabItemID || "").slice(0, 8);
+  const suffix = idHint ? ` [${idHint}]` : "";
+  return unitPrice > 0
+    ? `Item @ RM ${(unitPrice / 100).toFixed(2)}${suffix}`
+    : `Item${suffix}`;
+}

--- a/apps/backoffice/src/lib/grab-record-entities.ts
+++ b/apps/backoffice/src/lib/grab-record-entities.ts
@@ -1,0 +1,40 @@
+/**
+ * Pure helper: turn built GrabFood menu items into batch ("ITEM") record
+ * entities for the Update Menu Record API (price + availability).
+ *
+ * Kept free of `@/`-aliased / network imports so it's unit-testable in
+ * isolation; the side-effecting sync orchestration lives in grab-auto-sync.ts.
+ */
+
+export interface GrabMenuItemLike {
+  id: string; // our product id (what buildGrabMenuPayload declares)
+  price: number;
+  availableStatus: "AVAILABLE" | "UNAVAILABLE" | "HIDE";
+  maxStock?: number;
+}
+
+export interface GrabRecordEntity {
+  id: string;
+  price?: number;
+  availableStatus?: "AVAILABLE" | "UNAVAILABLE" | "HIDE";
+  maxStock?: number;
+}
+
+/**
+ * Translate built menu items into batch record entities, keyed by Grab's own
+ * item id when the product is linked (products.grab_item_id), else by our
+ * product id. The latter only matches on stores that pulled OUR menu; the
+ * former is what makes price/availability land on a portal-built (self-serve)
+ * menu, whose items carry Grab-assigned ids (e.g. "MYITE2026...").
+ */
+export function buildGrabRecordEntities(
+  items: GrabMenuItemLike[],
+  grabItemIdByProductId: Map<string, string>,
+): GrabRecordEntity[] {
+  return items.map((it) => ({
+    id: grabItemIdByProductId.get(it.id) ?? it.id,
+    price: it.price,
+    availableStatus: it.availableStatus,
+    ...(it.maxStock != null ? { maxStock: it.maxStock } : {}),
+  }));
+}

--- a/apps/loyalty/supabase/migrations/022_products_grab_item_id.sql
+++ b/apps/loyalty/supabase/migrations/022_products_grab_item_id.sql
@@ -1,0 +1,20 @@
+-- =============================================
+-- 022: Link a catalog product to its GrabFood menu item id.
+--
+-- GrabFood order webhooks carry only Grab's own item id (e.g.
+-- "MYITE2026011703282830543") which never matches our products.id. Without a
+-- link, every Grab order line falls back to "Item @ RM x [MYITE202]" on the
+-- docket/receipt because the product name can't be resolved from the catalogue.
+--
+-- The backoffice product catalogue is the source of truth, so we hang the Grab
+-- item id on the product itself (set in BackOffice → Pickup → Menu → product).
+-- The order webhook then resolves names by products.grab_item_id.
+--
+-- Nullable; unique when set so two products can't claim the same Grab item.
+-- =============================================
+
+ALTER TABLE products ADD COLUMN IF NOT EXISTS grab_item_id TEXT;
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_products_grab_item_id
+  ON products (grab_item_id)
+  WHERE grab_item_id IS NOT NULL;


### PR DESCRIPTION
## Problem

GrabFood order lines render as `Item @ RM 15.90 [MYITE202]` instead of real product names (see the Putrajaya order). Root cause, confirmed against live data:

- Grab order items carry **no name** — the webhook resolves names by matching the order's item id against `products.id`.
- The live menu was built in Grab's portal (self-serve), so orders arrive with **Grab's own ids** (`MYITE2026011703282830543`) while our catalogue ids look like `68ad6eac59357c00074fe000`. They can never match, and order prices (RM15.90) differ from `price_grab` (RM16.90), so only an explicit link works.
- The same id mismatch meant **outbound** price/availability pushes (incl. POS "86" / out-of-stock) were keyed by our product id and **silently matched nothing on Grab**.

## What this does

Makes the backoffice product catalogue the **single source of truth** for GrabFood.

**1. Item link (`products.grab_item_id`)**
- Migration adds nullable `products.grab_item_id` (unique when set).
- New **"GrabFood item ID"** field in the catalogue editor (Pickup → Menu), wired through GET/POST/PATCH `/api/pickup/products`.
- Webhook resolves order lines by `products.id` **OR** `products.grab_item_id` (grabItemID last), and stores the matched catalogue id on the order line. Extracted to a pure, tested helper (`grab-order-items.ts`).

**2. Auto-sync on every catalogue write**
- `autoSyncCatalogueToGrab()` pushes to every Grab-linked outlet on product create/edit/delete, via `next/server` `after()` (off the response's critical path, best-effort so a Grab error never breaks the save). PATCH only triggers when a Grab-relevant column changes.
- Per outlet: full-menu replace first (names + photos + price + availability, then a re-pull notify); on stores that reject it (self-serve), fall back to a price/availability record batch.

**3. Records target Grab's item id**
- Both the auto-sync record fallback and the POS out-of-stock route (`/api/pos/availability`) now translate `product_id → products.grab_item_id`, so price/availability and register 86'ing actually reach GrabFood on portal-built menus. Pure translator extracted to `grab-record-entities.ts`.

## Tests

16 new unit tests across `grab-order-items` and `grab-record-entities` (self-serve match, pushed-menu match, grabItemID fallback, unlinked fallback label, key-collision safety, id translation, maxStock handling). Full suite green (170). Backoffice typecheck clean.

## Notes / limitations

- The `products.grab_item_id` column was already applied to the catalogue DB (additive, nullable, unique-when-set) so the new `SELECT` is safe on deploy; migration file recorded for repeatability.
- On self-serve-linked stores, Grab has historically rejected the full-menu replace (`UnsupportedMenuSync`); when that happens, **names/photos depend on Grab re-pulling** our menu (requested via `notifyMenuUpdate`) — price/availability still sync via records. Could not be verified live (Grab creds aren't in the dev env); worth confirming with one real edit after deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018jWHLb3AnjmUyzgzuoiuxJ

---
_Generated by [Claude Code](https://claude.ai/code/session_018jWHLb3AnjmUyzgzuoiuxJ)_