### PR TITLE
fix(sales): count transition-window StoreHub Grab/Beep in dashboards (QA follow-up)

### DIFF
--- a/apps/backoffice/src/app/api/sales/_lib/unified-sales.ts
+++ b/apps/backoffice/src/app/api/sales/_lib/unified-sales.ts
@@ -1,15 +1,13 @@
 // Unified sales source for the sales dashboard during/after the StoreHub →
 // POS-native migration. Per outlet, merges:
-//   • StoreHub: the local archive (storehub_sales) for days STRICTLY BEFORE the
-//     outlet's cutover, plus a LIVE pull for TODAY only while the outlet is
-//     still pre-cutover. StoreHub is never counted on/after cutover — Grab is
-//     native (pos_orders) and Beep is now the Celsius app (orders), so counting
-//     the StoreHub rows too would double-count (StoreHub tags till sales
-//     OFFLINE_PAYMENTS, i.e. they DO carry a channel).
+//   • StoreHub: the local archive (storehub_sales) for HISTORY. Pre-cutover:
+//     every row. Post-cutover: ONLY external delivery (Grab/Beep) that was still
+//     on StoreHub during the brief window before it went native — the till
+//     (OFFLINE_PAYMENTS) is on pos_orders now, so keeping it would double-count.
+//     A live "today" pull runs only while the outlet is still pre-cutover.
 //   • POS-native (pos_orders) + pickup (orders): real-time, AT/AFTER cutover.
-// Each sale is counted once from the authoritative source for its time. Once an
-// outlet has cut over it touches StoreHub for history only — so StoreHub can be
-// cancelled with no effect on current numbers.
+// Each sale is counted once. StoreHub is frozen after the final cutover (no new
+// rows) and its Grab never shares a day with native Grab, so no double-count.
 
 import { prisma } from "@/lib/prisma";
 import { getTransactions, type StoreHubTransaction } from "@/lib/storehub";
@@ -55,6 +53,13 @@ function posIsDeliveryQR(orderType: string | null, source: string | null): boole
 
 const toISO = (ts: unknown): string => (ts instanceof Date ? ts.toISOString() : String(ts));
 
