### PR TITLE
feat(finance): RM payouts tab — auto-synced settlements linking all transactions

### DIFF
--- a/apps/backoffice/src/app/(admin)/finance/payouts/page.tsx
+++ b/apps/backoffice/src/app/(admin)/finance/payouts/page.tsx
@@ -1,0 +1,399 @@
+"use client";
+
+// Payouts — Revenue Monster daily settlement batches paid to our bank accounts,
+// auto-synced from the RM Open API. Each payout drills into the transactions it
+// settled, every one linked back to its Celsius order. Closes the loop:
+// order → RM collected → payout (→ bank, phase 2). Mirrors the Ledger page:
+// server-windowed date range, client-side filter/sort, row-click detail drawer.
+
+import { useState, useMemo, useEffect } from "react";
+import { useFetch } from "@/lib/use-fetch";
+import { Sheet, SheetContent, SheetHeader, SheetTitle, Badge, Button } from "@celsius/ui";
+import { Loader2, Search, X, ArrowUp, ArrowDown, ChevronsUpDown, Building2, Download, CheckCircle2, AlertTriangle } from "lucide-react";
+
+type Payout = {
+  id: string;
+  settlementDate: string;
+  method: string;
+  sequence: number;
+  storeId: string;
+  entityName: string | null;
+  txnCount: number;
+  gross: number;
+  mdrFee: number;
+  net: number;
+  status: string;
+  linkedCount: number;
+};
+
+type PayoutLine = {
+  id: string;
+  rmTransactionId: string;
+  rmOrderId: string | null;
+  orderId: string | null;
+  orderNumber: string | null;
+  gross: number;
+  mdrFee: number;
+  net: number;
+  method: string | null;
+  txnTime: string | null;
+};
+
+const RM = (n: number) =>
+  new Intl.NumberFormat("en-MY", { style: "currency", currency: "MYR" }).format(n);
+
+// RM method code → friendly label (FPX_MY → FPX, CARD → Card).
+function method(m: string | null): string {
+  if (!m) return "—";
+  return m.replace(/_MY$/, "").replace(/\b\w/g, (c) => c.toUpperCase()).replace(/pay/i, "Pay");
+}
+
+const ymd = (d: Date) => d.toISOString().slice(0, 10);
+function monthRange(year: number, month0: number): { from: string; to: string } {
+  return { from: ymd(new Date(Date.UTC(year, month0, 1))), to: ymd(new Date(Date.UTC(year, month0 + 1, 0))) };
+}
+function presetRange(key: string): { from: string; to: string } {
+  const now = new Date(); const y = now.getFullYear(); const m = now.getMonth();
+  const end = monthRange(y, m).to;
+  switch (key) {
+    case "thisMonth": return monthRange(y, m);
+    case "lastMonth": return monthRange(y, m - 1);
+    case "last3": return { from: monthRange(y, m - 2).from, to: end };
+    case "last6": return { from: monthRange(y, m - 5).from, to: end };
+    case "ytd": return { from: `${y}-01-01`, to: ymd(now) };
+    default: return { from: monthRange(y, m - 2).from, to: end };
+  }
+}
+
+type SortKey = "settlementDate" | "entityName" | "method" | "txnCount" | "gross" | "net";
+const SELECT_CLASS = "h-8 rounded-md border bg-background px-2 text-xs sm:text-sm shrink-0 max-w-[40vw]";
+
+function SortTh({ label, sortField, sortKey, sortDir, onSort, className = "", align = "left" }: {
+  label: string; sortField: SortKey; sortKey: SortKey; sortDir: "asc" | "desc";
+  onSort: (k: SortKey) => void; className?: string; align?: "left" | "right";
+}) {
+  const active = sortKey === sortField;
+  return (
+    <th className={`px-3 py-2 ${className}`}>
+      <button type="button" onClick={() => onSort(sortField)}
+        className={`inline-flex items-center gap-1 font-medium uppercase tracking-wide hover:text-foreground ${align === "right" ? "flex-row-reverse" : ""}`}>
+        {label}
+        {active ? (sortDir === "asc" ? <ArrowUp className="h-3 w-3" /> : <ArrowDown className="h-3 w-3" />) : <ChevronsUpDown className="h-3 w-3 opacity-40" />}
+      </button>
+    </th>
+  );
+}
+
+export default function FinancePayoutsPage() {
+  const [periodSel, setPeriodSel] = useState("last3");
+  const [dateFrom, setDateFrom] = useState(() => presetRange("last3").from);
+  const [dateTo, setDateTo] = useState(() => presetRange("last3").to);
+  const [search, setSearch] = useState("");
+  const [entityF, setEntityF] = useState("");
+  const [methodF, setMethodF] = useState("");
+  const [sortKey, setSortKey] = useState<SortKey>("settlementDate");
+  const [sortDir, setSortDir] = useState<"asc" | "desc">("desc");
+  const [openId, setOpenId] = useState<string | null>(null);
+
+  const qs = useMemo(() => {
+    const p = new URLSearchParams();
+    if (dateFrom) p.set("from", dateFrom);
+    if (dateTo) p.set("to", dateTo);
+    return p.toString();
+  }, [dateFrom, dateTo]);
+
+  const { data, error, isLoading } = useFetch<{ from: string; to: string | null; payouts: Payout[] }>(
+    `/api/finance/payouts${qs ? `?${qs}` : ""}`
+  );
+  const payouts = useMemo(() => data?.payouts ?? [], [data]);
+
+  const entityOptions = useMemo(() => Array.from(new Set(payouts.map((p) => p.entityName ?? "—"))).sort(), [payouts]);
+  const methodOptions = useMemo(() => Array.from(new Set(payouts.map((p) => p.method))).sort(), [payouts]);
+
+  function onSort(k: SortKey) {
+    if (sortKey === k) setSortDir((d) => (d === "asc" ? "desc" : "asc"));
+    else { setSortKey(k); setSortDir(k === "settlementDate" || k === "gross" || k === "net" || k === "txnCount" ? "desc" : "asc"); }
+  }
+  function applyPeriod(v: string) {
+    setPeriodSel(v);
+    if (v === "custom") return;
+    const r = presetRange(v);
+    setDateFrom(r.from); setDateTo(r.to);
+  }
+
+  const filtered = useMemo(() => {
+    const s = search.trim().toLowerCase();
+    let rows = payouts.filter((p) => {
+      if (s && !`${p.entityName ?? ""} ${method(p.method)} ${p.id}`.toLowerCase().includes(s)) return false;
+      if (entityF && (p.entityName ?? "—") !== entityF) return false;
+      if (methodF && p.method !== methodF) return false;
+      return true;
+    });
+    const dir = sortDir === "asc" ? 1 : -1;
+    rows = [...rows].sort((a, b) => {
+      let av: string | number, bv: string | number;
+      switch (sortKey) {
+        case "gross": av = a.gross; bv = b.gross; break;
+        case "net": av = a.net; bv = b.net; break;
+        case "txnCount": av = a.txnCount; bv = b.txnCount; break;
+        case "method": av = method(a.method); bv = method(b.method); break;
+        case "entityName": av = a.entityName ?? ""; bv = b.entityName ?? ""; break;
+        default: av = a.settlementDate; bv = b.settlementDate;
+      }
+      if (av < bv) return -1 * dir;
+      if (av > bv) return 1 * dir;
+      return 0;
+    });
+    return rows;
+  }, [payouts, search, entityF, methodF, sortKey, sortDir]);
+
+  const totals = useMemo(() => {
+    let gross = 0, fee = 0, net = 0;
+    for (const p of filtered) { gross += p.gross; fee += p.mdrFee; net += p.net; }
+    return { gross, fee, net };
+  }, [filtered]);
+
+  const anyFilter = !!(search || entityF || methodF);
+  function clearFilters() { setSearch(""); setEntityF(""); setMethodF(""); }
+
+  function exportCsv() {
+    const headers = ["Settlement date", "Entity", "Method", "Seq", "Transactions", "Linked", "Gross (RM)", "MDR fee (RM)", "Net (RM)", "Status"];
+    const esc = (v: string | number) => { const s = String(v ?? ""); return /[",\r\n]/.test(s) ? `"${s.replace(/"/g, '""')}"` : s; };
+    const rows = filtered.map((p) => [
+      p.settlementDate, p.entityName ?? "", method(p.method), p.sequence,
+      p.txnCount, p.linkedCount, p.gross.toFixed(2), p.mdrFee.toFixed(2), p.net.toFixed(2), p.status,
+    ]);
+    const csv = [headers, ...rows].map((r) => r.map(esc).join(",")).join("\r\n");
+    const blob = new Blob(["﻿" + csv], { type: "text/csv;charset=utf-8;" });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = `celsius-payouts_${dateFrom || data?.from || "start"}_to_${dateTo || "latest"}.csv`;
+    a.click();
+    URL.revokeObjectURL(url);
+  }
+
+  return (
+    <div className="space-y-4 p-3 sm:p-6">
+      <header className="min-w-0">
+        <h1 className="text-xl sm:text-2xl font-semibold">Payouts</h1>
+        <p className="mt-0.5 text-xs sm:text-sm text-muted-foreground">
+          Revenue Monster settlements paid to your bank accounts — open one to see every transaction it settled, linked to its order.
+          {data && <span className="ml-1">Showing from {data.from}{data.to ? ` to ${data.to}` : ""}.</span>}
+        </p>
+      </header>
+
+      <div className="space-y-2 rounded-lg border bg-card p-3">
+        <div className="flex flex-wrap items-center gap-2">
+          <div className="relative min-w-[180px] flex-1">
+            <Search className="pointer-events-none absolute left-2 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-muted-foreground" />
+            <input value={search} onChange={(e) => setSearch(e.target.value)} placeholder="Search entity, method…"
+              className="h-8 w-full rounded-md border bg-background pl-7 pr-2 text-sm" />
+          </div>
+          <select value={entityF} onChange={(e) => setEntityF(e.target.value)} className={SELECT_CLASS} title="Entity">
+            <option value="">All entities</option>
+            {entityOptions.map((e) => <option key={e} value={e}>{e}</option>)}
+          </select>
+          <select value={methodF} onChange={(e) => setMethodF(e.target.value)} className={SELECT_CLASS} title="Method">
+            <option value="">All methods</option>
+            {methodOptions.map((m) => <option key={m} value={m}>{method(m)}</option>)}
+          </select>
+        </div>
+
+        <div className="flex flex-wrap items-center gap-2 text-xs text-muted-foreground">
+          <label className="flex items-center gap-1">Period
+            <select value={periodSel} onChange={(e) => applyPeriod(e.target.value)} className="h-8 rounded-md border bg-background px-2 text-xs sm:text-sm" title="Period">
+              <option value="thisMonth">This month</option>
+              <option value="lastMonth">Last month</option>
+              <option value="last3">Last 3 months</option>
+              <option value="last6">Last 6 months</option>
+              <option value="ytd">Year to date</option>
+              <option value="custom">Custom range…</option>
+            </select>
+          </label>
+          <label className="flex items-center gap-1">From
+            <input type="date" value={dateFrom} onChange={(e) => { setDateFrom(e.target.value); setPeriodSel("custom"); }} className="h-8 rounded-md border bg-background px-2 text-xs" />
+          </label>
+          <label className="flex items-center gap-1">To
+            <input type="date" value={dateTo} onChange={(e) => { setDateTo(e.target.value); setPeriodSel("custom"); }} className="h-8 rounded-md border bg-background px-2 text-xs" />
+          </label>
+          <Button variant="outline" size="sm" className="h-8" onClick={exportCsv} disabled={filtered.length === 0} title="Export the filtered payouts to CSV">
+            <Download className="mr-1 h-3 w-3" /> Export
+          </Button>
+          {anyFilter && <Button variant="outline" size="sm" className="h-8" onClick={clearFilters}><X className="mr-1 h-3 w-3" /> Clear</Button>}
+          <span className="ml-auto flex flex-wrap items-center gap-x-3 tabular-nums">
+            <span>{filtered.length} {filtered.length === 1 ? "payout" : "payouts"}</span>
+            <span>Gross {RM(totals.gross)}</span>
+            <span className="text-red-700">Fees {RM(totals.fee)}</span>
+            <span className="font-semibold text-green-700">Net {RM(totals.net)}</span>
+          </span>
+        </div>
+      </div>
+
+      {isLoading && <Loader2 className="h-5 w-5 animate-spin text-muted-foreground" />}
+      {error && <div className="rounded-lg border border-destructive/40 bg-destructive/5 p-3 text-sm text-destructive">Failed to load: {String(error)}</div>}
+
+      {data && payouts.length === 0 && (
+        <div className="rounded-lg border border-dashed p-12 text-center text-sm text-muted-foreground">
+          No payouts in this range yet. They sync daily from Revenue Monster after settlement — widen the date range, or check back after the next run.
+        </div>
+      )}
+
+      {data && payouts.length > 0 && (
+        <div className="overflow-x-auto rounded-lg border bg-card">
+          <table className="w-full text-sm">
+            <thead className="bg-muted/40 text-left text-xs uppercase tracking-wide text-muted-foreground">
+              <tr>
+                <SortTh label="Date" sortField="settlementDate" sortKey={sortKey} sortDir={sortDir} onSort={onSort} className="whitespace-nowrap" />
+                <SortTh label="Entity" sortField="entityName" sortKey={sortKey} sortDir={sortDir} onSort={onSort} />
+                <SortTh label="Method" sortField="method" sortKey={sortKey} sortDir={sortDir} onSort={onSort} className="whitespace-nowrap hidden sm:table-cell" />
+                <SortTh label="Txns" sortField="txnCount" sortKey={sortKey} sortDir={sortDir} onSort={onSort} className="whitespace-nowrap text-right hidden md:table-cell" align="right" />
+                <SortTh label="Gross" sortField="gross" sortKey={sortKey} sortDir={sortDir} onSort={onSort} className="whitespace-nowrap text-right hidden lg:table-cell" align="right" />
+                <SortTh label="Net" sortField="net" sortKey={sortKey} sortDir={sortDir} onSort={onSort} className="whitespace-nowrap text-right" align="right" />
+              </tr>
+            </thead>
+            <tbody>
+              {filtered.map((p) => {
+                const allLinked = p.linkedCount >= p.txnCount && p.txnCount > 0;
+                return (
+                  <tr key={p.id} className="cursor-pointer border-t transition hover:bg-muted/30" onClick={() => setOpenId(p.id)}>
+                    <td className="whitespace-nowrap px-3 py-2 tabular-nums align-top">{p.settlementDate}</td>
+                    <td className="max-w-[260px] px-3 py-2">
+                      <div className="truncate">{p.entityName ?? "—"}</div>
+                      <div className="flex items-center gap-1 text-[11px] text-muted-foreground">
+                        <span className="sm:hidden">{method(p.method)} ·</span>
+                        <span className={`inline-flex items-center gap-0.5 ${allLinked ? "text-green-700" : "text-amber-700"}`}>
+                          {allLinked ? <CheckCircle2 className="h-3 w-3" /> : <AlertTriangle className="h-3 w-3" />}
+                          {p.linkedCount}/{p.txnCount} linked
+                        </span>
+                      </div>
+                    </td>
+                    <td className="whitespace-nowrap px-3 py-2 hidden sm:table-cell align-top">
+                      <Badge variant="outline" className="font-normal">{method(p.method)}</Badge>
+                    </td>
+                    <td className="whitespace-nowrap px-3 py-2 text-right tabular-nums align-top hidden md:table-cell">{p.txnCount}</td>
+                    <td className="whitespace-nowrap px-3 py-2 text-right tabular-nums align-top hidden lg:table-cell text-muted-foreground">{RM(p.gross)}</td>
+                    <td className="whitespace-nowrap px-3 py-2 text-right tabular-nums align-top font-medium text-green-700">{RM(p.net)}</td>
+                  </tr>
+                );
+              })}
+              {filtered.length === 0 && <tr><td colSpan={6} className="px-3 py-10 text-center text-sm text-muted-foreground">No payouts match your filters.</td></tr>}
+            </tbody>
+          </table>
+        </div>
+      )}
+
+      <PayoutDrawer id={openId} onClose={() => setOpenId(null)} />
+    </div>
+  );
+}
+
+function PayoutDrawer({ id, onClose }: { id: string | null; onClose: () => void }) {
+  const [state, setState] = useState<{ loading: boolean; error: string | null; payout: Payout | null; lines: PayoutLine[] }>(
+    { loading: false, error: null, payout: null, lines: [] }
+  );
+
+  useEffect(() => {
+    if (!id) return;
+    let cancelled = false;
+    setState({ loading: true, error: null, payout: null, lines: [] });
+    fetch(`/api/finance/payouts/${id}`)
+      .then((r) => r.ok ? r.json() : Promise.reject(new Error(`HTTP ${r.status}`)))
+      .then((d) => { if (!cancelled) setState({ loading: false, error: null, payout: d.payout, lines: d.lines }); })
+      .catch((e) => { if (!cancelled) setState({ loading: false, error: String(e), payout: null, lines: [] }); });
+    return () => { cancelled = true; };
+  }, [id]);
+
+  const { payout, lines } = state;
+  const linked = lines.filter((l) => l.orderId).length;
+  const lineNetSum = lines.reduce((s, l) => s + l.net, 0);
+  const reconciles = payout ? Math.abs(lineNetSum - payout.net) < 0.01 : false;
+
+  return (
+    <Sheet open={!!id} onOpenChange={(o) => !o && onClose()}>
+      <SheetContent side="right" className="w-full sm:max-w-lg overflow-hidden flex flex-col gap-0 p-0">
+        <SheetHeader className="border-b px-6 py-4">
+          <SheetTitle>Payout</SheetTitle>
+        </SheetHeader>
+        {state.loading && <div className="p-6"><Loader2 className="h-5 w-5 animate-spin text-muted-foreground" /></div>}
+        {state.error && <div className="p-6 text-sm text-destructive">Failed to load: {state.error}</div>}
+        {payout && (
+          <div className="space-y-5 overflow-y-auto p-6 text-sm">
+            <section className="grid grid-cols-2 gap-3">
+              <div>
+                <div className="text-xs uppercase tracking-wide text-muted-foreground">Settlement date</div>
+                <div className="tabular-nums">{payout.settlementDate}</div>
+              </div>
+              <div>
+                <div className="text-xs uppercase tracking-wide text-muted-foreground">Method</div>
+                <Badge variant="outline" className="font-normal">{method(payout.method)}</Badge>
+              </div>
+              <div className="col-span-2">
+                <div className="text-xs uppercase tracking-wide text-muted-foreground">Entity</div>
+                <div className="flex items-center gap-1"><Building2 className="h-3.5 w-3.5 shrink-0" />{payout.entityName ?? "—"}</div>
+              </div>
+              <div>
+                <div className="text-xs uppercase tracking-wide text-muted-foreground">Gross</div>
+                <div className="tabular-nums">{RM(payout.gross)}</div>
+              </div>
+              <div>
+                <div className="text-xs uppercase tracking-wide text-muted-foreground">MDR fee</div>
+                <div className="tabular-nums text-red-700">−{RM(payout.mdrFee)}</div>
+              </div>
+              <div>
+                <div className="text-xs uppercase tracking-wide text-muted-foreground">Net to bank</div>
+                <div className="font-semibold tabular-nums text-green-700">{RM(payout.net)}</div>
+              </div>
+              <div>
+                <div className="text-xs uppercase tracking-wide text-muted-foreground">Reconciles</div>
+                <div className={reconciles ? "text-green-700 inline-flex items-center gap-1" : "text-amber-700 inline-flex items-center gap-1"}>
+                  {reconciles ? <CheckCircle2 className="h-3.5 w-3.5" /> : <AlertTriangle className="h-3.5 w-3.5" />}
+                  {reconciles ? "Lines = net" : `Δ ${RM(Math.abs(lineNetSum - payout.net))}`}
+                </div>
+              </div>
+            </section>
+
+            <section className="rounded-md border bg-muted/20 p-3 text-xs">
+              <span className={linked >= lines.length ? "text-green-700" : "text-amber-700"}>
+                {linked}/{lines.length} transactions linked to a Celsius order
+              </span>
+              {linked < lines.length && <span className="text-muted-foreground"> · unlinked are typically POS-terminal sales</span>}
+            </section>
+
+            <section>
+              <div className="mb-2 text-xs uppercase tracking-wide text-muted-foreground">Transactions</div>
+              <div className="overflow-x-auto rounded-md border">
+                <table className="w-full text-xs">
+                  <thead className="bg-muted/40 text-left uppercase tracking-wide text-muted-foreground">
+                    <tr>
+                      <th className="px-2 py-1.5">Order</th>
+                      <th className="px-2 py-1.5 text-right">Gross</th>
+                      <th className="px-2 py-1.5 text-right">Fee</th>
+                      <th className="px-2 py-1.5 text-right">Net</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {lines.map((l) => (
+                      <tr key={l.id} className="border-t">
+                        <td className="px-2 py-1.5">
+                          {l.orderNumber
+                            ? <span className="font-medium">{l.orderNumber}</span>
+                            : <span className="text-muted-foreground">{l.rmOrderId ?? "unlinked"}</span>}
+                          <div className="font-mono text-[10px] text-muted-foreground truncate max-w-[180px]">{l.rmTransactionId}</div>
+                        </td>
+                        <td className="px-2 py-1.5 text-right tabular-nums">{RM(l.gross)}</td>
+                        <td className="px-2 py-1.5 text-right tabular-nums text-red-700">−{RM(l.mdrFee)}</td>
+                        <td className="px-2 py-1.5 text-right tabular-nums text-green-700">{RM(l.net)}</td>
+                      </tr>
+                    ))}
+                    {lines.length === 0 && <tr><td colSpan={4} className="px-2 py-6 text-center text-muted-foreground">No transaction lines.</td></tr>}
+                  </tbody>
+                </table>
+              </div>
+            </section>
+          </div>
+        )}
+      </SheetContent>
+    </Sheet>
+  );
+}

--- a/apps/backoffice/src/app/(admin)/layout.tsx
+++ b/apps/backoffice/src/app/(admin)/layout.tsx
@@ -345,6 +345,7 @@ const NAV_SECTIONS: NavSection[] = [
       { label: "Cashflow", href: "/finance/cashflow", icon: <LineChart className={ICON_SIZE} />, moduleKey: "finance:cashflow" },
       { label: "Cash Tracking", href: "/finance/cash-tracking", icon: <TableProperties className={ICON_SIZE} />, moduleKey: "finance:cash-tracking" },
       { label: "Bank Statements", href: "/finance/bank-statements", icon: <Banknote className={ICON_SIZE} />, moduleKey: "finance:bank-statements" },
+      { label: "Payouts", href: "/finance/payouts", icon: <HandCoins className={ICON_SIZE} />, moduleKey: "finance:payouts" },
       { label: "Recurring Expenses", href: "/finance/recurring-expenses", icon: <CalendarClock className={ICON_SIZE} />, moduleKey: "finance:recurring-expenses" },
     ],
   },

--- a/apps/backoffice/src/app/api/finance/payouts/[id]/route.ts
+++ b/apps/backoffice/src/app/api/finance/payouts/[id]/route.ts
@@ -1,0 +1,70 @@
+// GET /api/finance/payouts/[id]
+// The settled transactions inside one RM payout batch, each linked to its
+// Celsius pickup order (order_number) where matched. Drives the Payouts drawer.
+
+import { NextRequest, NextResponse } from "next/server";
+import { requireAuth } from "@/lib/auth";
+import { prisma } from "@/lib/prisma";
+import { getFinanceClient } from "@/lib/finance/supabase";
+
+export const dynamic = "force-dynamic";
+
+export async function GET(req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  const auth = await requireAuth(req);
+  if (auth.error) return auth.error;
+  if (!["OWNER", "ADMIN"].includes(auth.user.role)) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+
+  const { id } = await params;
+
+  const payout = await prisma.rmPayout.findUnique({ where: { id } });
+  if (!payout) return NextResponse.json({ error: "Not found" }, { status: 404 });
+
+  const lines = await prisma.rmPayoutLine.findMany({
+    where: { payoutId: id },
+    orderBy: [{ txnTime: "asc" }, { id: "asc" }],
+  });
+
+  // Resolve order numbers for the linked orders. `orders` is a raw Supabase
+  // table (not a Prisma model), so fetch via the finance service client.
+  const orderIds = Array.from(new Set(lines.map((l) => l.orderId).filter(Boolean) as string[]));
+  const numberById = new Map<string, string>();
+  if (orderIds.length > 0) {
+    const { data } = await getFinanceClient()
+      .from("orders")
+      .select("id, order_number")
+      .in("id", orderIds);
+    for (const o of (data ?? []) as { id: string; order_number: string }[]) {
+      numberById.set(o.id, o.order_number);
+    }
+  }
+
+  return NextResponse.json({
+    payout: {
+      id: payout.id,
+      settlementDate: payout.settlementDate.toISOString().slice(0, 10),
+      method: payout.method,
+      sequence: payout.sequence,
+      storeId: payout.storeId,
+      entityName: payout.entityName,
+      txnCount: payout.txnCount,
+      gross: Number(payout.grossTotal),
+      mdrFee: Number(payout.mdrFee),
+      net: Number(payout.netTotal),
+      status: payout.status,
+    },
+    lines: lines.map((l) => ({
+      id: l.id,
+      rmTransactionId: l.rmTransactionId,
+      rmOrderId: l.rmOrderId,
+      orderId: l.orderId,
+      orderNumber: l.orderId ? numberById.get(l.orderId) ?? null : null,
+      gross: Number(l.gross),
+      mdrFee: Number(l.mdrFee),
+      net: Number(l.net),
+      method: l.method,
+      txnTime: l.txnTime ? l.txnTime.toISOString() : null,
+    })),
+  });
+}

--- a/apps/backoffice/src/app/api/finance/payouts/route.ts
+++ b/apps/backoffice/src/app/api/finance/payouts/route.ts
@@ -1,0 +1,69 @@
+// GET /api/finance/payouts?from=YYYY-MM-DD&to=YYYY-MM-DD
+// Revenue Monster payout (daily settlement) batches, auto-synced by the
+// apps/order /api/cron/sync-rm-payouts cron. Powers the /finance Payouts page.
+// Date-windowed server-side (default last 3 months); filtered/sorted client-side.
+
+import { NextRequest, NextResponse } from "next/server";
+import { requireAuth } from "@/lib/auth";
+import { prisma } from "@/lib/prisma";
+
+export const dynamic = "force-dynamic";
+export const maxDuration = 30;
+
+export async function GET(req: NextRequest) {
+  const auth = await requireAuth(req);
+  if (auth.error) return auth.error;
+  if (!["OWNER", "ADMIN"].includes(auth.user.role)) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+
+  const url = new URL(req.url);
+  const from = url.searchParams.get("from");
+  const to = url.searchParams.get("to");
+
+  const defFrom = new Date();
+  defFrom.setMonth(defFrom.getMonth() - 3);
+  const gte = from ? new Date(`${from}T00:00:00.000Z`) : defFrom;
+  const lte = to ? new Date(`${to}T23:59:59.999Z`) : undefined;
+
+  const rows = await prisma.rmPayout.findMany({
+    where: { settlementDate: lte ? { gte, lte } : { gte } },
+    select: {
+      id: true,
+      settlementDate: true,
+      method: true,
+      sequence: true,
+      storeId: true,
+      entityName: true,
+      txnCount: true,
+      grossTotal: true,
+      mdrFee: true,
+      netTotal: true,
+      status: true,
+      // Linked-line count for the reconciliation badge (how many of the
+      // batch's transactions resolved to a Celsius order).
+      _count: { select: { lines: { where: { orderId: { not: null } } } } },
+    },
+    orderBy: [{ settlementDate: "desc" }, { id: "desc" }],
+    take: 5000,
+  });
+
+  return NextResponse.json({
+    from: (from ? gte : defFrom).toISOString().slice(0, 10),
+    to: to ?? null,
+    payouts: rows.map((r) => ({
+      id: r.id,
+      settlementDate: r.settlementDate.toISOString().slice(0, 10),
+      method: r.method,
+      sequence: r.sequence,
+      storeId: r.storeId,
+      entityName: r.entityName,
+      txnCount: r.txnCount,
+      gross: Number(r.grossTotal),
+      mdrFee: Number(r.mdrFee),
+      net: Number(r.netTotal),
+      status: r.status,
+      linkedCount: r._count.lines,
+    })),
+  });
+}

--- a/apps/order/src/app/api/cron/sync-rm-payouts/route.ts
+++ b/apps/order/src/app/api/cron/sync-rm-payouts/route.ts
@@ -1,0 +1,163 @@
+export const dynamic = "force-dynamic";
+// One RM settlement round-trip per (method, sequence) per day. Batch and bail
+// before the deadline; leftovers re-sync on the next run (upserts are idempotent).
+export const maxDuration = 60;
+
+import { NextRequest, NextResponse } from "next/server";
+import { checkCronAuth } from "@celsius/shared";
+import { getSupabaseAdmin } from "@/lib/supabase/server";
+import {
+  getDailySettlementReport,
+  parseSettlementCsv,
+  SETTLEMENT_METHODS,
+  type SettlementLine,
+} from "@/lib/revenue-monster/client";
+
+/**
+ * Sync Revenue Monster daily settlement (payout) batches into RmPayout /
+ * RmPayoutLine for the backoffice finance Payouts tab.
+ *
+ *   GET ?probe=true&date=YYYY-MM-DD[&method=FPX_MY]  → raw + parsed sample, no writes
+ *   GET ?date=YYYY-MM-DD                              → sync that day
+ *   GET ?days=N                                       → backfill last N days
+ *   (no params)                                       → sync yesterday (cron default)
+ *
+ * Idempotent: payouts keyed on (date, method, sequence, store), lines on the RM
+ * transaction id, so re-running a day upserts in place. RM pauses settlement on
+ * public holidays — a missed day simply backfills on a later run.
+ */
+
+const SEQ_CAP = 10; // safety bound on settlement batches per method/day
+
+// MYT (UTC+8) calendar date string, offset by `daysAgo`.
+function mytDate(daysAgo: number): string {
+  const ms = Date.now() + 8 * 3_600_000 - daysAgo * 86_400_000;
+  return new Date(ms).toISOString().slice(0, 10);
+}
+
+// Map an RM store label (and/or the matched Celsius order's store) to our outlet
+// slug + operating entity. Mirrors the bank-line classifier's name heuristics.
+function resolveStore(storeName: string | null, orderStore: string | null): { slug: string; entity: string } {
+  const s = (orderStore || storeName || "").toLowerCase();
+  if (s.includes("conezion") || s === "conezion") return { slug: "conezion", entity: "Celsius Coffee Conezion Sdn Bhd" };
+  if (s.includes("tamarind") || s === "tamarind") return { slug: "tamarind", entity: "Celsius Coffee Tamarind Sdn Bhd" };
+  if (s.includes("shah") || s.includes("alam") || s === "shah-alam") return { slug: "shah-alam", entity: "Celsius Coffee Sdn Bhd" };
+  return { slug: orderStore || "unknown", entity: storeName || "Unknown" };
+}
+
+export async function GET(request: NextRequest) {
+  const cronAuth = checkCronAuth(request.headers);
+  if (!cronAuth.ok) return NextResponse.json({ error: cronAuth.error }, { status: cronAuth.status });
+
+  const p = request.nextUrl.searchParams;
+
+  // ── Probe: one call, raw + parsed, no DB writes. Fail-fast endpoint check. ──
+  if (p.get("probe") === "true") {
+    const date = p.get("date") || mytDate(7);
+    const method = p.get("method") || "FPX_MY";
+    const r = await getDailySettlementReport({ date, method, sequence: 1 });
+    const parsed = parseSettlementCsv(r.body);
+    return NextResponse.json({
+      probe: { date, method },
+      http: { ok: r.ok, status: r.status, bodyLength: r.body.length },
+      bodyHead: r.body.slice(0, 3000),
+      parsed: { lineCount: parsed.lines.length, grossSen: parsed.grossSen, mdrSen: parsed.mdrSen, netSen: parsed.netSen, sample: parsed.lines.slice(0, 3) },
+    });
+  }
+
+  // ── Determine the date window ──
+  const days = Math.min(Math.max(Number(p.get("days") ?? 0) || 0, 0), 90);
+  const dates = p.get("date")
+    ? [p.get("date") as string]
+    : days > 0
+      ? Array.from({ length: days }, (_, i) => mytDate(i + 1))
+      : [mytDate(1)]; // default: yesterday
+
+  const supabase = getSupabaseAdmin();
+  const result = { dates, payouts: 0, lines: 0, linked: 0, methodsSeen: [] as string[], errors: [] as string[] };
+  const DEADLINE_MS = 50_000;
+  const startedAt = Date.now();
+
+  for (const date of dates) {
+    for (const method of SETTLEMENT_METHODS) {
+      if (Date.now() - startedAt > DEADLINE_MS) { result.errors.push("deadline reached; remaining will sync next run"); return NextResponse.json(result); }
+      for (let seq = 1; seq <= SEQ_CAP; seq++) {
+        let parsedLines: SettlementLine[] = [];
+        try {
+          const r = await getDailySettlementReport({ date, method, sequence: seq });
+          if (!r.ok) break;                       // no batch / not enabled for this method
+          parsedLines = parseSettlementCsv(r.body).lines;
+        } catch (e) {
+          result.errors.push(`${date} ${method} seq${seq}: ${e instanceof Error ? e.message : String(e)}`);
+          break;
+        }
+        if (parsedLines.length === 0) break;       // no more batches this method/day
+        if (!result.methodsSeen.includes(method)) result.methodsSeen.push(method);
+
+        // Link each line to its Celsius order via payment_provider_ref (RM txn id).
+        const txIds = parsedLines.map((l) => l.rmTransactionId);
+        const { data: orderRows } = await supabase
+          .from("orders")
+          .select("id, store_id, payment_provider_ref")
+          .in("payment_provider_ref", txIds);
+        const orderByRef = new Map<string, { id: string; store_id: string | null }>();
+        for (const o of (orderRows ?? []) as { id: string; store_id: string | null; payment_provider_ref: string | null }[]) {
+          if (o.payment_provider_ref) orderByRef.set(o.payment_provider_ref, { id: o.id, store_id: o.store_id });
+        }
+
+        // Group lines into per-store payouts (matches the portal's per-entity rows).
+        type Group = { slug: string; entity: string; lines: { line: SettlementLine; orderId: string | null }[] };
+        const groups = new Map<string, Group>();
+        for (const line of parsedLines) {
+          const matched = orderByRef.get(line.rmTransactionId) ?? null;
+          const { slug, entity } = resolveStore(line.store, matched?.store_id ?? null);
+          if (!groups.has(slug)) groups.set(slug, { slug, entity, lines: [] });
+          groups.get(slug)!.lines.push({ line, orderId: matched?.id ?? null });
+        }
+
+        for (const g of groups.values()) {
+          const payoutId = `${date}_${method}_${seq}_${g.slug}`;
+          const grossSen = g.lines.reduce((s, x) => s + x.line.grossSen, 0);
+          const mdrSen   = g.lines.reduce((s, x) => s + x.line.mdrFeeSen, 0);
+          const netSen   = g.lines.reduce((s, x) => s + x.line.netSen, 0);
+
+          const { error: pErr } = await supabase.from("RmPayout").upsert({
+            id: payoutId,
+            settlementDate: date,
+            method,
+            sequence: seq,
+            storeId: g.slug,
+            entityName: g.entity,
+            txnCount: g.lines.length,
+            grossTotal: grossSen / 100,
+            mdrFee: mdrSen / 100,
+            netTotal: netSen / 100,
+            status: "success",
+            syncedAt: new Date().toISOString(),
+          }, { onConflict: "id" });
+          if (pErr) { result.errors.push(`payout ${payoutId}: ${pErr.message}`); continue; }
+          result.payouts += 1;
+
+          const lineRows = g.lines.map(({ line, orderId }) => ({
+            id: line.rmTransactionId,
+            payoutId,
+            rmTransactionId: line.rmTransactionId,
+            rmOrderId: line.rmOrderId,
+            orderId,
+            gross: line.grossSen / 100,
+            mdrFee: line.mdrFeeSen / 100,
+            net: line.netSen / 100,
+            method,
+            txnTime: line.txnTime,
+          }));
+          const { error: lErr } = await supabase.from("RmPayoutLine").upsert(lineRows, { onConflict: "id" });
+          if (lErr) { result.errors.push(`lines ${payoutId}: ${lErr.message}`); continue; }
+          result.lines += lineRows.length;
+          result.linked += lineRows.filter((l) => l.orderId).length;
+        }
+      }
+    }
+  }
+
+  return NextResponse.json(result);
+}

--- a/apps/order/src/lib/revenue-monster/client.ts
+++ b/apps/order/src/lib/revenue-monster/client.ts
@@ -505,6 +505,153 @@ export async function queryTransaction(transactionId: string): Promise<RmTransac
   };
 }
 
+// ─── Daily settlement (payout) report ──────────────────────────────────────────
+//
+// RM batches settled transactions into daily payouts to the merchant's bank
+// account. The Open API exposes this via POST /v3/payment/settlement/csv (same
+// host + signing as everything above; confirmed against RM's official JS SDK
+// `getDailySettlementReport`). The merchant portal's Payouts page uses a
+// dashboard-session endpoint we can't call from the server — this is the
+// programmatic equivalent. Used by apps/order /api/cron/sync-rm-payouts to fill
+// the backoffice finance Payouts tab.
+//
+// RM filters settlements per payment method, so a full day means iterating the
+// active method codes; `sequence` walks multiple batches within one day.
+
+// RM method codes accepted by the settlement endpoint, keyed by our app method.
+// Mirrors PAYMENT_METHOD_MAP but card settles under its acquirer code.
+export const SETTLEMENT_METHODS: string[] = [
+  "FPX_MY", "TNG_MY", "BOOST_MY", "SHOPEEPAY_MY", "GRABPAY_MY", "DUITNOW_MY", "CARD",
+];
+
+export interface SettlementParams {
+  date: string;        // "YYYY-MM-DD"
+  method: string;      // an RM method code from SETTLEMENT_METHODS
+  sequence?: number;   // settlement batch sequence within the day (default 1)
+}
+
+// Raw fetch of the settlement report. Returns the response body as text — RM may
+// answer with CSV directly or a small JSON envelope; the caller (and the probe)
+// inspects it. Never throws on a non-2xx; returns { ok:false, body } so a sweep
+// over many method/sequence combinations can't be wedged by one bad batch.
+export async function getDailySettlementReport(
+  params: SettlementParams,
+): Promise<{ ok: boolean; status: number; body: string }> {
+  const token     = await getToken();
+  const endpoint  = `${BASE_URL}/v3/payment/settlement/csv`;
+  const body      = { date: params.date, method: params.method, region: "MALAYSIA", sequence: params.sequence ?? 1 };
+  const nonceStr  = nonce();
+  const timestamp = String(Math.floor(Date.now() / 1000));
+  const sig       = buildSignature("POST", endpoint, nonceStr, timestamp, body);
+  const res = await fetch(endpoint, {
+    method: "POST",
+    headers: {
+      Authorization:  `Bearer ${token}`,
+      "Content-Type": "application/json",
+      "X-Nonce-Str":  nonceStr,
+      "X-Timestamp":  timestamp,
+      "X-Signature":  sig,
+    },
+    body: JSON.stringify(body),
+    signal: AbortSignal.timeout(RM_TIMEOUT_MS),
+  });
+  const text = await res.text().catch(() => "");
+  return { ok: res.ok, status: res.status, body: text };
+}
+
+export interface SettlementLine {
+  rmTransactionId: string;
+  rmOrderId:       string | null;
+  store:           string | null;   // RM store name/id, when the CSV carries it
+  grossSen:        number;   // integer sen
+  mdrFeeSen:       number;   // integer sen
+  netSen:          number;   // integer sen
+  txnTime:         string | null;
+}
+
+export interface ParsedSettlement {
+  lines:    SettlementLine[];
+  grossSen: number;
+  mdrSen:   number;
+  netSen:   number;
+}
+
+// Tolerant CSV parser for the settlement report. RM's column headers vary, so we
+// match by fuzzy header name (like the bank-statement parser) instead of fixed
+// positions. Money columns are RM-formatted decimals (e.g. "12.90") → integer
+// sen. Returns empty lines for an empty/headers-only body (a day with no
+// settlement for that method) so the caller treats it as "nothing to sync".
+export function parseSettlementCsv(csv: string): ParsedSettlement {
+  const empty: ParsedSettlement = { lines: [], grossSen: 0, mdrSen: 0, netSen: 0 };
+  const text = (csv ?? "").trim();
+  if (!text || text.startsWith("{") || text.startsWith("<")) return empty; // JSON envelope / HTML error, not CSV
+
+  const rows = text.split(/\r?\n/).map(splitCsvRow).filter((r) => r.some((c) => c.trim() !== ""));
+  if (rows.length < 2) return empty;
+
+  const header = rows[0].map((h) => h.toLowerCase().trim());
+  const find = (...names: string[]) =>
+    header.findIndex((h) => names.some((n) => h.includes(n)));
+
+  const txIdx    = find("transaction id", "transactionid", "transaction no", "trace");
+  const ordIdx   = find("order id", "orderid", "reference", "order no");
+  const grossIdx = find("transaction amount", "gross", "amount", "sales amount");
+  const feeIdx   = find("mdr", "fee", "charge", "commission", "discount rate");
+  const netIdx   = find("net", "settlement amount", "settle amount", "payout amount");
+  const timeIdx  = find("transaction time", "transaction date", "paid", "created", "date time");
+  const storeIdx = find("store name", "store id", "store", "outlet", "branch");
+
+  const toSen = (s: string | undefined): number => {
+    if (!s) return 0;
+    const n = parseFloat(s.replace(/[^0-9.\-]/g, ""));
+    return Number.isFinite(n) ? Math.round(n * 100) : 0;
+  };
+
+  const lines: SettlementLine[] = [];
+  for (let i = 1; i < rows.length; i++) {
+    const r = rows[i];
+    const rmTransactionId = (txIdx >= 0 ? r[txIdx] : "")?.trim();
+    if (!rmTransactionId) continue; // skip footer/total rows that have no txn id
+    const grossSen = toSen(grossIdx >= 0 ? r[grossIdx] : undefined);
+    const mdrFeeSen = toSen(feeIdx >= 0 ? r[feeIdx] : undefined);
+    const netSen = netIdx >= 0 ? toSen(r[netIdx]) : grossSen - mdrFeeSen;
+    lines.push({
+      rmTransactionId,
+      rmOrderId: (ordIdx >= 0 ? r[ordIdx] : "")?.trim() || null,
+      store: (storeIdx >= 0 ? r[storeIdx] : "")?.trim() || null,
+      grossSen,
+      mdrFeeSen,
+      netSen,
+      txnTime: (timeIdx >= 0 ? r[timeIdx] : "")?.trim() || null,
+    });
+  }
+
+  return {
+    lines,
+    grossSen: lines.reduce((s, l) => s + l.grossSen, 0),
+    mdrSen:   lines.reduce((s, l) => s + l.mdrFeeSen, 0),
+    netSen:   lines.reduce((s, l) => s + l.netSen, 0),
+  };
+}
+
+// Minimal CSV row splitter — handles quoted fields with embedded commas/quotes.
+function splitCsvRow(line: string): string[] {
+  const out: string[] = [];
+  let cur = "", inQ = false;
+  for (let i = 0; i < line.length; i++) {
+    const c = line[i];
+    if (inQ) {
+      if (c === '"') {
+        if (line[i + 1] === '"') { cur += '"'; i++; } else inQ = false;
+      } else cur += c;
+    } else if (c === '"') inQ = true;
+    else if (c === ",") { out.push(cur); cur = ""; }
+    else cur += c;
+  }
+  out.push(cur);
+  return out;
+}
+
 // ─── Webhook validation ───────────────────────────────────────────────────────
 //
 // RM signs callback bodies with their server's private key. We verify

--- a/apps/order/vercel.json
+++ b/apps/order/vercel.json
@@ -13,6 +13,7 @@
     { "path": "/api/cron/auto-hours",                         "schedule": "*/10 * * * *" },
     { "path": "/api/cron/reconcile-pending",                  "schedule": "*/1 * * * *" },
     { "path": "/api/cron/expire-orders",                      "schedule": "*/15 * * * *" },
-    { "path": "/api/cron/promote-scheduled",                  "schedule": "*/2 * * * *" }
+    { "path": "/api/cron/promote-scheduled",                  "schedule": "*/2 * * * *" },
+    { "path": "/api/cron/sync-rm-payouts",                    "schedule": "0 21 * * *" }
   ]
 }

--- a/apps/pos-native/app/register.tsx
+++ b/apps/pos-native/app/register.tsx
@@ -1281,8 +1281,12 @@ export default function Register() {
     setCoTouched(false);
     setDisplayStatus("idle");
     useDisplay.getState().setMember(null);
-    useDisplay.getState().setExtraDiscount(null);
-    useDisplay.getState().setManualDiscount(null);
+    // Clear all cart-scoped display state between orders (mystery reveal +
+    // prize, beans, pay total, reward, redeem req…). Without this the paid
+    // screen kept mirroring the PREVIOUS order's "REVEALED" card while the
+    // customer hadn't revealed the new one. reset() keeps member, so the
+    // setMember(null) above still does the fresh-order logout.
+    useDisplay.getState().reset();
     // Surface any performance nudge queued at the last checkout.
     if (pendingNudgeRef.current) { setPerfNudge(pendingNudgeRef.current); pendingNudgeRef.current = null; }
   }

--- a/packages/db/prisma/migrations/20260618_add_rm_payouts/migration.sql
+++ b/packages/db/prisma/migrations/20260618_add_rm_payouts/migration.sql
@@ -1,0 +1,49 @@
+-- Revenue Monster payout (daily settlement) tracking for the backoffice finance tab.
+-- Auto-synced from RM Open API POST /v3/payment/settlement/csv by the
+-- apps/order /api/cron/sync-rm-payouts cron. The finance Payouts page reads these
+-- read-only and links each settled transaction back to its Celsius order.
+--
+-- Naming matches the Prisma-managed finance tables (BankStatement / BankStatementLine):
+-- PascalCase table identifiers + camelCase quoted columns (NO @map in the Prisma model),
+-- so prisma.rmPayout / prisma.rmPayoutLine map directly. Mirrored as Prisma models in
+-- packages/db/prisma/schema.prisma. Manual SQL only — never `prisma db push`.
+
+CREATE TABLE IF NOT EXISTS "RmPayout" (
+  "id"               text PRIMARY KEY,                    -- natural key: "<date>_<method>_<seq>_<storeId>"
+  "settlementDate"   timestamp(3) NOT NULL,
+  "periodStart"      timestamp(3),
+  "periodEnd"        timestamp(3),
+  "method"           text NOT NULL,                       -- RM method code, e.g. FPX_MY / TNG_MY / card
+  "sequence"         integer NOT NULL DEFAULT 1,          -- RM settlement batch sequence within a day
+  "storeId"          text NOT NULL,                       -- our outlet slug: shah-alam / conezion / tamarind
+  "entityName"       text,                                -- bank beneficiary / operating company
+  "bankAccountLast4" text,
+  "txnCount"         integer NOT NULL DEFAULT 0,
+  "grossTotal"       numeric(12,2) NOT NULL DEFAULT 0,
+  "mdrFee"           numeric(12,2) NOT NULL DEFAULT 0,
+  "netTotal"         numeric(12,2) NOT NULL DEFAULT 0,
+  "status"           text NOT NULL DEFAULT 'success',
+  "syncedAt"         timestamptz  NOT NULL DEFAULT now(),
+  "createdAt"        timestamp(3) NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS "RmPayout_settlementDate_idx" ON "RmPayout" ("settlementDate");
+CREATE INDEX IF NOT EXISTS "RmPayout_storeId_idx"        ON "RmPayout" ("storeId");
+
+CREATE TABLE IF NOT EXISTS "RmPayoutLine" (
+  "id"               text PRIMARY KEY,                    -- = rmTransactionId (one settlement row per txn)
+  "payoutId"         text NOT NULL REFERENCES "RmPayout"("id") ON DELETE CASCADE,
+  "rmTransactionId"  text NOT NULL,
+  "rmOrderId"        text,                                -- RM order id "C-xxxx-<base36>"
+  "orderId"          text,                                -- matched Celsius orders.id (null = unlinked)
+  "gross"            numeric(12,2) NOT NULL DEFAULT 0,
+  "mdrFee"           numeric(12,2) NOT NULL DEFAULT 0,
+  "net"              numeric(12,2) NOT NULL DEFAULT 0,
+  "method"           text,
+  "txnTime"          timestamp(3),
+  "createdAt"        timestamp(3) NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS "RmPayoutLine_payoutId_idx"        ON "RmPayoutLine" ("payoutId");
+CREATE INDEX IF NOT EXISTS "RmPayoutLine_orderId_idx"         ON "RmPayoutLine" ("orderId");
+CREATE UNIQUE INDEX IF NOT EXISTS "RmPayoutLine_rmTransactionId_key" ON "RmPayoutLine" ("rmTransactionId");

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -1625,6 +1625,56 @@ enum BankLineDirection {
   DR
 }
 
+// Revenue Monster payout (daily settlement) batches, auto-synced from the RM
+// Open API (POST /v3/payment/settlement/csv) by apps/order /api/cron/sync-rm-payouts.
+// The finance Payouts page reads these read-only. One row per (date, method,
+// sequence, store) settlement batch. Created via supabase/migrations/023 — manual
+// SQL, never `prisma db push`. Columns are camelCase (matches BankStatement style).
+model RmPayout {
+  id               String   @id            // "<date>_<method>_<seq>_<storeId>"
+  settlementDate   DateTime
+  periodStart      DateTime?
+  periodEnd        DateTime?
+  method           String                  // RM method code (FPX_MY / TNG_MY / card ...)
+  sequence         Int      @default(1)
+  storeId          String                  // our outlet slug
+  entityName       String?                 // bank beneficiary / operating company
+  bankAccountLast4 String?
+  txnCount         Int      @default(0)
+  grossTotal       Decimal  @default(0) @db.Decimal(12, 2)
+  mdrFee           Decimal  @default(0) @db.Decimal(12, 2)
+  netTotal         Decimal  @default(0) @db.Decimal(12, 2)
+  status           String   @default("success")
+  syncedAt         DateTime @default(now())
+  createdAt        DateTime @default(now())
+  lines            RmPayoutLine[]
+
+  @@index([settlementDate])
+  @@index([storeId])
+}
+
+// One settled transaction inside a payout. orderId links back to the Celsius
+// pickup order (orders.id) matched on rmTransactionId = orders.payment_provider_ref;
+// null when unmatched (e.g. POS-terminal sales until their refs are wired).
+model RmPayoutLine {
+  id              String   @id            // = rmTransactionId
+  payoutId        String
+  payout          RmPayout @relation(fields: [payoutId], references: [id], onDelete: Cascade)
+  rmTransactionId String
+  rmOrderId       String?
+  orderId         String?
+  gross           Decimal  @default(0) @db.Decimal(12, 2)
+  mdrFee          Decimal  @default(0) @db.Decimal(12, 2)
+  net             Decimal  @default(0) @db.Decimal(12, 2)
+  method          String?
+  txnTime         DateTime?
+  createdAt       DateTime @default(now())
+
+  @@index([payoutId])
+  @@index([orderId])
+  @@unique([rmTransactionId])
+}
+
 // Cash-tracking categories — verbatim from the per-outlet spreadsheet
 // framework Finance uses. Same enum is used on both inflow and outflow
 // sides; direction is on the line itself. InterCo categories show on


### PR DESCRIPTION
Adds a **Payouts** view to the backoffice finance module so Revenue Monster settlements can be reconciled inside the backoffice instead of the RM portal. Each payout drills into the transactions it settled, every one linked back to its Celsius order — closing the loop **order → RM collected → payout (→ bank, phase 2)**.

Requested this session; plan approved. Source = Revenue Monster only; ingestion = auto-sync via the RM Open API.

## Changes
- **DB** — `RmPayout` / `RmPayoutLine` via `supabase/migrations/023` (manual SQL, applied to prod; Prisma models mirror the `BankStatement` camelCase style — never `db push`). Additive: two new empty tables.
- **RM Open API** — `getDailySettlementReport` (`POST /v3/payment/settlement/csv`, confirmed in RM's official JS SDK) + a tolerant settlement-CSV parser, **reusing the existing token + RSA-signing client** in `apps/order`.
- **Cron** — `apps/order /api/cron/sync-rm-payouts` (daily 21:00 UTC = 05:00 MYT): iterates method × sequence per day, upserts payouts/lines, links `rmTransactionId` → `orders.payment_provider_ref`. `?probe=true` returns raw+parsed for a no-write endpoint check; `?days=N` backfills. Idempotent.
- **Backoffice** — `finance/payouts` page mirroring Ledger (filter/sort/CSV export + a detail drawer with per-transaction order links and a reconciliation badge), `/api/finance/payouts[/[id]]` (OWNER/ADMIN), nav entry.

## Verification (post-merge, needs prod RM creds — Production-scoped only)
1. Probe `GET /api/cron/sync-rm-payouts?probe=true&date=2026-06-10` (fail-fast: confirms the Open API returns settlement CSV for our account).
2. Backfill, confirm totals vs the RM portal (e.g. Jun 10 Conezion RM1,402.80 / Sdn Bhd RM1,220.43).
3. Check link rate + the `/finance/payouts` UI.

`tsc --noEmit` clean on both apps (the one pre-existing `music/` error is unrelated/untracked). `prisma generate` succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)