### PR TITLE
feat(grab): per-outlet "Push full menu" to GrabFood

### DIFF
--- a/apps/backoffice/src/app/(admin)/settings/integrations/grab/page.tsx
+++ b/apps/backoffice/src/app/(admin)/settings/integrations/grab/page.tsx
@@ -25,6 +25,7 @@ import {
   Store,
   Activity,
   Rocket,
+  UploadCloud,
 } from "lucide-react";
 import { GrabItemLinker } from "./_GrabItemLinker";
 import { GrabModifierLinker } from "./_GrabModifierLinker";
@@ -79,6 +80,9 @@ export default function GrabIntegrationPage() {
   // Manual "push latest menu to Grab": per-outlet busy flag + last result message.
   const [syncBusy, setSyncBusy] = useState<Record<string, boolean>>({});
   const [syncMsg, setSyncMsg] = useState<Record<string, { ok: boolean; text: string }>>({});
+  // Full-menu push (replaces Grab's menu with ours): per-outlet busy + result.
+  const [pushBusy, setPushBusy] = useState<Record<string, boolean>>({});
+  const [pushMsg, setPushMsg] = useState<Record<string, { ok: boolean; text: string }>>({});
   // "Sync all menus" — push every connected outlet's menu to Grab in one click.
   const [syncAllBusy, setSyncAllBusy] = useState(false);
   const [syncAllMsg, setSyncAllMsg] = useState<{ ok: boolean; text: string } | null>(null);
@@ -182,6 +186,51 @@ export default function GrabIntegrationPage() {
       }));
     } finally {
       setSyncBusy((s) => ({ ...s, [outletId]: false }));
+    }
+  };
+
+  // Push the FULL menu to this outlet (replaces Grab's menu with our catalogue,
+  // so Grab adopts our item ids → no per-item linking needed). Destructive if
+  // Grab accepts it; surfaces Grab's raw response so we learn whether a
+  // self-serve store allows a full replace ("UnsupportedMenuSync" if not).
+  const pushFullMenu = async (outletId: string, merchantID: string, outletName: string) => {
+    if (
+      !window.confirm(
+        `Push the FULL catalogue menu to "${outletName}" on GrabFood?\n\n` +
+          `If Grab accepts it, this REPLACES the current GrabFood menu (categories, ` +
+          `modifiers, photos) with ours and makes Grab use our item ids — after which ` +
+          `orders match the catalogue automatically. If Grab rejects it (common for ` +
+          `self-serve stores), nothing changes.`,
+      )
+    ) {
+      return;
+    }
+    setPushBusy((s) => ({ ...s, [outletId]: true }));
+    setPushMsg((s) => ({ ...s, [outletId]: { ok: true, text: "" } }));
+    try {
+      const res = await fetch("/api/pos/grab/menu/push", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ merchantID }),
+      });
+      const json = await res.json();
+      if (!res.ok || !json.ok) {
+        throw new Error(json.error_description || json.error || `HTTP ${res.status}`);
+      }
+      setPushMsg((s) => ({
+        ...s,
+        [outletId]: {
+          ok: true,
+          text: `Full menu accepted by Grab — ${json.items} items in ${json.categories} categories pushed${json.notified ? " + re-pull notified" : ""}. New orders should now match the catalogue automatically.`,
+        },
+      }));
+    } catch (e) {
+      setPushMsg((s) => ({
+        ...s,
+        [outletId]: { ok: false, text: e instanceof Error ? e.message : "Push failed" },
+      }));
+    } finally {
+      setPushBusy((s) => ({ ...s, [outletId]: false }));
     }
   };
 
@@ -396,6 +445,17 @@ export default function GrabIntegrationPage() {
                       Sync menu
                     </button>
                   ) : null}
+                  {o.grabMerchantId ? (
+                    <button
+                      onClick={() => pushFullMenu(o.id, o.grabMerchantId!, o.name)}
+                      disabled={pushBusy[o.id]}
+                      title="Push the FULL catalogue menu (replaces Grab's menu; makes Grab use our item ids)"
+                      className="inline-flex items-center gap-1.5 rounded border border-amber-300 bg-amber-50 px-2.5 py-1 text-sm font-medium text-amber-700 hover:bg-amber-100 disabled:cursor-not-allowed disabled:opacity-50"
+                    >
+                      {pushBusy[o.id] ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <UploadCloud className="h-3.5 w-3.5" />}
+                      Push full menu
+                    </button>
+                  ) : null}
                   <button
                     onClick={() => generateSelfServe(o.id)}
                     disabled={ssBusy[o.id]}
@@ -427,6 +487,9 @@ export default function GrabIntegrationPage() {
                 {err ? <div className="mt-2 text-xs text-red-600">{err}</div> : null}
                 {sync && sync.text ? (
                   <div className={`mt-2 text-xs ${sync.ok ? "text-emerald-700" : "text-red-600"}`}>{sync.text}</div>
+                ) : null}
+                {pushMsg[o.id] && pushMsg[o.id].text ? (
+                  <div className={`mt-2 text-xs ${pushMsg[o.id].ok ? "text-emerald-700" : "text-red-600"}`}>{pushMsg[o.id].text}</div>
                 ) : null}
               </div>
             );

