### PR TITLE
fix(pos-native): make the overdue-orders popup scrollable so buttons stay reachable

### DIFF
--- a/apps/pos-native/app/register.tsx
+++ b/apps/pos-native/app/register.tsx
@@ -2241,7 +2241,12 @@ export default function Register() {
             <Text className="text-cream/60 text-sm mb-5" style={{ fontFamily: "SpaceGrotesk_600SemiBold" }}>
               Serving target exceeded — mark Ready / Done / Served as soon as they're handed over.
             </Text>
-            <View className="gap-2 mb-6">
+            <ScrollView
+              style={{ maxHeight: 360 }}
+              className="mb-6"
+              contentContainerStyle={{ gap: 8 }}
+              showsVerticalScrollIndicator
+            >
               {overdueOrders.map((o) => {
                 const mins = Math.max(0, Math.floor((Date.now() - new Date(o.createdAt).getTime()) / 60000));
                 const chanTag =
@@ -2261,7 +2266,7 @@ export default function Register() {
                   </View>
                 );
               })}
-            </View>
+            </ScrollView>
             <View className="flex-row gap-3">
               <Pressable onPress={() => { Haptics.selectionAsync(); setOverdueAck(true); }} className="flex-1 items-center justify-center rounded-2xl py-4 border border-cream/15 active:opacity-60">
                 <Text className="text-cream/70 text-base" style={{ fontFamily: "SpaceGrotesk_600SemiBold" }}>Dismiss</Text>


### PR DESCRIPTION
## Why
From the photo: when a lot of orders are overdue at once (e.g. a backlog of un-served counter "Stand #…" orders), the overdue-alert popup's list runs **past the bottom of the screen**, pushing the **Dismiss / Open Live Orders** buttons off-screen — so staff can't dismiss the alert or jump to the orders. The screen is effectively stuck.

## Fix
Wrap the order list in a height-capped (`maxHeight: 360`) `ScrollView`, so the list scrolls **inside** the card and the action buttons stay fixed and reachable no matter how many orders are overdue.

JS-only → ships over the pos-native OTA.

## Test plan
- [x] `register.tsx` type-clean
- [ ] 15+ overdue orders → list scrolls; Dismiss + Open Live Orders always visible/tappable
- [ ] 1–3 overdue orders → looks unchanged (list shorter than the cap)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01SXF3GNPYGpZzwMWy9AR9DV)_