### PR TITLE
feat(grab): Edit Order (V2) client + staff route

### DIFF
--- a/apps/backoffice/src/app/api/pos/grab/orders/route.ts
+++ b/apps/backoffice/src/app/api/pos/grab/orders/route.ts
@@ -16,9 +16,12 @@ import {
   checkOrderCancelable,
   updateOrderReadyTime,
   listOrders,
+  editOrder,
+  type EditOrderItem,
 } from "@/lib/grab";
 
-type OrderAction = "accept" | "reject" | "ready" | "cancel" | "update_ready_time" | "check_cancelable" | "list";
+type OrderAction =
+  | "accept" | "reject" | "ready" | "cancel" | "update_ready_time" | "check_cancelable" | "list" | "edit";
 
 export async function POST(request: NextRequest) {
   const auth = await requireAuth(request);
@@ -90,6 +93,28 @@ export async function POST(request: NextRequest) {
           date: body.date,
         });
         return NextResponse.json({ success: true, orders: result });
+      }
+
+      case "edit": {
+        if (!orderID) return NextResponse.json({ error: "orderID required" }, { status: 400 });
+        const items = body.items as EditOrderItem[] | undefined;
+        // Grab requires the FULL item array (every line, changed or not) and
+        // rejects an empty payload ("nothing changed" / "can't remove all items").
+        if (!Array.isArray(items) || items.length === 0) {
+          return NextResponse.json(
+            { error: "items required: send ALL order items (changed and unchanged)" },
+            { status: 400 },
+          );
+        }
+        // onlyRecalculate=true validates/repricing WITHOUT submitting — the safe
+        // path to confirm a payload before mutating a real order.
+        const onlyRecalculate = body.onlyRecalculate === true;
+        const result = await editOrder(orderID, items, {
+          onlyRecalculate,
+          depositAmountInMin: body.depositAmountInMin,
+          offlinePOSDiscountInMin: body.offlinePOSDiscountInMin,
+        });
+        return NextResponse.json({ success: true, action: "edited", onlyRecalculate, result });
       }
 
       default:

--- a/apps/backoffice/src/lib/grab.ts
+++ b/apps/backoffice/src/lib/grab.ts
@@ -341,6 +341,73 @@ export async function listOrders(
   });
 }
 
