### PR TITLE
Deny backoffice URL access when manager moduleAccess is empty

### DIFF
--- a/apps/backoffice/src/app/(admin)/layout.tsx
+++ b/apps/backoffice/src/app/(admin)/layout.tsx
@@ -935,8 +935,13 @@ export default function AdminLayout({ children }: { children: React.ReactNode })
     if (pathname === "/dashboard" || pathname === "/") return;
     // OWNER and ADMIN bypass all checks
     if (user.role === "ADMIN" || user.role === "OWNER") return;
-    // Empty moduleAccess = full access (legacy behavior)
-    if (!user.moduleAccess || user.moduleAccess.length === 0) return;
+    // NOTE: there is no "empty moduleAccess = full access" escape here. The
+    // sidebar render path (canAccess) already denies every gated item when
+    // moduleAccess is empty, so such a manager only ever sees Dashboard in the
+    // nav. Letting the URL guard fall through to the same canAccess check below
+    // keeps direct-URL access consistent with what the sidebar exposes —
+    // previously an empty-moduleAccess manager had a blank sidebar but could
+    // still reach every non-finance page by typing the URL.
 
     // Match the current path to the MOST SPECIFIC (longest-href) nav item,
     // then gate on that item's module. A first-match loop let a broad parent


### PR DESCRIPTION
## Problem (from the staff-access audit, Finding 1)

The backoffice admin route guard had an **"empty `moduleAccess` = full access"** escape:

```ts
if (!user.moduleAccess || user.moduleAccess.length === 0) return;
```

This only ever affects **MANAGER** users (OWNER/ADMIN bypass earlier). But the sidebar render path (`canAccess`) already **denies every gated item when `moduleAccess` is empty** — so such a manager sees a blank nav (only Dashboard) yet could still reach **every non-finance page by typing the URL**. The two layers disagreed about what "empty" means.

## Change

Remove the escape so the URL guard falls through to the **same `canAccess` check the sidebar uses**. Net effect:

- An empty-`moduleAccess` manager is now confined to **Dashboard** — exactly what their sidebar exposes — instead of having hidden direct-URL access.
- OWNER/ADMIN still bypass all checks.
- Pages with no nav entry (e.g. detail routes not in `NAV_SECTIONS`) are unaffected, same as for any other manager.

## Why this is low-risk

Managers with empty `moduleAccess` already have an empty sidebar today, so they cannot navigate normally — this only closes the typed-URL workaround. Well-guarded APIs already treat empty as deny, so this aligns the page guard with both the sidebar and the server.

## Testing

⚠️ Not built locally (fresh container, no `node_modules`). Single-line logic change in the existing route-guard `useEffect`; verified by inspection. Please confirm against CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PfVviAtVbppgRTt5pG3D8j)_