### PR TITLE
fix(grab): drop campaignInfo:null from menu push + log payload shape

### DIFF
--- a/apps/backoffice/src/app/api/pos/grab/menu/push/route.ts
+++ b/apps/backoffice/src/app/api/pos/grab/menu/push/route.ts
@@ -70,6 +70,18 @@ export async function POST(request: NextRequest) {
     );
   }
 
+  // Diagnostic: Grab's "Invalid parameters!" gives no field, so log the shape we
+  // send (top-level + a representative item/modifier) to pinpoint the bad field.
+  console.log(
+    `[grab:menu-push] merchant=${merchantID} cats=${menu.categories.length} items=${itemsCount} ` +
+      `sample=${JSON.stringify({
+        currency: menu.currency,
+        sellingTimes: menu.sellingTimes,
+        firstCategory: { ...menu.categories[0], items: undefined },
+        firstItem: menu.categories[0]?.items[0],
+      })}`,
+  );
+
   try {
     const result = await updateMenu(menu);
     // Best-effort nudge to re-pull (also the lever for photos/structure refresh).

--- a/apps/backoffice/src/lib/grab-menu.ts
+++ b/apps/backoffice/src/lib/grab-menu.ts
@@ -134,7 +134,6 @@ export function convertProductToGrabItem(product: RawProduct, sequence = 1): Gra
     availableStatus,
     description: product.description || undefined,
     price: Math.round(resolveGrabPriceRM(product) * 100), // RM → sen
-    campaignInfo: null,
     photos: product.image_url ? [grabSafeImageUrl(product.image_url)] : undefined,
     // Grab REQUIRES maxStock:0 whenever availableStatus is UNAVAILABLE — omitting it
     // makes Grab reject the entire menu push ("failed to push your menu"). AVAILABLE


### PR DESCRIPTION
## Context

Clicking "Push full menu" (PR #320) for Putrajaya/Shah Alam returned:

```
Grab API PUT /partner/v1/menu failed (400):
{"target":"","reason":"invalid_argument","message":"Invalid parameters!"}
```

Good news: that's **not** `UnsupportedMenuSync` — Grab **will** accept a full-menu push for these self-serve stores; our **payload is just malformed**. The error names no field, and the catalogue data is clean (86 items, no empty names, no zero prices, all https images), so this is a payload-shape issue.

## Changes

- **Drop `campaignInfo: null`** from each item. We were explicitly emitting a bare `null` for an optional object — a classic `invalid_argument` trigger. Now the field is omitted. (Shared builder, so the inbound get-menu webhook benefits too.)
- **Log the outgoing payload shape** (currency, sellingTimes, first category + first item) in the push route, so if Grab still rejects it we can read the exact field we send from the runtime logs and fix precisely — rather than guess against an opaque error.

Typecheck + full suite green (178).

## Next

After deploy, click "Push full menu" once more — either it succeeds (campaignInfo was it), or I read the logged payload and pinpoint the remaining bad field.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018jWHLb3AnjmUyzgzuoiuxJ

---
_Generated by [Claude Code](https://claude.ai/code/session_018jWHLb3AnjmUyzgzuoiuxJ)_