### PR TITLE
feat(marketing): GrabFood campaigns + ad-spend section under Marketing

### DIFF
--- a/apps/backoffice/src/app/(admin)/ads/grab/page.tsx
+++ b/apps/backoffice/src/app/(admin)/ads/grab/page.tsx
@@ -1,0 +1,306 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { useFetch } from "@/lib/use-fetch";
+import { Card } from "@/components/ui/card";
+import { Loader2, RefreshCw, Trash2, Megaphone } from "lucide-react";
+
+/* ─── types ─── */
+type OverviewRow = {
+  outletId: string; name: string; orders: number;
+  revenueMYR: number; promoMYR: number; adSpendMYR: number;
+  totalMYR: number; marketingPctOfRevenue: number | null;
+};
+type Overview = {
+  range: { from: string; to: string };
+  totals: { revenueMYR: number; promoMYR: number; adSpendMYR: number; totalMYR: number; orders: number; marketingPctOfRevenue: number | null };
+  byOutlet: OverviewRow[];
+};
+type Campaign = {
+  id: string; outletId: string; outletName: string; grabCampaignId: string;
+  name: string | null; createdBy: string | null; status: string | null;
+  discountSummary: string | null; syncedAt: string;
+};
+type AdSpend = {
+  id: string; outletId: string; outletName: string;
+  periodStart: string; periodEnd: string; amountMYR: number; note: string | null; createdBy: string | null;
+};
+// Minimal shape of a useFetch() result, for typing the section sub-components.
+type Q<T> = { data: T | undefined; isLoading: boolean; mutate: () => void };
+
+/* ─── helpers ─── */
+const fmtMYR = (n: number) => new Intl.NumberFormat("en-MY", { style: "currency", currency: "MYR" }).format(n || 0);
+const fmtPct = (n: number | null) => (n == null ? "—" : `${n.toFixed(1)}%`);
+function monthToDate(): { from: string; to: string } {
+  const t = new Date();
+  return { from: `${t.toISOString().slice(0, 8)}01`, to: t.toISOString().slice(0, 10) };
+}
+
+type Tab = "overview" | "campaigns" | "spend";
+
+export default function GrabMarketingPage() {
+  const [tab, setTab] = useState<Tab>("overview");
+  const def = useMemo(monthToDate, []);
+  const [from, setFrom] = useState(def.from);
+  const [to, setTo] = useState(def.to);
+  const [outletId, setOutletId] = useState("all");
+
+  const { data: outlets } = useFetch<Array<{ id: string; name: string }>>("/api/ops/outlets");
+  const q = `from=${from}&to=${to}&outletId=${outletId}`;
+  const overview = useFetch<Overview>(`/api/ads/grab/overview?${q}`);
+  const campaigns = useFetch<{ campaigns: Campaign[] }>(`/api/ads/grab/campaigns?outletId=${outletId}`);
+  const spend = useFetch<{ entries: AdSpend[] }>(`/api/ads/grab/ad-spend?${q}`);
+
+  const [syncing, setSyncing] = useState(false);
+  const [syncMsg, setSyncMsg] = useState<string | null>(null);
+  async function syncCampaigns() {
+    setSyncing(true); setSyncMsg(null);
+    try {
+      const res = await fetch("/api/ads/grab/campaigns", { method: "POST" });
+      const j = await res.json();
+      setSyncMsg(res.ok ? `Synced ${j.upserted} campaign(s) across ${j.outlets} outlet(s).${j.errors?.length ? ` ${j.errors.length} error(s).` : ""}` : (j.errors?.[0] ?? "Sync failed"));
+      campaigns.mutate();
+    } catch (e) {
+      setSyncMsg(e instanceof Error ? e.message : "Sync failed");
+    } finally {
+      setSyncing(false);
+    }
+  }
+
+  return (
+    <div className="space-y-4 p-4 lg:p-6">
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+        <div className="flex items-center gap-2">
+          <Megaphone className="h-5 w-5 text-emerald-600" />
+          <h1 className="text-xl font-semibold">GrabFood Marketing</h1>
+        </div>
+        <div className="flex flex-wrap items-center gap-2">
+          <select value={outletId} onChange={(e) => setOutletId(e.target.value)} className="rounded-md border border-neutral-200 bg-white px-3 py-1.5 text-sm">
+            <option value="all">All outlets</option>
+            {(outlets ?? []).map((o) => <option key={o.id} value={o.id}>{o.name}</option>)}
+          </select>
+          <input type="date" value={from} onChange={(e) => setFrom(e.target.value)} className="rounded-md border border-neutral-200 bg-white px-3 py-1.5 text-sm" />
+          <span className="text-neutral-400">→</span>
+          <input type="date" value={to} onChange={(e) => setTo(e.target.value)} className="rounded-md border border-neutral-200 bg-white px-3 py-1.5 text-sm" />
+        </div>
+      </div>
+
+      {/* tabs */}
+      <div className="flex gap-1 border-b border-neutral-200">
+        {([["overview", "Overview"], ["campaigns", "Campaigns"], ["spend", "Ad Spend"]] as [Tab, string][]).map(([k, label]) => (
+          <button key={k} onClick={() => setTab(k)}
+            className={`px-3 py-2 text-sm font-medium border-b-2 -mb-px ${tab === k ? "border-emerald-600 text-emerald-700" : "border-transparent text-neutral-500 hover:text-neutral-800"}`}>
+            {label}
+          </button>
+        ))}
+      </div>
+
+      {tab === "overview" && <OverviewTab q={overview} />}
+      {tab === "campaigns" && <CampaignsTab q={campaigns} onSync={syncCampaigns} syncing={syncing} syncMsg={syncMsg} />}
+      {tab === "spend" && <SpendTab q={spend} outlets={outlets ?? []} defaults={{ from, to }} />}
+    </div>
+  );
+}
+
+/* ─── Overview ─── */
+function OverviewTab({ q }: { q: Q<Overview> }) {
+  if (q.isLoading || !q.data) return <Spinner />;
+  const { totals, byOutlet } = q.data;
+  const stats = [
+    { label: "GrabFood revenue", value: fmtMYR(totals.revenueMYR) },
+    { label: "Promo cost (merchant-funded)", value: fmtMYR(totals.promoMYR) },
+    { label: "GrabAds spend", value: fmtMYR(totals.adSpendMYR) },
+    { label: "Total marketing", value: fmtMYR(totals.totalMYR), accent: true },
+    { label: "% of revenue", value: fmtPct(totals.marketingPctOfRevenue) },
+  ];
+  return (
+    <div className="space-y-4">
+      <div className="grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-5">
+        {stats.map((s) => (
+          <Card key={s.label} className="p-4">
+            <div className="text-xs uppercase tracking-wide text-neutral-500">{s.label}</div>
+            <div className={`mt-1 text-lg font-semibold ${s.accent ? "text-emerald-700" : "text-neutral-900"}`}>{s.value}</div>
+          </Card>
+        ))}
+      </div>
+      <Card className="overflow-hidden">
+        <div className="overflow-x-auto">
+          <table className="w-full text-sm">
+            <thead className="bg-neutral-50 text-xs text-neutral-500">
+              <tr>
+                <th className="px-3 py-2 text-left font-normal">Outlet</th>
+                <th className="px-3 py-2 text-right font-normal">Orders</th>
+                <th className="px-3 py-2 text-right font-normal">Revenue</th>
+                <th className="px-3 py-2 text-right font-normal">Promo cost</th>
+                <th className="px-3 py-2 text-right font-normal">Ad spend</th>
+                <th className="px-3 py-2 text-right font-normal">Total mktg</th>
+                <th className="px-3 py-2 text-right font-normal">% of rev</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-neutral-100">
+              {byOutlet.length === 0 ? (
+                <tr><td colSpan={7} className="p-8 text-center text-neutral-500">No GrabFood activity in this range.</td></tr>
+              ) : byOutlet.map((r) => (
+                <tr key={r.outletId}>
+                  <td className="px-3 py-2">{r.name}</td>
+                  <td className="px-3 py-2 text-right">{r.orders}</td>
+                  <td className="px-3 py-2 text-right">{fmtMYR(r.revenueMYR)}</td>
+                  <td className="px-3 py-2 text-right">{fmtMYR(r.promoMYR)}</td>
+                  <td className="px-3 py-2 text-right">{fmtMYR(r.adSpendMYR)}</td>
+                  <td className="px-3 py-2 text-right font-medium">{fmtMYR(r.totalMYR)}</td>
+                  <td className="px-3 py-2 text-right">{fmtPct(r.marketingPctOfRevenue)}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </Card>
+      <p className="text-xs text-neutral-400">
+        Promo cost = merchant-funded discounts on GrabFood orders (Grab-funded promos excluded). GrabAds spend is entered
+        manually on the Ad Spend tab — GrabAds paid advertising isn&apos;t exposed by the GrabFood Partner API.
+      </p>
+    </div>
+  );
+}
+
+/* ─── Campaigns ─── */
+function CampaignsTab({ q, onSync, syncing, syncMsg }: {
+  q: Q<{ campaigns: Campaign[] }>; onSync: () => void; syncing: boolean; syncMsg: string | null;
+}) {
+  return (
+    <div className="space-y-3">
+      <div className="flex items-center justify-between gap-2">
+        <p className="text-sm text-neutral-500">Promotions mirrored from GrabFood (read-only).</p>
+        <button onClick={onSync} disabled={syncing}
+          className="inline-flex items-center gap-1.5 rounded-md bg-emerald-600 px-3 py-1.5 text-sm font-medium text-white hover:bg-emerald-700 disabled:opacity-60">
+          {syncing ? <Loader2 className="h-4 w-4 animate-spin" /> : <RefreshCw className="h-4 w-4" />} Sync from Grab
+        </button>
+      </div>
+      {syncMsg && <p className="text-xs text-neutral-500">{syncMsg}</p>}
+      <Card className="overflow-hidden">
+        {q.isLoading || !q.data ? <Spinner /> : q.data.campaigns.length === 0 ? (
+          <p className="p-8 text-center text-sm text-neutral-500">No campaigns synced yet — hit &ldquo;Sync from Grab&rdquo;.</p>
+        ) : (
+          <div className="overflow-x-auto">
+            <table className="w-full text-sm">
+              <thead className="bg-neutral-50 text-xs text-neutral-500">
+                <tr>
+                  <th className="px-3 py-2 text-left font-normal">Campaign</th>
+                  <th className="px-3 py-2 text-left font-normal">Outlet</th>
+                  <th className="px-3 py-2 text-left font-normal">Discount</th>
+                  <th className="px-3 py-2 text-left font-normal">Funded by</th>
+                  <th className="px-3 py-2 text-left font-normal">Status</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-neutral-100">
+                {q.data.campaigns.map((c) => (
+                  <tr key={c.id}>
+                    <td className="px-3 py-2">{c.name ?? c.grabCampaignId}</td>
+                    <td className="px-3 py-2">{c.outletName}</td>
+                    <td className="px-3 py-2">{c.discountSummary ?? "—"}</td>
+                    <td className="px-3 py-2">{c.createdBy ?? "—"}</td>
+                    <td className="px-3 py-2">{c.status ?? "—"}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </Card>
+    </div>
+  );
+}
+
+/* ─── Ad Spend (manual) ─── */
+function SpendTab({ q, outlets, defaults }: {
+  q: Q<{ entries: AdSpend[] }>; outlets: Array<{ id: string; name: string }>; defaults: { from: string; to: string };
+}) {
+  const [outletId, setOutletId] = useState("");
+  const [periodStart, setPeriodStart] = useState(defaults.from);
+  const [periodEnd, setPeriodEnd] = useState(defaults.to);
+  const [amount, setAmount] = useState("");
+  const [note, setNote] = useState("");
+  const [busy, setBusy] = useState(false);
+  const [err, setErr] = useState<string | null>(null);
+
+  async function add() {
+    setErr(null);
+    const amountMYR = Number(amount);
+    if (!outletId || !Number.isFinite(amountMYR) || amountMYR < 0) { setErr("Pick an outlet and enter a valid amount."); return; }
+    setBusy(true);
+    try {
+      const res = await fetch("/api/ads/grab/ad-spend", {
+        method: "POST", headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ outletId, periodStart, periodEnd, amountMYR, note: note || undefined }),
+      });
+      if (!res.ok) { setErr((await res.json()).error ?? "Failed to add"); return; }
+      setAmount(""); setNote(""); q.mutate();
+    } finally {
+      setBusy(false);
+    }
+  }
+  async function del(id: string) {
+    await fetch(`/api/ads/grab/ad-spend?id=${id}`, { method: "DELETE" });
+    q.mutate();
+  }
+
+  return (
+    <div className="space-y-3">
+      <Card className="p-4">
+        <div className="text-sm font-medium text-neutral-800">Add GrabAds spend</div>
+        <p className="mt-0.5 text-xs text-neutral-500">From your Grab merchant billing/payout statement (GrabAds isn&apos;t in the API).</p>
+        <div className="mt-3 grid grid-cols-1 gap-2 sm:grid-cols-2 lg:grid-cols-6">
+          <select value={outletId} onChange={(e) => setOutletId(e.target.value)} className="rounded-md border border-neutral-200 bg-white px-3 py-1.5 text-sm lg:col-span-2">
+            <option value="">Select outlet…</option>
+            {outlets.map((o) => <option key={o.id} value={o.id}>{o.name}</option>)}
+          </select>
+          <input type="date" value={periodStart} onChange={(e) => setPeriodStart(e.target.value)} className="rounded-md border border-neutral-200 bg-white px-3 py-1.5 text-sm" />
+          <input type="date" value={periodEnd} onChange={(e) => setPeriodEnd(e.target.value)} className="rounded-md border border-neutral-200 bg-white px-3 py-1.5 text-sm" />
+          <input type="number" min="0" step="0.01" placeholder="Amount (RM)" value={amount} onChange={(e) => setAmount(e.target.value)} className="rounded-md border border-neutral-200 bg-white px-3 py-1.5 text-sm" />
+          <button onClick={add} disabled={busy} className="rounded-md bg-emerald-600 px-3 py-1.5 text-sm font-medium text-white hover:bg-emerald-700 disabled:opacity-60">
+            {busy ? "Adding…" : "Add"}
+          </button>
+        </div>
+        <input type="text" placeholder="Note (optional)" value={note} onChange={(e) => setNote(e.target.value)} className="mt-2 w-full rounded-md border border-neutral-200 bg-white px-3 py-1.5 text-sm" />
+        {err && <p className="mt-2 text-xs text-red-600">{err}</p>}
+      </Card>
+
+      <Card className="overflow-hidden">
+        {q.isLoading || !q.data ? <Spinner /> : q.data.entries.length === 0 ? (
+          <p className="p-8 text-center text-sm text-neutral-500">No ad spend entered for this range.</p>
+        ) : (
+          <div className="overflow-x-auto">
+            <table className="w-full text-sm">
+              <thead className="bg-neutral-50 text-xs text-neutral-500">
+                <tr>
+                  <th className="px-3 py-2 text-left font-normal">Outlet</th>
+                  <th className="px-3 py-2 text-left font-normal">Period</th>
+                  <th className="px-3 py-2 text-right font-normal">Amount</th>
+                  <th className="px-3 py-2 text-left font-normal">Note</th>
+                  <th className="px-3 py-2 text-right font-normal"></th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-neutral-100">
+                {q.data.entries.map((e) => (
+                  <tr key={e.id}>
+                    <td className="px-3 py-2">{e.outletName}</td>
+                    <td className="px-3 py-2">{e.periodStart} → {e.periodEnd}</td>
+                    <td className="px-3 py-2 text-right font-medium">{fmtMYR(e.amountMYR)}</td>
+                    <td className="px-3 py-2 text-neutral-500">{e.note ?? "—"}</td>
+                    <td className="px-3 py-2 text-right">
+                      <button onClick={() => del(e.id)} className="text-neutral-400 hover:text-red-600" title="Delete"><Trash2 className="h-4 w-4" /></button>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </Card>
+    </div>
+  );
+}
+
+function Spinner() {
+  return <div className="flex h-48 items-center justify-center"><Loader2 className="h-6 w-6 animate-spin text-neutral-400" /></div>;
+}

--- a/apps/backoffice/src/app/(admin)/layout.tsx
+++ b/apps/backoffice/src/app/(admin)/layout.tsx
@@ -333,6 +333,12 @@ const NAV_SECTIONS: NavSection[] = [
           { label: "Invoices",  href: "/ads/invoices",  icon: <Receipt className={ICON_SIZE} />,          moduleKey: "ads:invoices" },
         ],
       },
+      {
+        label: "GrabFood",
+        items: [
+          { label: "Campaigns & Ad Spend", href: "/ads/grab", icon: <Megaphone className={ICON_SIZE} />, moduleKey: "ads:grab" },
+        ],
+      },
     ],
   },
   {

--- a/apps/backoffice/src/app/api/ads/grab/ad-spend/route.ts
+++ b/apps/backoffice/src/app/api/ads/grab/ad-spend/route.ts
@@ -1,0 +1,112 @@
+/**
+ * Manual GrabAds spend entry — GrabAds (paid advertising) isn't in the Partner
+ * API, so spend is keyed in from Grab's billing/payout statements.
+ *
+ * GET    /api/ads/grab/ad-spend?from=&to=&outletId=  → { entries[] }
+ * POST   /api/ads/grab/ad-spend  { outletId, periodStart, periodEnd, amountMYR, note? }
+ * DELETE /api/ads/grab/ad-spend?id=...
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+import { Prisma } from "@prisma/client";
+import { requireRole } from "@/lib/auth";
+import { randomUUID } from "crypto";
+
+export const dynamic = "force-dynamic";
+
+const isDate = (s: unknown): s is string => typeof s === "string" && /^\d{4}-\d{2}-\d{2}$/.test(s);
+
+type SpendRow = {
+  id: string;
+  outlet_id: string;
+  outlet_name: string | null;
+  period_start: Date;
+  period_end: Date;
+  amount_sen: number;
+  note: string | null;
+  created_by: string | null;
+  created_at: Date;
+};
+
+export async function GET(req: NextRequest) {
+  try {
+    await requireRole(req.headers, "OWNER", "ADMIN");
+  } catch {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+  const url = new URL(req.url);
+  const outletId = url.searchParams.get("outletId");
+  const oFilter = outletId && outletId !== "all" ? outletId : null;
+  const from = isDate(url.searchParams.get("from")) ? url.searchParams.get("from") : null;
+  const to = isDate(url.searchParams.get("to")) ? url.searchParams.get("to") : null;
+
+  const rows = await prisma.$queryRaw<SpendRow[]>(Prisma.sql`
+    SELECT s.id, s.outlet_id, o.name AS outlet_name, s.period_start, s.period_end,
+           s.amount_sen, s.note, s.created_by, s.created_at
+    FROM grab_ads_spend s
+    LEFT JOIN outlets o ON o.id = s.outlet_id
+    WHERE (${oFilter}::text IS NULL OR s.outlet_id = ${oFilter})
+      AND (${from}::date IS NULL OR s.period_start >= ${from}::date)
+      AND (${to}::date   IS NULL OR s.period_start <= ${to}::date)
+    ORDER BY s.period_start DESC, s.created_at DESC
+  `);
+
+  return NextResponse.json({
+    entries: rows.map((r) => ({
+      id: r.id,
+      outletId: r.outlet_id,
+      outletName: r.outlet_name ?? r.outlet_id,
+      periodStart: r.period_start.toISOString().slice(0, 10),
+      periodEnd: r.period_end.toISOString().slice(0, 10),
+      amountMYR: r.amount_sen / 100,
+      note: r.note,
+      createdBy: r.created_by,
+      createdAt: r.created_at,
+    })),
+  });
+}
+
+export async function POST(req: NextRequest) {
+  let user;
+  try {
+    user = await requireRole(req.headers, "OWNER", "ADMIN");
+  } catch {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+  const body = (await req.json().catch(() => ({}))) as {
+    outletId?: string; periodStart?: string; periodEnd?: string; amountMYR?: number; note?: string;
+  };
+  const outletId = (body.outletId || "").trim();
+  const { periodStart, periodEnd } = body;
+  const amountMYR = Number(body.amountMYR);
+  if (!outletId || !isDate(periodStart) || !isDate(periodEnd) || !Number.isFinite(amountMYR) || amountMYR < 0) {
+    return NextResponse.json(
+      { error: "outletId, periodStart, periodEnd (YYYY-MM-DD) and a non-negative amountMYR are required" },
+      { status: 400 },
+    );
+  }
+  if (periodEnd < periodStart) {
+    return NextResponse.json({ error: "periodEnd must be on or after periodStart" }, { status: 400 });
+  }
+  const amountSen = Math.round(amountMYR * 100);
+  const id = randomUUID();
+  await prisma.$executeRaw(Prisma.sql`
+    INSERT INTO grab_ads_spend (id, outlet_id, period_start, period_end, amount_sen, note, created_by)
+    VALUES (${id}, ${outletId}, ${periodStart}::date, ${periodEnd}::date, ${amountSen}, ${body.note ?? null}, ${user.name})
+  `);
+  return NextResponse.json({ ok: true, id });
+}
+
+export async function DELETE(req: NextRequest) {
+  try {
+    await requireRole(req.headers, "OWNER", "ADMIN");
+  } catch {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+  const id = (req.nextUrl.searchParams.get("id") || "").trim();
+  if (!id) return NextResponse.json({ error: "id required" }, { status: 400 });
+  const n = await prisma.$executeRaw(Prisma.sql`DELETE FROM grab_ads_spend WHERE id = ${id}`);
+  if (n === 0) return NextResponse.json({ error: "not found" }, { status: 404 });
+  return NextResponse.json({ ok: true });
+}

--- a/apps/backoffice/src/app/api/ads/grab/campaigns/route.ts
+++ b/apps/backoffice/src/app/api/ads/grab/campaigns/route.ts
@@ -1,0 +1,69 @@
+/**
+ * GrabFood campaigns — list the synced mirror + trigger a re-sync.
+ *
+ * GET  /api/ads/grab/campaigns?outletId=outlet-sa   → { campaigns[] }
+ * POST /api/ads/grab/campaigns                        → runs syncGrabCampaigns()
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+import { Prisma } from "@prisma/client";
+import { requireRole } from "@/lib/auth";
+import { syncGrabCampaigns } from "@/lib/grab-campaigns";
+
+export const dynamic = "force-dynamic";
+
+type CampaignRow = {
+  id: string;
+  outlet_id: string;
+  outlet_name: string | null;
+  grab_campaign_id: string;
+  name: string | null;
+  created_by: string | null;
+  status: string | null;
+  discount_summary: string | null;
+  synced_at: Date;
+};
+
+export async function GET(req: NextRequest) {
+  try {
+    await requireRole(req.headers, "OWNER", "ADMIN");
+  } catch {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+  const outletId = req.nextUrl.searchParams.get("outletId");
+  const oFilter = outletId && outletId !== "all" ? outletId : null;
+
+  const rows = await prisma.$queryRaw<CampaignRow[]>(Prisma.sql`
+    SELECT c.id, c.outlet_id, o.name AS outlet_name, c.grab_campaign_id, c.name,
+           c.created_by, c.status, c.discount_summary, c.synced_at
+    FROM grab_campaigns c
+    LEFT JOIN outlets o ON o.id = c.outlet_id
+    WHERE (${oFilter}::text IS NULL OR c.outlet_id = ${oFilter})
+    ORDER BY c.synced_at DESC, c.name ASC
+  `);
+
+  return NextResponse.json({
+    campaigns: rows.map((r) => ({
+      id: r.id,
+      outletId: r.outlet_id,
+      outletName: r.outlet_name ?? r.outlet_id,
+      grabCampaignId: r.grab_campaign_id,
+      name: r.name,
+      createdBy: r.created_by,
+      status: r.status,
+      discountSummary: r.discount_summary,
+      syncedAt: r.synced_at,
+    })),
+  });
+}
+
+export async function POST(req: NextRequest) {
+  try {
+    await requireRole(req.headers, "OWNER", "ADMIN");
+  } catch {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+  const result = await syncGrabCampaigns();
+  return NextResponse.json(result, { status: result.errors.length && result.upserted === 0 ? 502 : 200 });
+}

--- a/apps/backoffice/src/app/api/ads/grab/overview/route.ts
+++ b/apps/backoffice/src/app/api/ads/grab/overview/route.ts
@@ -1,0 +1,105 @@
+/**
+ * GrabFood marketing overview — promo cost + GrabAds spend per outlet.
+ *
+ * GET /api/ads/grab/overview?from=YYYY-MM-DD&to=YYYY-MM-DD&outletId=outlet-sa
+ *   → { range, totals, byOutlet[] }
+ *
+ * Promo cost = Σ pos_orders.grab_merchant_promo (merchant-funded discounts on
+ * GrabFood orders in range). Ad spend = Σ grab_ads_spend.amount_sen (manually
+ * entered GrabAds, since GrabAds isn't in the Partner API). Revenue = Σ total,
+ * for marketing-cost-as-%-of-revenue. Raw SQL so aggregation isn't capped by
+ * the Supabase REST 1000-row limit.
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+import { Prisma } from "@prisma/client";
+import { requireRole } from "@/lib/auth";
+
+export const dynamic = "force-dynamic";
+
+function parseDate(s: string | null): string | null {
+  return s && /^\d{4}-\d{2}-\d{2}$/.test(s) ? s : null;
+}
+
+export async function GET(req: NextRequest) {
+  try {
+    await requireRole(req.headers, "OWNER", "ADMIN");
+  } catch {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const url = new URL(req.url);
+  const today = new Date().toISOString().slice(0, 10);
+  const from = parseDate(url.searchParams.get("from")) ?? `${today.slice(0, 8)}01`;
+  const to = parseDate(url.searchParams.get("to")) ?? today;
+  const outletId = url.searchParams.get("outletId");
+  const oFilter = outletId && outletId !== "all" ? outletId : null;
+
+  const promoRows = await prisma.$queryRaw<
+    { outlet_id: string; name: string | null; orders: bigint; revenue_sen: bigint; promo_sen: bigint }[]
+  >(Prisma.sql`
+    SELECT po.outlet_id, o.name,
+           COUNT(*)                              AS orders,
+           COALESCE(SUM(po.total), 0)            AS revenue_sen,
+           COALESCE(SUM(po.grab_merchant_promo), 0) AS promo_sen
+    FROM pos_orders po
+    LEFT JOIN outlets o ON o.id = po.outlet_id
+    WHERE po.source = 'grabfood'
+      AND po.created_at::date BETWEEN ${from}::date AND ${to}::date
+      AND (${oFilter}::text IS NULL OR po.outlet_id = ${oFilter})
+    GROUP BY po.outlet_id, o.name
+  `);
+
+  const adRows = await prisma.$queryRaw<{ outlet_id: string; ad_sen: bigint }[]>(Prisma.sql`
+    SELECT s.outlet_id, COALESCE(SUM(s.amount_sen), 0) AS ad_sen
+    FROM grab_ads_spend s
+    WHERE s.period_start BETWEEN ${from}::date AND ${to}::date
+      AND (${oFilter}::text IS NULL OR s.outlet_id = ${oFilter})
+    GROUP BY s.outlet_id
+  `);
+  const adByOutlet = new Map(adRows.map((r) => [r.outlet_id, Number(r.ad_sen)]));
+
+  const byOutlet = promoRows.map((r) => {
+    const promoMYR = Number(r.promo_sen) / 100;
+    const adSpendMYR = (adByOutlet.get(r.outlet_id) ?? 0) / 100;
+    const revenueMYR = Number(r.revenue_sen) / 100;
+    adByOutlet.delete(r.outlet_id);
+    const totalMYR = promoMYR + adSpendMYR;
+    return {
+      outletId: r.outlet_id,
+      name: r.name ?? r.outlet_id,
+      orders: Number(r.orders),
+      revenueMYR,
+      promoMYR,
+      adSpendMYR,
+      totalMYR,
+      marketingPctOfRevenue: revenueMYR > 0 ? (totalMYR / revenueMYR) * 100 : null,
+    };
+  });
+  // Outlets with ad spend but no orders in range still surface.
+  for (const [oid, sen] of adByOutlet) {
+    byOutlet.push({
+      outletId: oid, name: oid, orders: 0, revenueMYR: 0, promoMYR: 0,
+      adSpendMYR: sen / 100, totalMYR: sen / 100, marketingPctOfRevenue: null,
+    });
+  }
+  byOutlet.sort((a, b) => b.totalMYR - a.totalMYR);
+
+  const t = byOutlet.reduce(
+    (a, b) => ({
+      revenueMYR: a.revenueMYR + b.revenueMYR,
+      promoMYR: a.promoMYR + b.promoMYR,
+      adSpendMYR: a.adSpendMYR + b.adSpendMYR,
+      totalMYR: a.totalMYR + b.totalMYR,
+      orders: a.orders + b.orders,
+    }),
+    { revenueMYR: 0, promoMYR: 0, adSpendMYR: 0, totalMYR: 0, orders: 0 },
+  );
+
+  return NextResponse.json({
+    range: { from, to },
+    totals: { ...t, marketingPctOfRevenue: t.revenueMYR > 0 ? (t.totalMYR / t.revenueMYR) * 100 : null },
+    byOutlet,
+  });
+}

--- a/apps/backoffice/src/app/api/cron/grab-campaigns-sync/route.ts
+++ b/apps/backoffice/src/app/api/cron/grab-campaigns-sync/route.ts
@@ -1,0 +1,17 @@
+import { NextRequest, NextResponse } from "next/server";
+import { checkCronAuth } from "@celsius/shared";
+import { syncGrabCampaigns } from "@/lib/grab-campaigns";
+
+export const dynamic = "force-dynamic";
+export const maxDuration = 120;
+
+// Daily refresh of the GrabFood campaign mirror (read-only) for every linked
+// outlet. Promo *cost* comes from order data, not here — this just keeps the
+// campaign list/status current.
+export async function GET(req: NextRequest) {
+  const cronAuth = checkCronAuth(req.headers);
+  if (!cronAuth.ok) return NextResponse.json({ error: cronAuth.error }, { status: cronAuth.status });
+
+  const result = await syncGrabCampaigns();
+  return NextResponse.json({ ok: true, ...result });
+}

--- a/apps/backoffice/src/app/api/pos/grab/webhook/route.ts
+++ b/apps/backoffice/src/app/api/pos/grab/webhook/route.ts
@@ -419,7 +419,14 @@ export async function POST(request: NextRequest) {
     {
       const { error: acceptColErr } = await supabase
         .from("pos_orders")
-        .update({ grab_accept_status: acceptStatus, grab_accept_error: acceptError })
+        .update({
+          grab_accept_status: acceptStatus,
+          grab_accept_error: acceptError,
+          // Merchant-funded promo only — the marketing cost we own (grabFundPromo
+          // is Grab paying, not us). discount_amount above keeps the combined
+          // figure for receipts/books; this column powers the Marketing module.
+          grab_merchant_promo: price.merchantFundPromo ?? 0,
+        })
         .eq("id", order.id);
       if (acceptColErr) console.warn("[grab:webhook] accept-outcome write skipped:", acceptColErr.message);
     }

--- a/apps/backoffice/src/lib/grab-campaigns.ts
+++ b/apps/backoffice/src/lib/grab-campaigns.ts
@@ -1,0 +1,63 @@
+/**
+ * Sync GrabFood campaigns (promotions) into `grab_campaigns`.
+ *
+ * Read-only mirror of GET /partner/v1/campaigns, per linked outlet. Shared by
+ * the BackOffice "sync now" button (/api/ads/grab/campaigns POST) and the daily
+ * cron (/api/cron/grab-campaigns-sync). Raw SQL via Prisma (grab_campaigns isn't
+ * a Prisma model) — same pattern as /api/integrations/grab.
+ */
+
+import { prisma } from "@/lib/prisma";
+import { Prisma } from "@prisma/client";
+import { isGrabConfigured, listCampaigns, type GrabCampaign } from "@/lib/grab";
+import { randomUUID } from "crypto";
+
+/** Best-effort human label from a campaign's discount block (shape varies). */
+export function summarizeDiscount(c: GrabCampaign): string | null {
+  const d = c.discount;
+  if (!d || typeof d !== "object") return null;
+  const type = String(d.type ?? "").toUpperCase();
+  const value = typeof d.value === "number" ? d.value : undefined;
+  const cap = typeof d.cap === "number" ? d.cap : undefined;
+  if (type.includes("PERCENT") && value != null) {
+    return `${value}% off${cap != null ? `, cap RM${(cap / 100).toFixed(2)}` : ""}`;
+  }
+  if ((type.includes("AMOUNT") || type.includes("FIXED") || type.includes("FLAT")) && value != null) {
+    return `RM${(value / 100).toFixed(2)} off`;
+  }
+  if (type.includes("DELIVERY")) return "Free / discounted delivery";
+  return type || null;
+}
+
+export async function syncGrabCampaigns(): Promise<{ outlets: number; upserted: number; errors: string[] }> {
+  if (!isGrabConfigured()) return { outlets: 0, upserted: 0, errors: ["Grab not configured (GRAB_CLIENT_ID/SECRET/MERCHANT_ID)"] };
+
+  const outlets = await prisma.$queryRaw<{ id: string; grab_merchant_id: string }[]>(Prisma.sql`
+    SELECT id, grab_merchant_id FROM outlets WHERE grab_merchant_id IS NOT NULL
+  `);
+
+  let upserted = 0;
+  const errors: string[] = [];
+  for (const o of outlets) {
+    try {
+      const campaigns = await listCampaigns(o.grab_merchant_id);
+      for (const c of campaigns) {
+        const gid = String(c.id ?? c.campaignID ?? "").trim();
+        if (!gid) continue;
+        await prisma.$executeRaw(Prisma.sql`
+          INSERT INTO grab_campaigns
+            (id, outlet_id, grab_campaign_id, name, created_by, status, discount_summary, raw, synced_at)
+          VALUES (${randomUUID()}, ${o.id}, ${gid}, ${c.name ?? null}, ${c.createdBy ?? null},
+                  ${c.status ?? null}, ${summarizeDiscount(c)}, ${JSON.stringify(c)}::jsonb, now())
+          ON CONFLICT (outlet_id, grab_campaign_id) DO UPDATE SET
+            name = EXCLUDED.name, created_by = EXCLUDED.created_by, status = EXCLUDED.status,
+            discount_summary = EXCLUDED.discount_summary, raw = EXCLUDED.raw, synced_at = now()
+        `);
+        upserted++;
+      }
+    } catch (e) {
+      errors.push(`${o.id}: ${e instanceof Error ? e.message : String(e)}`);
+    }
+  }
+  return { outlets: outlets.length, upserted, errors };
+}

--- a/apps/backoffice/src/lib/grab.ts
+++ b/apps/backoffice/src/lib/grab.ts
@@ -408,6 +408,38 @@ export async function editOrder(
   });
 }
 
+// ─── Marketing / Campaigns ───────────────────────────────────────────────────
+
+export interface GrabCampaign {
+  id?: string;
+  campaignID?: string;
+  name?: string;
+  createdBy?: string; // PARTNER | MERCHANT | GRAB
+  status?: string;
+  discount?: { type?: string; value?: number; cap?: number; [k: string]: unknown };
+  conditions?: Record<string, unknown>;
+  quotas?: Record<string, unknown>;
+  startTime?: string;
+  endTime?: string;
+  [k: string]: unknown;
+}
+
+/**
+ * List GrabFood campaigns (promotions) for a merchant.
+ * Read-only mirror — GrabFood "campaigns" are merchant/partner/Grab-funded
+ * promos, NOT paid GrabAds advertising (which isn't in the Partner API).
+ * The response shape varies by version, so tolerate both a bare array and a
+ * `{ campaigns: [] }` envelope.
+ */
+export async function listCampaigns(merchantID: string): Promise<GrabCampaign[]> {
+  const res = await grabRequest<{ campaigns?: GrabCampaign[] } | GrabCampaign[]>(
+    "/partner/v1/campaigns",
+    { params: { merchantID } },
+  );
+  if (Array.isArray(res)) return res;
+  return res?.campaigns ?? [];
+}
+
 // ─── Store Management ────────────────────────────────────────────────────────
 
 /**

--- a/apps/backoffice/src/lib/modules.ts
+++ b/apps/backoffice/src/lib/modules.ts
@@ -86,6 +86,7 @@ export const APP_MODULES: Record<string, ModuleDef[]> = {
     { label: "Campaigns", key: "campaigns" },
     { label: "Invoices", key: "invoices" },
     { label: "Ad Settings", key: "settings" },
+    { label: "GrabFood Marketing", key: "grab" },
   ],
 };
 
@@ -215,6 +216,12 @@ export const NAV_TABS: GrantTab[] = [
           m("ads", "overview", "Overview"),
           m("ads", "campaigns", "Campaigns"),
           m("ads", "invoices", "Invoices"),
+        ],
+      },
+      {
+        label: "GrabFood",
+        modules: [
+          m("ads", "grab", "Campaigns & Ad Spend"),
         ],
       },
     ],

--- a/apps/backoffice/vercel.json
+++ b/apps/backoffice/vercel.json
@@ -59,6 +59,10 @@
     {
       "path": "/api/cron/pos-loyalty-reconcile",
       "schedule": "*/5 * * * *"
+    },
+    {
+      "path": "/api/cron/grab-campaigns-sync",
+      "schedule": "0 18 * * *"
     }
   ]
 }

--- a/supabase/migrations/033_grab_marketing.sql
+++ b/supabase/migrations/033_grab_marketing.sql
@@ -1,0 +1,41 @@
+-- GrabFood marketing: synced campaigns, manual GrabAds spend, and the
+-- per-order merchant-funded promo cost.
+--
+-- "Marketing" for GrabFood splits into two costs:
+--   • promo/campaign cost — merchant-funded discounts. The order webhook gets
+--     this as price.merchantFundPromo, but we used to MERGE it with Grab-funded
+--     promo into discount_amount. Only the merchant-funded part is OUR cost, so
+--     capture it on its own column.
+--   • GrabAds paid advertising — a separate Grab product NOT exposed by the
+--     Partner API, so its spend is entered manually (grab_ads_spend).
+-- Campaigns themselves are mirrored read-only from GET /partner/v1/campaigns.
+--
+-- All additive (new column defaulted, new tables) — safe to run anytime.
+
+ALTER TABLE pos_orders ADD COLUMN IF NOT EXISTS grab_merchant_promo integer NOT NULL DEFAULT 0;
+
+CREATE TABLE IF NOT EXISTS grab_campaigns (
+  id               text PRIMARY KEY,
+  outlet_id        text NOT NULL,
+  grab_campaign_id text NOT NULL,
+  name             text,
+  created_by       text,           -- PARTNER | MERCHANT | GRAB
+  status           text,
+  discount_summary text,
+  raw              jsonb,
+  synced_at        timestamptz NOT NULL DEFAULT now(),
+  UNIQUE (outlet_id, grab_campaign_id)
+);
+CREATE INDEX IF NOT EXISTS idx_grab_campaigns_outlet ON grab_campaigns(outlet_id);
+
+CREATE TABLE IF NOT EXISTS grab_ads_spend (
+  id           text PRIMARY KEY,
+  outlet_id    text NOT NULL,
+  period_start date NOT NULL,
+  period_end   date NOT NULL,
+  amount_sen   integer NOT NULL,
+  note         text,
+  created_by   text,
+  created_at   timestamptz NOT NULL DEFAULT now()
+);
+CREATE INDEX IF NOT EXISTS idx_grab_ads_spend_outlet ON grab_ads_spend(outlet_id, period_start);


### PR DESCRIPTION
## What
Adds a dedicated **GrabFood** section to the Marketing module (separate from Google Ads, as scoped), covering both GrabFood marketing costs and the campaign list.

## Why
The Grab Partner API exposes campaigns (promotions) but **not** GrabAds paid advertising. And "marketing cost" splits in two: merchant-funded promo (a real cost we already receive on orders but were discarding) and GrabAds spend (only on Grab's statements). This surfaces both in one place.

## Changes
**Data (migration `033`, applied to prod via Supabase MCP — additive/safe):**
- `pos_orders.grab_merchant_promo` — captures `merchantFundPromo` per order. The webhook used to merge `grabFundPromo + merchantFundPromo` into `discount_amount`; only the merchant-funded part is *our* cost. Written via the existing best-effort post-insert update, so order creation can't break.
- `grab_campaigns` — read-only mirror of `GET /partner/v1/campaigns`.
- `grab_ads_spend` — manual GrabAds spend entries.

**Backend:**
- `lib/grab.ts` → `listCampaigns(merchantID)`.
- `lib/grab-campaigns.ts` → `syncGrabCampaigns()` (per linked outlet, upsert).
- API (OWNER/ADMIN, prisma raw SQL like `/api/integrations/grab`):
  - `GET /api/ads/grab/overview` — revenue, promo cost, GrabAds spend, total marketing, % of revenue, per outlet.
  - `GET /api/ads/grab/campaigns` (list) · `POST` (sync now).
  - `GET/POST/DELETE /api/ads/grab/ad-spend` (manual entry).
- `GET /api/cron/grab-campaigns-sync` + `vercel.json` daily schedule.

**UI / nav:**
- `(admin)/ads/grab` page — **Overview / Campaigns / Ad Spend** tabs, with outlet + date-range filters.
- `modules.ts` (`ads:grab` grant key + nav group) and the sidebar entry in `layout.tsx`.

## Verification
- `tsc --noEmit` clean; ESLint 0 errors on changed files; migration `033` applied to prod.

## Scope / follow-ups
- Campaign sync is **read-only** for now (create/pause via the API is a follow-up).
- Promo spend rolls up at **outlet + period** (the order payload doesn't carry per-campaign attribution).
- No P&L tie-in yet — Grab marketing cost can later flow into Finance as an expense.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01EsqLcUvzHqo2BA2LToav19)_