### PR TITLE
feat(grab): Edit Order backend — persist line ids + pos-callable edit route

### DIFF
--- a/apps/backoffice/src/app/api/pos/grab/order-edit/route.ts
+++ b/apps/backoffice/src/app/api/pos/grab/order-edit/route.ts
@@ -1,0 +1,118 @@
+import { NextRequest, NextResponse } from "next/server";
+import { createClient, type SupabaseClient } from "@supabase/supabase-js";
+import { isGrabConfigured, editOrder, type EditOrderItem } from "@/lib/grab";
+
+/**
+ * POST /api/pos/grab/order-edit
+ * Body: { orderID: string, edits: [{ grabItemId, quantity }], onlyRecalculate?: boolean }
+ *
+ * Cashier-driven GrabFood order edit from the POS live-orders panel: drop an item
+ * (quantity 0) or change its quantity. Builds the full Edit Order V2 payload from
+ * the order's stored lines (Grab requires EVERY line, changed or not, keyed by its
+ * grabItemID) and applies the requested final quantities, then calls Grab's
+ * PUT /partner/v2/orders/{orderID} via editOrder().
+ *
+ * `onlyRecalculate:true` previews/repricings WITHOUT submitting — always preview
+ * before the real submit. Modifier edits / adding replacement items are NOT
+ * supported here (delete + quantity only); unchanged modifiers are omitted per
+ * the Grab contract.
+ *
+ * Service-role + CSRF (Origin/Referer enforced by the POS middleware), same trust
+ * model as /api/pos/order-status — pos-native has no staff bearer token.
+ */
+let cachedSupabase: SupabaseClient | null = null;
+function getSupabase(): SupabaseClient {
+  if (!cachedSupabase) {
+    cachedSupabase = createClient(
+      process.env.NEXT_PUBLIC_SUPABASE_URL!,
+      process.env.SUPABASE_SERVICE_ROLE_KEY || process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+    );
+  }
+  return cachedSupabase;
+}
+
+type StoredItem = { grab_item_id: string | null; quantity: number | null };
+
+export async function POST(req: NextRequest) {
+  if (!isGrabConfigured()) {
+    return NextResponse.json({ error: "Grab not configured" }, { status: 400 });
+  }
+
+  let body: { orderID?: string; edits?: Array<{ grabItemId?: string; quantity?: number }>; onlyRecalculate?: boolean };
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: "invalid JSON body" }, { status: 400 });
+  }
+
+  const orderID = String(body.orderID ?? "").trim();
+  if (!orderID) return NextResponse.json({ error: "orderID required" }, { status: 400 });
+
+  // Desired FINAL quantity per Grab line id (0 = remove). Lines not listed are
+  // sent unchanged.
+  const editMap = new Map<string, number>();
+  for (const e of body.edits ?? []) {
+    const id = String(e?.grabItemId ?? "").trim();
+    const q = Number(e?.quantity);
+    if (!id || !Number.isInteger(q) || q < 0) {
+      return NextResponse.json({ error: "each edit needs grabItemId + integer quantity >= 0" }, { status: 400 });
+    }
+    editMap.set(id, q);
+  }
+  if (editMap.size === 0) {
+    return NextResponse.json({ error: "no edits provided" }, { status: 400 });
+  }
+
+  const supabase = getSupabase();
+
+  // Resolve the order + its stored lines (pos_orders.external_id = Grab orderID).
+  const { data: order } = await supabase
+    .from("pos_orders").select("id").eq("external_id", orderID).maybeSingle();
+  if (!order) return NextResponse.json({ error: "order not found" }, { status: 404 });
+
+  const { data: lines } = await supabase
+    .from("pos_order_items").select("grab_item_id, quantity").eq("order_id", (order as { id: string }).id);
+  const stored = (lines ?? []) as StoredItem[];
+  if (stored.length === 0) {
+    return NextResponse.json({ error: "order has no items" }, { status: 409 });
+  }
+  // Every line must carry its grabItemID, or we can't build a valid payload.
+  if (stored.some((l) => !l.grab_item_id)) {
+    return NextResponse.json(
+      { error: "this order predates edit support (no Grab line ids stored) and can't be edited" },
+      { status: 409 },
+    );
+  }
+  // Every edited id must actually be on the order.
+  const onOrder = new Set(stored.map((l) => l.grab_item_id as string));
+  for (const id of editMap.keys()) {
+    if (!onOrder.has(id)) {
+      return NextResponse.json({ error: `item ${id} is not on this order` }, { status: 400 });
+    }
+  }
+
+  // Build the full payload: every line, with its final quantity. Modifiers are
+  // omitted (no modifier change) per the Grab contract ("if no change to the
+  // item's modifiers, you don't need to provide the modifier object").
+  const items: EditOrderItem[] = stored.map((l) => ({
+    itemID: l.grab_item_id as string,
+    quantity: editMap.has(l.grab_item_id as string) ? editMap.get(l.grab_item_id as string)! : (l.quantity ?? 1),
+  }));
+  // Grab rejects an order with everything removed ("can't remove all items").
+  if (items.every((i) => i.quantity <= 0)) {
+    return NextResponse.json({ error: "can't remove all items from the order" }, { status: 400 });
+  }
+
+  const onlyRecalculate = body.onlyRecalculate === true;
+  try {
+    const result = await editOrder(orderID, items, { onlyRecalculate });
+    console.log(`[grab:order-edit] orderID=${orderID} edits=${editMap.size} onlyRecalculate=${onlyRecalculate} ok`);
+    return NextResponse.json({ success: true, onlyRecalculate, result });
+  } catch (err) {
+    console.error(`[grab:order-edit] orderID=${orderID} failed:`, err instanceof Error ? err.message : err);
+    return NextResponse.json(
+      { error: err instanceof Error ? err.message : "edit failed" },
+      { status: 502 },
+    );
+  }
+}

