### PR TITLE
fix(sales): one source of truth for week/month periods (calendar week)

### DIFF
--- a/apps/backoffice/src/app/api/sales/dashboard/route.ts
+++ b/apps/backoffice/src/app/api/sales/dashboard/route.ts
@@ -20,6 +20,7 @@ import {
 } from "../_lib/storehub-helpers";
 import { getUnifiedSalesForOutlet, type UnifiedSale } from "../_lib/unified-sales";
 import { getActiveTargets } from "../_lib/targets";
+import { startOfWeekMYT, startOfMonthMYT } from "@celsius/shared";
 
 // ─── GET /api/sales/dashboard ────────────────────────────────────────────
 
@@ -64,15 +65,14 @@ export async function GET(request: NextRequest) {
       fromDate = d.toISOString().split("T")[0];
       toDate = todayMYT;
     } else if (period === "weekly") {
-      // Last 7 days including today
-      const d = new Date(mytNow);
-      d.setDate(d.getDate() - 6);
-      fromDate = d.toISOString().split("T")[0];
+      // Calendar week to date (Sunday-start, MYT) — shared definition so the
+      // headline, the comparison chart, and the staff app all mean the same
+      // "this week". (Was a trailing-7-day window, which disagreed with both.)
+      fromDate = startOfWeekMYT(todayMYT);
       toDate = todayMYT;
     } else if (period === "monthly") {
-      // Current month
-      const d = new Date(mytNow.getUTCFullYear(), mytNow.getUTCMonth(), 1);
-      fromDate = d.toISOString().split("T")[0];
+      // Calendar month to date (MYT).
+      fromDate = startOfMonthMYT(todayMYT);
       toDate = todayMYT;
     } else {
       // daily — today only

--- a/apps/staff/src/app/api/sales/_lib/sales-helpers.ts
+++ b/apps/staff/src/app/api/sales/_lib/sales-helpers.ts
@@ -5,6 +5,8 @@
  * Day boundaries + dayparts are MYT (UTC+8, no DST).
  */
 
+import { dowMYT, startOfMonthMYT, endOfMonthMYT } from "@celsius/shared";
+
 // ─── MYT time ──────────────────────────────────────────────────────────────
 export function getMYTToday(): string {
   return new Date(Date.now() + 8 * 60 * 60 * 1000).toISOString().split("T")[0];
@@ -36,17 +38,18 @@ export function addDays(dateStr: string, n: number): string {
   d.setDate(d.getDate() + n);
   return d.toISOString().split("T")[0];
 }
+// Week/month boundaries come from @celsius/shared so the staff dashboard,
+// the backoffice headline, and the comparison chart share ONE definition of
+// "this week" (calendar week, Sun-start) and "this month". These thin wrappers
+// keep the local call sites unchanged.
 export function dayOfWeek(dateStr: string): number {
-  return new Date(`${dateStr}T12:00:00+08:00`).getDay(); // 0=Sun
+  return dowMYT(dateStr); // 0=Sun
 }
 export function monthStart(dateStr: string): string {
-  const d = new Date(`${dateStr}T12:00:00+08:00`);
-  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-01`;
+  return startOfMonthMYT(dateStr);
 }
 export function monthEnd(dateStr: string): string {
-  const d = new Date(`${dateStr}T12:00:00+08:00`);
-  const last = new Date(d.getFullYear(), d.getMonth() + 1, 0);
-  return `${last.getFullYear()}-${String(last.getMonth() + 1).padStart(2, "0")}-${String(last.getDate()).padStart(2, "0")}`;
+  return endOfMonthMYT(dateStr);
 }
 export function daysBetween(from: string, to: string): number {
   const a = new Date(`${from}T12:00:00+08:00`);

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -194,3 +194,15 @@ export { scrubSecrets, scrubSentryEvent } from "./sentry-scrub";
 
 // ─── Startup env validation ─────────────────────────
 export { validateEnv, formatEnvReport, checkEnvAtBoot, type EnvSpec, type EnvProblems, type EnvCheckResult } from "./env";
+
+// ─── Sales period definitions (one source of truth for "this week/month") ───
+export {
+  mytToday,
+  dowMYT,
+  addDaysMYT,
+  startOfWeekMYT,
+  startOfMonthMYT,
+  endOfMonthMYT,
+  salesPeriodRange,
+} from "./sales-periods";
+export type { SalesMode, SalesRange } from "./sales-periods";

--- a/packages/shared/src/sales-periods.ts
+++ b/packages/shared/src/sales-periods.ts
@@ -1,0 +1,86 @@
+// Single source of truth for what "this week" / "this month" mean across the
+// sales surfaces — backoffice headline (/api/sales/dashboard), the backoffice
+// comparison chart, and the staff-native dashboard. Keep ONE definition here so
+// the three can never drift again (they previously did: the backoffice headline
+// used a trailing-7-day window while the chart + staff used a calendar week).
+//
+// All boundaries are MYT (UTC+8, no DST). The calendar week starts SUNDAY.
+// Helpers operate on YYYY-MM-DD strings and are timezone-safe regardless of the
+// server's local TZ (anchored at noon MYT = 04:00 UTC, same calendar day).
+
+/** Today's date as YYYY-MM-DD in MYT. */
+export function mytToday(now: Date = new Date()): string {
+  return new Date(now.getTime() + 8 * 3600 * 1000).toISOString().slice(0, 10);
+}
+
+/** Day of week in MYT for a YYYY-MM-DD date. 0 = Sunday … 6 = Saturday. */
+export function dowMYT(dateStr: string): number {
+  return new Date(`${dateStr}T12:00:00+08:00`).getUTCDay();
+}
+
+/** Add n calendar days to a YYYY-MM-DD date (MYT-safe). */
+export function addDaysMYT(dateStr: string, n: number): string {
+  const d = new Date(`${dateStr}T12:00:00+08:00`); // = `date` 04:00 UTC
+  d.setUTCDate(d.getUTCDate() + n);
+  return d.toISOString().slice(0, 10);
+}
+
+/** Sunday of the calendar week containing `dateStr` (MYT). */
+export function startOfWeekMYT(dateStr: string): string {
+  return addDaysMYT(dateStr, -dowMYT(dateStr));
+}
+
+/** First day of the calendar month containing `dateStr`. */
+export function startOfMonthMYT(dateStr: string): string {
+  return `${dateStr.slice(0, 7)}-01`;
+}
+
+/** Last day of the calendar month containing `dateStr`. */
+export function endOfMonthMYT(dateStr: string): string {
+  const [y, m] = dateStr.split("-").map(Number);
+  const last = new Date(Date.UTC(y, m, 0)).getUTCDate(); // day 0 of next month
+  return `${dateStr.slice(0, 7)}-${String(last).padStart(2, "0")}`;
+}
+
+export type SalesMode = "day" | "week" | "month" | "custom";
+export type SalesRange = { from: string; to: string };
+
+/**
+ * Canonical current + previous period for a sales mode, as MYT YYYY-MM-DD
+ * ranges. Week = calendar week (Sun-start) to date; Month = calendar month to
+ * date; Day = today. The previous period is the equivalent calendar period
+ * immediately before (callers apply their own same-elapsed cutoff for
+ * like-for-like headline deltas).
+ */
+export function salesPeriodRange(
+  mode: SalesMode,
+  todayStr: string = mytToday(),
+  from?: string | null,
+  to?: string | null,
+): { cur: SalesRange; prev: SalesRange } {
+  if (mode === "week") {
+    const sun = startOfWeekMYT(todayStr);
+    return {
+      cur: { from: sun, to: todayStr },
+      prev: { from: addDaysMYT(sun, -7), to: addDaysMYT(sun, -1) },
+    };
+  }
+  if (mode === "month") {
+    const ms = startOfMonthMYT(todayStr);
+    const prevEnd = addDaysMYT(ms, -1);
+    return {
+      cur: { from: ms, to: todayStr },
+      prev: { from: startOfMonthMYT(prevEnd), to: prevEnd },
+    };
+  }
+  if (mode === "custom" && from && to) {
+    const f = from <= to ? from : to;
+    const t = from <= to ? to : from;
+    const span = Math.round(
+      (new Date(`${t}T12:00:00+08:00`).getTime() - new Date(`${f}T12:00:00+08:00`).getTime()) / 86_400_000,
+    );
+    return { cur: { from: f, to: t }, prev: { from: addDaysMYT(f, -(span + 1)), to: addDaysMYT(f, -1) } };
+  }
+  // day
+  return { cur: { from: todayStr, to: todayStr }, prev: { from: addDaysMYT(todayStr, -1), to: addDaysMYT(todayStr, -1) } };
+}


### PR DESCRIPTION
## Problem
QA of the sales dashboards found staff-native and the backoffice headline showing different "This Week" totals. Root cause: **three surfaces defined the week window differently** (the aggregation is identical):

| Surface | "This Week" window | This Week total |
|---|---|---|
| Backoffice **headline** (`/api/sales/dashboard`) | trailing 7 days | ~RM69.5k |
| Backoffice **chart** (page → `/api/sales/compare`) | calendar week (Sun–Sat) | ~RM46.2k |
| **Staff-native** (`rangesForMode`) | calendar week (Sun–Sat) | ~RM46.2k |

So staff matched the backoffice *chart* but not its *headline*. The ~RM23k gap is Jun 12–13 (the Fri/Sat a trailing-7-day window includes but a calendar week doesn't). Verified per-outlet against the DB.

## Fix (per owner decision: calendar week + month)
- **New `@celsius/shared/sales-periods`** — the single definition of "this week" (calendar week, **Sunday-start**, MYT) and "this month" (calendar month-to-date), with tz-safe MYT date helpers + `salesPeriodRange()`.
- **backoffice `/api/sales/dashboard`** — `weekly` is now calendar-week-to-date (was trailing 7 days); `monthly` sourced from the same helper. **Headline now matches the chart + staff.**
- **staff `sales-helpers`** — `dayOfWeek`/`monthStart`/`monthEnd` delegate to the shared helpers so the definition lives in one place and can't drift again (staff output unchanged — it was already calendar week).

Month-to-date already agreed across surfaces; only the weekly window changes.

**Visible effect:** the backoffice "This Week" headline now reads calendar-week-to-date (~RM46.2k) instead of trailing-7-days (~RM69.5k) — matching its own chart and the staff app. Per-outlet canonical numbers (this week, Sun Jun 14→): Putrajaya 17,294.82 · Shah Alam 15,939.96 · Tamarind 12,933.95 · total 46,168.73.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Vj1dCLb24vyszqQujFg2kw)_