### PR TITLE
feat(grab): wire PushGrabMenu webhook — persist names + auto-link by name

### DIFF
--- a/apps/backoffice/src/app/api/pos/grab/menus/route.ts
+++ b/apps/backoffice/src/app/api/pos/grab/menus/route.ts
@@ -3,10 +3,17 @@
  *
  * POST /api/grab/menus
  *
- * During the self-serve store-activation journey, GrabFood pushes the store's
- * canonical menu (as it exists on Grab's side) to the partner. We just need to
- * accept and acknowledge it — our POS is the menu source of truth, so there's
- * nothing to persist yet; we log the shape for debugging during staging.
+ * GrabFood pushes the store's canonical menu (as it exists on Grab's side) to
+ * the partner — carrying Grab's item id, the item NAME, and price. This is the
+ * ONE place we ever learn a Grab item's name (order webhooks carry none), so:
+ *   1. persist each item into grab_menu_items (id → name → price), and
+ *   2. auto-link any item whose name uniquely matches a catalogue product by
+ *      setting products.grab_item_id, then backfilling already-received order
+ *      lines (name + product_id → fixes kitchen-station routing on reprint).
+ *
+ * This is the safety net for Grab-internal ("MYITE…") ids. When Grab sends our
+ * own product id on orders, no link is needed and the order resolves directly.
+ * Items with no unique name match are left for the BackOffice item-link panel.
  *
  * Authenticated with the partner Bearer token Grab obtained from our
  * /api/grab/oauth/token endpoint. Register this URL in the portal
@@ -15,6 +22,27 @@
 
 import { NextRequest, NextResponse } from "next/server";
 import { verifyGrabPartnerToken } from "@/lib/grab-partner";
