### PR TITLE
fix(pos-native): serving alarm dedupe — accumulate ids so a list refresh can't re-fire

### DIFF
--- a/apps/pos-native/lib/use-serving-alarm.ts
+++ b/apps/pos-native/lib/use-serving-alarm.ts
@@ -40,13 +40,17 @@ function pickOverdue(items: ServingItem[], now: number): ServingItem[] {
 
 const idKey = (list: ServingItem[]) => list.map((o) => o.id).sort().join("|");
 
-// MODULE-LEVEL state — survives a screen REMOUNT. Held in per-component useRefs
-// before, which reset on every remount of the register: each remount then saw
-// every still-overdue order as "new" and re-sounded the alarm immediately (same
-// remount-reset bug as the new-order chime loop). Persisting them means a
-// remount no longer re-alarms an order we've already sounded for; the 5-min
-// REPEAT_MS cadence still drives the ongoing nag.
-let servingPrevOverdue = new Set<string>();
+// MODULE-LEVEL state — survives a screen REMOUNT (a per-component ref reset on
+// every remount, making every still-overdue order look "new" → re-alarm).
+//
+// servingAlarmedIds ACCUMULATES the ids we've already sounded the first overdue
+// alarm for; it is NOT reset to the current overdue set each tick. That matters:
+// an orders/tables reload can briefly drop an overdue order from the list and
+// re-add it — keying "new" off "overdue last tick" would re-alarm on that flap.
+// Served orders get fresh uuids and never reappear, so never re-alarming a known
+// id is correct; the 5-min REPEAT_MS cadence still drives the ongoing nag.
+// Capped so it can't grow unbounded over a long shift.
+const servingAlarmedIds = new Set<string>();
 let servingLastAlarmAt = 0;
 
 /** Returns the orders currently past the serving target (for a popup) and
@@ -60,17 +64,22 @@ export function useServingAlarm(items: ServingItem[]): ServingItem[] {
   const evaluate = useCallback(() => {
     const now = Date.now();
     const od = pickOverdue(itemsRef.current, now);
-    // An order that wasn't overdue a moment ago → ring straight away (don't
-    // wait out the repeat window). Otherwise re-ring only every REPEAT_MS.
-    // "new" is judged against MODULE state so a remount doesn't make every
-    // already-overdue order look new and re-alarm.
-    const hasNew = od.some((o) => !servingPrevOverdue.has(o.id));
-    servingPrevOverdue = new Set(od.map((o) => o.id));
+    // An order we've NEVER alarmed for → ring straight away (don't wait out the
+    // repeat window). Judged against the accumulating module set, so neither a
+    // remount nor a transient list refresh re-triggers a "first" alarm.
+    const hasNew = od.some((o) => !servingAlarmedIds.has(o.id));
+    for (const o of od) servingAlarmedIds.add(o.id);
+    if (servingAlarmedIds.size > 1000) {
+      for (const old of [...servingAlarmedIds].slice(0, 500)) servingAlarmedIds.delete(old);
+    }
     setOverdue((prev) => (idKey(prev) === idKey(od) ? prev : od)); // avoid no-op re-renders
     if (od.length > 0 && (hasNew || now - servingLastAlarmAt >= REPEAT_MS)) {
       servingLastAlarmAt = now;
       playAlarm();
     }
+    // Note: servingAlarmedIds intentionally keeps served orders' ids until the
+    // cap evicts them — re-adding the same id can't happen (uuids are unique),
+    // so a served order is never re-alarmed.
   }, []);
 
   useEffect(() => {


### PR DESCRIPTION
## QA re-check of the alarm dedupe (follow-up to #334)

#334 made both alert hooks remount-proof. Re-reviewing the dedupe, the **chime is solid** (accumulating, capped set), but the **serving alarm had a residual flap**:

```js
const hasNew = od.some((o) => !servingPrevOverdue.has(o.id));
servingPrevOverdue = new Set(od.map((o) => o.id));   // reset to THIS tick's overdue set
```

It judged "newly overdue" against **the previous tick's overdue set**. An orders/tables **reload that briefly drops an overdue order and re-adds it** would reset that diff → the order looks "new" again → **re-alarm**. (Pre-existing; the remount fix didn't touch this.)

## Fix
Switch to an **accumulating, capped id set** (`servingAlarmedIds`) — same pattern as the new-order chime. An order's first-overdue alarm fires **once** and is never re-triggered by a remount *or* a transient list refresh. Served orders use fresh uuids and never reappear, so never re-alarming a known id is correct; the **5-min `REPEAT_MS` nag cadence is unchanged**.

## Dedupe status after this
| Alert | Dedupe | Remount-safe | Flap-safe |
|---|---|---|---|
| New-order chime | accumulating capped set | ✅ | ✅ |
| Serving alarm | **now** accumulating capped set | ✅ | ✅ (this PR) |

JS-only → ships OTA.

## Test plan
- [x] No new type errors (CI typecheck-native covers full deps)
- [ ] Overdue table/pickup order whose list reloads (60s poll / Realtime) → alarm does NOT re-fire on the refresh; still nags on the 5-min cadence; stops when actioned

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SXF3GNPYGpZzwMWy9AR9DV

---
_Generated by [Claude Code](https://claude.ai/code/session_01SXF3GNPYGpZzwMWy9AR9DV)_