### PR TITLE
fix(pos-native): stop the new-order chime AND serving alarm looping on remount

### DIFF
--- a/apps/pos-native/lib/chime.ts
+++ b/apps/pos-native/lib/chime.ts
@@ -87,7 +87,16 @@ export function primeSounds(): void {
  *  and the expo-audio path seeks to 0 — so we space them by the clip length).
  *  Works on both playback paths and ships over OTA, no asset/rebuild needed. */
 const CHIME_REPEAT_MS = 2500; // chime clip is ~2.40s; small gap before ring #2
+// Rapid-fire guard: coalesce chime triggers fired within this window into ONE
+// cue. Defence-in-depth against a runaway loop machine-gunning the speaker (the
+// intended double-ring below is scheduled via setTimeout→play, NOT playChime, so
+// it is never throttled). 1.5s is well under the gap between distinct orders.
+const CHIME_MIN_GAP_MS = 1500;
+let lastChimeAt = 0;
 export function playChime(): void {
+  const now = Date.now();
+  if (now - lastChimeAt < CHIME_MIN_GAP_MS) return;
+  lastChimeAt = now;
   play("chime");
   setTimeout(() => play("chime"), CHIME_REPEAT_MS);
 }

--- a/apps/pos-native/lib/chime.ts
+++ b/apps/pos-native/lib/chime.ts
@@ -100,8 +100,16 @@ export function playChime(): void {
   play("chime");
   setTimeout(() => play("chime"), CHIME_REPEAT_MS);
 }
-/** Urgent warble — an order is past the serving-time target. */
-export function playAlarm(): void { play("alarm"); }
+/** Urgent warble — an order is past the serving-time target. Same rapid-fire
+ *  guard as the chime: the legit re-sound cadence is minutes apart, so 1.5s
+ *  never blocks a real alarm but stops any runaway loop from machine-gunning. */
+let lastAlarmAt = 0;
+export function playAlarm(): void {
+  const now = Date.now();
+  if (now - lastAlarmAt < CHIME_MIN_GAP_MS) return;
+  lastAlarmAt = now;
+  play("alarm");
+}
 
 // Back-compat alias (use-order-chime imports primeChime).
 export const primeChime = primeSounds;

--- a/apps/pos-native/lib/use-order-chime.ts
+++ b/apps/pos-native/lib/use-order-chime.ts
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useState } from "react";
 import { supabase } from "./supabase";
 import { playChime, primeChime } from "./chime";
 
@@ -30,11 +30,22 @@ const GRAB_ACTIONABLE = new Set(["sent_to_kitchen", "preparing", "ready"]);
 
 type ChangeRow = { id?: string; status?: string; source?: string } | undefined;
 
