### PR TITLE
feat(grab): BackOffice panel to link GrabFood order items to catalogue products

### DIFF
--- a/apps/backoffice/src/app/(admin)/settings/integrations/grab/_GrabItemLinker.tsx
+++ b/apps/backoffice/src/app/(admin)/settings/integrations/grab/_GrabItemLinker.tsx
@@ -1,0 +1,165 @@
+"use client";
+
+/**
+ * "Unlinked GrabFood items" panel.
+ *
+ * GrabFood order webhooks carry only Grab's own item id (e.g. "MYITE2026...").
+ * Until a catalogue product claims that id (products.grab_item_id), the line
+ * prints as "Item @ RM x" and outbound price/availability pushes don't reach
+ * Grab. This panel lists the ids seen in real orders that aren't linked yet and
+ * lets staff point each at the right catalogue product. Linking also backfills
+ * past order lines' names. Data + writes via /api/integrations/grab/links.
+ */
+
+import { useCallback, useEffect, useState } from "react";
+import { Loader2, Link2, CheckCircle2, RefreshCw } from "lucide-react";
+import { formatGrabItemPrice } from "@/lib/grab-item-links";
+
+type UnlinkedItem = {
+  grabItemId: string;
+  timesOrdered: number;
+  minPriceRm: number | null;
+  maxPriceRm: number | null;
+  lastSeen: string;
+};
+type PickerProduct = { id: string; name: string; category: string | null; grabPriceRm: number | null };
+type LinksData = { items: UnlinkedItem[]; products: PickerProduct[] };
+
+export function GrabItemLinker() {
+  const [data, setData] = useState<LinksData | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [picked, setPicked] = useState<Record<string, string>>({});
+  const [busy, setBusy] = useState<Record<string, boolean>>({});
+  const [msg, setMsg] = useState<string | null>(null);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await fetch("/api/integrations/grab/links", { cache: "no-store" });
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      setData((await res.json()) as LinksData);
+      setPicked({});
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Failed to load");
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  const link = async (grabItemId: string) => {
+    const productId = picked[grabItemId];
+    if (!productId) return;
+    setBusy((b) => ({ ...b, [grabItemId]: true }));
+    setMsg(null);
+    try {
+      const res = await fetch("/api/integrations/grab/links", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ grabItemId, productId }),
+      });
+      const json = await res.json();
+      if (!res.ok || !json.success) throw new Error(json.error || `HTTP ${res.status}`);
+      const name = data?.products.find((p) => p.id === productId)?.name ?? productId;
+      setMsg(`Linked to "${name}" — ${json.backfilledLines ?? 0} past order line(s) updated.`);
+      await load();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Link failed");
+    } finally {
+      setBusy((b) => ({ ...b, [grabItemId]: false }));
+    }
+  };
+
+  return (
+    <section className="rounded-lg border border-neutral-200 bg-white">
+      <header className="flex items-start justify-between gap-4 border-b border-neutral-200 px-5 py-3">
+        <div>
+          <h2 className="text-base font-medium text-neutral-900">Unlinked GrabFood items</h2>
+          <p className="mt-0.5 text-sm text-neutral-600">
+            Grab orders arrive with Grab&rsquo;s own item id. Point each at a catalogue product so
+            orders show the real name + route to the right kitchen station, and price/availability
+            sync to Grab. Tip: match by the order price &amp; how recently it sold.
+          </p>
+        </div>
+        <button
+          onClick={load}
+          className="inline-flex shrink-0 items-center gap-2 rounded border border-neutral-300 bg-white px-3 py-1.5 text-sm font-medium text-neutral-700 hover:bg-neutral-50"
+        >
+          <RefreshCw className="h-4 w-4" /> Refresh
+        </button>
+      </header>
+
+      {msg ? (
+        <div className="border-b border-emerald-100 bg-emerald-50 px-5 py-2 text-sm text-emerald-700">{msg}</div>
+      ) : null}
+      {error ? (
+        <div className="border-b border-red-100 bg-red-50 px-5 py-2 text-sm text-red-700">{error}</div>
+      ) : null}
+
+      {loading ? (
+        <div className="flex h-24 items-center justify-center">
+          <Loader2 className="h-5 w-5 animate-spin text-neutral-400" />
+        </div>
+      ) : !data || data.items.length === 0 ? (
+        <div className="flex items-center justify-center gap-2 px-5 py-8 text-sm text-neutral-500">
+          <CheckCircle2 className="h-4 w-4 text-emerald-500" /> Every GrabFood item seen in orders is linked.
+        </div>
+      ) : (
+        <table className="w-full text-sm">
+          <thead className="border-b border-neutral-100 text-left text-xs uppercase tracking-wide text-neutral-500">
+            <tr>
+              <th className="px-5 py-2">Grab item id</th>
+              <th className="px-5 py-2 text-right">Order price</th>
+              <th className="px-5 py-2 text-right">Times</th>
+              <th className="px-5 py-2 text-right">Last seen</th>
+              <th className="px-5 py-2">Link to product</th>
+              <th className="px-5 py-2" />
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-neutral-100">
+            {data.items.map((it) => (
+              <tr key={it.grabItemId} className="align-middle text-neutral-800">
+                <td className="px-5 py-2 font-mono text-xs">{it.grabItemId}</td>
+                <td className="px-5 py-2 text-right font-mono">{formatGrabItemPrice(it.minPriceRm, it.maxPriceRm)}</td>
+                <td className="px-5 py-2 text-right">{it.timesOrdered}</td>
+                <td className="px-5 py-2 text-right text-xs text-neutral-500">
+                  {new Date(it.lastSeen).toLocaleString("en-MY", { dateStyle: "short", timeStyle: "short" })}
+                </td>
+                <td className="px-5 py-2">
+                  <select
+                    value={picked[it.grabItemId] ?? ""}
+                    onChange={(e) => setPicked((p) => ({ ...p, [it.grabItemId]: e.target.value }))}
+                    className="w-64 rounded border border-neutral-300 px-2 py-1 text-sm focus:border-neutral-500 focus:outline-none"
+                  >
+                    <option value="">Select a product…</option>
+                    {data.products.map((p) => (
+                      <option key={p.id} value={p.id}>
+                        {p.name}
+                        {p.grabPriceRm != null ? ` — RM ${p.grabPriceRm.toFixed(2)}` : ""}
+                      </option>
+                    ))}
+                  </select>
+                </td>
+                <td className="px-5 py-2">
+                  <button
+                    onClick={() => link(it.grabItemId)}
+                    disabled={!picked[it.grabItemId] || busy[it.grabItemId]}
+                    className="inline-flex items-center gap-1.5 rounded border border-emerald-300 bg-emerald-50 px-2.5 py-1 text-sm font-medium text-emerald-700 hover:bg-emerald-100 disabled:cursor-not-allowed disabled:opacity-50"
+                  >
+                    {busy[it.grabItemId] ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <Link2 className="h-3.5 w-3.5" />}
+                    Link
+                  </button>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      )}
+    </section>
+  );
+}

--- a/apps/backoffice/src/app/(admin)/settings/integrations/grab/page.tsx
+++ b/apps/backoffice/src/app/(admin)/settings/integrations/grab/page.tsx
@@ -26,6 +26,7 @@ import {
   Activity,
   Rocket,
 } from "lucide-react";
+import { GrabItemLinker } from "./_GrabItemLinker";
 
 type Outlet = {
   id: string;
@@ -349,6 +350,9 @@ export default function GrabIntegrationPage() {
           })}
         </div>
       </section>
+
+      {/* Unlinked GrabFood items → catalogue product linking */}
+      <GrabItemLinker />
 
       {/* Self-serve store activation */}
       <section className="rounded-lg border border-neutral-200 bg-white">

--- a/apps/backoffice/src/app/api/integrations/grab/links/route.ts
+++ b/apps/backoffice/src/app/api/integrations/grab/links/route.ts
@@ -1,0 +1,136 @@
+/**
+ * GrabFood item-link admin API.
+ *
+ * GrabFood order webhooks carry only Grab's own item id (e.g. "MYITE2026...")
+ * which never matches our products.id. Until a product carries that id in
+ * products.grab_item_id, its Grab order lines print as "Item @ RM x" and
+ * outbound price/availability pushes don't reach Grab. This endpoint powers the
+ * BackOffice panel that links them.
+ *
+ * GET  → { items[], products[] }
+ *        items: distinct Grab item ids seen in orders that aren't linked yet
+ *               (id, price, timesOrdered, lastSeen), most-ordered first.
+ *        products: catalogue products for the picker (id, name, category, grabPriceRm).
+ * POST { grabItemId, productId } → link the item to a product. Clears the id
+ *        from any other product first (the column is unique), then backfills
+ *        past order lines' name + product_id so history reads correctly too.
+ *
+ * Raw SQL (parity with ../route.ts): products / pos_order_items aren't in the
+ * generated Prisma client.
+ */
+
+import { NextRequest, NextResponse, after } from "next/server";
+import { prisma } from "@/lib/prisma";
+import { getUserFromHeaders } from "@/lib/auth";
+import { Prisma } from "@prisma/client";
+import { getSupabaseAdmin } from "@/lib/pickup/supabase";
+import { autoSyncCatalogueToGrab } from "@/lib/grab-auto-sync";
+
+type UnlinkedRow = {
+  grab_item_id: string;
+  times_ordered: bigint;
+  min_price: number | null;
+  max_price: number | null;
+  last_seen: Date;
+};
+
+type ProductRow = {
+  id: string;
+  name: string;
+  category: string | null;
+  price_grab: number | null;
+  price: number | null;
+};
+
+export async function GET(req: NextRequest) {
+  const caller = await getUserFromHeaders(req.headers);
+  if (!caller) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+
+  const [items, products] = await Promise.all([
+    prisma.$queryRaw<UnlinkedRow[]>(Prisma.sql`
+      SELECT oi.product_id AS grab_item_id,
+             COUNT(*)            AS times_ordered,
+             MIN(oi.unit_price)  AS min_price,
+             MAX(oi.unit_price)  AS max_price,
+             MAX(oi.created_at)  AS last_seen
+      FROM pos_order_items oi
+      JOIN pos_orders o ON o.id = oi.order_id
+      WHERE o.source = 'grabfood'
+        AND oi.product_id NOT IN (
+          SELECT grab_item_id FROM products WHERE grab_item_id IS NOT NULL
+        )
+      GROUP BY oi.product_id
+      ORDER BY COUNT(*) DESC, MAX(oi.created_at) DESC
+      LIMIT 100
+    `),
+    prisma.$queryRaw<ProductRow[]>(Prisma.sql`
+      SELECT id, name, category, price_grab, price
+      FROM products
+      WHERE brand_id = 'brand-celsius'
+      ORDER BY name ASC
+    `),
+  ]);
+
+  return NextResponse.json({
+    items: items.map((r) => ({
+      grabItemId: r.grab_item_id,
+      timesOrdered: Number(r.times_ordered),
+      minPriceRm: r.min_price != null ? Number(r.min_price) / 100 : null,
+      maxPriceRm: r.max_price != null ? Number(r.max_price) / 100 : null,
+      lastSeen: r.last_seen,
+    })),
+    products: products.map((p) => ({
+      id: p.id,
+      name: p.name,
+      category: p.category,
+      grabPriceRm: p.price_grab != null ? Number(p.price_grab) : p.price != null ? Number(p.price) : null,
+    })),
+  });
+}
+
+export async function POST(req: NextRequest) {
+  const caller = await getUserFromHeaders(req.headers);
+  if (!caller) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+
+  const body = (await req.json().catch(() => ({}))) as {
+    grabItemId?: string;
+    productId?: string;
+  };
+  const grabItemId = (body.grabItemId || "").trim();
+  const productId = (body.productId || "").trim();
+  if (!grabItemId || !productId) {
+    return NextResponse.json({ error: "grabItemId and productId are required" }, { status: 400 });
+  }
+
+  // 1. Clear the id from any other product (grab_item_id is unique when set).
+  await prisma.$executeRaw(Prisma.sql`
+    UPDATE products SET grab_item_id = NULL
+    WHERE grab_item_id = ${grabItemId} AND id <> ${productId}
+  `);
+  // 2. Assign it to the chosen product.
+  const updated = await prisma.$executeRaw(Prisma.sql`
+    UPDATE products SET grab_item_id = ${grabItemId} WHERE id = ${productId}
+  `);
+  if (updated === 0) {
+    return NextResponse.json({ error: "product not found" }, { status: 404 });
+  }
+  // 3. Backfill past Grab order lines for this id so history reads correctly:
+  //    the real product name + the catalogue product_id (which also fixes
+  //    kitchen-station routing on any reprint).
+  const backfilled = await prisma.$executeRaw(Prisma.sql`
+    UPDATE pos_order_items oi
+    SET product_name = p.name, product_id = p.id
+    FROM products p
+    WHERE p.id = ${productId} AND oi.product_id = ${grabItemId}
+  `);
+
+  // 4. Push the now-linked item's price/availability to Grab (best-effort, off
+  //    the response path — same as a catalogue edit).
+  after(() =>
+    autoSyncCatalogueToGrab(getSupabaseAdmin())
+      .then((r) => console.log(`[grab:link] ${grabItemId} → ${productId} synced`, JSON.stringify(r)))
+      .catch((e) => console.error(`[grab:link] sync failed for ${productId}:`, e)),
+  );
+
+  return NextResponse.json({ success: true, grabItemId, productId, backfilledLines: backfilled });
+}

--- a/apps/backoffice/src/lib/grab-item-links.test.ts
+++ b/apps/backoffice/src/lib/grab-item-links.test.ts
@@ -1,0 +1,21 @@
+import { describe, it, expect } from "vitest";
+import { formatGrabItemPrice } from "./grab-item-links";
+
+describe("formatGrabItemPrice", () => {
+  it("shows a single price when min and max agree", () => {
+    expect(formatGrabItemPrice(16.87, 16.87)).toBe("RM 16.87");
+  });
+
+  it("shows a range when prices differ", () => {
+    expect(formatGrabItemPrice(13.87, 16.87)).toBe("RM 13.87–RM 16.87");
+  });
+
+  it("handles a single populated bound", () => {
+    expect(formatGrabItemPrice(15.9, null)).toBe("RM 15.90");
+    expect(formatGrabItemPrice(null, 9.87)).toBe("RM 9.87");
+  });
+
+  it("falls back to a dash when both are null", () => {
+    expect(formatGrabItemPrice(null, null)).toBe("—");
+  });
+});

--- a/apps/backoffice/src/lib/grab-item-links.ts
+++ b/apps/backoffice/src/lib/grab-item-links.ts
@@ -1,0 +1,20 @@
+/**
+ * Pure formatting helpers for the GrabFood item-link panel. Kept free of
+ * `@/`-aliased / React imports so they're unit-testable in isolation.
+ */
+
+/**
+ * Render a Grab order line's observed price for the link panel. Orders for the
+ * same Grab item can arrive at different prices (promos / size variants), so we
+ * show a single value when they agree and a range when they don't.
+ */
+export function formatGrabItemPrice(
+  minRm: number | null,
+  maxRm: number | null,
+): string {
+  if (minRm == null && maxRm == null) return "—";
+  const lo = minRm ?? maxRm!;
+  const hi = maxRm ?? minRm!;
+  const fmt = (n: number) => `RM ${n.toFixed(2)}`;
+  return lo === hi ? fmt(lo) : `${fmt(lo)}–${fmt(hi)}`;
+}


### PR DESCRIPTION
## Why

Populating `products.grab_item_id` (shipped in #317) is the switch that turns on real names on Grab order prints, kitchen-station docket routing, and outbound price/availability sync. But there was no way to **discover** the Grab item ids or set them in bulk — and 0/86 products are linked, so none of those behaviors are active yet.

## What

Adds an **"Unlinked GrabFood items"** panel to Settings → Integrations → GrabFood. It lists every Grab item id seen in real orders that isn't linked yet — with **order price, times ordered, and last seen** — each with a catalogue product picker.

Linking a row:
- sets `products.grab_item_id` (clearing the id from any other product first, since the column is unique),
- **backfills past Grab order lines'** `product_name` + `product_id`, so order history reads correctly and any reprint routes to the right kitchen station,
- best-effort pushes the now-linked item's price/availability to Grab (same `after()` path as a catalogue edit).

API at `/api/integrations/grab/links` (`GET` unlinked items + product picker; `POST` to link), mirroring the sibling `/api/integrations/grab` route's prisma + auth pattern. Price formatting extracted to a pure, unit-tested helper (`grab-item-links.ts`).

## QA context

I verified the end-to-end chain by code trace + live DB:
- Prints show `pos_order_items.product_name` → resolved via `grab_item_id` ✅ (once linked)
- Kitchen docket routes by `productsById.get(product_id).kitchen_station` → resolves once the matched line carries the catalogue `product_id` ✅ (once linked); unlinked still prints to one combined docket
- POS "86" + catalogue edits push to Grab keyed by `grab_item_id` ✅ (once linked)

Note: **modifiers** are still unlinked (orders show "Add-on @ RM 0.97" instead of names) — that's a separate, larger change tracked as a follow-up.

Tests: 4 new (price formatting); full suite green (174). Backoffice typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018jWHLb3AnjmUyzgzuoiuxJ

---
_Generated by [Claude Code](https://claude.ai/code/session_018jWHLb3AnjmUyzgzuoiuxJ)_