### PR TITLE
Add packaging to menu BOM with dine-in / takeaway costing

### DIFF
--- a/apps/backoffice/src/app/(admin)/inventory/menus/page.tsx
+++ b/apps/backoffice/src/app/(admin)/inventory/menus/page.tsx
@@ -10,16 +10,41 @@ import { Card } from "@/components/ui/card";
 import { Pencil, ChevronDown, Coffee, Search, Loader2, Trash2, X, Check, ArrowUp, ArrowDown, ChevronsUpDown } from "lucide-react";
 import { useFetch } from "@/lib/use-fetch";
 
-type Ingredient = { product: string; productId: string; sku: string; qty: number; uom: string; unitCost: number; cost: number };
+type ServiceMode = "ALL" | "DINE_IN" | "TAKEAWAY";
+const SERVICE_MODE_LABEL: Record<ServiceMode, string> = {
+  ALL: "Both",
+  DINE_IN: "Dine-in",
+  TAKEAWAY: "Takeaway",
+};
+
+type Ingredient = {
+  product: string;
+  productId: string;
+  sku: string;
+  qty: number;
+  uom: string;
+  unitCost: number;
+  cost: number;
+  serviceMode: ServiceMode;
+  kind: "ingredient" | "packaging";
+};
 
 type MenuItem = {
   id: string;
   name: string;
   category: string;
   sellingPrice: number;
-  cogs: number;
+  cogs: number; // all-in (takeaway) — headline
   cogsPercent: number;
+  ingredientCost: number;
+  packagingDineIn: number;
+  packagingTakeaway: number;
+  dineInCogs: number;
+  takeawayCogs: number;
+  dineInCogsPercent: number;
+  takeawayCogsPercent: number;
   ingredientCount: number;
+  packagingCount: number;
   ingredients: Ingredient[];
 };
 
@@ -28,6 +53,7 @@ type ProductOption = {
   name: string;
   sku: string;
   baseUom: string;
+  itemType: string; // INGREDIENT | PERISHABLE | PACKAGING
 };
 
 type EditIngredient = {
@@ -36,6 +62,8 @@ type EditIngredient = {
   sku: string;
   quantityUsed: number;
   uom: string;
+  serviceMode: ServiceMode;
+  kind: "ingredient" | "packaging";
 };
 
 type SortKey = "name" | "category" | "sellingPrice" | "cogs" | "cogsPercent" | "ingredientCount";
@@ -108,6 +136,8 @@ export default function MenusPage() {
         sku: ing.sku,
         quantityUsed: ing.qty,
         uom: ing.uom,
+        serviceMode: ing.serviceMode,
+        kind: ing.kind,
       }))
     );
     setAddSearch("");
@@ -133,11 +163,25 @@ export default function MenusPage() {
     setEditIngredients((prev) => prev.filter((ing) => ing.productId !== productId));
   };
 
+  const updateIngredientMode = (productId: string, mode: ServiceMode) => {
+    setEditIngredients((prev) =>
+      prev.map((ing) => (ing.productId === productId ? { ...ing, serviceMode: mode } : ing))
+    );
+  };
+
   const addIngredient = (product: ProductOption) => {
     if (editIngredients.some((ing) => ing.productId === product.id)) return;
     setEditIngredients((prev) => [
       ...prev,
-      { productId: product.id, productName: product.name, sku: product.sku, quantityUsed: 0, uom: product.baseUom },
+      {
+        productId: product.id,
+        productName: product.name,
+        sku: product.sku,
+        quantityUsed: 0,
+        uom: product.baseUom,
+        serviceMode: "ALL",
+        kind: product.itemType === "PACKAGING" ? "packaging" : "ingredient",
+      },
     ]);
     setAddSearch("");
   };
@@ -154,6 +198,7 @@ export default function MenusPage() {
             productId: ing.productId,
             quantityUsed: ing.quantityUsed,
             uom: ing.uom,
+            serviceMode: ing.serviceMode,
           })),
         }),
       });
