### PR TITLE
feat(grab): resolve + link GrabFood add-on (modifier) names

### DIFF
--- a/apps/backoffice/src/app/(admin)/settings/integrations/grab/_GrabModifierLinker.tsx
+++ b/apps/backoffice/src/app/(admin)/settings/integrations/grab/_GrabModifierLinker.tsx
@@ -1,0 +1,175 @@
+"use client";
+
+/**
+ * "Unlinked GrabFood add-ons" panel.
+ *
+ * Grab order modifiers arrive with only an id + price, so add-ons print as
+ * "Add-on @ RM 0.97" on the kitchen docket. This panel lists the modifier ids
+ * seen in orders that aren't named yet and lets staff give each a label (e.g.
+ * "Oat Milk"). Linking backfills past order lines too. Note: only modifiers from
+ * orders received AFTER this feature shipped carry an id, so the list fills up
+ * as new Grab orders arrive. Data + writes via /api/integrations/grab/modifier-links.
+ */
+
+import { useCallback, useEffect, useState } from "react";
+import { Loader2, Link2, CheckCircle2, RefreshCw } from "lucide-react";
+import { formatGrabItemPrice } from "@/lib/grab-item-links";
+
+type UnlinkedMod = {
+  grabModifierId: string;
+  timesOrdered: number;
+  minPriceRm: number | null;
+  maxPriceRm: number | null;
+  lastSeen: string;
+};
+type ModData = { items: UnlinkedMod[]; suggestions: string[]; products: { id: string; name: string }[] };
+
+export function GrabModifierLinker() {
+  const [data, setData] = useState<ModData | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [name, setName] = useState<Record<string, string>>({});
+  const [product, setProduct] = useState<Record<string, string>>({});
+  const [busy, setBusy] = useState<Record<string, boolean>>({});
+  const [msg, setMsg] = useState<string | null>(null);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await fetch("/api/integrations/grab/modifier-links", { cache: "no-store" });
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      setData((await res.json()) as ModData);
+      setName({});
+      setProduct({});
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Failed to load");
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  const link = async (grabModifierId: string) => {
+    const label = (name[grabModifierId] ?? "").trim();
+    if (!label) return;
+    setBusy((b) => ({ ...b, [grabModifierId]: true }));
+    setMsg(null);
+    try {
+      const res = await fetch("/api/integrations/grab/modifier-links", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ grabModifierId, name: label, productId: product[grabModifierId] || null }),
+      });
+      const json = await res.json();
+      if (!res.ok || !json.success) throw new Error(json.error || `HTTP ${res.status}`);
+      setMsg(`Named "${label}" — ${json.backfilledLines ?? 0} past order line(s) updated.`);
+      await load();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Link failed");
+    } finally {
+      setBusy((b) => ({ ...b, [grabModifierId]: false }));
+    }
+  };
+
+  return (
+    <section className="rounded-lg border border-neutral-200 bg-white">
+      <header className="flex items-start justify-between gap-4 border-b border-neutral-200 px-5 py-3">
+        <div>
+          <h2 className="text-base font-medium text-neutral-900">Unlinked GrabFood add-ons</h2>
+          <p className="mt-0.5 text-sm text-neutral-600">
+            Grab sends add-ons with only an id + price, so they print as &ldquo;Add-on @ RM x&rdquo;.
+            Give each a name (e.g. &ldquo;Oat Milk&rdquo;) so the kitchen docket reads correctly.
+            Fills as new Grab orders arrive.
+          </p>
+        </div>
+        <button
+          onClick={load}
+          className="inline-flex shrink-0 items-center gap-2 rounded border border-neutral-300 bg-white px-3 py-1.5 text-sm font-medium text-neutral-700 hover:bg-neutral-50"
+        >
+          <RefreshCw className="h-4 w-4" /> Refresh
+        </button>
+      </header>
+
+      {msg ? (
+        <div className="border-b border-emerald-100 bg-emerald-50 px-5 py-2 text-sm text-emerald-700">{msg}</div>
+      ) : null}
+      {error ? (
+        <div className="border-b border-red-100 bg-red-50 px-5 py-2 text-sm text-red-700">{error}</div>
+      ) : null}
+
+      <datalist id="grab-modifier-suggestions">
+        {(data?.suggestions ?? []).map((s) => (
+          <option key={s} value={s} />
+        ))}
+      </datalist>
+
+      {loading ? (
+        <div className="flex h-24 items-center justify-center">
+          <Loader2 className="h-5 w-5 animate-spin text-neutral-400" />
+        </div>
+      ) : !data || data.items.length === 0 ? (
+        <div className="flex items-center justify-center gap-2 px-5 py-8 text-sm text-neutral-500">
+          <CheckCircle2 className="h-4 w-4 text-emerald-500" /> No unnamed GrabFood add-ons seen in orders.
+        </div>
+      ) : (
+        <table className="w-full text-sm">
+          <thead className="border-b border-neutral-100 text-left text-xs uppercase tracking-wide text-neutral-500">
+            <tr>
+              <th className="px-5 py-2">Grab modifier id</th>
+              <th className="px-5 py-2 text-right">Price</th>
+              <th className="px-5 py-2 text-right">Times</th>
+              <th className="px-5 py-2">Name</th>
+              <th className="px-5 py-2">Belongs to (optional)</th>
+              <th className="px-5 py-2" />
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-neutral-100">
+            {data.items.map((it) => (
+              <tr key={it.grabModifierId} className="align-middle text-neutral-800">
+                <td className="px-5 py-2 font-mono text-xs">{it.grabModifierId}</td>
+                <td className="px-5 py-2 text-right font-mono">{formatGrabItemPrice(it.minPriceRm, it.maxPriceRm)}</td>
+                <td className="px-5 py-2 text-right">{it.timesOrdered}</td>
+                <td className="px-5 py-2">
+                  <input
+                    type="text"
+                    list="grab-modifier-suggestions"
+                    value={name[it.grabModifierId] ?? ""}
+                    onChange={(e) => setName((n) => ({ ...n, [it.grabModifierId]: e.target.value }))}
+                    placeholder="e.g. Oat Milk"
+                    className="w-44 rounded border border-neutral-300 px-2 py-1 text-sm focus:border-neutral-500 focus:outline-none"
+                  />
+                </td>
+                <td className="px-5 py-2">
+                  <select
+                    value={product[it.grabModifierId] ?? ""}
+                    onChange={(e) => setProduct((p) => ({ ...p, [it.grabModifierId]: e.target.value }))}
+                    className="w-48 rounded border border-neutral-300 px-2 py-1 text-sm focus:border-neutral-500 focus:outline-none"
+                  >
+                    <option value="">—</option>
+                    {data.products.map((p) => (
+                      <option key={p.id} value={p.id}>{p.name}</option>
+                    ))}
+                  </select>
+                </td>
+                <td className="px-5 py-2">
+                  <button
+                    onClick={() => link(it.grabModifierId)}
+                    disabled={!((name[it.grabModifierId] ?? "").trim()) || busy[it.grabModifierId]}
+                    className="inline-flex items-center gap-1.5 rounded border border-emerald-300 bg-emerald-50 px-2.5 py-1 text-sm font-medium text-emerald-700 hover:bg-emerald-100 disabled:cursor-not-allowed disabled:opacity-50"
+                  >
+                    {busy[it.grabModifierId] ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <Link2 className="h-3.5 w-3.5" />}
+                    Save
+                  </button>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      )}
+    </section>
+  );
+}

--- a/apps/backoffice/src/app/(admin)/settings/integrations/grab/page.tsx
+++ b/apps/backoffice/src/app/(admin)/settings/integrations/grab/page.tsx
@@ -27,6 +27,7 @@ import {
   Rocket,
 } from "lucide-react";
 import { GrabItemLinker } from "./_GrabItemLinker";
+import { GrabModifierLinker } from "./_GrabModifierLinker";
 
 type Outlet = {
   id: string;
@@ -353,6 +354,9 @@ export default function GrabIntegrationPage() {
 
       {/* Unlinked GrabFood items → catalogue product linking */}
       <GrabItemLinker />
+
+      {/* Unlinked GrabFood add-ons → modifier name linking */}
+      <GrabModifierLinker />
 
       {/* Self-serve store activation */}
       <section className="rounded-lg border border-neutral-200 bg-white">

--- a/apps/backoffice/src/app/api/integrations/grab/modifier-links/route.ts
+++ b/apps/backoffice/src/app/api/integrations/grab/modifier-links/route.ts
@@ -1,0 +1,129 @@
+/**
+ * GrabFood modifier-link admin API.
+ *
+ * Grab order modifiers arrive as { id, price } with NO name, so add-ons print
+ * as "Add-on @ RM 0.97". This endpoint powers the panel that maps a Grab
+ * modifier id → a real label (e.g. "Oat Milk"); the order webhook then resolves
+ * names from grab_modifier_links.
+ *
+ * GET  → { items[], suggestions[], products[] }
+ *        items: distinct Grab modifier ids seen in orders that aren't linked yet
+ *               (id, price, timesOrdered, lastSeen). Populated from orders that
+ *               landed AFTER the webhook started persisting grab_modifier_id.
+ *        suggestions: catalogue modifier option labels (datalist hints).
+ *        products: catalogue products for the optional association picker.
+ * POST { grabModifierId, name, productId? } → upsert the link + backfill past
+ *        order lines' modifier name.
+ *
+ * Raw SQL (parity with ../route.ts): these tables aren't in the Prisma client.
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+import { getUserFromHeaders } from "@/lib/auth";
+import { Prisma } from "@prisma/client";
+
+type UnlinkedModRow = {
+  grab_modifier_id: string;
+  times_ordered: bigint;
+  min_price: number | null;
+  max_price: number | null;
+  last_seen: Date;
+};
+
+export async function GET(req: NextRequest) {
+  const caller = await getUserFromHeaders(req.headers);
+  if (!caller) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+
+  const [items, suggestions, products] = await Promise.all([
+    prisma.$queryRaw<UnlinkedModRow[]>(Prisma.sql`
+      SELECT m->>'grab_modifier_id'         AS grab_modifier_id,
+             COUNT(*)                        AS times_ordered,
+             MIN((m->>'price')::numeric)     AS min_price,
+             MAX((m->>'price')::numeric)     AS max_price,
+             MAX(oi.created_at)              AS last_seen
+      FROM pos_order_items oi
+      JOIN pos_orders o ON o.id = oi.order_id
+      CROSS JOIN LATERAL jsonb_array_elements(
+        CASE WHEN jsonb_typeof(oi.modifiers) = 'array' THEN oi.modifiers ELSE '[]'::jsonb END
+      ) m
+      WHERE o.source = 'grabfood'
+        AND m->>'grab_modifier_id' IS NOT NULL
+        AND m->>'grab_modifier_id' NOT IN (SELECT grab_modifier_id FROM grab_modifier_links)
+      GROUP BY 1
+      ORDER BY COUNT(*) DESC, MAX(oi.created_at) DESC
+      LIMIT 100
+    `),
+    prisma.$queryRaw<{ label: string }[]>(Prisma.sql`
+      SELECT DISTINCT opt->>'label' AS label
+      FROM products p
+      CROSS JOIN LATERAL jsonb_array_elements(
+        CASE WHEN jsonb_typeof(p.modifiers) = 'array' THEN p.modifiers ELSE '[]'::jsonb END
+      ) grp
+      CROSS JOIN LATERAL jsonb_array_elements(
+        CASE WHEN jsonb_typeof(grp->'options') = 'array' THEN grp->'options' ELSE '[]'::jsonb END
+      ) opt
+      WHERE p.brand_id = 'brand-celsius' AND COALESCE(opt->>'label', '') <> ''
+      ORDER BY 1
+    `),
+    prisma.$queryRaw<{ id: string; name: string }[]>(Prisma.sql`
+      SELECT id, name FROM products WHERE brand_id = 'brand-celsius' ORDER BY name ASC
+    `),
+  ]);
+
+  return NextResponse.json({
+    items: items.map((r) => ({
+      grabModifierId: r.grab_modifier_id,
+      timesOrdered: Number(r.times_ordered),
+      minPriceRm: r.min_price != null ? Number(r.min_price) / 100 : null,
+      maxPriceRm: r.max_price != null ? Number(r.max_price) / 100 : null,
+      lastSeen: r.last_seen,
+    })),
+    suggestions: suggestions.map((s) => s.label),
+    products: products.map((p) => ({ id: p.id, name: p.name })),
+  });
+}
+
+export async function POST(req: NextRequest) {
+  const caller = await getUserFromHeaders(req.headers);
+  if (!caller) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+
+  const body = (await req.json().catch(() => ({}))) as {
+    grabModifierId?: string;
+    name?: string;
+    productId?: string | null;
+  };
+  const grabModifierId = (body.grabModifierId || "").trim();
+  const name = (body.name || "").trim();
+  const productId = (body.productId || "").trim() || null;
+  if (!grabModifierId || !name) {
+    return NextResponse.json({ error: "grabModifierId and name are required" }, { status: 400 });
+  }
+
+  // 1. Upsert the link.
+  await prisma.$executeRaw(Prisma.sql`
+    INSERT INTO grab_modifier_links (grab_modifier_id, name, product_id, updated_at)
+    VALUES (${grabModifierId}, ${name}, ${productId}, now())
+    ON CONFLICT (grab_modifier_id)
+    DO UPDATE SET name = EXCLUDED.name, product_id = EXCLUDED.product_id, updated_at = now()
+  `);
+
+  // 2. Backfill the name onto past order lines' matching modifier elements.
+  const contains = JSON.stringify([{ grab_modifier_id: grabModifierId }]);
+  const backfilled = await prisma.$executeRaw(Prisma.sql`
+    UPDATE pos_order_items
+    SET modifiers = (
+      SELECT jsonb_agg(
+        CASE WHEN elem->>'grab_modifier_id' = ${grabModifierId}
+             THEN jsonb_set(elem, '{name}', to_jsonb(${name}::text))
+             ELSE elem END
+      )
+      FROM jsonb_array_elements(modifiers) elem
+    )
+    WHERE jsonb_typeof(modifiers) = 'array'
+      AND modifiers @> ${contains}::jsonb
+  `);
+
+  // (No Grab push — modifier names live only on our docket/receipt, not on Grab.)
+  return NextResponse.json({ success: true, grabModifierId, name, productId, backfilledLines: backfilled });
+}

--- a/apps/backoffice/src/app/api/pos/grab/webhook/route.ts
+++ b/apps/backoffice/src/app/api/pos/grab/webhook/route.ts
@@ -18,6 +18,7 @@ import {
   indexProductsByGrabKeys,
   resolveGrabItemProduct,
   fallbackGrabItemName,
+  resolveGrabModifierName,
   type GrabItemProductRow,
 } from "@/lib/grab-order-items";
 import { createClient } from "@/lib/supabase-server";
@@ -284,6 +285,26 @@ export async function POST(request: NextRequest) {
       ];
       for (const [k, v] of indexProductsByGrabKeys(rows)) productIndex.set(k, v);
     }
+
+    // Modifier name resolution — Grab order modifiers carry only id + price.
+    // Resolve real labels (e.g. "Oat Milk") from grab_modifier_links by id;
+    // unmatched ones keep the "Add-on @ RM x" fallback. (We also persist the
+    // grab_modifier_id on each line so unmatched ones can be linked later.)
+    const modifierIds = Array.from(
+      new Set(
+        itemsArr.flatMap((i) => (i.modifiers ?? []).map((m) => m.id)).filter(Boolean) as string[],
+      ),
+    );
+    const modifierNameById = new Map<string, string>();
+    if (modifierIds.length > 0) {
+      const { data: links } = await supabase
+        .from("grab_modifier_links")
+        .select("grab_modifier_id, name")
+        .in("grab_modifier_id", modifierIds);
+      for (const l of (links ?? []) as Array<{ grab_modifier_id: string; name: string }>) {
+        modifierNameById.set(l.grab_modifier_id, l.name);
+      }
+    }
     const orderItems = itemsArr.map((item) => {
       const product = resolveGrabItemProduct(item, productIndex);
       const qty = item.quantity ?? 1;
@@ -300,8 +321,11 @@ export async function POST(request: NextRequest) {
         quantity: qty,
         unit_price: unitPrice,
         modifiers: (item.modifiers ?? []).map((m) => ({
-          // Grab order modifiers carry no name — show the price (real labels TODO).
-          name: m.price ? `Add-on @ RM ${((m.price ?? 0) / 100).toFixed(2)}` : "Add-on",
+          // Grab order modifiers carry no name — resolve from grab_modifier_links
+          // by id, else show the price. Persist grab_modifier_id so an unmatched
+          // add-on can be linked from BackOffice and backfilled.
+          grab_modifier_id: m.id ?? null,
+          name: resolveGrabModifierName(m, modifierNameById),
           price: m.price,
           qty: m.quantity,
         })),

--- a/apps/backoffice/src/lib/grab-order-items.test.ts
+++ b/apps/backoffice/src/lib/grab-order-items.test.ts
@@ -3,6 +3,8 @@ import {
   indexProductsByGrabKeys,
   resolveGrabItemProduct,
   fallbackGrabItemName,
+  fallbackGrabModifierName,
+  resolveGrabModifierName,
   type GrabItemProductRow,
 } from "./grab-order-items";
 
@@ -77,5 +79,29 @@ describe("fallbackGrabItemName", () => {
   it("omits the price when it is zero or missing", () => {
     expect(fallbackGrabItemName({ id: "MYITE202", price: 0 })).toBe("Item [MYITE202]");
     expect(fallbackGrabItemName({})).toBe("Item");
+  });
+});
+
+describe("resolveGrabModifierName", () => {
+  const links = new Map([["MYMOD-OAT", "Oat Milk"]]);
+
+  it("resolves a linked modifier to its real name", () => {
+    expect(resolveGrabModifierName({ id: "MYMOD-OAT", price: 200 }, links)).toBe("Oat Milk");
+  });
+
+  it("falls back to a priced add-on when unlinked", () => {
+    expect(resolveGrabModifierName({ id: "MYMOD-???", price: 97 }, links)).toBe("Add-on @ RM 0.97");
+  });
+
+  it("falls back to a bare add-on when free and unlinked", () => {
+    expect(resolveGrabModifierName({ id: "x", price: 0 }, links)).toBe("Add-on");
+    expect(resolveGrabModifierName({}, links)).toBe("Add-on");
+  });
+});
+
+describe("fallbackGrabModifierName", () => {
+  it("shows the price when set, bare otherwise", () => {
+    expect(fallbackGrabModifierName({ price: 300 })).toBe("Add-on @ RM 3.00");
+    expect(fallbackGrabModifierName({ price: 0 })).toBe("Add-on");
   });
 });

--- a/apps/backoffice/src/lib/grab-order-items.ts
+++ b/apps/backoffice/src/lib/grab-order-items.ts
@@ -75,3 +75,26 @@ export function fallbackGrabItemName(item: GrabOrderItemRef): string {
     ? `Item @ RM ${(unitPrice / 100).toFixed(2)}${suffix}`
     : `Item${suffix}`;
 }
+
+// ─── Modifiers (add-ons) ─────────────────────────────────────────────────────
+// Grab order modifiers also carry NO name — only an id + price. The real label
+// is resolved from grab_modifier_links by id; otherwise we surface the price so
+// the kitchen still sees the add-on cost.
+
+export interface GrabOrderModifierRef {
+  id?: string;
+  price?: number; // minor units (sen)
+}
+
+/** "Add-on @ RM x" (or bare "Add-on" when free) for an unlinked modifier. */
+export function fallbackGrabModifierName(m: GrabOrderModifierRef): string {
+  return m.price ? `Add-on @ RM ${((m.price ?? 0) / 100).toFixed(2)}` : "Add-on";
+}
+
+/** Resolve a modifier's display name from the id→name link map, else fallback. */
+export function resolveGrabModifierName(
+  m: GrabOrderModifierRef,
+  nameById: Map<string, string>,
+): string {
+  return (m.id ? nameById.get(m.id) : undefined) ?? fallbackGrabModifierName(m);
+}

--- a/apps/loyalty/supabase/migrations/023_grab_modifier_links.sql
+++ b/apps/loyalty/supabase/migrations/023_grab_modifier_links.sql
@@ -1,0 +1,19 @@
+-- =============================================
+-- 023: Map a GrabFood order modifier id → display name (+ optional product).
+--
+-- GrabFood order webhooks send modifiers as { id, price, quantity, tax } with
+-- NO name, so add-ons print as "Add-on @ RM 0.97" on the kitchen docket instead
+-- of "Oat Milk" / "Extra Shot". This table lets BackOffice link Grab's modifier
+-- id to a real label; the order webhook resolves names from it.
+--
+-- Backoffice-owned (we don't pull these from any sync). grab_modifier_id is
+-- Grab's globally-unique modifier id, so it's the primary key.
+-- =============================================
+
+CREATE TABLE IF NOT EXISTS grab_modifier_links (
+  grab_modifier_id TEXT PRIMARY KEY,
+  name             TEXT NOT NULL,
+  product_id       TEXT REFERENCES products(id) ON DELETE SET NULL,
+  created_at       TIMESTAMPTZ DEFAULT now(),
+  updated_at       TIMESTAMPTZ DEFAULT now()
+);


### PR DESCRIPTION
## Problem (from the QA check)

GrabFood order modifiers arrive as `{ id, price }` with **no name**, so add-ons print on the kitchen docket as generic placeholders — and the webhook was even **dropping the modifier id**, so there was nothing to link against. Live evidence:

```
"Item @ RM 16.87" → modifiers: [ "Add-on", "Add-on @ RM 3.00", "Add-on @ RM 0.97" ]
```

A barista sees "Add-on @ RM 0.97" instead of "Oat Milk" / "Extra Shot".

## What this does

Same pattern as the item link (#317/#318), for modifiers:

- **Webhook** now persists `grab_modifier_id` on each stored modifier and resolves its display name from `grab_modifier_links` (falling back to the priced "Add-on"). Pure `resolveGrabModifierName` / `fallbackGrabModifierName` helpers with tests.
- **Migration** `grab_modifier_links` (`grab_modifier_id` PK → `name`, optional `product_id`).
- **API** `/api/integrations/grab/modifier-links`: `GET` unlinked modifier ids seen in orders (price, times ordered, last seen) + catalogue option-label suggestions + product list; `POST` to name one — upserts the link and **backfills** past order lines' modifier name via `jsonb_set`.
- **BackOffice panel** "Unlinked GrabFood add-ons" on Settings → Integrations → GrabFood: a name field (datalist of existing catalogue option labels) + optional product association per add-on.

## Important limitation

The webhook only **starts capturing** `grab_modifier_id` from this change forward — orders that landed before it predate the id, so the panel fills as **new** Grab orders arrive (it can't retroactively list add-ons from old orders that never stored an id).

## Notes

- `grab_modifier_links` table already applied to the catalogue DB (additive); migration file recorded for repeatability.
- Modifier names are docket/receipt-only — not pushed to Grab (Grab owns its own modifier labels), so no outbound sync here.

Tests: 4 new modifier-resolution cases; full suite green (178). Backoffice typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018jWHLb3AnjmUyzgzuoiuxJ

---
_Generated by [Claude Code](https://claude.ai/code/session_018jWHLb3AnjmUyzgzuoiuxJ)_