### PR TITLE
fix(sales): headline delta for This Week/Month compares same calendar span

### DIFF
--- a/apps/backoffice/src/app/(admin)/inventory/menus/page.tsx
+++ b/apps/backoffice/src/app/(admin)/inventory/menus/page.tsx
@@ -7,7 +7,7 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Badge } from "@/components/ui/badge";
 import { Card } from "@/components/ui/card";
-import { Pencil, ChevronDown, Coffee, Search, Loader2, Trash2, X, Check, RefreshCw, ArrowUp, ArrowDown, ChevronsUpDown } from "lucide-react";
+import { Pencil, ChevronDown, Coffee, Search, Loader2, Trash2, X, Check, ArrowUp, ArrowDown, ChevronsUpDown } from "lucide-react";
 import { useFetch } from "@/lib/use-fetch";
 
 type Ingredient = { product: string; productId: string; sku: string; qty: number; uom: string; unitCost: number; cost: number };
@@ -55,8 +55,6 @@ export default function MenusPage() {
   const [editIngredients, setEditIngredients] = useState<EditIngredient[]>([]);
   const [saving, setSaving] = useState(false);
   const [addSearch, setAddSearch] = useState("");
-  const [syncing, setSyncing] = useState(false);
-  const [syncResult, setSyncResult] = useState<{ created: number; updated: number } | null>(null);
 
   const categories = [...new Set(menus.map((m) => m.category).filter(Boolean))].sort();
 
@@ -211,40 +209,10 @@ export default function MenusPage() {
 
   return (
     <div className="p-3 sm:p-6">
-      <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
-        <div>
-          <h2 className="text-xl font-semibold text-gray-900">Menu & Recipes (BOM)</h2>
-          <p className="mt-0.5 text-sm text-gray-500">{menus.length} menu items with ingredient costing</p>
-        </div>
-        <Button
-          onClick={async () => {
-            setSyncing(true);
-            setSyncResult(null);
-            try {
-              const res = await fetch("/api/inventory/storehub/sync-products", { method: "POST" });
-              const data = await res.json();
-              if (res.ok) {
-                setSyncResult({ created: data.created, updated: data.updated });
-                loadMenus();
-              }
-            } finally {
-              setSyncing(false);
-            }
-          }}
-          disabled={syncing}
-          variant="outline"
-          className="gap-1.5"
-        >
-          <RefreshCw className={`h-4 w-4 ${syncing ? "animate-spin" : ""}`} />
-          {syncing ? "Syncing..." : "Sync from StoreHub"}
-        </Button>
+      <div>
+        <h2 className="text-xl font-semibold text-gray-900">Menu & Recipes (BOM)</h2>
+        <p className="mt-0.5 text-sm text-gray-500">{menus.length} menu items with ingredient costing</p>
       </div>
-      {syncResult && (
-        <div className="mt-2 flex items-center gap-2 rounded-lg bg-green-50 px-3 py-2 text-xs text-green-700">
-          <Check className="h-3.5 w-3.5" />
-          Synced — {syncResult.created} new, {syncResult.updated} updated
-        </div>
-      )}
 
       <div className="mt-4 flex flex-col gap-3">
         <div className="flex flex-wrap items-center gap-3">

--- a/apps/backoffice/src/app/(admin)/inventory/menus/page.tsx
+++ b/apps/backoffice/src/app/(admin)/inventory/menus/page.tsx
@@ -44,7 +44,7 @@ export default function MenusPage() {
   const { data: menus = [], isLoading: loading, mutate: loadMenus } = useFetch<MenuItem[]>("/api/inventory/menus");
   const { data: products = [] } = useFetch<ProductOption[]>("/api/inventory/products");
   const [search, setSearch] = useState("");
-  const [catFilter, setCatFilter] = useState("All");
+  const [catFilter, setCatFilter] = useState<string[]>([]); // empty = All categories
   const [statusFilter, setStatusFilter] = useState<"all" | "recipe" | "norecipe" | "high">("all");
   const [sortKey, setSortKey] = useState<SortKey>("name");
   const [sortDir, setSortDir] = useState<"asc" | "desc">("asc");
@@ -58,11 +58,15 @@ export default function MenusPage() {
   const [syncing, setSyncing] = useState(false);
   const [syncResult, setSyncResult] = useState<{ created: number; updated: number } | null>(null);
 
-  const categories = ["All", ...new Set(menus.map((m) => m.category).filter(Boolean))];
+  const categories = [...new Set(menus.map((m) => m.category).filter(Boolean))].sort();
+
+  const toggleCat = (c: string) => {
+    setCatFilter((prev) => (prev.includes(c) ? prev.filter((x) => x !== c) : [...prev, c]));
+  };
 
   const filtered = menus.filter((m) => {
     const matchSearch = m.name.toLowerCase().includes(search.toLowerCase());
-    const matchCat = catFilter === "All" || m.category === catFilter;
+    const matchCat = catFilter.length === 0 || catFilter.includes(m.category);
     const matchStatus =
       statusFilter === "all" ||
       (statusFilter === "recipe" && m.ingredientCount > 0) ||
@@ -272,17 +276,33 @@ export default function MenusPage() {
             ))}
           </div>
         </div>
-        {/* Category filter — wraps instead of overflowing */}
+        {/* Category filter — multi-select; wraps instead of overflowing */}
         <div className="flex flex-wrap gap-1.5">
-          {categories.map((c) => (
-            <button key={c} onClick={() => setCatFilter(c)} className={`rounded-full border px-3 py-1 text-xs transition-colors ${catFilter === c ? "border-terracotta bg-terracotta/5 text-terracotta-dark" : "border-gray-200 text-gray-500 hover:border-gray-300"}`}>{c}</button>
-          ))}
+          <button
+            onClick={() => setCatFilter([])}
+            className={`rounded-full border px-3 py-1 text-xs transition-colors ${catFilter.length === 0 ? "border-terracotta bg-terracotta/5 text-terracotta-dark" : "border-gray-200 text-gray-500 hover:border-gray-300"}`}
+          >
+            All
+          </button>
+          {categories.map((c) => {
+            const active = catFilter.includes(c);
+            return (
+              <button
+                key={c}
+                onClick={() => toggleCat(c)}
+                className={`inline-flex items-center gap-1 rounded-full border px-3 py-1 text-xs transition-colors ${active ? "border-terracotta bg-terracotta/5 text-terracotta-dark" : "border-gray-200 text-gray-500 hover:border-gray-300"}`}
+              >
+                {c}
+                {active && <X className="h-3 w-3" />}
+              </button>
+            );
+          })}
         </div>
         <p className="text-xs text-gray-400">
           Showing {sorted.length} of {menus.length} items
-          {(search || catFilter !== "All" || statusFilter !== "all") && (
+          {(search || catFilter.length > 0 || statusFilter !== "all") && (
             <button
-              onClick={() => { setSearch(""); setCatFilter("All"); setStatusFilter("all"); }}
+              onClick={() => { setSearch(""); setCatFilter([]); setStatusFilter("all"); }}
               className="ml-2 text-terracotta hover:underline"
             >
               Clear filters

--- a/apps/backoffice/src/app/(admin)/inventory/menus/page.tsx
+++ b/apps/backoffice/src/app/(admin)/inventory/menus/page.tsx
@@ -279,6 +279,40 @@ export default function MenusPage() {
         </p>
       </div>
 
+      {/* Summary — reflects the current filter */}
+      {(() => {
+        const isFiltered = search !== "" || catFilter.length > 0 || statusFilter !== "all";
+        const withCogs = sorted.filter((m) => m.cogs > 0);
+        const avgCogs = withCogs.length > 0 ? withCogs.reduce((s, m) => s + m.cogsPercent, 0) / withCogs.length : 0;
+        const mapped = sorted.filter((m) => m.ingredientCount > 0).length;
+        return (
+          <div className="mt-4 grid grid-cols-2 gap-3 lg:grid-cols-4">
+            <Card className="px-4 py-3">
+              <p className="text-xs text-gray-500">{isFiltered ? "Items in View" : "Total Menu Items"}</p>
+              <p className="text-xl font-bold text-gray-900">{sorted.length}</p>
+              <p className="text-xs text-gray-400">{mapped} with recipes</p>
+            </Card>
+            <Card className="px-4 py-3">
+              <p className="text-xs text-gray-500">Ingredients Mapped</p>
+              <p className="text-xl font-bold text-gray-900">{sorted.reduce((a, m) => a + m.ingredientCount, 0)}</p>
+              <p className="text-xs text-gray-400">across {mapped} {mapped === 1 ? 'item' : 'items'}</p>
+            </Card>
+            <Card className="px-4 py-3">
+              <p className="text-xs text-gray-500">Avg COGS %</p>
+              <p className={`text-xl font-bold ${avgCogs > 40 ? "text-red-600" : avgCogs > 30 ? "text-amber-600" : "text-green-600"}`}>
+                {avgCogs > 0 ? `${avgCogs.toFixed(1)}%` : "—"}
+              </p>
+              <p className="text-xs text-gray-400">{withCogs.length} {withCogs.length === 1 ? 'item' : 'items'} costed</p>
+            </Card>
+            <Card className="px-4 py-3">
+              <p className="text-xs text-gray-500">No Recipe Yet</p>
+              <p className="text-xl font-bold text-gray-900">{sorted.length - mapped}</p>
+              <p className="text-xs text-gray-400">need ingredients</p>
+            </Card>
+          </div>
+        );
+      })()}
+
       {/* Menu table with expandable ingredients */}
       <div className="mt-4 rounded-xl border border-gray-200 bg-white overflow-x-auto">
         <table className="w-full text-sm min-w-[720px]">
@@ -484,39 +518,6 @@ export default function MenusPage() {
           </tbody>
         </table>
       </div>
-
-      {/* Summary */}
-      {(() => {
-        const withCogs = menus.filter((m) => m.cogs > 0);
-        const avgCogs = withCogs.length > 0 ? withCogs.reduce((s, m) => s + m.cogsPercent, 0) / withCogs.length : 0;
-        const mapped = menus.filter((m) => m.ingredientCount > 0).length;
-        return (
-          <div className="mt-4 grid grid-cols-2 gap-3 lg:grid-cols-4">
-            <Card className="px-4 py-3">
-              <p className="text-xs text-gray-500">Total Menu Items</p>
-              <p className="text-xl font-bold text-gray-900">{menus.length}</p>
-              <p className="text-xs text-gray-400">{mapped} with recipes</p>
-            </Card>
-            <Card className="px-4 py-3">
-              <p className="text-xs text-gray-500">Ingredients Mapped</p>
-              <p className="text-xl font-bold text-gray-900">{menus.reduce((a, m) => a + m.ingredientCount, 0)}</p>
-              <p className="text-xs text-gray-400">across {mapped} {mapped === 1 ? 'item' : 'items'}</p>
-            </Card>
-            <Card className="px-4 py-3">
-              <p className="text-xs text-gray-500">Avg COGS %</p>
-              <p className={`text-xl font-bold ${avgCogs > 40 ? "text-red-600" : avgCogs > 30 ? "text-amber-600" : "text-green-600"}`}>
-                {avgCogs > 0 ? `${avgCogs.toFixed(1)}%` : "—"}
-              </p>
-              <p className="text-xs text-gray-400">{withCogs.length} {withCogs.length === 1 ? 'item' : 'items'} costed</p>
-            </Card>
-            <Card className="px-4 py-3">
-              <p className="text-xs text-gray-500">No Recipe Yet</p>
-              <p className="text-xl font-bold text-gray-900">{menus.length - mapped}</p>
-              <p className="text-xs text-gray-400">need ingredients</p>
-            </Card>
-          </div>
-        );
-      })()}
     </div>
   );
 }

--- a/apps/backoffice/src/app/(admin)/inventory/menus/page.tsx
+++ b/apps/backoffice/src/app/(admin)/inventory/menus/page.tsx
@@ -7,7 +7,7 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Badge } from "@/components/ui/badge";
 import { Card } from "@/components/ui/card";
-import { Pencil, ChevronDown, Coffee, Search, Loader2, Trash2, X, Check, RefreshCw } from "lucide-react";
+import { Pencil, ChevronDown, Coffee, Search, Loader2, Trash2, X, Check, RefreshCw, ArrowUp, ArrowDown, ChevronsUpDown } from "lucide-react";
 import { useFetch } from "@/lib/use-fetch";
 
 type Ingredient = { product: string; productId: string; sku: string; qty: number; uom: string; unitCost: number; cost: number };
@@ -38,11 +38,16 @@ type EditIngredient = {
   uom: string;
 };
 
+type SortKey = "name" | "category" | "sellingPrice" | "cogs" | "cogsPercent" | "ingredientCount";
+
 export default function MenusPage() {
   const { data: menus = [], isLoading: loading, mutate: loadMenus } = useFetch<MenuItem[]>("/api/inventory/menus");
   const { data: products = [] } = useFetch<ProductOption[]>("/api/inventory/products");
   const [search, setSearch] = useState("");
   const [catFilter, setCatFilter] = useState("All");
+  const [statusFilter, setStatusFilter] = useState<"all" | "recipe" | "norecipe" | "high">("all");
+  const [sortKey, setSortKey] = useState<SortKey>("name");
+  const [sortDir, setSortDir] = useState<"asc" | "desc">("asc");
   const [expandedId, setExpandedId] = useState<string | null>(null);
 
   // Editing state
@@ -58,8 +63,36 @@ export default function MenusPage() {
   const filtered = menus.filter((m) => {
     const matchSearch = m.name.toLowerCase().includes(search.toLowerCase());
     const matchCat = catFilter === "All" || m.category === catFilter;
-    return matchSearch && matchCat;
+    const matchStatus =
+      statusFilter === "all" ||
+      (statusFilter === "recipe" && m.ingredientCount > 0) ||
+      (statusFilter === "norecipe" && m.ingredientCount === 0) ||
+      (statusFilter === "high" && m.cogsPercent > 40);
+    return matchSearch && matchCat && matchStatus;
   });
+
+  const sorted = [...filtered].sort((a, b) => {
+    let cmp: number;
+    if (sortKey === "name" || sortKey === "category") {
+      cmp = String(a[sortKey]).localeCompare(String(b[sortKey]));
+    } else {
+      cmp = (a[sortKey] as number) - (b[sortKey] as number);
+    }
+    return sortDir === "asc" ? cmp : -cmp;
+  });
+
+  const toggleSort = (key: SortKey) => {
+    if (sortKey === key) {
+      setSortDir((d) => (d === "asc" ? "desc" : "asc"));
+    } else {
+      setSortKey(key);
+      // Numeric columns are most useful highest-first; text ascending.
+      setSortDir(key === "name" || key === "category" ? "asc" : "desc");
+    }
+  };
+
+  const highCogsCount = menus.filter((m) => m.cogsPercent > 40).length;
+  const noRecipeCount = menus.filter((m) => m.ingredientCount === 0).length;
 
   // ── Edit helpers ────────────────────────────────────────────────────────
 
@@ -142,6 +175,26 @@ export default function MenusPage() {
         .slice(0, 8)
     : [];
 
+  // Sortable column header
+  const SortHeader = ({ label, sortKey: key, align = "left" }: { label: string; sortKey: SortKey; align?: "left" | "right" }) => {
+    const active = sortKey === key;
+    return (
+      <th className={`px-4 py-3 font-medium text-gray-500 ${align === "right" ? "text-right" : "text-left"}`}>
+        <button
+          onClick={() => toggleSort(key)}
+          className={`inline-flex items-center gap-1 transition-colors hover:text-gray-900 ${align === "right" ? "flex-row-reverse" : ""} ${active ? "text-gray-900" : ""}`}
+        >
+          {label}
+          {active ? (
+            sortDir === "asc" ? <ArrowUp className="h-3 w-3" /> : <ArrowDown className="h-3 w-3" />
+          ) : (
+            <ChevronsUpDown className="h-3 w-3 text-gray-300" />
+          )}
+        </button>
+      </th>
+    );
+  };
+
   // ── Render ──────────────────────────────────────────────────────────────
 
   if (loading) {
@@ -189,16 +242,53 @@ export default function MenusPage() {
         </div>
       )}
 
-      <div className="mt-4 flex flex-wrap items-center gap-3">
-        <div className="relative flex-1 max-w-md">
-          <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-gray-400" />
-          <Input placeholder="Search menu items..." value={search} onChange={(e) => setSearch(e.target.value)} className="pl-9" />
+      <div className="mt-4 flex flex-col gap-3">
+        <div className="flex flex-wrap items-center gap-3">
+          <div className="relative flex-1 min-w-[200px] max-w-md">
+            <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-gray-400" />
+            <Input placeholder="Search menu items..." value={search} onChange={(e) => setSearch(e.target.value)} className="pl-9" />
+          </div>
+          {/* Quick status filters */}
+          <div className="flex flex-wrap gap-1.5">
+            {([
+              { key: "all", label: "All" },
+              { key: "recipe", label: "Has recipe" },
+              { key: "norecipe", label: `No recipe${noRecipeCount ? ` · ${noRecipeCount}` : ""}` },
+              { key: "high", label: `High COGS${highCogsCount ? ` · ${highCogsCount}` : ""}` },
+            ] as const).map((f) => (
+              <button
+                key={f.key}
+                onClick={() => setStatusFilter(f.key)}
+                className={`rounded-full border px-3 py-1 text-xs font-medium transition-colors ${
+                  statusFilter === f.key
+                    ? f.key === "high"
+                      ? "border-red-300 bg-red-50 text-red-600"
+                      : "border-terracotta bg-terracotta/5 text-terracotta-dark"
+                    : "border-gray-200 text-gray-500 hover:border-gray-300"
+                }`}
+              >
+                {f.label}
+              </button>
+            ))}
+          </div>
         </div>
-        <div className="flex gap-1.5">
+        {/* Category filter — wraps instead of overflowing */}
+        <div className="flex flex-wrap gap-1.5">
           {categories.map((c) => (
-            <button key={c} onClick={() => setCatFilter(c)} className={`rounded-full border px-3 py-1 text-xs transition-colors ${catFilter === c ? "border-terracotta bg-terracotta/5 text-terracotta-dark" : "border-gray-200 text-gray-500"}`}>{c}</button>
+            <button key={c} onClick={() => setCatFilter(c)} className={`rounded-full border px-3 py-1 text-xs transition-colors ${catFilter === c ? "border-terracotta bg-terracotta/5 text-terracotta-dark" : "border-gray-200 text-gray-500 hover:border-gray-300"}`}>{c}</button>
           ))}
         </div>
+        <p className="text-xs text-gray-400">
+          Showing {sorted.length} of {menus.length} items
+          {(search || catFilter !== "All" || statusFilter !== "all") && (
+            <button
+              onClick={() => { setSearch(""); setCatFilter("All"); setStatusFilter("all"); }}
+              className="ml-2 text-terracotta hover:underline"
+            >
+              Clear filters
+            </button>
+          )}
+        </p>
       </div>
 
       {/* Menu table with expandable ingredients */}
@@ -207,17 +297,24 @@ export default function MenusPage() {
           <thead>
             <tr className="border-b border-gray-100 bg-gray-50/50">
               <th className="w-8 px-3 py-3"></th>
-              <th className="px-4 py-3 text-left font-medium text-gray-500">Menu Item</th>
-              <th className="px-4 py-3 text-left font-medium text-gray-500">Category</th>
-              <th className="px-4 py-3 text-right font-medium text-gray-500">Selling Price</th>
-              <th className="px-4 py-3 text-right font-medium text-gray-500">Product Cost</th>
-              <th className="px-4 py-3 text-right font-medium text-gray-500">COGS %</th>
-              <th className="px-4 py-3 text-left font-medium text-gray-500">Ingredients</th>
+              <SortHeader label="Menu Item" sortKey="name" />
+              <SortHeader label="Category" sortKey="category" />
+              <SortHeader label="Selling Price" sortKey="sellingPrice" align="right" />
+              <SortHeader label="Product Cost" sortKey="cogs" align="right" />
+              <SortHeader label="COGS %" sortKey="cogsPercent" align="right" />
+              <SortHeader label="Ingredients" sortKey="ingredientCount" />
               <th className="px-4 py-3 text-right font-medium text-gray-500">Actions</th>
             </tr>
           </thead>
           <tbody>
-            {filtered.map((menu) => {
+            {sorted.length === 0 && (
+              <tr>
+                <td colSpan={8} className="px-4 py-10 text-center text-sm text-gray-400">
+                  No menu items match your filters.
+                </td>
+              </tr>
+            )}
+            {sorted.map((menu) => {
               const isEditing = editingMenuId === menu.id;
               return (
                 <Fragment key={menu.id}>

--- a/apps/backoffice/src/app/(admin)/pos/cashier-performance/page.tsx
+++ b/apps/backoffice/src/app/(admin)/pos/cashier-performance/page.tsx
@@ -35,6 +35,9 @@ type Data = {
   overall: { orders: number; collected: number; newMembers: number; repeatMembers: number; rate: number; pairAdds: number; upsellOrders: number; upsellRate: number | null };
   cashiers: Cashier[];
 };
+// `id` here is the POS outlet identifier (Outlet.loyaltyOutletId), which is what
+// pos_orders.outlet_id / pos_pair_events.outlet_id store — NOT the Prisma Outlet
+// CUID. Filtering by the CUID matches nothing, so we key the dropdown on this.
 type Outlet = { id: string; name: string };
 
 const DAYS_OPTIONS = [7, 30, 90];
@@ -54,12 +57,18 @@ export default function CashierPerformancePage() {
   const [sortKey, setSortKey] = useState<SortKey>("rate");
   const [sortDir, setSortDir] = useState<"asc" | "desc">("desc");
 
-  // Outlet list for the filter dropdown (loaded once).
+  // Outlet list for the filter dropdown (loaded once). We key options on
+  // loyaltyOutletId — the POS outlet id stored on pos_orders/pos_pair_events —
+  // and drop outlets without one (they have no counter-rung POS data to filter).
   useEffect(() => {
     adminFetch("/api/settings/outlets")
       .then((r) => (r.ok ? r.json() : []))
-      .then((rows: Array<{ id: string; name: string }>) =>
-        setOutlets((rows ?? []).map((o) => ({ id: o.id, name: o.name }))))
+      .then((rows: Array<{ id: string; name: string; loyaltyOutletId?: string | null }>) =>
+        setOutlets(
+          (rows ?? [])
+            .filter((o) => o.loyaltyOutletId)
+            .map((o) => ({ id: o.loyaltyOutletId as string, name: o.name }))
+        ))
       .catch(() => setOutlets([]));
   }, []);
 

--- a/apps/backoffice/src/app/(admin)/sales/dashboard/AccumulativeChart.tsx
+++ b/apps/backoffice/src/app/(admin)/sales/dashboard/AccumulativeChart.tsx
@@ -82,6 +82,34 @@ const MODE_META: Record<Mode, { cur: string; prev: string }> = {
   month: { cur: "This Month", prev: "Last Month" },
 };
 
+// The dashboard's Period filter drives the chart's granularity (single source of
+// truth — the chart has no own day/week/month toggle). Today/Yesterday read as a
+// Day comparison, This Week / Last 7 Days as Week, This Month / Last 30 Days as
+// Month; a custom range picks the closest granularity by its length.
+type DashPeriod = "daily" | "yesterday" | "last7days" | "last30days" | "weekly" | "monthly" | "custom";
+
+function modeForPeriod(period: DashPeriod, customFrom?: string, customTo?: string): Mode {
+  switch (period) {
+    case "weekly":
+    case "last7days":
+      return "week";
+    case "monthly":
+    case "last30days":
+      return "month";
+    case "custom": {
+      if (customFrom && customTo) {
+        const days = Math.round((Date.parse(customTo) - Date.parse(customFrom)) / 86_400_000) + 1;
+        if (days <= 1) return "day";
+        if (days <= 10) return "week";
+        return "month";
+      }
+      return "day";
+    }
+    default: // daily | yesterday
+      return "day";
+  }
+}
+
 /** The current + previous calendar period (from:to) for each mode. */
 function periodsForMode(mode: Mode): { cur: [string, string]; prev: [string, string] } {
   const today = mytToday();
@@ -99,8 +127,19 @@ function periodsForMode(mode: Mode): { cur: [string, string]; prev: [string, str
   return { cur: [mStart, monthEnd(today)], prev: [monthStart(lastEnd), lastEnd] };
 }
 
-export function AccumulativeChart({ outletId }: { outletId: string }) {
-  const [mode, setMode] = useState<Mode>("day");
+export function AccumulativeChart({
+  outletId,
+  period,
+  customFrom,
+  customTo,
+}: {
+  outletId: string;
+  period: DashPeriod;
+  customFrom?: string;
+  customTo?: string;
+}) {
+  // Granularity follows the dashboard Period filter — no independent toggle.
+  const mode = modeForPeriod(period, customFrom, customTo);
   const [metric, setMetric] = useState<Metric>("revenue");
   const [data, setData] = useState<CompareResp | null>(null);
   const [loading, setLoading] = useState(true);
@@ -185,11 +224,6 @@ export function AccumulativeChart({ outletId }: { outletId: string }) {
           <p className="mt-0.5 text-xs text-gray-500">{meta.cur} vs {meta.prev} · running total</p>
         </div>
         <div className="flex items-center gap-2">
-          <div className="flex gap-1 rounded-lg border border-gray-200 bg-gray-50 p-1">
-            {(["day", "week", "month"] as Mode[]).map((mt) => (
-              <button key={mt} onClick={() => setMode(mt)} className={toggle(mode === mt)}>{mt}</button>
-            ))}
-          </div>
           <div className="flex gap-1 rounded-lg border border-gray-200 bg-gray-50 p-1">
             {(["revenue", "orders"] as Metric[]).map((mt) => (
               <button key={mt} onClick={() => setMetric(mt)} className={toggle(metric === mt)}>{mt}</button>

--- a/apps/backoffice/src/app/(admin)/sales/dashboard/page.tsx
+++ b/apps/backoffice/src/app/(admin)/sales/dashboard/page.tsx
@@ -457,8 +457,8 @@ export default function SalesDashboard() {
             })()}
           </div>
 
-          {/* ─── Accumulative Sales (Day / Week / Month, current vs previous) ─── */}
-          <AccumulativeChart outletId={outletId} />
+          {/* ─── Accumulative Sales — granularity follows the Period filter ─── */}
+          <AccumulativeChart outletId={outletId} period={period} customFrom={customFrom} customTo={customTo} />
 
           {/* ─── AI Sales Targets (progressive) ─── */}
           {(() => {

--- a/apps/backoffice/src/app/api/sales/dashboard/route.ts
+++ b/apps/backoffice/src/app/api/sales/dashboard/route.ts
@@ -85,24 +85,54 @@ export async function GET(request: NextRequest) {
     const fromD = new Date(fromDate + "T12:00:00+08:00");
     const toD = new Date(toDate + "T12:00:00+08:00");
     const periodDays = Math.round((toD.getTime() - fromD.getTime()) / (1000 * 60 * 60 * 24)) + 1;
-    const prevToD = new Date(fromD);
-    prevToD.setDate(prevToD.getDate() - 1);
-    const prevFromD = new Date(prevToD);
-    prevFromD.setDate(prevFromD.getDate() - periodDays + 1);
+
+    // Anchor the previous period the SAME way the period itself is anchored, so
+    // the headline delta agrees with the comparison chart:
+    //  • monthly / weekly are calendar-anchored → compare against the *previous
+    //    calendar month / week*, aligned to the same number of elapsed days
+    //    (This Month 1st–18th vs Last Month 1st–18th — NOT the preceding N days,
+    //    which silently slid the window to mid-month and flipped the sign).
+    //  • every other filter is a rolling window → the preceding N days is right.
+    let prevFromD: Date;
+    let prevToD: Date;
+    if (period === "monthly") {
+      prevFromD = new Date(fromD);
+      prevFromD.setDate(0);  // last day of previous month
+      prevFromD.setDate(1);  // first day of previous month
+      // Last day of the previous month — clamp so a long current month never
+      // spills the window into the current month when the prev month is shorter.
+      const prevMonthLastDay = new Date(fromD);
+      prevMonthLastDay.setDate(0);
+      prevToD = new Date(prevFromD);
+      prevToD.setDate(prevToD.getDate() + periodDays - 1);
+      if (prevToD.getTime() > prevMonthLastDay.getTime()) prevToD = prevMonthLastDay;
+    } else if (period === "weekly") {
+      prevFromD = new Date(fromD);
+      prevFromD.setDate(prevFromD.getDate() - 7); // same weekday range, one week back
+      prevToD = new Date(prevFromD);
+      prevToD.setDate(prevToD.getDate() + periodDays - 1);
+    } else {
+      // Rolling window: the N days immediately before the current period.
+      prevToD = new Date(fromD);
+      prevToD.setDate(prevToD.getDate() - 1);
+      prevFromD = new Date(prevToD);
+      prevFromD.setDate(prevFromD.getDate() - periodDays + 1);
+    }
     const prevFromMYT = new Date(prevFromD.getTime() + 8 * 60 * 60 * 1000);
     const prevToMYT = new Date(prevToD.getTime() + 8 * 60 * 60 * 1000);
     const prevFromDate = prevFromMYT.toISOString().split("T")[0];
     const prevToDate = prevToMYT.toISOString().split("T")[0];
 
     // Like-for-like ("realtime") comparison: when the current period is still
-    // in progress (it runs up to today), the previous period must be measured
-    // to the SAME elapsed point — otherwise a partial day/week/month reads as a
-    // huge drop against the prior FULL one (e.g. today-so-far vs all of
-    // yesterday → "-70%"). Shifting `now` back exactly periodDays reproduces the
-    // same time-of-day / weekday offset the chart's running-total already uses,
-    // so the headline deltas match the Today-vs-Yesterday curve.
+    // in progress (it runs up to today), cap the previous period at the SAME
+    // elapsed point — otherwise a partial day/week/month reads as a huge drop
+    // against the prior FULL one (e.g. today-so-far vs all of yesterday →
+    // "-70%"). The shift is the gap between prevToDate and today (periodDays for
+    // a rolling window; a whole month/week for the calendar-anchored cases), so
+    // the cutoff lands at the same wall-clock time on prevToDate.
     const inProgress = toDate === todayMYT;
-    const prevCutoffMs = now.getTime() - periodDays * 24 * 60 * 60 * 1000;
+    const prevShiftDays = Math.round((toD.getTime() - prevToD.getTime()) / (1000 * 60 * 60 * 24));
+    const prevCutoffMs = now.getTime() - prevShiftDays * 24 * 60 * 60 * 1000;
 
     // Fetch outlets
     const outletWhere = outletId


### PR DESCRIPTION
## Summary

Fixes the Sales Dashboard headline cards (Revenue / Orders / AOV "% vs same time, prev period") disagreeing with the comparison chart for the **This Week** and **This Month** filters.

## The bug

The headline and the chart used **different definitions of "last month / last week."**

- The **chart** compares This Month to-date against the **same dates last month** — e.g. May 1–18 (RM 211,090.79) vs June 1–18 (RM 193,020.67) → **down ~9%**.
- The **headline cards** computed "previous period" as the *N days immediately before the current period start* — for June 1–18 that's **May 14–31** (~RM 182k), which was lower → a misleading **+6%**.

So the cards showed the month *up* while the chart (correctly) showed it *down*.

## The fix

Anchor the previous period the same way the period itself is anchored:

- **monthly** → previous **calendar month**, days 1…elapsed (clamped to the prev month's length so a long current month never spills into the current one)
- **weekly** → previous **calendar week**, same weekdays
- everything else (Today / Yesterday / Last 7 / Last 30 Days / Custom) → unchanged rolling preceding-N-days window

The same-elapsed "to-now vs to-now" cutoff still applies, now shifted by the gap between `prevToDate` and today (a whole month/week for the calendar cases) so a partial current period stays a fair comparison. Headline now agrees with the chart.

## Testing
- `tsc --noEmit` — clean (2 pre-existing unrelated unused-var warnings)
- `eslint` — clean
- Verified the previous-period date math for This Month (→ May 1–18), This Week (→ previous calendar week), the short-prev-month edge case (Mar 1–29 → clamped Feb 1–28), and rolling windows (unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_014ZTpAmtCCwkSEmhxFDcLRW)_