### PR TITLE
fix(pos-native): reserve the speaker for each cue's real clip length (alarm overlap stutter)

### DIFF
--- a/apps/pos-native/lib/chime.ts
+++ b/apps/pos-native/lib/chime.ts
@@ -85,32 +85,38 @@ export function primeSounds(): void {
 // double-ring restarted the shared native MediaPlayer mid-clip and staff heard a
 // stutter). The native DeviceSpeaker drives a SINGLE MediaPlayer, so chime and
 // alarm would otherwise cut each other off when they land together — "a new
-// order chimes just as another goes overdue". With one reservation, whichever
-// cue starts first holds the speaker for its clip; any cue — chime OR alarm —
-// arriving within the window is dropped, never restarting the player mid-clip.
-// Both clips are ~2.4s. A dropped alarm re-fires on its 5-min cadence; a dropped
-// chime's order is still on screen — so nothing important is lost. Also coalesces
-// a burst of orders (Grab + pickup + table together) into one clean ring.
+// order chimes just as another goes overdue", or two orders going overdue at
+// once. Whichever cue starts first holds the speaker for the length of ITS clip;
+// any cue — chime OR alarm — arriving within that window is dropped, never
+// restarting the player mid-clip. A dropped alarm re-fires on its 5-min cadence;
+// a dropped chime's order is still on screen — so nothing important is lost. Also
+// coalesces a burst of orders (Grab + pickup + table together) into one clean cue.
+//
+// The hold is PER-CUE because the clips differ in length (measured): a single
+// fixed 2.4s hold under-covered the 2.96s alarm by ~0.5s, so a second cue landing
+// in that gap clipped it ("alarm spam/stutter when overdue orders overlap").
 // JS-only → ships over OTA, no asset/rebuild needed.
-const SOUND_CLIP_MS = 2400;                  // chime.wav / alarm.wav length (~2.40s)
-const SPEAKER_HOLD_MS = SOUND_CLIP_MS + 200; // + native prepare slack
+const CLIP_MS: Record<Sound, number> = { chime: 2400, alarm: 2960 }; // measured WAV lengths
+const HOLD_SLACK_MS = 300; // covers native MediaPlayer prepareAsync latency before the clip starts
 let speakerBusyUntil = 0;
+/** Reserve the shared speaker for `sound`'s full clip. Returns false (play
+ *  nothing) when a cue is still sounding, so no cue ever cuts another. */
+function reserveSpeaker(sound: Sound): boolean {
+  const now = Date.now();
+  if (now < speakerBusyUntil) return false;
+  speakerBusyUntil = now + CLIP_MS[sound] + HOLD_SLACK_MS;
+  return true;
+}
 /** Soft bell — a new external order arrived. Rings once; dropped if the speaker
  *  is mid-cue (see shared reservation above). */
 export function playChime(): void {
-  const now = Date.now();
-  if (now < speakerBusyUntil) return;
-  speakerBusyUntil = now + SPEAKER_HOLD_MS;
-  play("chime");
+  if (reserveSpeaker("chime")) play("chime");
 }
 /** Urgent warble — an order is past the serving-time target. Same shared
  *  reservation: dropped if a cue is mid-play; its 5-min re-sound cadence means a
  *  dropped instance is re-tried shortly, so a real overdue order is never missed. */
 export function playAlarm(): void {
-  const now = Date.now();
-  if (now < speakerBusyUntil) return;
-  speakerBusyUntil = now + SPEAKER_HOLD_MS;
-  play("alarm");
+  if (reserveSpeaker("alarm")) play("alarm");
 }
 
 // Back-compat alias (use-order-chime imports primeChime).


### PR DESCRIPTION
## Why
You flagged the **alarm** can still spam/stutter when overdue orders overlap. Confirmed — the shared speaker guard (#344) reserved one fixed **2.4s** hold, but the clips aren't equal:

| cue | measured length |
|---|---|
| chime.wav | 2.40s |
| alarm.wav | **2.96s** |

So the reservation **under-covered the alarm by ~0.5s**. A second cue (another overdue order, or a new-order chime) landing in that 2.6–2.96s gap restarted the shared native `MediaPlayer` and chopped the alarm mid-warble — the stutter you heard. (A *single* alarm was fine; it's the overlap that exposed it.)

## Fix
Make the hold **per-cue**: reserve the speaker for the *actual* clip being played (`CLIP_MS = { chime: 2400, alarm: 2960 }`) plus prepare-latency slack. Whatever is sounding now always finishes before another cue can start; a cue arriving mid-play is dropped (the alarm re-fires on its 5-min cadence, the order's still on screen).

JS-only → ships over the pos-native OTA.

## Test plan
- [x] `chime.ts` type-clean
- [ ] Two orders go overdue within ~3s → one clean full alarm, no stutter/clip
- [ ] New order chimes while an alarm is sounding → alarm finishes clean, chime dropped
- [ ] Single overdue order → one clean alarm, still re-sounds every 5 min

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01SXF3GNPYGpZzwMWy9AR9DV)_