### PR TITLE
fix(pickup): persist product image zoom + order Grab menu to follow pickup catalog

### DIFF
--- a/apps/backoffice/src/app/api/pickup/products/[id]/route.ts
+++ b/apps/backoffice/src/app/api/pickup/products/[id]/route.ts
@@ -37,6 +37,12 @@ export async function PATCH(
   if (typeof body.description === "string")  update.description  = body.description;
   if (typeof body.category_id === "string")  update.category     = body.category_id;
   if (typeof body.image === "string")        update.image_url    = body.image;
+  // Product-image zoom (percentage, 50–200; 100 = no zoom). Clamp to the
+  // slider's range so a stray value can't break the storefront layout. Not in
+  // GRAB_RELEVANT_COLUMNS — zoom is display-only and doesn't change the Grab menu.
+  if (typeof body.image_zoom === "number" && Number.isFinite(body.image_zoom)) {
+    update.image_zoom = Math.min(200, Math.max(50, Math.round(body.image_zoom)));
+  }
   if (typeof body.is_available === "boolean") update.is_available = body.is_available;
   if (typeof body.is_popular === "boolean")  update.is_featured  = body.is_popular;
   if (typeof body.position === "number" && Number.isFinite(body.position)) {

--- a/apps/backoffice/src/app/api/pickup/products/route.ts
+++ b/apps/backoffice/src/app/api/pickup/products/route.ts
@@ -11,7 +11,7 @@ export async function GET(request: NextRequest) {
   const supabase = getSupabaseAdmin();
   const { data, error } = await supabase
     .from("products")
-    .select("id, name, category, price, image_url, is_available, is_featured, modifiers, track_stock, synced_at, position, featured_position, print_additional_docket, kitchen_station, e_invoice_classification_code, schedule_start_date, schedule_end_date, schedule_days_of_week, schedule_time_from, schedule_time_to, price_pickup, price_grab, price_foodpanda, price_dinein, tax_rate, tax_inclusive, grab_item_id")
+    .select("id, name, category, price, image_url, image_zoom, is_available, is_featured, modifiers, track_stock, synced_at, position, featured_position, print_additional_docket, kitchen_station, e_invoice_classification_code, schedule_start_date, schedule_end_date, schedule_days_of_week, schedule_time_from, schedule_time_to, price_pickup, price_grab, price_foodpanda, price_dinein, tax_rate, tax_inclusive, grab_item_id")
     .eq("brand_id", "brand-celsius")
     .order("category")
     .order("position")
@@ -27,7 +27,7 @@ export async function GET(request: NextRequest) {
     description:  "",
     base_price:   Math.round((p.price as number) * 100),
     image:        (p.image_url as string) ?? "",
-    image_zoom:   100,
+    image_zoom:   (p.image_zoom as number) ?? 100,
     is_available: p.is_available ?? true,
     is_popular:   p.is_featured ?? false,
     is_new:       false,
@@ -85,6 +85,7 @@ export async function POST(request: NextRequest) {
     image?: string;
     is_available?: boolean;
     is_popular?: boolean;
+    image_zoom?: number;
     modifiers?: unknown[];
     // Channel pricing + tax/e-Invoice (StoreHub-parity, added 2026-05-26).
     // All optional — empty/undefined channel price means "use base price".
@@ -152,13 +153,16 @@ export async function POST(request: NextRequest) {
       category,
       price:       body.base_price_rm,
       image_url:   body.image ?? "",
+      image_zoom:  typeof body.image_zoom === "number" && Number.isFinite(body.image_zoom)
+        ? Math.min(200, Math.max(50, Math.round(body.image_zoom)))
+        : 100,
       is_available: body.is_available ?? true,
       is_featured:  body.is_popular ?? false,
       modifiers:    body.modifiers ?? [],
       position:     nextPosition,
       ...channelTaxInsert,
     })
-    .select("id, name, category, price, image_url, is_available, is_featured, modifiers, position")
+    .select("id, name, category, price, image_url, image_zoom, is_available, is_featured, modifiers, position")
     .single();
 
   if (error) return NextResponse.json({ error: error.message }, { status: 500 });
@@ -177,7 +181,7 @@ export async function POST(request: NextRequest) {
     description:  "",
     base_price:   Math.round(((data as Record<string,unknown>).price as number) * 100),
     image:        (data as Record<string,unknown>).image_url ?? "",
-    image_zoom:   100,
+    image_zoom:   ((data as Record<string,unknown>).image_zoom as number) ?? 100,
     is_available: (data as Record<string,unknown>).is_available ?? true,
     is_popular:   (data as Record<string,unknown>).is_featured ?? false,
     is_new:       false,

--- a/apps/backoffice/src/lib/grab-menu-outlet.ts
+++ b/apps/backoffice/src/lib/grab-menu-outlet.ts
@@ -25,7 +25,7 @@ export async function buildOutletGrabMenu(
   merchantId: string,
 ): Promise<ReturnType<typeof buildGrabMenuPayload> | null> {
   const [productsRes, categoriesRes] = await Promise.all([
-    supabase.from("products").select("*").order("category").order("name"),
+    supabase.from("products").select("*").order("category").order("position").order("name"),
     supabase.from("categories").select("id, slug, name").order("position", { ascending: true }),
   ]);
 
@@ -67,11 +67,16 @@ export async function buildOutletGrabMenu(
   }
 
   // Build slug→displayName map so Grab sees "Artisan Choc" instead of "artisan-choc".
+  // Also capture each category's rank (categoriesRes is ordered by position) so the
+  // Grab menu can mirror the pickup catalog's category order, not just A–Z.
   const categoryNames: Record<string, string> = {};
-  for (const c of categoriesRes.data || []) {
+  const categoryRank: Record<string, number> = {};
+  (categoriesRes.data || []).forEach((c, idx) => {
     if (c.slug && c.name) categoryNames[c.slug] = c.name;
     if (c.id && c.name) categoryNames[c.id] = c.name; // products.category might store id too
-  }
+    if (c.slug) categoryRank[c.slug] = idx;
+    if (c.id) categoryRank[c.id] = idx; // products.category might store id too
+  });
 
   // "Show on" placement: only products visible on the Grab channel ship (empty
   // visible_channels = everywhere — same allow-list rule as modifiers).
@@ -79,6 +84,22 @@ export async function buildOutletGrabMenu(
     const vc = (p as { visible_channels?: string[] }).visible_channels;
     return !Array.isArray(vc) || vc.length === 0 || vc.includes("grab");
   });
+
+  // Follow the pickup catalog's arrangement: category order by categories.position,
+  // then products by their per-category position (then name). buildGrabMenuPayload
+  // emits categories in first-seen order and items in array order, so sorting the
+  // array here is what drives the on-Grab ordering.
+  const rankOf = (p: RawProduct) => categoryRank[p.category] ?? Number.MAX_SAFE_INTEGER;
+  const posOf = (p: RawProduct) => {
+    const n = Number((p as { position?: number }).position);
+    return Number.isFinite(n) ? n : Number.MAX_SAFE_INTEGER;
+  };
+  grabProducts.sort(
+    (a, b) =>
+      rankOf(a) - rankOf(b) ||
+      posOf(a) - posOf(b) ||
+      (a.name || "").localeCompare(b.name || ""),
+  );
 
   return buildGrabMenuPayload(grabProducts, merchantId, {
     ...grabMenuOptionsFromEnv(),

--- a/supabase/migrations/026_product_image_zoom.sql
+++ b/supabase/migrations/026_product_image_zoom.sql
@@ -1,0 +1,7 @@
+-- Product-image zoom level (percentage, 50–200; 100 = no zoom), set per product
+-- in BackOffice → Pickup → Menu. The zoom slider in the product form had no
+-- backing column here, so saves were silently dropped and the value reverted to
+-- 100 on reload. Mirrors apps/order/supabase/migrations/009 (never applied to
+-- this project). Idempotent.
+ALTER TABLE products
+  ADD COLUMN IF NOT EXISTS image_zoom integer NOT NULL DEFAULT 100;


### PR DESCRIPTION
## Two related BackOffice → Pickup menu fixes

### 1. Product image zoom now persists
The zoom slider under a product image (BackOffice → Pickup → Menu) only changed client-side preview state — on save it was silently dropped and reverted to 100% ("normal") on reload. Three gaps:

- **No `image_zoom` column** existed in this project — the migration only lived in `apps/order` and was never applied here. Added (idempotent, default 100). *Already applied to the live DB.*
- **GET `/api/pickup/products`** hardcoded `image_zoom: 100` instead of reading the row.
- **PATCH/POST** never wrote `image_zoom`.

Now GET returns the stored value and PATCH/POST persist it (clamped 50–200 to match the slider). `image_zoom` is intentionally **not** in `GRAB_RELEVANT_COLUMNS` — zoom is display-only and must not trigger a Grab menu re-sync.

### 2. Grab menu follows the pickup catalog order
The GrabFood menu builder emitted categories A–Z (first-seen) and items by name, ignoring the merchant's arrangement. The pickup catalog (and the customer Order app) order by `categories.position` then `products.position`. Now the Grab builder sorts the product array by **category rank (`categories.position`) → product `position` → name** before building, so Grab mirrors the order the merchant sets via drag-reorder in BackOffice → Pickup → Menu. Takes effect on the next Grab menu push.

## Test plan
- [x] `tsc --noEmit` clean (backoffice)
- [x] `image_zoom` column applied + verified on the live DB
- [ ] Set a zoom, save, reload → value sticks (form + menu grid)
- [ ] Reorder products/categories in Pickup → Menu, push Grab menu → Grab order matches pickup

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SXF3GNPYGpZzwMWy9AR9DV

---
_Generated by [Claude Code](https://claude.ai/code/session_01SXF3GNPYGpZzwMWy9AR9DV)_