### PR TITLE
fix(grab): full-menu sync via re-pull notification, not the record PUT

### DIFF
--- a/apps/backoffice/src/app/(admin)/settings/integrations/grab/page.tsx
+++ b/apps/backoffice/src/app/(admin)/settings/integrations/grab/page.tsx
@@ -189,18 +189,19 @@ export default function GrabIntegrationPage() {
     }
   };
 
-  // Push the FULL menu to this outlet (replaces Grab's menu with our catalogue,
-  // so Grab adopts our item ids → no per-item linking needed). Destructive if
-  // Grab accepts it; surfaces Grab's raw response so we learn whether a
-  // self-serve store allows a full replace ("UnsupportedMenuSync" if not).
+  // Ask Grab to re-pull our get-menu webhook for this outlet (the menu-update
+  // notification — Grab's actual full-menu sync mechanism). If the outlet is
+  // partner-managed, Grab adopts our catalogue + our item ids → no per-item
+  // linking needed. If it's still merchant-managed (self-serve), Grab returns
+  // "UnsupportedMenuSync" and nothing changes — surfaced verbatim.
   const pushFullMenu = async (outletId: string, merchantID: string, outletName: string) => {
     if (
       !window.confirm(
-        `Push the FULL catalogue menu to "${outletName}" on GrabFood?\n\n` +
-          `If Grab accepts it, this REPLACES the current GrabFood menu (categories, ` +
-          `modifiers, photos) with ours and makes Grab use our item ids — after which ` +
-          `orders match the catalogue automatically. If Grab rejects it (common for ` +
-          `self-serve stores), nothing changes.`,
+        `Sync the full catalogue menu to "${outletName}" on GrabFood?\n\n` +
+          `This asks Grab to re-pull our menu. If the outlet is in partner-managed ` +
+          `mode, Grab replaces its menu with ours (using our item ids), after which ` +
+          `orders match the catalogue automatically. If it's still self-serve ` +
+          `(merchant-managed), Grab returns "UnsupportedMenuSync" and nothing changes.`,
       )
     ) {
       return;
@@ -221,7 +222,7 @@ export default function GrabIntegrationPage() {
         ...s,
         [outletId]: {
           ok: true,
-          text: `Full menu accepted by Grab — ${json.items} items in ${json.categories} categories pushed${json.notified ? " + re-pull notified" : ""}. New orders should now match the catalogue automatically.`,
+          text: `Grab accepted the sync — it will re-pull our menu (${json.items} items, ${json.categories} categories) and adopt our item ids. New orders should match the catalogue automatically once the re-pull completes.`,
         },
       }));
     } catch (e) {
@@ -449,11 +450,11 @@ export default function GrabIntegrationPage() {
                     <button
                       onClick={() => pushFullMenu(o.id, o.grabMerchantId!, o.name)}
                       disabled={pushBusy[o.id]}
-                      title="Push the FULL catalogue menu (replaces Grab's menu; makes Grab use our item ids)"
+                      title="Ask Grab to re-pull our full catalogue menu (works only when the outlet is partner-managed on Grab)"
                       className="inline-flex items-center gap-1.5 rounded border border-amber-300 bg-amber-50 px-2.5 py-1 text-sm font-medium text-amber-700 hover:bg-amber-100 disabled:cursor-not-allowed disabled:opacity-50"
                     >
                       {pushBusy[o.id] ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <UploadCloud className="h-3.5 w-3.5" />}
-                      Push full menu
+                      Sync full menu
                     </button>
                   ) : null}
                   <button

--- a/apps/backoffice/src/app/api/pos/grab/menu/push/route.ts
+++ b/apps/backoffice/src/app/api/pos/grab/menu/push/route.ts
@@ -1,25 +1,32 @@
 /**
- * Per-outlet FULL-MENU push (us → Grab) — replaces the outlet's entire GrabFood
- * menu with our catalogue (PUT /partner/v1/menu), then notifies Grab to re-pull.
+ * Per-outlet full-menu SYNC (us → Grab) via the menu-update NOTIFICATION.
  *
  * POST /api/pos/grab/menu/push   { merchantID }   (staff-auth)
  *
- * Why this exists separately from /api/pos/grab/sync (which only pushes price +
- * availability RECORDS): a full push makes Grab adopt OUR item ids (= products.id)
- * as each item's externalID, so future order webhooks match the catalogue without
- * any manual grab_item_id linking. The open question is whether GrabFood accepts
- * a full-menu replace for a self-serve-linked store — historically it has returned
- * "UnsupportedMenuSync". This endpoint surfaces Grab's RAW response so we can see
- * exactly what happens for a given outlet.
+ * GrabFood has NO "replace the whole menu" push endpoint. The full menu is
+ * delivered by Grab PULLING our get-menu webhook (/api/pos/grab/merchant/menu),
+ * which already serves the catalogue keyed by OUR product ids. To refresh it we
+ * call the menu-update notification (POST /partner/v1/merchant/menu/notification)
+ * — Grab then re-pulls our webhook. This is how StoreHub "pushes" a menu.
  *
- * ⚠️ DESTRUCTIVE if accepted: it replaces the live (portal-built) menu — categories,
- * modifiers and photos as Grab currently holds them — with our payload.
+ * (The earlier PUT /partner/v1/menu attempt failed with "invalid_argument:
+ * Invalid parameters!" because that endpoint is Grab's Update Menu RECORD API —
+ * a single item/modifier by id — not a full-menu body.)
+ *
+ * Outcome surfaced verbatim:
+ *   - ok               → Grab accepted the sync; it will re-pull our menu and
+ *                        adopt our item ids (orders then match the catalogue,
+ *                        no per-item linking needed).
+ *   - "UnsupportedMenuSync" → this outlet is still MERCHANT-managed (self-serve)
+ *                        on Grab's side. Grab must switch it to partner/
+ *                        integration-managed menu mode (onboarding step) before
+ *                        a sync is accepted — the same mode StoreHub stores use.
  */
 
 import { NextRequest, NextResponse } from "next/server";
 import { createClient } from "@supabase/supabase-js";
 import { requireAuth } from "@/lib/auth";
