### PR TITLE
Retire loyalty app customer UI — redirect to order app (Phase 2)

### DIFF
--- a/apps/loyalty/src/middleware.ts
+++ b/apps/loyalty/src/middleware.ts
@@ -12,8 +12,14 @@ const ALLOWED_ORIGINS = [
 ];
 
 /**
- * Middleware — redirects admin to backoffice, adds security headers,
- * enforces CSRF Origin check on state-changing requests.
+ * Middleware — retires the loyalty app's human-facing UI while keeping it
+ * running as a headless backend:
+ *   - /admin/*  → backoffice (Rewards admin moved there); /admin/staff stays
+ *     as a read-only directory view.
+ *   - /, /rewards, /portal/* → the order app (customer rewards/portal moved to
+ *     order.celsiuscoffee.com); redirect legacy links instead of 404ing.
+ *   - /staff (POS-moved notice), /privacy, and /api/* stay served here.
+ * Also adds security headers and enforces CSRF Origin checks on writes.
  */
 export async function middleware(request: NextRequest) {
   const { pathname } = request.nextUrl;
@@ -39,6 +45,18 @@ export async function middleware(request: NextRequest) {
   const ALLOWED_ADMIN_PATHS = ['/admin/staff'];
   if (pathname.startsWith('/admin') && !ALLOWED_ADMIN_PATHS.some((p) => pathname.startsWith(p))) {
     return NextResponse.redirect('https://backoffice.celsiuscoffee.com');
+  }
+
+  // ─── Redirect retired customer UI to the order app ──────────
+  // The customer landing / rewards / portal experience moved to
+  // order.celsiuscoffee.com. These legacy loyalty-app pages are retired;
+  // redirect old links/bookmarks rather than 404. /staff (a POS-moved
+  // notice), /privacy, and the headless /api/* stay served here.
+  if (pathname === '/' || pathname === '/portal' || pathname.startsWith('/portal/')) {
+    return NextResponse.redirect('https://order.celsiuscoffee.com');
+  }
+  if (pathname === '/rewards' || pathname.startsWith('/rewards/')) {
+    return NextResponse.redirect('https://order.celsiuscoffee.com/rewards');
   }
 
   return response;


### PR DESCRIPTION
Phase 2 of retiring the loyalty app. The app **stays deployed as a headless backend** (its OTP / members / member-tier / promotions APIs are still consumed by the order app and backoffice/POS), but its human-facing UI is now fully retired.

## Change
One file — `apps/loyalty/src/middleware.ts` — redirects the legacy customer pages to the order app (so old links/bookmarks/QR still land somewhere useful instead of 404ing):

| Route | →  |
|---|---|
| `/` | `https://order.celsiuscoffee.com` |
| `/portal`, `/portal/*` | `https://order.celsiuscoffee.com` |
| `/rewards`, `/rewards/*` | `https://order.celsiuscoffee.com/rewards` |

`/admin/*` already redirected to `backoffice.celsiuscoffee.com` (unchanged; `/admin/staff` stays a read-only view).

## Verification (nothing live breaks)
- **No in-repo references** to the loyalty app's customer UI routes — the customer rewards/account/privacy experience already lives in the order app.
- **Left served:** `/staff` (the Phase 1 "use the POS app" notice), `/privacy` (compliance; order/pickup/staff each host their own, but kept as insurance), and all `/api/*` (the headless backend).
- Redirect targets confirmed from the codebase (`order.celsiuscoffee.com`, `backoffice.celsiuscoffee.com`).
- The legacy page components (`app/page.tsx`, `rewards/`, `portal/`) are now unreachable but still compile (they never used the helpers removed in Phase 1); they can be deleted in a later pass.

Not built locally (no `node_modules` in the dev container) — the loyalty CI lint/typecheck/build jobs will confirm.

## Remaining
- Phase 3 — migrate the 4 headless APIs (OTP, members, member-tier, promotions) off the app
- Phase 4 — delete `apps/loyalty` + Vercel project + domain (keep `LOYALTY_SUPABASE_*`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PfVviAtVbppgRTt5pG3D8j)_