### PR TITLE
feat(finance): scope RM settlement sync per store

### DIFF
--- a/apps/order/src/app/api/cron/sync-rm-payouts/route.ts
+++ b/apps/order/src/app/api/cron/sync-rm-payouts/route.ts
@@ -10,6 +10,7 @@ import {
   getDailySettlementReport,
   parseSettlementCsv,
   SETTLEMENT_METHODS,
+  SETTLEMENT_STORES,
   type SettlementLine,
 } from "@/lib/revenue-monster/client";
 
@@ -52,17 +53,31 @@ export async function GET(request: NextRequest) {
   const p = request.nextUrl.searchParams;
 
   // ── Probe: one call, raw + parsed, no DB writes. Fail-fast endpoint check. ──
+  // ?storeId=<rm store id> scopes to one store; ?store=conezion|shah-alam|tamarind
+  // resolves via SETTLEMENT_STORES. ?allStores=true sweeps all three.
   if (p.get("probe") === "true") {
     const date = p.get("date") || mytDate(7);
     const method = p.get("method") || "FPX_MY";
-    const r = await getDailySettlementReport({ date, method, sequence: 1 });
-    const parsed = parseSettlementCsv(r.body);
-    return NextResponse.json({
-      probe: { date, method },
-      http: { ok: r.ok, status: r.status, bodyLength: r.body.length },
-      bodyHead: r.body.slice(0, 3000),
-      parsed: { lineCount: parsed.lines.length, grossSen: parsed.grossSen, mdrSen: parsed.mdrSen, netSen: parsed.netSen, sample: parsed.lines.slice(0, 3) },
-    });
+    const storeParam = p.get("store");
+    const explicitStoreId = p.get("storeId")
+      || (storeParam ? SETTLEMENT_STORES.find((s) => s.slug === storeParam)?.storeId : undefined);
+
+    const targets = p.get("allStores") === "true"
+      ? SETTLEMENT_STORES.map((s) => ({ label: s.slug, storeId: s.storeId }))
+      : [{ label: storeParam || "default", storeId: explicitStoreId }];
+
+    const out = [];
+    for (const t of targets) {
+      const r = await getDailySettlementReport({ date, method, sequence: 1, storeId: t.storeId });
+      const parsed = parseSettlementCsv(r.body);
+      out.push({
+        store: t.label, storeId: t.storeId ?? null,
+        http: { ok: r.ok, status: r.status, bodyLength: r.body.length },
+        bodyHead: r.body.slice(0, 2500),
+        parsed: { lineCount: parsed.lines.length, grossSen: parsed.grossSen, netSen: parsed.netSen, sample: parsed.lines.slice(0, 3) },
+      });
+    }
+    return NextResponse.json({ probe: { date, method }, results: out });
   }
 
   // ── Determine the date window ──

--- a/apps/order/src/lib/revenue-monster/client.ts
+++ b/apps/order/src/lib/revenue-monster/client.ts
@@ -524,10 +524,21 @@ export const SETTLEMENT_METHODS: string[] = [
   "FPX_MY", "TNG_MY", "BOOST_MY", "SHOPEEPAY_MY", "GRABPAY_MY", "DUITNOW_MY", "CARD",
 ];
 
+// The active per-outlet RM stores to pull settlement for. The bare
+// settlement call (no storeId) only returns the merchant's default store —
+// a legacy "Celsius Coffee SDN BHD" record with no transaction volume — so
+// the sync iterates these explicitly. slug = our orders.store_id.
+export const SETTLEMENT_STORES: { slug: string; storeId: string; entity: string }[] = [
+  { slug: "shah-alam", storeId: PROD_STORE_MAP["shah-alam"], entity: "Celsius Coffee Sdn Bhd" },
+  { slug: "conezion",  storeId: PROD_STORE_MAP["conezion"],  entity: "Celsius Coffee Conezion Sdn Bhd" },
+  { slug: "tamarind",  storeId: PROD_STORE_MAP["tamarind"],  entity: "Celsius Coffee Tamarind Sdn Bhd" },
+];
+
 export interface SettlementParams {
   date: string;        // "YYYY-MM-DD"
   method: string;      // an RM method code from SETTLEMENT_METHODS
   sequence?: number;   // settlement batch sequence within the day (default 1)
+  storeId?: string;    // RM store id to scope the settlement to (see SETTLEMENT_STORES)
 }
 
 // Raw fetch of the settlement report. Returns the response body as text — RM may
@@ -539,7 +550,10 @@ export async function getDailySettlementReport(
 ): Promise<{ ok: boolean; status: number; body: string }> {
   const token     = await getToken();
   const endpoint  = `${BASE_URL}/v3/payment/settlement/csv`;
-  const body      = { date: params.date, method: params.method, region: "MALAYSIA", sequence: params.sequence ?? 1 };
+  const body: Record<string, unknown> = { date: params.date, method: params.method, region: "MALAYSIA", sequence: params.sequence ?? 1 };
+  // Scope to a specific store when given — the bare call only returns the
+  // merchant default store (empty). Probing whether RM honours storeId here.
+  if (params.storeId) body.storeId = params.storeId;
   const nonceStr  = nonce();
   const timestamp = String(Math.floor(Date.now() / 1000));
   const sig       = buildSignature("POST", endpoint, nonceStr, timestamp, body);


### PR DESCRIPTION
Follow-up to #333. The bare settlement call returns only the merchant default store (legacy 'Celsius Coffee SDN BHD', zero volume) — verified via prod probe. This adds an optional `storeId` to the settlement request + `SETTLEMENT_STORES` (the 3 active outlet stores), and lets the cron probe scope per store to test whether RM honours `storeId` and to capture the real transaction-row CSV format. Sync loop unchanged this step (read-only probe first). Additive/low-risk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)