### PR TITLE
Let recipe lines differ by temperature (Hot/Iced)

### DIFF
--- a/apps/backoffice/src/app/(admin)/inventory/menus/page.tsx
+++ b/apps/backoffice/src/app/(admin)/inventory/menus/page.tsx
@@ -67,6 +67,7 @@ type EditIngredient = {
   quantityUsed: number;
   uom: string;
   serviceMode: ServiceMode;
+  modifier: string; // "" = both temperatures; "Iced" / "Hot"
   kind: "ingredient" | "packaging";
 };
 
@@ -145,6 +146,7 @@ export default function MenusPage() {
           quantityUsed: ing.qty,
           uom: ing.uom,
           serviceMode: ing.serviceMode,
+          modifier: ing.modifier ?? "",
           kind: ing.kind,
         }))
     );
@@ -177,6 +179,12 @@ export default function MenusPage() {
     );
   };
 
+  const updateIngredientModifier = (productId: string, modifier: string) => {
+    setEditIngredients((prev) =>
+      prev.map((ing) => (ing.productId === productId ? { ...ing, modifier } : ing))
+    );
+  };
+
   const addIngredient = (product: ProductOption) => {
     if (editIngredients.some((ing) => ing.productId === product.id)) return;
     setEditIngredients((prev) => [
@@ -188,6 +196,7 @@ export default function MenusPage() {
         quantityUsed: 0,
         uom: product.baseUom,
         serviceMode: "ALL",
+        modifier: "",
         kind: product.itemType === "PACKAGING" ? "packaging" : "ingredient",
       },
     ]);
@@ -207,6 +216,7 @@ export default function MenusPage() {
             quantityUsed: ing.quantityUsed,
             uom: ing.uom,
             serviceMode: ing.serviceMode,
+            modifier: ing.modifier,
           })),
         }),
       });
