### PR TITLE
StoreHub-style Sales Reports (Reports 2.0 clone)

### DIFF
--- a/apps/backoffice/src/app/(admin)/pos/reports/page.tsx
+++ b/apps/backoffice/src/app/(admin)/pos/reports/page.tsx
@@ -1,104 +1,343 @@
 "use client";
 
-import { useEffect, useState } from "react";
-import { Loader2, TrendingUp, ShoppingBag, Wallet, Trophy } from "lucide-react";
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { Loader2, Download, ArrowUpDown, ArrowUp, ArrowDown, Info, Search, ChevronLeft, ChevronRight } from "lucide-react";
 import { adminFetch } from "@/lib/pickup/admin-fetch";
 import { toast } from "@celsius/ui";
 import { ReportsTabs } from "../_ReportsTabs";
 
 /**
- * POS Reports — analytics over pos_orders + pos_order_items +
- * pos_order_payments. Ported from POS-local /backoffice/reports as part
- * of the BO-canonical migration. Money is sent in sen; format() does
- * the sen→RM conversion at display time.
+ * Sales Reports — StoreHub-style "Reports 2.0" on our own data (POS-native +
+ * pickup + StoreHub archive, cutover-routed; see /api/sales/reports). One
+ * toolbar (report · date range · outlet · group-by · filters · download)
+ * drives eight reports. Money arrives in RM already converted; this page
+ * formats, filters/searches, sorts, paginates, charts and exports.
  */
 
-type Sales    = { date: string; orders: number; revenue: number; avg_order: number };
-type Product  = { name: string; qty: number; revenue: number; pct: number };
-type Payment  = { method: string; count: number; total: number; pct: number };
-type Staff    = { id: string; name: string; orders: number; revenue: number; avg_order: number };
-type Reports  = { sales: Sales[]; products: Product[]; payments: Payment[]; staff: Staff[] };
+type ColKind = "text" | "rm" | "int" | "pct";
+type Column = { key: string; label: string; kind: ColKind; tip?: string };
+type Row = Record<string, string | number>;
+type ReportData = {
+  report: string;
+  columns: Column[];
+  rows: Row[];
+  total: Row | null;
+  chart?: { label: string; value: number }[];
+  note?: string;
+  from: string;
+  to: string;
+  groupBy: string;
+  outletId: string;
+  outletName: string;
+  availableOutlets?: { id: string; name: string }[];
+  generatedAt: string;
+};
 
-const formatRM = (sen: number) =>
-  `RM ${(sen / 100).toLocaleString("en-MY", { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`;
+const REPORTS = [
+  { id: "over-time", label: "Sales over time" },
+  { id: "channel", label: "By Channel" },
+  { id: "product", label: "By Product" },
+  { id: "category", label: "By Category" },
+  { id: "sku", label: "By SKU" },
+  { id: "payment", label: "By Payment" },
+  { id: "promotion", label: "Promotions" },
+  { id: "shift", label: "Shifts" },
+] as const;
+type ReportId = (typeof REPORTS)[number]["id"];
 
-const TABS = [
-  { id: "sales",    label: "Sales Summary"     },
-  { id: "payments", label: "Payment Methods"   },
-  { id: "products", label: "Product Mix"       },
-  { id: "staff",    label: "Staff Performance" },
+const GROUPS = [
+  { id: "day", label: "Daily" },
+  { id: "week", label: "Weekly" },
+  { id: "month", label: "Monthly" },
 ] as const;
 
-type TabId = (typeof TABS)[number]["id"];
+const PAGE_SIZE = 50;
 
-export default function POSReportsPage() {
-  const [tab, setTab] = useState<TabId>("sales");
-  const [data, setData] = useState<Reports | null>(null);
+const fmtRM = (v: number) =>
+  `RM ${v.toLocaleString("en-MY", { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`;
+const fmtInt = (v: number) => v.toLocaleString("en-MY");
+const fmtPct = (v: number) => `${v.toFixed(2)}%`;
+const fmtCell = (v: string | number, kind: ColKind) => {
+  if (kind === "text") return String(v ?? "");
+  const n = typeof v === "number" ? v : Number(v) || 0;
+  if (kind === "rm") return fmtRM(n);
+  if (kind === "pct") return fmtPct(n);
+  return fmtInt(n);
+};
+
+const mytToday = () => new Date(Date.now() + 8 * 3600 * 1000).toISOString().slice(0, 10);
+const addDaysStr = (d: string, n: number) => {
+  const dt = new Date(`${d}T12:00:00+08:00`);
+  dt.setDate(dt.getDate() + n);
+  return dt.toISOString().slice(0, 10);
+};
+const startOfWeek = (d: string) => addDaysStr(d, -new Date(`${d}T12:00:00+08:00`).getDay());
+const startOfMonth = (d: string) => `${d.slice(0, 7)}-01`;
+
+export default function SalesReportsPage() {
+  const today = mytToday();
+  const [report, setReport] = useState<ReportId>("over-time");
+  const [groupBy, setGroupBy] = useState<"day" | "week" | "month">("day");
+  const [from, setFrom] = useState(addDaysStr(today, -6));
+  const [to, setTo] = useState(today);
+  const [outletId, setOutletId] = useState("all");
+  const [data, setData] = useState<ReportData | null>(null);
   const [loading, setLoading] = useState(true);
+  const [sort, setSort] = useState<{ key: string; dir: "asc" | "desc" } | null>(null);
+  const [search, setSearch] = useState("");
+  const [category, setCategory] = useState("all");
+  const [page, setPage] = useState(1);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    try {
+      const qs = new URLSearchParams({ report, from, to, outletId, groupBy });
+      const res = await adminFetch(`/api/sales/reports?${qs.toString()}`);
+      if (!res.ok) throw new Error((await res.json().catch(() => ({})))?.error || "Load failed");
+      const json = (await res.json()) as ReportData;
+      setData(json);
+      setSort(null);
+      setSearch("");
+      setCategory("all");
+      setPage(1);
+    } catch (e) {
+      toast.error(e instanceof Error ? e.message : "Failed to load report");
+    } finally {
+      setLoading(false);
+    }
+  }, [report, from, to, outletId, groupBy]);
 
   useEffect(() => {
-    let cancelled = false;
-    (async () => {
-      setLoading(true);
-      try {
-        const res = await adminFetch("/api/pos/reports");
-        if (!res.ok) throw new Error("Load failed");
-        const json = (await res.json()) as Reports;
-        if (!cancelled) setData(json);
-      } catch (e) {
-        toast.error(e instanceof Error ? e.message : "Failed to load reports");
-      } finally {
-        setLoading(false);
-      }
-    })();
-    return () => { cancelled = true; };
-  }, []);
+    load();
+  }, [load]);
 
-  const sales    = data?.sales    ?? [];
-  const payments = data?.payments ?? [];
-  const products = data?.products ?? [];
-  const staff    = data?.staff    ?? [];
+  const columns = data?.columns ?? [];
+  const firstTextKey = columns.find((c) => c.kind === "text")?.key;
+  const hasCategory = columns.some((c) => c.key === "category");
 