-import { updateMenu, notifyMenuUpdate } from "@/lib/grab";
+import { notifyMenuUpdate } from "@/lib/grab";
 import { buildOutletGrabMenu } from "@/lib/grab-menu-outlet";
 
 function serviceClient() {
@@ -54,55 +61,30 @@ export async function POST(request: NextRequest) {
     );
   }
 
+  // Sanity-check that our get-menu webhook will serve a non-empty menu for this
+  // outlet (we don't send it here — Grab pulls it — but an empty pull is pointless).
   const menu = await buildOutletGrabMenu(serviceClient(), merchantID);
-  if (!menu) {
+  const itemsCount = menu ? menu.categories.reduce((n, c) => n + c.items.length, 0) : 0;
+  if (!menu || itemsCount === 0) {
     return NextResponse.json(
-      { ok: false, error: "build_failed", error_description: "Could not build the menu for this outlet." },
-      { status: 500 },
-    );
-  }
-
-  const itemsCount = menu.categories.reduce((n, c) => n + c.items.length, 0);
-  if (itemsCount === 0) {
-    return NextResponse.json(
-      { ok: false, error: "empty_menu", error_description: "No Grab-visible items to push for this outlet." },
+      { ok: false, error: "empty_menu", error_description: "No Grab-visible items to serve for this outlet." },
       { status: 400 },
     );
   }
 
-  // Diagnostic: Grab's "Invalid parameters!" gives no field, so log the shape we
-  // send (top-level + a representative item/modifier) to pinpoint the bad field.
-  console.log(
-    `[grab:menu-push] merchant=${merchantID} cats=${menu.categories.length} items=${itemsCount} ` +
-      `sample=${JSON.stringify({
-        currency: menu.currency,
-        sellingTimes: menu.sellingTimes,
-        firstCategory: { ...menu.categories[0], items: undefined },
-        firstItem: menu.categories[0]?.items[0],
-      })}`,
-  );
-
   try {
-    const result = await updateMenu(menu);
-    // Best-effort nudge to re-pull (also the lever for photos/structure refresh).
-    let notified = true;
-    try {
-      await notifyMenuUpdate(merchantID);
-    } catch {
-      notified = false;
-    }
+    const result = await notifyMenuUpdate(merchantID);
     return NextResponse.json({
       ok: true,
       merchantID,
       categories: menu.categories.length,
       items: itemsCount,
-      notified,
       result,
     });
   } catch (err) {
     // Surface Grab's exact message (e.g. "UnsupportedMenuSync") verbatim.
     return NextResponse.json(
-      { ok: false, error: "push_failed", error_description: err instanceof Error ? err.message : "Unknown error" },
+      { ok: false, error: "notify_failed", error_description: err instanceof Error ? err.message : "Unknown error" },
       { status: 502 },
     );
   }


### PR DESCRIPTION
## Root cause

The "Push full menu" button (PRs #320/#321) PUT our entire menu (`currency` + `sellingTimes` + `categories`) to `PUT /partner/v1/menu` — but in Grab's official SDK that endpoint is the **Update Menu *Record*** API (a single item/modifier by `id` + `field`), **not** a full-menu body. So Grab rejected it with `invalid_argument: Invalid parameters!`. Our field names were all correct; the *endpoint* was wrong.

**GrabFood has no full-menu-replace push.** The full menu is delivered by Grab **pulling** our get-menu webhook (`/api/pos/grab/merchant/menu`) — which already serves the catalogue keyed by **our product ids** — and the partner triggers a refresh with the **menu-update notification** (`POST /partner/v1/merchant/menu/notification`). This is exactly how StoreHub "pushes" a menu.

## Change

- `/api/pos/grab/menu/push` now calls **`notifyMenuUpdate`** (trigger re-pull) instead of `updateMenu`, after sanity-checking the outlet has Grab-visible items. Grab's response is surfaced verbatim:
  - **ok** → re-pull accepted; Grab adopts our menu + our item ids → orders match the catalogue automatically, **no per-item linking needed**.
  - **`UnsupportedMenuSync`** → the outlet is still **merchant-managed** (self-serve) on Grab; it must be switched to **partner/integration-managed menu mode** (a Grab onboarding step — the same mode StoreHub stores use). No API call from our side can flip that.
- BackOffice button relabeled **"Sync full menu"** with confirm + result copy matching the re-pull mechanism.

So this turns the button into both the correct mechanism *and* a clean probe of whether each outlet is already partner-managed.

Typecheck + full suite green (178).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018jWHLb3AnjmUyzgzuoiuxJ

---
_Generated by [Claude Code](https://claude.ai/code/session_018jWHLb3AnjmUyzgzuoiuxJ)_