### PR TITLE
fix(order): stop the outlet picker from dropping a table customer into pickup

### DIFF
--- a/apps/order/src/app/menu/_OutletPickerRow.tsx
+++ b/apps/order/src/app/menu/_OutletPickerRow.tsx
@@ -3,20 +3,25 @@
 import { useEffect, useState } from "react";
 import Link from "next/link";
 import { MapPin, ChevronDown } from "lucide-react";
+import { getDineInContext } from "@/lib/checkout-session";
 
 /**
  * Outlet picker row at the top of /menu. Shows the actual selected
  * outlet name from localStorage; same visual as apps/pickup-native
  * /app/menu.tsx:460-473 (MapPin terracotta + bold name + ChevronDown).
  *
- * In dine-in (table-QR) mode it shows "Table N · {outlet}" and is not
- * a link — the customer is seated, so there's no outlet to change.
+ * In dine-in (table-QR) mode it shows "Table N · {outlet}" and is NOT a
+ * link — the customer is seated, so there's no outlet to change, and
+ * routing them into /store would clear their dine-in context (the
+ * silent-pickup bug). Dine-in is read from the authoritative
+ * "celsius-dinein" key (via getDineInContext), NOT the shared
+ * "celsius-pickup" blob — the blob's orderType/tableNumber get stripped
+ * by the Expo store partialize, which used to flip this row back into a
+ * tappable pickup link mid-session.
  */
 type Persisted = {
   state?: {
     outletName?: string | null;
-    orderType?: "pickup" | "dine_in" | null;
-    tableNumber?: string | null;
   };
 };
 
@@ -31,8 +36,11 @@ export function OutletPickerRow() {
       if (raw) {
         const parsed = JSON.parse(raw) as Persisted;
         setName(parsed.state?.outletName ?? null);
-        setDineIn(parsed.state?.orderType === "dine_in");
-        setTable(parsed.state?.tableNumber ?? null);
+      }
+      const dine = getDineInContext();
+      if (dine) {
+        setDineIn(true);
+        setTable(dine.tableNumber);
       }
     } catch {
       /* ignore */

--- a/apps/order/src/app/store/_StoreList.tsx
+++ b/apps/order/src/app/store/_StoreList.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState } from "react";
 import Link from "next/link";
 import { useRouter, useSearchParams } from "next/navigation";
 import { ArrowLeft, MapPin, CheckCircle2, Clock, Users } from "lucide-react";
+import { getDineInContext } from "@/lib/checkout-session";
 
 type Outlet = {
   store_id: string;
@@ -55,10 +56,14 @@ export function StoreList({ outlets }: { outlets: Outlet[] }) {
       state.outletIsBusy = o.is_busy;
       state.outletPickupTimeMins = o.pickup_time_mins;
       window.localStorage.setItem("celsius-pickup", JSON.stringify({ ...parsed, state }));
-      // Choosing an outlet from the picker is an explicit pickup action —
-      // drop any dine-in context from a prior table scan so the order isn't
-      // mistakenly treated as dine-in.
-      window.localStorage.removeItem("celsius-dinein");
+      // Picking a DIFFERENT outlet is an explicit pickup action — drop any
+      // dine-in context from a prior table scan. But re-picking the SAME
+      // outlet a seated customer is already dining at must NOT strand them as
+      // pickup (web checkout is QR-table-only and would then reject the order).
+      const dine = getDineInContext();
+      if (!dine || dine.outletId !== o.store_id) {
+        window.localStorage.removeItem("celsius-dinein");
+      }
     } catch {
       /* ignore */
     }


### PR DESCRIPTION
## Problem

A customer scanned table 13 (Shah Alam) but landed on a **pickup** checkout and hit *"Please scan the QR code on your table to order. To order for pickup, use the Celsius app."* — a dead end.

The web order app (`order.celsiuscoffee.com`) is **QR-table-only**: `/api/checkout/initiate` deliberately rejects any non-`dine_in` order rather than write a mis-seated pickup order. So the real bug is that the **dine-in context was lost between scanning and checkout**, turning the order into a (blocked) pickup.

### Root cause
The menu's outlet row already tried to hide the picker in dine-in mode, but it decided dine-in from the shared **`celsius-pickup` blob's `orderType`**, which the Expo store `partialize` strips mid-session. Once stripped, the row reverted to a tappable `→ /store` link. Tapping it ran `_StoreList.choose()`, which **deleted the authoritative `celsius-dinein` key** — the one checkout actually trusts — so the order silently became pickup.

## Fix (targeted — app otherwise unchanged)

- **`_OutletPickerRow`** now reads dine-in from `getDineInContext()` (the `celsius-dinein` key, with the same <6h freshness check checkout uses). A seated customer always sees a static **"Table N · {outlet}"** row and is never routed into `/store`.
- **`_StoreList.choose()`** only clears `celsius-dinein` when switching to a **different** outlet; re-picking the same outlet no longer strands a seated customer.

The server-side QR-table guard is unchanged (still blocks genuine web-pickup attempts).

## Not included
The remaining edge cases (context lost across browsers, >6h TTL, direct/bookmarked visits) still surface the flat error text. A friendly "scan your table QR / re-scan" screen would be a good follow-up — happy to add it if wanted.

## Test plan
- [x] `tsc --noEmit` clean (order app)
- [ ] Scan table QR → on menu, tap the outlet row → it's static (no `/store`); dine-in survives to checkout
- [ ] Scan table QR, then re-pick the same outlet in `/store` → still dine-in; pick a different outlet → becomes pickup

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SXF3GNPYGpZzwMWy9AR9DV

---
_Generated by [Claude Code](https://claude.ai/code/session_01SXF3GNPYGpZzwMWy9AR9DV)_