+// ─── Edit Order (V2) ─────────────────────────────────────────────────────────
+// PUT /partner/v2/orders/{orderID} — edit a live order: delete items, change
+// quantities, change/remove modifiers, or add a replacement item. V1
+// (/partner/v1/orders/{orderID}) is deprecated. Grab re-emits the edited order
+// via the submit-order webhook (same orderID, featureFlags.isMexEditOrder=true).
+//
+// Rules baked into the contract (see Grab docs):
+//   • The payload MUST include EVERY item in the order (changed or not).
+//   • Item price is NOT editable — Grab keeps the original price.
+//   • A replacement (newly ADDED) item uses externalItemID (= our products.id)
+//     and must be appended to the END of the array. Adding items is unsupported
+//     in staging and may be feature-flagged in production.
+//   • Modifiers: omit the field if unchanged; send quantity 0 to remove one.
+//   • onlyRecalculate:true recalculates WITHOUT submitting — the safe way to
+//     validate a payload before mutating a real order.
+//
+// NOTE: Grab's published schema collapses the EditOrderItem object, so the field
+// names below are modelled on the order webhook's item shape + the documented
+// behaviour. Validate with onlyRecalculate:true before relying on a live edit.
+
+export interface EditOrderItemModifier {
+  /** Grab's modifier id (or our minted "<productId>-m-<g>-<i>"). */
+  id?: string;
+  /** Final quantity for this modifier; 0 removes it. */
+  quantity?: number;
+}
+
+export interface EditOrderItem {
+  /** Grab's item id for an EXISTING line. */
+  itemID?: string;
+  /** Our products.id — only for an ADDED replacement item (isExternalItemID:true). */
+  externalItemID?: string;
+  isExternalItemID?: boolean;
+  /** Final quantity for the line; 0 deletes it. */
+  quantity: number;
+  /** Item lifecycle for this edit; absent = unchanged. */
+  status?: "ADDED" | "DELETED" | "UPDATED" | "UNCHANGED";
+  /** Include only when modifiers change; omit to keep them as-is. */
+  modifiers?: EditOrderItemModifier[];
+}
+
+export interface EditOrderOptions {
+  /** true = recalculate only, do NOT submit (testing). Defaults to false. */
+  onlyRecalculate?: boolean;
+  /** STO-only: deposit amount, minor units. */
+  depositAmountInMin?: number;
+  /** STO-only: POS-side discount, minor units. */
+  offlinePOSDiscountInMin?: number;
+}
+
+export async function editOrder(
+  orderID: string,
+  items: EditOrderItem[],
+  opts: EditOrderOptions = {},
+) {
+  return grabRequest(`/partner/v2/orders/${encodeURIComponent(orderID)}`, {
+    method: "PUT",
+    body: {
+      orderID,
+      items,
+      onlyRecalculate: opts.onlyRecalculate ?? false,
+      ...(opts.depositAmountInMin != null ? { depositAmountInMin: opts.depositAmountInMin } : {}),
+      ...(opts.offlinePOSDiscountInMin != null ? { offlinePOSDiscountInMin: opts.offlinePOSDiscountInMin } : {}),
+    },
+  });
+}
+
 // ─── Store Management ────────────────────────────────────────────────────────
 
 /**


### PR DESCRIPTION
## What

Implements the GrabFood **Edit Order** module (Partner Portal "Edit order"), using the **V2** endpoint `PUT /partner/v2/orders/{orderID}` (V1 is deprecated). Supports delete item, change quantity, change/remove modifier, and add replacement item. Grab re-emits the edited order via the submit-order webhook (`featureFlags.isMexEditOrder=true`) — which our existing webhook already ingests, so status/items stay in sync automatically.

- **`editOrder()`** client in `grab.ts` — typed `EditOrderItem` / `EditOrderItemModifier` / `EditOrderOptions`. Contract rules encoded in types + comments: full item array required, price not editable, replacement item uses `externalItemID` and appends last, `onlyRecalculate:true` = recalculate without submitting.
- **`edit` action** on `POST /api/pos/grab/orders` (staff-auth) — forwards the caller's full item array; supports `onlyRecalculate` and the STO deposit/discount fields. Validates that items aren't empty (Grab rejects "nothing changed" / "can't remove all items").

## Important: one assumption + why no UI yet

Grab's published schema **collapses the `EditOrderItem` object** (`items:[{}]`), so the per-item field names here are modelled on the order webhook's item shape (`itemID`, `quantity`, `status`, `modifiers`, `externalItemID`/`isExternalItemID`). **Before any live edit**, this should be validated with `onlyRecalculate:true` (recalculates without submitting) against a staging order.

I deliberately **did not build the POS live-orders UI** in this PR — wiring a screen that fires real edits at live orders on inferred field names is the risky part. Once an `onlyRecalculate` round-trip confirms the item schema, I'll add the POS UI in a follow-up. This PR gives the verified-by-recalc foundation.

Also note: adding replacement items is **not supported in staging** and is **feature-flagged in production** (per Grab) — delete / qty / modifier edits are the immediately usable ones.

## Test plan
- [x] `tsc --noEmit` + eslint clean
- [ ] `POST /api/pos/grab/orders {action:"edit", orderID, items:[…all items…], onlyRecalculate:true}` against a staging order → 200/recalc, confirm `EditOrderItem` field names
- [ ] Flip `onlyRecalculate:false` on staging → edited order returns via submit-order webhook
- [ ] Then: build POS live-orders edit UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SXF3GNPYGpZzwMWy9AR9DV

---
_Generated by [Claude Code](https://claude.ai/code/session_01SXF3GNPYGpZzwMWy9AR9DV)_