@@ -211,7 +256,7 @@ export default function MenusPage() {
     <div className="p-3 sm:p-6">
       <div>
         <h2 className="text-xl font-semibold text-gray-900">Menu & Recipes (BOM)</h2>
-        <p className="mt-0.5 text-sm text-gray-500">{menus.length} menu items with ingredient costing</p>
+        <p className="mt-0.5 text-sm text-gray-500">{menus.length} menu items · ingredient + packaging costing (dine-in / takeaway)</p>
       </div>
 
       <div className="mt-4 flex flex-col gap-3">
@@ -322,7 +367,7 @@ export default function MenusPage() {
               <SortHeader label="Menu Item" sortKey="name" />
               <SortHeader label="Category" sortKey="category" />
               <SortHeader label="Selling Price" sortKey="sellingPrice" align="right" />
-              <SortHeader label="Product Cost" sortKey="cogs" align="right" />
+              <SortHeader label="All-in Cost" sortKey="cogs" align="right" />
               <SortHeader label="COGS %" sortKey="cogsPercent" align="right" />
               <SortHeader label="Ingredients" sortKey="ingredientCount" />
               <th className="px-4 py-3 text-right font-medium text-gray-500">Actions</th>
@@ -395,17 +440,27 @@ export default function MenusPage() {
                             <table className="w-full text-xs">
                               <thead>
                                 <tr className="text-gray-400">
-                                  <th className="pb-1 text-left font-medium">Ingredient</th>
+                                  <th className="pb-1 text-left font-medium">Item</th>
                                   <th className="pb-1 text-left font-medium w-20">SKU</th>
                                   <th className="pb-1 w-28 text-right font-medium">Qty</th>
-                                  <th className="pb-1 w-20 text-center font-medium">UOM</th>
+                                  <th className="pb-1 w-16 text-center font-medium">UOM</th>
+                                  <th className="pb-1 w-28 text-center font-medium">Channel</th>
                                   <th className="pb-1 w-8"></th>
                                 </tr>
                               </thead>
                               <tbody>
                                 {editIngredients.map((ing) => (
                                   <tr key={ing.productId} className="border-t border-gray-200/50">
-                                    <td className="py-1.5 text-gray-700">{ing.productName}</td>
+                                    <td className="py-1.5 text-gray-700">
+                                      <span className="inline-flex items-center gap-1.5">
+                                        {ing.productName}
+                                        {ing.kind === "packaging" && (
+                                          <Badge variant="outline" className="border-amber-300 bg-amber-50 text-[9px] text-amber-700">
+                                            Packaging
+                                          </Badge>
+                                        )}
+                                      </span>
+                                    </td>
                                     <td className="py-1.5"><code className="text-gray-500">{ing.sku}</code></td>
                                     <td className="py-1.5 text-right">
                                       <input
@@ -421,6 +476,17 @@ export default function MenusPage() {
                                       {ing.uom}
                                     </td>
                                     <td className="py-1.5 text-center">
+                                      <select
+                                        value={ing.serviceMode}
+                                        onChange={(e) => updateIngredientMode(ing.productId, e.target.value as ServiceMode)}
+                                        className="rounded border border-gray-200 px-1.5 py-1 text-xs text-gray-600"
+                                      >
+                                        <option value="ALL">Both</option>
+                                        <option value="DINE_IN">Dine-in</option>
+                                        <option value="TAKEAWAY">Takeaway</option>
+                                      </select>
+                                    </td>
+                                    <td className="py-1.5 text-center">
                                       <button onClick={() => removeIngredient(ing.productId)} className="text-red-400 hover:text-red-600">
                                         <Trash2 className="h-3 w-3" />
                                       </button>
@@ -429,8 +495,8 @@ export default function MenusPage() {
                                 ))}
                                 {editIngredients.length === 0 && (
                                   <tr>
-                                    <td colSpan={5} className="py-4 text-center text-gray-400">
-                                      No ingredients yet. Search below to add products.
+                                    <td colSpan={6} className="py-4 text-center text-gray-400">
+                                      No items yet. Search below to add ingredients or packaging.
                                     </td>
                                   </tr>
                                 )}
@@ -457,7 +523,14 @@ export default function MenusPage() {
                                       onClick={() => addIngredient(product)}
                                       className="flex w-full items-center justify-between px-3 py-2 text-left text-xs hover:bg-gray-50"
                                     >
-                                      <span className="font-medium text-gray-700">{product.name}</span>
+                                      <span className="flex items-center gap-1.5 font-medium text-gray-700">
+                                        {product.name}
+                                        {product.itemType === "PACKAGING" && (
+                                          <Badge variant="outline" className="border-amber-300 bg-amber-50 text-[9px] text-amber-700">
+                                            Packaging
+                                          </Badge>
+                                        )}
+                                      </span>
                                       <span className="text-gray-400">{product.sku} &middot; {product.baseUom}</span>
                                     </button>
                                   ))}
@@ -470,21 +543,37 @@ export default function MenusPage() {
                           <table className="w-full text-xs">
                             <thead>
                               <tr className="text-gray-400">
-                                <th className="pb-1 text-left font-medium">Ingredient</th>
+                                <th className="pb-1 text-left font-medium">Item</th>
                                 <th className="pb-1 text-left font-medium">SKU</th>
                                 <th className="pb-1 text-right font-medium">Qty</th>
                                 <th className="pb-1 text-left font-medium">UOM</th>
+                                <th className="pb-1 text-center font-medium">Channel</th>
                                 <th className="pb-1 text-right font-medium">Unit Cost</th>
                                 <th className="pb-1 text-right font-medium">Cost</th>
                               </tr>
                             </thead>
                             <tbody>
-                              {menu.ingredients.map((ing, i) => (
+                              {/* Ingredients first, then packaging */}
+                              {[...menu.ingredients]
+                                .sort((a, b) => (a.kind === b.kind ? 0 : a.kind === "ingredient" ? -1 : 1))
+                                .map((ing, i) => (
                                 <tr key={i} className="border-t border-gray-200/50">
-                                  <td className="py-1.5 text-gray-700">{ing.product}</td>
+                                  <td className="py-1.5 text-gray-700">
+                                    <span className="inline-flex items-center gap-1.5">
+                                      {ing.product}
+                                      {ing.kind === "packaging" && (
+                                        <Badge variant="outline" className="border-amber-300 bg-amber-50 text-[9px] text-amber-700">
+                                          Packaging
+                                        </Badge>
+                                      )}
+                                    </span>
+                                  </td>
                                   <td className="py-1.5"><code className="text-gray-500">{ing.sku}</code></td>
                                   <td className="py-1.5 text-right text-gray-700">{ing.qty}</td>
                                   <td className="py-1.5 text-gray-500">{ing.uom}</td>
+                                  <td className="py-1.5 text-center text-gray-500">
+                                    {ing.kind === "packaging" ? SERVICE_MODE_LABEL[ing.serviceMode] : "—"}
+                                  </td>
                                   <td className="py-1.5 text-right text-gray-500">
                                     {ing.unitCost > 0 ? `RM ${ing.unitCost.toFixed(4)}` : "—"}
                                   </td>
@@ -495,16 +584,42 @@ export default function MenusPage() {
                               ))}
                               {menu.ingredients.length === 0 && (
                                 <tr>
-                                  <td colSpan={6} className="py-4 text-center text-gray-400">
-                                    No ingredients mapped. Click the pencil icon to add.
+                                  <td colSpan={7} className="py-4 text-center text-gray-400">
+                                    No recipe yet. Click the pencil icon to add ingredients or packaging.
                                   </td>
                                 </tr>
                               )}
                               {menu.ingredients.length > 0 && (
-                                <tr className="border-t border-gray-300">
-                                  <td colSpan={5} className="py-1.5 text-right font-semibold text-gray-600">Total Product Cost</td>
-                                  <td className="py-1.5 text-right font-bold text-gray-900">RM {menu.cogs.toFixed(2)}</td>
-                                </tr>
+                                <>
+                                  <tr className="border-t border-gray-300">
+                                    <td colSpan={6} className="py-1.5 text-right font-medium text-gray-500">Ingredient cost</td>
+                                    <td className="py-1.5 text-right font-medium text-gray-700">RM {menu.ingredientCost.toFixed(2)}</td>
+                                  </tr>
+                                  {menu.packagingCount > 0 && (
+                                    <>
+                                      <tr>
+                                        <td colSpan={6} className="py-1 text-right text-gray-500">+ Packaging · Dine-in</td>
+                                        <td className="py-1 text-right text-gray-700">RM {menu.packagingDineIn.toFixed(2)}</td>
+                                      </tr>
+                                      <tr>
+                                        <td colSpan={6} className="py-1 text-right text-gray-500">+ Packaging · Takeaway</td>
+                                        <td className="py-1 text-right text-gray-700">RM {menu.packagingTakeaway.toFixed(2)}</td>
+                                      </tr>
+                                    </>
+                                  )}
+                                  <tr className="border-t border-gray-200">
+                                    <td colSpan={6} className="py-1.5 text-right font-semibold text-gray-600">
+                                      Dine-in COGS{menu.dineInCogsPercent > 0 ? ` (${menu.dineInCogsPercent.toFixed(1)}%)` : ""}
+                                    </td>
+                                    <td className="py-1.5 text-right font-bold text-gray-900">RM {menu.dineInCogs.toFixed(2)}</td>
+                                  </tr>
+                                  <tr>
+                                    <td colSpan={6} className="py-1.5 text-right font-semibold text-gray-600">
+                                      Takeaway COGS{menu.takeawayCogsPercent > 0 ? ` (${menu.takeawayCogsPercent.toFixed(1)}%)` : ""}
+                                    </td>
+                                    <td className="py-1.5 text-right font-bold text-gray-900">RM {menu.takeawayCogs.toFixed(2)}</td>
+                                  </tr>
+                                </>
                               )}
                             </tbody>
                           </table>

--- a/apps/backoffice/src/app/api/inventory/menus/[id]/ingredients/route.ts
+++ b/apps/backoffice/src/app/api/inventory/menus/[id]/ingredients/route.ts
@@ -2,11 +2,16 @@ import { NextResponse, NextRequest } from "next/server";
 import { prisma } from "@/lib/prisma";
 import { requireAuth } from "@/lib/auth";
 
+type ServiceMode = "ALL" | "DINE_IN" | "TAKEAWAY";
+const SERVICE_MODES: ServiceMode[] = ["ALL", "DINE_IN", "TAKEAWAY"];
+
 /**
  * PUT /api/menus/[id]/ingredients
  *
- * Replace all ingredients for a menu item.
- * Body: { ingredients: [{ productId, quantityUsed, uom }] }
+ * Replace all BOM lines (ingredients + packaging) for a menu item.
+ * Body: { ingredients: [{ productId, quantityUsed, uom, serviceMode? }] }
+ * serviceMode defaults to ALL; packaging lines use DINE_IN / TAKEAWAY to scope
+ * a line to one fulfillment channel.
  */
 export async function PUT(
   req: NextRequest,
@@ -28,17 +33,20 @@ export async function PUT(
     return NextResponse.json({ error: "Menu not found" }, { status: 404 });
   }
 
-  // Replace all ingredients in a transaction
+  // Replace all BOM lines in a transaction
   await prisma.$transaction([
     prisma.menuIngredient.deleteMany({ where: { menuId } }),
     ...ingredients.map(
-      (ing: { productId: string; quantityUsed: number; uom: string }) =>
+      (ing: { productId: string; quantityUsed: number; uom: string; serviceMode?: string }) =>
         prisma.menuIngredient.create({
           data: {
             menuId,
             productId: ing.productId,
             quantityUsed: ing.quantityUsed,
             uom: ing.uom,
+            serviceMode: SERVICE_MODES.includes(ing.serviceMode as ServiceMode)
+              ? (ing.serviceMode as ServiceMode)
+              : "ALL",
           },
         }),
     ),

--- a/apps/backoffice/src/app/api/inventory/menus/route.ts
+++ b/apps/backoffice/src/app/api/inventory/menus/route.ts
@@ -45,33 +45,72 @@ export async function GET(request: NextRequest) {
     }
   }
 
+  const round2 = (n: number) => Math.round(n * 100) / 100;
+  const round1 = (n: number) => Math.round(n * 10) / 10;
+
   const mapped = menus.map((m) => {
     const ingredients = m.ingredients.map((ing) => {
       const unitCost = costMap.get(ing.productId) ?? 0;
       const cost = Number(ing.quantityUsed) * unitCost;
+      const kind = ing.product.itemType === "PACKAGING" ? "packaging" : "ingredient";
       return {
         productId: ing.productId,
         product: ing.product.name,
         sku: ing.product.sku,
         qty: Number(ing.quantityUsed),
         uom: ing.uom,
+        serviceMode: ing.serviceMode, // ALL | DINE_IN | TAKEAWAY
+        kind, // "ingredient" | "packaging"
         unitCost: Math.round(unitCost * 10000) / 10000,
-        cost: Math.round(cost * 100) / 100,
+        cost: round2(cost),
       };
     });
 
-    const cogs = ingredients.reduce((sum, ing) => sum + ing.cost, 0);
+    // Bucket each BOM line by kind × channel. ALL lines are billed on every
+    // sale; DINE_IN / TAKEAWAY lines only on that channel. Channel COGS =
+    // (ALL + that-channel ingredient) + (ALL + that-channel packaging).
+    let ingredientCost = 0; // channel-agnostic recipe cost (the food/drink)
+    let packagingDineIn = 0;
+    let packagingTakeaway = 0;
+    let ingredientDineExtra = 0;
+    let ingredientTakeExtra = 0;
+    let packagingCount = 0;
+    for (const ing of ingredients) {
+      if (ing.kind === "packaging") {
+        packagingCount += 1;
+        if (ing.serviceMode !== "TAKEAWAY") packagingDineIn += ing.cost;
+        if (ing.serviceMode !== "DINE_IN") packagingTakeaway += ing.cost;
+      } else {
+        if (ing.serviceMode === "DINE_IN") ingredientDineExtra += ing.cost;
+        else if (ing.serviceMode === "TAKEAWAY") ingredientTakeExtra += ing.cost;
+        else ingredientCost += ing.cost;
+      }
+    }
+
+    const dineInCogs = ingredientCost + ingredientDineExtra + packagingDineIn;
+    const takeawayCogs = ingredientCost + ingredientTakeExtra + packagingTakeaway;
     const sellingPrice = Number(m.sellingPrice ?? 0);
-    const cogsPercent = sellingPrice > 0 ? (cogs / sellingPrice) * 100 : 0;
+    const pct = (cogs: number) => (sellingPrice > 0 ? (cogs / sellingPrice) * 100 : 0);
 
     return {
       id: m.id,
       name: m.name,
       category: m.category ?? "",
       sellingPrice,
-      cogs: Math.round(cogs * 100) / 100,
-      cogsPercent: Math.round(cogsPercent * 10) / 10,
-      ingredientCount: ingredients.length,
+      // Recipe/ingredient cost only (what the old `cogs` meant).
+      ingredientCost: round2(ingredientCost + ingredientDineExtra + ingredientTakeExtra),
+      packagingDineIn: round2(packagingDineIn),
+      packagingTakeaway: round2(packagingTakeaway),
+      dineInCogs: round2(dineInCogs),
+      takeawayCogs: round2(takeawayCogs),
+      dineInCogsPercent: round1(pct(dineInCogs)),
+      takeawayCogsPercent: round1(pct(takeawayCogs)),
+      // Headline COGS = all-in worst case (takeaway). Keeps the "High COGS"
+      // filter and sort meaningful now that packaging is included.
+      cogs: round2(takeawayCogs),
+      cogsPercent: round1(pct(takeawayCogs)),
+      ingredientCount: ingredients.length - packagingCount,
+      packagingCount,
       ingredients,
     };
   });

--- a/apps/backoffice/src/app/api/inventory/reports/cogs/route.ts
+++ b/apps/backoffice/src/app/api/inventory/reports/cogs/route.ts
@@ -2,6 +2,12 @@ import { NextResponse, NextRequest } from "next/server";
 import { prisma } from "@/lib/prisma";
 import { requireAuth } from "@/lib/auth";
 
+// StoreHub sales carry no per-item fulfillment channel, so channel-scoped
+// packaging (a takeaway-only cup, a dine-in-only tissue) is blended by an
+// assumed takeaway share. ALL lines are always billed. Tier 2 replaces this
+// blend with the exact per-line split from pos_order_items.fulfillment.
+const DEFAULT_TAKEAWAY_RATIO = 0.5;
+
 export async function GET(req: NextRequest) {
   const auth = await requireAuth(req);
   if (auth.error) return auth.error;
@@ -38,11 +44,11 @@ export async function GET(req: NextRequest) {
       },
     });
 
-    // 2. Fetch all menu ingredient records (recipes)
+    // 2. Fetch all menu BOM lines (ingredients + packaging)
     const menuIngredients = await prisma.menuIngredient.findMany({
       include: {
         menu: { select: { id: true, name: true, category: true } },
-        product: { select: { id: true, name: true, baseUom: true } },
+        product: { select: { id: true, name: true, baseUom: true, itemType: true } },
       },
     });
 
@@ -72,16 +78,23 @@ export async function GET(req: NextRequest) {
       }
     }
 
-    // Build recipe map: menuItemId -> array of { productId, quantityUsed }
+    // Build recipe map: menuItemId -> array of BOM lines (with kind + channel)
     const recipeMap = new Map<
       string,
-      Array<{ productId: string; quantityUsed: number }>
+      Array<{
+        productId: string;
+        quantityUsed: number;
+        isPackaging: boolean;
+        serviceMode: "ALL" | "DINE_IN" | "TAKEAWAY";
+      }>
     >();
     for (const mi of menuIngredients) {
       const existing = recipeMap.get(mi.menuId) || [];
       existing.push({
         productId: mi.productId,
         quantityUsed: Number(mi.quantityUsed),
+        isPackaging: mi.product.itemType === "PACKAGING",
+        serviceMode: mi.serviceMode,
       });
       recipeMap.set(mi.menuId, existing);
     }
@@ -144,6 +157,8 @@ export async function GET(req: NextRequest) {
       qtySold: number;
       revenue: number;
       expectedCogs: number;
+      ingredientCogs: number;
+      packagingCogs: number;
       margin: number;
       marginPercent: number;
       outletId: string;
@@ -152,21 +167,36 @@ export async function GET(req: NextRequest) {
 
     let totalRevenue = 0;
     let totalCogs = 0;
+    let totalPackagingCogs = 0;
+
+    // Channel weight for a line: ALL bills every sale; TAKEAWAY / DINE_IN are
+    // blended by the assumed takeaway share (no per-sale channel in StoreHub).
+    const channelWeight = (mode: "ALL" | "DINE_IN" | "TAKEAWAY") =>
+      mode === "TAKEAWAY"
+        ? DEFAULT_TAKEAWAY_RATIO
+        : mode === "DINE_IN"
+          ? 1 - DEFAULT_TAKEAWAY_RATIO
+          : 1;
 
     for (const agg of salesAgg.values()) {
       const recipe = recipeMap.get(agg.menuId);
       const menuInfo = menuInfoMap.get(agg.menuId);
 
-      // Calculate cost per unit from recipe
-      let costPerUnit = 0;
+      // Cost per unit, split into ingredient vs packaging
+      let ingredientPerUnit = 0;
+      let packagingPerUnit = 0;
       if (recipe) {
         for (const ing of recipe) {
           const costPerBaseUnit = priceMap.get(ing.productId) || 0;
-          costPerUnit += ing.quantityUsed * costPerBaseUnit;
+          const lineCost = ing.quantityUsed * costPerBaseUnit * channelWeight(ing.serviceMode);
+          if (ing.isPackaging) packagingPerUnit += lineCost;
+          else ingredientPerUnit += lineCost;
         }
       }
 
-      const expectedCogs = Math.round(costPerUnit * agg.qtySold * 100) / 100;
+      const ingredientCogs = Math.round(ingredientPerUnit * agg.qtySold * 100) / 100;
+      const packagingCogs = Math.round(packagingPerUnit * agg.qtySold * 100) / 100;
+      const expectedCogs = Math.round((ingredientCogs + packagingCogs) * 100) / 100;
       const revenue = Math.round(agg.revenue * 100) / 100;
       const margin = Math.round((revenue - expectedCogs) * 100) / 100;
       const marginPercent =
@@ -174,6 +204,7 @@ export async function GET(req: NextRequest) {
 
       totalRevenue += revenue;
       totalCogs += expectedCogs;
+      totalPackagingCogs += packagingCogs;
 
       items.push({
         menuName: menuInfo?.name || "Unknown Item",
@@ -181,6 +212,8 @@ export async function GET(req: NextRequest) {
         qtySold: agg.qtySold,
         revenue,
         expectedCogs,
+        ingredientCogs,
+        packagingCogs,
         margin,
         marginPercent,
         outletId: agg.outletId,
@@ -193,6 +226,8 @@ export async function GET(req: NextRequest) {
 
     totalRevenue = Math.round(totalRevenue * 100) / 100;
     totalCogs = Math.round(totalCogs * 100) / 100;
+    totalPackagingCogs = Math.round(totalPackagingCogs * 100) / 100;
+    const totalIngredientCogs = Math.round((totalCogs - totalPackagingCogs) * 100) / 100;
     const grossMargin = Math.round((totalRevenue - totalCogs) * 100) / 100;
     const grossMarginPercent =
       totalRevenue > 0
@@ -203,6 +238,8 @@ export async function GET(req: NextRequest) {
       summary: {
         totalRevenue,
         totalCogs,
+        totalIngredientCogs,
+        totalPackagingCogs,
         grossMargin,
         grossMarginPercent,
         menuItemCount: items.length,

--- a/packages/db/prisma/baseline/0000_baseline.sql
+++ b/packages/db/prisma/baseline/0000_baseline.sql
@@ -14,7 +14,10 @@ CREATE TYPE "UserRole" AS ENUM ('OWNER', 'ADMIN', 'MANAGER', 'STAFF');
 CREATE TYPE "UserStatus" AS ENUM ('ACTIVE', 'DEACTIVATED');
 
 -- CreateEnum
-CREATE TYPE "ItemType" AS ENUM ('INGREDIENT', 'PERISHABLE');
+CREATE TYPE "ItemType" AS ENUM ('INGREDIENT', 'PERISHABLE', 'PACKAGING');
+
+-- CreateEnum
+CREATE TYPE "ServiceMode" AS ENUM ('ALL', 'DINE_IN', 'TAKEAWAY');
 
 -- CreateEnum
 CREATE TYPE "SupplierStatus" AS ENUM ('ACTIVE', 'INACTIVE');
@@ -569,6 +572,7 @@ CREATE TABLE "MenuIngredient" (
     "productId" TEXT NOT NULL,
     "quantityUsed" DECIMAL(65,30) NOT NULL,
     "uom" TEXT NOT NULL,
+    "serviceMode" "ServiceMode" NOT NULL DEFAULT 'ALL',
 
     CONSTRAINT "MenuIngredient_pkey" PRIMARY KEY ("id")
 );
@@ -1150,6 +1154,45 @@ CREATE TABLE "BankStatementLine" (
 );
 
 -- CreateTable
+CREATE TABLE "RmPayout" (
+    "id" TEXT NOT NULL,
+    "settlementDate" TIMESTAMP(3) NOT NULL,
+    "periodStart" TIMESTAMP(3),
+    "periodEnd" TIMESTAMP(3),
+    "method" TEXT NOT NULL,
+    "sequence" INTEGER NOT NULL DEFAULT 1,
+    "storeId" TEXT NOT NULL,
+    "entityName" TEXT,
+    "bankAccountLast4" TEXT,
+    "txnCount" INTEGER NOT NULL DEFAULT 0,
+    "grossTotal" DECIMAL(12,2) NOT NULL DEFAULT 0,
+    "mdrFee" DECIMAL(12,2) NOT NULL DEFAULT 0,
+    "netTotal" DECIMAL(12,2) NOT NULL DEFAULT 0,
+    "status" TEXT NOT NULL DEFAULT 'success',
+    "syncedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "RmPayout_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "RmPayoutLine" (
+    "id" TEXT NOT NULL,
+    "payoutId" TEXT NOT NULL,
+    "rmTransactionId" TEXT NOT NULL,
+    "rmOrderId" TEXT,
+    "orderId" TEXT,
+    "gross" DECIMAL(12,2) NOT NULL DEFAULT 0,
+    "mdrFee" DECIMAL(12,2) NOT NULL DEFAULT 0,
+    "net" DECIMAL(12,2) NOT NULL DEFAULT 0,
+    "method" TEXT,
+    "txnTime" TIMESTAMP(3),
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "RmPayoutLine_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
 CREATE TABLE "RecurringExpense" (
     "id" TEXT NOT NULL,
     "name" TEXT NOT NULL,
@@ -1230,10 +1273,22 @@ CREATE UNIQUE INDEX "Order_orderNumber_key" ON "Order"("orderNumber");
 CREATE UNIQUE INDEX "Order_clientRequestId_key" ON "Order"("clientRequestId");
 
 -- CreateIndex
+CREATE INDEX "Order_outletId_createdAt_idx" ON "Order"("outletId", "createdAt" DESC);
+
+-- CreateIndex
+CREATE INDEX "Order_status_createdAt_idx" ON "Order"("status", "createdAt" DESC);
+
+-- CreateIndex
 CREATE UNIQUE INDEX "OrderItem_orderId_productId_productPackageId_key" ON "OrderItem"("orderId", "productId", "productPackageId");
 
 -- CreateIndex
 CREATE INDEX "Invoice_aiPrefilledAt_idx" ON "Invoice"("aiPrefilledAt");
+
+-- CreateIndex
+CREATE INDEX "Invoice_outletId_idx" ON "Invoice"("outletId");
+
+-- CreateIndex
+CREATE INDEX "Invoice_status_dueDate_idx" ON "Invoice"("status", "dueDate");
 
 -- CreateIndex
 CREATE UNIQUE INDEX "Invoice_supplierId_invoiceNumber_key" ON "Invoice"("supplierId", "invoiceNumber");
@@ -1260,7 +1315,7 @@ CREATE UNIQUE INDEX "ParLevel_productId_outletId_key" ON "ParLevel"("productId",
 CREATE UNIQUE INDEX "Menu_storehubId_key" ON "Menu"("storehubId");
 
 -- CreateIndex
-CREATE UNIQUE INDEX "MenuIngredient_menuId_productId_key" ON "MenuIngredient"("menuId", "productId");
+CREATE UNIQUE INDEX "MenuIngredient_menuId_productId_serviceMode_key" ON "MenuIngredient"("menuId", "productId", "serviceMode");
 
 -- CreateIndex
 CREATE UNIQUE INDEX "SalesTransaction_storehubTxId_key" ON "SalesTransaction"("storehubTxId");
@@ -1504,6 +1559,21 @@ CREATE INDEX "BankStatementLine_txnDate_idx" ON "BankStatementLine"("txnDate");
 
 -- CreateIndex
 CREATE INDEX "BankStatementLine_category_outletId_idx" ON "BankStatementLine"("category", "outletId");
+
+-- CreateIndex
+CREATE INDEX "RmPayout_settlementDate_idx" ON "RmPayout"("settlementDate");
+
+-- CreateIndex
+CREATE INDEX "RmPayout_storeId_idx" ON "RmPayout"("storeId");
+
+-- CreateIndex
+CREATE INDEX "RmPayoutLine_payoutId_idx" ON "RmPayoutLine"("payoutId");
+
+-- CreateIndex
+CREATE INDEX "RmPayoutLine_orderId_idx" ON "RmPayoutLine"("orderId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "RmPayoutLine_rmTransactionId_key" ON "RmPayoutLine"("rmTransactionId");
 
 -- CreateIndex
 CREATE INDEX "RecurringExpense_isActive_nextDueDate_idx" ON "RecurringExpense"("isActive", "nextDueDate");
@@ -1798,6 +1868,9 @@ ALTER TABLE "BankStatementLine" ADD CONSTRAINT "BankStatementLine_statementId_fk
 
 -- AddForeignKey
 ALTER TABLE "BankStatementLine" ADD CONSTRAINT "BankStatementLine_outletId_fkey" FOREIGN KEY ("outletId") REFERENCES "Outlet"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "RmPayoutLine" ADD CONSTRAINT "RmPayoutLine_payoutId_fkey" FOREIGN KEY ("payoutId") REFERENCES "RmPayout"("id") ON DELETE CASCADE ON UPDATE CASCADE;
 
 -- AddForeignKey
 ALTER TABLE "RecurringExpense" ADD CONSTRAINT "RecurringExpense_outletId_fkey" FOREIGN KEY ("outletId") REFERENCES "Outlet"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/packages/db/prisma/migrations/20260619_menu_packaging_service_mode/migration.sql
+++ b/packages/db/prisma/migrations/20260619_menu_packaging_service_mode/migration.sql
@@ -1,0 +1,36 @@
+-- Packaging on the menu BOM + per-channel (dine-in / takeaway) costing.
+--
+-- 1. ItemType gains PACKAGING so cups / lids / straws / tissues are first-class
+--    inventory products (priced, stock-counted, par-levelled) just like
+--    ingredients, and flow through the existing cheapest-supplier-price costing.
+-- 2. New ServiceMode enum scopes a BOM line to a fulfillment channel. Mirrors
+--    pos_order_items.fulfillment (dine_in / takeaway) so per-channel COGS can be
+--    costed exactly from native POS lines later (Tier 2).
+-- 3. MenuIngredient (the generic BOM-line table) gains serviceMode, default ALL
+--    so every existing ingredient line is unchanged. The unique key widens to
+--    include serviceMode so the same product can appear once per channel.
+--
+-- Applied to production via Supabase MCP apply_migration. Manual SQL only —
+-- never `prisma db push`. See docs/database-migrations.md.
+
+-- 1. PACKAGING item type (idempotent; safe to use only in later statements/txns)
+ALTER TYPE "ItemType" ADD VALUE IF NOT EXISTS 'PACKAGING';
+
+-- 2. ServiceMode enum
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname = 'ServiceMode') THEN
+    CREATE TYPE "ServiceMode" AS ENUM ('ALL', 'DINE_IN', 'TAKEAWAY');
+  END IF;
+END$$;
+
+-- 3. BOM line gains a channel scope. Existing rows default to ALL, so current
+--    ingredient costing is byte-for-byte unchanged.
+ALTER TABLE "MenuIngredient"
+  ADD COLUMN IF NOT EXISTS "serviceMode" "ServiceMode" NOT NULL DEFAULT 'ALL';
+
+-- Widen uniqueness to (menu, product, channel): a product may appear once per
+-- channel (e.g. a takeaway-only cup alongside a both-ways ALL straw).
+DROP INDEX IF EXISTS "MenuIngredient_menuId_productId_key";
+CREATE UNIQUE INDEX IF NOT EXISTS "MenuIngredient_menuId_productId_serviceMode_key"
+  ON "MenuIngredient" ("menuId", "productId", "serviceMode");

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -223,6 +223,18 @@ model StorageArea {
 enum ItemType {
   INGREDIENT
   PERISHABLE
+  PACKAGING // cups, lids, straws, napkins/tissues, carrier bags, cup holders
+}
+
+// Which fulfillment channel a BOM line applies to. Ingredients are ALL (the
+// drink is the same however it's served); packaging differs — a takeaway latte
+// needs a plastic cup + lid, a dine-in latte uses a (reusable) mug + a napkin.
+// Mirrors pos_order_items.fulfillment (dine_in / takeaway) so per-channel COGS
+// can be costed exactly from native POS lines.
+enum ServiceMode {
+  ALL
+  DINE_IN
+  TAKEAWAY
 }
 
 // ─── INVENTORY ITEMS (Ingredients + Perishables) ────────────
@@ -821,16 +833,24 @@ model Menu {
   salesData   SalesTransaction[]
 }
 
+// A single line on a menu item's bill of materials. Despite the name this is
+// the generic BOM line — it holds both INGREDIENT/PERISHABLE products and
+// PACKAGING (cups, lids, straws, tissues). The product's itemType distinguishes
+// them; serviceMode scopes packaging to a fulfillment channel.
 model MenuIngredient {
-  id           String  @id @default(uuid())
+  id           String      @id @default(uuid())
   menuId       String
-  menu         Menu    @relation(fields: [menuId], references: [id], onDelete: Cascade)
+  menu         Menu        @relation(fields: [menuId], references: [id], onDelete: Cascade)
   productId    String
-  product      Product @relation(fields: [productId], references: [id])
+  product      Product     @relation(fields: [productId], references: [id])
   quantityUsed Decimal
   uom          String
+  // ALL = costed on every sale; DINE_IN / TAKEAWAY = only that channel. A
+  // product can appear once per (menu, serviceMode) — e.g. a straw used both
+  // ways is one ALL line, while a takeaway-only cup is a separate TAKEAWAY line.
+  serviceMode  ServiceMode @default(ALL)
 
-  @@unique([menuId, productId])
+  @@unique([menuId, productId, serviceMode])
 }
 
 // ─── SALES TRANSACTIONS (from StoreHub) ─────────────────────


### PR DESCRIPTION
## What & why

Menu recipes only tracked **ingredients** — packaging (cups, lids, straws, tissues) was uncosted. This models packaging as first-class BOM lines and splits COGS by **fulfillment channel**, since dine-in and takeaway use different packaging (a takeaway latte needs a plastic cup + lid; a dine-in latte uses a reusable mug + a napkin).

This is **Tier 1** of the design discussed with the requester. Order-level packaging (cup holders "if two", carrier bags) is intentionally deferred — it's basket-conditional and will use `pos_order_items.fulfillment` in a follow-up.

## Approach

Packaging is modelled as `Product` rows (`itemType = PACKAGING`), so it reuses the existing supplier pricing, multi-UOM packages, stock counts and par levels — costing flows through the existing cheapest-supplier-price map with no core math change.

## Changes

- **schema**: `ItemType` += `PACKAGING`; new `ServiceMode` enum (`ALL` / `DINE_IN` / `TAKEAWAY`) on `MenuIngredient` (the generic BOM-line table). Unique key widens to `(menuId, productId, serviceMode)`. Existing rows default to `ALL`, so ingredient costing is unchanged.
- **`GET /api/inventory/menus`**: returns `ingredientCost`, `packagingDineIn`/`packagingTakeaway`, and per-channel COGS + %. Headline `cogs` is now all-in (takeaway, worst case) so the High-COGS filter stays meaningful.
- **`PUT /api/inventory/menus/[id]/ingredients`**: accepts `serviceMode` per line.
- **`GET /api/inventory/reports/cogs`**: includes packaging, blended by an assumed takeaway share (StoreHub sales carry no per-item channel); exposes ingredient vs packaging totals.
- **menus page**: pick a line's channel when editing, packaging tagged in the BOM, and the row expansion shows an ingredient + packaging breakdown with dine-in / takeaway COGS.

## Migration

SQL captured under `packages/db/prisma/migrations/20260619_menu_packaging_service_mode/`. Additive and low-risk (new enum value, new enum, nullable-with-default column, swap a unique index). Applied via Supabase MCP per `docs/database-migrations.md`. Baseline snapshot regenerated (also captures prior `RmPayout` drift).

## Test plan

- [x] `tsc --noEmit` clean (backoffice)
- [x] eslint clean on all changed files
- [x] Prisma client regenerated (v6.19.3)
- [ ] After migration applied: seed a packaging Product (`itemType=PACKAGING`) + supplier price, tag onto a menu, confirm dine-in vs takeaway COGS split renders

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SgZXN9d3uBVRy19QbrXdE9

---
_Generated by [Claude Code](https://claude.ai/code/session_01SgZXN9d3uBVRy19QbrXdE9)_