--- a/apps/backoffice/src/app/api/pos/grab/menu/push/route.ts
+++ b/apps/backoffice/src/app/api/pos/grab/menu/push/route.ts
@@ -1,0 +1,97 @@
+/**
+ * Per-outlet FULL-MENU push (us → Grab) — replaces the outlet's entire GrabFood
+ * menu with our catalogue (PUT /partner/v1/menu), then notifies Grab to re-pull.
+ *
+ * POST /api/pos/grab/menu/push   { merchantID }   (staff-auth)
+ *
+ * Why this exists separately from /api/pos/grab/sync (which only pushes price +
+ * availability RECORDS): a full push makes Grab adopt OUR item ids (= products.id)
+ * as each item's externalID, so future order webhooks match the catalogue without
+ * any manual grab_item_id linking. The open question is whether GrabFood accepts
+ * a full-menu replace for a self-serve-linked store — historically it has returned
+ * "UnsupportedMenuSync". This endpoint surfaces Grab's RAW response so we can see
+ * exactly what happens for a given outlet.
+ *
+ * ⚠️ DESTRUCTIVE if accepted: it replaces the live (portal-built) menu — categories,
+ * modifiers and photos as Grab currently holds them — with our payload.
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import { createClient } from "@supabase/supabase-js";
+import { requireAuth } from "@/lib/auth";
+import { updateMenu, notifyMenuUpdate } from "@/lib/grab";
+import { buildOutletGrabMenu } from "@/lib/grab-menu-outlet";
+
+function serviceClient() {
+  return createClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.SUPABASE_SERVICE_ROLE_KEY || process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+  );
+}
+
+export async function POST(request: NextRequest) {
+  const auth = await requireAuth(request);
+  if (auth.error) return auth.error;
+
+  if (!process.env.GRAB_CLIENT_ID || !process.env.GRAB_CLIENT_SECRET) {
+    return NextResponse.json(
+      { ok: false, error: "missing_credentials", error_description: "Set GRAB_CLIENT_ID and GRAB_CLIENT_SECRET." },
+      { status: 400 },
+    );
+  }
+
+  let body: Record<string, unknown> = {};
+  try {
+    body = await request.json();
+  } catch {
+    /* tolerate empty body */
+  }
+  const merchantID = String(body.merchantID ?? "").trim();
+  if (!merchantID) {
+    return NextResponse.json(
+      { ok: false, error: "invalid_request", error_description: "merchantID is required" },
+      { status: 400 },
+    );
+  }
+
+  const menu = await buildOutletGrabMenu(serviceClient(), merchantID);
+  if (!menu) {
+    return NextResponse.json(
+      { ok: false, error: "build_failed", error_description: "Could not build the menu for this outlet." },
+      { status: 500 },
+    );
+  }
+
+  const itemsCount = menu.categories.reduce((n, c) => n + c.items.length, 0);
+  if (itemsCount === 0) {
+    return NextResponse.json(
+      { ok: false, error: "empty_menu", error_description: "No Grab-visible items to push for this outlet." },
+      { status: 400 },
+    );
+  }
+
+  try {
+    const result = await updateMenu(menu);
+    // Best-effort nudge to re-pull (also the lever for photos/structure refresh).
+    let notified = true;
+    try {
+      await notifyMenuUpdate(merchantID);
+    } catch {
+      notified = false;
+    }
+    return NextResponse.json({
+      ok: true,
+      merchantID,
+      categories: menu.categories.length,
+      items: itemsCount,
+      notified,
+      result,
+    });
+  } catch (err) {
+    // Surface Grab's exact message (e.g. "UnsupportedMenuSync") verbatim.
+    return NextResponse.json(
+      { ok: false, error: "push_failed", error_description: err instanceof Error ? err.message : "Unknown error" },
+      { status: 502 },
+    );
+  }
+}


### PR DESCRIPTION
## Why

The cleanest fix for GrabFood order names/dockets/sync is to make Grab use **our** item ids instead of linking each one by hand. A full-menu push (`PUT /partner/v1/menu`) does exactly that: Grab adopts our `products.id` as each item's externalID, so future order webhooks match the catalogue automatically — no `grab_item_id` linking needed.

The open question is whether a **self-serve-linked** store (like Putrajaya) accepts a full-menu replace, or returns `UnsupportedMenuSync` as it has historically. This PR adds a controlled way to **try it per outlet and read Grab's exact response**.

## What

- **`POST /api/pos/grab/menu/push { merchantID }`** — builds the outlet's menu via the same per-outlet builder used by the record sync, `PUT`s the full menu to Grab, fires a re-pull notify, and returns Grab's **verbatim** error (e.g. `UnsupportedMenuSync`) on failure. Staff-gated; service-role read.
- **BackOffice → Integrations → GrabFood**: a per-outlet **"Push full menu"** button (amber, next to "Sync menu") with a confirm dialog warning that it **replaces the live Grab menu** if accepted, plus a result line showing items/categories pushed or Grab's error.

## ⚠️ Behaviour / risk

- **Destructive if accepted:** a successful push **replaces** the current GrabFood menu (categories, modifiers, photos as Grab holds them) with our catalogue payload. If Grab rejects it, nothing changes.
- **Outcome tells us the path forward:**
  - ✅ accepted → Grab uses our ids; the manual item-linking (#318) becomes unnecessary going forward.
  - ❌ `UnsupportedMenuSync` → confirmed; linking remains the only route.

Typecheck + full suite green (178); lint clean (0 errors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018jWHLb3AnjmUyzgzuoiuxJ

---
_Generated by [Claude Code](https://claude.ai/code/session_018jWHLb3AnjmUyzgzuoiuxJ)_