### PR TITLE
Packaging rules: pick multiple items / categories per add

### DIFF
--- a/apps/backoffice/src/app/(admin)/inventory/packaging/page.tsx
+++ b/apps/backoffice/src/app/(admin)/inventory/packaging/page.tsx
@@ -55,13 +55,16 @@ type Rule = {
 type ProductOption = { id: string; name: string; sku: string; baseUom: string; itemType: string };
 type MenuLite = { id: string; name: string; category: string };
 
+type PickedItem = { id: string; name: string; sku: string };
+
 type Form = {
-  productId: string;
-  productName: string;
-  productSku: string;
+  // One or more packaging items (Add can fan out into a rule per item). Edit
+  // keeps exactly one.
+  items: PickedItem[];
   quantity: string;
   scope: Scope;
-  category: string;
+  // One or more categories when scope = CATEGORY (Add can fan out per category).
+  categories: string[];
   menuIds: string[];
   channel: Channel;
   modifier: string; // "" = any; "Iced" / "Hot"
@@ -71,8 +74,8 @@ type Form = {
 };
 
 const emptyForm: Form = {
-  productId: "", productName: "", productSku: "", quantity: "1",
-  scope: "ALL", category: "", menuIds: [], channel: "ALL",
+  items: [], quantity: "1",
+  scope: "ALL", categories: [], menuIds: [], channel: "ALL",
   modifier: "", perOrder: false, isActive: true, notes: "",
 };
 
@@ -94,8 +97,8 @@ export default function PackagingPage() {
   const openAdd = () => { setForm(emptyForm); setEditingId(null); setProductSearch(""); setMenuSearch(""); setDialogOpen(true); };
   const openEdit = (r: Rule) => {
     setForm({
-      productId: r.productId, productName: r.productName, productSku: r.productSku,
-      quantity: String(r.quantity), scope: r.scope, category: r.category ?? "",
+      items: [{ id: r.productId, name: r.productName, sku: r.productSku }],
+      quantity: String(r.quantity), scope: r.scope, categories: r.category ? [r.category] : [],
       menuIds: r.menuIds, channel: r.channel, modifier: r.modifier ?? "",
       perOrder: r.perOrder, isActive: r.isActive,
       notes: r.notes ?? "",
@@ -103,26 +106,32 @@ export default function PackagingPage() {
     setEditingId(r.id); setProductSearch(""); setMenuSearch(""); setDialogOpen(true);
   };
 
+  // How many rules a submit will create: one per (item × category) for Add.
+  const targetCount = form.scope === "CATEGORY" ? Math.max(form.categories.length, 1) : 1;
+  const createCount = form.items.length * targetCount;
+
   const save = async () => {
-    if (!form.productId) return;
+    if (!form.items.length) return;
     setSaving(true);
     try {
+      const common = {
+        quantity: parseFloat(form.quantity) || 1,
+        scope: form.scope,
+        menuIds: form.menuIds,
+        channel: form.channel,
+        modifier: form.modifier,
+        perOrder: form.perOrder,
+        isActive: form.isActive,
+        notes: form.notes,
+      };
       const url = editingId ? `/api/inventory/packaging-rules/${editingId}` : "/api/inventory/packaging-rules";
+      const body = editingId
+        ? { ...common, productId: form.items[0].id, category: form.categories[0] ?? "" }
+        : { ...common, productIds: form.items.map((i) => i.id), categories: form.categories };
       const res = await fetch(url, {
         method: editingId ? "PATCH" : "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          productId: form.productId,
-          quantity: parseFloat(form.quantity) || 1,
-          scope: form.scope,
-          category: form.category,
-          menuIds: form.menuIds,
-          channel: form.channel,
-          modifier: form.modifier,
-          perOrder: form.perOrder,
-          isActive: form.isActive,
-          notes: form.notes,
-        }),
+        body: JSON.stringify(body),
       });
       if (!res.ok) { alert("Failed to save packaging rule."); return; }
       setDialogOpen(false);
@@ -150,8 +159,9 @@ export default function PackagingPage() {
 
   const productResults = productSearch.trim().length >= 2
     ? products.filter((p) =>
-        p.name.toLowerCase().includes(productSearch.toLowerCase()) ||
-        p.sku.toLowerCase().includes(productSearch.toLowerCase())
+        !form.items.some((i) => i.id === p.id) &&
+        (p.name.toLowerCase().includes(productSearch.toLowerCase()) ||
+         p.sku.toLowerCase().includes(productSearch.toLowerCase()))
       ).slice(0, 8)
     : [];
 
@@ -273,15 +283,23 @@ export default function PackagingPage() {
           </DialogHeader>
 
           <div className="grid gap-5 py-3 overflow-y-auto flex-1 min-h-0">
-            {/* Packaging item */}
+            {/* Packaging item(s) */}
             <div>
-              <label className="text-sm font-medium text-gray-700">Packaging item</label>
-              {form.productId ? (
-                <div className="mt-1.5 flex items-center justify-between rounded-md border border-gray-200 bg-gray-50 px-3 py-2">
-                  <span className="text-sm text-gray-700">{form.productName} <code className="ml-1 text-xs text-gray-400">{form.productSku}</code></span>
-                  <button onClick={() => { set("productId", ""); set("productName", ""); set("productSku", ""); }} className="text-gray-400 hover:text-red-500"><X className="h-4 w-4" /></button>
+              <label className="text-sm font-medium text-gray-700">
+                {editingId ? "Packaging item" : "Packaging item(s)"}
+              </label>
+              {form.items.length > 0 && (
+                <div className="mt-1.5 flex flex-wrap gap-1.5">
+                  {form.items.map((it) => (
+                    <span key={it.id} className="inline-flex items-center gap-1.5 rounded-md border border-gray-200 bg-gray-50 px-2.5 py-1 text-sm text-gray-700">
+                      {it.name} <code className="text-xs text-gray-400">{it.sku}</code>
+                      <button onClick={() => set("items", form.items.filter((x) => x.id !== it.id))} className="text-gray-400 hover:text-red-500"><X className="h-3.5 w-3.5" /></button>
+                    </span>
+                  ))}
                 </div>
-              ) : (
+              )}
+              {/* Add mode keeps the search open so you can pick several; Edit caps at one. */}
+              {(!editingId || form.items.length === 0) && (
                 <div className="relative mt-1.5">
                   <Search className="absolute left-2.5 top-1/2 h-4 w-4 -translate-y-1/2 text-gray-400" />
                   <input
@@ -293,7 +311,11 @@ export default function PackagingPage() {
                   {productResults.length > 0 && (
                     <div className="absolute z-10 mt-1 w-full rounded-md border border-gray-200 bg-white shadow-lg">
                       {productResults.map((p) => (
-                        <button key={p.id} onClick={() => { set("productId", p.id); set("productName", p.name); set("productSku", p.sku); setProductSearch(""); }}
+                        <button key={p.id} onClick={() => {
+                            const picked = { id: p.id, name: p.name, sku: p.sku };
+                            set("items", editingId ? [picked] : [...form.items, picked]);
+                            setProductSearch("");
+                          }}
                           className="flex w-full items-center justify-between px-3 py-2 text-left text-xs hover:bg-gray-50">
                           <span className="font-medium text-gray-700">{p.name}</span>
                           <span className="text-gray-400">{p.sku} · {p.baseUom}</span>
@@ -302,6 +324,9 @@ export default function PackagingPage() {
                     </div>
                   )}
                 </div>
+              )}
+              {!editingId && form.items.length > 0 && (
+                <p className="mt-1 text-[11px] text-gray-400">A separate rule is created for each item — e.g. cup + lid + straw.</p>
               )}
             </div>
 
@@ -353,10 +378,25 @@ export default function PackagingPage() {
               </div>
 
               {form.scope === "CATEGORY" && (
-                <select className="mt-2.5 h-10 w-full rounded-md border border-gray-200 px-3 text-sm" value={form.category} onChange={(e) => set("category", e.target.value)}>
-                  <option value="">Select category…</option>
-                  {categories.map((c) => <option key={c} value={c}>{c}</option>)}
-                </select>
+                <div className="mt-2.5">
+                  <div className="flex flex-wrap gap-1.5">
+                    {categories.map((c) => {
+                      const active = form.categories.includes(c);
+                      return (
+                        <button key={c} onClick={() => {
+                            if (editingId) set("categories", active ? [] : [c]); // Edit = single category
+                            else set("categories", active ? form.categories.filter((x) => x !== c) : [...form.categories, c]);
+                          }}
+                          className={`inline-flex items-center gap-1 rounded-full border px-3 py-1 text-xs transition-colors ${active ? "border-terracotta bg-terracotta/5 text-terracotta-dark" : "border-gray-200 text-gray-500 hover:border-gray-300"}`}>
+                          {c}{active && <Check className="h-3 w-3" />}
+                        </button>
+                      );
+                    })}
+                  </div>
+                  {!editingId && (
+                    <p className="mt-1 text-[11px] text-gray-400">Select one or more categories — a rule is created for each.</p>
+                  )}
+                </div>
               )}
 
               {form.scope === "ITEMS" && (
@@ -401,9 +441,9 @@ export default function PackagingPage() {
           </div>
 
           <div className="flex-shrink-0 border-t pt-4">
-            <Button onClick={save} disabled={saving || !form.productId} className="h-11 w-full bg-terracotta text-base hover:bg-terracotta-dark disabled:opacity-50">
+            <Button onClick={save} disabled={saving || !form.items.length} className="h-11 w-full bg-terracotta text-base hover:bg-terracotta-dark disabled:opacity-50">
               {saving ? <Loader2 className="mr-1.5 h-4 w-4 animate-spin" /> : <Check className="mr-1.5 h-4 w-4" />}
-              {editingId ? "Save Changes" : "Add Rule"}
+              {editingId ? "Save Changes" : `Add ${createCount} Rule${createCount === 1 ? "" : "s"}`}
             </Button>
           </div>
         </DialogContent>

--- a/apps/backoffice/src/app/api/inventory/packaging-rules/route.ts
+++ b/apps/backoffice/src/app/api/inventory/packaging-rules/route.ts
@@ -93,28 +93,50 @@ export async function POST(req: NextRequest) {
   if (auth.error) return auth.error;
 
   const body = await req.json();
-  const { productId, quantity, scope, category, menuIds, channel, modifier, perOrder, isActive, notes } = body;
+  const { productId, productIds, quantity, scope, category, categories, menuIds, channel, modifier, perOrder, isActive, notes } = body;
 
-  if (!productId) {
-    return NextResponse.json({ error: "productId is required" }, { status: 400 });
+  // Accept either a single productId / category (back-compat) or arrays so one
+  // submit can fan out into several rules — e.g. cup + lid + straw across
+  // several drink categories. We create the cross product of the two.
+  const productList: string[] = Array.isArray(productIds) && productIds.length
+    ? productIds.filter((x: unknown): x is string => typeof x === "string" && !!x)
+    : productId ? [productId] : [];
+  if (!productList.length) {
+    return NextResponse.json({ error: "productId(s) required" }, { status: 400 });
   }
   const scopeVal: Scope = SCOPES.includes(scope) ? scope : "ALL";
   const channelVal: Channel = CHANNELS.includes(channel) ? channel : "ALL";
 
-  const rule = await prisma.packagingRule.create({
-    data: {
-      productId,
-      quantity: quantity != null ? Number(quantity) : 1,
-      scope: scopeVal,
-      category: scopeVal === "CATEGORY" ? category || null : null,
-      menuIds: scopeVal === "ITEMS" && Array.isArray(menuIds) ? menuIds : [],
-      channel: channelVal,
-      modifier: modifier || null,
-      perOrder: !!perOrder,
-      isActive: isActive ?? true,
-      notes: notes || null,
-    },
-  });
+  // Target categories only matter for CATEGORY scope; [null] = one rule with no
+  // category (ALL / ITEMS scope, or a CATEGORY rule left blank).
+  const catList: (string | null)[] =
+    scopeVal === "CATEGORY"
+      ? (Array.isArray(categories) && categories.length
+          ? categories.filter((c: unknown): c is string => typeof c === "string" && !!c)
+          : category ? [category] : [null])
+      : [null];
+  const targets = catList.length ? catList : [null];
 
-  return NextResponse.json(rule, { status: 201 });
+  const menuIdsVal = scopeVal === "ITEMS" && Array.isArray(menuIds) ? menuIds : [];
+  const common = {
+    quantity: quantity != null ? Number(quantity) : 1,
+    scope: scopeVal,
+    menuIds: menuIdsVal,
+    channel: channelVal,
+    modifier: modifier || null,
+    perOrder: !!perOrder,
+    isActive: isActive ?? true,
+    notes: notes || null,
+  };
+
+  const data = productList.flatMap((pid) =>
+    targets.map((cat) => ({
+      ...common,
+      productId: pid,
+      category: scopeVal === "CATEGORY" ? cat : null,
+    })),
+  );
+
+  const result = await prisma.packagingRule.createMany({ data });
+  return NextResponse.json({ count: result.count }, { status: 201 });
 }


### PR DESCRIPTION
## Why

On the Add Packaging Rule form you asked **"can multi packaging, multi category etc"**. Today each rule is one packaging item + one category, so setting up *"iced cup + lid + straw across Espresso, Matcha & Artisan Choc"* means creating 9 rules by hand.

## What

The **Add** dialog now lets you pick:
- **multiple packaging items** (chips + search), and
- **multiple categories** (toggle chips) when scope = Category.

On submit it creates **one rule per (item × category)** combination — the button shows how many ("Add 9 Rules"). Each underlying rule stays single-item / single-target, so:
- costing and the grouped list are unchanged,
- every rule remains individually editable / deletable / toggleable.

**Edit is unchanged** — it still targets exactly one rule (one item, one category). The multi-select only applies when adding. Specific-items scope was already multi and stays as-is.

## API

`POST /api/inventory/packaging-rules` now accepts `productIds[]` / `categories[]` (falling back to the existing single `productId` / `category` for back-compat) and `createMany`s the cross product in one call. **No schema change.**

## Test

- `typecheck` + `lint` clean (0 errors; warning count unchanged).
- Back-compat: a single `productId` + `category` body still creates one rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01SgZXN9d3uBVRy19QbrXdE9)_