### PR TITLE
fix(ai): repoint retired Sonnet 4 model so invoice autopopulate works again

### DIFF
--- a/apps/backoffice/src/app/(admin)/inventory/invoices/page.tsx
+++ b/apps/backoffice/src/app/(admin)/inventory/invoices/page.tsx
@@ -507,8 +507,15 @@ export default function InvoicesPage() {
                 toast.success(`AI detected ${formatRM(capped)} on the receipt`);
               }
             }
+          } else {
+            toast.error("AI couldn't read the receipt — enter the amount manually.");
           }
-        } catch { /* AI extract is best-effort — user can type the amount */ }
+        } catch {
+          // Surface transport failures instead of swallowing them — a silent
+          // catch here is what made the model retirement look like the dialog
+          // freezing rather than the AI being down.
+          toast.error("AI couldn't read the receipt — enter the amount manually.");
+        }
       }
     } catch { /* ignore */ }
     setPayUploading(false);
@@ -775,8 +782,15 @@ export default function InvoicesPage() {
             if (filled.length > 0) {
               toast.success(`AI filled ${filled.join(", ")} from the invoice — review before attaching.`);
             }
+          } else {
+            toast.error("AI couldn't read the invoice — enter the details manually.");
           }
-        } catch { /* AI extract is best-effort */ }
+        } catch {
+          // Surface transport failures instead of swallowing them — a silent
+          // catch here is what made the model retirement look like the dialog
+          // freezing rather than the AI being down.
+          toast.error("AI couldn't read the invoice — enter the details manually.");
+        }
       }
     } catch { /* ignore */ }
     setAttachUploading(false);

--- a/apps/backoffice/src/app/api/inventory/extract/route.ts
+++ b/apps/backoffice/src/app/api/inventory/extract/route.ts
@@ -130,7 +130,7 @@ IMPORTANT: Return ONLY the JSON object, no markdown, no explanation. If a field 
     });
 
     const response = await client.messages.create({
-      model: "claude-sonnet-4-20250514",
+      model: "claude-sonnet-4-6",
       max_tokens: 2000,
       messages: [{ role: "user", content: contentBlocks }],
     });

--- a/apps/backoffice/src/app/api/reviews/auto-post/route.ts
+++ b/apps/backoffice/src/app/api/reviews/auto-post/route.ts
@@ -37,7 +37,7 @@ const POST_TYPE_PROMPTS: Record<PostType, string> = {
 
 async function generatePost(outletName: string, postType: PostType): Promise<string> {
   const response = await anthropic.messages.create({
-    model: "claude-sonnet-4-20250514",
+    model: "claude-sonnet-4-6",
     max_tokens: 300,
     messages: [
       {

--- a/apps/backoffice/src/app/api/reviews/auto-reply/route.ts
+++ b/apps/backoffice/src/app/api/reviews/auto-reply/route.ts
@@ -35,7 +35,7 @@ Review: ${review.comment || "(no comment, just a low rating)"}
 Reply:`;
 
   const response = await anthropic.messages.create({
-    model: "claude-sonnet-4-20250514",
+    model: "claude-sonnet-4-6",
     max_tokens: 300,
     messages: [{ role: "user", content: prompt }],
   });

--- a/apps/backoffice/src/app/api/sales/recommendations/route.ts
+++ b/apps/backoffice/src/app/api/sales/recommendations/route.ts
@@ -330,7 +330,7 @@ Specificity rules (this is what makes insights useful, not generic):
 Return ONLY valid JSON array, no markdown or explanation.`;
 
     const response = await client.messages.create({
-      model: "claude-sonnet-4-20250514",
+      model: "claude-sonnet-4-6",
       max_tokens: 1500,
       messages: [{ role: "user", content: analysisPrompt }],
     });

--- a/apps/backoffice/src/app/api/sales/targets/recompute/route.ts
+++ b/apps/backoffice/src/app/api/sales/targets/recompute/route.ts
@@ -173,7 +173,7 @@ Return ONLY a JSON object with this exact shape (no markdown, no wrapping):
 }`;
 
     const response = await client.messages.create({
-      model: "claude-sonnet-4-20250514",
+      model: "claude-sonnet-4-6",
       max_tokens: 2500,
       messages: [{ role: "user", content: prompt }],
     });

--- a/apps/staff/src/app/api/claims/extract/route.ts
+++ b/apps/staff/src/app/api/claims/extract/route.ts
@@ -103,7 +103,7 @@ IMPORTANT: Return ONLY the JSON object, no markdown, no explanation. If a field 
 
     const client = await getClient();
     const response = await client.messages.create({
-      model: "claude-sonnet-4-20250514",
+      model: "claude-sonnet-4-6",
       max_tokens: 2000,
       messages: [{ role: "user", content: contentBlocks }],
     });


### PR DESCRIPTION
## Problem

The invoice-upload AI autopopulate stopped responding. Root cause: the extract route called Anthropic with model `claude-sonnet-4-20250514` (Claude Sonnet 4.0), which **retired on 2026-06-15**. Requests to a retired model return a 404, and the autopopulate handlers swallow the error in a best-effort `catch {}`, so the UI silently stopped filling fields.

The same retired model ID was used in 5 other AI routes, all broken by the same retirement.

## Changes

1. **Repoint all 6 call sites** `claude-sonnet-4-20250514` → `claude-sonnet-4-6` (the current Sonnet, already used elsewhere in this codebase). All are plain `messages.create` calls with no thinking/sampling/prefill params, so it's a clean model-ID swap.
   - `inventory/extract` — invoice upload autopopulate (the reported bug)
   - staff `claims/extract` — claim receipt autopopulate
   - `reviews/auto-post`, `reviews/auto-reply`
   - `sales/recommendations`, `sales/targets/recompute`

2. **Surface extract failures** in the two invoice-upload handlers (POP dialog + Attach Invoice dialog) — they now show a toast on a non-OK response or network error instead of swallowing it, so a future outage looks like "AI down" rather than a frozen dialog.

## Verification

- Vercel auto-built the branch tip — preview deploy is `READY` (compiles clean).
- Could not run an end-to-end AI call from the dev container (no API key there); model `claude-sonnet-4-6` is confirmed active and already in use by other routes with the same key.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01YbfVBM5F6Gsygrp6aeADKX)_