+import { getSupabaseAdmin } from "@/lib/pickup/supabase";
+import { normalizeMenuName } from "@/lib/grab-menu";
+
+type IncomingItem = { id?: string; itemID?: string; grabItemID?: string; name?: string; price?: number };
+type IncomingCategory = { items?: IncomingItem[]; name?: string };
+
+// Flatten Grab's menu payload (categories[].items[]) into {id, name, price}.
+// Tolerant of field aliases across API versions.
+function flattenItems(body: Record<string, unknown>): { id: string; name: string; price: number | null; category: string | null }[] {
+  const categories = (body.categories as IncomingCategory[] | undefined) ?? [];
+  const out: { id: string; name: string; price: number | null; category: string | null }[] = [];
+  for (const c of categories) {
+    for (const it of c.items ?? []) {
+      const id = (it.id || it.itemID || it.grabItemID || "").trim();
+      const name = (it.name || "").trim();
+      if (!id || !name) continue;
+      out.push({ id, name, price: typeof it.price === "number" ? it.price : null, category: c.name ?? null });
+    }
+  }
+  return out;
+}
 
 export async function POST(request: NextRequest) {
   if (!(await verifyGrabPartnerToken(request))) {
@@ -29,16 +57,81 @@ export async function POST(request: NextRequest) {
   }
 
   const merchantID = (body.merchantID || body.merchantId || "") as string;
-  const categories = Array.isArray((body as { categories?: unknown[] }).categories)
-    ? (body as { categories: unknown[] }).categories.length
-    : undefined;
-  console.log(
-    `[grab:push-menu] received merchant=${merchantID}` +
-      (categories !== undefined ? ` categories=${categories}` : ""),
-  );
+  const items = flattenItems(body);
+  console.log(`[grab:push-menu] received merchant=${merchantID} items=${items.length}`);
+
+  // Nothing to persist (URL-reachability ping / empty push) → just ack.
+  if (items.length === 0) return NextResponse.json({ success: true, items: 0 });
+
+  let autoLinked = 0;
+  try {
+    const supabase = getSupabaseAdmin();
+
+    // 1. Persist every item's name + price (idempotent upsert).
+    await supabase.from("grab_menu_items").upsert(
+      items.map((it) => ({
+        grab_item_id: it.id,
+        merchant_id: merchantID || null,
+        name: it.name,
+        price: it.price,
+        category: it.category,
+        updated_at: new Date().toISOString(),
+      })),
+      { onConflict: "grab_item_id" },
+    );
+
+    // 2. Auto-link by unique name. Only a single unmistakable name match is safe;
+    //    ambiguous names stay for a manual pick in BackOffice.
+    const { data: prods } = await supabase
+      .from("products")
+      .select("id, name, grab_item_id")
+      .eq("brand_id", "brand-celsius");
+    const products = (prods ?? []) as { id: string; name: string; grab_item_id: string | null }[];
+
+    // grab ids already assigned to a product (column is unique) → never reassign.
+    const takenGrabIds = new Set(products.map((p) => p.grab_item_id).filter(Boolean) as string[]);
+    // normalised name → product ids WITHOUT a link yet (only those are linkable).
+    const byName = new Map<string, string[]>();
+    for (const p of products) {
+      if (p.grab_item_id) continue;
+      const key = normalizeMenuName(p.name);
+      (byName.get(key) ?? byName.set(key, []).get(key)!).push(p.id);
+    }
+    const nameById = new Map(products.map((p) => [p.id, p.name] as const));
+
+    for (const it of items) {
+      if (takenGrabIds.has(it.id)) continue; // already linked to some product
+      const matches = byName.get(normalizeMenuName(it.name));
+      if (!matches || matches.length !== 1) continue; // none / ambiguous → manual
+      const productId = matches[0];
+      // Assign the link (sets products.grab_item_id), then backfill order lines.
+      const { error: linkErr } = await supabase
+        .from("products")
+        .update({ grab_item_id: it.id })
+        .eq("id", productId);
+      if (linkErr) continue; // raced / unique violation — leave for manual.
+      await supabase
+        .from("pos_order_items")
+        .update({ product_id: productId, product_name: nameById.get(productId) })
+        .eq("product_id", it.id);
+      // Don't reuse this product (or grab id) again within the same push.
+      takenGrabIds.add(it.id);
+      for (const [k, ids] of byName) {
+        const i = ids.indexOf(productId);
+        if (i >= 0) ids.splice(i, 1);
+        if (ids.length === 0) byName.delete(k);
+      }
+      autoLinked += 1;
+    }
+    console.log(`[grab:push-menu] persisted=${items.length} auto-linked=${autoLinked} merchant=${merchantID}`);
+  } catch (e) {
+    // Never fail the webhook on a persistence hiccup — Grab retries any non-2xx
+    // and the menu data isn't order-critical. Log and ack.
+    console.error("[grab:push-menu] persist/auto-link failed:", e instanceof Error ? e.message : e);
+  }
 
   // Ack — Grab retries on any non-2xx, so we only return non-200 on auth failure.
-  return NextResponse.json({ success: true });
+  return NextResponse.json({ success: true, items: items.length, autoLinked });
 }
 
 // Grab may GET to verify the URL is reachable before activation.

--- a/apps/backoffice/src/lib/grab-menu.ts
+++ b/apps/backoffice/src/lib/grab-menu.ts
@@ -14,6 +14,20 @@ import type {
 } from "@/lib/grab";
 import { filterModifiersForChannel } from "@celsius/shared";
 
+/**
+ * Normalise a product / menu-item name for cross-system matching: lowercase,
+ * trim, collapse whitespace + punctuation. Used to auto-link a Grab menu item
+ * (from the PushGrabMenu webhook) to our product by name — Grab order webhooks
+ * carry no name, so the menu push is our one chance to learn it.
+ */
+export function normalizeMenuName(name: string): string {
+  return name
+    .toLowerCase()
+    .normalize("NFKD")
+    .replace(/[^a-z0-9]+/g, " ")
+    .trim();
+}
+
 export interface RawProduct {
   id: string;
   name: string;

--- a/supabase/migrations/027_grab_menu_items.sql
+++ b/supabase/migrations/027_grab_menu_items.sql
@@ -1,0 +1,20 @@
+-- GrabFood menu items learned from the PushGrabMenu webhook (/api/grab/menus).
+--
+-- Grab order webhooks carry NO item name — only an id + price. The PushGrabMenu
+-- webhook is the one place Grab sends us its canonical menu WITH names, so we
+-- persist them here. On receipt we also auto-link any item whose name uniquely
+-- matches a catalogue product (sets products.grab_item_id), so future Grab order
+-- lines resolve to the right product + kitchen station with no manual work.
+-- This is the safety net for any Grab-internal ("MYITE…") id; when Grab sends
+-- our own product id, no link is needed.
+CREATE TABLE IF NOT EXISTS grab_menu_items (
+  grab_item_id text PRIMARY KEY,
+  merchant_id  text,
+  name         text,
+  price        integer,        -- minor units (sen), as Grab reports it
+  category     text,
+  updated_at   timestamptz NOT NULL DEFAULT now()
+);
+
+-- Server-only (service-role webhook + privileged Prisma); no anon/auth access.
+ALTER TABLE grab_menu_items ENABLE ROW LEVEL SECURITY;


### PR DESCRIPTION
## What

Wires up the **Push Grab menu webhook** (GrabFood Partner Portal "Push grab menu" module), which previously just acked + logged.

It's the **one place Grab sends item names** (order webhooks carry none), so it now acts as the safety net for any Grab-internal (`MYITE…`) id:

1. **Persist** each menu item into a new `grab_menu_items` table (`grab_item_id → name → price`). *(Migration `027`, already applied to the live DB.)*
2. **Auto-link by name**: when an item's name uniquely matches a catalogue product, set `products.grab_item_id`, then **backfill** already-received order lines (`product_id` + name → fixes kitchen-station routing on reprint).
3. Ambiguous / no-match names are left for the BackOffice item-link panel.

Guards: already-linked products and already-taken grab ids are skipped (never overrides a manual decision); the webhook always acks 200 (Grab retries non-2xx) and never fails an order path.

## Relationship to #325
Complementary, no overlap. #325 makes orders that carry **our** ids resolve automatically (the common case now). This PR is the fallback for when Grab sends its **own internal** id — it learns the name from the menu push and links it. Different files, no conflict.

## How to activate
Register the URL in the Grab portal → "Partner configuration → Push grab menu": `…/api/grab/menus` (or `…/api/pos/grab/menus`). Until Grab actually pushes a menu, this is dormant (harmless).

## Test plan
- [x] `tsc --noEmit` + eslint clean
- [x] Migration `027` applied + verified on the live DB
- [ ] Trigger a Grab menu push → `grab_menu_items` fills; unique-name items get `products.grab_item_id` set + past order lines backfilled

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SXF3GNPYGpZzwMWy9AR9DV

---
_Generated by [Claude Code](https://claude.ai/code/session_01SXF3GNPYGpZzwMWy9AR9DV)_