### PR TITLE
feat(scorecard): replace Rewards Overview with per-outlet Area Scorecard

### DIFF
--- a/apps/backoffice/src/app/(admin)/layout.tsx
+++ b/apps/backoffice/src/app/(admin)/layout.tsx
@@ -243,15 +243,15 @@ const NAV_SECTIONS: NavSection[] = [
     dividerBefore: true,
     subgroups: [
       {
-        // Single Overview entry — was three (Dashboard, v2 Analytics,
-        // AI Insights). Dashboard is the canonical operator view; the
-        // mechanic-specific Analytics and AI Insights pages remain
-        // available via deep-link (/loyalty/analytics, /loyalty/insights)
-        // for the rare admin who needs them, but don't crowd the
-        // sidebar for daily ops.
+        // The rewards-program Overview was replaced by the Area Scorecard:
+        // a per-outlet KPI scoreboard (loyalty capture, upsell, ops
+        // compliance, wastage) sourced from the live POS / apps system —
+        // answers "which area is hitting KPI". The mechanic-specific
+        // rewards Analytics / AI Insights pages remain available via
+        // deep-link (/loyalty/analytics, /loyalty/insights).
         label: "Overview",
         items: [
-          { label: "Overview", href: "/loyalty/dashboard", icon: <LayoutDashboard className={ICON_SIZE} />, moduleKey: "loyalty:dashboard" },
+          { label: "Area Scorecard", href: "/loyalty/dashboard", icon: <Trophy className={ICON_SIZE} />, moduleKey: "loyalty:dashboard" },
         ],
       },
       {

--- a/apps/backoffice/src/app/(admin)/loyalty/dashboard/page.tsx
+++ b/apps/backoffice/src/app/(admin)/loyalty/dashboard/page.tsx
@@ -41,7 +41,7 @@ type OutletRow = {
     upsell: Kpi & { orders: number; upsellOrders: number };
     ops: Kpi & { completed: number; total: number; photoRate: number | null };
     wastage: Kpi & { cost: number };
-    serving: { value: null; status: "nodata"; note: string };
+    serving: Kpi & { orders: number };
   };
 };
 
@@ -53,6 +53,7 @@ type Scorecard = {
     upsellRate: number;
     opsCompletion: number;
     wastagePctOfSales: number;
+    servingMins: number;
   };
   summary: {
     totalOutlets: number;
@@ -64,6 +65,7 @@ type Scorecard = {
       upsell: number | null;
       ops: number | null;
       wastagePct: number | null;
+      servingMins: number | null;
     };
   };
   outlets: OutletRow[];
@@ -77,13 +79,13 @@ type KpiKey = "collection" | "upsell" | "ops" | "wastage" | "serving";
 
 const KPI_META: Record<
   KpiKey,
-  { label: string; short: string; icon: React.ElementType; unit: "pct" | "none"; betterText: string }
+  { label: string; short: string; icon: React.ElementType; unit: "pct" | "mins"; lowerBetter: boolean }
 > = {
-  collection: { label: "Loyalty capture", short: "Capture", icon: Phone, unit: "pct", betterText: "≥ target" },
-  upsell: { label: "Upsell", short: "Upsell", icon: TrendingUp, unit: "pct", betterText: "≥ target" },
-  ops: { label: "Ops compliance", short: "Ops", icon: ClipboardCheck, unit: "pct", betterText: "≥ target" },
-  wastage: { label: "Wastage", short: "Wastage", icon: Trash2, unit: "pct", betterText: "≤ target" },
-  serving: { label: "Serving time", short: "Serving", icon: Clock, unit: "none", betterText: "" },
+  collection: { label: "Loyalty capture", short: "Capture", icon: Phone, unit: "pct", lowerBetter: false },
+  upsell: { label: "Upsell", short: "Upsell", icon: TrendingUp, unit: "pct", lowerBetter: false },
+  ops: { label: "Ops compliance", short: "Ops", icon: ClipboardCheck, unit: "pct", lowerBetter: false },
+  wastage: { label: "Wastage", short: "Wastage", icon: Trash2, unit: "pct", lowerBetter: true },
+  serving: { label: "Serving time", short: "Serving", icon: Clock, unit: "mins", lowerBetter: true },
 };
 
 const PERIODS: { value: Period; label: string }[] = [
@@ -100,6 +102,12 @@ const PERIODS: { value: Period; label: string }[] = [
 
 function fmtPct(v: number | null): string {
   return v === null ? "—" : `${v}%`;
+}
+function fmtMins(v: number | null): string {
+  return v === null ? "—" : `${v}m`;
+}
+function fmtUnit(v: number | null, unit: "pct" | "mins"): string {
+  return unit === "mins" ? fmtMins(v) : fmtPct(v);
 }
 function fmtRM(v: number): string {
   return `RM ${v.toLocaleString("en-MY", { minimumFractionDigits: 0, maximumFractionDigits: 0 })}`;
@@ -145,7 +153,8 @@ function SummaryTile({
 function KpiCell({ kpiKey, kpi }: { kpiKey: KpiKey; kpi: Kpi }) {
   const meta = KPI_META[kpiKey];
   const style = STATUS_STYLE[kpi.status];
-  const valueText = meta.unit === "pct" ? fmtPct(kpi.value) : "—";
+  const valueText = fmtUnit(kpi.value, meta.unit);
+  const targetUnit = meta.unit === "mins" ? "m" : "%";
   return (
     <div className={cn("rounded-lg border px-2.5 py-2", style.pill)}>
       <div className="flex items-center justify-between gap-1">
@@ -159,9 +168,7 @@ function KpiCell({ kpiKey, kpi }: { kpiKey: KpiKey; kpi: Kpi }) {
       <div className="mt-1 text-[10px] text-gray-400">
         {kpi.status === "nodata"
           ? "no data"
-          : kpiKey === "wastage"
-            ? `target ≤ ${kpi.target}%`
-            : `target ≥ ${kpi.target}%`}
+          : `target ${meta.lowerBetter ? "≤" : "≥"} ${kpi.target}${targetUnit}`}
       </div>
     </div>
   );
@@ -343,16 +350,15 @@ export default function AreaScorecardPage() {
             })}
           </div>
 
-          {/* Serving-time instrumentation note */}
+          {/* Serving-time scope note */}
           <div className="mt-4 rounded-xl border border-dashed border-gray-300 bg-gray-50 p-4">
             <div className="flex items-start gap-2">
               <Clock className="mt-0.5 h-4 w-4 shrink-0 text-gray-400" />
               <div className="text-xs text-gray-500">
-                <span className="font-semibold text-gray-700">Serving time is not tracked yet.</span> POS orders
-                record when an order is <em>placed</em> but not when it is <em>ready/served</em>, so speed-of-service
-                can&apos;t be computed. Lighting it up needs a small POS change: stamp a <code>ready_at</code> /{" "}
-                <code>served_at</code> timestamp on <code>pos_orders</code> when the kitchen bumps the order. Say the
-                word and I&apos;ll wire it.
+                <span className="font-semibold text-gray-700">Serving time</span> measures order placed →
+                kitchen <em>Ready</em> (target ≤ {data.targets.servingMins}m) for <strong>queued pickup &amp; Grab
+                orders</strong> — the only ones with a kitchen bump. Dine-in sales are rung up already paid, so they
+                have no &ldquo;ready&rdquo; event to measure; an outlet with no queued orders shows <em>no data</em>.
               </div>
             </div>
           </div>

--- a/apps/backoffice/src/app/(admin)/loyalty/dashboard/page.tsx
+++ b/apps/backoffice/src/app/(admin)/loyalty/dashboard/page.tsx
@@ -2,1053 +2,362 @@
 
 import { useState, useEffect, useCallback } from "react";
 import {
-  DollarSign,
-  Users,
-  Star,
-  Gift,
+  Trophy,
+  Phone,
   TrendingUp,
+  ClipboardCheck,
+  Trash2,
+  Clock,
+  RefreshCw,
   Loader2,
-  Activity as ActivityIcon,
-  Crown,
   Store,
   Target,
-  UserCheck,
-  Repeat,
-  UserX,
-  Zap,
-  TrendingDown,
-  PieChart,
+  CheckCircle2,
+  XCircle,
+  MinusCircle,
 } from "lucide-react";
 import { cn } from "@/lib/utils";
 
 // ---------------------------------------------------------------------------
-// Types
+// Types — mirror /api/scorecard
 // ---------------------------------------------------------------------------
 
-type KpiPeriod = "daily" | "yesterday" | "last7days" | "last30days" | "weekly" | "monthly" | "custom";
-type KpiShift = "all" | "morning" | "evening";
+type KpiStatus = "hit" | "miss" | "nodata";
+type Period = "daily" | "yesterday" | "last7days" | "last30days" | "weekly" | "monthly";
 
-type OutletOption = { id: string; name: string };
+type Kpi = { value: number | null; target?: number; status: KpiStatus };
 
-type KpiData = {
-  period: { from: string; to: string; type: string };
-  collection_rate: {
-    pos_orders: number;
-    loyalty_claims: number;
-    rate: number;
-    outlets: { outlet_id: string; outlet_name: string; pos_orders: number; loyalty_claims: number; claim_rate: number }[];
+type OutletRow = {
+  id: string;
+  code: string;
+  name: string;
+  onPos: boolean;
+  revenue: number;
+  met: number;
+  measurable: number;
+  score: number | null;
+  kpis: {
+    collection: Kpi & { orders: number; collected: number };
+    upsell: Kpi & { orders: number; upsellOrders: number };
+    ops: Kpi & { completed: number; total: number; photoRate: number | null };
+    wastage: Kpi & { cost: number };
+    serving: { value: null; status: "nodata"; note: string };
   };
-  new_members: number;
-  returning_members: number;
-  returning_sales: number;
-  available_outlets: OutletOption[];
-  _debug?: string[];
 };
 
-type SegmentPeriod = "weekly" | "monthly" | "yearly";
-
-type SegmentData = {
-  period: string;
-  period_start: string;
-  total_members: number;
-  active_this_period: number;
-  repeat: number;
-  frequent: number;
-  ltv: number;
-  ltv_projected_months: number;
-  churned: number;
-  avg_spend: number;
-  total_spend: number;
+type Scorecard = {
+  period: { from: string; to: string; type: string; label: string };
+  generatedAt: string;
+  targets: {
+    collectionRate: number;
+    upsellRate: number;
+    opsCompletion: number;
+    wastagePctOfSales: number;
+  };
+  summary: {
+    totalOutlets: number;
+    measuredOutlets: number;
+    hittingAll: number;
+    totalRevenue: number;
+    avg: {
+      collection: number | null;
+      upsell: number | null;
+      ops: number | null;
+      wastagePct: number | null;
+    };
+  };
+  outlets: OutletRow[];
 };
 
-type DashboardStats = {
-  total_members: number;
-  new_members_today: number;
-  new_members_this_month: number;
-  total_points_issued: number;
-  total_points_redeemed: number;
-  total_redemptions: number;
-  total_revenue_attributed: number;
-  active_campaigns: number;
-  active_members_30d: number;
-  floating_points: number;
-  member_transaction_pct: number;
-  avg_lifetime_value_members: number;
-  avg_lifetime_value_nonmembers: number;
-  reward_redemption_rate: number;
-  top_spenders: TopSpender[];
-  recent_activity: Activity[];
-  new_members_by_month: { month: string; count: number }[];
-  redemptions_by_month: { month: string; count: number }[];
+// ---------------------------------------------------------------------------
+// KPI column metadata
+// ---------------------------------------------------------------------------
+
+type KpiKey = "collection" | "upsell" | "ops" | "wastage" | "serving";
+
+const KPI_META: Record<
+  KpiKey,
+  { label: string; short: string; icon: React.ElementType; unit: "pct" | "none"; betterText: string }
+> = {
+  collection: { label: "Loyalty capture", short: "Capture", icon: Phone, unit: "pct", betterText: "≥ target" },
+  upsell: { label: "Upsell", short: "Upsell", icon: TrendingUp, unit: "pct", betterText: "≥ target" },
+  ops: { label: "Ops compliance", short: "Ops", icon: ClipboardCheck, unit: "pct", betterText: "≥ target" },
+  wastage: { label: "Wastage", short: "Wastage", icon: Trash2, unit: "pct", betterText: "≤ target" },
+  serving: { label: "Serving time", short: "Serving", icon: Clock, unit: "none", betterText: "" },
 };
 
-type TopSpender = {
-  id: string;
-  name: string;
-  phone: string;
-  total_spent: number;
-  total_visits: number;
-  total_points_earned: number;
-  total_rewards_redeemed: number;
-  last_visit_at: string;
-};
-
-type Activity = {
-  id: string;
-  name: string;
-  text: string;
-  type: "earn" | "redeem" | "bonus";
-  date: string;
-};
-
-const PERIOD_LABELS: Record<KpiPeriod, string> = {
-  daily: "Today",
-  yesterday: "Yesterday",
-  last7days: "Last 7 Days",
-  last30days: "Last 30 Days",
-  weekly: "This Week",
-  monthly: "This Month",
-  custom: "Custom",
-};
+const PERIODS: { value: Period; label: string }[] = [
+  { value: "daily", label: "Today" },
+  { value: "yesterday", label: "Yesterday" },
+  { value: "last7days", label: "Last 7 Days" },
+  { value: "last30days", label: "Last 30 Days" },
+  { value: "monthly", label: "This Month" },
+];
 
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
 
-function formatPoints(n: number): string {
-  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
-  if (n >= 1_000) return `${(n / 1_000).toFixed(1)}K`;
-  return n.toLocaleString();
+function fmtPct(v: number | null): string {
+  return v === null ? "—" : `${v}%`;
+}
+function fmtRM(v: number): string {
+  return `RM ${v.toLocaleString("en-MY", { minimumFractionDigits: 0, maximumFractionDigits: 0 })}`;
 }
 
-function formatPhone(phone: string): string {
-  const d = phone.replace(/\D/g, "");
-  if (d.length === 0) return phone;
-  const local = d.startsWith("60") ? d.slice(2) : d.startsWith("0") ? d.slice(1) : d;
-  if (local.length <= 2) return `+60 ${local}`;
-  if (local.length <= 5) return `+60 ${local.slice(0, 2)}-${local.slice(2)}`;
-  return `+60 ${local.slice(0, 2)}-${local.slice(2, 5)} ${local.slice(5)}`;
-}
-
-function getTimeAgo(dateStr: string): string {
-  const diff = Date.now() - new Date(dateStr).getTime();
-  const mins = Math.floor(diff / 60_000);
-  if (mins < 1) return "Just now";
-  if (mins < 60) return `${mins}m ago`;
-  const hrs = Math.floor(mins / 60);
-  if (hrs < 24) return `${hrs}h ago`;
-  const days = Math.floor(hrs / 24);
-  return `${days}d ago`;
-}
-
-// ---------------------------------------------------------------------------
-// Activity color map
-// ---------------------------------------------------------------------------
-
-const activityColors: Record<string, string> = {
-  earn: "bg-green-100 text-green-700",
-  redeem: "bg-orange-100 text-orange-700",
-  bonus: "bg-blue-100 text-blue-700",
-};
-
-const activityDotColors: Record<string, string> = {
-  earn: "bg-green-500",
-  redeem: "bg-orange-500",
-  bonus: "bg-blue-500",
+const STATUS_STYLE: Record<KpiStatus, { pill: string; text: string; Icon: React.ElementType }> = {
+  hit: { pill: "bg-emerald-50 border-emerald-200", text: "text-emerald-700", Icon: CheckCircle2 },
+  miss: { pill: "bg-red-50 border-red-200", text: "text-red-700", Icon: XCircle },
+  nodata: { pill: "bg-gray-50 border-gray-200", text: "text-gray-400", Icon: MinusCircle },
 };
 
 // ---------------------------------------------------------------------------
-// Horizontal Bar Chart
+// Small components
 // ---------------------------------------------------------------------------
 
-function HorizontalBarChart({
-  data,
+function SummaryTile({
+  icon: Icon,
   label,
-  icon,
+  value,
+  sub,
+  tone = "default",
 }: {
-  data: { month: string; count: number }[];
+  icon: React.ElementType;
   label: string;
-  icon: React.ReactNode;
+  value: string;
+  sub?: string;
+  tone?: "default" | "good";
 }) {
-  const maxCount = Math.max(...data.map((d) => d.count), 1);
-
   return (
-    <div className="rounded-xl border border-gray-200 bg-white shadow-sm p-5">
-      <div className="flex items-center gap-2 mb-4">
-        {icon}
-        <h3 className="text-sm font-semibold text-gray-900">{label}</h3>
+    <div className="rounded-xl border border-gray-200 bg-white p-4 shadow-sm">
+      <div className="flex items-center gap-2 mb-2">
+        <Icon className={cn("h-4 w-4", tone === "good" ? "text-emerald-500" : "text-gray-400")} />
+        <span className="text-xs font-medium text-gray-500">{label}</span>
       </div>
-      <div className="space-y-2.5">
-        {data.map((item) => (
-          <div key={item.month} className="flex items-center gap-3">
-            <span className="text-xs font-medium text-gray-500 w-16 shrink-0 text-right">
-              {item.month}
-            </span>
-            <div className="flex-1 h-6 bg-gray-100 rounded-md overflow-hidden">
-              <div
-                className="h-full rounded-md transition-all duration-500"
-                style={{
-                  width: `${(item.count / maxCount) * 100}%`,
-                  backgroundColor: "#C2452D",
-                  minWidth: item.count > 0 ? "8px" : "0px",
-                }}
-              />
-            </div>
-            <span className="text-xs font-bold text-gray-700 w-10 shrink-0">
-              {formatPoints(item.count)}
-            </span>
-          </div>
-        ))}
-        {data.length === 0 && (
-          <p className="text-sm text-gray-400 text-center py-4">No data available.</p>
-        )}
+      <div className={cn("text-2xl font-bold", tone === "good" ? "text-emerald-600" : "text-gray-900")}>
+        {value}
+      </div>
+      {sub && <div className="mt-0.5 text-xs text-gray-400">{sub}</div>}
+    </div>
+  );
+}
+
+function KpiCell({ kpiKey, kpi }: { kpiKey: KpiKey; kpi: Kpi }) {
+  const meta = KPI_META[kpiKey];
+  const style = STATUS_STYLE[kpi.status];
+  const valueText = meta.unit === "pct" ? fmtPct(kpi.value) : "—";
+  return (
+    <div className={cn("rounded-lg border px-2.5 py-2", style.pill)}>
+      <div className="flex items-center justify-between gap-1">
+        <span className="flex items-center gap-1 text-[10px] font-medium uppercase tracking-wide text-gray-400">
+          <meta.icon className="h-3 w-3" />
+          {meta.short}
+        </span>
+        <style.Icon className={cn("h-3.5 w-3.5", style.text)} />
+      </div>
+      <div className={cn("mt-1 text-base font-bold leading-none", style.text)}>{valueText}</div>
+      <div className="mt-1 text-[10px] text-gray-400">
+        {kpi.status === "nodata"
+          ? "no data"
+          : kpiKey === "wastage"
+            ? `target ≤ ${kpi.target}%`
+            : `target ≥ ${kpi.target}%`}
       </div>
     </div>
   );
 }
 
 // ---------------------------------------------------------------------------
-// Component
+// Page
 // ---------------------------------------------------------------------------
 
-export default function LoyaltyDashboard() {
-  const [stats, setStats] = useState<DashboardStats | null>(null);
-  const [activities, setActivities] = useState<Activity[]>([]);
-  const [statsError, setStatsError] = useState(false);
-  const [lastUpdated, setLastUpdated] = useState<Date | null>(null);
+export default function AreaScorecardPage() {
+  const [period, setPeriod] = useState<Period>("last7days");
+  const [data, setData] = useState<Scorecard | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
 
-  // Segment state
-  const [segments, setSegments] = useState<SegmentData | null>(null);
-  const [segPeriod, setSegPeriod] = useState<SegmentPeriod>("monthly");
-  const [segLoading, setSegLoading] = useState(false);
-
-  // KPI state
-  const [kpiPeriod, setKpiPeriod] = useState<KpiPeriod>("daily");
-  const [kpiOutlet, setKpiOutlet] = useState<string>("all");
-  const [kpi, setKpi] = useState<KpiData | null>(null);
-  const [kpiLoading, setKpiLoading] = useState(true);
-  const [kpiCustomFrom, setKpiCustomFrom] = useState(() => new Date().toISOString().split("T")[0]);
-  const [kpiCustomTo, setKpiCustomTo] = useState(() => new Date().toISOString().split("T")[0]);
-  const [kpiShift, setKpiShift] = useState<KpiShift>("all");
-
-  // Load KPI data when period or outlet changes
-  const loadKpi = useCallback(async (period: KpiPeriod, outlet: string, shift: KpiShift, customFrom?: string, customTo?: string) => {
-    setKpiLoading(true);
+  const load = useCallback(async (p: Period) => {
+    setLoading(true);
+    setError(null);
     try {
-      let url: string;
-      if (period === "custom" && customFrom && customTo) {
-        url = `/api/loyalty/dashboard/kpi?brand_id=brand-celsius&period=custom&from=${customFrom}&to=${customTo}`;
-      } else {
-        url = `/api/loyalty/dashboard/kpi?brand_id=brand-celsius&period=${period}`;
-      }
-      if (outlet !== "all") url += `&outlet_id=${outlet}`;
-      if (shift !== "all") url += `&shift=${shift}`;
-      const res = await fetch(url, { credentials: "include" });
-      if (res.ok) {
-        setKpi(await res.json());
-      }
-    } catch { /* ignore */ }
-    setKpiLoading(false);
-  }, []);
-
-  useEffect(() => {
-    if (kpiPeriod === "custom") {
-      loadKpi(kpiPeriod, kpiOutlet, kpiShift, kpiCustomFrom, kpiCustomTo);
-    } else {
-      loadKpi(kpiPeriod, kpiOutlet, kpiShift);
+      const res = await fetch(`/api/scorecard?period=${p}`, { credentials: "include" });
+      const json = await res.json();
+      if (!res.ok) throw new Error(json.error || "Failed to load");
+      setData(json);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Network error");
+    } finally {
+      setLoading(false);
     }
-  }, [kpiPeriod, kpiOutlet, kpiShift, kpiCustomFrom, kpiCustomTo, loadKpi]);
-
-  // Load segments when period changes — auto-refresh every 60s
-  const loadSegments = useCallback(async (p: SegmentPeriod) => {
-    setSegLoading(true);
-    try {
-      const res = await fetch(`/api/loyalty/dashboard/segments?brand_id=brand-celsius&period=${p}`, { credentials: "include" });
-      if (res.ok) setSegments(await res.json());
-    } catch { /* ignore */ }
-    setSegLoading(false);
   }, []);
 
   useEffect(() => {
-    loadSegments(segPeriod);
-    const interval = setInterval(() => loadSegments(segPeriod), 60_000);
-    return () => clearInterval(interval);
-  }, [segPeriod, loadSegments]);
+    load(period);
+  }, [period, load]);
 
-  // Load general stats — auto-refresh every 60s for realtime progress
-  useEffect(() => {
-    async function loadStats() {
-      try {
-        const res = await fetch("/api/loyalty/dashboard/stats?brand_id=brand-celsius", {
-          credentials: "include",
-        });
-        if (!res.ok) throw new Error();
-        const data = await res.json();
-        setStats(data);
-        setLastUpdated(new Date());
-        setActivities(
-          (data.recent_activity ?? []).map((a: Activity) => ({
-            ...a,
-            type: a.type as "earn" | "redeem" | "bonus",
-          }))
-        );
-      } catch {
-        setStatsError(true);
-      }
-    }
-    loadStats();
-    const interval = setInterval(loadStats, 60_000);
-    return () => clearInterval(interval);
-  }, []);
-
-  // Loading / error
-  if (!stats && !statsError && kpiLoading) {
-    return (
-      <div className="flex items-center justify-center h-96">
-        <div className="flex flex-col items-center gap-3">
-          <Loader2 className="h-8 w-8 animate-spin text-[#C2452D]" />
-          <p className="text-sm text-gray-500">Loading rewards dashboard...</p>
-        </div>
-      </div>
-    );
-  }
+  const s = data?.summary;
 
   return (
-    <div className="p-3 sm:p-6 pb-10 min-h-0 w-full">
-      <div className="mb-8 flex items-start justify-between">
+    <div className="p-4 sm:p-6 lg:p-8 overflow-x-hidden">
+      {/* Header */}
+      <div className="mb-5 flex items-start justify-between gap-3 flex-wrap">
         <div>
-          <h1 className="text-2xl font-bold text-gray-900">Dashboard</h1>
-          <p className="mt-1 text-sm text-gray-500">Overview of your rewards program performance</p>
+          <h1 className="font-heading text-xl sm:text-2xl font-bold text-foreground">Area Scorecard</h1>
+          <p className="mt-0.5 text-sm text-muted-foreground">
+            Which outlets are hitting KPI — live from the POS &amp; apps
+          </p>
         </div>
-        {lastUpdated && (
-          <div className="flex items-center gap-2 text-xs text-gray-400">
-            <div className="h-1.5 w-1.5 rounded-full bg-green-400 animate-pulse" />
-            <span>Live · updated {lastUpdated.toLocaleTimeString("en-MY", { hour: "2-digit", minute: "2-digit" })}</span>
-          </div>
-        )}
+        <div className="flex items-center gap-2">
+          <select
+            value={period}
+            onChange={(e) => setPeriod(e.target.value as Period)}
+            className="rounded-lg border border-gray-200 bg-white px-3 py-1.5 text-xs font-medium text-gray-700 shadow-sm focus:outline-none focus:ring-2 focus:ring-gray-200"
+          >
+            {PERIODS.map((p) => (
+              <option key={p.value} value={p.value}>
+                {p.label}
+              </option>
+            ))}
+          </select>
+          <button
+            type="button"
+            onClick={() => load(period)}
+            disabled={loading}
+            className="inline-flex items-center gap-1.5 rounded-lg border border-gray-200 bg-white px-3 py-1.5 text-xs font-medium text-gray-700 hover:bg-gray-50 disabled:opacity-50"
+          >
+            {loading ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <RefreshCw className="h-3.5 w-3.5" />}
+            Refresh
+          </button>
+        </div>
       </div>
 
-      <div className="flex flex-col gap-8">
-        {/* ═══════════════════════════════════════════════════════════════════ */}
-        {/* KEY METRICS — Collection Rate, New Members, Returning Members, Sales */}
-        {/* ═══════════════════════════════════════════════════════════════════ */}
-        <div className="rounded-xl border border-gray-200 bg-white shadow-sm p-5">
-          {/* Header + period toggle */}
-          <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3 mb-5">
-            <div className="flex items-center gap-2">
-              <Target className="h-5 w-5 text-[#C2452D]" />
-              <h2 className="text-sm font-semibold text-gray-900">Key Metrics</h2>
-              {kpi && (
-                <span className="text-xs text-gray-400">
-                  {kpi.period.from === kpi.period.to
-                    ? kpi.period.from
-                    : `${kpi.period.from} — ${kpi.period.to}`}
-                </span>
-              )}
-            </div>
-            <div className="flex items-center gap-2">
-              {/* Outlet filter */}
-              {kpi?.available_outlets && kpi.available_outlets.length > 1 && (
-                <select
-                  value={kpiOutlet}
-                  onChange={(e) => setKpiOutlet(e.target.value)}
-                  className="rounded-lg border border-gray-200 bg-white px-2.5 py-1.5 text-xs font-medium text-gray-700 focus:outline-none focus:ring-1 focus:ring-[#C2452D]"
-                >
-                  <option value="all">All Outlets</option>
-                  {kpi.available_outlets.map((o) => (
-                    <option key={o.id} value={o.id}>{o.name}</option>
-                  ))}
-                </select>
-              )}
-              {/* Shift filter */}
-              <div className="flex rounded-lg border border-gray-200 overflow-hidden">
-                {([
-                  { value: "all", label: "All" },
-                  { value: "morning", label: "AM" },
-                  { value: "evening", label: "PM" },
-                ] as { value: KpiShift; label: string }[]).map((s) => (
-                  <button
-                    key={s.value}
-                    onClick={() => setKpiShift(s.value)}
-                    className={cn(
-                      "px-2.5 py-1.5 text-xs font-medium transition-colors",
-                      kpiShift === s.value
-                        ? "bg-gray-800 text-white"
-                        : "bg-white text-gray-600 hover:bg-gray-50"
-                    )}
-                  >
-                    {s.label}
-                  </button>
-                ))}
-              </div>
-              {/* Period dropdown */}
-              <select
-                value={kpiPeriod}
-                onChange={(e) => setKpiPeriod(e.target.value as KpiPeriod)}
-                className="rounded-lg border border-gray-200 bg-white px-2.5 py-1.5 text-xs font-medium text-gray-700 focus:outline-none focus:ring-1 focus:ring-[#C2452D]"
-              >
-                {(Object.entries(PERIOD_LABELS) as [KpiPeriod, string][]).map(([value, label]) => (
-                  <option key={value} value={value}>{label}</option>
-                ))}
-              </select>
-            </div>
+      {error && (
+        <div className="mb-4 rounded-lg border border-red-200 bg-red-50 px-3 py-2 text-xs text-red-700">{error}</div>
+      )}
+
+      {/* Loading */}
+      {loading && !data && (
+        <div className="space-y-3">
+          <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
+            {[1, 2, 3, 4].map((i) => (
+              <div key={i} className="h-24 rounded-xl bg-gray-100 animate-pulse" />
+            ))}
           </div>
-
-          {/* Custom date pickers */}
-          {kpiPeriod === "custom" && (
-            <div className="flex items-center gap-2 mb-4">
-              <input
-                type="date"
-                value={kpiCustomFrom}
-                onChange={(e) => setKpiCustomFrom(e.target.value)}
-                className="rounded-lg border border-gray-200 px-3 py-1.5 text-xs text-gray-700 focus:outline-none focus:ring-1 focus:ring-[#C2452D]"
-              />
-              <span className="text-xs text-gray-400">to</span>
-              <input
-                type="date"
-                value={kpiCustomTo}
-                onChange={(e) => setKpiCustomTo(e.target.value)}
-                className="rounded-lg border border-gray-200 px-3 py-1.5 text-xs text-gray-700 focus:outline-none focus:ring-1 focus:ring-[#C2452D]"
-              />
-            </div>
-          )}
-
-          {/* KPI Cards */}
-          {kpiLoading ? (
-            <div className="flex items-center justify-center py-8">
-              <Loader2 className="h-5 w-5 animate-spin text-[#C2452D]" />
-            </div>
-          ) : kpi ? (
-            <>
-              <div className="grid grid-cols-2 lg:grid-cols-4 gap-4 mb-5">
-                {/* 1 — Collection Rate */}
-                <div className="rounded-lg bg-gray-50 p-4">
-                  <div className="flex items-center gap-1.5 mb-2">
-                    <Target className="h-4 w-4 text-[#C2452D]" />
-                    <p className="text-xs font-medium text-gray-500">Collection Rate</p>
-                  </div>
-                  <p
-                    className={`text-2xl font-bold font-sans ${
-                      kpi.collection_rate.rate >= 50
-                        ? "text-green-600"
-                        : kpi.collection_rate.rate >= 20
-                          ? "text-orange-500"
-                          : kpi.collection_rate.pos_orders === 0
-                            ? "text-gray-400"
-                            : "text-red-500"
-                    }`}
-                  >
-                    {kpi.collection_rate.pos_orders === 0 ? "—" : `${kpi.collection_rate.rate}%`}
-                  </p>
-                  <p className="text-xs text-gray-500 mt-1">
-                    <span className="font-sans font-semibold text-gray-700">
-                      {kpi.collection_rate.loyalty_claims.toLocaleString()}
-                    </span>
-                    {" / "}
-                    <span className="font-sans">
-                      {kpi.collection_rate.pos_orders.toLocaleString()}
-                    </span>
-                    {" orders"}
-                  </p>
-                </div>
-
-                {/* 2 — New Members */}
-                <div className="rounded-lg bg-gray-50 p-4">
-                  <div className="flex items-center gap-1.5 mb-2">
-                    <UserCheck className="h-4 w-4 text-blue-500" />
-                    <p className="text-xs font-medium text-gray-500">New Members</p>
-                  </div>
-                  <p className="text-2xl font-bold font-sans text-gray-900">
-                    {kpi.new_members.toLocaleString()}
-                  </p>
-                  <p className="text-xs text-gray-500 mt-1">{PERIOD_LABELS[kpiPeriod]}</p>
-                </div>
-
-                {/* 3 — Returning Members */}
-                <div className="rounded-lg bg-gray-50 p-4">
-                  <div className="flex items-center gap-1.5 mb-2">
-                    <Repeat className="h-4 w-4 text-emerald-500" />
-                    <p className="text-xs font-medium text-gray-500">Returning Members</p>
-                  </div>
-                  <p className="text-2xl font-bold font-sans text-gray-900">
-                    {kpi.returning_members.toLocaleString()}
-                  </p>
-                  <p className="text-xs text-gray-500 mt-1">2+ visits</p>
-                </div>
-
-                {/* 4 — Sales from Returning Members */}
-                <div className="rounded-lg bg-gray-50 p-4">
-                  <div className="flex items-center gap-1.5 mb-2">
-                    <DollarSign className="h-4 w-4 text-green-500" />
-                    <p className="text-xs font-medium text-gray-500">Returning Sales</p>
-                  </div>
-                  <p className="text-2xl font-bold font-sans text-gray-900">
-                    RM {kpi.returning_sales.toLocaleString()}
-                  </p>
-                  <p className="text-xs text-gray-500 mt-1">from returning members</p>
-                </div>
-              </div>
-
-              {/* Per-outlet collection rate breakdown */}
-              {kpi.collection_rate.outlets.length > 0 && kpi.collection_rate.pos_orders > 0 && (
-                <div className="border-t border-gray-100 pt-4">
-                  <p className="text-xs font-medium text-gray-500 uppercase tracking-wide mb-3">
-                    Collection Rate by Outlet
-                  </p>
-                  <div className="space-y-2">
-                    {kpi.collection_rate.outlets.map((o) => (
-                      <div key={o.outlet_name} className="flex items-center gap-3">
-                        <Store className="h-4 w-4 text-gray-400 shrink-0" />
-                        <span className="text-sm text-gray-700 w-32 truncate">{o.outlet_name}</span>
-                        <div className="flex-1 h-2 rounded-full bg-gray-100 overflow-hidden">
-                          <div
-                            className={`h-full rounded-full transition-all ${
-                              o.claim_rate >= 50 ? "bg-green-500" : o.claim_rate >= 20 ? "bg-orange-400" : "bg-red-400"
-                            }`}
-                            style={{ width: `${Math.min(o.claim_rate, 100)}%` }}
-                          />
-                        </div>
-                        <div className="flex items-center gap-2 shrink-0">
-                          <span className="text-xs font-sans text-gray-500 w-20 text-right">
-                            {o.loyalty_claims.toLocaleString()}/{o.pos_orders.toLocaleString()}
-                          </span>
-                          <span
-                            className={`text-xs font-bold font-sans w-10 text-right ${
-                              o.claim_rate >= 50 ? "text-green-600" : o.claim_rate >= 20 ? "text-orange-500" : "text-red-500"
-                            }`}
-                          >
-                            {o.claim_rate}%
-                          </span>
-                        </div>
-                      </div>
-                    ))}
-                  </div>
-                </div>
-              )}
-            </>
-          ) : (
-            <p className="text-sm text-gray-400 text-center py-4">Failed to load metrics</p>
-          )}
+          {[1, 2, 3, 4].map((i) => (
+            <div key={i} className="h-28 rounded-xl bg-gray-100 animate-pulse" />
+          ))}
         </div>
+      )}
 
-        {/* ─── Overview Stats ─── */}
-        <div className="grid grid-cols-2 lg:grid-cols-4 gap-4">
-          <div className="rounded-xl border border-gray-200 bg-white p-5 shadow-sm">
-            <div className="flex items-start gap-3 mb-4">
-              <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-blue-100">
-                <Users className="h-5 w-5 text-blue-600" />
-              </div>
-              <p className="text-xs font-medium text-gray-500 uppercase tracking-wide">Total Members</p>
-            </div>
-            <p className="font-sans text-2xl font-bold text-gray-900 mb-2">
-              {(stats?.total_members || 0).toLocaleString()}
-            </p>
-            <p className="text-xs text-gray-500">
-              <span className="font-sans font-semibold text-gray-700">
-                {formatPoints(stats?.active_members_30d ?? 0)}
-              </span>{" "}
-              active (30d)
-            </p>
+      {data && s && (
+        <>
+          {/* Summary tiles */}
+          <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
+            <SummaryTile
+              icon={Trophy}
+              label="Hitting every KPI"
+              value={`${s.hittingAll} / ${s.measuredOutlets}`}
+              sub="outlets at 100%"
+              tone={s.hittingAll > 0 ? "good" : "default"}
+            />
+            <SummaryTile icon={Phone} label="Avg loyalty capture" value={fmtPct(s.avg.collection)} sub={`target ${data.targets.collectionRate}%`} />
+            <SummaryTile icon={TrendingUp} label="Avg upsell" value={fmtPct(s.avg.upsell)} sub={`target ${data.targets.upsellRate}%`} />
+            <SummaryTile icon={ClipboardCheck} label="Avg ops compliance" value={fmtPct(s.avg.ops)} sub={`target ${data.targets.opsCompletion}%`} />
           </div>
 
-          <div className="rounded-xl border border-gray-200 bg-white p-5 shadow-sm">
-            <div className="flex items-start gap-3 mb-4">
-              <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-orange-100">
-                <Star className="h-5 w-5 text-orange-600" />
-              </div>
-              <p className="text-xs font-medium text-gray-500 uppercase tracking-wide">Points Issued</p>
-            </div>
-            <p className="font-sans text-2xl font-bold text-gray-900 mb-2">
-              {formatPoints(stats?.total_points_issued ?? 0)}
-            </p>
-            <p className="text-xs text-gray-500">
-              <span className="font-sans font-semibold text-gray-700">
-                {formatPoints(stats?.total_points_redeemed ?? 0)}
-              </span>{" "}
-              redeemed
-            </p>
+          {/* Period note */}
+          <div className="mt-3 flex items-center gap-2 text-xs text-gray-400">
+            <Target className="h-3.5 w-3.5" />
+            <span>
+              {data.period.label} ({data.period.from} → {data.period.to}) · {s.totalOutlets} outlets ·{" "}
+              {fmtRM(s.totalRevenue)} POS sales
+            </span>
           </div>
 
-          <div className="rounded-xl border border-gray-200 bg-white p-5 shadow-sm">
-            <div className="flex items-start gap-3 mb-4">
-              <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-purple-100">
-                <Gift className="h-5 w-5 text-purple-600" />
-              </div>
-              <p className="text-xs font-medium text-gray-500 uppercase tracking-wide">Redemptions</p>
-            </div>
-            <p className="font-sans text-2xl font-bold text-gray-900 mb-2">
-              {(stats?.total_redemptions || 0).toLocaleString()}
-            </p>
-            <p className="text-xs text-gray-500">
-              <span className="font-sans font-semibold text-gray-700">
-                {(stats?.active_campaigns || 0).toLocaleString()}
-              </span>{" "}
-              active campaigns
-            </p>
-          </div>
-
-          <div className="rounded-xl border border-gray-200 bg-white p-5 shadow-sm">
-            <div className="flex items-start gap-3 mb-4">
-              <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-green-100">
-                <DollarSign className="h-5 w-5 text-green-600" />
-              </div>
-              <p className="text-xs font-medium text-gray-500 uppercase tracking-wide">Total Sales</p>
-            </div>
-            <p className="font-sans text-2xl font-bold text-gray-900 mb-2">
-              RM {stats?.total_revenue_attributed?.toLocaleString() || "0"}
-            </p>
-            <p className="text-xs text-gray-500">attributed to loyalty</p>
-          </div>
-        </div>
-
-        {/* ─── Customer Segments ─── */}
-        <div className="rounded-xl border border-gray-200 bg-white shadow-sm p-5">
-          <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3 mb-5">
-            <div className="flex items-center gap-2">
-              <PieChart className="h-5 w-5 text-[#C2452D]" />
-              <h2 className="text-sm font-semibold text-gray-900">Customer Segments</h2>
-              {segments && (
-                <span className="text-xs text-gray-400">
-                  {segments.active_this_period.toLocaleString()} active customers
-                </span>
-              )}
-            </div>
-            <div className="flex rounded-lg border border-gray-200 overflow-hidden">
-              {(["weekly", "monthly", "yearly"] as SegmentPeriod[]).map((p) => (
-                <button
-                  key={p}
-                  onClick={() => setSegPeriod(p)}
+          {/* Outlet ranking */}
+          <div className="mt-4 space-y-3">
+            {data.outlets.map((o, i) => {
+              const allHit = o.measurable > 0 && o.met === o.measurable;
+              return (
+                <div
+                  key={o.id}
                   className={cn(
-                    "px-3 py-1.5 text-xs font-medium transition-colors capitalize",
-                    segPeriod === p
-                      ? "bg-gray-800 text-white"
-                      : "bg-white text-gray-600 hover:bg-gray-50"
+                    "rounded-xl border bg-white p-4 shadow-sm",
+                    allHit ? "border-emerald-200" : "border-gray-200",
                   )}
                 >
-                  {p}
-                </button>
-              ))}
-            </div>
-          </div>
-
-          {segLoading && !segments ? (
-            <div className="flex items-center justify-center py-8">
-              <Loader2 className="h-5 w-5 animate-spin text-[#C2452D]" />
-            </div>
-          ) : segments ? (() => {
-            const base = segments.active_this_period || 0;
-            const pct = (n: number) => base > 0 ? ((n / base) * 100).toFixed(1) : "0";
-            return (
-            <>
-              <div className="grid grid-cols-2 lg:grid-cols-4 gap-4 mb-5">
-                {/* Repeat */}
-                <div className="rounded-lg border border-blue-100 bg-blue-50/50 p-4">
-                  <div className="flex items-center gap-1.5 mb-2">
-                    <Repeat className="h-4 w-4 text-blue-500" />
-                    <p className="text-xs font-medium text-gray-600">Repeat</p>
-                  </div>
-                  <p className="text-2xl font-bold font-sans text-gray-900">
-                    {segments.repeat.toLocaleString()}
-                  </p>
-                  <p className="text-xs text-gray-500 mt-1">
-                    <span className="font-sans font-semibold text-blue-600">{pct(segments.repeat)}%</span>{" "}
-                    of active · 2+ visits
-                  </p>
-                </div>
-
-                {/* Frequent */}
-                <div className="rounded-lg border border-emerald-100 bg-emerald-50/50 p-4">
-                  <div className="flex items-center gap-1.5 mb-2">
-                    <Zap className="h-4 w-4 text-emerald-500" />
-                    <p className="text-xs font-medium text-gray-600">Frequent</p>
-                  </div>
-                  <p className="text-2xl font-bold font-sans text-gray-900">
-                    {segments.frequent.toLocaleString()}
-                  </p>
-                  <p className="text-xs text-gray-500 mt-1">
-                    <span className="font-sans font-semibold text-emerald-600">{pct(segments.frequent)}%</span>{" "}
-                    of active · 1+/week
-                  </p>
-                </div>
-
-                {/* LTV */}
-                <div className="rounded-lg border border-amber-100 bg-amber-50/50 p-4">
-                  <div className="flex items-center gap-1.5 mb-2">
-                    <Crown className="h-4 w-4 text-amber-500" />
-                    <p className="text-xs font-medium text-gray-600">Avg LTV</p>
-                  </div>
-                  <p className="text-2xl font-bold font-sans text-gray-900">
-                    RM {segments.ltv.toLocaleString()}
-                  </p>
-                  <p className="text-xs text-gray-500 mt-1">
-                    projected over{" "}
-                    <span className="font-sans font-semibold text-amber-600">{segments.ltv_projected_months} months</span>
-                  </p>
-                </div>
-
-                {/* Churned */}
-                <div className="rounded-lg border border-red-100 bg-red-50/50 p-4">
-                  <div className="flex items-center gap-1.5 mb-2">
-                    <UserX className="h-4 w-4 text-red-400" />
-                    <p className="text-xs font-medium text-gray-600">Churned</p>
-                  </div>
-                  <p className="text-2xl font-bold font-sans text-gray-900">
-                    {segments.churned.toLocaleString()}
-                  </p>
-                  <p className="text-xs text-gray-500 mt-1">
-                    <span className="font-sans font-semibold text-red-500">{pct(segments.churned)}%</span>{" "}
-                    of active · no visit in period
-                  </p>
-                </div>
-              </div>
-
-              {/* Summary row */}
-              <div className="flex items-center justify-between border-t border-gray-100 pt-3">
-                <div className="flex items-center gap-4 text-xs text-gray-500">
-                  <span>Total spend: <span className="font-sans font-semibold text-gray-700">RM {segments.total_spend.toLocaleString()}</span></span>
-                  <span>Avg/customer: <span className="font-sans font-semibold text-gray-700">RM {segments.avg_spend.toLocaleString()}</span></span>
-                  <span>LTV: <span className="font-sans font-semibold text-amber-600">RM {segments.ltv.toLocaleString()}</span></span>
-                </div>
-                {segLoading && <Loader2 className="h-3 w-3 animate-spin text-gray-400" />}
-              </div>
-
-              {/* Segment bar visualization */}
-              {base > 0 && (
-                <div className="mt-3">
-                  <div className="flex h-3 rounded-full overflow-hidden bg-gray-100">
-                    {[
-                      { count: segments.frequent, color: "bg-emerald-500", label: "Frequent" },
-                      { count: segments.repeat - segments.frequent, color: "bg-blue-400", label: "Repeat" },
-                      { count: base - segments.repeat, color: "bg-gray-300", label: "One-time" },
-                    ].map((seg) => {
-                      const p = (Math.max(0, seg.count) / base) * 100;
-                      return p > 0 ? (
-                        <div
-                          key={seg.label}
-                          className={`${seg.color} transition-all duration-500`}
-                          style={{ width: `${p}%` }}
-                          title={`${seg.label}: ${Math.max(0, seg.count).toLocaleString()} (${p.toFixed(1)}%)`}
-                        />
-                      ) : null;
-                    })}
-                  </div>
-                  <div className="flex items-center gap-4 mt-2">
-                    {[
-                      { color: "bg-emerald-500", label: "Frequent (1+/week)" },
-                      { color: "bg-blue-400", label: "Repeat (2+ visits)" },
-                      { color: "bg-gray-300", label: "One-time" },
-                    ].map((seg) => (
-                      <div key={seg.label} className="flex items-center gap-1.5">
-                        <div className={`h-2 w-2 rounded-full ${seg.color}`} />
-                        <span className="text-[10px] text-gray-500">{seg.label}</span>
+                  <div className="flex flex-col gap-3 lg:flex-row lg:items-center">
+                    {/* Rank + name */}
+                    <div className="flex items-center gap-3 lg:w-64 lg:shrink-0">
+                      <div
+                        className={cn(
+                          "flex h-9 w-9 shrink-0 items-center justify-center rounded-lg text-sm font-bold",
+                          i === 0 && o.measurable > 0
+                            ? "bg-amber-100 text-amber-700"
+                            : "bg-gray-100 text-gray-500",
+                        )}
+                      >
+                        {i + 1}
                       </div>
-                    ))}
+                      <div className="min-w-0">
+                        <div className="flex items-center gap-1.5">
+                          <Store className="h-3.5 w-3.5 text-gray-400 shrink-0" />
+                          <h3 className="truncate text-sm font-semibold text-gray-900">{o.name}</h3>
+                        </div>
+                        <div className="mt-0.5 flex items-center gap-2 text-[11px] text-gray-400">
+                          <span>{fmtRM(o.revenue)}</span>
+                          {!o.onPos && <span className="text-amber-500">· not on POS</span>}
+                        </div>
+                      </div>
+                    </div>
+
+                    {/* Score */}
+                    <div className="lg:w-28 lg:shrink-0">
+                      <div
+                        className={cn(
+                          "inline-flex items-center gap-1.5 rounded-full px-2.5 py-1 text-xs font-semibold",
+                          allHit
+                            ? "bg-emerald-100 text-emerald-700"
+                            : o.measurable === 0
+                              ? "bg-gray-100 text-gray-400"
+                              : "bg-amber-100 text-amber-700",
+                        )}
+                      >
+                        <Trophy className="h-3.5 w-3.5" />
+                        {o.measurable === 0 ? "no data" : `${o.met}/${o.measurable} KPIs`}
+                      </div>
+                    </div>
+
+                    {/* KPI cells */}
+                    <div className="grid flex-1 grid-cols-2 gap-2 sm:grid-cols-3 lg:grid-cols-5">
+                      <KpiCell kpiKey="collection" kpi={o.kpis.collection} />
+                      <KpiCell kpiKey="upsell" kpi={o.kpis.upsell} />
+                      <KpiCell kpiKey="ops" kpi={o.kpis.ops} />
+                      <KpiCell kpiKey="wastage" kpi={o.kpis.wastage} />
+                      <KpiCell kpiKey="serving" kpi={o.kpis.serving} />
+                    </div>
                   </div>
                 </div>
-              )}
-            </>
-            );
-          })() : null}
-        </div>
+              );
+            })}
+          </div>
 
-        {/* ─── Charts: Trends ─── */}
-        <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
-          <HorizontalBarChart
-            data={stats?.new_members_by_month ?? []}
-            label="New Members Trend"
-            icon={<TrendingUp className="h-4 w-4 text-[#C2452D]" />}
-          />
-          <HorizontalBarChart
-            data={stats?.redemptions_by_month ?? []}
-            label="Redemptions Trend"
-            icon={<Gift className="h-4 w-4 text-[#C2452D]" />}
-          />
-        </div>
-
-        {/* ─── Top Spenders ─── */}
-        {(stats?.top_spenders?.length ?? 0) > 0 && (
-          <div className="rounded-xl border border-gray-200 bg-white shadow-sm">
-            <div className="border-b border-gray-200 px-4 py-3 flex items-center gap-2">
-              <Crown className="h-4 w-4 text-[#C2452D]" />
-              <h3 className="text-sm font-semibold text-gray-900">Top Spenders</h3>
-            </div>
-            <div className="overflow-x-auto">
-              <table className="w-full min-w-[700px] text-sm">
-                <thead>
-                  <tr className="border-b border-gray-100 text-left">
-                    <th className="px-4 py-3 text-xs font-medium uppercase tracking-wider text-gray-500 w-12">#</th>
-                    <th className="px-3 py-3 text-xs font-medium uppercase tracking-wider text-gray-500">Name</th>
-                    <th className="px-3 py-3 text-xs font-medium uppercase tracking-wider text-gray-500">Phone</th>
-                    <th className="px-3 py-3 text-xs font-medium uppercase tracking-wider text-gray-500">Total Spent</th>
-                    <th className="px-3 py-3 text-xs font-medium uppercase tracking-wider text-gray-500">Visits</th>
-                    <th className="px-3 py-3 text-xs font-medium uppercase tracking-wider text-gray-500">Points Earned</th>
-                    <th className="px-3 py-3 text-xs font-medium uppercase tracking-wider text-gray-500">Last Visit</th>
-                  </tr>
-                </thead>
-                <tbody className="divide-y divide-gray-50">
-                  {stats?.top_spenders?.slice(0, 5).map((spender, idx) => (
-                    <tr key={spender.id} className="hover:bg-gray-50 transition-colors">
-                      <td className="px-4 py-3">
-                        <span
-                          className={cn(
-                            "inline-flex h-6 w-6 items-center justify-center rounded-full text-xs font-bold",
-                            idx === 0
-                              ? "bg-yellow-100 text-yellow-700"
-                              : idx === 1
-                                ? "bg-gray-100 text-gray-600"
-                                : idx === 2
-                                  ? "bg-orange-100 text-orange-700"
-                                  : "bg-gray-50 text-gray-500"
-                          )}
-                        >
-                          {idx + 1}
-                        </span>
-                      </td>
-                      <td className="px-3 py-3 font-medium text-gray-900 whitespace-nowrap">
-                        {spender.name || "No Name"}
-                      </td>
-                      <td className="px-3 py-3 font-sans text-gray-700 whitespace-nowrap">
-                        {formatPhone(spender.phone)}
-                      </td>
-                      <td className="px-3 py-3 font-sans font-bold text-gray-900 whitespace-nowrap">
-                        RM {spender.total_spent.toLocaleString()}
-                      </td>
-                      <td className="px-3 py-3 font-sans text-gray-700 whitespace-nowrap">
-                        {formatPoints(spender.total_visits)}
-                      </td>
-                      <td className="px-3 py-3 whitespace-nowrap">
-                        <span className="font-sans font-bold text-gray-900">
-                          {formatPoints(spender.total_points_earned)}
-                        </span>{" "}
-                        <span className="text-xs text-gray-400">pts</span>
-                      </td>
-                      <td className="px-3 py-3 text-gray-500 whitespace-nowrap">
-                        {spender.last_visit_at ? getTimeAgo(spender.last_visit_at) : "Never"}
-                      </td>
-                    </tr>
-                  ))}
-                </tbody>
-              </table>
+          {/* Serving-time instrumentation note */}
+          <div className="mt-4 rounded-xl border border-dashed border-gray-300 bg-gray-50 p-4">
+            <div className="flex items-start gap-2">
+              <Clock className="mt-0.5 h-4 w-4 shrink-0 text-gray-400" />
+              <div className="text-xs text-gray-500">
+                <span className="font-semibold text-gray-700">Serving time is not tracked yet.</span> POS orders
+                record when an order is <em>placed</em> but not when it is <em>ready/served</em>, so speed-of-service
+                can&apos;t be computed. Lighting it up needs a small POS change: stamp a <code>ready_at</code> /{" "}
+                <code>served_at</code> timestamp on <code>pos_orders</code> when the kitchen bumps the order. Say the
+                word and I&apos;ll wire it.
+              </div>
             </div>
           </div>
-        )}
-
-        {/* ─── Recent Activity ─── */}
-        {activities.length > 0 && (
-          <div className="rounded-xl border border-gray-200 bg-white shadow-sm">
-            <div className="border-b border-gray-200 px-5 py-3 flex items-center gap-2">
-              <ActivityIcon className="h-4 w-4 text-[#C2452D]" />
-              <h2 className="text-sm font-semibold text-gray-900">Recent Activity</h2>
-              <span className="ml-auto text-xs text-gray-400">
-                Last {activities.length} transactions
-              </span>
-            </div>
-            <div className="divide-y divide-gray-100">
-              {activities.map((activity) => (
-                <div key={activity.id} className="flex items-center gap-3 px-5 py-3">
-                  <div
-                    className={cn(
-                      "flex h-8 w-8 shrink-0 items-center justify-center rounded-full text-xs font-bold",
-                      activityColors[activity.type]
-                    )}
-                  >
-                    {activity.name.charAt(0).toUpperCase()}
-                  </div>
-                  <div className="min-w-0 flex-1">
-                    <p className="text-sm text-gray-700 leading-snug">
-                      <span className="font-medium text-gray-900">{activity.name}</span>{" "}
-                      {activity.text}
-                    </p>
-                  </div>
-                  <span className="shrink-0 text-xs text-gray-400">{getTimeAgo(activity.date)}</span>
-                  <div className={cn("h-2 w-2 shrink-0 rounded-full", activityDotColors[activity.type])} />
-                </div>
-              ))}
-            </div>
-          </div>
-        )}
-
-        {/* Rewards mechanics — merged from the retired /loyalty/analytics
-            page so admins see mission/mystery/voucher/referral health
-            in the same view as core loyalty KPIs. Last 30 days. */}
-        <RewardsMechanicsSection />
-      </div>
-    </div>
-  );
-}
-
-interface MechanicsResponse {
-  range: { since: string; generated_at: string };
-  missions: {
-    total: number;
-    active: number;
-    rows: Array<{
-      id: string; title: string; difficulty: string;
-      picked: number; completed: number; completion_rate: number; is_active: boolean;
-    }>;
-  };
-  mystery: {
-    total_drops: number; revealed: number; reveal_rate: number;
-    distribution: Array<{ type: string; count: number; pct: number }>;
-  };
-  vouchers: {
-    total_issued: number; total_redeemed: number;
-    by_source: Array<{ source: string; issued: number; redeemed: number; expired: number; redemption_rate: number }>;
-  };
-  referrals: { total: number; pending: number; rewarded: number; voided: number };
-}
-
-function RewardsMechanicsSection() {
-  const [data, setData] = useState<MechanicsResponse | null>(null);
-  const [loading, setLoading] = useState(true);
-
-  useEffect(() => {
-    (async () => {
-      try {
-        const res = await fetch(`/api/loyalty/v2-analytics?brand_id=brand-celsius`, { credentials: "include" });
-        setData(await res.json());
-      } catch { /* ignore */ }
-      finally { setLoading(false); }
-    })();
-  }, []);
-
-  if (loading) {
-    return (
-      <div className="rounded-xl border bg-white p-5 text-sm text-gray-500">
-        Loading rewards mechanics…
-      </div>
-    );
-  }
-  if (!data) return null;
-
-  return (
-    <div className="space-y-4">
-      <div>
-        <h2 className="text-lg font-semibold text-gray-900">Rewards mechanics</h2>
-        <p className="text-xs text-gray-500 mt-0.5">
-          Mission completion, mystery distribution, voucher funnel by source, referral attribution. Last 30 days.
-        </p>
-      </div>
-
-      {/* KPI row */}
-      <div className="grid grid-cols-2 md:grid-cols-4 gap-3">
-        <MechKpi label="Missions active"      value={`${data.missions.active}/${data.missions.total}`} />
-        <MechKpi label="Mystery reveal rate"  value={`${data.mystery.reveal_rate}%`} sub={`${data.mystery.revealed}/${data.mystery.total_drops}`} />
-        <MechKpi label="Vouchers issued"      value={data.vouchers.total_issued.toString()} sub={`${data.vouchers.total_redeemed} redeemed`} />
-        <MechKpi label="Referrals rewarded"   value={`${data.referrals.rewarded}`} sub={`${data.referrals.pending} pending`} />
-      </div>
-
-      {/* Mission completion table */}
-      <section className="rounded-xl border bg-white overflow-hidden">
-        <div className="px-4 py-3 border-b bg-gray-50">
-          <h3 className="text-sm font-semibold">Mission completion rates</h3>
-        </div>
-        <table className="w-full text-sm">
-          <thead className="bg-gray-50/60 text-xs uppercase tracking-wide text-gray-500">
-            <tr>
-              <th className="text-left px-4 py-2">Mission</th>
-              <th className="text-left px-4 py-2">Difficulty</th>
-              <th className="text-right px-4 py-2">Picked</th>
-              <th className="text-right px-4 py-2">Completed</th>
-              <th className="text-right px-4 py-2">Rate</th>
-              <th className="text-left px-4 py-2">Status</th>
-            </tr>
-          </thead>
-          <tbody className="divide-y">
-            {data.missions.rows.length === 0 ? (
-              <tr><td colSpan={6} className="px-4 py-8 text-center text-gray-500">No missions yet</td></tr>
-            ) : (
-              data.missions.rows.map((m) => (
-                <tr key={m.id} className="hover:bg-gray-50/60">
-                  <td className="px-4 py-2.5 font-medium">{m.title}</td>
-                  <td className="px-4 py-2.5">
-                    <span className={cn(
-                      "text-xs px-2 py-0.5 rounded font-medium",
-                      m.difficulty === "easy"   && "bg-emerald-50 text-emerald-700",
-                      m.difficulty === "medium" && "bg-amber-50 text-amber-700",
-                      m.difficulty === "hard"   && "bg-rose-50 text-rose-700",
-                    )}>{m.difficulty}</span>
-                  </td>
-                  <td className="px-4 py-2.5 text-right tabular-nums">{m.picked}</td>
-                  <td className="px-4 py-2.5 text-right tabular-nums">{m.completed}</td>
-                  <td className="px-4 py-2.5 text-right tabular-nums font-semibold">{m.completion_rate}%</td>
-                  <td className="px-4 py-2.5">
-                    <span className={cn("text-xs", m.is_active ? "text-emerald-600" : "text-gray-400")}>
-                      {m.is_active ? "● Active" : "○ Paused"}
-                    </span>
-                  </td>
-                </tr>
-              ))
-            )}
-          </tbody>
-        </table>
-      </section>
-
-      {/* Mystery distribution + Voucher funnel side-by-side on md+ */}
-      <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
-        <section className="rounded-xl border bg-white p-5">
-          <h3 className="text-sm font-semibold mb-3">Mystery outcome distribution</h3>
-          {data.mystery.distribution.length === 0 ? (
-            <div className="text-sm text-gray-500">No drops yet</div>
-          ) : (
-            <div className="space-y-2">
-              {data.mystery.distribution.map((d) => (
-                <div key={d.type}>
-                  <div className="flex justify-between text-xs mb-1">
-                    <span className="font-medium">{d.type}</span>
-                    <span className="text-gray-500 tabular-nums">{d.count} · {d.pct}%</span>
-                  </div>
-                  <div className="h-2 rounded bg-gray-100 overflow-hidden">
-                    <div className="h-full bg-gray-900" style={{ width: `${d.pct}%` }} />
-                  </div>
-                </div>
-              ))}
-            </div>
-          )}
-        </section>
-
-        <section className="rounded-xl border bg-white overflow-hidden">
-          <div className="px-4 py-3 border-b bg-gray-50">
-            <h3 className="text-sm font-semibold">Voucher funnel by source</h3>
-          </div>
-          <table className="w-full text-sm">
-            <thead className="bg-gray-50/60 text-xs uppercase tracking-wide text-gray-500">
-              <tr>
-                <th className="text-left px-4 py-2">Source</th>
-                <th className="text-right px-4 py-2">Issued</th>
-                <th className="text-right px-4 py-2">Redeemed</th>
-                <th className="text-right px-4 py-2">Expired</th>
-                <th className="text-right px-4 py-2">Rate</th>
-              </tr>
-            </thead>
-            <tbody className="divide-y">
-              {data.vouchers.by_source.length === 0 ? (
-                <tr><td colSpan={5} className="px-4 py-8 text-center text-gray-500">No vouchers issued yet</td></tr>
-              ) : (
-                data.vouchers.by_source.map((v) => (
-                  <tr key={v.source} className="hover:bg-gray-50/60">
-                    <td className="px-4 py-2.5 font-medium capitalize">{v.source.replace("_", " ")}</td>
-                    <td className="px-4 py-2.5 text-right tabular-nums">{v.issued}</td>
-                    <td className="px-4 py-2.5 text-right tabular-nums">{v.redeemed}</td>
-                    <td className="px-4 py-2.5 text-right tabular-nums text-gray-500">{v.expired}</td>
-                    <td className="px-4 py-2.5 text-right tabular-nums font-semibold">{v.redemption_rate}%</td>
-                  </tr>
-                ))
-              )}
-            </tbody>
-          </table>
-        </section>
-      </div>
-    </div>
-  );
-}
-
-function MechKpi({ label, value, sub }: { label: string; value: string; sub?: string }) {
-  return (
-    <div className="rounded-xl border bg-white px-4 py-3">
-      <div className="text-xs text-gray-500 uppercase tracking-wide">{label}</div>
-      <div className="text-2xl font-semibold mt-1">{value}</div>
-      {sub && <div className="text-xs text-gray-500 mt-0.5">{sub}</div>}
+        </>
+      )}
     </div>
   );
 }

--- a/apps/backoffice/src/app/api/pos/order-status/route.ts
+++ b/apps/backoffice/src/app/api/pos/order-status/route.ts
@@ -39,6 +39,13 @@ function getSupabase(): SupabaseClient {
 // "preparing" would 500 on the grab path. Keep the set tight.
 const ALLOWED = new Set(["ready", "completed"]);
 
+// True when an update failed only because the serving-time columns aren't
+// migrated yet (PostgREST schema-cache miss) — lets us degrade gracefully.
+function missingServingCol(err: { code?: string; message?: string } | null): boolean {
+  if (!err) return false;
+  return err.code === "PGRST204" || /ready_at|completed_at/i.test(err.message ?? "");
+}
+
 export async function POST(req: NextRequest) {
   const supabase = getSupabase();
   try {
@@ -76,7 +83,13 @@ export async function POST(req: NextRequest) {
 
     // pickup + qr dine-in both live in `orders`; only grab is `pos_orders`.
     const table = source === "grab" ? "pos_orders" : "orders";
-    const patch: Record<string, unknown> = { status, updated_at: new Date().toISOString() };
+    const now = new Date().toISOString();
+    const patch: Record<string, unknown> = { status, updated_at: now };
+    // Serving-time instrumentation: stamp the kitchen-bump moments so the Area
+    // Scorecard can measure speed of service (ready_at - created_at). Both
+    // tables carry these columns (migrations 029 / orders-020).
+    if (status === "ready") patch.ready_at = now;
+    else if (status === "completed") patch.completed_at = now;
     // pos_orders carries the Grab order id in external_id; pickup orders
     // don't have that column, so only ask for it on the grab path.
     const selectCols = source === "grab" ? "id, order_number, status, external_id" : "id, order_number, status";
@@ -85,12 +98,24 @@ export async function POST(req: NextRequest) {
     // error. .single() instead throws PGRST116 → a misleading 500 for what is
     // really "order not found". Map the null case to a clean 404 so the
     // register can tell "gone" from "server broke".
-    const { data, error } = await supabase
+    let { data, error } = await supabase
       .from(table)
       .update(patch)
       .eq("id", id)
       .select(selectCols)
       .maybeSingle();
+
+    // The serving-time columns are applied out-of-band (migrations 029 /
+    // orders-020). If they aren't live yet, retry with a status-only patch so a
+    // "Mark Ready" tap never 500s mid-service — serving data just starts later.
+    if (error && missingServingCol(error)) {
+      ({ data, error } = await supabase
+        .from(table)
+        .update({ status, updated_at: now })
+        .eq("id", id)
+        .select(selectCols)
+        .maybeSingle());
+    }
 
     if (error) return NextResponse.json({ error: error.message }, { status: 500 });
     if (!data) return NextResponse.json({ error: "order not found" }, { status: 404 });

--- a/apps/backoffice/src/app/api/scorecard/route.ts
+++ b/apps/backoffice/src/app/api/scorecard/route.ts
@@ -36,6 +36,7 @@ export const KPI_TARGETS = {
   upsellRate: 10, // % of cashier-rung orders with a Pair-with-a-Bite add
   opsCompletion: 90, // % of checklists completed
   wastagePctOfSales: 3, // wastage cost ≤ 3% of POS sales
+  servingMins: 15, // avg minutes from order placed → kitchen "ready" (matches the on-register serving alarm)
 } as const;
 
 const CASHIER_SOURCES = ["pos"]; // till-rung only (excludes grab / pickup / qr)
@@ -143,14 +144,18 @@ export async function GET(request: NextRequest) {
   // ── Outlets: the join hub (active storefronts only) ─────────
   const outlets = await prisma.outlet.findMany({
     where: { status: "ACTIVE", type: "OUTLET" },
-    select: { id: true, code: true, name: true, loyaltyOutletId: true },
+    select: { id: true, code: true, name: true, loyaltyOutletId: true, pickupStoreId: true },
     orderBy: { name: "asc" },
   });
 
-  // Map loyaltyOutletId → Prisma outlet (for the POS-side joins)
+  // Map the cross-app outlet ids back to the Prisma outlet:
+  //  • loyaltyOutletId → pos_orders.outlet_id (POS / Grab)
+  //  • pickupStoreId   → orders.store_id      (pickup app / QR-table)
   const byLoyaltyId = new Map<string, (typeof outlets)[number]>();
+  const byPickupId = new Map<string, (typeof outlets)[number]>();
   for (const o of outlets) {
     if (o.loyaltyOutletId) byLoyaltyId.set(o.loyaltyOutletId, o);
+    if (o.pickupStoreId) byPickupId.set(o.pickupStoreId, o);
   }
 
   // ── 1+2+sales. POS orders → collection, upsell, revenue ─────
@@ -168,6 +173,28 @@ export async function GET(request: NextRequest) {
     .eq("source", "register")
     .gte("created_at", p.fromISO)
     .lte("created_at", p.toISO)
+    .limit(50000);
+
+  // ── 5. Serving time — orders that reached a kitchen "ready" bump ─────
+  // Only queued orders carry a ready event: Grab (pos_orders) + pickup/QR
+  // (orders). Dine-in POS sales are rung up already paid, so they have no bump.
+  // Defensive: these select ready_at, which may not exist until migrations
+  // 029 / orders-020 are applied — on error we just skip serving (nodata),
+  // never break the other KPIs.
+  const servingPosQ = supabase
+    .from("pos_orders")
+    .select("outlet_id, created_at, ready_at")
+    .not("ready_at", "is", null)
+    .gte("ready_at", p.fromISO)
+    .lte("ready_at", p.toISO)
+    .limit(50000);
+
+  const servingPickupQ = supabase
+    .from("orders")
+    .select("store_id, created_at, ready_at")
+    .not("ready_at", "is", null)
+    .gte("ready_at", p.fromISO)
+    .lte("ready_at", p.toISO)
     .limit(50000);
 
   // ── 3. Ops compliance — checklists in range ─────────────────
@@ -202,8 +229,8 @@ export async function GET(request: NextRequest) {
     },
   });
 
-  const [ordersRes, pairRes, checklists, adjustments, supplierPrices] =
-    await Promise.all([ordersQ, pairQ, checklistsP, adjustmentsP, supplierPricesP]);
+  const [ordersRes, pairRes, servingPosRes, servingPickupRes, checklists, adjustments, supplierPrices] =
+    await Promise.all([ordersQ, pairQ, servingPosQ, servingPickupQ, checklistsP, adjustmentsP, supplierPricesP]);
 
   if (ordersRes.error) {
     return NextResponse.json({ error: ordersRes.error.message }, { status: 500 });
@@ -223,6 +250,8 @@ export async function GET(request: NextRequest) {
     photoItems: number;
     totalItems: number;
     wasteCost: number;
+    servingSumMins: number; // Σ (ready_at − created_at) over bumped orders
+    servingCount: number;
   };
   const acc = new Map<string, Acc>();
   const ensure = (outletId: string): Acc => {
@@ -239,6 +268,8 @@ export async function GET(request: NextRequest) {
         photoItems: 0,
         totalItems: 0,
         wasteCost: 0,
+        servingSumMins: 0,
+        servingCount: 0,
       };
       acc.set(outletId, a);
     }
@@ -265,6 +296,32 @@ export async function GET(request: NextRequest) {
     const a = acc.get(outlet.id);
     const oid = pe.order_id as string | null;
     if (a && oid && a.posOrderIds.has(oid)) a.upsellOrderIds.add(oid);
+  }
+
+  // Serving time → avg (ready_at − created_at) in minutes. Grab via
+  // loyaltyOutletId, pickup/QR via pickupStoreId. Skip silently if the
+  // ready_at column isn't there yet (migration not applied) or values are junk.
+  const addServing = (a: Acc | undefined, createdAt: unknown, readyAt: unknown) => {
+    if (!a) return;
+    const start = Date.parse(createdAt as string);
+    const end = Date.parse(readyAt as string);
+    if (!Number.isFinite(start) || !Number.isFinite(end)) return;
+    const mins = (end - start) / 60000;
+    if (mins < 0 || mins > 600) return; // drop clock-skew / stale-sweep outliers (>10h)
+    a.servingSumMins += mins;
+    a.servingCount++;
+  };
+  if (!servingPosRes.error) {
+    for (const o of servingPosRes.data ?? []) {
+      const outlet = byLoyaltyId.get(o.outlet_id as string);
+      if (outlet) addServing(ensure(outlet.id), o.created_at, o.ready_at);
+    }
+  }
+  if (!servingPickupRes.error) {
+    for (const o of servingPickupRes.data ?? []) {
+      const outlet = byPickupId.get(o.store_id as string);
+      if (outlet) addServing(ensure(outlet.id), o.created_at, o.ready_at);
+    }
   }
 
   // Checklists → ops compliance (key by Outlet.id)
@@ -315,6 +372,8 @@ export async function GET(request: NextRequest) {
     const totalItems = a?.totalItems ?? 0;
     const photoItems = a?.photoItems ?? 0;
     const wasteCost = round2(a?.wasteCost ?? 0);
+    const servingCount = a?.servingCount ?? 0;
+    const servingAvg = servingCount > 0 ? round2((a?.servingSumMins ?? 0) / servingCount) : null;
 
     const collectionVal = rate(collected, posOrders);
     const upsellVal = rate(upsellOrders, posOrders);
@@ -357,13 +416,21 @@ export async function GET(request: NextRequest) {
       status: wastageStatus,
       cost: wasteCost,
     };
+    // Serving time is lower-is-better; only queued (pickup/Grab) orders have a
+    // kitchen "ready" bump to measure — dine-in sales are paid at the till with
+    // no bump, so an outlet with no queued orders is "no data" here.
     const serving = {
-      value: null as number | null,
-      status: "nodata" as KpiStatus,
-      note: "Not tracked yet — needs a ready/served timestamp on pos_orders.",
+      value: servingAvg, // avg minutes placed → ready
+      target: KPI_TARGETS.servingMins,
+      status: (servingAvg === null
+        ? "nodata"
+        : servingAvg <= KPI_TARGETS.servingMins
+          ? "hit"
+          : "miss") as KpiStatus,
+      orders: servingCount,
     };
 
-    const tracked = [collection, upsell, ops, wastage];
+    const tracked = [collection, upsell, ops, wastage, serving];
     const met = tracked.filter((k) => k.status === "hit").length;
     const measurable = tracked.filter((k) => k.status !== "nodata").length;
 
@@ -410,6 +477,7 @@ export async function GET(request: NextRequest) {
         upsell: avg(rows.map((r) => r.kpis.upsell.value)),
         ops: avg(rows.map((r) => r.kpis.ops.value)),
         wastagePct: avg(rows.map((r) => r.kpis.wastage.value)),
+        servingMins: avg(rows.map((r) => r.kpis.serving.value)),
       },
     },
     outlets: rows,

--- a/apps/backoffice/src/app/api/scorecard/route.ts
+++ b/apps/backoffice/src/app/api/scorecard/route.ts
@@ -1,0 +1,417 @@
+import { NextRequest, NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+import { requireAuth } from "@/lib/auth";
+import { getSupabaseAdmin } from "@/lib/pickup/supabase";
+
+/**
+ * GET /api/scorecard?period=last7days
+ *
+ * Per-OUTLET ("area") KPI scoreboard — answers "which area is hitting KPI".
+ * Built entirely on the CURRENT POS / apps system (pos_orders, pos_pair_events,
+ * checklists, stock adjustments) — NOT the retired StoreHub feed. Each outlet is
+ * scored against a small set of operational KPIs and ranked by how many it meets.
+ *
+ * KPIs (per outlet, per period):
+ *   1. Loyalty capture — % of cashier-rung orders where a loyalty phone was
+ *      collected (pos_orders.loyalty_phone). Target 70% (see the cashier-
+ *      performance design doc).
+ *   2. Upsell — % of cashier-rung orders that ended up containing a
+ *      Pair-with-a-Bite add (pos_pair_events stamped to a completed order).
+ *   3. Ops compliance — checklist completion %.
+ *   4. Wastage — wastage cost as % of POS sales (lower is better).
+ *   5. Serving time — NOT YET INSTRUMENTED. pos_orders has no ready/served
+ *      timestamp, so this is surfaced as "not tracked" rather than faked.
+ *
+ * Outlet identity: Prisma Outlet is the join hub. pos_orders.outlet_id maps to
+ * Outlet.loyaltyOutletId; checklists / stock adjustments key by Outlet.id.
+ */
+
+export const dynamic = "force-dynamic";
+
+// ── Default KPI targets ──────────────────────────────────────
+// First-class constants (returned to the client so the UI shows the bar). These
+// are the benchmarks the owner nags about; make them settings-editable later.
+export const KPI_TARGETS = {
+  collectionRate: 70, // % of cashier-rung orders with a loyalty phone
+  upsellRate: 10, // % of cashier-rung orders with a Pair-with-a-Bite add
+  opsCompletion: 90, // % of checklists completed
+  wastagePctOfSales: 3, // wastage cost ≤ 3% of POS sales
+} as const;
+
+const CASHIER_SOURCES = ["pos"]; // till-rung only (excludes grab / pickup / qr)
+const WASTE_TYPES = [
+  "WASTAGE",
+  "BREAKAGE",
+  "EXPIRED",
+  "SPILLAGE",
+  "THEFT",
+  "USED_NOT_RECORDED",
+] as const;
+
+type PeriodType =
+  | "daily"
+  | "yesterday"
+  | "last7days"
+  | "last30days"
+  | "weekly"
+  | "monthly"
+  | "custom";
+
+const PERIOD_LABELS: Record<PeriodType, string> = {
+  daily: "Today",
+  yesterday: "Yesterday",
+  last7days: "Last 7 Days",
+  last30days: "Last 30 Days",
+  weekly: "This Week",
+  monthly: "This Month",
+  custom: "Custom",
+};
+
+// Resolve a period to MYT (UTC+8) day boundaries + matching ISO timestamps.
+function resolvePeriod(period: PeriodType, fromParam?: string, toParam?: string) {
+  const now = new Date();
+  const mytNow = new Date(now.getTime() + 8 * 60 * 60 * 1000);
+  const todayMYT = mytNow.toISOString().split("T")[0];
+  let fromDate: string;
+  let toDate = todayMYT;
+
+  if (period === "custom") {
+    fromDate = fromParam || toDate;
+    toDate = toParam || toDate;
+  } else if (period === "daily") {
+    fromDate = toDate;
+  } else if (period === "yesterday") {
+    const d = new Date(mytNow);
+    d.setDate(d.getDate() - 1);
+    fromDate = toDate = d.toISOString().split("T")[0];
+  } else if (period === "last30days") {
+    const d = new Date(mytNow);
+    d.setDate(d.getDate() - 29);
+    fromDate = d.toISOString().split("T")[0];
+  } else if (period === "monthly") {
+    fromDate = new Date(mytNow.getUTCFullYear(), mytNow.getUTCMonth(), 1)
+      .toISOString()
+      .split("T")[0];
+  } else {
+    // last7days / weekly → trailing 7 days
+    const d = new Date(mytNow);
+    d.setDate(d.getDate() - 6);
+    fromDate = d.toISOString().split("T")[0];
+  }
+
+  return {
+    type: period,
+    label: PERIOD_LABELS[period] ?? "Custom",
+    fromDate,
+    toDate,
+    fromISO: `${fromDate}T00:00:00+08:00`,
+    toISO: `${toDate}T23:59:59+08:00`,
+    fromObj: new Date(`${fromDate}T00:00:00+08:00`),
+    toObj: new Date(`${toDate}T23:59:59+08:00`),
+  };
+}
+
+type KpiStatus = "hit" | "miss" | "nodata";
+
+function rate(num: number, den: number): number | null {
+  return den > 0 ? Math.round((num / den) * 100) : null;
+}
+
+// hit when value ≥ target (higher-is-better metrics)
+function statusHigher(value: number | null, target: number): KpiStatus {
+  if (value === null) return "nodata";
+  return value >= target ? "hit" : "miss";
+}
+
+export async function GET(request: NextRequest) {
+  const auth = await requireAuth(request);
+  if (auth.error) return auth.error;
+  if (!["OWNER", "ADMIN", "MANAGER"].includes(auth.user.role)) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+
+  const { searchParams } = new URL(request.url);
+  const period = (searchParams.get("period") || "last7days") as PeriodType;
+  const p = resolvePeriod(
+    period,
+    searchParams.get("from") || undefined,
+    searchParams.get("to") || undefined,
+  );
+
+  const supabase = getSupabaseAdmin();
+
+  // ── Outlets: the join hub (active storefronts only) ─────────
+  const outlets = await prisma.outlet.findMany({
+    where: { status: "ACTIVE", type: "OUTLET" },
+    select: { id: true, code: true, name: true, loyaltyOutletId: true },
+    orderBy: { name: "asc" },
+  });
+
+  // Map loyaltyOutletId → Prisma outlet (for the POS-side joins)
+  const byLoyaltyId = new Map<string, (typeof outlets)[number]>();
+  for (const o of outlets) {
+    if (o.loyaltyOutletId) byLoyaltyId.set(o.loyaltyOutletId, o);
+  }
+
+  // ── 1+2+sales. POS orders → collection, upsell, revenue ─────
+  const ordersQ = supabase
+    .from("pos_orders")
+    .select("id, source, status, loyalty_phone, outlet_id, total, created_at")
+    .eq("status", "completed")
+    .gte("created_at", p.fromISO)
+    .lte("created_at", p.toISO)
+    .limit(50000);
+
+  const pairQ = supabase
+    .from("pos_pair_events")
+    .select("order_id, outlet_id")
+    .eq("source", "register")
+    .gte("created_at", p.fromISO)
+    .lte("created_at", p.toISO)
+    .limit(50000);
+
+  // ── 3. Ops compliance — checklists in range ─────────────────
+  const checklistsP = prisma.checklist.findMany({
+    where: { date: { gte: p.fromObj, lte: p.toObj } },
+    select: {
+      outletId: true,
+      status: true,
+      items: { select: { photoUrl: true } },
+    },
+  });
+
+  // ── 4. Wastage — stock adjustments in range + cost lookup ───
+  const adjustmentsP = prisma.stockAdjustment.findMany({
+    where: {
+      adjustmentType: { in: [...WASTE_TYPES] },
+      createdAt: { gte: p.fromObj, lte: p.toObj },
+    },
+    select: {
+      outletId: true,
+      quantity: true,
+      costAmount: true,
+      productId: true,
+    },
+  });
+  const supplierPricesP = prisma.supplierProduct.findMany({
+    where: { isActive: true },
+    select: {
+      productId: true,
+      price: true,
+      productPackage: { select: { conversionFactor: true } },
+    },
+  });
+
+  const [ordersRes, pairRes, checklists, adjustments, supplierPrices] =
+    await Promise.all([ordersQ, pairQ, checklistsP, adjustmentsP, supplierPricesP]);
+
+  if (ordersRes.error) {
+    return NextResponse.json({ error: ordersRes.error.message }, { status: 500 });
+  }
+  const orders = ordersRes.data ?? [];
+  const pairRows = pairRes.data ?? [];
+
+  // Per-outlet accumulators keyed by Prisma Outlet.id
+  type Acc = {
+    posOrders: number; // cashier-rung order count (denominator)
+    collected: number; // cashier-rung orders with a loyalty phone
+    revenue: number; // RM across ALL completed pos_orders sources
+    upsellOrderIds: Set<string>; // distinct cashier orders containing a pair add
+    posOrderIds: Set<string>; // cashier order ids (to bind pair events)
+    checklistTotal: number;
+    checklistDone: number;
+    photoItems: number;
+    totalItems: number;
+    wasteCost: number;
+  };
+  const acc = new Map<string, Acc>();
+  const ensure = (outletId: string): Acc => {
+    let a = acc.get(outletId);
+    if (!a) {
+      a = {
+        posOrders: 0,
+        collected: 0,
+        revenue: 0,
+        upsellOrderIds: new Set(),
+        posOrderIds: new Set(),
+        checklistTotal: 0,
+        checklistDone: 0,
+        photoItems: 0,
+        totalItems: 0,
+        wasteCost: 0,
+      };
+      acc.set(outletId, a);
+    }
+    return a;
+  };
+
+  // POS orders → collection + revenue (map via loyaltyOutletId)
+  for (const o of orders) {
+    const outlet = byLoyaltyId.get(o.outlet_id as string);
+    if (!outlet) continue; // pos_orders for an outlet we don't track
+    const a = ensure(outlet.id);
+    a.revenue += (Number(o.total) || 0) / 100; // total is in sen
+    if (CASHIER_SOURCES.includes(o.source as string)) {
+      a.posOrders++;
+      a.posOrderIds.add(o.id as string);
+      if (o.loyalty_phone) a.collected++;
+    }
+  }
+
+  // Pair events → upsell (only ones bound to a cashier order in scope)
+  for (const pe of pairRows) {
+    const outlet = byLoyaltyId.get(pe.outlet_id as string);
+    if (!outlet) continue;
+    const a = acc.get(outlet.id);
+    const oid = pe.order_id as string | null;
+    if (a && oid && a.posOrderIds.has(oid)) a.upsellOrderIds.add(oid);
+  }
+
+  // Checklists → ops compliance (key by Outlet.id)
+  for (const cl of checklists) {
+    const a = ensure(cl.outletId);
+    a.checklistTotal++;
+    if (cl.status === "COMPLETED") a.checklistDone++;
+    for (const item of cl.items) {
+      a.totalItems++;
+      if (item.photoUrl) a.photoItems++;
+    }
+  }
+
+  // Wastage cost (cheapest active supplier price / conversion factor as fallback)
+  const costMap = new Map<string, number>();
+  for (const sp of supplierPrices) {
+    const conversion = sp.productPackage?.conversionFactor
+      ? Number(sp.productPackage.conversionFactor)
+      : 0;
+    if (conversion <= 0) continue;
+    const costPerBase = Number(sp.price) / conversion;
+    const existing = costMap.get(sp.productId);
+    if (existing === undefined || costPerBase < existing) {
+      costMap.set(sp.productId, costPerBase);
+    }
+  }
+  for (const adj of adjustments) {
+    const a = ensure(adj.outletId);
+    const qty = Math.abs(Number(adj.quantity));
+    const cost =
+      adj.costAmount !== null
+        ? Math.abs(Number(adj.costAmount))
+        : qty * (costMap.get(adj.productId) ?? 0);
+    a.wasteCost += cost;
+  }
+
+  // ── Assemble per-outlet rows ────────────────────────────────
+  const round2 = (n: number) => Math.round(n * 100) / 100;
+
+  const rows = outlets.map((o) => {
+    const a = acc.get(o.id);
+    const posOrders = a?.posOrders ?? 0;
+    const collected = a?.collected ?? 0;
+    const upsellOrders = a?.upsellOrderIds.size ?? 0;
+    const revenue = round2(a?.revenue ?? 0);
+    const checklistTotal = a?.checklistTotal ?? 0;
+    const checklistDone = a?.checklistDone ?? 0;
+    const totalItems = a?.totalItems ?? 0;
+    const photoItems = a?.photoItems ?? 0;
+    const wasteCost = round2(a?.wasteCost ?? 0);
+
+    const collectionVal = rate(collected, posOrders);
+    const upsellVal = rate(upsellOrders, posOrders);
+    const opsVal = rate(checklistDone, checklistTotal);
+    const photoRate = rate(photoItems, totalItems);
+    const wastagePct = revenue > 0 ? round2((wasteCost / revenue) * 100) : null;
+
+    const collection = {
+      value: collectionVal,
+      target: KPI_TARGETS.collectionRate,
+      status: statusHigher(collectionVal, KPI_TARGETS.collectionRate),
+      orders: posOrders,
+      collected,
+    };
+    const upsell = {
+      value: upsellVal,
+      target: KPI_TARGETS.upsellRate,
+      status: statusHigher(upsellVal, KPI_TARGETS.upsellRate),
+      orders: posOrders,
+      upsellOrders,
+    };
+    const ops = {
+      value: opsVal,
+      target: KPI_TARGETS.opsCompletion,
+      status: statusHigher(opsVal, KPI_TARGETS.opsCompletion),
+      completed: checklistDone,
+      total: checklistTotal,
+      photoRate,
+    };
+    // Wastage is lower-is-better; "no data" when there's no sales to measure against.
+    const wastageStatus: KpiStatus =
+      wastagePct === null
+        ? "nodata"
+        : wastagePct <= KPI_TARGETS.wastagePctOfSales
+          ? "hit"
+          : "miss";
+    const wastage = {
+      value: wastagePct,
+      target: KPI_TARGETS.wastagePctOfSales,
+      status: wastageStatus,
+      cost: wasteCost,
+    };
+    const serving = {
+      value: null as number | null,
+      status: "nodata" as KpiStatus,
+      note: "Not tracked yet — needs a ready/served timestamp on pos_orders.",
+    };
+
+    const tracked = [collection, upsell, ops, wastage];
+    const met = tracked.filter((k) => k.status === "hit").length;
+    const measurable = tracked.filter((k) => k.status !== "nodata").length;
+
+    return {
+      id: o.id,
+      code: o.code,
+      name: o.name,
+      onPos: !!o.loyaltyOutletId,
+      revenue,
+      kpis: { collection, upsell, ops, wastage, serving },
+      met,
+      measurable,
+      score: measurable > 0 ? Math.round((met / measurable) * 100) : null,
+    };
+  });
+
+  // Rank: highest score first, then most KPIs met, then revenue
+  rows.sort(
+    (x, y) =>
+      (y.score ?? -1) - (x.score ?? -1) ||
+      y.met - x.met ||
+      y.revenue - x.revenue,
+  );
+
+  // ── Summary ─────────────────────────────────────────────────
+  const measured = rows.filter((r) => r.measurable > 0);
+  const hittingAll = measured.filter((r) => r.met === r.measurable).length;
+  const avg = (vals: (number | null)[]) => {
+    const nums = vals.filter((v): v is number => v !== null);
+    return nums.length ? Math.round(nums.reduce((s, v) => s + v, 0) / nums.length) : null;
+  };
+
+  return NextResponse.json({
+    period: { from: p.fromDate, to: p.toDate, type: p.type, label: p.label },
+    generatedAt: new Date().toISOString(),
+    targets: KPI_TARGETS,
+    summary: {
+      totalOutlets: rows.length,
+      measuredOutlets: measured.length,
+      hittingAll,
+      totalRevenue: round2(rows.reduce((s, r) => s + r.revenue, 0)),
+      avg: {
+        collection: avg(rows.map((r) => r.kpis.collection.value)),
+        upsell: avg(rows.map((r) => r.kpis.upsell.value)),
+        ops: avg(rows.map((r) => r.kpis.ops.value)),
+        wastagePct: avg(rows.map((r) => r.kpis.wastage.value)),
+      },
+    },
+    outlets: rows,
+  });
+}

--- a/apps/order/src/app/api/orders/[orderId]/status/route.ts
+++ b/apps/order/src/app/api/orders/[orderId]/status/route.ts
@@ -98,10 +98,28 @@ export async function PATCH(
       );
     }
 
-    const { error: updateError } = await supabase
+    // Serving-time instrumentation: stamp the kitchen-bump moments so the Area
+    // Scorecard can measure speed of service (ready_at - created_at). `updated_at`
+    // can't carry this — a trigger overwrites it on every later write. (migration
+    // orders-020.)
+    const patch: Record<string, unknown> = { status: newStatus };
+    if (newStatus === "ready") patch.ready_at = new Date().toISOString();
+    else if (newStatus === "completed") patch.completed_at = new Date().toISOString();
+
+    let { error: updateError } = await supabase
       .from("orders")
-      .update({ status: newStatus })
+      .update(patch)
       .eq("id", orderId);
+
+    // ready_at/completed_at are applied out-of-band (migration orders-020). If
+    // they aren't live yet, retry with a status-only update so the customer's
+    // order flow never breaks — serving data just starts accruing later.
+    if (updateError && (updateError.code === "PGRST204" || /ready_at|completed_at/i.test(updateError.message ?? ""))) {
+      ({ error: updateError } = await supabase
+        .from("orders")
+        .update({ status: newStatus })
+        .eq("id", orderId));
+    }
 
     if (updateError) {
       return NextResponse.json({ error: "Update failed" }, { status: 500 });

--- a/apps/order/supabase/migrations/020_orders_serving_timestamps.sql
+++ b/apps/order/supabase/migrations/020_orders_serving_timestamps.sql
@@ -1,0 +1,19 @@
+-- Serving-time instrumentation for the pickup `orders` table.
+--
+-- An order's `updated_at` is bumped by a trigger on every write, so it can't mark
+-- the moment an order became ready (the later "completed" write overwrites it).
+-- These dedicated timestamps are stamped when the kitchen advances an order to
+-- "ready" / "completed" (the pickup status route + the on-register order panel via
+-- /api/pos/order-status), letting the Area Scorecard measure speed of service
+-- (ready_at - created_at) per outlet.
+--
+-- Additive + nullable + idempotent.
+
+ALTER TABLE orders
+  ADD COLUMN IF NOT EXISTS ready_at     timestamptz,
+  ADD COLUMN IF NOT EXISTS completed_at timestamptz;
+
+-- Per-outlet serving-time aggregate (orders that reached "ready" in a period).
+CREATE INDEX IF NOT EXISTS idx_orders_ready_at
+  ON orders (store_id, ready_at)
+  WHERE ready_at IS NOT NULL;

--- a/supabase/migrations/029_pos_orders_serving_timestamps.sql
+++ b/supabase/migrations/029_pos_orders_serving_timestamps.sql
@@ -1,0 +1,20 @@
+-- Serving-time instrumentation for pos_orders (Grab + any kitchen-bumped sale).
+--
+-- pos_orders are created already status='completed' at the till (create_pos_sale),
+-- so the order STATUS is not a "served" signal. The only kitchen-bump event that
+-- exists is the on-register order panel advancing a queued (Grab) order to
+-- "ready" / "completed" via /api/pos/order-status. We stamp dedicated timestamps
+-- there so speed-of-service can be measured (ready_at - created_at) without
+-- relying on updated_at (which any later write overwrites).
+--
+-- Additive + nullable + idempotent: safe to (re)apply, never blocks an insert.
+
+ALTER TABLE public.pos_orders
+  ADD COLUMN IF NOT EXISTS ready_at     timestamptz,
+  ADD COLUMN IF NOT EXISTS completed_at timestamptz;
+
+-- Supports the Area Scorecard's per-outlet serving-time aggregate
+-- (avg over orders that reached "ready" in a period, grouped by outlet).
+CREATE INDEX IF NOT EXISTS idx_pos_orders_ready_at
+  ON public.pos_orders (outlet_id, ready_at)
+  WHERE ready_at IS NOT NULL;


### PR DESCRIPTION
## What & why

Rebuilds the dashboard at `/loyalty/dashboard` from scratch on the **current POS / apps system** (`pos_orders`, `pos_pair_events`, `orders`, checklists, stock adjustments) instead of the retired StoreHub feed — which was the source of the blank / `RM 0` tiles in the old rewards overview.

It answers a single question: **which area (outlet) is hitting KPI?** Each active outlet is scored against operational KPIs and ranked by how many it meets.

## KPIs (per outlet, per period)

| KPI | Source (live) | Target |
|---|---|---|
| **Loyalty capture** | `pos_orders.loyalty_phone` ÷ cashier-rung orders | ≥ 70% |
| **Upsell** | Pair-with-a-Bite events ÷ cashier-rung orders | ≥ 10% |
| **Ops compliance** | checklist completion % | ≥ 90% |
| **Wastage** | wastage cost as % of POS sales | ≤ 3% |
| **Serving time** | avg `ready_at − created_at` for queued (pickup + Grab) orders | ≤ 15 min |

## How

- **New API** `GET /api/scorecard` aggregates every source and joins on the Prisma `Outlet`: `pos_orders.outlet_id → Outlet.loyaltyOutletId`, `orders.store_id → Outlet.pickupStoreId`, checklists / stock adjustments key by `Outlet.id`. Query patterns mirror the existing cashier-performance / ops-performance / wastage routes.
- **Page** `loyalty/dashboard/page.tsx` rebuilt: summary tiles + a ranked outlet list with green/red/grey hit-miss pills per KPI and an `X/Y KPIs met` score. Period selector (Today → This Month).
- **Nav**: the Rewards → Overview entry is relabeled **Area Scorecard** (Trophy icon).

### Serving-time instrumentation (2nd commit)

POS dine-in sales are rung up **already paid** — no kitchen bump to measure. The only "served" event is a queued order reaching **ready** (Grab `pos_orders` + pickup/QR `orders`), advanced via the on-register panel and the pickup status route.

- **Migrations** (additive, nullable, idempotent): add `ready_at` / `completed_at` to `pos_orders` (`supabase/migrations/029`) and `orders` (`apps/order/supabase/migrations/020`), each with a partial index for the per-outlet aggregate.
- **Write path**: stamp `ready_at` / `completed_at` in `/api/pos/order-status` and the pickup status route. Both **retry status-only if the columns aren't migrated yet**, so a "Mark Ready" tap can never 500 during the rollout gap.
- Target ≤ 15 min matches the existing on-register serving alarm. Serving counts toward each outlet's score; it shows **no data** until the migration is applied + data accrues.

## ⚠️ Deploy note

The Supabase migrations are applied **out-of-band** (no CI step applies them). Apply `029` + `orders-020` to the project to start collecting serving-time data. The code is **safe to deploy before** that (status-only fallback), so there's no ordering hazard — serving simply reads "no data" until applied.

## Other notes / follow-ups

- **Targets** (70 / 10 / 90 / 3% / 15m) are sensible defaults hardcoded in the API and shown in the UI — easy to make Settings-editable later.
- The old StoreHub-based `/api/loyalty/dashboard/kpi` route is now orphaned (no remaining references); left in place — can be deleted as cleanup.

## Verification

- `tsc --noEmit` clean (backoffice + order)
- ESLint clean on all changed files (the 3 pre-existing `layout.tsx` warnings are untouched)
- No live data run — no DB/Supabase credentials in the build environment; every table/column queried is taken from working routes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TP7XLohtzb2YHLGGQ1EvFw