### PR TITLE
StoreHub retirement: native finance EOD, sales double-count fix, par-levels repoint

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,7 +10,11 @@ AUTH_COOKIE_DOMAIN=".celsiuscoffee.com"
 NEXT_PUBLIC_SUPABASE_URL="https://xxx.supabase.co"
 NEXT_PUBLIC_SUPABASE_ANON_KEY="eyJ..."
 
-# ── StoreHub (inventory only) ────────────────────
+# ── StoreHub (LEGACY — POS migrated to native) ───
+# Only used to read historical sales/products during the StoreHub → native
+# migration. Safe to remove (here and from Vercel: backoffice + loyalty) once
+# StoreHub is retired — target 2026-06-27. Loyalty used STOREHUB_USERNAME for
+# the same account id; collapse to STOREHUB_ACCOUNT_ID when removing.
 STOREHUB_ACCOUNT_ID=""
 STOREHUB_API_KEY=""
 

--- a/apps/backoffice/src/app/(admin)/settings/integrations/page.tsx
+++ b/apps/backoffice/src/app/(admin)/settings/integrations/page.tsx
@@ -49,7 +49,8 @@ type MaybankQrConfig = { enabled: boolean; outlets: Record<string, MaybankQrOutl
 const STORE_NAMES: Record<string, string> = {
   "shah-alam": "Shah Alam",
   conezion: "Putrajaya",
-  tamarind: "Tamarind Square",
+  tamarind: "Tamarind",
+  nilai: "Nilai",
 };
 
 type Provider = "stripe" | "revenue_monster";
@@ -574,7 +575,7 @@ export default function IntegrationsPage() {
           { label: "Payment Methods", value: `${enabledMethods}/${METHOD_DEFS.length}`, sub: "active", color: "bg-terracotta/10 text-terracotta" },
           { label: "Revenue Monster", value: `${rmConfiguredCount}/${outlets.length}`, sub: "outlets", color: "bg-blue-50 text-blue-600" },
           { label: "Bukku", value: `${bukkuConfiguredCount}/${outlets.length}`, sub: "outlets", color: "bg-purple-50 text-purple-600" },
-          { label: "StoreHub", value: "Active", sub: "syncing", color: "bg-green-50 text-green-600" },
+          { label: "StoreHub", value: "Legacy", sub: "archive only", color: "bg-gray-100 text-gray-500" },
         ].map((s) => (
           <div key={s.label} className="rounded-xl border border-gray-200 bg-white p-3.5">
             <p className="text-[11px] font-medium text-gray-500 uppercase tracking-wider">{s.label}</p>
@@ -945,9 +946,9 @@ export default function IntegrationsPage() {
           <div className="flex-1 min-w-0">
             <div className="flex items-center gap-2">
               <h2 className="font-semibold text-gray-900 text-sm">StoreHub POS</h2>
-              <StatusPill ok={true} label="Connected" />
+              <StatusPill ok={false} label="Retired" />
             </div>
-            <p className="text-xs text-gray-500 mt-0.5">Source of truth for product catalog and sales data. Syncs automatically via cron.</p>
+            <p className="text-xs text-gray-500 mt-0.5">Legacy POS — fully replaced by the native POS for catalogue, sales, and loyalty. Kept read-only for historical sales reporting (the <code>storehub_sales</code> archive); no longer syncing.</p>
           </div>
         </div>
       </section>

--- a/apps/backoffice/src/app/api/cron/finance-eod-backfill/route.ts
+++ b/apps/backoffice/src/app/api/cron/finance-eod-backfill/route.ts
@@ -1,0 +1,138 @@
+// One-off backfill — repairs AR for the StoreHub→native cutover window.
+//
+// While the live finance-eod cron was still StoreHub-only, each outlet's AR was
+// understated from its cutover onward: it booked only the dying StoreHub Grab
+// tail, not the native till/app revenue (~RM46k across con+sa). This walks a
+// date range and, per outlet that was native on that day:
+//   • if a stale StoreHub-sourced ar_invoice exists → reverseTransaction() it,
+//   • re-post the day via the native ingestor (pos_orders + pickup orders, plus
+//     the StoreHub GRABFOOD/BEEP archive for days before Grab went native —
+//     handled by ingestOutletNativeEod's includeStorehubDelivery flag).
+//
+// SAFE BY DEFAULT: dryRun unless `?dryRun=false`. Idempotent — a day already
+// re-posted from pos_native is skipped. Auth: CRON_SECRET bearer.
+//
+//   GET /api/cron/finance-eod-backfill?from=2026-06-08&to=2026-06-17&dryRun=false
+
+import { NextRequest, NextResponse } from "next/server";
+import { checkCronAuth } from "@celsius/shared";
+import { prisma } from "@/lib/prisma";
+import { getFinanceClient } from "@/lib/finance/supabase";
+import { reverseTransaction } from "@/lib/finance/ledger";
+import { AR_AGENT_VERSION } from "@/lib/finance/agents/ar";
+import { ingestOutletNativeEod, isNativeOnDate } from "@/lib/finance/ingestors/pos-native-eod";
+
+export const dynamic = "force-dynamic";
+export const maxDuration = 300;
+
+// Inclusive list of YYYY-MM-DD between from..to. Anchored at noon UTC so day
+// arithmetic never trips on offsets.
+function eachDate(from: string, to: string): string[] {
+  const out: string[] = [];
+  let d = new Date(`${from}T12:00:00Z`);
+  const end = new Date(`${to}T12:00:00Z`);
+  while (d <= end) {
+    out.push(d.toISOString().slice(0, 10));
+    d = new Date(d.getTime() + 86_400_000);
+  }
+  return out;
+}
+
+type BackfillResult = {
+  date: string;
+  outlet: string;
+  action: "skip" | "would-repost" | "would-post" | "reposted" | "posted";
+  reason?: string;
+  reversedAmount?: number;
+  posted?: { transactionId: string; amount: number };
+  skipped?: string;
+  error?: string;
+};
+
+export async function GET(req: NextRequest) {
+  const cronAuth = checkCronAuth(req.headers);
+  if (!cronAuth.ok) return NextResponse.json({ error: cronAuth.error }, { status: cronAuth.status });
+
+  const url = new URL(req.url);
+  const from = url.searchParams.get("from");
+  const to = url.searchParams.get("to");
+  const dryRun = url.searchParams.get("dryRun") !== "false"; // default true
+  if (!from || !to || !/^\d{4}-\d{2}-\d{2}$/.test(from) || !/^\d{4}-\d{2}-\d{2}$/.test(to)) {
+    return NextResponse.json({ error: "from and to (YYYY-MM-DD) are required" }, { status: 400 });
+  }
+
+  const outlets = await prisma.outlet.findMany({
+    where: { status: "ACTIVE", posNativeCutoverAt: { not: null } },
+    select: { id: true, name: true, posNativeCutoverAt: true, loyaltyOutletId: true, pickupStoreId: true },
+  });
+  const client = getFinanceClient();
+  const dates = eachDate(from, to);
+  const results: BackfillResult[] = [];
+
+  for (const date of dates) {
+    for (const o of outlets) {
+      if (!isNativeOnDate(date, o.posNativeCutoverAt)) continue;
+
+      // Existing, non-reversed AR journal for this outlet/day (if any).
+      const { data: existing } = await client
+        .from("fin_transactions")
+        .select("id, amount, source_doc_id")
+        .eq("outlet_id", o.id)
+        .eq("txn_date", date)
+        .eq("txn_type", "ar_invoice")
+        .eq("posted_by_agent", "ar")
+        .neq("status", "reversed")
+        .maybeSingle();
+
+      // Is it already native (a prior backfill)? Then there's nothing to do.
+      let existingSource: string | null = null;
+      if (existing?.source_doc_id) {
+        const { data: doc } = await client
+          .from("fin_documents").select("source").eq("id", existing.source_doc_id).maybeSingle();
+        existingSource = (doc?.source as string) ?? null;
+      }
+      if (existing && existingSource === "pos_native") {
+        results.push({ date, outlet: o.name, action: "skip", reason: "already native" });
+        continue;
+      }
+
+      if (dryRun) {
+        results.push({
+          date, outlet: o.name,
+          action: existing ? "would-repost" : "would-post",
+          reversedAmount: existing ? Number(existing.amount) : 0,
+        });
+        continue;
+      }
+
+      try {
+        if (existing) {
+          await reverseTransaction(existing.id as string, {
+            reason: "StoreHub→native cutover backfill: replace partial StoreHub EOD with native",
+            agent: "ar",
+            agentVersion: AR_AGENT_VERSION,
+          });
+        }
+        const r = await ingestOutletNativeEod(o, date, { includeStorehubDelivery: true });
+        results.push({
+          date, outlet: o.name,
+          action: existing ? "reposted" : "posted",
+          reversedAmount: existing ? Number(existing.amount) : 0,
+          posted: r.posted, skipped: r.skipped, error: r.error,
+        });
+      } catch (err) {
+        results.push({ date, outlet: o.name, action: existing ? "reposted" : "posted", error: err instanceof Error ? err.message : String(err) });
+      }
+    }
+  }
+
+  const summary = {
+    from, to, dryRun, days: dates.length,
+    actions: results.length,
+    reposted: results.filter((r) => r.action === "reposted" || r.action === "posted").length,
+    skipped: results.filter((r) => r.action === "skip").length,
+    errors: results.filter((r) => r.error).length,
+    repostedAmount: Math.round(results.reduce((s, r) => s + (r.posted?.amount ?? 0), 0) * 100) / 100,
+  };
+  return NextResponse.json({ summary, results });
+}

--- a/apps/backoffice/src/app/api/cron/finance-eod/route.ts
+++ b/apps/backoffice/src/app/api/cron/finance-eod/route.ts
@@ -1,11 +1,13 @@
-// Daily cron — runs at 4 AM MYT to ingest yesterday's StoreHub EOD across
-// all outlets and post AR journals via the AR agent.
+// Daily cron — runs at 4 AM MYT to ingest yesterday's EOD across all outlets
+// and post AR journals via the AR agent. Each outlet is routed by ingestEodForDate
+// to the POS that owned it that day: POS-native on/after its cutover, StoreHub
+// before (historical). Once every outlet has cut over this is fully native.
 //
 // Idempotent: re-running for a date that's already been posted skips the
-// outlet (see ingestOutletEod's existing-txn guard).
+// outlet (shared outlet+date guard in the ingestors).
 
 import { NextRequest, NextResponse } from "next/server";
-import { ingestAllOutletsEod } from "@/lib/finance/ingestors/storehub-eod";
+import { ingestEodForDate } from "@/lib/finance/ingestors/pos-native-eod";
 import { checkCronAuth } from "@celsius/shared";
 
 export const dynamic = "force-dynamic";
@@ -23,7 +25,7 @@ export async function GET(req: NextRequest) {
   if (!cronAuth.ok) return NextResponse.json({ error: cronAuth.error }, { status: cronAuth.status });
 
   const date = yesterdayMyt();
-  const results = await ingestAllOutletsEod(date);
+  const results = await ingestEodForDate(date);
 
   const summary = {
     date,

--- a/apps/backoffice/src/app/api/inventory/par-levels/calculate/route.ts
+++ b/apps/backoffice/src/app/api/inventory/par-levels/calculate/route.ts
@@ -39,16 +39,32 @@ export async function POST(req: NextRequest) {
   const since = new Date();
   since.setDate(since.getDate() - lookbackDays);
 
+  // POS-native sales source (StoreHub retired). pos_orders.outlet_id is the
+  // native/loyalty id (e.g. "outlet-con"); the inventory `outletId` here is the
+  // Outlet uuid, so resolve across. The native POS reuses StoreHub product ids,
+  // so pos_order_items.product_id maps to Menu.storehubId — the same join the
+  // old StoreHub sync used to set SalesTransaction.menuId.
+  const outletRow = await prisma.outlet.findUnique({
+    where: { id: outletId },
+    select: { loyaltyOutletId: true },
+  });
+  const loyaltyOutletId = outletRow?.loyaltyOutletId ?? null;
+
   // ── Parallel data fetches ──────────────────────────────────────────
-  const [salesCount, salesByMenu, bom, supplierProducts, existingParLevels, productPackages] = await Promise.all([
-    prisma.salesTransaction.count({
-      where: { outletId, transactedAt: { gte: since } },
-    }),
-    prisma.salesTransaction.groupBy({
-      by: ["menuId"],
-      where: { outletId, transactedAt: { gte: since }, menuId: { not: null } },
-      _sum: { quantity: true },
-    }),
+  const [salesByMenuRaw, bom, supplierProducts, existingParLevels, productPackages] = await Promise.all([
+    loyaltyOutletId
+      ? prisma.$queryRaw<Array<{ menuId: string; quantity: number }>>`
+          SELECT m.id AS "menuId", COALESCE(SUM(i.quantity), 0)::int AS quantity
+          FROM pos_order_items i
+          JOIN pos_orders o ON o.id = i.order_id
+          JOIN "Menu" m ON m."storehubId" = i.product_id
+          WHERE o.outlet_id = ${loyaltyOutletId}
+            AND o.status = 'completed'
+            AND o.refund_of_order_id IS NULL
+            AND o.created_at >= ${since}
+          GROUP BY m.id
+        `
+      : Promise.resolve([] as Array<{ menuId: string; quantity: number }>),
     prisma.menuIngredient.findMany({
       include: { menu: true, product: true },
     }),
@@ -75,11 +91,15 @@ export async function POST(req: NextRequest) {
     }),
   ]);
 
+  // Shape native rows like the old SalesTransaction.groupBy result + a units total.
+  const salesByMenu = salesByMenuRaw.map((r) => ({ menuId: r.menuId, _sum: { quantity: Number(r.quantity) } }));
+  const salesCount = salesByMenu.reduce((s, r) => s + (r._sum.quantity ?? 0), 0);
+
   if (salesCount === 0) {
     return NextResponse.json(
       {
         error: "No sales data found",
-        message: `No sales transactions for this outlet in the last ${lookbackDays} days. Import sales data from StoreHub first.`,
+        message: `No POS sales for this outlet in the last ${lookbackDays} days.`,
       },
       { status: 422 },
     );

--- a/apps/backoffice/src/app/api/sales/_lib/unified-sales.ts
+++ b/apps/backoffice/src/app/api/sales/_lib/unified-sales.ts
@@ -1,14 +1,15 @@
 // Unified sales source for the sales dashboard during/after the StoreHub →
 // POS-native migration. Per outlet, merges:
-//   • StoreHub: the local archive (storehub_sales) for PAST days + a LIVE pull
-//     for TODAY (so today is real-time like the old dashboard, while history
-//     stays fast on the DB). Cutover-routed: pre-cutover all channels,
-//     post-cutover external/online only (Grab/Beep — still on StoreHub).
-//   • POS-native (pos_orders): real-time, for transactions AT/AFTER cutover.
-// Each sale is counted once from the authoritative source for its time. The
-// live today-pull falls back to the archive if StoreHub is unreachable, and
-// disappears per outlet as it cuts over — so StoreHub can still be cancelled
-// once it's fully off (all tills + Grab on POS-native).
+//   • StoreHub: the local archive (storehub_sales) for days STRICTLY BEFORE the
+//     outlet's cutover, plus a LIVE pull for TODAY only while the outlet is
+//     still pre-cutover. StoreHub is never counted on/after cutover — Grab is
+//     native (pos_orders) and Beep is now the Celsius app (orders), so counting
+//     the StoreHub rows too would double-count (StoreHub tags till sales
+//     OFFLINE_PAYMENTS, i.e. they DO carry a channel).
+//   • POS-native (pos_orders) + pickup (orders): real-time, AT/AFTER cutover.
+// Each sale is counted once from the authoritative source for its time. Once an
+// outlet has cut over it touches StoreHub for history only — so StoreHub can be
+// cancelled with no effect on current numbers.
 
 import { prisma } from "@/lib/prisma";
 import { getTransactions, type StoreHubTransaction } from "@/lib/storehub";
@@ -79,15 +80,10 @@ export async function getUnifiedSalesForOutlet(
     Date.UTC(mytNow.getUTCFullYear(), mytNow.getUTCMonth(), mytNow.getUTCDate()) - 8 * 3600 * 1000,
   );
 
-  // Apply cutover routing to one StoreHub txn and push it. Pre-cutover: keep all.
-  // Post-cutover: keep only EXTERNAL/online orders (Grab, Beep — they carry a
-  // `channel`); drop post-cutover direct/till (no channel) — those are on
-  // POS-native now (counted below), so keeping them would double-count.
+  // Push one StoreHub txn. Callers only ever pass PRE-cutover rows (the archive
+  // window is capped at cutover and the live pull is gated to pre-cutover
+  // outlets), so there's no per-row cutover gate here — StoreHub is history only.
   const pushStorehub = (ts: string, total: number, raw: StoreHubTransaction) => {
-    if (outlet.cutoverAt && new Date(ts).getTime() >= outlet.cutoverAt.getTime()) {
-      const hasChannel = typeof raw?.channel === "string" && raw.channel.trim() !== "";
-      if (!hasChannel) return;
-    }
     sales.push({
       ts,
       total,
@@ -116,10 +112,6 @@ export async function getUnifiedSalesForOutlet(
       return;
     }
     const ts = toISO(r.ts);
-    if (outlet.cutoverAt && new Date(ts).getTime() >= outlet.cutoverAt.getTime()) {
-      const hasChannel = typeof r.channel === "string" && r.channel.trim() !== "";
-      if (!hasChannel) return;
-    }
     sales.push({
       ts,
       total: Number(r.total) || 0,
@@ -129,26 +121,35 @@ export async function getUnifiedSalesForOutlet(
     });
   };
 
-  // ── StoreHub PAST — local archive, up to (not including) today 00:00 MYT ──
-  const archiveTo = to.getTime() < todayStartMyt.getTime() ? to : new Date(todayStartMyt.getTime() - 1);
+  // ── StoreHub PAST — local archive, strictly BEFORE cutover and before today
+  // 00:00 MYT (today is served by the live pull below). On/after cutover the
+  // outlet is fully native, so the archive contributes history only. ──
+  const cutoverCapMs = outlet.cutoverAt ? outlet.cutoverAt.getTime() - 1 : Number.POSITIVE_INFINITY;
+  const archiveToBase = Math.min(to.getTime(), todayStartMyt.getTime() - 1);
+  const archiveTo = new Date(Math.min(archiveToBase, cutoverCapMs));
   // channel_class / is_delivery_qr are materialized at import (and
   // backfilled) so this no longer ships the heavy `raw` JSONB — only
   // rows that somehow missed classification fall back to it.
-  const shRows = await prisma.$queryRaw<Array<ArchiveRow>>`
-    SELECT transaction_time AS ts, total, channel, channel_class, is_delivery_qr,
-           CASE WHEN channel_class IS NULL THEN raw END AS raw
-    FROM storehub_sales
-    WHERE outlet_id = ${outlet.outletId}
-      AND NOT is_cancelled
-      AND transaction_time IS NOT NULL
-      AND transaction_time >= ${from}
-      AND transaction_time <= ${archiveTo}
-  `;
-  for (const r of shRows) pushArchive(r);
+  if (archiveTo.getTime() >= from.getTime()) {
+    const shRows = await prisma.$queryRaw<Array<ArchiveRow>>`
+      SELECT transaction_time AS ts, total, channel, channel_class, is_delivery_qr,
+             CASE WHEN channel_class IS NULL THEN raw END AS raw
+      FROM storehub_sales
+      WHERE outlet_id = ${outlet.outletId}
+        AND NOT is_cancelled
+        AND transaction_time IS NOT NULL
+        AND transaction_time >= ${from}
+        AND transaction_time <= ${archiveTo}
+    `;
+    for (const r of shRows) pushArchive(r);
+  }
 
-  // ── StoreHub TODAY — LIVE pull so today is real-time (outlets still on
-  // StoreHub). Falls back to the archive if StoreHub is unreachable. ──
-  if (outlet.storehubStoreId && to.getTime() >= todayStartMyt.getTime()) {
+  // ── StoreHub TODAY — LIVE pull so today is real-time, but ONLY while the
+  // outlet is still pre-cutover (its till is still on StoreHub). After cutover
+  // today comes from pos_orders/pickup below. Falls back to the archive if
+  // StoreHub is unreachable. ──
+  const preCutoverToday = !outlet.cutoverAt || todayStartMyt.getTime() < outlet.cutoverAt.getTime();
+  if (preCutoverToday && outlet.storehubStoreId && to.getTime() >= todayStartMyt.getTime()) {
     try {
       const liveTxns = await getTransactions(outlet.storehubStoreId, todayStartMyt, now);
       for (const t of liveTxns) {

--- a/apps/backoffice/src/lib/finance/ingestors/pos-native-eod.ts
+++ b/apps/backoffice/src/lib/finance/ingestors/pos-native-eod.ts
@@ -208,10 +208,13 @@ async function persistDoc(
 export async function ingestOutletNativeEod(
   outlet: { id: string; name: string; loyaltyOutletId: string | null; pickupStoreId: string | null },
   date: string,
+  opts: { includeStorehubDelivery?: boolean } = {},
 ): Promise<IngestEodResult> {
   const { id: outletId, name: outletName } = outlet;
 
-  // Already posted for this outlet/day? (matches storehub-eod's guard.)
+  // Already posted for this outlet/day? (matches storehub-eod's guard.) A
+  // REVERSED journal doesn't count — that's how the cutover backfill re-posts a
+  // day after reversing its stale StoreHub partial.
   const client = getFinanceClient();
   const { data: existingTxn } = await client
     .from("fin_transactions")
@@ -220,6 +223,7 @@ export async function ingestOutletNativeEod(
     .eq("txn_date", date)
     .eq("txn_type", "ar_invoice")
     .eq("posted_by_agent", "ar")
+    .neq("status", "reversed")
     .maybeSingle();
   if (existingTxn?.id) {
     return {
@@ -289,6 +293,30 @@ export async function ingestOutletNativeEod(
   const docId = await persistDoc(companyId, outletId, date, orders);
   const summary = aggregateNativeEod(companyId, outletId, outletName, date, orders, paymentsByOrder, docId);
 
+  // Backfill only: Grab went native (~Jun 17) AFTER the till cutovers, so for
+  // historical cut-over days Grab still flowed through StoreHub. Fold those
+  // StoreHub delivery-channel archive rows into grabfood — UNLESS the day
+  // already has native Grab in pos_orders (counted above; avoid double). For
+  // current dates StoreHub is empty, so this adds nothing.
+  if (opts.includeStorehubDelivery) {
+    const hasNativeGrab = orders.some((o) => classifySourceOverride(o.source) === "grabfood");
+    if (!hasNativeGrab) {
+      const shRows = await prisma.$queryRaw<Array<{ total: number | null }>>`
+        SELECT total FROM storehub_sales
+        WHERE outlet_id = ${outletId}
+          AND NOT is_cancelled
+          AND channel IN ('GRABFOOD', 'BEEP_ORDERS')
+          AND transaction_time >= ${from} AND transaction_time <= ${to}
+      `;
+      const shNet = round2(shRows.reduce((s, r) => s + Number(r.total ?? 0), 0));
+      if (shNet > 0) {
+        summary.channels.grabfood = round2(summary.channels.grabfood + shNet);
+        summary.netSales = round2(summary.netSales + shNet);
+        summary.transactions += shRows.length;
+      }
+    }
+  }
+
   if (summary.netSales <= 0) {
     return { outletId, outletName, date, transactionsFetched: orders.length, skipped: "zero net sales" };
   }
@@ -309,7 +337,7 @@ export async function ingestOutletNativeEod(
 
 // True if `date` (YYYY-MM-DD, MYT) is on/after the outlet's POS-native cutover.
 // Cutover is stored at midnight MYT, so a date-string compare is exact.
-function isNativeOnDate(date: string, cutoverAt: Date | null): boolean {
+export function isNativeOnDate(date: string, cutoverAt: Date | null): boolean {
   if (!cutoverAt) return false;
   const cutoverDateMyt = new Date(cutoverAt.getTime() + 8 * 3600 * 1000).toISOString().slice(0, 10);
   return date >= cutoverDateMyt;

--- a/apps/backoffice/src/lib/finance/ingestors/pos-native-eod.ts
+++ b/apps/backoffice/src/lib/finance/ingestors/pos-native-eod.ts
@@ -1,0 +1,340 @@
+// POS-native EOD ingestor — the StoreHub-free replacement for storehub-eod.ts.
+//
+// Builds the same EodSummary the AR agent consumes, but sourced from our own
+// system instead of the StoreHub API:
+//   • pos_orders (+ pos_order_payments) — the till / register, and native
+//     GrabFood orders (source='grabfood', no payment rows → bucketed by source).
+//   • orders — the Celsius pickup/ordering app. This is where the former
+//     StoreHub "Beep" online channel now lands, so it MUST be included or the
+//     online revenue StoreHub-EOD used to post would silently vanish from AR.
+//
+// An outlet's day is sourced from whichever POS owned it that day: the cron
+// router (ingestEodForDate) sends pre-cutover dates to the StoreHub ingestor and
+// on/after-cutover dates here. posNativeCutoverAt is always set to midnight MYT,
+// so a day is never split across both POSs — no double-count risk.
+//
+// Idempotent: re-running the same outlet+date returns the existing AR journal
+// without re-posting (shares storehub-eod's per-day guard, keyed only on
+// outlet+date+ar_invoice, so a day can be posted by at most one source).
+//
+// Amounts: pos_orders/orders store sen. netSales is RM, NET of SST
+// (total − sst_amount); the AR agent books SST separately. Tender → channel
+// mapping mirrors storehub-eod's classifier. Two policy calls worth a finance
+// review: the Celsius-app "wallet" tender is treated as cash-equivalent
+// (cashQr), since the cash was collected at top-up; partial refunds recorded on
+// a payment row (refund_amount) are not netted in v1 (full refunds are separate
+// reversal orders, excluded via refund_of_order_id).
+
+import { randomUUID } from "crypto";
+import { prisma } from "@/lib/prisma";
+import { Prisma } from "@prisma/client";
+import { getFinanceClient } from "../supabase";
+import { postDailyAr, type EodSummary, type EodChannelSplit } from "../agents/ar";
+import { resolveCompanyFromOutlet, getDefaultCompanyId } from "../companies";
+import type { IngestEodResult } from "./storehub-eod";
+import { ingestOutletEod } from "./storehub-eod";
+
+type ChannelKey = keyof EodChannelSplit;
+
+// Normalize a tender label for robust matching: uppercase, strip non-alphanumerics.
+function normTender(s: string): string {
+  return s.trim().toUpperCase().replace(/[^A-Z0-9]/g, "");
+}
+
+const CASH_QR_TENDERS = new Set([
+  "CASH",
+  "QR", "QRCODE", "DUITNOW", "DUITNOWQR", "MAYBANKQR", "MAE",
+  "ONLINEBANKING", "FPX",
+  "TOUCHNGOEWALLET", "TNG", "TNGEWALLET",
+  "GRABPAY", "BOOST", "SHOPEEPAY",
+  "WALLET", // Celsius-app stored value — settled as cash at top-up (see header).
+]);
+const CARD_TENDERS = new Set([
+  "CARD", "DEBITCARD", "CREDITCARD", "VISA", "MASTERCARD", "MASTER", "AMEX",
+  "APPLEPAY", "GOOGLEPAY", "SAMSUNGPAY",
+]);
+const VOUCHER_TENDERS = new Set([
+  "VOUCHER", "REDEEM", "REWARD", "MEMBER", "FREEFLOW", "MULAH", "GIFTCARD", "STORECREDIT",
+]);
+
+function classifyTender(method: string | null | undefined): ChannelKey {
+  const t = normTender(method ?? "");
+  if (!t) return "cashQr"; // unknown/blank tender on a real sale → assume cash/QR
+  if (CASH_QR_TENDERS.has(t)) return "cashQr";
+  if (CARD_TENDERS.has(t)) return "card";
+  if (VOUCHER_TENDERS.has(t)) return "voucher";
+  return "other"; // genuinely unrecognized → drops AR confidence → exception
+}
+
+// Whole-order channel override when the order came from a delivery aggregator
+// (native Grab, etc.). These settle net of commission via a debtor, like the
+// StoreHub-side `channel` override.
+function classifySourceOverride(source: string | null | undefined): ChannelKey | null {
+  const s = (source ?? "").toLowerCase();
+  if (/grab|foodpanda|shopee|deliveroo|panda/.test(s)) return "grabfood";
+  return null;
+}
+
+function emptySplit(): EodChannelSplit {
+  return { cashQr: 0, card: 0, voucher: 0, grabfood: 0, gastrohub: 0, other: 0 };
+}
+function round2(n: number): number {
+  return Math.round(n * 100) / 100;
+}
+
+type OrderRow = {
+  id: string;
+  source: string | null;
+  subtotal: number | null;
+  sst_amount: number | null;
+  total: number | null;
+  discount_amount: number | null;
+};
+type PaymentRow = { order_id: string; payment_method: string | null; amount: number | null };
+
+// Aggregates one outlet's orders for one day into an EodSummary.
+// `posPayments` maps pos_orders.id → its payment lines; pickup `orders` carry
+// their single tender inline (order.payment_method, handled via a synthetic line).
+export function aggregateNativeEod(
+  companyId: string,
+  outletId: string,
+  outletName: string,
+  date: string,
+  orders: OrderRow[],
+  paymentsByOrder: Map<string, PaymentRow[]>,
+  sourceDocId: string | null,
+): EodSummary {
+  const channels = emptySplit();
+  let netSales = 0;
+  let sst = 0;
+  let discounts = 0;
+  let txnCount = 0;
+  const refIds: string[] = [];
+
+  for (const o of orders) {
+    const total = Number(o.total ?? 0) / 100;
+    const sstRm = Number(o.sst_amount ?? 0) / 100;
+    const net = round2(Math.max(total - sstRm, 0)); // revenue ex-SST
+    if (net <= 0) continue;
+
+    txnCount += 1;
+    refIds.push(o.id);
+    sst += sstRm;
+    discounts += Number(o.discount_amount ?? 0) / 100;
+
+    // Delivery aggregator → whole order to that channel, ignore tender.
+    const override = classifySourceOverride(o.source);
+    if (override) {
+      channels[override] += net;
+      netSales += net;
+      continue;
+    }
+
+    const lines = paymentsByOrder.get(o.id) ?? [];
+    const paySum = lines.reduce((s, p) => s + Number(p.amount ?? 0), 0);
+    if (lines.length === 0 || paySum <= 0) {
+      // No tender detail (offline sync gap, comp, etc.) → assume cash/QR.
+      channels.cashQr += net;
+      netSales += net;
+      continue;
+    }
+    // Split the SST-excluded net across tenders by their paid proportion.
+    for (const p of lines) {
+      const amt = Number(p.amount ?? 0);
+      if (amt === 0) continue;
+      const share = round2(net * (amt / paySum));
+      channels[classifyTender(p.payment_method)] += share;
+      netSales += share;
+    }
+  }
+
+  for (const k of Object.keys(channels) as ChannelKey[]) channels[k] = round2(channels[k]);
+
+  return {
+    companyId,
+    outletId,
+    outletName,
+    date,
+    transactions: txnCount,
+    netSales: round2(netSales),
+    sst: round2(sst),
+    discounts: round2(discounts),
+    channels,
+    sourceDocId,
+    storehubRefIds: refIds, // native order ids — same provenance slot
+  };
+}
+
+// Persists the native EOD as a fin_documents row (source='pos_native') for
+// journal provenance. Idempotent on (source, source_ref).
+async function persistDoc(
+  companyId: string,
+  outletId: string,
+  date: string,
+  orders: OrderRow[],
+): Promise<string> {
+  const client = getFinanceClient();
+  const sourceRef = `pos-native-eod-${outletId}-${date}`;
+
+  const { data: existing } = await client
+    .from("fin_documents")
+    .select("id")
+    .eq("source", "pos_native")
+    .eq("source_ref", sourceRef)
+    .maybeSingle();
+  if (existing?.id) return existing.id as string;
+
+  const id = randomUUID();
+  const { error } = await client.from("fin_documents").insert({
+    id,
+    company_id: companyId,
+    source: "pos_native",
+    source_ref: sourceRef,
+    doc_type: "pos_eod",
+    outlet_id: outletId,
+    raw_text: null,
+    metadata: { date, orderCount: orders.length, orderIds: orders.map((o) => o.id) },
+    received_at: new Date().toISOString(),
+    ingested_at: new Date().toISOString(),
+    status: "processed",
+  });
+  if (error) throw error;
+  return id;
+}
+
+// Ingests one outlet for one MYT date from native sources. Idempotent — reuses
+// the same outlet+date guard as the StoreHub ingestor, so a day already posted
+// (by either source) is never double-posted.
+export async function ingestOutletNativeEod(
+  outlet: { id: string; name: string; loyaltyOutletId: string | null; pickupStoreId: string | null },
+  date: string,
+): Promise<IngestEodResult> {
+  const { id: outletId, name: outletName } = outlet;
+
+  // Already posted for this outlet/day? (matches storehub-eod's guard.)
+  const client = getFinanceClient();
+  const { data: existingTxn } = await client
+    .from("fin_transactions")
+    .select("id, amount")
+    .eq("outlet_id", outletId)
+    .eq("txn_date", date)
+    .eq("txn_type", "ar_invoice")
+    .eq("posted_by_agent", "ar")
+    .maybeSingle();
+  if (existingTxn?.id) {
+    return {
+      outletId, outletName, date, transactionsFetched: 0,
+      posted: { transactionId: existingTxn.id as string, amount: Number(existingTxn.amount) },
+      skipped: "already posted",
+    };
+  }
+
+  // MYT day boundaries (UTC+8).
+  const from = new Date(`${date}T00:00:00+08:00`);
+  const to = new Date(`${date}T23:59:59.999+08:00`);
+
+  const orders: OrderRow[] = [];
+  const paymentsByOrder = new Map<string, PaymentRow[]>();
+
+  // ── Till + native delivery (pos_orders) ──
+  if (outlet.loyaltyOutletId) {
+    const posRows = await prisma.$queryRaw<OrderRow[]>`
+      SELECT id, source, subtotal, sst_amount, total, discount_amount
+      FROM pos_orders
+      WHERE outlet_id = ${outlet.loyaltyOutletId}
+        AND status = 'completed'
+        AND refund_of_order_id IS NULL
+        AND created_at >= ${from} AND created_at <= ${to}
+    `;
+    orders.push(...posRows);
+    if (posRows.length > 0) {
+      const ids = posRows.map((r) => r.id);
+      const pays = await prisma.$queryRaw<PaymentRow[]>`
+        SELECT order_id, payment_method, amount
+        FROM pos_order_payments
+        WHERE order_id IN (${Prisma.join(ids)})
+          AND COALESCE(status, 'completed') NOT IN ('failed', 'voided', 'cancelled')
+      `;
+      for (const p of pays) {
+        const arr = paymentsByOrder.get(p.order_id) ?? [];
+        arr.push(p);
+        paymentsByOrder.set(p.order_id, arr);
+      }
+    }
+  }
+
+  // ── Celsius pickup/ordering app (orders) — the former Beep online channel.
+  // Single inline tender per order → synthesize a payment line for `total`. ──
+  if (outlet.pickupStoreId) {
+    const pickupRows = await prisma.$queryRaw<Array<OrderRow & { payment_method: string | null }>>`
+      SELECT id, source, subtotal, sst_amount, total, discount_amount, payment_method
+      FROM orders
+      WHERE store_id = ${outlet.pickupStoreId}
+        AND status = 'completed'
+        AND created_at >= ${from} AND created_at <= ${to}
+    `;
+    for (const r of pickupRows) {
+      orders.push(r);
+      paymentsByOrder.set(r.id, [
+        { order_id: r.id, payment_method: r.payment_method, amount: Number(r.total ?? 0) },
+      ]);
+    }
+  }
+
+  if (orders.length === 0) {
+    return { outletId, outletName, date, transactionsFetched: 0, skipped: "no native orders" };
+  }
+
+  const companyId = (await resolveCompanyFromOutlet(outletId)) ?? (await getDefaultCompanyId());
+  const docId = await persistDoc(companyId, outletId, date, orders);
+  const summary = aggregateNativeEod(companyId, outletId, outletName, date, orders, paymentsByOrder, docId);
+
+  if (summary.netSales <= 0) {
+    return { outletId, outletName, date, transactionsFetched: orders.length, skipped: "zero net sales" };
+  }
+
+  try {
+    const result = await postDailyAr(summary);
+    return {
+      outletId, outletName, date, transactionsFetched: orders.length,
+      posted: { transactionId: result.transactionId, amount: result.amount },
+    };
+  } catch (err) {
+    return {
+      outletId, outletName, date, transactionsFetched: orders.length,
+      error: err instanceof Error ? err.message : String(err),
+    };
+  }
+}
+
+// True if `date` (YYYY-MM-DD, MYT) is on/after the outlet's POS-native cutover.
+// Cutover is stored at midnight MYT, so a date-string compare is exact.
+function isNativeOnDate(date: string, cutoverAt: Date | null): boolean {
+  if (!cutoverAt) return false;
+  const cutoverDateMyt = new Date(cutoverAt.getTime() + 8 * 3600 * 1000).toISOString().slice(0, 10);
+  return date >= cutoverDateMyt;
+}
+
+// Cron entrypoint: ingest every ACTIVE outlet for `date`, routing each to the
+// POS that owned it that day — native on/after cutover, StoreHub before. Once
+// every outlet has cut over, this is fully native and StoreHub is never called.
+export async function ingestEodForDate(date: string): Promise<IngestEodResult[]> {
+  const outlets = await prisma.outlet.findMany({
+    where: { status: "ACTIVE" },
+    select: {
+      id: true, name: true, storehubId: true,
+      posNativeCutoverAt: true, loyaltyOutletId: true, pickupStoreId: true,
+    },
+  });
+
+  const results: IngestEodResult[] = [];
+  for (const o of outlets) {
+    if (isNativeOnDate(date, o.posNativeCutoverAt)) {
+      results.push(await ingestOutletNativeEod(o, date));
+    } else if (o.storehubId) {
+      results.push(await ingestOutletEod(o.id, date)); // historical / pre-cutover
+    }
+    // else: outlet has neither a cutover nor StoreHub on this date → no source, skip.
+  }
+  return results;
+}

--- a/apps/backoffice/vercel.json
+++ b/apps/backoffice/vercel.json
@@ -53,10 +53,6 @@
       "schedule": "0 20 * * *"
     },
     {
-      "path": "/api/cron/storehub-sync",
-      "schedule": "0 * * * *"
-    },
-    {
       "path": "/api/cron/music-alerts",
       "schedule": "*/5 * * * *"
     },

--- a/apps/staff/src/app/api/sales/_lib/storehub-bridge.ts
+++ b/apps/staff/src/app/api/sales/_lib/storehub-bridge.ts
@@ -3,11 +3,11 @@
  * shared `storehub_sales` archive (same DB the route already queries for
  * pos_orders/orders). No cross-app bridge, no JWT — so it can't 401.
  *
- * Cutover-routed like the backoffice unified reader: pre-cutover keep ALL
- * StoreHub; post-cutover keep ONLY external/online rows (Grab/Beep/offline —
- * they carry a `channel`) and drop channel-less till rows, which are on
- * pos_orders now (keeping them would double-count). Returns SEN so the dashboard
- * route adds it straight onto the native pos+pickup totals.
+ * Cutover-routed like the backoffice unified reader: StoreHub counts for days
+ * STRICTLY BEFORE the outlet's cutover only. On/after cutover the till + native
+ * Grab are on pos_orders and the old Beep channel is the Celsius app (orders),
+ * both added by the route — so any post-cutover StoreHub row would double-count.
+ * Returns SEN so the dashboard route adds it straight onto the native totals.
  *
  * "Today" freshness depends on the storehub-sync cron (now hourly) populating
  * the archive — the staff app has no live StoreHub client, so today can lag
@@ -103,12 +103,13 @@ export async function getStorehubFromDB(opts: {
   for (const r of data) {
     if (r.is_cancelled === true) continue;
     const ts = typeof r.transaction_time === "string" ? r.transaction_time : r.transaction_time.toISOString();
-    // Cutover routing: after cutover keep only channel-carrying (external) rows;
-    // channel-less till rows are on pos_orders now → keeping them double-counts.
+    // StoreHub is history only: drop everything on/after cutover. The till is on
+    // pos_orders, native Grab on pos_orders, and Beep is the Celsius app (orders)
+    // now — the route adds those separately, so keeping any post-cutover StoreHub
+    // row (incl. the OFFLINE_PAYMENTS till rows, which DO carry a channel) would
+    // double-count.
     const co = cutover.get(r.outlet_id);
-    if (co && new Date(ts).getTime() >= co.getTime()) {
-      if (!(r.channel && r.channel.trim() !== "")) continue;
-    }
+    if (co && new Date(ts).getTime() >= co.getTime()) continue;
     const d = getMYTDateStr(ts);
     const h = getMYTHour(ts);
     // Revenue = `total` (net of discounts), matching the backoffice unified

--- a/docs/storehub-export-checklist.md
+++ b/docs/storehub-export-checklist.md
@@ -1,0 +1,34 @@
+# StoreHub Export Checklist — before cancelling (~2026-06-26)
+
+Portal access dies with the subscription. Grab everything below first. Good
+news: **most of it is already in our own DB** (main Supabase project) and
+survives cancellation — only the bottom section is portal-only and must be
+exported manually.
+
+## Already owned in-DB — nothing to do (verify, don't re-export)
+
+| Data | Where | Coverage |
+|---|---|---|
+| Every transaction (full raw payload) | `storehub_sales.raw` | 2025-08-29 → 2026-06-17, 67,535 rows, 100% with raw |
+| Line items (per-product) | `storehub_sale_items` | 2025-08-29 → 2026-06-17 — **gap Jun 9–17 rebuilt from `raw` on 2026-06-18**, complete |
+| Product catalogue **with cost** | `storehub_products` | 102 items (cost, unit_price, sku, barcode, category, raw) |
+| Daily EOD blobs (AR provenance) | `fin_documents` where `source='storehub'` | through each outlet's cutover |
+
+These are now the permanent system-of-record archive. **Do not drop the
+`storehub_*` tables.**
+
+## Portal-only — export manually from StoreHub BackOffice before cancelling
+
+- [ ] **Settlement / payout statements** — Grab, Beep, card, e-wallet payouts. The final settlement (money StoreHub still holds on your behalf) won't appear in our DB. Export every statement + note the final payout date.
+- [ ] **Inventory / stock** — StoreHub-side stock levels, stock counts, stock-take history, and supplier/purchase records if you kept them there (our inventory is separate, but reconcile opening balances).
+- [ ] **Customers / members** — if StoreHub loyalty/CRM was used, export the member list + balances (our loyalty is native, but capture anything historical).
+- [ ] **Tax / financial reports** — monthly sales, SST, and any reports your accountant relies on, as PDF/CSV, for the full StoreHub period.
+- [ ] **Employees / timesheets** — only if anything lived in StoreHub (HR is on the native module, so likely nothing).
+- [ ] **Final product-cost snapshot** — re-run the product sync once more (or export the product list) so `storehub_products` has the latest costs at cancellation.
+
+## Account / commercial — confirm with StoreHub
+
+- [ ] Cancellation notice period (some require 30 days) and whether billing stops immediately or at cycle end.
+- [ ] Hardware return / buyout terms.
+- [ ] Final settlement payout cleared to the bank before access is cut.
+- [ ] Grab handover: confirm native GrabFood keeps receiving orders for a day before StoreHub is disconnected (so the Grab store link isn't dropped with StoreHub).

--- a/docs/storehub-retirement-readiness-2026-06-17.md
+++ b/docs/storehub-retirement-readiness-2026-06-17.md
@@ -28,7 +28,7 @@ Remediation, two parts:
 
 **Also:** Nilai is native-by-birth but has `posNativeCutoverAt = NULL` and 0 orders — the sales/finance native paths are cutover-gated, so when Nilai starts trading, set its cutover (= launch date) or its revenue won't be picked up.
 
-The 27th housekeeping (cancel StoreHub, remove `storehub-sync` cron, export StoreHub data, drop the Jun-06 backups) is unchanged.
+**`storehub-sync` cron removed** from `apps/backoffice/vercel.json` — StoreHub is dead (0 txns since Jun 18), the archive is history-only now, so there's nothing left to pull. (The route handler stays for manual/backfill use.) Remaining 27th housekeeping (cancel the StoreHub account, export portal-only data, drop the Jun-06 backups) is unchanged.
 
 ---
 

--- a/docs/storehub-retirement-readiness-2026-06-17.md
+++ b/docs/storehub-retirement-readiness-2026-06-17.md
@@ -11,6 +11,27 @@
 
 ---
 
+## Update — 2026-06-18 (Tamarind cut over — migration COMPLETE; finance backfill required)
+
+**Tamarind cut over.** Set `Outlet.posNativeCutoverAt = '2026-06-17 16:00:00+00'` (= Jun 18 00:00 MYT) for `outlet-tam`. Verified clean: StoreHub's last Tamarind txn was Jun 17 22:10 MYT, native till started Jun 18 07:54 MYT, native Grab already flowing — clean overnight boundary, nothing dropped/doubled. **Fleet now fully native** (Putrajaya Jun 8, Shah Alam Jun 15, Tamarind Jun 18; Nilai never on StoreHub). **Zero StoreHub transactions fleet-wide on/after Jun 18 00:00 MYT** — StoreHub is operationally dead.
+
+**🔴 Finance backfill required — AR understated ~RM46.5k since the cutovers.** The live `finance-eod` cron is still the old StoreHub-only code (the native ingestor is on this branch, not deployed), so since each outlet cut over, AR booked only the dying StoreHub Grab tail, not the native till/app revenue:
+
+| Outlet | Native revenue since cutover | Posted to AR | Understated |
+|---|---|---|---|
+| Putrajaya (since Jun 8) | RM40,818 (till 29,872 + app 10,947) | RM3,043 | **−RM37,776** |
+| Shah Alam (since Jun 15) | RM9,629 (till 7,196 + app 2,434) | RM875 | **−RM8,754** |
+
+Remediation, two parts:
+1. **Deploy this branch.** From Jun 18 the native ingestor is *complete* (till + app + native Grab; StoreHub dead) — go-forward needs nothing more.
+2. **Backfill Jun 8–17 (con) / Jun 15–17 (sa)** — one-time. For each post-cutover day: `reverseTransaction()` the stale StoreHub `ar_invoice` (it's `source_doc_id` → `fin_documents.source='storehub'`), then re-post via `ingestOutletNativeEod`. **Nuance:** Grab moved to native only ~Jun 17, so for con Jun 8–16 / sa Jun 15–16 the till was native but Grab was still StoreHub — recomputing from `pos_orders` alone misses that Grab. Those days must add the StoreHub GRABFOOD/BEEP rows (excluding the OFFLINE_PAYMENTS till residual, which native already has). Needs a finance-agreed method before running; the native ingestor's idempotency guard also needs to ignore `status='reversed'` so a reversed day can re-post.
+
+**Also:** Nilai is native-by-birth but has `posNativeCutoverAt = NULL` and 0 orders — the sales/finance native paths are cutover-gated, so when Nilai starts trading, set its cutover (= launch date) or its revenue won't be picked up.
+
+The 27th housekeeping (cancel StoreHub, remove `storehub-sync` cron, export StoreHub data, drop the Jun-06 backups) is unchanged.
+
+---
+
 ## Update — 2026-06-17 (implementation)
 
 Decisions confirmed by owner + work done this session:

--- a/docs/storehub-retirement-readiness-2026-06-17.md
+++ b/docs/storehub-retirement-readiness-2026-06-17.md
@@ -7,7 +7,23 @@
 
 ## Verdict
 
-**Tamarind can cut over tomorrow — the native path is already proven on Putrajaya (cut over Jun 8) and Shah Alam (cut over Jun 15), both ringing real-time `pos_orders` today.** But **"cancel StoreHub on the 27th" is not safe yet.** Three back-office systems still read StoreHub as their *only* source, and one of them — **daily finance/AR posting — has no native replacement at all.** The cutover itself is a 6-item checklist; the cancellation has 3 real blockers and a housekeeping tail. The 9-day buffer (Jun 18→27) is exactly enough to close them if work starts now.
+**Tamarind can cut over tomorrow — the native path is already proven on Putrajaya (cut over Jun 8) and Shah Alam (cut over Jun 15), both ringing real-time `pos_orders` today.** The 3 cancellation blockers are now largely closed in code (see the status update below); the cutover itself remains a 6-item operational checklist. The 9-day buffer (Jun 18→27) is enough to deploy + verify.
+
+---
+
+## Update — 2026-06-17 (implementation)
+
+Decisions confirmed by owner + work done this session:
+
+- **C3 Beep → resolved (no code).** Beep is already replaced by the Celsius App, so its orders now land in the `orders` table, not StoreHub. Only operational step left: retire the StoreHub Beep storefront link/QR so no customer hits a dead Beep page.
+- **C1 Finance → built.** New `pos-native-eod.ts` ingestor posts the daily AR journal from `pos_orders` (+ `pos_order_payments`) **and** the pickup `orders` table (where former-Beep revenue lives). `finance-eod` now routes per outlet by cutover (`ingestEodForDate`): native on/after cutover, StoreHub before. Validated against Putrajaya 2026-06-16 (95 till txns RM2,755.58 + 13 app orders ≈ RM489, tenders mapped correctly). **Pending: deploy + watch the first native run (4 AM MYT) reconcile to the dashboard before the 27th.**
+- **C2 Sales double-count → fixed.** `unified-sales` + staff `storehub-bridge` now count StoreHub for days *strictly before* cutover only; the live "today" pull is gated to still-pre-cutover outlets. No more `OFFLINE_PAYMENTS`/`GRABFOOD` post-cutover double-count.
+- **Housekeeping done:** integrations UI shows StoreHub as *Retired / archive-only* (+ "Tamarind Square"→"Tamarind", added Nilai); `.env.example` marks `STOREHUB_*` legacy; dropped the 3 orphan `*_test_del_20260615` tables.
+- **Housekeeping deferred (on purpose):**
+  - **`storehub-sync` cron** — keep until the 27th. Tamarind is on StoreHub until tomorrow and con/sa still have a small Grab tail; the archive (used for pre-cutover history) must stay fresh. Remove the entry from `apps/backoffice/vercel.json` at cancellation.
+  - **`*_backup_20260606` + `_outlets_backup` / `_outlet_settings_backup`** — kept. These are cutover safety snapshots; dropping them while the migration is still in flight is the wrong call. Drop after the 27th once validated.
+  - **Par-levels repoint — blocked on a mapping.** `inventory/par-levels/calculate` reads `SalesTransaction.menuId`; the only catalogue link is `Menu.storehubId`, and there is no `pos_order_items.product_id → menuId` path. Needs a POS-product↔inventory-menu mapping before it can be repointed. Until then par-levels go stale after the StoreHub `sync-sales` stops.
+  - **Loyalty StoreHub endpoints — still UI-wired, not orphaned.** `/api/storehub/match` (button in `apps/loyalty staff/page.tsx:563`), `/api/storehub/test` (`admin/settings/page.tsx:117`), and `dashboard/kpi` (`fetchTransactionCount`) all still reference `lib/storehub.ts`. Accrual is native, so they're harmless, but "retiring" them means removing those UI surfaces too — a small loyalty-app task, not a one-liner.
 
 ---
 

--- a/docs/storehub-retirement-readiness-2026-06-17.md
+++ b/docs/storehub-retirement-readiness-2026-06-17.md
@@ -1,0 +1,86 @@
+# StoreHub Retirement & Tamarind Cutover — Readiness Report
+
+**Date:** 2026-06-17 · **Tamarind cutover:** 2026-06-18 (tomorrow) · **StoreHub cancellation target:** 2026-06-27
+**Scope:** Final outlet (Tamarind / `outlet-tam`) moves off StoreHub onto POS-native, after which StoreHub can be fully retired. Verified live against Supabase `kqdcdhpnyuwrxqhbuyfl` (main ops DB) + code audit on this branch.
+
+---
+
+## Verdict
+
+**Tamarind can cut over tomorrow — the native path is already proven on Putrajaya (cut over Jun 8) and Shah Alam (cut over Jun 15), both ringing real-time `pos_orders` today.** But **"cancel StoreHub on the 27th" is not safe yet.** Three back-office systems still read StoreHub as their *only* source, and one of them — **daily finance/AR posting — has no native replacement at all.** The cutover itself is a 6-item checklist; the cancellation has 3 real blockers and a housekeeping tail. The 9-day buffer (Jun 18→27) is exactly enough to close them if work starts now.
+
+---
+
+## A. Live state (verified in DB, 2026-06-17)
+
+| Outlet | id | StoreHub | `posNativeCutoverAt` | Native orders / 30d | StoreHub rows / last 3d |
+|---|---|---|---|---|---|
+| Putrajaya | `outlet-con` | linked | **2026-06-07 16:00Z** (Jun 8 MYT) | 1,039 (293 in 3d) | 2,666 → only 5 |
+| Shah Alam | `outlet-sa` | linked | **2026-06-14 16:00Z** (Jun 15 MYT) | 268 (all in 3d) | 3,070 → 22 |
+| **Tamarind** | **`outlet-tam`** | **linked** | **NULL — still on StoreHub** | **0** | **2,924 → 302 (≈100/day, last txn today)** |
+| Nilai | `outlet-nilai` | none | NULL | 0 | — (never on StoreHub) |
+| IOI Mall | — | none | — | — | INACTIVE (closed) |
+
+- StoreHub `channel` is always one of three: `OFFLINE_PAYMENTS` (in-store till, ~6.8k/30d), `BEEP_ORDERS` (StoreHub online storefront, ~1.1k/30d), `GRABFOOD` (~0.8k/30d).
+- Native GrabFood is **already live** — `pos_orders.source='grabfood'` for con (10) and sa (9), last orders today. Tamarind is **not** Grab-linked natively yet.
+- Nilai has no StoreHub link and 0 native orders in 30d — confirm it's pre-launch, not a dead till (not a StoreHub-retirement concern either way).
+
+---
+
+## B. Tamarind cutover — do before/at go-live (Jun 18)
+
+1. **Set the cutover timestamp.** `UPDATE "Outlet" SET "posNativeCutoverAt" = '2026-06-17 16:00:00+00' WHERE id = 'outlet-tam';` (= midnight Jun 18 MYT, mirroring the con/sa pattern). This is the switch that makes the sales dashboard read `pos_orders` for Tamarind and stop counting StoreHub till rows.
+2. **Link Tamarind to native GrabFood** (set its `grabMerchantId` on the integrations/grab page) so Grab inbound lands in `pos_orders`. Today Tamarind's Grab still flows only through StoreHub — if it isn't moved, Grab orders vanish on the 27th.
+3. **Verify the native catalogue for Tamarind** — products, prices, modifiers, categories. StoreHub was the declared "source of truth for product catalog"; confirm parity in the native POS and print a test receipt with the correct legal identity (`companyName` / `regNo` / SSM).
+4. **Verify payments for the `tamarind` store** — Revenue Monster creds, enabled methods, and the Maybank QR poster image (integrations page) all configured.
+5. **Hardware + staff** — register/printer paired (`network-printer`), `staffPin`s set, staff briefed.
+6. **Stop ringing sales into the StoreHub till at cutover.** Any in-store sale put through StoreHub after the cutover timestamp is tagged `OFFLINE_PAYMENTS` and will **double-count** against `pos_orders` (see C2).
+
+---
+
+## C. Blockers before cancelling StoreHub (27th)
+
+**C1 — Daily finance/AR posting is StoreHub-only. (highest priority)**
+The `finance-eod` cron (`0 20 * * *` = 4 AM MYT) → `storehub-eod.ts` ingestor is the *only* path that posts daily revenue AR journals, and it reads exclusively from the StoreHub API for outlets with a `storehubId`. There is **no `pos_orders` ingestor** (`lib/finance/ingestors/` contains only `storehub-eod.ts`). On the 27th, AR/EOD posting stops for **every** outlet, not just Tamarind. Options: (a) build a native EOD ingestor that aggregates `pos_orders` + `orders` (pickup) + native Grab into the same `EodSummary` → `postDailyAr`; (b) keep StoreHub alive solely for finance a bit longer; or (c) accept manual revenue journals in the interim. (a) is the clean fix and fits the 9-day buffer.
+
+**C2 — Sales dashboard double-counts post-cutover StoreHub rows. (verified bug)**
+The cutover de-dup (in `unified-sales.ts` and the staff `storehub-bridge.ts`) keeps post-cutover StoreHub rows *"only if they carry a channel"*, on the assumption that till sales have no channel. **That assumption is false** — StoreHub tags till sales `OFFLINE_PAYMENTS`. Verified: 6 post-cutover `OFFLINE_PAYMENTS` rows for Putrajaya (RM140) are counted *on top of* `pos_orders`. Worse, now that Grab is native, post-cutover `GRABFOOD` StoreHub rows (65 for con) also duplicate the native `grabfood` `pos_orders`. Fix the filter to keep only channels with **no** native equivalent (today that's just `BEEP_ORDERS`), not "any channel". Note: once StoreHub is cancelled and `storehub-sync` stops, this self-resolves going *forward*, but the June overlap days are overstated and may want a correction.
+
+**C3 — Beep online ordering has no native replacement.**
+`BEEP_ORDERS` is StoreHub's own customer storefront (~1.1k orders/30d). Killing StoreHub kills Beep. Before the 27th: route those customers to the pickup/order app (`orders` table), swap any Beep links/QR codes/Google-profile "order online" URLs, and tell regulars. Otherwise that demand disappears with no fallback.
+
+---
+
+## D. Housekeeping (at / after the 27th)
+
+- **Crons:** remove `storehub-sync` (`apps/backoffice/vercel.json`, hourly) once cancelled — it will otherwise throw a caught 401 every hour for every linked outlet. **Keep the `storehub_sales` archive** — it's the historical sales record. Also guard the StoreHub branch of `finance-eod` so it doesn't error nightly.
+- **Inventory:** `inventory/par-levels/calculate` reads `SalesTransaction`, which is fed *only* by `inventory/storehub/sync-sales` (live StoreHub API). After cancellation, par-level / depletion recommendations go stale — repoint to native `pos_order_items`.
+- **Loyalty:** in-store accrual is already native (`/api/pos/loyalty/complete` + the `pos-loyalty-reconcile` safety-net cron writing Beans + mystery drops from `pos_orders`). The legacy StoreHub points matcher (`apps/loyalty /api/storehub/{match,compare,test}` + `lib/storehub.ts`) is **dormant — not on any cron** — so it's safe to retire, not a blocker.
+- **Product catalog:** flip "source of truth" from StoreHub to the native catalogue. The integrations page hardcodes a "StoreHub · Connected / Active · syncing" pill and "source of truth for product catalog and sales" copy — update it. `storehub_products` + the `StorehubSync` table become archival.
+- **Secrets:** keep `STOREHUB_ACCOUNT_ID` / `STOREHUB_API_KEY` / `STOREHUB_USERNAME` until fully retired, then remove from Vercel (backoffice **and** loyalty) and `.env.example`. (Backoffice uses `STOREHUB_ACCOUNT_ID`, loyalty uses `STOREHUB_USERNAME` for the same value — collapse to one.)
+- **Temp tables:** drop the leftovers when convenient — `pos_orders_test_del_20260615`, `pos_order_items_test_del_20260615`, `pos_order_payments_test_del_20260615`, `*_backup_20260606`, `_outlets_backup`, `_outlet_settings_backup`.
+- **Label drift:** integrations `STORE_NAMES` says "Tamarind Square" (standard is "Tamarind") and omits Nilai.
+
+## D2. Before you lose StoreHub access (do by ~Jun 26)
+
+- **Export everything you'll ever want from StoreHub** while the account is live: full transaction history (CSV), product catalogue **with costs**, inventory/stock counts, and settlement/payout statements. Portal access usually dies with the subscription.
+- **Confirm cancellation terms** with StoreHub: notice period (some require 30 days), whether billing stops immediately or at cycle end, hardware return/buyout, and any **final settlement payout** of Beep/Grab money StoreHub is holding on your behalf.
+- **Grab handover:** if your Grab merchant link was provisioned *through* StoreHub, make sure moving Grab to the native integration doesn't disconnect the Grab store when StoreHub is removed — verify native Grab keeps receiving orders for a day before pulling the StoreHub plug.
+- **Run the final `finance-eod`** for the last StoreHub trading day (25th/26th) and confirm it posted before access lapses.
+
+---
+
+## E. Verified safe / already native (don't re-litigate)
+
+Till → `pos_orders` real-time (con/sa live today); in-store loyalty Beans + mystery drops native + reconciled; GrabFood inbound native for con/sa (orders today); native + unified sales dashboards exist and the archive is retained for history; payments native (Revenue Monster / Stripe / Maybank QR). Tamarind is the only remaining StoreHub-dependent till.
+
+---
+
+## F. Recommended sequence
+
+1. **Today:** set Tamarind `posNativeCutoverAt` = `2026-06-17 16:00Z`; link Tamarind native Grab; verify catalogue / payments / printers (§B).
+2. **Jun 18:** Tamarind live; staff stop using the StoreHub till; watch `pos_orders` flow and catch any stray `OFFLINE_PAYMENTS` still hitting StoreHub.
+3. **Jun 18–26 (buffer):** ship native finance-EOD ingestor (C1); fix the de-dup filter (C2); stand up the Beep redirect (C3); repoint inventory par-levels (D).
+4. **~Jun 26:** export StoreHub data/reports; confirm cancellation terms + final settlement; run/confirm the last StoreHub EOD (§D2).
+5. **Jun 27:** cancel StoreHub; remove `storehub-sync`, guard `finance-eod`'s StoreHub branch, flip the integrations UI.
+6. **After:** remove secrets, retire the dormant loyalty StoreHub endpoints, drop the temp tables.

--- a/docs/storehub-retirement-readiness-2026-06-17.md
+++ b/docs/storehub-retirement-readiness-2026-06-17.md
@@ -30,6 +30,12 @@ Remediation, two parts:
 
 **`storehub-sync` cron removed** from `apps/backoffice/vercel.json` — StoreHub is dead (0 txns since Jun 18), the archive is history-only now, so there's nothing left to pull. (The route handler stays for manual/backfill use.) Remaining 27th housekeeping (cancel the StoreHub account, export portal-only data, drop the Jun-06 backups) is unchanged.
 
+**Data preservation + cleanups done (2026-06-18):**
+- **StoreHub data is fully owned in-DB.** `storehub_sales` (67,535 rows, every row with full `raw` payload, Aug 2025→Jun 17), `storehub_products` (with cost), and EOD blobs survive cancellation. **Rebuilt the `storehub_sale_items` Jun 9–17 gap from `raw`** (3,348 items, all named) — the line-item archive is now complete. See `docs/storehub-export-checklist.md` for the portal-only artifacts (settlements/stock/customers) to export before the 27th.
+- **Par-levels repointed to native** (`inventory/par-levels/calculate`): now reads `pos_order_items` via `Menu.storehubId = product_id` (the native POS reuses StoreHub product ids; 96% of sales quantity maps) instead of the StoreHub-fed `SalesTransaction`. The StoreHub `sync-sales` route + `SalesTransaction` are now unused (kept as historical).
+- **Finance backfill tool built** (`/api/cron/finance-eod-backfill?from=&to=&dryRun=`): reverses each stale StoreHub partial and re-posts native, folding in StoreHub GRABFOOD/BEEP for the days before Grab went native (and skipping it when native Grab exists, to avoid double-count). **Dry-run by default.** Run after the branch deploys: `?from=2026-06-08&to=2026-06-17&dryRun=false`. The native ingestor's idempotency guard now ignores `status='reversed'` so reversed days can re-post.
+- **Consolidation:** not needed as a DB merge. StoreHub data is already consolidated into the main DB as a frozen archive; native POS is now the single source for sales/finance/inventory. (Two Supabase projects exist — main + celsius-inventory — but merging them is orthogonal to StoreHub retirement.)
+
 ---
 
 ## Update — 2026-06-17 (implementation)


### PR DESCRIPTION
Completes the StoreHub → POS-native migration (Tamarind was the last outlet, cut over Jun 18) so StoreHub can be cancelled on the 27th.

## Finance
- **New POS-native EOD ingestor** (`pos-native-eod.ts`) builds the AR `EodSummary` from `pos_orders` (+ `pos_order_payments`) **and** the pickup `orders` table (where the former StoreHub "Beep" channel now lands — leaving it out would drop that revenue from AR). Native Grab (`source=grabfood`) bucketed by source.
- `finance-eod` cron routes per outlet by cutover (`ingestEodForDate`): native on/after `posNativeCutoverAt`, StoreHub before (history). Once every outlet is cut over it never calls StoreHub.
- **Backfill tool** `/api/cron/finance-eod-backfill?from=&to=&dryRun=` (dry-run by default): reverses each stale StoreHub partial AR journal and re-posts native, folding in StoreHub GRABFOOD/BEEP for days before Grab went native (skips when native Grab exists). Repairs the ~RM46.5k cutover-window understatement. Idempotency guard now ignores `status='reversed'`.

## Sales dashboard
- `unified-sales` + staff `storehub-bridge` count StoreHub for days **strictly before** cutover only; live "today" pull gated to still-pre-cutover outlets. Fixes a verified post-cutover double-count (StoreHub tags till sales `OFFLINE_PAYMENTS`, so they carried a channel; Grab/Beep are native now).

## Inventory
- `par-levels/calculate` sources demand from native `pos_order_items` (joined to `Menu` via `storehubId` — the native POS reuses StoreHub product ids, 96% mapped) instead of the StoreHub-fed `SalesTransaction`.

## Housekeeping
- Removed the hourly `storehub-sync` cron (StoreHub is dead; archive is history-only).
- Integrations UI: StoreHub shown as Retired/archive-only; fixed "Tamarind Square"→"Tamarind", added Nilai.
- `.env.example`: `STOREHUB_*` marked legacy.
- Docs: `storehub-retirement-readiness-2026-06-17.md`, `storehub-export-checklist.md`.

## After merge / deploy
1. Run the backfill dry-run, then apply: `…/finance-eod-backfill?from=2026-06-08&to=2026-06-17&dryRun=false`.
2. Before the 27th: export StoreHub portal-only data (see checklist), confirm cancellation terms.

Note: DB-side changes already applied live — Tamarind cutover timestamp, `storehub_sale_items` Jun 9–17 rebuild, orphan `*_test_del_*` table drops.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Vj1dCLb24vyszqQujFg2kw)_