+// MODULE-LEVEL dedup — survives a screen REMOUNT. A per-component ref reset on
+// every remount of the register, which let a SINGLE order re-chime on each later
+// Realtime event (Grab orders get many Push-Order-State updates) → the chime
+// "looped". A module set is the source of truth for "already rang this order".
+// Capped so it can't grow unbounded over a long shift.
+const chimedIds = new Set<string>();
+function markChimedOnce(id: string): boolean {
+  if (chimedIds.has(id)) return false;
+  chimedIds.add(id);
+  if (chimedIds.size > 1000) {
+    for (const old of [...chimedIds].slice(0, 500)) chimedIds.delete(old);
+  }
+  return true;
+}
+
 export function useOrderChime(outletId: string | null | undefined) {
-  // Order ids already chimed this session → never chime the same order twice
-  // (an order INSERTs pending then UPDATEs to paid; only the first actionable
-  // event rings).
-  const chimedRef = useRef<Set<string>>(new Set());
   const [storeId, setStoreId] = useState<string | null>(null);
 
   // POS outlet → pickup store_id (same mapping the printers / orders-panel use).
@@ -61,8 +72,7 @@ export function useOrderChime(outletId: string | null | undefined) {
       const id = row?.id;
       const status = row?.status;
       if (!id || !status || !actionable.has(status)) return;
-      if (chimedRef.current.has(id)) return;
-      chimedRef.current.add(id);
+      if (!markChimedOnce(id)) return; // already rang this order (even before a remount)
       playChime();
     };
 

--- a/apps/pos-native/lib/use-serving-alarm.ts
+++ b/apps/pos-native/lib/use-serving-alarm.ts
@@ -40,14 +40,21 @@ function pickOverdue(items: ServingItem[], now: number): ServingItem[] {
 
 const idKey = (list: ServingItem[]) => list.map((o) => o.id).sort().join("|");
 
+// MODULE-LEVEL state — survives a screen REMOUNT. Held in per-component useRefs
+// before, which reset on every remount of the register: each remount then saw
+// every still-overdue order as "new" and re-sounded the alarm immediately (same
+// remount-reset bug as the new-order chime loop). Persisting them means a
+// remount no longer re-alarms an order we've already sounded for; the 5-min
+// REPEAT_MS cadence still drives the ongoing nag.
+let servingPrevOverdue = new Set<string>();
+let servingLastAlarmAt = 0;
+
 /** Returns the orders currently past the serving target (for a popup) and
  *  sounds the alarm while any remain. */
 export function useServingAlarm(items: ServingItem[]): ServingItem[] {
   // Always read the latest items inside the interval without re-arming it.
   const itemsRef = useRef<ServingItem[]>(items);
   itemsRef.current = items;
-  const lastAlarmRef = useRef(0);
-  const prevOverdueRef = useRef<Set<string>>(new Set());
   const [overdue, setOverdue] = useState<ServingItem[]>([]);
 
   const evaluate = useCallback(() => {
@@ -55,11 +62,13 @@ export function useServingAlarm(items: ServingItem[]): ServingItem[] {
     const od = pickOverdue(itemsRef.current, now);
     // An order that wasn't overdue a moment ago → ring straight away (don't
     // wait out the repeat window). Otherwise re-ring only every REPEAT_MS.
-    const hasNew = od.some((o) => !prevOverdueRef.current.has(o.id));
-    prevOverdueRef.current = new Set(od.map((o) => o.id));
+    // "new" is judged against MODULE state so a remount doesn't make every
+    // already-overdue order look new and re-alarm.
+    const hasNew = od.some((o) => !servingPrevOverdue.has(o.id));
+    servingPrevOverdue = new Set(od.map((o) => o.id));
     setOverdue((prev) => (idKey(prev) === idKey(od) ? prev : od)); // avoid no-op re-renders
-    if (od.length > 0 && (hasNew || now - lastAlarmRef.current >= REPEAT_MS)) {
-      lastAlarmRef.current = now;
+    if (od.length > 0 && (hasNew || now - servingLastAlarmAt >= REPEAT_MS)) {
+      servingLastAlarmAt = now;
       playAlarm();
     }
   }, []);


### PR DESCRIPTION
## Bug
Order alert sounds **looped** — first reported on Grab orders, then confirmed on **table/QR orders** too. So it's not channel-specific.

## Root cause (one bug class, two instances)
Both alert hooks kept their "already fired for this order" dedup state in a **per-component `useRef`**, which **resets on every remount** of the register screen. Orders that emit multiple Realtime updates over time (Grab Push-Order-State; table/pickup status changes) then re-fired after each remount → loop.

## Fixes (both JS-only → ship OTA)
1. **New-order chime** (`useOrderChime`) — dedup moved to a **module-level Set** (survives remounts, capped at 1000). An order chimes **exactly once, ever**, across grab / pickup / **table-QR**.
2. **Serving alarm** (`useServingAlarm`) — `prevOverdue` + `lastAlarm` moved to **module scope**, so a remount no longer treats every still-overdue order as new and re-alarms. The 5-min `REPEAT_MS` nag cadence is unchanged.
3. **Rapid-fire guard** (1.5s) added to both `playChime()` and `playAlarm()` as defence-in-depth — the legit cadences are seconds/minutes apart, so it only stops a runaway loop.

## QA — full blast radius checked
- **Chime**: covers grab, pickup, **and table/QR** (shared dedup). ✅
- **Serving alarm**: pickup + table. ✅
- **Auto-printers** (grab + pickup): **safe** — dedup is DB-backed (`kitchen_docket_printed_at` atomic claim), not an in-memory ref, so a remount can't reprint. ✅ (no change needed)

## Test plan
- [x] No new type errors in changed files (CI typecheck-native covers full deps)
- [ ] Grab/table/pickup order → exactly one chime, even across register remounts + further status updates
- [ ] An overdue table/pickup order → alarm sounds on the 5-min cadence, NOT repeatedly on remount

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SXF3GNPYGpZzwMWy9AR9DV