+/** External delivery aggregator still settling through StoreHub (Grab/Beep/
+ *  Panda/Shopee) vs the in-store till (OFFLINE_PAYMENTS). Post-cutover only the
+ *  former is kept — the till is on pos_orders. Matches the StoreHub raw
+ *  `channel` values (GRABFOOD, BEEP_ORDERS, FOODPANDA, SHOPEEFOOD). */
+const isExternalDelivery = (channel: string | null | undefined): boolean =>
+  !!channel && /grab|panda|shopee|beep|deliver/i.test(channel);
+
 /**
  * All sales for one outlet across [from, to], routed by the outlet's cutover.
  * Returns a flat, source-agnostic list the dashboard aggregates exactly as it
@@ -80,10 +85,15 @@ export async function getUnifiedSalesForOutlet(
     Date.UTC(mytNow.getUTCFullYear(), mytNow.getUTCMonth(), mytNow.getUTCDate()) - 8 * 3600 * 1000,
   );
 
-  // Push one StoreHub txn. Callers only ever pass PRE-cutover rows (the archive
-  // window is capped at cutover and the live pull is gated to pre-cutover
-  // outlets), so there's no per-row cutover gate here — StoreHub is history only.
+  // StoreHub is HISTORY only. Pre-cutover keep every row; post-cutover keep ONLY
+  // external delivery (Grab/Beep) — the till (OFFLINE_PAYMENTS) is on pos_orders
+  // now, so keeping it would double-count.
+  const cutoverMs = outlet.cutoverAt ? outlet.cutoverAt.getTime() : Number.POSITIVE_INFINITY;
+  const keepStorehub = (ts: string, channel: string | null | undefined): boolean =>
+    new Date(ts).getTime() < cutoverMs || isExternalDelivery(channel);
+
   const pushStorehub = (ts: string, total: number, raw: StoreHubTransaction) => {
+    if (!keepStorehub(ts, raw?.channel as string | null | undefined)) return;
     sales.push({
       ts,
       total,
@@ -112,6 +122,7 @@ export async function getUnifiedSalesForOutlet(
       return;
     }
     const ts = toISO(r.ts);
+    if (!keepStorehub(ts, r.channel)) return;
     sales.push({
       ts,
       total: Number(r.total) || 0,
@@ -121,12 +132,10 @@ export async function getUnifiedSalesForOutlet(
     });
   };
 
-  // ── StoreHub PAST — local archive, strictly BEFORE cutover and before today
-  // 00:00 MYT (today is served by the live pull below). On/after cutover the
-  // outlet is fully native, so the archive contributes history only. ──
-  const cutoverCapMs = outlet.cutoverAt ? outlet.cutoverAt.getTime() - 1 : Number.POSITIVE_INFINITY;
-  const archiveToBase = Math.min(to.getTime(), todayStartMyt.getTime() - 1);
-  const archiveTo = new Date(Math.min(archiveToBase, cutoverCapMs));
+  // ── StoreHub PAST — local archive up to today 00:00 MYT (today is the live
+  // pull below). pushArchive applies the cutover rule per row: all rows
+  // pre-cutover, delivery-only post-cutover. ──
+  const archiveTo = new Date(Math.min(to.getTime(), todayStartMyt.getTime() - 1));
   // channel_class / is_delivery_qr are materialized at import (and
   // backfilled) so this no longer ships the heavy `raw` JSONB — only
   // rows that somehow missed classification fall back to it.

--- a/apps/staff/src/app/api/sales/_lib/storehub-bridge.ts
+++ b/apps/staff/src/app/api/sales/_lib/storehub-bridge.ts
@@ -3,11 +3,11 @@
  * shared `storehub_sales` archive (same DB the route already queries for
  * pos_orders/orders). No cross-app bridge, no JWT — so it can't 401.
  *
- * Cutover-routed like the backoffice unified reader: StoreHub counts for days
- * STRICTLY BEFORE the outlet's cutover only. On/after cutover the till + native
- * Grab are on pos_orders and the old Beep channel is the Celsius app (orders),
- * both added by the route — so any post-cutover StoreHub row would double-count.
- * Returns SEN so the dashboard route adds it straight onto the native totals.
+ * Cutover-routed like the backoffice unified reader: pre-cutover keep every
+ * StoreHub row; post-cutover keep ONLY external delivery (Grab/Beep) that was
+ * still on StoreHub before it went native. The till (OFFLINE_PAYMENTS) is on
+ * pos_orders post-cutover, so keeping it would double-count. Returns SEN so the
+ * dashboard route adds it straight onto the native totals.
  *
  * "Today" freshness depends on the storehub-sync cron (now hourly) populating
  * the archive — the staff app has no live StoreHub client, so today can lag
@@ -103,13 +103,12 @@ export async function getStorehubFromDB(opts: {
   for (const r of data) {
     if (r.is_cancelled === true) continue;
     const ts = typeof r.transaction_time === "string" ? r.transaction_time : r.transaction_time.toISOString();
-    // StoreHub is history only: drop everything on/after cutover. The till is on
-    // pos_orders, native Grab on pos_orders, and Beep is the Celsius app (orders)
-    // now — the route adds those separately, so keeping any post-cutover StoreHub
-    // row (incl. the OFFLINE_PAYMENTS till rows, which DO carry a channel) would
-    // double-count.
+    // StoreHub is history only. Pre-cutover keep every row; post-cutover keep
+    // ONLY external delivery (Grab/Beep) that was still on StoreHub before it
+    // went native — the till (OFFLINE_PAYMENTS) is on pos_orders now, so keeping
+    // it would double-count.
     const co = cutover.get(r.outlet_id);
-    if (co && new Date(ts).getTime() >= co.getTime()) continue;
+    if (co && new Date(ts).getTime() >= co.getTime() && !/grab|panda|shopee|beep|deliver/i.test(r.channel ?? "")) continue;
     const d = getMYTDateStr(ts);
     const h = getMYTHour(ts);
     // Revenue = `total` (net of discounts), matching the backoffice unified


### PR DESCRIPTION
Follow-up from QA of the sales dashboards (staff-native + backoffice — both read `/api/sales/dashboard`).

## Bug
The StoreHub-retirement PR (#330) excluded **all** post-cutover StoreHub from the sales readers to kill a till double-count. But Grab moved StoreHub→native only ~Jun 16, **after** the till cutovers (Putrajaya Jun 8, Shah Alam Jun 15). So for the transition window, StoreHub still carried real Grab orders that were never in `pos_orders` — and excluding them **undercounts Grab** for any range spanning those days:

| Outlet | Undercount (last-7-days) |
|---|---|
| Putrajaya | −RM1,457 |
| Shah Alam | −RM875 |

It self-heals as the window rolls past the transition, but until then the dashboard reads low and below the (backfilled) finance AR. Verified there's no same-day native Grab on those days, so it's a pure undercount, not a double-count.

## Fix
Post-cutover, keep StoreHub **external delivery** rows (`channel` matches Grab/Beep/Panda/Shopee) but still drop `OFFLINE_PAYMENTS` (the till — that's native `pos_orders` now). Pre-cutover unchanged (all rows = history). Applied to both `unified-sales` and the staff `storehub-bridge`; matches the finance backfill's StoreHub-delivery fold-in.

Verified against prod: Putrajaya post-cutover → keeps RM2,902 delivery, drops RM140 till; Shah Alam → RM875 / RM0. StoreHub is frozen (no rows after the final cutover) and its Grab never shares a day with native Grab, so no double-count.

QA also confirmed (no change needed): staff-native == backoffice to the ringgit, clean cutover boundaries, no refund rows, today/yesterday views correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Vj1dCLb24vyszqQujFg2kw)_