-  const totalRevenue = sales.reduce((s, d) => s + d.revenue, 0);
-  const totalOrders  = sales.reduce((s, d) => s + d.orders,  0);
-  const avgOrder     = totalOrders > 0 ? Math.round(totalRevenue / totalOrders) : 0;
-  const topProduct   = products[0]?.name ?? "—";
-  const topProductQty = products[0]?.qty ?? 0;
+  const categoryOptions = useMemo(() => {
+    if (!hasCategory) return [];
+    const set = new Set<string>();
+    for (const r of data?.rows ?? []) {
+      const v = String(r.category ?? "").trim();
+      if (v) set.add(v);
+    }
+    return [...set].sort();
+  }, [data, hasCategory]);
+
+  // sort → filter (search + category) → the totals row reflects the filtered set.
+  const sortedRows = useMemo(() => {
+    const rows = data?.rows ?? [];
+    if (!sort) return rows;
+    const col = columns.find((c) => c.key === sort.key);
+    const isText = col?.kind === "text";
+    return [...rows].sort((a, b) => {
+      const av = a[sort.key];
+      const bv = b[sort.key];
+      const cmp = isText ? String(av).localeCompare(String(bv)) : (Number(av) || 0) - (Number(bv) || 0);
+      return sort.dir === "asc" ? cmp : -cmp;
+    });
+  }, [data, sort, columns]);
+
+  const filteredRows = useMemo(() => {
+    let rows = sortedRows;
+    const q = search.trim().toLowerCase();
+    if (q) {
+      const textKeys = columns.filter((c) => c.kind === "text").map((c) => c.key);
+      rows = rows.filter((r) => textKeys.some((k) => String(r[k] ?? "").toLowerCase().includes(q)));
+    }
+    if (hasCategory && category !== "all") rows = rows.filter((r) => String(r.category ?? "") === category);
+    return rows;
+  }, [sortedRows, search, category, columns, hasCategory]);
+
+  const isFiltered = search.trim() !== "" || category !== "all";
+  const pageCount = Math.max(1, Math.ceil(filteredRows.length / PAGE_SIZE));
+  const safePage = Math.min(page, pageCount);
+  const pagedRows = filteredRows.slice((safePage - 1) * PAGE_SIZE, safePage * PAGE_SIZE);
+
+  // Totals: server total when unfiltered; when filtered, sum additive columns
+  // only (rm/int) and blank ratios/averages (pct + avg) to avoid wrong math.
+  const AVG_KEYS = new Set(["aov", "avgCost"]);
+  const totalRow: Row | null = useMemo(() => {
+    if (!data?.total) return null;
+    if (!isFiltered) return data.total;
+    const t: Row = {};
+    columns.forEach((c, i) => {
+      if (i === 0) t[c.key] = "Total";
+      else if (c.kind === "rm" && !AVG_KEYS.has(c.key)) t[c.key] = filteredRows.reduce((s, r) => s + (Number(r[c.key]) || 0), 0);
+      else if (c.kind === "int") t[c.key] = filteredRows.reduce((s, r) => s + (Number(r[c.key]) || 0), 0);
+      else t[c.key] = "";
+    });
+    return t;
+  }, [data, isFiltered, filteredRows, columns]);
+
+  const toggleSort = (key: string) =>
+    setSort((s) => (s?.key === key ? { key, dir: s.dir === "asc" ? "desc" : "asc" } : { key, dir: "desc" }));
+
+  const setPreset = (preset: "today" | "7d" | "week" | "month" | "30d") => {
+    const t = mytToday();
+    if (preset === "today") { setFrom(t); setTo(t); }
+    else if (preset === "7d") { setFrom(addDaysStr(t, -6)); setTo(t); }
+    else if (preset === "30d") { setFrom(addDaysStr(t, -29)); setTo(t); }
+    else if (preset === "week") { setFrom(startOfWeek(t)); setTo(t); }
+    else if (preset === "month") { setFrom(startOfMonth(t)); setTo(t); }
+  };
+  const presetActive = (preset: "today" | "7d" | "week" | "month" | "30d"): boolean => {
+    const t = today;
+    if (preset === "today") return from === t && to === t;
+    if (preset === "7d") return from === addDaysStr(t, -6) && to === t;
+    if (preset === "30d") return from === addDaysStr(t, -29) && to === t;
+    if (preset === "week") return from === startOfWeek(t) && to === t;
+    return from === startOfMonth(t) && to === t;
+  };
+
+  const downloadCsv = () => {
+    if (!data) return;
+    const esc = (v: string | number) => {
+      const s = String(v ?? "");
+      return /[",\n]/.test(s) ? `"${s.replace(/"/g, '""')}"` : s;
+    };
+    const head = columns.map((c) => esc(c.label)).join(",");
+    const body = filteredRows.map((r) => columns.map((c) => esc(r[c.key])).join(",")).join("\n");
+    const totalLine = totalRow ? "\n" + columns.map((c) => esc(totalRow[c.key])).join(",") : "";
+    const csv = `${head}\n${body}${totalLine}`;
+    const blob = new Blob([csv], { type: "text/csv;charset=utf-8;" });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = `celsius-${report}-${from}_to_${to}.csv`;
+    a.click();
+    URL.revokeObjectURL(url);
+  };
 
   return (
     <div className="p-3 sm:p-6 space-y-5 max-w-6xl">
       <ReportsTabs />
-      <div>
-        <h1 className="text-2xl font-bold text-[#160800]">POS Reports</h1>
-        <p className="text-sm text-muted-foreground mt-0.5">
-          Last 14 days of completed POS orders — sales, payment methods, product mix, staff performance.
-        </p>
+
+      <div className="flex flex-wrap items-end justify-between gap-3">
+        <div>
+          <h1 className="text-2xl font-bold text-[#160800]">Sales Reports</h1>
+          <p className="text-sm text-muted-foreground mt-0.5">
+            {data?.outletName ?? "All outlets"}
+            {data?.generatedAt && (
+              <> · Data as of {new Date(data.generatedAt).toLocaleString("en-MY", { dateStyle: "medium", timeStyle: "short" })}</>
+            )}
+          </p>
+        </div>
+        <button
+          onClick={downloadCsv}
+          disabled={!data || loading}
+          className="inline-flex items-center gap-2 rounded-lg border border-gray-200 bg-white px-4 py-2 text-sm font-medium text-[#160800] hover:bg-gray-50 disabled:opacity-50"
+        >
+          <Download className="h-4 w-4" /> Download CSV
+        </button>
       </div>
 
-      {/* Summary KPIs */}
-      <div className="grid grid-cols-2 md:grid-cols-4 gap-3">
-        <KpiCard Icon={Wallet}      label="Total Revenue"   value={formatRM(totalRevenue)} />
-        <KpiCard Icon={ShoppingBag} label="Total Orders"    value={String(totalOrders)} />
-        <KpiCard Icon={TrendingUp}  label="Avg Order Value" value={formatRM(avgOrder)} />
-        <KpiCard Icon={Trophy}      label="Top Product"     value={topProduct} sub={topProductQty > 0 ? `${topProductQty} sold` : undefined} />
-      </div>
-
-      {/* Tabs */}
-      <div className="flex gap-1 border-b border-gray-200">
-        {TABS.map((t) => (
+      {/* Report selector */}
+      <div className="flex flex-wrap gap-1 bg-white rounded-xl p-1 w-fit border border-border/40">
+        {REPORTS.map((r) => (
           <button
-            key={t.id}
-            onClick={() => setTab(t.id)}
-            className={`border-b-2 px-4 py-2 text-sm font-medium transition-colors ${
-              tab === t.id
-                ? "border-[#160800] text-[#160800]"
-                : "border-transparent text-muted-foreground hover:text-[#160800]"
+            key={r.id}
+            onClick={() => setReport(r.id)}
+            className={`px-3.5 py-2 rounded-lg text-sm font-medium transition-colors ${
+              report === r.id ? "bg-[#160800] text-white shadow-sm" : "text-muted-foreground hover:text-[#160800]"
             }`}
           >
-            {t.label}
+            {r.label}
           </button>
         ))}
       </div>
+
+      {/* Toolbar: date range + presets + outlet + group-by */}
+      <div className="flex flex-wrap items-center gap-2">
+        <div className="flex items-center gap-1.5 rounded-lg border border-gray-200 bg-white px-2 py-1.5">
+          <input type="date" value={from} max={to} onChange={(e) => setFrom(e.target.value)} className="bg-transparent text-sm text-[#160800] outline-none" />
+          <span className="text-gray-400">→</span>
+          <input type="date" value={to} min={from} max={today} onChange={(e) => setTo(e.target.value)} className="bg-transparent text-sm text-[#160800] outline-none" />
+        </div>
+
+        <div className="flex gap-1">
+          {([
+            { id: "today", label: "Today" },
+            { id: "7d", label: "7 days" },
+            { id: "week", label: "This week" },
+            { id: "month", label: "This month" },
+            { id: "30d", label: "30 days" },
+          ] as const).map((p) => (
+            <button
+              key={p.id}
+              onClick={() => setPreset(p.id)}
+              className={`rounded-lg px-3 py-1.5 text-xs font-medium transition-colors ${
+                presetActive(p.id) ? "bg-[#FBEBE8] text-[#A2492C]" : "text-muted-foreground hover:bg-gray-100"
+              }`}
+            >
+              {p.label}
+            </button>
+          ))}
+        </div>
+
+        {data?.availableOutlets && (
+          <select value={outletId} onChange={(e) => setOutletId(e.target.value)} className="rounded-lg border border-gray-200 bg-white px-3 py-2 text-sm text-[#160800] outline-none">
+            <option value="all">All outlets</option>
+            {data.availableOutlets.map((o) => (
+              <option key={o.id} value={o.id}>{o.name}</option>
+            ))}
+          </select>
+        )}
+
+        {report === "over-time" && (
+          <div className="flex gap-1 rounded-lg border border-gray-200 bg-white p-1">
+            {GROUPS.map((g) => (
+              <button
+                key={g.id}
+                onClick={() => setGroupBy(g.id)}
+                className={`rounded-md px-3 py-1 text-xs font-medium transition-colors ${
+                  groupBy === g.id ? "bg-[#160800] text-white" : "text-muted-foreground hover:text-[#160800]"
+                }`}
+              >
+                {g.label}
+              </button>
+            ))}
+          </div>
+        )}
+      </div>
+
+      {/* Filters: search + category */}
+      <div className="flex flex-wrap items-center gap-2">
+        <div className="flex items-center gap-2 rounded-lg border border-gray-200 bg-white px-3 py-2 min-w-[220px]">
+          <Search className="h-4 w-4 text-gray-400" />
+          <input
+            value={search}
+            onChange={(e) => { setSearch(e.target.value); setPage(1); }}
+            placeholder="Search…"
+            className="bg-transparent text-sm text-[#160800] outline-none w-full"
+          />
+        </div>
+        {hasCategory && categoryOptions.length > 0 && (
+          <select
+            value={category}
+            onChange={(e) => { setCategory(e.target.value); setPage(1); }}
+            className="rounded-lg border border-gray-200 bg-white px-3 py-2 text-sm text-[#160800] outline-none"
+          >
+            <option value="all">All categories</option>
+            {categoryOptions.map((c) => (
+              <option key={c} value={c}>{c}</option>
+            ))}
+          </select>
+        )}
+        {isFiltered && (
+          <button onClick={() => { setSearch(""); setCategory("all"); setPage(1); }} className="text-xs text-[#A2492C] hover:underline">
+            Clear filters
+          </button>
+        )}
+      </div>
+
+      {data?.note && (
+        <div className="flex items-start gap-2 rounded-lg bg-amber-50 border border-amber-200 px-3 py-2 text-xs text-amber-800">
+          <Info className="h-4 w-4 shrink-0 mt-0.5" />
+          <span>{data.note}</span>
+        </div>
+      )}
 
       {loading && (
         <div className="flex items-center justify-center py-16">
@@ -106,133 +345,122 @@ export default function POSReportsPage() {
         </div>
       )}
 
-      {!loading && tab === "sales" && (
-        <Table cols={["Date", "Orders", "Revenue", "Avg Order"]} empty="No sales data yet">
-          {sales.map((d) => (
-            <tr key={d.date} className="hover:bg-gray-50">
-              <Td>{d.date}</Td>
-              <Td align="right">{d.orders}</Td>
-              <Td align="right" bold>{formatRM(d.revenue)}</Td>
-              <Td align="right" muted>{formatRM(d.avg_order)}</Td>
-            </tr>
-          ))}
-        </Table>
-      )}
+      {!loading && data && (
+        <>
+          {data.chart && data.chart.length > 0 && !isFiltered && <Chart data={data.chart} />}
 
-      {!loading && tab === "payments" && (
-        <Table cols={["Payment Method", "Transactions", "Total", "% of Revenue"]} empty="No payment data yet">
-          {payments.map((p) => (
-            <tr key={p.method} className="hover:bg-gray-50">
-              <Td>{p.method}</Td>
-              <Td align="right">{p.count}</Td>
-              <Td align="right" bold>{formatRM(p.total)}</Td>
-              <Td align="right"><PctBar pct={p.pct} /></Td>
-            </tr>
-          ))}
-        </Table>
-      )}
+          <div className="rounded-2xl border border-gray-200 bg-white overflow-auto max-h-[68vh]">
+            <table className="w-full border-separate border-spacing-0">
+              <thead className="sticky top-0 z-10">
+                <tr className="bg-gray-50 text-left text-xs font-medium text-gray-700">
+                  {columns.map((c, i) => (
+                    <th
+                      key={c.key}
+                      onClick={() => toggleSort(c.key)}
+                      className={`cursor-pointer select-none px-4 py-3 whitespace-nowrap border-b border-gray-200 hover:text-[#160800] ${i === 0 ? "" : "text-right"}`}
+                    >
+                      <span className={`inline-flex items-center gap-1 ${i === 0 ? "" : "justify-end"}`}>
+                        {c.label}
+                        {c.tip && (
+                          <span title={c.tip} aria-label={c.tip} className="cursor-help">
+                            <Info className="h-3 w-3 text-gray-300" />
+                          </span>
+                        )}
+                        <SortIcon active={sort?.key === c.key} dir={sort?.dir} />
+                      </span>
+                    </th>
+                  ))}
+                </tr>
+              </thead>
+              <tbody>
+                {pagedRows.length === 0 ? (
+                  <tr>
+                    <td colSpan={columns.length} className="px-4 py-10 text-center text-sm text-gray-500">
+                      {isFiltered ? "No rows match your filters." : "No data in this period."}
+                    </td>
+                  </tr>
+                ) : (
+                  pagedRows.map((r, ri) => (
+                    <tr key={ri} className="hover:bg-gray-50">
+                      {columns.map((c, ci) => (
+                        <td
+                          key={c.key}
+                          className={`px-4 py-3 text-sm whitespace-nowrap border-b border-gray-100 ${ci === 0 ? "text-[#160800] font-medium" : "text-right text-[#160800]"}`}
+                        >
+                          {fmtCell(r[c.key], c.kind)}
+                        </td>
+                      ))}
+                    </tr>
+                  ))
+                )}
+              </tbody>
+              {totalRow && pagedRows.length > 0 && (
+                <tfoot className="sticky bottom-0">
+                  <tr className="bg-gray-100 font-semibold">
+                    {columns.map((c, ci) => (
+                      <td key={c.key} className={`px-4 py-3 text-sm whitespace-nowrap text-[#160800] border-t-2 border-gray-300 ${ci === 0 ? "" : "text-right"}`}>
+                        {totalRow[c.key] === "" ? "" : fmtCell(totalRow[c.key], c.kind)}
+                      </td>
+                    ))}
+                  </tr>
+                </tfoot>
+              )}
+            </table>
+          </div>
 
-      {!loading && tab === "products" && (
-        <Table cols={["#", "Product", "Qty Sold", "Revenue", "% of Sales"]} empty="No product data yet">
-          {products.map((p, i) => (
-            <tr key={p.name} className="hover:bg-gray-50">
-              <Td muted>{i + 1}</Td>
-              <Td>{p.name}</Td>
-              <Td align="right">{p.qty}</Td>
-              <Td align="right" bold>{formatRM(p.revenue)}</Td>
-              <Td align="right"><PctBar pct={p.pct} /></Td>
-            </tr>
-          ))}
-        </Table>
-      )}
-
-      {!loading && tab === "staff" && (
-        <Table cols={["Staff", "Orders", "Revenue", "Avg Order"]} empty="No staff data yet">
-          {staff.map((s) => (
-            <tr key={s.id} className="hover:bg-gray-50">
-              <Td>
-                <div className="flex items-center gap-2">
-                  <div className="flex h-7 w-7 items-center justify-center rounded-full bg-[#FBEBE8] text-xs font-bold text-[#A2492C]">
-                    {s.name.charAt(0)}
-                  </div>
-                  <span>{s.name}</span>
-                </div>
-              </Td>
-              <Td align="right">{s.orders}</Td>
-              <Td align="right" bold>{formatRM(s.revenue)}</Td>
-              <Td align="right" muted>{formatRM(s.avg_order)}</Td>
-            </tr>
-          ))}
-        </Table>
+          {/* Pagination */}
+          <div className="flex items-center justify-between text-xs text-gray-500">
+            <span>
+              {filteredRows.length === 0
+                ? "0 rows"
+                : `Showing ${(safePage - 1) * PAGE_SIZE + 1}–${Math.min(safePage * PAGE_SIZE, filteredRows.length)} of ${filteredRows.length}`}
+              {isFiltered && data && ` (filtered from ${data.rows.length})`}
+            </span>
+            {pageCount > 1 && (
+              <div className="flex items-center gap-2">
+                <button onClick={() => setPage((p) => Math.max(1, p - 1))} disabled={safePage <= 1} className="inline-flex items-center gap-1 rounded-md border border-gray-200 px-2 py-1 disabled:opacity-40 hover:bg-gray-50">
+                  <ChevronLeft className="h-3.5 w-3.5" /> Prev
+                </button>
+                <span>Page {safePage} / {pageCount}</span>
+                <button onClick={() => setPage((p) => Math.min(pageCount, p + 1))} disabled={safePage >= pageCount} className="inline-flex items-center gap-1 rounded-md border border-gray-200 px-2 py-1 disabled:opacity-40 hover:bg-gray-50">
+                  Next <ChevronRight className="h-3.5 w-3.5" />
+                </button>
+              </div>
+            )}
+          </div>
+        </>
       )}
     </div>
   );
 }
 
-function KpiCard({
-  Icon, label, value, sub,
-}: {
-  Icon: React.ComponentType<{ className?: string }>;
-  label: string;
-  value: string;
-  sub?: string;
-}) {
+function SortIcon({ active, dir }: { active?: boolean; dir?: "asc" | "desc" }) {
+  if (!active) return <ArrowUpDown className="h-3 w-3 text-gray-300" />;
+  return dir === "asc" ? <ArrowUp className="h-3 w-3 text-[#A2492C]" /> : <ArrowDown className="h-3 w-3 text-[#A2492C]" />;
+}
+
+function Chart({ data }: { data: { label: string; value: number }[] }) {
+  const max = Math.max(...data.map((d) => d.value), 1);
+  const bars = data.slice(0, 31);
   return (
-    <div className="rounded-2xl bg-white p-4 border border-gray-100">
-      <div className="flex items-center gap-2 mb-1.5">
-        <Icon className="h-4 w-4 text-[#A2492C]" />
-        <p className="text-[11px] font-bold uppercase tracking-wider text-gray-500">{label}</p>
+    <div className="rounded-2xl border border-gray-200 bg-white p-4">
+      <div className="flex items-end gap-1.5 h-44">
+        {bars.map((d, i) => (
+          <div key={i} className="group flex flex-1 flex-col items-center justify-end gap-1 min-w-0">
+            <div className="text-[10px] font-medium text-[#160800] opacity-0 group-hover:opacity-100 whitespace-nowrap">
+              {fmtRM(d.value)}
+            </div>
+            <div
+              className="w-full max-w-[36px] rounded-t bg-[#A2492C]/85 hover:bg-[#A2492C] transition-colors"
+              style={{ height: `${Math.max((d.value / max) * 100, 1)}%` }}
+              title={`${d.label}: ${fmtRM(d.value)}`}
+            />
+            <div className="text-[9px] text-gray-500 truncate w-full text-center" title={d.label}>
+              {d.label}
+            </div>
+          </div>
+        ))}
       </div>
-      <p className="text-xl font-bold text-[#160800]">{value}</p>
-      {sub && <p className="mt-0.5 text-[11px] text-[#A2492C]">{sub}</p>}
-    </div>
-  );
-}
-
-function Table({ cols, empty, children }: { cols: string[]; empty: string; children: React.ReactNode }) {
-  const hasRows = Array.isArray(children) ? children.length > 0 : !!children;
-  return (
-    <div className="overflow-hidden rounded-2xl border border-gray-200 bg-white">
-      <table className="w-full">
-        <thead>
-          <tr className="border-b border-gray-200 bg-gray-50 text-left text-xs font-medium text-gray-700">
-            {cols.map((c, i) => (
-              <th key={c} className={`px-4 py-3 ${i === 0 ? "" : "text-right"}`}>{c}</th>
-            ))}
-          </tr>
-        </thead>
-        <tbody className="divide-y divide-gray-100">
-          {hasRows ? children : (
-            <tr><td colSpan={cols.length} className="px-4 py-10 text-center text-sm text-gray-500">{empty}</td></tr>
-          )}
-        </tbody>
-      </table>
-    </div>
-  );
-}
-
-function Td({
-  children, align, bold, muted,
-}: {
-  children: React.ReactNode;
-  align?: "right" | "left";
-  bold?: boolean;
-  muted?: boolean;
-}) {
-  return (
-    <td className={`px-4 py-3 text-sm ${align === "right" ? "text-right" : ""} ${bold ? "font-medium" : ""} ${muted ? "text-gray-500" : "text-[#160800]"}`}>
-      {children}
-    </td>
-  );
-}
-
-function PctBar({ pct }: { pct: number }) {
-  return (
-    <div className="flex items-center justify-end gap-2">
-      <div className="h-1.5 w-16 rounded-full bg-gray-200">
-        <div className="h-1.5 rounded-full bg-[#A2492C]" style={{ width: `${pct}%` }} />
-      </div>
-      <span className="text-xs text-gray-500 w-8 text-right">{pct}%</span>
     </div>
   );
 }

--- a/apps/backoffice/src/app/api/sales/_lib/reports.ts
+++ b/apps/backoffice/src/app/api/sales/_lib/reports.ts
@@ -1,0 +1,818 @@
+/**
+ * StoreHub-style "Reports 2.0" data builders for the backoffice Sales reports.
+ * Mirrors StoreHub's report set on our own data, now that StoreHub is retired:
+ *   • over-time  — sales/transactions/AOV per day|week|month, split by channel
+ *   • product    — qty sold, sales, cost, gross profit per product
+ *   • category   — same, grouped by product category
+ *   • payment    — sales/transactions per payment method
+ *
+ * Sources & cutover routing (identical rule to unified-sales.ts, so the
+ * over-time totals reconcile with the Sales dashboard):
+ *   • over-time uses getUnifiedSalesForOutlet (StoreHub archive pre-cutover +
+ *     live-today + POS-native + pickup, already cutover-routed, no double-count).
+ *   • product/category gather line items with the SAME per-outlet cutover gate:
+ *     storehub_sale_items pre-cutover (+ external delivery), pos_order_items and
+ *     pickup order_items at/after cutover. Pickup never lived in StoreHub so it
+ *     is always included.
+ *   • payment is POS-native (pos_order_payments) + pickup only — StoreHub never
+ *     exposed payment splits, so this report is post-cutover by nature.
+ *
+ * Money: storehub archive is already RM (numeric); pos and orders are SEN (int).
+ * Everything is normalised to RM (number) inside here; the client just formats.
+ * Dates are MYT (UTC+8) calendar days.
+ */
+
+import { prisma } from "@/lib/prisma";
+import { getSupabaseAdmin } from "@/lib/pickup/supabase";
+import { getUnifiedSalesForOutlet } from "./unified-sales";
+import {
+  CHANNEL_LABELS,
+  normalizePayment,
+  PAY_LABELS,
+  getMYTDateStr,
+  addDays,
+  dayOfWeek,
+  round2,
+  type ChannelKey,
+  type PayKey,
+} from "./native-sales-helpers";
+
+const MON = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"];
+
+export type ReportKind =
+  | "over-time"
+  | "channel"
+  | "product"
+  | "category"
+  | "sku"
+  | "payment"
+  | "promotion"
+  | "shift";
+export type GroupBy = "day" | "week" | "month";
+
+export type OutletPick = {
+  id: string;
+  name: string;
+  storehubId: string | null;
+  loyaltyOutletId: string | null;
+  pickupStoreId: string | null;
+  posNativeCutoverAt: Date | null;
+};
+
+/** A generic report column. `kind` drives client formatting; `tip` shows a ⓘ. */
+export type Column = { key: string; label: string; kind: "text" | "rm" | "int" | "pct"; tip?: string };
+export type Row = Record<string, string | number>;
+export type ReportResult = {
+  report: ReportKind;
+  columns: Column[];
+  rows: Row[];
+  total: Row | null;
+  chart?: { label: string; value: number }[];
+  note?: string;
+};
+
+const isExternalDelivery = (channel: string | null | undefined): boolean =>
+  !!channel && /grab|panda|shopee|beep|deliver/i.test(channel);
+
+const dmy = (dateStr: string): string => {
+  const d = new Date(`${dateStr}T12:00:00+08:00`);
+  return `${d.getDate()} ${MON[d.getMonth()]}`;
+};
+const WK = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
+
+// ── helper: MYT day bounds as UTC Date for SQL params ──
+const dayStart = (dateStr: string) => new Date(`${dateStr}T00:00:00+08:00`);
+const dayEnd = (dateStr: string) => new Date(`${dateStr}T23:59:59.999+08:00`);
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Over time
+// ─────────────────────────────────────────────────────────────────────────────
+export async function buildOverTime(
+  outlets: OutletPick[],
+  from: string,
+  to: string,
+  groupBy: GroupBy,
+): Promise<ReportResult> {
+  const fromD = dayStart(from);
+  const toD = dayEnd(to);
+
+  const settled = await Promise.allSettled(
+    outlets.map((o) =>
+      getUnifiedSalesForOutlet(
+        {
+          outletId: o.id,
+          storehubStoreId: o.storehubId,
+          loyaltyOutletId: o.loyaltyOutletId,
+          pickupStoreId: o.pickupStoreId,
+          cutoverAt: o.posNativeCutoverAt,
+        },
+        fromD,
+        toD,
+        {},
+      ),
+    ),
+  );
+
+  type Bucket = {
+    sortKey: string;
+    label: string;
+    total: number;
+    txns: number;
+    chan: Record<ChannelKey, number>;
+  };
+  const buckets = new Map<string, Bucket>();
+  const blankChan = (): Record<ChannelKey, number> =>
+    ({ dine_in: 0, takeaway: 0, delivery: 0, pickup: 0, qr_table: 0 });
+
+  const periodFor = (dateStr: string): { sortKey: string; label: string } => {
+    if (groupBy === "month") {
+      const d = new Date(`${dateStr}T12:00:00+08:00`);
+      const key = `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}`;
+      return { sortKey: key, label: `${MON[d.getMonth()]} ${d.getFullYear()}` };
+    }
+    if (groupBy === "week") {
+      const wkStart = addDays(dateStr, -dayOfWeek(dateStr));
+      const wkEnd = addDays(wkStart, 6);
+      return { sortKey: wkStart, label: `${dmy(wkStart)} – ${dmy(wkEnd)}` };
+    }
+    return { sortKey: dateStr, label: `${dmy(dateStr)} (${WK[dayOfWeek(dateStr)]})` };
+  };
+
+  for (const r of settled) {
+    if (r.status !== "fulfilled") continue;
+    for (const ev of r.value) {
+      const dateStr = getMYTDateStr(ev.ts);
+      if (dateStr < from || dateStr > to) continue;
+      const { sortKey, label } = periodFor(dateStr);
+      let b = buckets.get(sortKey);
+      if (!b) {
+        b = { sortKey, label, total: 0, txns: 0, chan: blankChan() };
+        buckets.set(sortKey, b);
+      }
+      b.total += ev.total;
+      b.txns += 1;
+      b.chan[ev.channel] += ev.total;
+    }
+  }
+
+  const ordered = [...buckets.values()].sort((a, b) => (a.sortKey < b.sortKey ? -1 : 1));
+  const rows: Row[] = ordered.map((b) => ({
+    period: b.label,
+    totalSales: round2(b.total),
+    transactions: b.txns,
+    aov: b.txns ? round2(b.total / b.txns) : 0,
+    dine_in: round2(b.chan.dine_in),
+    takeaway: round2(b.chan.takeaway),
+    delivery: round2(b.chan.delivery),
+  }));
+
+  const tTotal = ordered.reduce((s, b) => s + b.total, 0);
+  const tTxns = ordered.reduce((s, b) => s + b.txns, 0);
+  const total: Row = {
+    period: "Total",
+    totalSales: round2(tTotal),
+    transactions: tTxns,
+    aov: tTxns ? round2(tTotal / tTxns) : 0,
+    dine_in: round2(ordered.reduce((s, b) => s + b.chan.dine_in, 0)),
+    takeaway: round2(ordered.reduce((s, b) => s + b.chan.takeaway, 0)),
+    delivery: round2(ordered.reduce((s, b) => s + b.chan.delivery, 0)),
+  };
+
+  return {
+    report: "over-time",
+    columns: [
+      { key: "period", label: groupBy === "month" ? "Month" : groupBy === "week" ? "Week" : "Date", kind: "text" },
+      { key: "totalSales", label: "Total Sales", kind: "rm" },
+      { key: "transactions", label: "Transactions", kind: "int" },
+      { key: "aov", label: "Avg Order", kind: "rm" },
+      { key: "dine_in", label: CHANNEL_LABELS.dine_in, kind: "rm" },
+      { key: "takeaway", label: CHANNEL_LABELS.takeaway, kind: "rm" },
+      { key: "delivery", label: CHANNEL_LABELS.delivery, kind: "rm" },
+    ],
+    rows,
+    total,
+    chart: ordered.map((b) => ({ label: b.label, value: round2(b.total) })),
+  };
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// By channel (Dine-in / Takeaway / Grab) — same unified, cutover-routed source
+// as over-time, so totals and the per-channel split reconcile exactly.
+// ─────────────────────────────────────────────────────────────────────────────
+export async function buildByChannel(outlets: OutletPick[], from: string, to: string): Promise<ReportResult> {
+  const fromD = dayStart(from);
+  const toD = dayEnd(to);
+
+  const settled = await Promise.allSettled(
+    outlets.map((o) =>
+      getUnifiedSalesForOutlet(
+        {
+          outletId: o.id,
+          storehubStoreId: o.storehubId,
+          loyaltyOutletId: o.loyaltyOutletId,
+          pickupStoreId: o.pickupStoreId,
+          cutoverAt: o.posNativeCutoverAt,
+        },
+        fromD,
+        toD,
+        {},
+      ),
+    ),
+  );
+
+  const agg = new Map<ChannelKey, { sales: number; txns: number }>();
+  for (const r of settled) {
+    if (r.status !== "fulfilled") continue;
+    for (const ev of r.value) {
+      const d = getMYTDateStr(ev.ts);
+      if (d < from || d > to) continue;
+      const cur = agg.get(ev.channel) ?? { sales: 0, txns: 0 };
+      cur.sales += ev.total;
+      cur.txns += 1;
+      agg.set(ev.channel, cur);
+    }
+  }
+
+  const grand = [...agg.values()].reduce((s, v) => s + v.sales, 0) || 1;
+  const rows: Row[] = [...agg.entries()]
+    .map(([k, v]) => ({
+      channel: CHANNEL_LABELS[k],
+      transactions: v.txns,
+      totalSales: round2(v.sales),
+      aov: v.txns ? round2(v.sales / v.txns) : 0,
+      sharePct: round2((v.sales / grand) * 100),
+    }))
+    .sort((a, b) => (b.totalSales as number) - (a.totalSales as number));
+
+  const tSales = [...agg.values()].reduce((s, v) => s + v.sales, 0);
+  const tTxns = [...agg.values()].reduce((s, v) => s + v.txns, 0);
+  const total: Row = {
+    channel: "Total",
+    transactions: tTxns,
+    totalSales: round2(tSales),
+    aov: tTxns ? round2(tSales / tTxns) : 0,
+    sharePct: 100,
+  };
+
+  return {
+    report: "channel",
+    columns: [
+      { key: "channel", label: "Channel", kind: "text" },
+      { key: "transactions", label: "Transactions", kind: "int" },
+      { key: "totalSales", label: "Total Sales", kind: "rm" },
+      { key: "aov", label: "Avg Order", kind: "rm" },
+      { key: "sharePct", label: "% of Total", kind: "pct" },
+    ],
+    rows,
+    total,
+    chart: rows.map((r) => ({ label: r.channel as string, value: r.totalSales as number })),
+  };
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Line-item gathering (shared by product + category), cutover-routed.
+// Returns one entry per source line, in RM, with category + unit cost resolved.
+// ─────────────────────────────────────────────────────────────────────────────
+type GatheredItem = { name: string; category: string; sku: string; qty: number; sales: number; cost: number };
+
+async function gatherItems(outlets: OutletPick[], from: string, to: string): Promise<GatheredItem[]> {
+  const supabase = getSupabaseAdmin();
+  const fromD = dayStart(from);
+  const toD = dayEnd(to);
+
+  // Product reference (category + unit cost in RM), keyed by lower(name) —
+  // the only reliable join across sources (our products carry no
+  // storehub_product_id link). Category prefers our canonical catalog;
+  // unit cost prefers the archived StoreHub catalog, which is the only place
+  // costs were ever recorded (our `products.cost` is empty). Made-to-order
+  // drinks legitimately have no unit cost → gross profit shows as 100%,
+  // exactly as StoreHub reported them.
+  const [{ data: products }, { data: shProducts }] = await Promise.all([
+    supabase.from("products").select("name, category, cost, sku"),
+    supabase.from("storehub_products").select("name, category, cost, sku"),
+  ]);
+  const norm = (n: string) => n.trim().toLowerCase();
+  const prettyCat = (c: string) =>
+    c.replace(/[-_]+/g, " ").replace(/\b\w/g, (m) => m.toUpperCase());
+
+  const catByName = new Map<string, string>();
+  const costByName = new Map<string, number>();
+  const skuByName = new Map<string, string>();
+  for (const p of shProducts ?? []) {
+    const name = (p.name as string) || "";
+    if (!name) continue;
+    const cost = Number(p.cost) || 0;
+    if (cost > 0) costByName.set(norm(name), cost);
+    if (p.category) catByName.set(norm(name), prettyCat(p.category as string));
+    if (p.sku) skuByName.set(norm(name), p.sku as string);
+  }
+  for (const p of products ?? []) {
+    const name = (p.name as string) || "";
+    if (!name) continue;
+    // our catalog is the canonical category source — it overrides StoreHub's.
+    if (p.category) catByName.set(norm(name), prettyCat(p.category as string));
+    const cost = Number(p.cost) || 0;
+    if (cost > 0 && !costByName.has(norm(name))) costByName.set(norm(name), cost);
+    if (p.sku) skuByName.set(norm(name), p.sku as string);
+  }
+  const refByName = (name: string) => ({
+    category: catByName.get(norm(name)) ?? "Uncategorized",
+    cost: costByName.get(norm(name)) ?? 0,
+    sku: skuByName.get(norm(name)) ?? "N/A",
+  });
+
+  type ShRow = { name: string | null; quantity: unknown; total: unknown; ts: Date; channel: string | null };
+  type NativeRow = { product_name: string | null; quantity: unknown; item_total: unknown };
+  const empty = Promise.resolve([] as never[]);
+
+  // One outlet's lines; its three source queries run concurrently.
+  const perOutlet = await Promise.all(
+    outlets.map(async (o): Promise<GatheredItem[]> => {
+      const cutoverMs = o.posNativeCutoverAt ? o.posNativeCutoverAt.getTime() : Number.POSITIVE_INFINITY;
+      const [shRows, posRows, appRows] = await Promise.all([
+        // StoreHub archive — pre-cutover, or external delivery post-cutover.
+        o.id
+          ? prisma.$queryRaw<ShRow[]>`
+              SELECT si.name, si.quantity, si.total, si.transaction_time AS ts, s.channel
+              FROM storehub_sale_items si
+              JOIN storehub_sales s ON s.id = si.sale_id
+              WHERE si.outlet_id = ${o.id}
+                AND NOT s.is_cancelled
+                AND si.transaction_time >= ${fromD}
+                AND si.transaction_time <= ${toD}`
+          : empty,
+        // POS-native — at/after cutover (no native rows exist pre-cutover).
+        o.loyaltyOutletId
+          ? prisma.$queryRaw<NativeRow[]>`
+              SELECT i.product_name, i.quantity, i.item_total
+              FROM pos_order_items i
+              JOIN pos_orders o ON o.id = i.order_id
+              WHERE o.outlet_id = ${o.loyaltyOutletId}
+                AND o.status = 'completed'
+                AND o.refund_of_order_id IS NULL
+                AND o.created_at >= ${fromD}
+                AND o.created_at <= ${toD}`
+          : empty,
+        // Pickup app — always included (never lived in StoreHub).
+        o.pickupStoreId
+          ? prisma.$queryRaw<NativeRow[]>`
+              SELECT i.product_name, i.quantity, i.item_total
+              FROM order_items i
+              JOIN orders o ON o.id = i.order_id
+              WHERE o.store_id = ${o.pickupStoreId}
+                AND o.status = 'completed'
+                AND o.created_at >= ${fromD}
+                AND o.created_at <= ${toD}`
+          : empty,
+      ]);
+
+      const out: GatheredItem[] = [];
+      for (const r of shRows as ShRow[]) {
+        const tsMs = r.ts instanceof Date ? r.ts.getTime() : new Date(String(r.ts)).getTime();
+        if (!(tsMs < cutoverMs || isExternalDelivery(r.channel))) continue; // cutover gate
+        const name = (r.name || "Unknown").trim();
+        const ref = refByName(name);
+        out.push({ name, category: ref.category, sku: ref.sku, qty: Number(r.quantity) || 0, sales: Number(r.total) || 0, cost: ref.cost });
+      }
+      for (const r of [...(posRows as NativeRow[]), ...(appRows as NativeRow[])]) {
+        const name = (r.product_name || "Unknown").trim();
+        const ref = refByName(name);
+        out.push({ name, category: ref.category, sku: ref.sku, qty: Number(r.quantity) || 0, sales: (Number(r.item_total) || 0) / 100, cost: ref.cost });
+      }
+      return out;
+    }),
+  );
+
+  return perOutlet.flat();
+}
+
+const GP_TIP = "Gross profit = sales − (qty × unit cost). Items with no cost in the catalog show 100%.";
+const COST_NOTE =
+  "Unit cost comes from the StoreHub catalog (by product name); only ~28 items have it, so made-to-order drinks read as 100% gross profit.";
+
+export async function buildByProduct(outlets: OutletPick[], from: string, to: string): Promise<ReportResult> {
+  const items = await gatherItems(outlets, from, to);
+  type Agg = { name: string; category: string; sku: string; qty: number; sales: number; costTotal: number };
+  const map = new Map<string, Agg>();
+  for (const it of items) {
+    let a = map.get(it.name);
+    if (!a) {
+      a = { name: it.name, category: it.category, sku: it.sku, qty: 0, sales: 0, costTotal: 0 };
+      map.set(it.name, a);
+    }
+    a.qty += it.qty;
+    a.sales += it.sales;
+    a.costTotal += it.qty * it.cost;
+  }
+  const rows: Row[] = [...map.values()]
+    .map((a) => {
+      const gp = a.sales - a.costTotal;
+      return {
+        name: a.name,
+        category: a.category,
+        sku: a.sku,
+        qty: round2(a.qty),
+        totalSales: round2(a.sales),
+        avgCost: a.qty ? round2(a.costTotal / a.qty) : 0,
+        grossProfit: round2(gp),
+        gpPct: a.sales ? round2((gp / a.sales) * 100) : 0,
+      };
+    })
+    .sort((x, y) => (y.totalSales as number) - (x.totalSales as number));
+
+  const tSales = rows.reduce((s, r) => s + (r.totalSales as number), 0);
+  const tCost = [...map.values()].reduce((s, a) => s + a.costTotal, 0);
+  const tQty = rows.reduce((s, r) => s + (r.qty as number), 0);
+  const total: Row = {
+    name: "Total",
+    category: "",
+    sku: "",
+    qty: round2(tQty),
+    totalSales: round2(tSales),
+    avgCost: tQty ? round2(tCost / tQty) : 0,
+    grossProfit: round2(tSales - tCost),
+    gpPct: tSales ? round2(((tSales - tCost) / tSales) * 100) : 0,
+  };
+
+  return {
+    report: "product",
+    columns: [
+      { key: "name", label: "Product", kind: "text" },
+      { key: "category", label: "Category", kind: "text" },
+      { key: "sku", label: "SKU", kind: "text" },
+      { key: "qty", label: "Qty Sold", kind: "int" },
+      { key: "totalSales", label: "Total Sales", kind: "rm" },
+      { key: "avgCost", label: "Avg Cost", kind: "rm", tip: COST_NOTE },
+      { key: "grossProfit", label: "Gross Profit", kind: "rm", tip: GP_TIP },
+      { key: "gpPct", label: "Gross Profit %", kind: "pct", tip: GP_TIP },
+    ],
+    rows,
+    total,
+    note: COST_NOTE,
+  };
+}
+
+export async function buildBySku(outlets: OutletPick[], from: string, to: string): Promise<ReportResult> {
+  const items = await gatherItems(outlets, from, to);
+  // Group by SKU where present; items without one each stay a row keyed by name
+  // (so "N/A" products don't collapse into a single bucket) — mirrors StoreHub.
+  type Agg = { sku: string; name: string; category: string; qty: number; sales: number; costTotal: number };
+  const map = new Map<string, Agg>();
+  for (const it of items) {
+    const key = it.sku !== "N/A" ? `sku:${it.sku}` : `name:${it.name}`;
+    let a = map.get(key);
+    if (!a) {
+      a = { sku: it.sku, name: it.name, category: it.category, qty: 0, sales: 0, costTotal: 0 };
+      map.set(key, a);
+    }
+    a.qty += it.qty;
+    a.sales += it.sales;
+    a.costTotal += it.qty * it.cost;
+  }
+  const rows: Row[] = [...map.values()]
+    .map((a) => {
+      const gp = a.sales - a.costTotal;
+      return {
+        sku: a.sku,
+        name: a.name,
+        category: a.category,
+        qty: round2(a.qty),
+        totalSales: round2(a.sales),
+        grossProfit: round2(gp),
+        gpPct: a.sales ? round2((gp / a.sales) * 100) : 0,
+      };
+    })
+    .sort((x, y) => (y.totalSales as number) - (x.totalSales as number));
+
+  const tSales = rows.reduce((s, r) => s + (r.totalSales as number), 0);
+  const tCost = [...map.values()].reduce((s, a) => s + a.costTotal, 0);
+  const total: Row = {
+    sku: "Total",
+    name: "",
+    category: "",
+    qty: round2(rows.reduce((s, r) => s + (r.qty as number), 0)),
+    totalSales: round2(tSales),
+    grossProfit: round2(tSales - tCost),
+    gpPct: tSales ? round2(((tSales - tCost) / tSales) * 100) : 0,
+  };
+
+  return {
+    report: "sku",
+    columns: [
+      { key: "sku", label: "SKU", kind: "text" },
+      { key: "name", label: "Product", kind: "text" },
+      { key: "category", label: "Category", kind: "text" },
+      { key: "qty", label: "Qty Sold", kind: "int" },
+      { key: "totalSales", label: "Total Sales", kind: "rm" },
+      { key: "grossProfit", label: "Gross Profit", kind: "rm", tip: GP_TIP },
+      { key: "gpPct", label: "Gross Profit %", kind: "pct", tip: GP_TIP },
+    ],
+    rows,
+    total,
+    note: "SKUs come from the StoreHub catalog (matched by product name); items without a SKU there show N/A.",
+  };
+}
+
+export async function buildByCategory(outlets: OutletPick[], from: string, to: string): Promise<ReportResult> {
+  const items = await gatherItems(outlets, from, to);
+  type Agg = { category: string; qty: number; sales: number; costTotal: number };
+  const map = new Map<string, Agg>();
+  for (const it of items) {
+    let a = map.get(it.category);
+    if (!a) {
+      a = { category: it.category, qty: 0, sales: 0, costTotal: 0 };
+      map.set(it.category, a);
+    }
+    a.qty += it.qty;
+    a.sales += it.sales;
+    a.costTotal += it.qty * it.cost;
+  }
+  const grand = [...map.values()].reduce((s, a) => s + a.sales, 0) || 1;
+  const rows: Row[] = [...map.values()]
+    .map((a) => {
+      const gp = a.sales - a.costTotal;
+      return {
+        category: a.category,
+        qty: round2(a.qty),
+        totalSales: round2(a.sales),
+        grossProfit: round2(gp),
+        gpPct: a.sales ? round2((gp / a.sales) * 100) : 0,
+        sharePct: round2((a.sales / grand) * 100),
+      };
+    })
+    .sort((x, y) => (y.totalSales as number) - (x.totalSales as number));
+
+  const tSales = rows.reduce((s, r) => s + (r.totalSales as number), 0);
+  const tCost = [...map.values()].reduce((s, a) => s + a.costTotal, 0);
+  const tQty = rows.reduce((s, r) => s + (r.qty as number), 0);
+  const total: Row = {
+    category: "Total",
+    qty: round2(tQty),
+    totalSales: round2(tSales),
+    grossProfit: round2(tSales - tCost),
+    gpPct: tSales ? round2(((tSales - tCost) / tSales) * 100) : 0,
+    sharePct: 100,
+  };
+
+  return {
+    report: "category",
+    columns: [
+      { key: "category", label: "Category", kind: "text" },
+      { key: "qty", label: "Qty Sold", kind: "int" },
+      { key: "totalSales", label: "Total Sales", kind: "rm" },
+      { key: "grossProfit", label: "Gross Profit", kind: "rm" },
+      { key: "gpPct", label: "Gross Profit %", kind: "pct" },
+      { key: "sharePct", label: "% of Sales", kind: "pct" },
+    ],
+    rows,
+    total,
+    chart: rows.map((r) => ({ label: r.category as string, value: r.totalSales as number })),
+  };
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Payment method (POS-native + pickup only)
+// ─────────────────────────────────────────────────────────────────────────────
+export async function buildByPayment(outlets: OutletPick[], from: string, to: string): Promise<ReportResult> {
+  const fromD = dayStart(from);
+  const toD = dayEnd(to);
+  const agg = new Map<PayKey, { amount: number; txns: number }>(); // amount RM
+  const bump = (method: string | null, amountRM: number) => {
+    const k = normalizePayment(method);
+    const cur = agg.get(k) ?? { amount: 0, txns: 0 };
+    cur.amount += amountRM;
+    cur.txns += 1;
+    agg.set(k, cur);
+  };
+  type PayRow = { payment_method: string | null; amount: unknown; refund_amount: unknown };
+  type AppPayRow = { payment_method: string | null; total: unknown };
+  const empty = Promise.resolve([] as never[]);
+
+  await Promise.all(
+    outlets.map(async (o) => {
+      const [payRows, appRows] = await Promise.all([
+        o.loyaltyOutletId
+          ? prisma.$queryRaw<PayRow[]>`
+              SELECT p.payment_method, p.amount, p.refund_amount
+              FROM pos_order_payments p
+              JOIN pos_orders o ON o.id = p.order_id
+              WHERE o.outlet_id = ${o.loyaltyOutletId}
+                AND o.status = 'completed'
+                AND o.refund_of_order_id IS NULL
+                AND o.created_at >= ${fromD}
+                AND o.created_at <= ${toD}`
+          : empty,
+        o.pickupStoreId
+          ? prisma.$queryRaw<AppPayRow[]>`
+              SELECT payment_method, total
+              FROM orders
+              WHERE store_id = ${o.pickupStoreId}
+                AND status = 'completed'
+                AND created_at >= ${fromD}
+                AND created_at <= ${toD}`
+          : empty,
+      ]);
+      for (const r of payRows as PayRow[]) {
+        bump(r.payment_method, ((Number(r.amount) || 0) - (Number(r.refund_amount) || 0)) / 100);
+      }
+      for (const r of appRows as AppPayRow[]) {
+        bump(r.payment_method, (Number(r.total) || 0) / 100);
+      }
+    }),
+  );
+
+  const grand = [...agg.values()].reduce((s, v) => s + v.amount, 0) || 1;
+  const rows: Row[] = [...agg.entries()]
+    .map(([k, v]) => ({
+      method: PAY_LABELS[k] ?? k,
+      transactions: v.txns,
+      totalSales: round2(v.amount),
+      sharePct: round2((v.amount / grand) * 100),
+    }))
+    .sort((a, b) => (b.totalSales as number) - (a.totalSales as number));
+
+  const total: Row = {
+    method: "Total",
+    transactions: rows.reduce((s, r) => s + (r.transactions as number), 0),
+    totalSales: round2([...agg.values()].reduce((s, v) => s + v.amount, 0)),
+    sharePct: 100,
+  };
+
+  return {
+    report: "payment",
+    columns: [
+      { key: "method", label: "Payment Method", kind: "text" },
+      { key: "transactions", label: "Transactions", kind: "int" },
+      { key: "totalSales", label: "Total Sales", kind: "rm" },
+      { key: "sharePct", label: "% of Total", kind: "pct" },
+    ],
+    rows,
+    total,
+    chart: rows.map((r) => ({ label: r.method as string, value: r.totalSales as number })),
+    note: "Payment-method data covers POS-native + pickup sales (from each outlet's cutover). StoreHub never exposed payment splits, so earlier history isn't included here.",
+  };
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Promotions (POS-native + pickup) — POS promos (promo_name) and loyalty reward
+// redemptions (reward_name) each become a row. StoreHub promos weren't archived.
+// ─────────────────────────────────────────────────────────────────────────────
+export async function buildByPromotion(outlets: OutletPick[], from: string, to: string): Promise<ReportResult> {
+  const fromD = dayStart(from);
+  const toD = dayEnd(to);
+  type Agg = { label: string; type: string; txns: number; discount: number; customers: Set<string> };
+  const map = new Map<string, Agg>();
+  const bump = (label: string, type: string, discountSen: number, phone: string | null) => {
+    const name = (label || "").trim();
+    if (!name) return;
+    const key = `${type}|${name}`;
+    let a = map.get(key);
+    if (!a) {
+      a = { label: name, type, txns: 0, discount: 0, customers: new Set() };
+      map.set(key, a);
+    }
+    a.txns += 1;
+    a.discount += (discountSen || 0) / 100;
+    if (phone) a.customers.add(phone);
+  };
+
+  type PosRow = { promo_name: string | null; voucher_code: string | null; promo_discount: number | null; reward_name: string | null; reward_discount_amount: number | null; customer_phone: string | null };
+  type AppRow = PosRow;
+  const empty = Promise.resolve([] as never[]);
+
+  await Promise.all(
+    outlets.map(async (o) => {
+      const [posRows, appRows] = await Promise.all([
+        o.loyaltyOutletId
+          ? prisma.$queryRaw<PosRow[]>`
+              SELECT promo_name, voucher_code, promo_discount, reward_name, reward_discount_amount, customer_phone
+              FROM pos_orders
+              WHERE outlet_id = ${o.loyaltyOutletId}
+                AND status = 'completed'
+                AND refund_of_order_id IS NULL
+                AND created_at >= ${fromD}
+                AND created_at <= ${toD}`
+          : empty,
+        o.pickupStoreId
+          ? prisma.$queryRaw<AppRow[]>`
+              SELECT promo_name, voucher_code, promo_discount, reward_name, reward_discount_amount, customer_phone
+              FROM orders
+              WHERE store_id = ${o.pickupStoreId}
+                AND status = 'completed'
+                AND created_at >= ${fromD}
+                AND created_at <= ${toD}`
+          : empty,
+      ]);
+      for (const r of [...(posRows as PosRow[]), ...(appRows as AppRow[])]) {
+        const promo = (r.promo_name || r.voucher_code || "").trim();
+        if (promo) bump(promo, "Promotion", Number(r.promo_discount) || 0, r.customer_phone);
+        if (r.reward_name) bump(r.reward_name, "Reward", Number(r.reward_discount_amount) || 0, r.customer_phone);
+      }
+    }),
+  );
+
+  const rows: Row[] = [...map.values()]
+    .map((a) => ({
+      label: a.label,
+      type: a.type,
+      transactions: a.txns,
+      customers: a.customers.size,
+      discount: round2(a.discount),
+    }))
+    .sort((a, b) => (b.discount as number) - (a.discount as number));
+
+  const total: Row = {
+    label: "Total",
+    type: "",
+    transactions: rows.reduce((s, r) => s + (r.transactions as number), 0),
+    customers: rows.reduce((s, r) => s + (r.customers as number), 0),
+    discount: round2([...map.values()].reduce((s, a) => s + a.discount, 0)),
+  };
+
+  return {
+    report: "promotion",
+    columns: [
+      { key: "label", label: "Promotion", kind: "text" },
+      { key: "type", label: "Type", kind: "text" },
+      { key: "transactions", label: "Transactions", kind: "int" },
+      { key: "customers", label: "Customers", kind: "int", tip: "Distinct customer phone numbers that used this promotion." },
+      { key: "discount", label: "Total Discount", kind: "rm" },
+    ],
+    rows,
+    total,
+    chart: rows.slice(0, 12).map((r) => ({ label: r.label as string, value: r.discount as number })),
+    note: "Promotions cover POS-native + pickup orders (promotions and loyalty reward redemptions). 'Customers' is summed per row, so a customer using two promotions counts in each.",
+  };
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Shifts (POS-native pos_shifts) — one row per register shift. Native only.
+// ─────────────────────────────────────────────────────────────────────────────
+export async function buildByShift(outlets: OutletPick[], from: string, to: string): Promise<ReportResult> {
+  const fromD = dayStart(from);
+  const toD = dayEnd(to);
+  const nameById = new Map(outlets.map((o) => [o.loyaltyOutletId, o.name] as const));
+  const ids = outlets.map((o) => o.loyaltyOutletId).filter((x): x is string => !!x);
+
+  type ShiftRow = {
+    outlet_id: string | null;
+    opened_at: Date | null;
+    closed_at: Date | null;
+    status: string | null;
+    total_sales: number | null;
+    total_orders: number | null;
+    variance: number | null;
+  };
+  const shifts = ids.length
+    ? await prisma.$queryRaw<ShiftRow[]>`
+        SELECT outlet_id, opened_at, closed_at, status, total_sales, total_orders, variance
+        FROM pos_shifts
+        WHERE outlet_id = ANY(${ids})
+          AND opened_at >= ${fromD}
+          AND opened_at <= ${toD}
+        ORDER BY opened_at DESC`
+    : [];
+
+  const fmtTs = (d: Date | null): string => {
+    if (!d) return "—";
+    const t = new Date(d.getTime() + 8 * 3600 * 1000);
+    const mon = MON[t.getUTCMonth()];
+    let h = t.getUTCHours();
+    const ap = h < 12 ? "AM" : "PM";
+    h = h % 12 || 12;
+    return `${t.getUTCDate()} ${mon} ${h}:${String(t.getUTCMinutes()).padStart(2, "0")}${ap}`;
+  };
+
+  const rows: Row[] = shifts.map((s) => ({
+    outlet: nameById.get(s.outlet_id ?? "") ?? s.outlet_id ?? "—",
+    opened: fmtTs(s.opened_at),
+    closed: s.status === "open" ? "Open" : fmtTs(s.closed_at),
+    orders: Number(s.total_orders) || 0,
+    totalSales: round2((Number(s.total_sales) || 0) / 100),
+    variance: s.variance == null ? 0 : round2((Number(s.variance) || 0) / 100),
+  }));
+
+  const total: Row = {
+    outlet: "Total",
+    opened: "",
+    closed: "",
+    orders: rows.reduce((s, r) => s + (r.orders as number), 0),
+    totalSales: round2(rows.reduce((s, r) => s + (r.totalSales as number), 0)),
+    variance: round2(rows.reduce((s, r) => s + (r.variance as number), 0)),
+  };
+
+  return {
+    report: "shift",
+    columns: [
+      { key: "outlet", label: "Outlet", kind: "text" },
+      { key: "opened", label: "Opened", kind: "text" },
+      { key: "closed", label: "Closed", kind: "text" },
+      { key: "orders", label: "Orders", kind: "int" },
+      { key: "totalSales", label: "Total Sales", kind: "rm" },
+      { key: "variance", label: "Cash Variance", kind: "rm", tip: "Counted closing cash minus expected. 0 when cash wasn't counted at close." },
+    ],
+    rows,
+    total,
+    note: "Shifts are POS-native register sessions (pos_shifts). Cash variance is 0 where closing cash wasn't counted — the outlets are card-heavy.",
+  };
+}

--- a/apps/backoffice/src/app/api/sales/reports/route.ts
+++ b/apps/backoffice/src/app/api/sales/reports/route.ts
@@ -1,0 +1,117 @@
+import { NextRequest, NextResponse } from "next/server";
+import { requireAuth } from "@/lib/auth";
+import { prisma } from "@/lib/prisma";
+import {
+  buildOverTime,
+  buildByChannel,
+  buildByProduct,
+  buildByCategory,
+  buildBySku,
+  buildByPayment,
+  buildByPromotion,
+  buildByShift,
+  type ReportKind,
+  type GroupBy,
+  type OutletPick,
+} from "../_lib/reports";
+import { getMYTToday, addDays } from "../_lib/native-sales-helpers";
+
+/**
+ * GET /api/sales/reports
+ *   ?report=over-time|product|category|payment   (default over-time)
+ *   &from=YYYY-MM-DD&to=YYYY-MM-DD                (MYT; default last 7 days)
+ *   &outletId=all|<Outlet.id>                     (admins only; others locked)
+ *   &groupBy=day|week|month                       (over-time only; default day)
+ *
+ * StoreHub-style Sales reports on our own data. See _lib/reports.ts for the
+ * source/cutover routing. Money is returned in RM (already converted).
+ */
+
+const VALID_REPORTS: ReportKind[] = [
+  "over-time",
+  "channel",
+  "product",
+  "category",
+  "sku",
+  "payment",
+  "promotion",
+  "shift",
+];
+const VALID_GROUP: GroupBy[] = ["day", "week", "month"];
+const DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
+
+export async function GET(request: NextRequest) {
+  const auth = await requireAuth(request);
+  if (auth.error) return auth.error;
+  const user = auth.user;
+
+  const sp = new URL(request.url).searchParams;
+  const report = (sp.get("report") || "over-time") as ReportKind;
+  if (!VALID_REPORTS.includes(report)) {
+    return NextResponse.json({ error: "Invalid report" }, { status: 400 });
+  }
+  const groupBy = (sp.get("groupBy") || "day") as GroupBy;
+  if (!VALID_GROUP.includes(groupBy)) {
+    return NextResponse.json({ error: "Invalid groupBy" }, { status: 400 });
+  }
+
+  const today = getMYTToday();
+  const qFrom = sp.get("from");
+  const qTo = sp.get("to");
+  let from = DATE_RE.test(qFrom || "") ? (qFrom as string) : addDays(today, -6);
+  let to = DATE_RE.test(qTo || "") ? (qTo as string) : today;
+  if (from > to) [from, to] = [to, from];
+
+  const isAdmin = user.role === "OWNER" || user.role === "ADMIN";
+  const reqOutlet = sp.get("outletId");
+  // Admins default to all outlets and may drill into one; everyone else is
+  // locked to their assigned outlet (client param ignored).
+  const scope = isAdmin ? reqOutlet || "all" : user.outletId;
+  if (!scope) return NextResponse.json({ error: "No outlet" }, { status: 400 });
+
+  const all = await prisma.outlet.findMany({
+    where: { status: "ACTIVE" },
+    select: {
+      id: true,
+      name: true,
+      storehubId: true,
+      loyaltyOutletId: true,
+      pickupStoreId: true,
+      posNativeCutoverAt: true,
+    },
+    orderBy: { name: "asc" },
+  });
+  const picked: OutletPick[] = scope === "all" ? all : all.filter((o) => o.id === scope);
+  if (scope !== "all" && picked.length === 0) {
+    return NextResponse.json({ error: "Outlet not found" }, { status: 404 });
+  }
+
+  try {
+    let result;
+    if (report === "channel") result = await buildByChannel(picked, from, to);
+    else if (report === "product") result = await buildByProduct(picked, from, to);
+    else if (report === "category") result = await buildByCategory(picked, from, to);
+    else if (report === "sku") result = await buildBySku(picked, from, to);
+    else if (report === "payment") result = await buildByPayment(picked, from, to);
+    else if (report === "promotion") result = await buildByPromotion(picked, from, to);
+    else if (report === "shift") result = await buildByShift(picked, from, to);
+    else result = await buildOverTime(picked, from, to, groupBy);
+
+    return NextResponse.json({
+      ...result,
+      from,
+      to,
+      groupBy,
+      outletId: scope === "all" ? "all" : picked[0].id,
+      outletName: scope === "all" ? "All outlets" : picked[0].name,
+      availableOutlets: isAdmin ? all.map((o) => ({ id: o.id, name: o.name })) : undefined,
+      generatedAt: new Date().toISOString(),
+    });
+  } catch (e) {
+    console.error("[sales/reports]", e);
+    return NextResponse.json(
+      { error: e instanceof Error ? e.message : "Report failed" },
+      { status: 500 },
+    );
+  }
+}


### PR DESCRIPTION
Replaces StoreHub's **Reports 2.0** with an in-house version under **Sales → Reports** (`/pos/reports`, "Sales" tab), now that StoreHub is being cancelled.

## Reports (8, one toolbar)
`over-time` · `channel` · `product` · `category` · `sku` · `payment` · `promotion` · `shift`

## Data — `src/app/api/sales/_lib/reports.ts` · `GET /api/sales/reports`
- **over-time / channel** reuse `getUnifiedSalesForOutlet` → StoreHub archive (pre-cutover) + POS-native + pickup, cutover-routed, **reconciles with the Sales dashboard**.
- **product / category / sku** gather line items with the same per-outlet cutover gate. Cost + SKU come from the StoreHub catalog matched **by product name** (`products.cost` is empty). Aggregate GP% ≈ **88%**, matching StoreHub's own 88.07%.
- **payment / promotion** are POS-native + pickup only (StoreHub exposed neither); **shift** reads `pos_shifts`. Each is flagged with an in-UI note.
- Skipped Variant & Pre-order — zero data exists (no variants sold, no pre-order products).

## UI — `page.tsx`
Report tabs, date-range + presets, outlet filter, group-by (over-time), **search**, **category filter**, sortable columns, **client pagination** (50/page), **sticky header + totals**, column ⓘ tooltips, **CSV export**.

## Verification
Typechecks clean; all 8 reports exercised against the live DB for 12–18 Jun 2026 and reconcile (over-time RM76,090 / 2,599 txns; product & sku totals match; channel split matches over-time).

🤖 Generated with [Claude Code](https://claude.com/claude-code)