@@ -452,6 +462,7 @@ export default function MenusPage() {
                                   <th className="pb-1 text-left font-medium w-20">SKU</th>
                                   <th className="pb-1 w-28 text-right font-medium">Qty</th>
                                   <th className="pb-1 w-16 text-center font-medium">UOM</th>
+                                  <th className="pb-1 w-24 text-center font-medium">When</th>
                                   <th className="pb-1 w-28 text-center font-medium">Channel</th>
                                   <th className="pb-1 w-8"></th>
                                 </tr>
@@ -485,6 +496,17 @@ export default function MenusPage() {
                                     </td>
                                     <td className="py-1.5 text-center">
                                       <select
+                                        value={ing.modifier}
+                                        onChange={(e) => updateIngredientModifier(ing.productId, e.target.value)}
+                                        className="rounded border border-gray-200 px-1.5 py-1 text-xs text-gray-600"
+                                      >
+                                        <option value="">Both</option>
+                                        <option value="Iced">Iced</option>
+                                        <option value="Hot">Hot</option>
+                                      </select>
+                                    </td>
+                                    <td className="py-1.5 text-center">
+                                      <select
                                         value={ing.serviceMode}
                                         onChange={(e) => updateIngredientMode(ing.productId, e.target.value as ServiceMode)}
                                         className="rounded border border-gray-200 px-1.5 py-1 text-xs text-gray-600"
@@ -503,7 +525,7 @@ export default function MenusPage() {
                                 ))}
                                 {editIngredients.length === 0 && (
                                   <tr>
-                                    <td colSpan={6} className="py-4 text-center text-gray-400">
+                                    <td colSpan={7} className="py-4 text-center text-gray-400">
                                       No items yet. Search below to add ingredients or packaging.
                                     </td>
                                   </tr>

--- a/apps/backoffice/src/app/api/inventory/menus/[id]/ingredients/route.ts
+++ b/apps/backoffice/src/app/api/inventory/menus/[id]/ingredients/route.ts
@@ -9,9 +9,10 @@ const SERVICE_MODES: ServiceMode[] = ["ALL", "DINE_IN", "TAKEAWAY"];
  * PUT /api/menus/[id]/ingredients
  *
  * Replace all BOM lines (ingredients + packaging) for a menu item.
- * Body: { ingredients: [{ productId, quantityUsed, uom, serviceMode? }] }
- * serviceMode defaults to ALL; packaging lines use DINE_IN / TAKEAWAY to scope
- * a line to one fulfillment channel.
+ * Body: { ingredients: [{ productId, quantityUsed, uom, serviceMode?, modifier? }] }
+ * serviceMode defaults to ALL (DINE_IN / TAKEAWAY scope a line to one channel);
+ * modifier is an optional temperature condition ("Iced" / "Hot"; null = both) so
+ * a recipe can differ by temperature without duplicating it.
  */
 export async function PUT(
   req: NextRequest,
@@ -37,7 +38,7 @@ export async function PUT(
   await prisma.$transaction([
     prisma.menuIngredient.deleteMany({ where: { menuId } }),
     ...ingredients.map(
-      (ing: { productId: string; quantityUsed: number; uom: string; serviceMode?: string }) =>
+      (ing: { productId: string; quantityUsed: number; uom: string; serviceMode?: string; modifier?: string }) =>
         prisma.menuIngredient.create({
           data: {
             menuId,
@@ -47,6 +48,7 @@ export async function PUT(
             serviceMode: SERVICE_MODES.includes(ing.serviceMode as ServiceMode)
               ? (ing.serviceMode as ServiceMode)
               : "ALL",
+            modifier: ing.modifier ? ing.modifier : null,
           },
         }),
     ),

--- a/apps/backoffice/src/app/api/inventory/menus/route.ts
+++ b/apps/backoffice/src/app/api/inventory/menus/route.ts
@@ -101,7 +101,7 @@ export async function GET(request: NextRequest) {
         qty: Number(ing.quantityUsed),
         uom: ing.uom,
         serviceMode: ing.serviceMode, // ALL | DINE_IN | TAKEAWAY
-        modifier: null, // BOM lines apply regardless of temperature
+        modifier: ing.modifier, // null = both temperatures; "Iced" / "Hot"
         kind: ing.product.itemType === "PACKAGING" ? "packaging" : "ingredient",
         source: "bom",
         unitCost: Math.round(unitCost * 10000) / 10000,
@@ -133,49 +133,42 @@ export async function GET(request: NextRequest) {
       });
     }
 
-    // Recipe (ingredient) cost — temperature-agnostic. Channel-tagged ingredient
-    // BOM lines are rare but supported.
-    let ingredientCost = 0;
-    let ingredientDineExtra = 0;
-    let ingredientTakeExtra = 0;
-    let packagingCount = 0;
-    for (const ing of ingredients) {
-      if (ing.kind === "packaging") {
-        packagingCount += 1;
-      } else if (ing.serviceMode === "DINE_IN") ingredientDineExtra += ing.cost;
-      else if (ing.serviceMode === "TAKEAWAY") ingredientTakeExtra += ing.cost;
-      else ingredientCost += ing.cost;
-    }
-    const recipeCost = round2(ingredientCost + ingredientDineExtra + ingredientTakeExtra);
+    // A line applies to a given temperature × channel when its channel is ALL or
+    // C, and its temperature is null (both) or V. Works for ingredient AND
+    // packaging lines, so a recipe can differ by Hot/Iced (e.g. different syrup)
+    // just like packaging does.
+    const lineApplies = (l: Line, variant: "Hot" | "Iced", chan: "DINE_IN" | "TAKEAWAY") =>
+      (l.serviceMode === "ALL" || l.serviceMode === chan) &&
+      (l.modifier == null || l.modifier === variant);
 
-    // Packaging by (temperature × channel). A line applies to variant V and
-    // channel C when its channel is ALL or C, and its modifier is null (any) or V.
-    const pkgFor = (variant: "Hot" | "Iced", chan: "DINE_IN" | "TAKEAWAY") =>
-      round2(
-        ingredients
-          .filter((l) => l.kind === "packaging"
-            && (l.serviceMode === "ALL" || l.serviceMode === chan)
-            && (l.modifier == null || l.modifier === variant))
-          .reduce((s, l) => s + l.cost, 0),
-      );
+    let packagingCount = 0;
+    let ingredientTotal = 0; // recipe list total (informational; matrix is authoritative)
+    for (const l of ingredients) {
+      if (l.kind === "packaging") packagingCount += 1;
+      else ingredientTotal += l.cost;
+    }
 
     const sellingPrice = Number(m.sellingPrice ?? 0);
     const pct = (cogs: number) => (sellingPrice > 0 ? round1((cogs / sellingPrice) * 100) : 0);
-    const ingBase = (chan: "DINE_IN" | "TAKEAWAY") =>
-      ingredientCost + (chan === "DINE_IN" ? ingredientDineExtra : ingredientTakeExtra);
 
     // 2×2 all-in COGS matrix: temperature (Hot/Iced) × channel (dine-in/takeaway).
     const cell = (variant: "Hot" | "Iced", chan: "DINE_IN" | "TAKEAWAY") => {
-      const pkg = pkgFor(variant, chan);
-      const cogs = round2(ingBase(chan) + pkg);
-      return { pkg, cogs, cogsPercent: pct(cogs) };
+      let cogs = 0;
+      let pkg = 0;
+      for (const l of ingredients) {
+        if (!lineApplies(l, variant, chan)) continue;
+        cogs += l.cost;
+        if (l.kind === "packaging") pkg += l.cost;
+      }
+      cogs = round2(cogs);
+      return { pkg: round2(pkg), cogs, cogsPercent: pct(cogs) };
     };
     const matrix = {
       hot: { dineIn: cell("Hot", "DINE_IN"), takeaway: cell("Hot", "TAKEAWAY") },
       iced: { dineIn: cell("Iced", "DINE_IN"), takeaway: cell("Iced", "TAKEAWAY") },
     };
-    // Does packaging actually differ by temperature for this item?
-    const hasIcedHotSplit = ingredients.some((l) => l.kind === "packaging" && l.modifier != null);
+    // Does anything (ingredient or packaging) differ by temperature for this item?
+    const hasIcedHotSplit = ingredients.some((l) => l.modifier != null);
     // Headline = worst case across the matrix (keeps High-COGS sort meaningful).
     const allIn = [matrix.hot.dineIn, matrix.hot.takeaway, matrix.iced.dineIn, matrix.iced.takeaway];
     const worst = allIn.reduce((a, b) => (b.cogs > a.cogs ? b : a));
@@ -185,7 +178,7 @@ export async function GET(request: NextRequest) {
       name: m.name,
       category: m.category ?? "",
       sellingPrice,
-      ingredientCost: recipeCost,
+      ingredientCost: round2(ingredientTotal),
       matrix,
       hasIcedHotSplit,
       cogs: worst.cogs,

--- a/packages/db/prisma/baseline/0000_baseline.sql
+++ b/packages/db/prisma/baseline/0000_baseline.sql
@@ -579,6 +579,7 @@ CREATE TABLE "MenuIngredient" (
     "quantityUsed" DECIMAL(65,30) NOT NULL,
     "uom" TEXT NOT NULL,
     "serviceMode" "ServiceMode" NOT NULL DEFAULT 'ALL',
+    "modifier" TEXT,
 
     CONSTRAINT "MenuIngredient_pkey" PRIMARY KEY ("id")
 );

--- a/packages/db/prisma/migrations/20260619_menu_ingredient_modifier/migration.sql
+++ b/packages/db/prisma/migrations/20260619_menu_ingredient_modifier/migration.sql
@@ -1,0 +1,6 @@
+-- Temperature condition on recipe (BOM) lines, mirroring PackagingRule.modifier.
+-- Lets a recipe differ by Hot/Iced (different syrup, different ml) without
+-- duplicating the whole recipe — null = both, "Iced" / "Hot" scope the line.
+-- Matches pos_order_items.modifiers[].name. Manual SQL only.
+
+ALTER TABLE "MenuIngredient" ADD COLUMN IF NOT EXISTS "modifier" TEXT;

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -850,6 +850,11 @@ model MenuIngredient {
   // product can appear once per (menu, serviceMode) — e.g. a straw used both
   // ways is one ALL line, while a takeaway-only cup is a separate TAKEAWAY line.
   serviceMode  ServiceMode @default(ALL)
+  // Optional temperature condition (matches pos_order_items.modifiers[].name).
+  // null = applies to both; "Iced" / "Hot" scope the line to that variant — so a
+  // recipe can differ by temperature (e.g. vanilla syrup on Hot, caramel on Iced)
+  // without duplicating the whole recipe.
+  modifier     String?
 
   @@unique([menuId, productId, serviceMode])
 }


### PR DESCRIPTION
## Problem
You couldn't set a recipe that differs by temperature — e.g. *vanilla syrup on Hot, caramel on Iced*, or a different ml of milk. The Menu & BOM editor only had **Qty + Channel** (dine-in/takeaway); there was **no temperature option on ingredient lines**, so the recipe froze to one set for both Hot and Iced.

## Fix
Adds the same **Hot/Iced condition** that already exists on packaging rules to the **recipe lines** themselves.

- **schema**: `MenuIngredient.modifier` (nullable) — `null` = both temperatures; `"Iced"` / `"Hot"` scope a line to that variant. Matches `PackagingRule.modifier` and `pos_order_items.modifiers[].name`.
- **Menu & BOM editor**: a **"When"** selector (Both / Iced / Hot) on each recipe line. Base ingredients stay *Both*; you add Hot-only / Iced-only lines for what differs — no recipe duplication.
- **costing**: the Hot/Iced × channel COGS matrix now buckets **ingredient** lines by temperature too (unified with packaging), so each drink's per-variant COGS reflects recipe differences, not just packaging.

So for a drink like Doppio Freddo you'd keep espresso/milk as *Both*, and add the iced-only / hot-only syrups tagged accordingly — the Iced vs Hot columns then cost correctly.

## Migration
`ALTER TABLE "MenuIngredient" ADD COLUMN modifier TEXT` — additive, applied to both DBs via Supabase MCP. Baseline regenerated.

## Test plan
- [x] `tsc --noEmit` + eslint clean
- [x] Prisma client + baseline regenerated
- [ ] After deploy: edit a drink, set a syrup to `Hot` and another to `Iced`, confirm the Iced/Hot COGS rows diverge

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SgZXN9d3uBVRy19QbrXdE9

---
_Generated by [Claude Code](https://claude.ai/code/session_01SgZXN9d3uBVRy19QbrXdE9)_