### PR TITLE
Add Packaging rules page: assign packaging cost by scope & channel

### DIFF
--- a/apps/backoffice/src/app/(admin)/inventory/menus/page.tsx
+++ b/apps/backoffice/src/app/(admin)/inventory/menus/page.tsx
@@ -27,6 +27,7 @@ type Ingredient = {
   cost: number;
   serviceMode: ServiceMode;
   kind: "ingredient" | "packaging";
+  source?: "bom" | "rule"; // "rule" = applied from a Packaging rule (read-only)
 };
 
 type MenuItem = {
@@ -130,15 +131,19 @@ export default function MenusPage() {
     setEditingMenuId(menu.id);
     setExpandedId(menu.id);
     setEditIngredients(
-      menu.ingredients.map((ing) => ({
-        productId: ing.productId,
-        productName: ing.product,
-        sku: ing.sku,
-        quantityUsed: ing.qty,
-        uom: ing.uom,
-        serviceMode: ing.serviceMode,
-        kind: ing.kind,
-      }))
+      // Rule-applied packaging is managed on the Packaging page — only the
+      // menu's own BOM lines are editable here.
+      menu.ingredients
+        .filter((ing) => ing.source !== "rule")
+        .map((ing) => ({
+          productId: ing.productId,
+          productName: ing.product,
+          sku: ing.sku,
+          quantityUsed: ing.qty,
+          uom: ing.uom,
+          serviceMode: ing.serviceMode,
+          kind: ing.kind,
+        }))
     );
     setAddSearch("");
   };
@@ -564,6 +569,11 @@ export default function MenusPage() {
                                       {ing.kind === "packaging" && (
                                         <Badge variant="outline" className="border-amber-300 bg-amber-50 text-[9px] text-amber-700">
                                           Packaging
+                                        </Badge>
+                                      )}
+                                      {ing.source === "rule" && (
+                                        <Badge variant="outline" className="border-gray-200 bg-gray-50 text-[9px] text-gray-500">
+                                          via rule
                                         </Badge>
                                       )}
                                     </span>

--- a/apps/backoffice/src/app/(admin)/inventory/menus/page.tsx
+++ b/apps/backoffice/src/app/(admin)/inventory/menus/page.tsx
@@ -26,8 +26,15 @@ type Ingredient = {
   unitCost: number;
   cost: number;
   serviceMode: ServiceMode;
+  modifier?: string | null; // null = any temperature; "Iced" / "Hot"
   kind: "ingredient" | "packaging";
   source?: "bom" | "rule"; // "rule" = applied from a Packaging rule (read-only)
+};
+
+type Cell = { pkg: number; cogs: number; cogsPercent: number };
+type CostMatrix = {
+  hot: { dineIn: Cell; takeaway: Cell };
+  iced: { dineIn: Cell; takeaway: Cell };
 };
 
 type MenuItem = {
@@ -35,15 +42,11 @@ type MenuItem = {
   name: string;
   category: string;
   sellingPrice: number;
-  cogs: number; // all-in (takeaway) — headline
+  cogs: number; // all-in worst case — headline
   cogsPercent: number;
   ingredientCost: number;
-  packagingDineIn: number;
-  packagingTakeaway: number;
-  dineInCogs: number;
-  takeawayCogs: number;
-  dineInCogsPercent: number;
-  takeawayCogsPercent: number;
+  matrix: CostMatrix; // COGS by temperature × channel
+  hasIcedHotSplit: boolean;
   ingredientCount: number;
   packagingCount: number;
   ingredients: Ingredient[];
@@ -571,6 +574,11 @@ export default function MenusPage() {
                                           Packaging
                                         </Badge>
                                       )}
+                                      {ing.modifier && (
+                                        <Badge variant="outline" className={`text-[9px] ${ing.modifier === "Iced" ? "border-sky-200 bg-sky-50 text-sky-600" : "border-orange-200 bg-orange-50 text-orange-600"}`}>
+                                          {ing.modifier}
+                                        </Badge>
+                                      )}
                                       {ing.source === "rule" && (
                                         <Badge variant="outline" className="border-gray-200 bg-gray-50 text-[9px] text-gray-500">
                                           via rule
@@ -605,30 +613,38 @@ export default function MenusPage() {
                                     <td colSpan={6} className="py-1.5 text-right font-medium text-gray-500">Ingredient cost</td>
                                     <td className="py-1.5 text-right font-medium text-gray-700">RM {menu.ingredientCost.toFixed(2)}</td>
                                   </tr>
-                                  {menu.packagingCount > 0 && (
+                                  {menu.packagingCount > 0 ? (
                                     <>
-                                      <tr>
-                                        <td colSpan={6} className="py-1 text-right text-gray-500">+ Packaging · Dine-in</td>
-                                        <td className="py-1 text-right text-gray-700">RM {menu.packagingDineIn.toFixed(2)}</td>
+                                      <tr className="border-t border-gray-200">
+                                        <td colSpan={5} className="py-1 text-right text-[10px] uppercase tracking-wide text-gray-400">All-in COGS (incl. packaging)</td>
+                                        <td className="py-1 text-right text-[10px] uppercase tracking-wide text-gray-400">Dine-in</td>
+                                        <td className="py-1 text-right text-[10px] uppercase tracking-wide text-gray-400">Takeaway</td>
                                       </tr>
-                                      <tr>
-                                        <td colSpan={6} className="py-1 text-right text-gray-500">+ Packaging · Takeaway</td>
-                                        <td className="py-1 text-right text-gray-700">RM {menu.packagingTakeaway.toFixed(2)}</td>
-                                      </tr>
+                                      {(menu.hasIcedHotSplit
+                                        ? ([["Iced", menu.matrix.iced], ["Hot", menu.matrix.hot]] as const)
+                                        : ([["", menu.matrix.iced]] as const)
+                                      ).map(([label, row]) => (
+                                        <tr key={label || "all"}>
+                                          <td colSpan={5} className="py-1.5 text-right font-semibold text-gray-600">
+                                            {label ? <span className={label === "Iced" ? "text-sky-600" : "text-orange-600"}>{label} drink</span> : "Total"}
+                                          </td>
+                                          <td className="py-1.5 text-right font-bold text-gray-900">
+                                            RM {row.dineIn.cogs.toFixed(2)}{row.dineIn.cogsPercent > 0 && <span className="ml-1 text-[10px] font-normal text-gray-400">{row.dineIn.cogsPercent.toFixed(0)}%</span>}
+                                          </td>
+                                          <td className="py-1.5 text-right font-bold text-gray-900">
+                                            RM {row.takeaway.cogs.toFixed(2)}{row.takeaway.cogsPercent > 0 && <span className="ml-1 text-[10px] font-normal text-gray-400">{row.takeaway.cogsPercent.toFixed(0)}%</span>}
+                                          </td>
+                                        </tr>
+                                      ))}
                                     </>
+                                  ) : (
+                                    <tr className="border-t border-gray-200">
+                                      <td colSpan={6} className="py-1.5 text-right font-semibold text-gray-600">
+                                        Total COGS{menu.matrix.iced.takeaway.cogsPercent > 0 ? ` (${menu.matrix.iced.takeaway.cogsPercent.toFixed(1)}%)` : ""}
+                                      </td>
+                                      <td className="py-1.5 text-right font-bold text-gray-900">RM {menu.matrix.iced.takeaway.cogs.toFixed(2)}</td>
+                                    </tr>
                                   )}
-                                  <tr className="border-t border-gray-200">
-                                    <td colSpan={6} className="py-1.5 text-right font-semibold text-gray-600">
-                                      Dine-in COGS{menu.dineInCogsPercent > 0 ? ` (${menu.dineInCogsPercent.toFixed(1)}%)` : ""}
-                                    </td>
-                                    <td className="py-1.5 text-right font-bold text-gray-900">RM {menu.dineInCogs.toFixed(2)}</td>
-                                  </tr>
-                                  <tr>
-                                    <td colSpan={6} className="py-1.5 text-right font-semibold text-gray-600">
-                                      Takeaway COGS{menu.takeawayCogsPercent > 0 ? ` (${menu.takeawayCogsPercent.toFixed(1)}%)` : ""}
-                                    </td>
-                                    <td className="py-1.5 text-right font-bold text-gray-900">RM {menu.takeawayCogs.toFixed(2)}</td>
-                                  </tr>
                                 </>
                               )}
                             </tbody>

--- a/apps/backoffice/src/app/(admin)/inventory/packaging/page.tsx
+++ b/apps/backoffice/src/app/(admin)/inventory/packaging/page.tsx
@@ -158,11 +158,6 @@ export default function PackagingPage() {
       ).slice(0, 8)
     : [];
 
-  const scopeSummary = (r: Rule) =>
-    r.scope === "ALL" ? "All menu items"
-    : r.scope === "CATEGORY" ? `Category: ${r.category || "—"}`
-    : `${r.menuIds.length} item${r.menuIds.length === 1 ? "" : "s"}`;
-
   return (
     <div className="p-3 sm:p-6">
       {/* Header */}
@@ -178,65 +173,86 @@ export default function PackagingPage() {
         </Button>
       </div>
 
-      {/* Table */}
-      <div className="mt-4 rounded-xl border border-gray-200 bg-white overflow-x-auto">
-        <table className="w-full text-sm min-w-[820px]">
-          <thead>
-            <tr className="border-b border-gray-100 bg-gray-50/50 text-left">
-              <th className="px-4 py-3 font-medium text-gray-500">Packaging Item</th>
-              <th className="px-4 py-3 font-medium text-gray-500">Applies to</th>
-              <th className="px-4 py-3 font-medium text-gray-500">Channel</th>
-              <th className="px-4 py-3 font-medium text-gray-500">Per</th>
-              <th className="px-4 py-3 text-right font-medium text-gray-500">Qty</th>
-              <th className="px-4 py-3 text-right font-medium text-gray-500">Cost / use</th>
-              <th className="px-4 py-3 font-medium text-gray-500">Status</th>
-              <th className="px-4 py-3 text-right font-medium text-gray-500">Actions</th>
-            </tr>
-          </thead>
-          <tbody>
-            {loading && (
-              <tr><td colSpan={8} className="px-4 py-12 text-center"><Loader2 className="mx-auto h-6 w-6 animate-spin text-terracotta" /></td></tr>
-            )}
-            {!loading && rules.length === 0 && (
-              <tr><td colSpan={8} className="px-4 py-12 text-center text-sm text-gray-400">No packaging rules yet. Click “Add Packaging Rule”.</td></tr>
-            )}
-            {!loading && rules.map((r) => (
-              <tr key={r.id} className={`border-b border-gray-50 hover:bg-gray-50/50 ${!r.isActive ? "opacity-50" : ""}`}>
-                <td className="px-4 py-3">
-                  <div className="flex items-center gap-2">
-                    <div className="flex h-8 w-8 items-center justify-center rounded-lg bg-gray-100"><Package className="h-4 w-4 text-gray-400" /></div>
-                    <div>
-                      <p className="font-medium text-gray-900">{r.productName}</p>
-                      <code className="text-[11px] text-gray-400">{r.productSku}</code>
+      {/* Packaging BOM — grouped by scope (category / all / specific items) */}
+      {loading ? (
+        <div className="mt-4 flex justify-center py-12"><Loader2 className="h-6 w-6 animate-spin text-terracotta" /></div>
+      ) : rules.length === 0 ? (
+        <div className="mt-4 rounded-xl border border-gray-200 bg-white px-4 py-12 text-center text-sm text-gray-400">
+          No packaging rules yet. Click “Add Packaging Rule” to start — e.g. add a plastic cup to the <em>Drinks</em> category on the <em>Takeaway</em> channel.
+        </div>
+      ) : (
+        (() => {
+          const cats = new Map<string, Rule[]>();
+          const allRules: Rule[] = [];
+          const itemRules: Rule[] = [];
+          for (const r of rules) {
+            if (r.scope === "CATEGORY") {
+              const k = r.category || "Uncategorised";
+              if (!cats.has(k)) cats.set(k, []);
+              cats.get(k)!.push(r);
+            } else if (r.scope === "ALL") allRules.push(r);
+            else itemRules.push(r);
+          }
+          const groups: { label: string; meta: string; rules: Rule[] }[] = [];
+          for (const k of [...cats.keys()].sort()) {
+            const rs = cats.get(k)!;
+            groups.push({ label: k, meta: `${rs[0].matchedMenuCount} menu item${rs[0].matchedMenuCount === 1 ? "" : "s"}`, rules: rs });
+          }
+          if (allRules.length) groups.push({ label: "All menu items", meta: `${allRules[0].matchedMenuCount} items`, rules: allRules });
+          if (itemRules.length) groups.push({ label: "Specific items", meta: "hand-picked", rules: itemRules });
+
+          return groups.map((g) => {
+            const perItemTotal = g.rules.filter((r) => r.isActive && !r.perOrder).reduce((s, r) => s + r.lineCost, 0);
+            return (
+              <div key={g.label} className="mt-4 rounded-xl border border-gray-200 bg-white">
+                <div className="flex items-center justify-between border-b border-gray-100 bg-gray-50/50 px-4 py-2.5">
+                  <div>
+                    <p className="font-semibold text-gray-900">{g.label}</p>
+                    <p className="text-xs text-gray-400">{g.meta} · {g.rules.length} packaging line{g.rules.length === 1 ? "" : "s"}</p>
+                  </div>
+                  {perItemTotal > 0 && (
+                    <div className="text-right">
+                      <p className="text-[11px] text-gray-400">Per-item packaging</p>
+                      <p className="text-sm font-semibold text-gray-900">{formatRM(perItemTotal)}</p>
                     </div>
-                  </div>
-                </td>
-                <td className="px-4 py-3 text-gray-600">{scopeSummary(r)}</td>
-                <td className="px-4 py-3"><Badge variant="outline" className={`text-xs ${CHANNEL_BADGE[r.channel]}`}>{CHANNEL_LABEL[r.channel]}</Badge></td>
-                <td className="px-4 py-3 text-gray-600">{r.perOrder ? "Per order" : "Per item"}</td>
-                <td className="px-4 py-3 text-right text-gray-700">{r.quantity}</td>
-                <td className="px-4 py-3 text-right font-medium text-gray-900">
-                  {r.lineCost > 0 ? formatRM(r.lineCost) : <span className="text-gray-300">—</span>}
-                  {!r.perOrder && r.matchedMenuCount > 0 && (
-                    <p className="text-[11px] font-normal text-gray-400">× {r.matchedMenuCount} items</p>
                   )}
-                </td>
-                <td className="px-4 py-3">
-                  <button onClick={() => toggleActive(r)} className={`rounded-full border px-2 py-0.5 text-[11px] font-medium ${r.isActive ? "border-green-200 bg-green-50 text-green-700" : "border-gray-200 bg-gray-50 text-gray-400"}`}>
-                    {r.isActive ? "Active" : "Off"}
-                  </button>
-                </td>
-                <td className="px-4 py-3">
-                  <div className="flex items-center justify-end gap-1">
-                    <button onClick={() => openEdit(r)} className="rounded-md p-1.5 text-gray-400 hover:bg-gray-100 hover:text-terracotta"><Pencil className="h-3.5 w-3.5" /></button>
-                    <button onClick={() => remove(r.id)} className="rounded-md p-1.5 text-gray-400 hover:bg-red-50 hover:text-red-500"><Trash2 className="h-3.5 w-3.5" /></button>
-                  </div>
-                </td>
-              </tr>
-            ))}
-          </tbody>
-        </table>
-      </div>
+                </div>
+                <div className="overflow-x-auto">
+                  <table className="w-full text-sm">
+                    <tbody>
+                      {g.rules.map((r) => (
+                        <tr key={r.id} className={`border-b border-gray-50 last:border-0 hover:bg-gray-50/50 ${!r.isActive ? "opacity-50" : ""}`}>
+                          <td className="px-4 py-2.5">
+                            <div className="flex items-center gap-2">
+                              <Package className="h-4 w-4 text-gray-400" />
+                              <span className="font-medium text-gray-900">{r.productName}</span>
+                              <code className="text-[11px] text-gray-400">{r.productSku}</code>
+                            </div>
+                          </td>
+                          <td className="px-2 py-2.5"><Badge variant="outline" className={`text-xs ${CHANNEL_BADGE[r.channel]}`}>{CHANNEL_LABEL[r.channel]}</Badge></td>
+                          <td className="px-2 py-2.5 text-xs text-gray-500">{r.perOrder ? "per order" : "per item"}</td>
+                          <td className="px-2 py-2.5 text-right text-gray-700">×{r.quantity}</td>
+                          <td className="px-2 py-2.5 text-right font-medium text-gray-900">{r.lineCost > 0 ? formatRM(r.lineCost) : <span className="text-gray-300">—</span>}</td>
+                          <td className="px-2 py-2.5 text-xs text-gray-400">{r.scope === "ITEMS" ? `${r.menuIds.length} item${r.menuIds.length === 1 ? "" : "s"}` : ""}</td>
+                          <td className="px-2 py-2.5">
+                            <button onClick={() => toggleActive(r)} className={`rounded-full border px-2 py-0.5 text-[11px] font-medium ${r.isActive ? "border-green-200 bg-green-50 text-green-700" : "border-gray-200 bg-gray-50 text-gray-400"}`}>{r.isActive ? "On" : "Off"}</button>
+                          </td>
+                          <td className="px-4 py-2.5">
+                            <div className="flex items-center justify-end gap-1">
+                              <button onClick={() => openEdit(r)} className="rounded-md p-1.5 text-gray-400 hover:bg-gray-100 hover:text-terracotta"><Pencil className="h-3.5 w-3.5" /></button>
+                              <button onClick={() => remove(r.id)} className="rounded-md p-1.5 text-gray-400 hover:bg-red-50 hover:text-red-500"><Trash2 className="h-3.5 w-3.5" /></button>
+                            </div>
+                          </td>
+                        </tr>
+                      ))}
+                    </tbody>
+                  </table>
+                </div>
+              </div>
+            );
+          });
+        })()
+      )}
 
       {/* Add/Edit dialog */}
       <Dialog open={dialogOpen} onOpenChange={(o) => { setDialogOpen(o); if (!o) { setEditingId(null); setForm(emptyForm); } }}>

--- a/apps/backoffice/src/app/(admin)/inventory/packaging/page.tsx
+++ b/apps/backoffice/src/app/(admin)/inventory/packaging/page.tsx
@@ -1,0 +1,372 @@
+"use client";
+
+import { useState } from "react";
+import { formatRM } from "@celsius/shared";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Badge } from "@/components/ui/badge";
+import { useFetch } from "@/lib/use-fetch";
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
+import { Plus, Search, Pencil, Trash2, Package, Loader2, X, Check } from "lucide-react";
+
+type Scope = "ALL" | "CATEGORY" | "ITEMS";
+type Channel = "ALL" | "DINE_IN" | "TAKEAWAY" | "GRAB" | "DELIVERY";
+
+const SCOPE_LABEL: Record<Scope, string> = {
+  ALL: "All menu items",
+  CATEGORY: "Category",
+  ITEMS: "Specific items",
+};
+const CHANNEL_LABEL: Record<Channel, string> = {
+  ALL: "All",
+  DINE_IN: "Dine-in",
+  TAKEAWAY: "Takeaway",
+  GRAB: "Grab",
+  DELIVERY: "Delivery",
+};
+const CHANNEL_BADGE: Record<Channel, string> = {
+  ALL: "border-gray-200 bg-gray-50 text-gray-600",
+  DINE_IN: "border-blue-200 bg-blue-50 text-blue-600",
+  TAKEAWAY: "border-amber-200 bg-amber-50 text-amber-700",
+  GRAB: "border-green-200 bg-green-50 text-green-700",
+  DELIVERY: "border-purple-200 bg-purple-50 text-purple-700",
+};
+
+type Rule = {
+  id: string;
+  productId: string;
+  productName: string;
+  productSku: string;
+  baseUom: string;
+  quantity: number;
+  scope: Scope;
+  category: string | null;
+  menuIds: string[];
+  channel: Channel;
+  perOrder: boolean;
+  isActive: boolean;
+  notes: string | null;
+  unitCost: number;
+  lineCost: number;
+  matchedMenuCount: number;
+};
+
+type ProductOption = { id: string; name: string; sku: string; baseUom: string; itemType: string };
+type MenuLite = { id: string; name: string; category: string };
+
+type Form = {
+  productId: string;
+  productName: string;
+  productSku: string;
+  quantity: string;
+  scope: Scope;
+  category: string;
+  menuIds: string[];
+  channel: Channel;
+  perOrder: boolean;
+  isActive: boolean;
+  notes: string;
+};
+
+const emptyForm: Form = {
+  productId: "", productName: "", productSku: "", quantity: "1",
+  scope: "ALL", category: "", menuIds: [], channel: "ALL",
+  perOrder: false, isActive: true, notes: "",
+};
+
+export default function PackagingPage() {
+  const { data: rules = [], isLoading: loading, mutate: reload } = useFetch<Rule[]>("/api/inventory/packaging-rules");
+  const { data: products = [] } = useFetch<ProductOption[]>("/api/inventory/products");
+  const { data: menus = [] } = useFetch<MenuLite[]>("/api/inventory/menus");
+
+  const [dialogOpen, setDialogOpen] = useState(false);
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [form, setForm] = useState<Form>(emptyForm);
+  const [saving, setSaving] = useState(false);
+  const [productSearch, setProductSearch] = useState("");
+  const [menuSearch, setMenuSearch] = useState("");
+
+  const categories = [...new Set(menus.map((m) => m.category).filter(Boolean))].sort();
+  const set = <K extends keyof Form>(k: K, v: Form[K]) => setForm((p) => ({ ...p, [k]: v }));
+
+  const openAdd = () => { setForm(emptyForm); setEditingId(null); setProductSearch(""); setMenuSearch(""); setDialogOpen(true); };
+  const openEdit = (r: Rule) => {
+    setForm({
+      productId: r.productId, productName: r.productName, productSku: r.productSku,
+      quantity: String(r.quantity), scope: r.scope, category: r.category ?? "",
+      menuIds: r.menuIds, channel: r.channel, perOrder: r.perOrder, isActive: r.isActive,
+      notes: r.notes ?? "",
+    });
+    setEditingId(r.id); setProductSearch(""); setMenuSearch(""); setDialogOpen(true);
+  };
+
+  const save = async () => {
+    if (!form.productId) return;
+    setSaving(true);
+    try {
+      const url = editingId ? `/api/inventory/packaging-rules/${editingId}` : "/api/inventory/packaging-rules";
+      const res = await fetch(url, {
+        method: editingId ? "PATCH" : "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          productId: form.productId,
+          quantity: parseFloat(form.quantity) || 1,
+          scope: form.scope,
+          category: form.category,
+          menuIds: form.menuIds,
+          channel: form.channel,
+          perOrder: form.perOrder,
+          isActive: form.isActive,
+          notes: form.notes,
+        }),
+      });
+      if (!res.ok) { alert("Failed to save packaging rule."); return; }
+      setDialogOpen(false);
+      reload();
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const remove = async (id: string) => {
+    if (!confirm("Delete this packaging rule?")) return;
+    const res = await fetch(`/api/inventory/packaging-rules/${id}`, { method: "DELETE" });
+    if (!res.ok) { alert("Failed to delete."); return; }
+    reload();
+  };
+
+  const toggleActive = async (r: Rule) => {
+    await fetch(`/api/inventory/packaging-rules/${r.id}`, {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ isActive: !r.isActive }),
+    });
+    reload();
+  };
+
+  const productResults = productSearch.trim().length >= 2
+    ? products.filter((p) =>
+        p.name.toLowerCase().includes(productSearch.toLowerCase()) ||
+        p.sku.toLowerCase().includes(productSearch.toLowerCase())
+      ).slice(0, 8)
+    : [];
+
+  const menuResults = menuSearch.trim().length >= 1
+    ? menus.filter((m) =>
+        !form.menuIds.includes(m.id) &&
+        m.name.toLowerCase().includes(menuSearch.toLowerCase())
+      ).slice(0, 8)
+    : [];
+
+  const scopeSummary = (r: Rule) =>
+    r.scope === "ALL" ? "All menu items"
+    : r.scope === "CATEGORY" ? `Category: ${r.category || "—"}`
+    : `${r.menuIds.length} item${r.menuIds.length === 1 ? "" : "s"}`;
+
+  return (
+    <div className="p-3 sm:p-6">
+      {/* Header */}
+      <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+        <div>
+          <h2 className="text-xl font-semibold text-gray-900">Packaging</h2>
+          <p className="mt-0.5 text-sm text-gray-500">
+            Rules that add packaging cost to menus by scope &amp; channel — e.g. <em>iced cup + lid on drinks (takeaway)</em>, <em>straw on all drinks</em>, <em>a paper bag per Grab order</em>.
+          </p>
+        </div>
+        <Button onClick={openAdd} className="bg-terracotta hover:bg-terracotta-dark">
+          <Plus className="mr-1.5 h-4 w-4" /> Add Packaging Rule
+        </Button>
+      </div>
+
+      {/* Table */}
+      <div className="mt-4 rounded-xl border border-gray-200 bg-white overflow-x-auto">
+        <table className="w-full text-sm min-w-[820px]">
+          <thead>
+            <tr className="border-b border-gray-100 bg-gray-50/50 text-left">
+              <th className="px-4 py-3 font-medium text-gray-500">Packaging Item</th>
+              <th className="px-4 py-3 font-medium text-gray-500">Applies to</th>
+              <th className="px-4 py-3 font-medium text-gray-500">Channel</th>
+              <th className="px-4 py-3 font-medium text-gray-500">Per</th>
+              <th className="px-4 py-3 text-right font-medium text-gray-500">Qty</th>
+              <th className="px-4 py-3 text-right font-medium text-gray-500">Cost / use</th>
+              <th className="px-4 py-3 font-medium text-gray-500">Status</th>
+              <th className="px-4 py-3 text-right font-medium text-gray-500">Actions</th>
+            </tr>
+          </thead>
+          <tbody>
+            {loading && (
+              <tr><td colSpan={8} className="px-4 py-12 text-center"><Loader2 className="mx-auto h-6 w-6 animate-spin text-terracotta" /></td></tr>
+            )}
+            {!loading && rules.length === 0 && (
+              <tr><td colSpan={8} className="px-4 py-12 text-center text-sm text-gray-400">No packaging rules yet. Click “Add Packaging Rule”.</td></tr>
+            )}
+            {!loading && rules.map((r) => (
+              <tr key={r.id} className={`border-b border-gray-50 hover:bg-gray-50/50 ${!r.isActive ? "opacity-50" : ""}`}>
+                <td className="px-4 py-3">
+                  <div className="flex items-center gap-2">
+                    <div className="flex h-8 w-8 items-center justify-center rounded-lg bg-gray-100"><Package className="h-4 w-4 text-gray-400" /></div>
+                    <div>
+                      <p className="font-medium text-gray-900">{r.productName}</p>
+                      <code className="text-[11px] text-gray-400">{r.productSku}</code>
+                    </div>
+                  </div>
+                </td>
+                <td className="px-4 py-3 text-gray-600">{scopeSummary(r)}</td>
+                <td className="px-4 py-3"><Badge variant="outline" className={`text-xs ${CHANNEL_BADGE[r.channel]}`}>{CHANNEL_LABEL[r.channel]}</Badge></td>
+                <td className="px-4 py-3 text-gray-600">{r.perOrder ? "Per order" : "Per item"}</td>
+                <td className="px-4 py-3 text-right text-gray-700">{r.quantity}</td>
+                <td className="px-4 py-3 text-right font-medium text-gray-900">
+                  {r.lineCost > 0 ? formatRM(r.lineCost) : <span className="text-gray-300">—</span>}
+                  {!r.perOrder && r.matchedMenuCount > 0 && (
+                    <p className="text-[11px] font-normal text-gray-400">× {r.matchedMenuCount} items</p>
+                  )}
+                </td>
+                <td className="px-4 py-3">
+                  <button onClick={() => toggleActive(r)} className={`rounded-full border px-2 py-0.5 text-[11px] font-medium ${r.isActive ? "border-green-200 bg-green-50 text-green-700" : "border-gray-200 bg-gray-50 text-gray-400"}`}>
+                    {r.isActive ? "Active" : "Off"}
+                  </button>
+                </td>
+                <td className="px-4 py-3">
+                  <div className="flex items-center justify-end gap-1">
+                    <button onClick={() => openEdit(r)} className="rounded-md p-1.5 text-gray-400 hover:bg-gray-100 hover:text-terracotta"><Pencil className="h-3.5 w-3.5" /></button>
+                    <button onClick={() => remove(r.id)} className="rounded-md p-1.5 text-gray-400 hover:bg-red-50 hover:text-red-500"><Trash2 className="h-3.5 w-3.5" /></button>
+                  </div>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+
+      {/* Add/Edit dialog */}
+      <Dialog open={dialogOpen} onOpenChange={(o) => { setDialogOpen(o); if (!o) { setEditingId(null); setForm(emptyForm); } }}>
+        <DialogContent className="sm:max-w-2xl max-h-[90vh] flex flex-col overflow-hidden">
+          <DialogHeader className="flex-shrink-0">
+            <DialogTitle>{editingId ? "Edit Packaging Rule" : "Add Packaging Rule"}</DialogTitle>
+          </DialogHeader>
+
+          <div className="grid gap-5 py-3 overflow-y-auto flex-1 min-h-0">
+            {/* Packaging item */}
+            <div>
+              <label className="text-sm font-medium text-gray-700">Packaging item</label>
+              {form.productId ? (
+                <div className="mt-1.5 flex items-center justify-between rounded-md border border-gray-200 bg-gray-50 px-3 py-2">
+                  <span className="text-sm text-gray-700">{form.productName} <code className="ml-1 text-xs text-gray-400">{form.productSku}</code></span>
+                  <button onClick={() => { set("productId", ""); set("productName", ""); set("productSku", ""); }} className="text-gray-400 hover:text-red-500"><X className="h-4 w-4" /></button>
+                </div>
+              ) : (
+                <div className="relative mt-1.5">
+                  <Search className="absolute left-2.5 top-1/2 h-4 w-4 -translate-y-1/2 text-gray-400" />
+                  <input
+                    className="w-full rounded-md border border-gray-200 py-2 pl-8 pr-3 text-sm"
+                    placeholder="Search a product (cup, lid, straw, bag)…"
+                    value={productSearch}
+                    onChange={(e) => setProductSearch(e.target.value)}
+                  />
+                  {productResults.length > 0 && (
+                    <div className="absolute z-10 mt-1 w-full rounded-md border border-gray-200 bg-white shadow-lg">
+                      {productResults.map((p) => (
+                        <button key={p.id} onClick={() => { set("productId", p.id); set("productName", p.name); set("productSku", p.sku); setProductSearch(""); }}
+                          className="flex w-full items-center justify-between px-3 py-2 text-left text-xs hover:bg-gray-50">
+                          <span className="font-medium text-gray-700">{p.name}</span>
+                          <span className="text-gray-400">{p.sku} · {p.baseUom}</span>
+                        </button>
+                      ))}
+                    </div>
+                  )}
+                </div>
+              )}
+            </div>
+
+            {/* Qty + channel + per */}
+            <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
+              <div>
+                <label className="text-sm font-medium text-gray-700">Quantity</label>
+                <Input type="number" step="any" min="0" className="mt-1.5 h-10" value={form.quantity} onChange={(e) => set("quantity", e.target.value)} />
+              </div>
+              <div>
+                <label className="text-sm font-medium text-gray-700">Channel</label>
+                <select className="mt-1.5 h-10 w-full rounded-md border border-gray-200 px-3 text-sm" value={form.channel} onChange={(e) => set("channel", e.target.value as Channel)}>
+                  {(Object.keys(CHANNEL_LABEL) as Channel[]).map((c) => <option key={c} value={c}>{CHANNEL_LABEL[c]}</option>)}
+                </select>
+              </div>
+              <div>
+                <label className="text-sm font-medium text-gray-700">Charge</label>
+                <select className="mt-1.5 h-10 w-full rounded-md border border-gray-200 px-3 text-sm" value={form.perOrder ? "order" : "item"} onChange={(e) => set("perOrder", e.target.value === "order")}>
+                  <option value="item">Per item sold</option>
+                  <option value="order">Per order</option>
+                </select>
+              </div>
+            </div>
+
+            {/* Scope */}
+            <div>
+              <label className="text-sm font-medium text-gray-700">Applies to</label>
+              <div className="mt-1.5 flex gap-1.5">
+                {(Object.keys(SCOPE_LABEL) as Scope[]).map((s) => (
+                  <button key={s} onClick={() => set("scope", s)}
+                    className={`rounded-full border px-3 py-1 text-xs transition-colors ${form.scope === s ? "border-terracotta bg-terracotta/5 text-terracotta-dark" : "border-gray-200 text-gray-500 hover:border-gray-300"}`}>
+                    {SCOPE_LABEL[s]}
+                  </button>
+                ))}
+              </div>
+
+              {form.scope === "CATEGORY" && (
+                <select className="mt-2.5 h-10 w-full rounded-md border border-gray-200 px-3 text-sm" value={form.category} onChange={(e) => set("category", e.target.value)}>
+                  <option value="">Select category…</option>
+                  {categories.map((c) => <option key={c} value={c}>{c}</option>)}
+                </select>
+              )}
+
+              {form.scope === "ITEMS" && (
+                <div className="mt-2.5">
+                  {form.menuIds.length > 0 && (
+                    <div className="mb-2 flex flex-wrap gap-1.5">
+                      {form.menuIds.map((id) => {
+                        const m = menus.find((x) => x.id === id);
+                        return (
+                          <span key={id} className="inline-flex items-center gap-1 rounded-full border border-gray-200 bg-gray-50 px-2 py-0.5 text-xs text-gray-600">
+                            {m?.name ?? id}
+                            <button onClick={() => set("menuIds", form.menuIds.filter((x) => x !== id))} className="text-gray-400 hover:text-red-500"><X className="h-3 w-3" /></button>
+                          </span>
+                        );
+                      })}
+                    </div>
+                  )}
+                  <div className="relative">
+                    <Search className="absolute left-2.5 top-1/2 h-4 w-4 -translate-y-1/2 text-gray-400" />
+                    <input className="w-full rounded-md border border-gray-200 py-2 pl-8 pr-3 text-sm" placeholder="Search menu items to add…" value={menuSearch} onChange={(e) => setMenuSearch(e.target.value)} />
+                    {menuResults.length > 0 && (
+                      <div className="absolute z-10 mt-1 w-full rounded-md border border-gray-200 bg-white shadow-lg">
+                        {menuResults.map((m) => (
+                          <button key={m.id} onClick={() => { set("menuIds", [...form.menuIds, m.id]); setMenuSearch(""); }}
+                            className="flex w-full items-center justify-between px-3 py-2 text-left text-xs hover:bg-gray-50">
+                            <span className="font-medium text-gray-700">{m.name}</span>
+                            <span className="text-gray-400">{m.category}</span>
+                          </button>
+                        ))}
+                      </div>
+                    )}
+                  </div>
+                </div>
+              )}
+            </div>
+
+            {/* Notes */}
+            <div>
+              <label className="text-sm font-medium text-gray-700">Notes <span className="text-gray-400">(optional)</span></label>
+              <Input className="mt-1.5 h-10" placeholder="e.g. cold drinks only" value={form.notes} onChange={(e) => set("notes", e.target.value)} />
+            </div>
+          </div>
+
+          <div className="flex-shrink-0 border-t pt-4">
+            <Button onClick={save} disabled={saving || !form.productId} className="h-11 w-full bg-terracotta text-base hover:bg-terracotta-dark disabled:opacity-50">
+              {saving ? <Loader2 className="mr-1.5 h-4 w-4 animate-spin" /> : <Check className="mr-1.5 h-4 w-4" />}
+              {editingId ? "Save Changes" : "Add Rule"}
+            </Button>
+          </div>
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+}

--- a/apps/backoffice/src/app/(admin)/inventory/packaging/page.tsx
+++ b/apps/backoffice/src/app/(admin)/inventory/packaging/page.tsx
@@ -43,6 +43,7 @@ type Rule = {
   category: string | null;
   menuIds: string[];
   channel: Channel;
+  modifier: string | null; // null = any temperature; "Iced" / "Hot"
   perOrder: boolean;
   isActive: boolean;
   notes: string | null;
@@ -63,6 +64,7 @@ type Form = {
   category: string;
   menuIds: string[];
   channel: Channel;
+  modifier: string; // "" = any; "Iced" / "Hot"
   perOrder: boolean;
   isActive: boolean;
   notes: string;
@@ -71,7 +73,7 @@ type Form = {
 const emptyForm: Form = {
   productId: "", productName: "", productSku: "", quantity: "1",
   scope: "ALL", category: "", menuIds: [], channel: "ALL",
-  perOrder: false, isActive: true, notes: "",
+  modifier: "", perOrder: false, isActive: true, notes: "",
 };
 
 export default function PackagingPage() {
@@ -94,7 +96,8 @@ export default function PackagingPage() {
     setForm({
       productId: r.productId, productName: r.productName, productSku: r.productSku,
       quantity: String(r.quantity), scope: r.scope, category: r.category ?? "",
-      menuIds: r.menuIds, channel: r.channel, perOrder: r.perOrder, isActive: r.isActive,
+      menuIds: r.menuIds, channel: r.channel, modifier: r.modifier ?? "",
+      perOrder: r.perOrder, isActive: r.isActive,
       notes: r.notes ?? "",
     });
     setEditingId(r.id); setProductSearch(""); setMenuSearch(""); setDialogOpen(true);
@@ -115,6 +118,7 @@ export default function PackagingPage() {
           category: form.category,
           menuIds: form.menuIds,
           channel: form.channel,
+          modifier: form.modifier,
           perOrder: form.perOrder,
           isActive: form.isActive,
           notes: form.notes,
@@ -229,7 +233,14 @@ export default function PackagingPage() {
                               <code className="text-[11px] text-gray-400">{r.productSku}</code>
                             </div>
                           </td>
-                          <td className="px-2 py-2.5"><Badge variant="outline" className={`text-xs ${CHANNEL_BADGE[r.channel]}`}>{CHANNEL_LABEL[r.channel]}</Badge></td>
+                          <td className="px-2 py-2.5">
+                            <span className="inline-flex items-center gap-1">
+                              <Badge variant="outline" className={`text-xs ${CHANNEL_BADGE[r.channel]}`}>{CHANNEL_LABEL[r.channel]}</Badge>
+                              {r.modifier && (
+                                <Badge variant="outline" className={`text-xs ${r.modifier === "Iced" ? "border-sky-200 bg-sky-50 text-sky-600" : "border-orange-200 bg-orange-50 text-orange-600"}`}>{r.modifier}</Badge>
+                              )}
+                            </span>
+                          </td>
                           <td className="px-2 py-2.5 text-xs text-gray-500">{r.perOrder ? "per order" : "per item"}</td>
                           <td className="px-2 py-2.5 text-right text-gray-700">×{r.quantity}</td>
                           <td className="px-2 py-2.5 text-right font-medium text-gray-900">{r.lineCost > 0 ? formatRM(r.lineCost) : <span className="text-gray-300">—</span>}</td>
@@ -313,6 +324,20 @@ export default function PackagingPage() {
                   <option value="order">Per order</option>
                 </select>
               </div>
+            </div>
+
+            {/* When (temperature) */}
+            <div>
+              <label className="text-sm font-medium text-gray-700">When (temperature)</label>
+              <div className="mt-1.5 flex gap-1.5">
+                {[{ v: "", label: "Any" }, { v: "Iced", label: "Iced" }, { v: "Hot", label: "Hot" }].map((o) => (
+                  <button key={o.v} onClick={() => set("modifier", o.v)}
+                    className={`rounded-full border px-3 py-1 text-xs transition-colors ${form.modifier === o.v ? "border-terracotta bg-terracotta/5 text-terracotta-dark" : "border-gray-200 text-gray-500 hover:border-gray-300"}`}>
+                    {o.label}
+                  </button>
+                ))}
+              </div>
+              <p className="mt-1 text-[11px] text-gray-400">Matches the Iced / Hot modifier on the sale. “Any” applies to both.</p>
             </div>
 
             {/* Scope */}

--- a/apps/backoffice/src/app/(admin)/layout.tsx
+++ b/apps/backoffice/src/app/(admin)/layout.tsx
@@ -18,6 +18,7 @@ import {
   BarChart3,
   Users,
   Package,
+  PackageOpen,
   Truck,
   Tag,
   Tags,
@@ -202,6 +203,7 @@ const NAV_SECTIONS: NavSection[] = [
         items: [
           { label: "Ingredients", href: "/inventory/products", icon: <Package className={ICON_SIZE} />, moduleKey: "inventory:products" },
           { label: "Perishables", href: "/inventory/perishables", icon: <Box className={ICON_SIZE} />, moduleKey: "inventory:perishables" },
+          { label: "Packaging", href: "/inventory/packaging", icon: <PackageOpen className={ICON_SIZE} />, moduleKey: "inventory:packaging" },
           { label: "Suppliers", href: "/inventory/suppliers", icon: <Truck className={ICON_SIZE} />, moduleKey: "inventory:suppliers" },
           { label: "Groups & Storage", href: "/inventory/groups", icon: <Tags className={ICON_SIZE} />, moduleKey: "inventory:categories" },
         ],

--- a/apps/backoffice/src/app/api/inventory/menus/route.ts
+++ b/apps/backoffice/src/app/api/inventory/menus/route.ts
@@ -28,7 +28,7 @@ export async function GET(request: NextRequest) {
     prisma.packagingRule.findMany({
       where: { isActive: true, perOrder: false, channel: { in: ["ALL", "DINE_IN", "TAKEAWAY"] } },
       select: {
-        productId: true, quantity: true, scope: true, category: true, menuIds: true, channel: true,
+        productId: true, quantity: true, scope: true, category: true, menuIds: true, channel: true, modifier: true,
         product: { select: { name: true, sku: true, baseUom: true } },
       },
     }),
@@ -69,6 +69,7 @@ export async function GET(request: NextRequest) {
       category: r.category,
       menuIdSet: new Set(r.menuIds),
       channel: r.channel as "ALL" | "DINE_IN" | "TAKEAWAY",
+      modifier: r.modifier, // null = any temperature; "Iced" / "Hot"
     };
   });
 
@@ -82,6 +83,7 @@ export async function GET(request: NextRequest) {
     qty: number;
     uom: string;
     serviceMode: "ALL" | "DINE_IN" | "TAKEAWAY";
+    modifier: string | null; // null = any temperature; "Iced" / "Hot"
     kind: "ingredient" | "packaging";
     source: "bom" | "rule"; // "rule" lines are managed on the Packaging page
     unitCost: number;
@@ -99,6 +101,7 @@ export async function GET(request: NextRequest) {
         qty: Number(ing.quantityUsed),
         uom: ing.uom,
         serviceMode: ing.serviceMode, // ALL | DINE_IN | TAKEAWAY
+        modifier: null, // BOM lines apply regardless of temperature
         kind: ing.product.itemType === "PACKAGING" ? "packaging" : "ingredient",
         source: "bom",
         unitCost: Math.round(unitCost * 10000) / 10000,
@@ -122,6 +125,7 @@ export async function GET(request: NextRequest) {
         qty: r.qty,
         uom: r.uom,
         serviceMode: r.channel,
+        modifier: r.modifier,
         kind: "packaging",
         source: "rule",
         unitCost: Math.round(r.unitCost * 10000) / 10000,
@@ -129,49 +133,63 @@ export async function GET(request: NextRequest) {
       });
     }
 
-    // Bucket each line by kind × channel. ALL lines are billed on every sale;
-    // DINE_IN / TAKEAWAY lines only on that channel. Channel COGS =
-    // (ALL + that-channel ingredient) + (ALL + that-channel packaging).
-    let ingredientCost = 0; // channel-agnostic recipe cost (the food/drink)
-    let packagingDineIn = 0;
-    let packagingTakeaway = 0;
+    // Recipe (ingredient) cost — temperature-agnostic. Channel-tagged ingredient
+    // BOM lines are rare but supported.
+    let ingredientCost = 0;
     let ingredientDineExtra = 0;
     let ingredientTakeExtra = 0;
     let packagingCount = 0;
     for (const ing of ingredients) {
       if (ing.kind === "packaging") {
         packagingCount += 1;
-        if (ing.serviceMode !== "TAKEAWAY") packagingDineIn += ing.cost;
-        if (ing.serviceMode !== "DINE_IN") packagingTakeaway += ing.cost;
-      } else {
-        if (ing.serviceMode === "DINE_IN") ingredientDineExtra += ing.cost;
-        else if (ing.serviceMode === "TAKEAWAY") ingredientTakeExtra += ing.cost;
-        else ingredientCost += ing.cost;
-      }
+      } else if (ing.serviceMode === "DINE_IN") ingredientDineExtra += ing.cost;
+      else if (ing.serviceMode === "TAKEAWAY") ingredientTakeExtra += ing.cost;
+      else ingredientCost += ing.cost;
     }
+    const recipeCost = round2(ingredientCost + ingredientDineExtra + ingredientTakeExtra);
 
-    const dineInCogs = ingredientCost + ingredientDineExtra + packagingDineIn;
-    const takeawayCogs = ingredientCost + ingredientTakeExtra + packagingTakeaway;
+    // Packaging by (temperature × channel). A line applies to variant V and
+    // channel C when its channel is ALL or C, and its modifier is null (any) or V.
+    const pkgFor = (variant: "Hot" | "Iced", chan: "DINE_IN" | "TAKEAWAY") =>
+      round2(
+        ingredients
+          .filter((l) => l.kind === "packaging"
+            && (l.serviceMode === "ALL" || l.serviceMode === chan)
+            && (l.modifier == null || l.modifier === variant))
+          .reduce((s, l) => s + l.cost, 0),
+      );
+
     const sellingPrice = Number(m.sellingPrice ?? 0);
-    const pct = (cogs: number) => (sellingPrice > 0 ? (cogs / sellingPrice) * 100 : 0);
+    const pct = (cogs: number) => (sellingPrice > 0 ? round1((cogs / sellingPrice) * 100) : 0);
+    const ingBase = (chan: "DINE_IN" | "TAKEAWAY") =>
+      ingredientCost + (chan === "DINE_IN" ? ingredientDineExtra : ingredientTakeExtra);
+
+    // 2×2 all-in COGS matrix: temperature (Hot/Iced) × channel (dine-in/takeaway).
+    const cell = (variant: "Hot" | "Iced", chan: "DINE_IN" | "TAKEAWAY") => {
+      const pkg = pkgFor(variant, chan);
+      const cogs = round2(ingBase(chan) + pkg);
+      return { pkg, cogs, cogsPercent: pct(cogs) };
+    };
+    const matrix = {
+      hot: { dineIn: cell("Hot", "DINE_IN"), takeaway: cell("Hot", "TAKEAWAY") },
+      iced: { dineIn: cell("Iced", "DINE_IN"), takeaway: cell("Iced", "TAKEAWAY") },
+    };
+    // Does packaging actually differ by temperature for this item?
+    const hasIcedHotSplit = ingredients.some((l) => l.kind === "packaging" && l.modifier != null);
+    // Headline = worst case across the matrix (keeps High-COGS sort meaningful).
+    const allIn = [matrix.hot.dineIn, matrix.hot.takeaway, matrix.iced.dineIn, matrix.iced.takeaway];
+    const worst = allIn.reduce((a, b) => (b.cogs > a.cogs ? b : a));
 
     return {
       id: m.id,
       name: m.name,
       category: m.category ?? "",
       sellingPrice,
-      // Recipe/ingredient cost only (what the old `cogs` meant).
-      ingredientCost: round2(ingredientCost + ingredientDineExtra + ingredientTakeExtra),
-      packagingDineIn: round2(packagingDineIn),
-      packagingTakeaway: round2(packagingTakeaway),
-      dineInCogs: round2(dineInCogs),
-      takeawayCogs: round2(takeawayCogs),
-      dineInCogsPercent: round1(pct(dineInCogs)),
-      takeawayCogsPercent: round1(pct(takeawayCogs)),
-      // Headline COGS = all-in worst case (takeaway). Keeps the "High COGS"
-      // filter and sort meaningful now that packaging is included.
-      cogs: round2(takeawayCogs),
-      cogsPercent: round1(pct(takeawayCogs)),
+      ingredientCost: recipeCost,
+      matrix,
+      hasIcedHotSplit,
+      cogs: worst.cogs,
+      cogsPercent: worst.cogsPercent,
       ingredientCount: ingredients.length - packagingCount,
       packagingCount,
       ingredients,

--- a/apps/backoffice/src/app/api/inventory/menus/route.ts
+++ b/apps/backoffice/src/app/api/inventory/menus/route.ts
@@ -27,7 +27,10 @@ export async function GET(request: NextRequest) {
     // cost. Per-order and Grab/Delivery rules are order-level, not per item.
     prisma.packagingRule.findMany({
       where: { isActive: true, perOrder: false, channel: { in: ["ALL", "DINE_IN", "TAKEAWAY"] } },
-      select: { productId: true, quantity: true, scope: true, category: true, menuIds: true, channel: true },
+      select: {
+        productId: true, quantity: true, scope: true, category: true, menuIds: true, channel: true,
+        product: { select: { name: true, sku: true, baseUom: true } },
+      },
     }),
   ]);
 
@@ -51,24 +54,44 @@ export async function GET(request: NextRequest) {
     }
   }
 
-  // Pre-resolve per-item packaging rules to {cost, scope, channel} so each
-  // menu just checks applicability.
-  const rules = packagingRules.map((r) => ({
-    cost: Number(r.quantity) * (costMap.get(r.productId) ?? 0),
-    scope: r.scope,
-    category: r.category,
-    menuIdSet: new Set(r.menuIds),
-    channel: r.channel as "ALL" | "DINE_IN" | "TAKEAWAY",
-  }));
+  // Pre-resolve per-item packaging rules so each menu just checks applicability.
+  const rules = packagingRules.map((r) => {
+    const unitCost = costMap.get(r.productId) ?? 0;
+    return {
+      productId: r.productId,
+      name: r.product.name,
+      sku: r.product.sku,
+      uom: r.product.baseUom,
+      qty: Number(r.quantity),
+      unitCost,
+      cost: Number(r.quantity) * unitCost,
+      scope: r.scope,
+      category: r.category,
+      menuIdSet: new Set(r.menuIds),
+      channel: r.channel as "ALL" | "DINE_IN" | "TAKEAWAY",
+    };
+  });
 
   const round2 = (n: number) => Math.round(n * 100) / 100;
   const round1 = (n: number) => Math.round(n * 10) / 10;
 
+  type Line = {
+    productId: string;
+    product: string;
+    sku: string;
+    qty: number;
+    uom: string;
+    serviceMode: "ALL" | "DINE_IN" | "TAKEAWAY";
+    kind: "ingredient" | "packaging";
+    source: "bom" | "rule"; // "rule" lines are managed on the Packaging page
+    unitCost: number;
+    cost: number;
+  };
+
   const mapped = menus.map((m) => {
-    const ingredients = m.ingredients.map((ing) => {
+    const ingredients: Line[] = m.ingredients.map((ing): Line => {
       const unitCost = costMap.get(ing.productId) ?? 0;
       const cost = Number(ing.quantityUsed) * unitCost;
-      const kind = ing.product.itemType === "PACKAGING" ? "packaging" : "ingredient";
       return {
         productId: ing.productId,
         product: ing.product.name,
@@ -76,14 +99,38 @@ export async function GET(request: NextRequest) {
         qty: Number(ing.quantityUsed),
         uom: ing.uom,
         serviceMode: ing.serviceMode, // ALL | DINE_IN | TAKEAWAY
-        kind, // "ingredient" | "packaging"
+        kind: ing.product.itemType === "PACKAGING" ? "packaging" : "ingredient",
+        source: "bom",
         unitCost: Math.round(unitCost * 10000) / 10000,
         cost: round2(cost),
       };
     });
 
-    // Bucket each BOM line by kind × channel. ALL lines are billed on every
-    // sale; DINE_IN / TAKEAWAY lines only on that channel. Channel COGS =
+    // Append matching packaging-rule lines (cup/lid/straw on a category or all
+    // drinks). Read-only here — managed on the Packaging page — but they cost in
+    // exactly like a BOM packaging line.
+    for (const r of rules) {
+      const applies =
+        r.scope === "ALL" ? true :
+        r.scope === "CATEGORY" ? (m.category ?? "") === (r.category ?? "") :
+        r.menuIdSet.has(m.id);
+      if (!applies) continue;
+      ingredients.push({
+        productId: r.productId,
+        product: r.name,
+        sku: r.sku,
+        qty: r.qty,
+        uom: r.uom,
+        serviceMode: r.channel,
+        kind: "packaging",
+        source: "rule",
+        unitCost: Math.round(r.unitCost * 10000) / 10000,
+        cost: round2(r.cost),
+      });
+    }
+
+    // Bucket each line by kind × channel. ALL lines are billed on every sale;
+    // DINE_IN / TAKEAWAY lines only on that channel. Channel COGS =
     // (ALL + that-channel ingredient) + (ALL + that-channel packaging).
     let ingredientCost = 0; // channel-agnostic recipe cost (the food/drink)
     let packagingDineIn = 0;
@@ -101,20 +148,6 @@ export async function GET(request: NextRequest) {
         else if (ing.serviceMode === "TAKEAWAY") ingredientTakeExtra += ing.cost;
         else ingredientCost += ing.cost;
       }
-    }
-
-    // Fold in matching per-item packaging rules (cup/lid/straw on a category or
-    // all drinks). ALL bills both channels; DINE_IN / TAKEAWAY only that one.
-    let ruleMatches = 0;
-    for (const r of rules) {
-      const applies =
-        r.scope === "ALL" ? true :
-        r.scope === "CATEGORY" ? (m.category ?? "") === (r.category ?? "") :
-        r.menuIdSet.has(m.id);
-      if (!applies) continue;
-      ruleMatches += 1;
-      if (r.channel !== "TAKEAWAY") packagingDineIn += r.cost;
-      if (r.channel !== "DINE_IN") packagingTakeaway += r.cost;
     }
 
     const dineInCogs = ingredientCost + ingredientDineExtra + packagingDineIn;
@@ -140,7 +173,7 @@ export async function GET(request: NextRequest) {
       cogs: round2(takeawayCogs),
       cogsPercent: round1(pct(takeawayCogs)),
       ingredientCount: ingredients.length - packagingCount,
-      packagingCount: packagingCount + ruleMatches,
+      packagingCount,
       ingredients,
     };
   });

--- a/apps/backoffice/src/app/api/inventory/menus/route.ts
+++ b/apps/backoffice/src/app/api/inventory/menus/route.ts
@@ -5,7 +5,7 @@ import { requireAuth } from "@/lib/auth";
 export async function GET(request: NextRequest) {
   const auth = await requireAuth(request);
   if (auth.error) return auth.error;
-  const [menus, supplierProducts] = await Promise.all([
+  const [menus, supplierProducts, packagingRules] = await Promise.all([
     prisma.menu.findMany({
       include: {
         ingredients: {
@@ -22,6 +22,12 @@ export async function GET(request: NextRequest) {
         productPackage: { select: { conversionFactor: true } },
         supplier: { select: { supplierCode: true } },
       },
+    }),
+    // Per-item packaging rules that fold into a menu item's dine-in/takeaway
+    // cost. Per-order and Grab/Delivery rules are order-level, not per item.
+    prisma.packagingRule.findMany({
+      where: { isActive: true, perOrder: false, channel: { in: ["ALL", "DINE_IN", "TAKEAWAY"] } },
+      select: { productId: true, quantity: true, scope: true, category: true, menuIds: true, channel: true },
     }),
   ]);
 
@@ -44,6 +50,16 @@ export async function GET(request: NextRequest) {
       costMap.set(sp.productId, costPerBase);
     }
   }
+
+  // Pre-resolve per-item packaging rules to {cost, scope, channel} so each
+  // menu just checks applicability.
+  const rules = packagingRules.map((r) => ({
+    cost: Number(r.quantity) * (costMap.get(r.productId) ?? 0),
+    scope: r.scope,
+    category: r.category,
+    menuIdSet: new Set(r.menuIds),
+    channel: r.channel as "ALL" | "DINE_IN" | "TAKEAWAY",
+  }));
 
   const round2 = (n: number) => Math.round(n * 100) / 100;
   const round1 = (n: number) => Math.round(n * 10) / 10;
@@ -87,6 +103,20 @@ export async function GET(request: NextRequest) {
       }
     }
 
+    // Fold in matching per-item packaging rules (cup/lid/straw on a category or
+    // all drinks). ALL bills both channels; DINE_IN / TAKEAWAY only that one.
+    let ruleMatches = 0;
+    for (const r of rules) {
+      const applies =
+        r.scope === "ALL" ? true :
+        r.scope === "CATEGORY" ? (m.category ?? "") === (r.category ?? "") :
+        r.menuIdSet.has(m.id);
+      if (!applies) continue;
+      ruleMatches += 1;
+      if (r.channel !== "TAKEAWAY") packagingDineIn += r.cost;
+      if (r.channel !== "DINE_IN") packagingTakeaway += r.cost;
+    }
+
     const dineInCogs = ingredientCost + ingredientDineExtra + packagingDineIn;
     const takeawayCogs = ingredientCost + ingredientTakeExtra + packagingTakeaway;
     const sellingPrice = Number(m.sellingPrice ?? 0);
@@ -110,7 +140,7 @@ export async function GET(request: NextRequest) {
       cogs: round2(takeawayCogs),
       cogsPercent: round1(pct(takeawayCogs)),
       ingredientCount: ingredients.length - packagingCount,
-      packagingCount,
+      packagingCount: packagingCount + ruleMatches,
       ingredients,
     };
   });

--- a/apps/backoffice/src/app/api/inventory/packaging-rules/[id]/route.ts
+++ b/apps/backoffice/src/app/api/inventory/packaging-rules/[id]/route.ts
@@ -1,0 +1,42 @@
+import { NextRequest, NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+import { requireAuth } from "@/lib/auth";
+
+const SCOPES = ["ALL", "CATEGORY", "ITEMS"] as const;
+const CHANNELS = ["ALL", "DINE_IN", "TAKEAWAY", "GRAB", "DELIVERY"] as const;
+
+export async function PATCH(req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  const auth = await requireAuth(req);
+  if (auth.error) return auth.error;
+  const { id } = await params;
+  const body = await req.json();
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const data: Record<string, any> = {};
+  if (body.productId) data.productId = body.productId;
+  if (body.quantity != null) data.quantity = Number(body.quantity);
+  if (body.scope && SCOPES.includes(body.scope)) {
+    data.scope = body.scope;
+    // Keep scope-specific fields consistent with the chosen scope.
+    data.category = body.scope === "CATEGORY" ? body.category || null : null;
+    data.menuIds = body.scope === "ITEMS" && Array.isArray(body.menuIds) ? body.menuIds : [];
+  } else {
+    if (body.category !== undefined) data.category = body.category || null;
+    if (Array.isArray(body.menuIds)) data.menuIds = body.menuIds;
+  }
+  if (body.channel && CHANNELS.includes(body.channel)) data.channel = body.channel;
+  if (body.perOrder !== undefined) data.perOrder = !!body.perOrder;
+  if (body.isActive !== undefined) data.isActive = !!body.isActive;
+  if (body.notes !== undefined) data.notes = body.notes || null;
+
+  const rule = await prisma.packagingRule.update({ where: { id }, data });
+  return NextResponse.json(rule);
+}
+
+export async function DELETE(req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  const auth = await requireAuth(req);
+  if (auth.error) return auth.error;
+  const { id } = await params;
+  await prisma.packagingRule.delete({ where: { id } });
+  return NextResponse.json({ ok: true });
+}

--- a/apps/backoffice/src/app/api/inventory/packaging-rules/[id]/route.ts
+++ b/apps/backoffice/src/app/api/inventory/packaging-rules/[id]/route.ts
@@ -25,6 +25,7 @@ export async function PATCH(req: NextRequest, { params }: { params: Promise<{ id
     if (Array.isArray(body.menuIds)) data.menuIds = body.menuIds;
   }
   if (body.channel && CHANNELS.includes(body.channel)) data.channel = body.channel;
+  if (body.modifier !== undefined) data.modifier = body.modifier || null;
   if (body.perOrder !== undefined) data.perOrder = !!body.perOrder;
   if (body.isActive !== undefined) data.isActive = !!body.isActive;
   if (body.notes !== undefined) data.notes = body.notes || null;

--- a/apps/backoffice/src/app/api/inventory/packaging-rules/route.ts
+++ b/apps/backoffice/src/app/api/inventory/packaging-rules/route.ts
@@ -1,0 +1,118 @@
+import { NextRequest, NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+import { requireAuth } from "@/lib/auth";
+
+const SCOPES = ["ALL", "CATEGORY", "ITEMS"] as const;
+const CHANNELS = ["ALL", "DINE_IN", "TAKEAWAY", "GRAB", "DELIVERY"] as const;
+type Scope = (typeof SCOPES)[number];
+type Channel = (typeof CHANNELS)[number];
+
+// Cheapest cost-per-base-unit per product (cheapest non-ADHOC, non-zero
+// supplier price ÷ package conversion) — same basis as the menu BOM costing.
+async function buildCostMap(): Promise<Map<string, number>> {
+  const supplierProducts = await prisma.supplierProduct.findMany({
+    where: { isActive: true },
+    select: {
+      productId: true,
+      price: true,
+      productPackage: { select: { conversionFactor: true } },
+      supplier: { select: { supplierCode: true } },
+    },
+  });
+  const costMap = new Map<string, number>();
+  for (const sp of supplierProducts) {
+    if (sp.supplier?.supplierCode === "ADHOC") continue;
+    const price = Number(sp.price);
+    if (price <= 0) continue;
+    const conversion = sp.productPackage?.conversionFactor ? Number(sp.productPackage.conversionFactor) : 0;
+    if (conversion <= 0) continue;
+    const costPerBase = price / conversion;
+    const existing = costMap.get(sp.productId);
+    if (!existing || costPerBase < existing) costMap.set(sp.productId, costPerBase);
+  }
+  return costMap;
+}
+
+export async function GET(req: NextRequest) {
+  const auth = await requireAuth(req);
+  if (auth.error) return auth.error;
+
+  const [rules, menus, costMap] = await Promise.all([
+    prisma.packagingRule.findMany({
+      include: { product: { select: { name: true, sku: true, baseUom: true } } },
+      orderBy: { createdAt: "asc" },
+    }),
+    prisma.menu.findMany({ select: { id: true, category: true } }),
+    buildCostMap(),
+  ]);
+
+  const round4 = (n: number) => Math.round(n * 10000) / 10000;
+  const round2 = (n: number) => Math.round(n * 100) / 100;
+
+  const mapped = rules.map((r) => {
+    // How many menus this rule matches (per-item rules cost into each).
+    let matchedMenuCount: number;
+    if (r.scope === "CATEGORY") {
+      matchedMenuCount = menus.filter((m) => (m.category ?? "") === (r.category ?? "")).length;
+    } else if (r.scope === "ITEMS") {
+      const set = new Set(r.menuIds);
+      matchedMenuCount = menus.filter((m) => set.has(m.id)).length;
+    } else {
+      matchedMenuCount = menus.length;
+    }
+
+    const unitCost = costMap.get(r.productId) ?? 0;
+    const lineCost = Number(r.quantity) * unitCost;
+
+    return {
+      id: r.id,
+      productId: r.productId,
+      productName: r.product.name,
+      productSku: r.product.sku,
+      baseUom: r.product.baseUom,
+      quantity: Number(r.quantity),
+      scope: r.scope,
+      category: r.category,
+      menuIds: r.menuIds,
+      channel: r.channel,
+      perOrder: r.perOrder,
+      isActive: r.isActive,
+      notes: r.notes,
+      unitCost: round4(unitCost),
+      lineCost: round2(lineCost),
+      matchedMenuCount,
+    };
+  });
+
+  return NextResponse.json(mapped);
+}
+
+export async function POST(req: NextRequest) {
+  const auth = await requireAuth(req);
+  if (auth.error) return auth.error;
+
+  const body = await req.json();
+  const { productId, quantity, scope, category, menuIds, channel, perOrder, isActive, notes } = body;
+
+  if (!productId) {
+    return NextResponse.json({ error: "productId is required" }, { status: 400 });
+  }
+  const scopeVal: Scope = SCOPES.includes(scope) ? scope : "ALL";
+  const channelVal: Channel = CHANNELS.includes(channel) ? channel : "ALL";
+
+  const rule = await prisma.packagingRule.create({
+    data: {
+      productId,
+      quantity: quantity != null ? Number(quantity) : 1,
+      scope: scopeVal,
+      category: scopeVal === "CATEGORY" ? category || null : null,
+      menuIds: scopeVal === "ITEMS" && Array.isArray(menuIds) ? menuIds : [],
+      channel: channelVal,
+      perOrder: !!perOrder,
+      isActive: isActive ?? true,
+      notes: notes || null,
+    },
+  });
+
+  return NextResponse.json(rule, { status: 201 });
+}

--- a/apps/backoffice/src/app/api/inventory/packaging-rules/route.ts
+++ b/apps/backoffice/src/app/api/inventory/packaging-rules/route.ts
@@ -75,6 +75,7 @@ export async function GET(req: NextRequest) {
       category: r.category,
       menuIds: r.menuIds,
       channel: r.channel,
+      modifier: r.modifier, // null = any temperature; "Iced" / "Hot"
       perOrder: r.perOrder,
       isActive: r.isActive,
       notes: r.notes,
@@ -92,7 +93,7 @@ export async function POST(req: NextRequest) {
   if (auth.error) return auth.error;
 
   const body = await req.json();
-  const { productId, quantity, scope, category, menuIds, channel, perOrder, isActive, notes } = body;
+  const { productId, quantity, scope, category, menuIds, channel, modifier, perOrder, isActive, notes } = body;
 
   if (!productId) {
     return NextResponse.json({ error: "productId is required" }, { status: 400 });
@@ -108,6 +109,7 @@ export async function POST(req: NextRequest) {
       category: scopeVal === "CATEGORY" ? category || null : null,
       menuIds: scopeVal === "ITEMS" && Array.isArray(menuIds) ? menuIds : [],
       channel: channelVal,
+      modifier: modifier || null,
       perOrder: !!perOrder,
       isActive: isActive ?? true,
       notes: notes || null,

--- a/apps/backoffice/src/lib/modules.ts
+++ b/apps/backoffice/src/lib/modules.ts
@@ -24,6 +24,7 @@ export const APP_MODULES: Record<string, ModuleDef[]> = {
   inventory: [
     { label: "Products", key: "products" },
     { label: "Perishables", key: "perishables" },
+    { label: "Packaging", key: "packaging" },
     { label: "Suppliers", key: "suppliers" },
     { label: "Categories", key: "categories" },
     { label: "Menu & BOM", key: "menus" },
@@ -147,6 +148,7 @@ export const NAV_TABS: GrantTab[] = [
         modules: [
           m("inventory", "products", "Ingredients & Dashboard"),
           m("inventory", "perishables", "Perishables"),
+          m("inventory", "packaging", "Packaging"),
           m("inventory", "suppliers", "Suppliers"),
           m("inventory", "categories", "Groups & Storage"),
         ],

--- a/packages/db/prisma/baseline/0000_baseline.sql
+++ b/packages/db/prisma/baseline/0000_baseline.sql
@@ -592,6 +592,7 @@ CREATE TABLE "PackagingRule" (
     "category" TEXT,
     "menuIds" TEXT[] DEFAULT ARRAY[]::TEXT[],
     "channel" "PackagingChannel" NOT NULL DEFAULT 'ALL',
+    "modifier" TEXT,
     "perOrder" BOOLEAN NOT NULL DEFAULT false,
     "isActive" BOOLEAN NOT NULL DEFAULT true,
     "notes" TEXT,

--- a/packages/db/prisma/baseline/0000_baseline.sql
+++ b/packages/db/prisma/baseline/0000_baseline.sql
@@ -53,6 +53,12 @@ CREATE TYPE "AdjustmentType" AS ENUM ('WASTAGE', 'BREAKAGE', 'EXPIRED', 'THEFT',
 CREATE TYPE "TransferStatus" AS ENUM ('DRAFT', 'PENDING_APPROVAL', 'PENDING', 'APPROVED', 'IN_TRANSIT', 'RECEIVED', 'COMPLETED', 'CANCELLED');
 
 -- CreateEnum
+CREATE TYPE "PackagingScope" AS ENUM ('ALL', 'CATEGORY', 'ITEMS');
+
+-- CreateEnum
+CREATE TYPE "PackagingChannel" AS ENUM ('ALL', 'DINE_IN', 'TAKEAWAY', 'GRAB', 'DELIVERY');
+
+-- CreateEnum
 CREATE TYPE "SyncType" AS ENUM ('PRODUCTS', 'SALES', 'EMPLOYEES');
 
 -- CreateEnum
@@ -575,6 +581,24 @@ CREATE TABLE "MenuIngredient" (
     "serviceMode" "ServiceMode" NOT NULL DEFAULT 'ALL',
 
     CONSTRAINT "MenuIngredient_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "PackagingRule" (
+    "id" TEXT NOT NULL,
+    "productId" TEXT NOT NULL,
+    "quantity" DECIMAL(65,30) NOT NULL DEFAULT 1,
+    "scope" "PackagingScope" NOT NULL DEFAULT 'ALL',
+    "category" TEXT,
+    "menuIds" TEXT[] DEFAULT ARRAY[]::TEXT[],
+    "channel" "PackagingChannel" NOT NULL DEFAULT 'ALL',
+    "perOrder" BOOLEAN NOT NULL DEFAULT false,
+    "isActive" BOOLEAN NOT NULL DEFAULT true,
+    "notes" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "PackagingRule_pkey" PRIMARY KEY ("id")
 );
 
 -- CreateTable
@@ -1318,6 +1342,15 @@ CREATE UNIQUE INDEX "Menu_storehubId_key" ON "Menu"("storehubId");
 CREATE UNIQUE INDEX "MenuIngredient_menuId_productId_serviceMode_key" ON "MenuIngredient"("menuId", "productId", "serviceMode");
 
 -- CreateIndex
+CREATE INDEX "PackagingRule_isActive_idx" ON "PackagingRule"("isActive");
+
+-- CreateIndex
+CREATE INDEX "PackagingRule_scope_idx" ON "PackagingRule"("scope");
+
+-- CreateIndex
+CREATE INDEX "PackagingRule_productId_idx" ON "PackagingRule"("productId");
+
+-- CreateIndex
 CREATE UNIQUE INDEX "SalesTransaction_storehubTxId_key" ON "SalesTransaction"("storehubTxId");
 
 -- CreateIndex
@@ -1751,6 +1784,9 @@ ALTER TABLE "MenuIngredient" ADD CONSTRAINT "MenuIngredient_menuId_fkey" FOREIGN
 
 -- AddForeignKey
 ALTER TABLE "MenuIngredient" ADD CONSTRAINT "MenuIngredient_productId_fkey" FOREIGN KEY ("productId") REFERENCES "Product"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "PackagingRule" ADD CONSTRAINT "PackagingRule_productId_fkey" FOREIGN KEY ("productId") REFERENCES "Product"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
 
 -- AddForeignKey
 ALTER TABLE "SalesTransaction" ADD CONSTRAINT "SalesTransaction_outletId_fkey" FOREIGN KEY ("outletId") REFERENCES "Outlet"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/packages/db/prisma/migrations/20260619_packaging_rule_modifier/migration.sql
+++ b/packages/db/prisma/migrations/20260619_packaging_rule_modifier/migration.sql
@@ -1,0 +1,8 @@
+-- Hot/Iced (and any) modifier condition on packaging rules. Matches
+-- pos_order_items.modifiers[].name so a rule can scope to the "Iced" or "Hot"
+-- variant without splitting the menu item — the packaging diff lives on the
+-- rule, not a duplicated recipe. NULL = applies regardless of temperature.
+--
+-- Applied to production via Supabase MCP apply_migration. Manual SQL only.
+
+ALTER TABLE "PackagingRule" ADD COLUMN IF NOT EXISTS "modifier" TEXT;

--- a/packages/db/prisma/migrations/20260619_packaging_rules/migration.sql
+++ b/packages/db/prisma/migrations/20260619_packaging_rules/migration.sql
@@ -1,0 +1,40 @@
+-- Packaging rules: central, rule-based packaging assignment — the counterpart
+-- to the per-recipe MenuIngredient BOM. A rule links an existing inventory
+-- product (typically a perishable: cup, lid, straw, bag) to a scope (all menus
+-- / a menu category / specific menus) and a channel, charged per item sold or
+-- once per order. See packages/db/prisma/schema.prisma.
+--
+-- Applied to production via Supabase MCP apply_migration. Manual SQL only —
+-- never `prisma db push`. See docs/database-migrations.md.
+
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname = 'PackagingScope') THEN
+    CREATE TYPE "PackagingScope" AS ENUM ('ALL', 'CATEGORY', 'ITEMS');
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname = 'PackagingChannel') THEN
+    CREATE TYPE "PackagingChannel" AS ENUM ('ALL', 'DINE_IN', 'TAKEAWAY', 'GRAB', 'DELIVERY');
+  END IF;
+END $$;
+
+CREATE TABLE IF NOT EXISTS "PackagingRule" (
+  "id"        TEXT NOT NULL,
+  "productId" TEXT NOT NULL,
+  "quantity"  DECIMAL(65,30) NOT NULL DEFAULT 1,
+  "scope"     "PackagingScope" NOT NULL DEFAULT 'ALL',
+  "category"  TEXT,
+  "menuIds"   TEXT[] NOT NULL DEFAULT ARRAY[]::TEXT[],
+  "channel"   "PackagingChannel" NOT NULL DEFAULT 'ALL',
+  "perOrder"  BOOLEAN NOT NULL DEFAULT false,
+  "isActive"  BOOLEAN NOT NULL DEFAULT true,
+  "notes"     TEXT,
+  "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "updatedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  CONSTRAINT "PackagingRule_pkey" PRIMARY KEY ("id"),
+  CONSTRAINT "PackagingRule_productId_fkey" FOREIGN KEY ("productId")
+    REFERENCES "Product"("id") ON DELETE RESTRICT ON UPDATE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS "PackagingRule_isActive_idx"  ON "PackagingRule" ("isActive");
+CREATE INDEX IF NOT EXISTS "PackagingRule_scope_idx"     ON "PackagingRule" ("scope");
+CREATE INDEX IF NOT EXISTS "PackagingRule_productId_idx" ON "PackagingRule" ("productId");

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -877,6 +877,11 @@ model PackagingRule {
   // When it applies. DINE_IN/TAKEAWAY/ALL cost into per-item menu COGS;
   // GRAB/DELIVERY are order-source channels (typically per-order overhead).
   channel   PackagingChannel @default(ALL)
+  // Optional order-line modifier condition (matches pos_order_items.modifiers
+  // .name). null = applies regardless of temperature; "Iced" / "Hot" scope the
+  // rule to that variant. This is how Hot vs Iced packaging is captured without
+  // splitting the menu item — the diff lives on the rule, not a duplicate recipe.
+  modifier  String?
   // false = charged per matching item sold (a cup per drink);
   // true  = charged once per order (a carrier bag per Grab order).
   perOrder  Boolean @default(false)

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -268,6 +268,7 @@ model Product {
   parLevels         ParLevel[]
   menuIngredients   MenuIngredient[]
   transferItems     StockTransferItem[]
+  packagingRules    PackagingRule[]
 }
 
 // ─── PRODUCT PACKAGES (Multi-UOM) ──────────────────────────
@@ -851,6 +852,56 @@ model MenuIngredient {
   serviceMode  ServiceMode @default(ALL)
 
   @@unique([menuId, productId, serviceMode])
+}
+
+// ─── PACKAGING RULES ────────────────────────────────────────
+// Central, rule-based packaging assignment — the counterpart to the per-recipe
+// MenuIngredient BOM. Packaging (cups, lids, straws, bags) repeats across many
+// menus, so instead of adding it to every recipe you define a rule once:
+// "this product applies to <scope> on <channel>, N per <item|order>". The
+// linked product is just an existing inventory item (typically a perishable);
+// its cost is resolved from the cheapest supplier price like any ingredient.
+//
+//   Iced cup + lid → scope CATEGORY "Drinks", channel TAKEAWAY, per item
+//   Straw          → scope CATEGORY "Drinks", channel ALL,      per item
+//   Paper bag      → scope ALL,               channel GRAB,     per order
+model PackagingRule {
+  id        String  @id @default(uuid())
+  productId String
+  product   Product @relation(fields: [productId], references: [id])
+  quantity  Decimal @default(1)
+  // What it applies to.
+  scope     PackagingScope @default(ALL)
+  category  String?        // Menu.category value when scope = CATEGORY
+  menuIds   String[] @default([]) // specific Menu ids when scope = ITEMS
+  // When it applies. DINE_IN/TAKEAWAY/ALL cost into per-item menu COGS;
+  // GRAB/DELIVERY are order-source channels (typically per-order overhead).
+  channel   PackagingChannel @default(ALL)
+  // false = charged per matching item sold (a cup per drink);
+  // true  = charged once per order (a carrier bag per Grab order).
+  perOrder  Boolean @default(false)
+  isActive  Boolean @default(true)
+  notes     String?
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  @@index([isActive])
+  @@index([scope])
+  @@index([productId])
+}
+
+enum PackagingScope {
+  ALL
+  CATEGORY
+  ITEMS
+}
+
+enum PackagingChannel {
+  ALL
+  DINE_IN
+  TAKEAWAY
+  GRAB
+  DELIVERY
 }
 
 // ─── SALES TRANSACTIONS (from StoreHub) ─────────────────────


### PR DESCRIPTION
## What & why

Adds a central, **rule-based** way to cost packaging onto menus — the counterpart to the per-recipe BOM. Packaging (cups, lids, straws, bags) repeats across many menus, so instead of editing every recipe you define a rule once.

Built from the requested examples:

| Example | Item | Applies to | Channel | Per |
|---|---|---|---|---|
| Iced cup + lid — if drinks | cup, lid | Category = Drinks | Takeaway | item |
| Straw — all drinks | straw | Category = Drinks | All | item |
| Grab — one paper bag | bag | All | Grab | order |

**No new product type needed** — the linked packaging item is just an existing inventory product (typically a perishable), and its cost resolves from the cheapest supplier price exactly like an ingredient.

## Changes
- **schema**: new `PackagingRule` table + `PackagingScope` (ALL/CATEGORY/ITEMS) and `PackagingChannel` (ALL/DINE_IN/TAKEAWAY/GRAB/DELIVERY) enums.
- **`/inventory/packaging` page**: list rules + add/edit (pick product, qty, scope, channel, per item vs per order). Nav entry under Procurement → Master Data.
- **`/api/inventory/packaging-rules`** CRUD; list returns each rule's per-unit cost + matched-menu count.
- **menu costing** (`/api/inventory/menus`): active per-item rules (Dine-in/Takeaway/All) fold into each matching menu's packaging COGS automatically.

## Scope / follow-ups
- Per-order and Grab/Delivery rules are **order-level**, so they're stored and shown on the Packaging page but not folded into a menu item's per-item dine-in/takeaway COGS. Order-level costing (applying the Grab bag per `pos_orders` row) and reflecting packaging rules in the COGS *report* are deliberate follow-ups.

## Migration
SQL captured under `packages/db/prisma/migrations/20260619_packaging_rules/`. Additive (two new enums + one new table). **Not yet applied** — to be applied via Supabase MCP to the live DB (`kqdcdhpnyuwrxqhbuyfl`) after review. Baseline snapshot regenerated.

## Test plan
- [x] `tsc --noEmit` clean (backoffice)
- [x] eslint clean on all new/changed files
- [x] Prisma client + baseline regenerated
- [ ] After migration: create a rule (straw → Drinks → All → per item), confirm matched-menu count + the drinks' packaging COGS reflect it

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SgZXN9d3uBVRy19QbrXdE9

---
_Generated by [Claude Code](https://claude.ai/code/session_01SgZXN9d3uBVRy19QbrXdE9)_