--- a/apps/backoffice/src/app/api/pos/grab/webhook/route.ts
+++ b/apps/backoffice/src/app/api/pos/grab/webhook/route.ts
@@ -332,6 +332,10 @@ export async function POST(request: NextRequest) {
         // to the catalogue; fall back to whatever Grab sent.
         product_id: product?.id || item.id || item.grabItemID || randomUUID(),
         product_name: product?.name || fallbackGrabItemName(item),
+        // Grab's own line-level item id, kept verbatim for the Edit Order payload
+        // (which keys existing lines by Grab's itemID). Distinct from product_id,
+        // which we resolve to our catalogue for naming/kitchen routing.
+        grab_item_id: item.grabItemID || item.id || null,
         quantity: qty,
         unit_price: unitPrice,
         modifiers: (item.modifiers ?? []).map((m) => ({

--- a/supabase/migrations/028_pos_order_items_grab_item_id.sql
+++ b/supabase/migrations/028_pos_order_items_grab_item_id.sql
@@ -1,0 +1,7 @@
+-- Grab's own per-line item id (the order item's grabItemID) on each Grab order
+-- line. Needed to build the GrabFood Edit Order payload (PUT /partner/v2/orders/
+-- {orderID}), which requires Grab's itemID for every existing line. We resolve
+-- the display product via products.grab_item_id, but that's a different id — this
+-- captures the raw line-level grabItemID the order webhook receives.
+ALTER TABLE pos_order_items
+  ADD COLUMN IF NOT EXISTS grab_item_id text;


### PR DESCRIPTION
## What
The **backend** for the POS "Edit order" feature (Edit Order V2 client merged in #327). Two parts:

### 1. Persist Grab's per-line item id
Grab's Edit Order payload keys **every existing line by Grab's own `itemID`**, but the webhook only stored the resolved catalogue `product_id`. Added `pos_order_items.grab_item_id` (migration `028`, **applied to live DB**) and the webhook now stores `item.grabItemID` verbatim. Nullable; historical lines stay null (not editable), new orders capture it.

### 2. pos-callable edit route
`POST /api/pos/grab/order-edit { orderID, edits:[{grabItemId, quantity}], onlyRecalculate? }` — service-role + CSRF (same trust model as `/api/pos/order-status`, since pos-native has no staff bearer token). It:
- loads the order's stored lines, builds the **full** payload (every line, keyed by `grab_item_id`, at its final quantity),
- applies the cashier's quantity edits (`0` = remove),
- calls `editOrder()` (Grab re-emits the edited order via the submit-order webhook).

Guards: order found · all lines carry a `grab_item_id` (else rejected as "predates edit support") · edited ids are on the order · not all items removed. **Delete + quantity only** for now (no modifier edits / no added items). `onlyRecalculate:true` previews without submitting.

## Still to come (next PR)
- **pos-native UI** — Edit action on the register's live-orders panel (item list → remove / qty steppers → Preview (recalculate) → Submit).
- First real `onlyRecalculate` round-trip on staging to confirm the `EditOrderItem` field names before any live submit.

## Test plan
- [x] `tsc --noEmit` + eslint clean
- [x] Migration `028` applied + verified live
- [ ] New Grab order → `grab_item_id` populated per line
- [ ] `POST /api/pos/grab/order-edit {…, onlyRecalculate:true}` on a staging order → confirms payload/schema

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SXF3GNPYGpZzwMWy9AR9DV