### PR TITLE
fix(pos-native): serving alarm — silence on action + cover all order types (add Grab)

### DIFF
--- a/apps/pos-native/app/register.tsx
+++ b/apps/pos-native/app/register.tsx
@@ -284,19 +284,28 @@ export default function Register() {
   // Mounted persistently so it keeps catching up + receiving Realtime even
   // while the modal is closed (drives the header badge count).
   const { orders: kdsOrders, reload: reloadOrders } = useOrdersPanel(outletId);
-  // Serving-time alarm candidates: pickup orders not yet "ready" + QR-table
-  // orders not yet "done". Pressing Ready/Done drops the order from these
-  // lists, which silences the alarm for it. (Grab runs to its own SLA.)
+  // Serving-time alarm candidates — ALL fulfilment-wait order types:
+  //   pickup + Grab orders not yet "ready", QR-table orders not yet "done".
+  // (Register/counter sales complete the instant they're rung up, so they're
+  // never live here.) Pressing Ready/Done drops the order from these lists AND
+  // calls silenceServingAlarmOrder() on its id, which silences the alarm at
+  // once. Grab orders carry uid `grab:<id>` — the same id advanceStatus()
+  // silences when "ready" is pressed, so the dedupe path lines up.
   const servingAlarmItems = useMemo<ServingItem[]>(() => {
-    const pickup = kdsOrders
-      .filter((o) => o.source === "pickup" && o.status !== "ready")
-      .map((o) => ({ id: o.uid, createdAt: o.createdAt, channel: "pickup" as const, label: o.orderNumber }));
+    const online = kdsOrders
+      .filter((o) => o.status !== "ready")
+      .map((o) => ({
+        id: o.uid,
+        createdAt: o.createdAt,
+        channel: (o.source === "grab" ? "grab" : "pickup") as "grab" | "pickup",
+        label: o.orderNumber,
+      }));
     const tables = tableSlots.flatMap((s) =>
       s.orders
         .filter((o) => o.source === "qr")
         .map((o) => ({ id: o.id, createdAt: o.createdAt, channel: "table" as const, label: s.label })),
     );
-    return [...pickup, ...tables];
+    return [...online, ...tables];
   }, [kdsOrders, tableSlots]);
   // Orders past the 15-min serving target → drives the alarm sound + the popup.
   const overdueOrders = useServingAlarm(servingAlarmItems);
@@ -369,9 +378,10 @@ export default function Register() {
     // the shift closed — so a close can never freeze a customer's in-progress
     // order. (Ringing up a NEW sale still requires the store open; see onAdd.)
     setBumpingUid(order.uid);
-    // Pickup orders leave the serving alarm at "ready" — silence immediately so
-    // the alarm stops on tap, not after the orders list refreshes. (Grab uids
-    // aren't in the serving set, so silencing them is a harmless no-op.)
+    // Pickup AND Grab orders leave the serving alarm at "ready" — silence
+    // immediately on tap (keyed by uid `<source>:<id>`, which is exactly the id
+    // servingAlarmItems registers), so the alarm stops at once rather than after
+    // the orders list refreshes / a dropped Realtime event.
     if (status === "ready") silenceServingAlarmOrder(order.uid);
     console.log(`[order-status] tap ${order.source} ${order.orderNumber} -> ${status}`);
     try {
@@ -2198,8 +2208,8 @@ export default function Register() {
                 return (
                   <View key={o.id} className="flex-row items-center justify-between rounded-2xl px-4 py-3" style={{ backgroundColor: "rgba(194,69,45,0.14)" }}>
                     <View className="flex-row items-center gap-3">
-                      <View className="rounded-lg px-2 py-1" style={{ backgroundColor: o.channel === "table" ? "#3B82F6" : "#FBBF24" }}>
-                        <Text className="text-[11px]" style={{ fontFamily: "SpaceGrotesk_700Bold", color: "#160800" }}>{o.channel === "table" ? "TABLE" : "PICKUP"}</Text>
+                      <View className="rounded-lg px-2 py-1" style={{ backgroundColor: o.channel === "table" ? "#3B82F6" : o.channel === "grab" ? "#00B14F" : "#FBBF24" }}>
+                        <Text className="text-[11px]" style={{ fontFamily: "SpaceGrotesk_700Bold", color: o.channel === "grab" ? "#FFFFFF" : "#160800" }}>{o.channel === "table" ? "TABLE" : o.channel === "grab" ? "GRAB" : "PICKUP"}</Text>
                       </View>
                       <Text className="text-cream text-lg" style={{ fontFamily: "SpaceGrotesk_700Bold" }}>{o.label}</Text>
                     </View>

--- a/apps/pos-native/app/register.tsx
+++ b/apps/pos-native/app/register.tsx
@@ -35,7 +35,7 @@ import { usePrintPrefs } from "@/lib/print-prefs";
 import { useTablesPanel, type TableSlot, type TableOrderRef } from "@/lib/use-tables-panel";
 import { useOrdersPanel, type KdsOrder } from "@/lib/use-orders-panel";
 import { useOrderChime } from "@/lib/use-order-chime";
-import { useServingAlarm, type ServingItem } from "@/lib/use-serving-alarm";
+import { useServingAlarm, silenceServingAlarmOrder, type ServingItem } from "@/lib/use-serving-alarm";
 import { useOrderHistory, type HistoryOrder, type HistoryChannel } from "@/lib/use-order-history";
 import { useShift, openShift, closeShift, reopenShift, findRecentClosedShift, shiftTotals, type Shift, type ShiftTotals } from "@/lib/shift";
 import { printReceipt80mm, printKitchenDocket80mm } from "@/lib/printer";
@@ -369,6 +369,10 @@ export default function Register() {
     // the shift closed — so a close can never freeze a customer's in-progress
     // order. (Ringing up a NEW sale still requires the store open; see onAdd.)
     setBumpingUid(order.uid);
+    // Pickup orders leave the serving alarm at "ready" — silence immediately so
+    // the alarm stops on tap, not after the orders list refreshes. (Grab uids
+    // aren't in the serving set, so silencing them is a harmless no-op.)
+    if (status === "ready") silenceServingAlarmOrder(order.uid);
     console.log(`[order-status] tap ${order.source} ${order.orderNumber} -> ${status}`);
     try {
       const res = await apiPost<{ ok?: boolean; grabPushed?: boolean }>("/api/pos/order-status", { source: order.source, id: order.id, status });
@@ -393,6 +397,9 @@ export default function Register() {
     // Not gated on store-open — see advanceOrderStatus: a table order must be
     // serve-able / clearable even after the shift closed.
     setBumpingUid(`qr:${order.id}`);
+    // Silence the serving alarm for this order AT ONCE — before the network
+    // round-trip — so it stops even if the tables list is slow to refresh.
+    silenceServingAlarmOrder(order.id);
     try {
       await apiPost("/api/pos/order-status", { source: "qr", id: order.id, status: "completed" });
       Haptics.notificationAsync(Haptics.NotificationFeedbackType.Success);

--- a/apps/pos-native/lib/use-serving-alarm.ts
+++ b/apps/pos-native/lib/use-serving-alarm.ts
@@ -7,6 +7,7 @@ import { playAlarm, primeSounds } from "./chime";
  * past the serving-time TARGET without being actioned:
  *
  *   - pickup order → "Ready" not pressed within 15 min
+ *   - Grab order   → "Ready" not pressed within 15 min
  *   - QR table     → "Done"  not pressed within 15 min
  *
  * The caller passes the currently-open serving items (already filtered to "not
@@ -27,7 +28,7 @@ const REPEAT_MS = 5 * 60 * 1000;                 // re-sound at most every 5 min
 export type ServingItem = {
   id: string;
   createdAt: string;
-  channel: "pickup" | "table";
+  channel: "pickup" | "grab" | "table";
   label: string; // order number ("C-1234") or table label ("T5")
 };
 

--- a/apps/pos-native/lib/use-serving-alarm.ts
+++ b/apps/pos-native/lib/use-serving-alarm.ts
@@ -33,12 +33,29 @@ export type ServingItem = {
 
 function pickOverdue(items: ServingItem[], now: number): ServingItem[] {
   return items.filter((o) => {
+    if (silencedIds.has(o.id)) return false; // cashier already actioned it
     const t = new Date(o.createdAt).getTime();
     return Number.isFinite(t) && now - t > SERVING_TARGET_MS;
   });
 }
 
 const idKey = (list: ServingItem[]) => list.map((o) => o.id).sort().join("|");
+
+// Orders the cashier has ALREADY actioned (Done / Ready). Silenced immediately
+// on tap so the alarm + popup stop AT ONCE — without waiting for the orders/
+// tables list to refresh. That refresh can lag or be missed (dropped Realtime),
+// which is what left a "done" order still sounding the serving alarm. Module-
+// level (survives remounts) + capped. Order ids are unique uuids, so a silenced
+// id can never suppress a future order.
+const silencedIds = new Set<string>();
+/** Stop the serving alarm for an order the moment it's actioned (Done/Ready). */
+export function silenceServingAlarmOrder(id: string | null | undefined): void {
+  if (!id) return;
+  silencedIds.add(id);
+  if (silencedIds.size > 1000) {
+    for (const old of [...silencedIds].slice(0, 500)) silencedIds.delete(old);
+  }
+}
 
 // MODULE-LEVEL state — survives a screen REMOUNT (a per-component ref reset on
 // every remount, making every still-overdue order look "new" → re-alarm).


### PR DESCRIPTION
## Bug 1 — alarm kept sounding after Done
Table 13 (QR dine-in): cashier pressed **Done**, but the serving alarm kept sounding.

### Diagnosis
- The order **did** flip to `completed` in the DB (verified). So the status update works.
- The serving alarm's **table candidates had no status filter** — unlike pickup (`status !== "ready"`), the table list was just `source === "qr"` and relied entirely on the order **dropping from `tableSlots`**.
- `tableSlots` drops done orders via a post-action `reloadTables()`, but if that reload lags or a **Realtime event is dropped** (flaky venue Wi-Fi), the completed order lingers locally → the alarm keeps nagging on its 5-min cadence even though it's done.

### Fix
Silence an order's serving alarm **the instant it's actioned**, independent of any list refresh:
- New `silenceServingAlarmOrder(id)` (module-level, capped, remount-proof) consulted by `pickOverdue`.
- Wired into `markTableOrderDone` (QR table → `order.id`) and the **"ready"** path (`order.uid`).
- Order ids are unique uuids, so a silenced id can never suppress a future order.

## Bug 2 — serving alarm should cover ALL fulfilment-wait orders
Per ops: chime = online orders only (already the case); **serving alarm should fire for every order type that waits on fulfilment**. Previously Grab was excluded ("runs to Grab's own SLA"), so only pickup + QR-table alarmed.

### Fix
- `servingAlarmItems` now includes **Grab** live orders (not yet `ready`), mapped to a new `"grab"` channel, alongside pickup + QR-table.
- Grab orders carry uid `grab:<id>` — the **same id** `advanceOrderStatus()` already passes to `silenceServingAlarmOrder()` when **Ready** is pressed — so the silence/dedupe path lines up with no extra wiring.
- Overdue popup shows a distinct **GRAB** badge (green).
- Register/counter sales complete the instant they're rung up → never live candidates, no change needed.

JS-only → ships OTA.

## Test plan
- [x] No new type errors in changed files (CI typecheck-native covers full deps)
- [ ] Overdue QR table order → **Done** → alarm + popup stop immediately, even with the tables list slow to refresh / Realtime dropped
- [ ] Overdue pickup order → **Ready** → same
- [ ] Overdue **Grab** order → **Ready** → alarm + popup stop immediately; GRAB badge shows in the popup
- [ ] A *different* still-overdue order keeps alarming (only the actioned one is silenced)

🤖 Generated with [Claude Code](https://claude.com/claude-code)