### PR TITLE
fix(pos-native): chime reliability — play cue to completion + self-apply OTA

### DIFF
--- a/apps/pos-native/app/_layout.tsx
+++ b/apps/pos-native/app/_layout.tsx
@@ -12,6 +12,7 @@ import * as SplashScreen from "expo-splash-screen";
 import * as SystemUI from "expo-system-ui";
 import * as NavigationBar from "expo-navigation-bar";
 import { useKeepAwake } from "expo-keep-awake";
+import { useOtaAutoUpdate } from "@/lib/use-ota-auto-update";
 import { useFonts } from "expo-font";
 import {
   SpaceGrotesk_400Regular,
@@ -68,6 +69,10 @@ function applyDefaultFont() {
 function RootLayout() {
   // Register hardware must never sleep mid-shift.
   useKeepAwake();
+
+  // Self-apply OTA fixes on foreground — the tills stay open for days, so
+  // without this a published fix never loads until a manual relaunch.
+  useOtaAutoUpdate();
 
   const [fontsLoaded] = useFonts({
     "Peachi-Bold": require("../assets/fonts/Peachi-Bold.otf"),

--- a/apps/pos-native/lib/chime.ts
+++ b/apps/pos-native/lib/chime.ts
@@ -86,28 +86,38 @@ export function primeSounds(): void {
  *  single play() can't overlap — native DeviceSpeaker restarts the MediaPlayer
  *  and the expo-audio path seeks to 0 — so we space them by the clip length).
  *  Works on both playback paths and ships over OTA, no asset/rebuild needed. */
-const CHIME_REPEAT_MS = 2500; // chime clip is ~2.40s; small gap before ring #2
-// Rapid-fire guard: coalesce chime triggers fired within this window into ONE
-// cue. Defence-in-depth against a runaway loop machine-gunning the speaker (the
-// intended double-ring below is scheduled via setTimeout→play, NOT playChime, so
-// it is never throttled). 1.5s is well under the gap between distinct orders.
-const CHIME_MIN_GAP_MS = 1500;
-let lastChimeAt = 0;
+const CHIME_CLIP_MS = 2400;   // chime.wav length (~2.40s)
+const CHIME_REPEAT_MS = 2700; // ring #2 — AFTER ring #1's clip has fully ended (was
+                              // 2500: with native prepare latency that could land
+                              // while ring #1 was still sounding and chop its tail).
+// A chime CUE is the two rings together — it occupies the speaker for the whole
+// span below. The native DeviceSpeaker drives ONE shared MediaPlayer and every
+// play() release()s it, so ANY trigger landing mid-cue restarts the clip and
+// chops the bell into a stutter — the "lagging / never-finishes" chime, heard
+// whenever orders arrive in a burst (Grab + pickup + table together). So we
+// reserve the full cue: a new trigger before it ends is dropped, not played.
+// Bursts coalesce into one CLEAN cue, which is all an audible alert needs.
+// (The intended ring #2 is scheduled via setTimeout→play, NOT playChime, so the
+// reservation never blocks the cue's own second ring.)
+const CHIME_CUE_MS = CHIME_REPEAT_MS + CHIME_CLIP_MS + 200; // both rings + prepare slack
+let chimeBusyUntil = 0;
 export function playChime(): void {
   const now = Date.now();
-  if (now - lastChimeAt < CHIME_MIN_GAP_MS) return;
-  lastChimeAt = now;
+  if (now < chimeBusyUntil) return; // a cue is still sounding — let it finish
+  chimeBusyUntil = now + CHIME_CUE_MS;
   play("chime");
   setTimeout(() => play("chime"), CHIME_REPEAT_MS);
 }
-/** Urgent warble — an order is past the serving-time target. Same rapid-fire
- *  guard as the chime: the legit re-sound cadence is minutes apart, so 1.5s
- *  never blocks a real alarm but stops any runaway loop from machine-gunning. */
-let lastAlarmAt = 0;
+/** Urgent warble — an order is past the serving-time target. Reserves the clip
+ *  duration so a re-trigger can't chop it mid-warble (same shared-MediaPlayer
+ *  hazard as the chime); the legit re-sound cadence is minutes apart, so this
+ *  never blocks a real alarm. */
+const ALARM_CLIP_MS = 2400; // alarm.wav length (~2.4s) — reserve so it plays in full
+let alarmBusyUntil = 0;
 export function playAlarm(): void {
   const now = Date.now();
-  if (now - lastAlarmAt < CHIME_MIN_GAP_MS) return;
-  lastAlarmAt = now;
+  if (now < alarmBusyUntil) return;
+  alarmBusyUntil = now + ALARM_CLIP_MS + 200;
   play("alarm");
 }
 

--- a/apps/pos-native/lib/use-ota-auto-update.ts
+++ b/apps/pos-native/lib/use-ota-auto-update.ts
@@ -1,0 +1,72 @@
+import { useEffect, useRef } from "react";
+import { AppState, type AppStateStatus } from "react-native";
+import * as Updates from "expo-updates";
+
+/**
+ * Self-applying OTA updates for the SUNMI tills.
+ *
+ * The problem this solves: `eas update` publishes JS/asset fixes to the
+ * `production` channel, but expo-updates only CHECKS for a new bundle on a cold
+ * app start by default. The registers stay open for days, so a published fix
+ * (e.g. the new-order chime dedup) never actually loads — the till keeps running
+ * the bundle it booted with. Staff experience: "you fixed it but it still
+ * happens."
+ *
+ * Here we check on every foreground (the screen waking after sleep is the
+ * natural, mid-shift-safe moment to swap the bundle — the till was idle, not
+ * mid-order) and, when a newer update has been fetched, reload into it. After
+ * this ships once, every future fix lands on the floor within seconds of a
+ * screen-wake with zero staff action.
+ *
+ * Fully crash-safe + gated: a no-op in dev / Expo Go / when updates are disabled
+ * (`Updates.isEnabled` false), so it can never interfere with development or the
+ * order/print path. Throttled so a flurry of foreground events can't hammer the
+ * update server.
+ */
+
+// Don't re-check more than this often — foreground events can fire in bursts
+// (system dialogs, the customer-display surface, lock/unlock), and an update
+// server round-trip per event is wasteful. A fix is never so urgent that 60s
+// matters, and a cold start always checks immediately anyway.
+const MIN_CHECK_INTERVAL_MS = 60 * 1000;
+
+export function useOtaAutoUpdate(): void {
+  const lastCheckAt = useRef(0);
+  const checking = useRef(false);
+
+  useEffect(() => {
+    // Dev client / Expo Go / updates disabled → nothing to do.
+    if (!Updates.isEnabled || __DEV__) return;
+
+    const checkAndApply = async () => {
+      const now = Date.now();
+      if (checking.current || now - lastCheckAt.current < MIN_CHECK_INTERVAL_MS) return;
+      checking.current = true;
+      lastCheckAt.current = now;
+      try {
+        const res = await Updates.checkForUpdateAsync();
+        if (!res.isAvailable) return;
+        const fetched = await Updates.fetchUpdateAsync();
+        // Only reload if a genuinely new bundle landed — reloadAsync restarts the
+        // JS app, so we never do it speculatively.
+        if (fetched.isNew) {
+          await Updates.reloadAsync();
+        }
+      } catch {
+        // Network blip / mid-publish race / anything else — swallow. The next
+        // foreground (or the next cold start) retries; a failed update check must
+        // never surface to the cashier or block the till.
+      } finally {
+        checking.current = false;
+      }
+    };
+
+    // Check once on mount (covers a long-running session that was already
+    // foregrounded when this code first ships), then on every return to active.
+    void checkAndApply();
+    const sub = AppState.addEventListener("change", (state: AppStateStatus) => {
+      if (state === "active") void checkAndApply();
+    });
+    return () => sub.remove();
+  }, []);
+}


### PR DESCRIPTION
Two fixes for the "chime keeps failing on the tills" problem — one for why fixes never reached the floor, one for why the chime itself sounded broken.

## 1. Chime/alarm cue plays to completion (`chime.ts`)
**Reported:** the chime "doesn't fulfill fully" → a lagging/stuttering chime.

**Root cause (audio layer, not dedup):** the native `DeviceSpeaker` drives **one shared `MediaPlayer`** and every `play()` `release()`s it. The chime guard was `1500ms` but the clip is **~2400ms**, so a second order arriving 1.5–2.4s later (a burst of Grab + pickup + table) `release()`d the still-playing bell and restarted it → chopped into a stutter. Even with perfect per-order dedup, two *different* orders close together cut each other off.

**Fix:** reserve the full cue duration instead of a 1.5s gap — a trigger landing mid-cue is dropped, so the bell always plays in full; bursts coalesce into one clean cue (all an audible alert needs). Bumped ring #2 `2500 → 2700ms` so native prepare latency can't clip ring #1's tail, and gave the serving alarm the same clip-length reservation.

## 2. Self-apply OTA updates on foreground (`use-ota-auto-update.ts`)
**Why fixes never landed:** `expo-updates` only checks for a new bundle on a **cold app start**, and the SUNMI tills stay open for days — so every published fix sat on the update server unused until a manual relaunch.

**Fix:** `useOtaAutoUpdate()` (mounted at the app root) checks on every return to **foreground** (screen-wake — a mid-shift-safe idle moment), fetches a newer bundle, and `reloadAsync`es into it. After this ships once, future fixes land within seconds of a screen-wake with zero staff action.

**Safety:** no-op in dev / when `Updates.isEnabled` is false; throttled to one check/60s; `reloadAsync` only on a genuinely new bundle (`isNew`); every failure swallowed so it can never touch the order/print path.

## Rollout caveat
The currently-stale tills need **ONE manual relaunch** (force-close + reopen) to pick up this bundle. After that they self-update forever. Floor staff should relaunch the POS today so both fixes take effect immediately.

## Test plan
- [x] Type-clean in changed files (CI `typecheck-native` covers full deps)
- [ ] Burst of orders (several within ~5s) → one clean, full chime, no stutter
- [ ] Relaunch a till → publish a trivial OTA → background/foreground → reloads into the new bundle
- [ ] Dev client: auto-updater is a no-op

🤖 Generated with [Claude Code](https://claude.com/claude-code)