### PR TITLE
fix(grab): receipt line double-counted add-ons (price is already modifier-inclusive)

### DIFF
--- a/apps/backoffice/src/app/api/pos/grab/webhook/route.ts
+++ b/apps/backoffice/src/app/api/pos/grab/webhook/route.ts
@@ -309,8 +309,14 @@ export async function POST(request: NextRequest) {
       const product = resolveGrabItemProduct(item, productIndex);
       const qty = item.quantity ?? 1;
       const unitPrice = item.price ?? 0;
+      // Grab's item.price is ALREADY modifier-inclusive (see the GrabOrderItem
+      // type: "single item + its modifiers, tax-inclusive"). modTotal is kept
+      // for display + the catalogue base-price match (base = unitPrice − modTotal)
+      // — but must NOT be added to the line total, or the receipt double-counts
+      // the add-ons (e.g. RM11.80 item printed as RM13.70). The order subtotal
+      // comes from Grab's price.subtotal = Σ unitPrice, so the line must match it.
       const modTotal = (item.modifiers ?? []).reduce((n, m) => n + (m.price ?? 0) * (m.quantity ?? 1), 0);
-      const itemTotal = (unitPrice + modTotal) * qty;
+      const itemTotal = unitPrice * qty;
       return {
         id: randomUUID(),
         order_id: order.id,


### PR DESCRIPTION
## Bug (from a real GrabFood receipt)

Receipt **GF-427T** showed:
```
1x Black                 RM 13.70
  Add-on @ RM 1.00, Add-on @ RM 0.90
Subtotal                 RM 11.80
TOTAL                    RM 11.80
```
The line (13.70) and the total (11.80) disagree — and 13.70 − 11.80 = 1.90 = exactly the two add-ons.

## Root cause

Grab's order `item.price` is **already modifier-inclusive** (the `GrabOrderItem` type literally says *"single item + its modifiers, tax-inclusive"*). The webhook added the modifiers **again**:
```
item_total = (unit_price + modifier_total) * qty   // 11.80 + 1.90 = 13.70 ✗
```
Confirmed against the DB for this order (`…C8A1JTU2RVECRX`): `unit_price`=1180, `modifier_total`=190, `item_total`=1370, order `total`/`subtotal`=1180. Another order reconciles its total to **Σ `unit_price`**, not Σ `item_total` — proving `unit_price` already includes modifiers.

**The customer was always charged correctly (RM 11.80).** Only the per-line `item_total` (docket/receipt line) was inflated.

## Fix
`item_total = unit_price * qty`. `modifier_total` is still stored — it's used to list add-ons and to derive the catalogue base price (`unit_price − modifier_total`) in the item-link panel — just no longer added to the line total.

## Historical data (not in this PR)
50 of 54 existing Grab order lines have the inflated `item_total` (overcount ≈ **RM 95.26** total). Order-level totals are unaffected (they come from Grab). I can backfill `item_total = unit_price * quantity` for Grab lines so reprints/line-level reports read correctly — say the word and I'll run it.

## Test plan
- [x] `tsc --noEmit` + eslint clean
- [ ] Next Grab order with add-ons → docket line equals the item's Grab price (no add-on double-count); Subtotal/Total still match

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SXF3GNPYGpZzwMWy9AR9DV

---
_Generated by [Claude Code](https://claude.ai/code/session_01SXF3GNPYGpZzwMWy9AR9DV)_