### PR TITLE
Store/Menu Status board for POS (backoffice)

### DIFF
--- a/apps/backoffice/src/app/(admin)/layout.tsx
+++ b/apps/backoffice/src/app/(admin)/layout.tsx
@@ -16,6 +16,7 @@ import {
   ClipboardList,
   UtensilsCrossed,
   BarChart3,
+  Power,
   Users,
   Package,
   Truck,
@@ -184,6 +185,7 @@ const NAV_SECTIONS: NavSection[] = [
       { label: "Compare",             href: "/sales/compare",           icon: <Scale className={ICON_SIZE} />,           moduleKey: "sales:dashboard" },
       { label: "Reports",             href: "/pos/reports",             icon: <BarChart3 className={ICON_SIZE} />,       moduleKey: "pickup:settings" },
       { label: "Cashier Performance", href: "/pos/cashier-performance", icon: <Users className={ICON_SIZE} />,           moduleKey: "pickup:settings" },
+      { label: "Store / Menu Status", href: "/pos/store-menu-status",    icon: <Power className={ICON_SIZE} />,           moduleKey: "pickup:settings" },
     ],
   },
   {

--- a/apps/backoffice/src/app/(admin)/pos/page.tsx
+++ b/apps/backoffice/src/app/(admin)/pos/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import Link from "next/link";
-import { Settings, BarChart3, QrCode, Printer, ClipboardList, Receipt, Users, type LucideIcon } from "lucide-react";
+import { Settings, BarChart3, QrCode, Printer, ClipboardList, Receipt, Users, Power, type LucideIcon } from "lucide-react";
 
 /**
  * POS section landing — quick links into the POS admin surfaces, grouped by
@@ -30,6 +30,12 @@ const GROUPS: PosGroup[] = [
         Icon: Users,
         title: "Cashier Performance",
         blurb: "Phone-collection rate per cashier — the loyalty top-of-funnel, tracked against the 70% target.",
+      },
+      {
+        href: "/pos/store-menu-status",
+        Icon: Power,
+        title: "Store / Menu Status",
+        blurb: "Live board: which outlets are open vs paused, today's orders vs the weekday norm, and what's 86'd.",
       },
       {
         href: "/pos/z-report",

--- a/apps/backoffice/src/app/(admin)/pos/store-menu-status/page.tsx
+++ b/apps/backoffice/src/app/(admin)/pos/store-menu-status/page.tsx
@@ -1,0 +1,307 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useState } from "react";
+import {
+  Loader2,
+  RefreshCw,
+  Power,
+  PauseCircle,
+  AlertTriangle,
+  Clock,
+  Search,
+} from "lucide-react";
+import { adminFetch } from "@/lib/pickup/admin-fetch";
+
+/**
+ * Store / Menu Status — live operational board (see /api/pos/store-menu-status).
+ * Benchmarked on Hubbo's report: which outlets are open/paused, are they
+ * actually selling today (vs the same-weekday norm), and what's "86'd". The
+ * headline alarm is an OPEN outlet with zero orders today.
+ */
+
+type StoreCard = {
+  outletId: string;
+  name: string;
+  storeId: string | null;
+  isOpen: boolean;
+  manualPause: boolean;
+  openTime: string | null;
+  closeTime: string | null;
+  openToday: boolean;
+  todayOrders: number;
+  avgWeekday: number;
+  lastOrderAt: string | null;
+  snoozed: number;
+  menuTotal: number;
+  alert: "open-no-orders" | "quiet" | "manual-pause" | "none";
+};
+type SnoozedItem = {
+  storeId: string;
+  outletName: string;
+  category: string;
+  item: string;
+  reason: string | null;
+  since: string;
+};
+type Data = {
+  generatedAt: string;
+  mytToday: string;
+  menuTotal: number;
+  stores: StoreCard[];
+  snoozedItems: SnoozedItem[];
+};
+
+const relTime = (iso: string | null): string => {
+  if (!iso) return "—";
+  const mins = Math.round((Date.now() - new Date(iso).getTime()) / 60000);
+  if (mins < 1) return "just now";
+  if (mins < 60) return `${mins}m ago`;
+  const hrs = Math.floor(mins / 60);
+  if (hrs < 24) return `${hrs}h ${mins % 60}m ago`;
+  return `${Math.floor(hrs / 24)}d ago`;
+};
+const clockTime = (iso: string) =>
+  new Date(iso).toLocaleTimeString("en-MY", {
+    hour: "2-digit",
+    minute: "2-digit",
+    timeZone: "Asia/Kuala_Lumpur",
+  });
+
+function StatusBadge({ s }: { s: StoreCard }) {
+  if (s.manualPause)
+    return <span className="inline-flex items-center gap-1 rounded-full bg-amber-100 px-2.5 py-0.5 text-xs font-semibold text-amber-800"><PauseCircle className="h-3.5 w-3.5" />Paused</span>;
+  if (s.isOpen)
+    return <span className="inline-flex items-center gap-1 rounded-full bg-emerald-100 px-2.5 py-0.5 text-xs font-semibold text-emerald-800"><Power className="h-3.5 w-3.5" />Open</span>;
+  return <span className="inline-flex items-center gap-1 rounded-full bg-gray-200 px-2.5 py-0.5 text-xs font-semibold text-gray-600"><Power className="h-3.5 w-3.5" />{s.openToday ? "Closed" : "Closed today"}</span>;
+}
+
+function AlertBanner({ alert }: { alert: StoreCard["alert"] }) {
+  if (alert === "none") return null;
+  const map = {
+    "open-no-orders": { cls: "bg-red-50 text-red-700 border-red-200", txt: "Open · 0 orders today" },
+    quiet: { cls: "bg-amber-50 text-amber-800 border-amber-200", txt: "Quiet · running below usual" },
+    "manual-pause": { cls: "bg-amber-50 text-amber-800 border-amber-200", txt: "Manually paused — won't auto-reopen" },
+  } as const;
+  const m = map[alert];
+  return (
+    <div className={`mt-3 flex items-center gap-1.5 rounded-lg border px-2.5 py-1.5 text-xs font-medium ${m.cls}`}>
+      <AlertTriangle className="h-3.5 w-3.5 shrink-0" />
+      {m.txt}
+    </div>
+  );
+}
+
+export default function StoreMenuStatusPage() {
+  const [data, setData] = useState<Data | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [err, setErr] = useState<string | null>(null);
+  const [search, setSearch] = useState("");
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setErr(null);
+    try {
+      const res = await adminFetch("/api/pos/store-menu-status");
+      const json = await res.json();
+      if (!res.ok) throw new Error(json.error || "Failed to load");
+      setData(json);
+    } catch (e) {
+      setErr(e instanceof Error ? e.message : "Failed to load");
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  const filteredSnoozed = useMemo(() => {
+    if (!data) return [];
+    const q = search.trim().toLowerCase();
+    if (!q) return data.snoozedItems;
+    return data.snoozedItems.filter(
+      (i) =>
+        i.item.toLowerCase().includes(q) ||
+        i.category.toLowerCase().includes(q) ||
+        i.outletName.toLowerCase().includes(q),
+    );
+  }, [data, search]);
+
+  const totalSnoozed = data?.snoozedItems.length ?? 0;
+
+  return (
+    <div className="p-3 sm:p-6 space-y-6 max-w-6xl">
+      {/* Header */}
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <div>
+          <h1 className="text-2xl font-bold text-[#160800]">Store / Menu Status</h1>
+          <p className="text-sm text-gray-500">
+            Live: who&rsquo;s open, who&rsquo;s selling, and what&rsquo;s 86&rsquo;d — across all outlets.
+          </p>
+        </div>
+        <div className="flex items-center gap-3">
+          {data && (
+            <span className="text-xs text-gray-400">as of {clockTime(data.generatedAt)}</span>
+          )}
+          <button
+            onClick={load}
+            disabled={loading}
+            className="inline-flex items-center gap-1.5 rounded-lg border border-gray-300 bg-white px-3 py-1.5 text-sm font-medium text-[#160800] hover:bg-gray-50 disabled:opacity-60"
+          >
+            <RefreshCw className={`h-4 w-4 ${loading ? "animate-spin" : ""}`} />
+            Refresh
+          </button>
+        </div>
+      </div>
+
+      {err && (
+        <div className="rounded-xl border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">{err}</div>
+      )}
+
+      {loading && !data ? (
+        <div className="flex items-center justify-center py-20 text-gray-400">
+          <Loader2 className="h-6 w-6 animate-spin" />
+        </div>
+      ) : data ? (
+        <>
+          {/* ── Store status ──────────────────────────────────────────── */}
+          <section className="space-y-3">
+            <h2 className="text-sm font-semibold uppercase tracking-wide text-gray-500">Store status</h2>
+            <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+              {data.stores.map((s) => {
+                const delta = s.todayOrders - s.avgWeekday;
+                return (
+                  <div key={s.outletId} className="rounded-2xl bg-white p-4 border border-gray-100 shadow-sm">
+                    <div className="flex items-start justify-between gap-2">
+                      <h3 className="font-semibold text-[#160800] leading-tight">{s.name}</h3>
+                      <StatusBadge s={s} />
+                    </div>
+
+                    <div className="mt-4 flex items-end justify-between">
+                      <div>
+                        <p className="text-3xl font-bold text-[#160800] leading-none">{s.todayOrders}</p>
+                        <p className="mt-1 text-xs text-gray-500">orders today</p>
+                      </div>
+                      <div className="text-right">
+                        <p className="text-sm font-medium text-gray-600">
+                          {s.avgWeekday > 0 ? (
+                            <span className={delta >= 0 ? "text-emerald-600" : "text-amber-600"}>
+                              {delta >= 0 ? "+" : ""}
+                              {Math.round(delta)}
+                            </span>
+                          ) : (
+                            "—"
+                          )}
+                        </p>
+                        <p className="text-xs text-gray-400">vs {s.avgWeekday} avg (this weekday)</p>
+                      </div>
+                    </div>
+
+                    <div className="mt-3 flex items-center justify-between border-t border-gray-100 pt-2 text-xs text-gray-500">
+                      <span className="inline-flex items-center gap-1">
+                        <Clock className="h-3.5 w-3.5" />
+                        {s.openTime ?? "—"}&ndash;{s.closeTime ?? "—"}
+                      </span>
+                      <span>Last order {relTime(s.lastOrderAt)}</span>
+                    </div>
+
+                    <div className="mt-1.5 text-xs text-gray-500">
+                      {s.snoozed > 0 ? (
+                        <span className="font-medium text-amber-700">{s.snoozed} item{s.snoozed === 1 ? "" : "s"} snoozed</span>
+                      ) : (
+                        <span className="text-emerald-600">Full menu live</span>
+                      )}
+                    </div>
+
+                    <AlertBanner alert={s.alert} />
+                  </div>
+                );
+              })}
+            </div>
+          </section>
+
+          {/* ── Menu status ───────────────────────────────────────────── */}
+          <section className="space-y-3">
+            <div className="flex flex-wrap items-center justify-between gap-2">
+              <h2 className="text-sm font-semibold uppercase tracking-wide text-gray-500">
+                Menu status &mdash; snoozed items ({totalSnoozed})
+              </h2>
+              <div className="relative">
+                <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-gray-400" />
+                <input
+                  value={search}
+                  onChange={(e) => setSearch(e.target.value)}
+                  placeholder="Search item, category, outlet"
+                  className="w-64 rounded-lg border border-gray-300 bg-white pl-9 pr-3 py-1.5 text-sm text-[#160800] placeholder:text-gray-400"
+                />
+              </div>
+            </div>
+
+            {/* Per-outlet snooze/live bars */}
+            <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+              {data.stores.map((s) => {
+                const live = Math.max(0, s.menuTotal - s.snoozed);
+                const pct = s.menuTotal > 0 ? (s.snoozed / s.menuTotal) * 100 : 0;
+                return (
+                  <div key={s.outletId} className="rounded-2xl bg-white p-4 border border-gray-100">
+                    <div className="flex items-center justify-between text-sm">
+                      <span className="font-medium text-[#160800]">{s.name}</span>
+                      <span className="text-gray-500">
+                        <span className="font-semibold text-amber-700">{s.snoozed}</span> / {s.menuTotal}
+                      </span>
+                    </div>
+                    <div className="mt-2 h-2 w-full overflow-hidden rounded-full bg-emerald-100">
+                      <div className="h-full bg-amber-400" style={{ width: `${pct}%` }} />
+                    </div>
+                    <p className="mt-1.5 text-xs text-gray-400">{live} live · {s.snoozed} snoozed</p>
+                  </div>
+                );
+              })}
+            </div>
+
+            {/* Snoozed detail table */}
+            <div className="overflow-hidden rounded-2xl border border-gray-200 bg-white">
+              <table className="w-full">
+                <thead>
+                  <tr className="border-b border-gray-200 bg-gray-50 text-left text-xs font-medium text-gray-700">
+                    <th className="px-4 py-3">Outlet</th>
+                    <th className="px-4 py-3">Category</th>
+                    <th className="px-4 py-3">Item</th>
+                    <th className="px-4 py-3">Reason</th>
+                    <th className="px-4 py-3 text-right">Snoozed since</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {filteredSnoozed.length === 0 ? (
+                    <tr>
+                      <td colSpan={5} className="px-4 py-10 text-center text-sm text-gray-500">
+                        {totalSnoozed === 0 ? "Nothing snoozed — full menu live everywhere. 🎉" : "No matches."}
+                      </td>
+                    </tr>
+                  ) : (
+                    filteredSnoozed.map((i, idx) => (
+                      <tr key={`${i.storeId}-${i.item}-${idx}`} className="border-b border-gray-50 hover:bg-gray-50">
+                        <td className="px-4 py-3 text-sm text-[#160800]">{i.outletName}</td>
+                        <td className="px-4 py-3 text-sm text-gray-600">{i.category}</td>
+                        <td className="px-4 py-3 text-sm font-medium text-[#160800]">{i.item}</td>
+                        <td className="px-4 py-3 text-sm text-gray-500">{i.reason || "—"}</td>
+                        <td className="px-4 py-3 text-sm text-right text-gray-500" title={new Date(i.since).toLocaleString("en-MY")}>
+                          {relTime(i.since)}
+                        </td>
+                      </tr>
+                    ))
+                  )}
+                </tbody>
+              </table>
+            </div>
+            <p className="text-[11px] text-gray-400">
+              Snoozed = an item turned off (&ldquo;86&rdquo;) at an outlet that is otherwise on the live menu. Snoozing on the
+              register also hides the item on GrabFood within seconds.
+            </p>
+          </section>
+        </>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/backoffice/src/app/api/pos/store-menu-status/route.ts
+++ b/apps/backoffice/src/app/api/pos/store-menu-status/route.ts
@@ -1,0 +1,252 @@
+import { NextRequest, NextResponse } from "next/server";
+import { requireAuth } from "@/lib/auth";
+import { prisma } from "@/lib/prisma";
+import { getSupabaseAdmin } from "@/lib/pickup/supabase";
+import {
+  getMYTToday,
+  getMYTDateStr,
+  getMYTHourNow,
+  addDays,
+  dayOfWeek,
+} from "../../sales/_lib/native-sales-helpers";
+
+/**
+ * GET /api/pos/store-menu-status
+ *
+ * Live operational board, benchmarked on Hubbo POS's "Store/Menu Status"
+ * report. Two halves on our own data:
+ *
+ *   • Store status — per active outlet: open/paused (Outlet.isOpen +
+ *     app_settings.outlet_open_override = a manual force-close), operating
+ *     hours, today's POS order count vs the same-weekday average, and the last
+ *     order time. The headline alarm mirrors Hubbo: an outlet that is OPEN but
+ *     has taken zero orders today (the "open but nobody's serving" failure the
+ *     order-alerts work targets), plus a softer "quiet" flag in the afternoon.
+ *
+ *   • Menu status — the "86" board. Snoozed = an outlet has an
+ *     outlet_product_availability row with is_available=false for a product
+ *     that is otherwise on the live menu (products.is_available=true). Normal =
+ *     live menu minus snoozed. We also return the snoozed line items (outlet ·
+ *     category · item · reason · since) — the current lost-sales list.
+ *
+ * Sources: Outlet (Prisma) + outlet_product_availability / products /
+ * pos_orders / app_settings (Supabase). Read-only. MYT (UTC+8) calendar days.
+ * Admins see every active outlet; everyone else is scoped to their own.
+ */
+
+export const dynamic = "force-dynamic";
+
+// A sale that no longer counts — must drop out of "real orders today".
+const DEAD = new Set(["cancelled", "failed", "refunded", "voided"]);
+
+// How far back to look for the same-weekday baseline (9 weeks → up to 8 prior
+// same-DOW days), and how many of those we average.
+const LOOKBACK_DAYS = 63;
+
+type StoreCard = {
+  outletId: string;
+  name: string;
+  storeId: string | null;
+  loyaltyId: string | null;
+  isOpen: boolean;
+  manualPause: boolean;
+  openTime: string | null;
+  closeTime: string | null;
+  daysOpen: number[];
+  openToday: boolean;
+  todayOrders: number;
+  avgWeekday: number;
+  lastOrderAt: string | null;
+  snoozed: number;
+  menuTotal: number;
+  alert: "open-no-orders" | "quiet" | "manual-pause" | "none";
+};
+
+export async function GET(request: NextRequest) {
+  const auth = await requireAuth(request);
+  if (auth.error) return auth.error;
+  const user = auth.user;
+
+  const isAdmin = user.role === "OWNER" || user.role === "ADMIN";
+
+  const outlets = await prisma.outlet.findMany({
+    where: { status: "ACTIVE" },
+    select: {
+      id: true,
+      name: true,
+      isOpen: true,
+      openTime: true,
+      closeTime: true,
+      daysOpen: true,
+      loyaltyOutletId: true,
+      pickupStoreId: true,
+    },
+    orderBy: { name: "asc" },
+  });
+  const scoped = isAdmin ? outlets : outlets.filter((o) => o.id === user.outletId);
+  if (scoped.length === 0) {
+    return NextResponse.json({ error: "No outlet" }, { status: 400 });
+  }
+
+  const supabase = getSupabaseAdmin();
+  const today = getMYTToday();
+  const todayDow = dayOfWeek(today);
+  const hourNow = getMYTHourNow();
+
+  // ── Manual-pause overrides (store slug → pinned-closed) ──────────────────
+  const { data: ovRow } = await supabase
+    .from("app_settings")
+    .select("value")
+    .eq("key", "outlet_open_override")
+    .maybeSingle();
+  const rawOv = (ovRow as { value?: unknown } | null)?.value;
+  const override: Record<string, boolean> =
+    rawOv && typeof rawOv === "object" && !Array.isArray(rawOv)
+      ? (rawOv as Record<string, boolean>)
+      : {};
+
+  // ── Orders: today + same-weekday baseline, per outlet (by loyalty id) ────
+  const sinceIso = new Date(`${addDays(today, -LOOKBACK_DAYS)}T00:00:00+08:00`).toISOString();
+  const { data: orderRows } = await supabase
+    .from("pos_orders")
+    .select("outlet_id, created_at, status, refund_of_order_id")
+    .gte("created_at", sinceIso);
+
+  // outletId → dateStr → count, and outletId → latest created_at
+  const byDate = new Map<string, Map<string, number>>();
+  const lastAt = new Map<string, string>();
+  for (const r of (orderRows ?? []) as {
+    outlet_id: string | null;
+    created_at: string;
+    status: string | null;
+    refund_of_order_id: string | null;
+  }[]) {
+    if (!r.outlet_id) continue;
+    if (r.refund_of_order_id) continue;
+    if (r.status && DEAD.has(r.status)) continue;
+    const d = getMYTDateStr(r.created_at);
+    let m = byDate.get(r.outlet_id);
+    if (!m) byDate.set(r.outlet_id, (m = new Map()));
+    m.set(d, (m.get(d) ?? 0) + 1);
+    const prev = lastAt.get(r.outlet_id);
+    if (!prev || r.created_at > prev) lastAt.set(r.outlet_id, r.created_at);
+  }
+
+  // Average over the last 8 same-weekday dates the outlet ACTUALLY traded
+  // (a date present in the map = it took ≥1 order). Skipping absent dates keeps
+  // pre-cutover / pre-launch zeros from diluting the baseline — a freshly
+  // migrated outlet shows "—" (no baseline) rather than a misleadingly low avg.
+  const sameWeekdayAvg = (loyaltyId: string): number => {
+    const m = byDate.get(loyaltyId);
+    if (!m) return 0;
+    const counts: number[] = [];
+    for (let w = 1; w <= 8; w++) {
+      const c = m.get(addDays(today, -7 * w));
+      if (c !== undefined) counts.push(c);
+    }
+    if (counts.length === 0) return 0;
+    const sum = counts.reduce((a, b) => a + b, 0);
+    return Math.round((sum / counts.length) * 10) / 10;
+  };
+
+  // ── Menu / availability ("86") ───────────────────────────────────────────
+  const { data: prodRows } = await supabase
+    .from("products")
+    .select("id, name, category, is_available");
+  const prodMap = new Map<string, { name: string; category: string | null; live: boolean }>();
+  let menuTotal = 0;
+  for (const p of (prodRows ?? []) as {
+    id: string;
+    name: string | null;
+    category: string | null;
+    is_available: boolean | null;
+  }[]) {
+    const live = p.is_available !== false;
+    if (live) menuTotal++;
+    prodMap.set(p.id, { name: p.name ?? p.id, category: p.category, live });
+  }
+
+  const { data: availRows } = await supabase
+    .from("outlet_product_availability")
+    .select("outlet_id, product_id, reason, updated_at")
+    .eq("is_available", false);
+
+  const slugToName = new Map<string, string>();
+  for (const o of scoped) if (o.pickupStoreId) slugToName.set(o.pickupStoreId, o.name);
+  const allowedSlugs = new Set(scoped.map((o) => o.pickupStoreId).filter(Boolean) as string[]);
+
+  const snoozedByStore = new Map<string, number>();
+  const snoozedItems: {
+    storeId: string;
+    outletName: string;
+    category: string;
+    item: string;
+    reason: string | null;
+    since: string;
+  }[] = [];
+  for (const a of (availRows ?? []) as {
+    outlet_id: string;
+    product_id: string;
+    reason: string | null;
+    updated_at: string;
+  }[]) {
+    if (!allowedSlugs.has(a.outlet_id)) continue; // scope + only known outlets
+    const prod = prodMap.get(a.product_id);
+    if (!prod || !prod.live) continue; // ignore globally-disabled items
+    snoozedByStore.set(a.outlet_id, (snoozedByStore.get(a.outlet_id) ?? 0) + 1);
+    snoozedItems.push({
+      storeId: a.outlet_id,
+      outletName: slugToName.get(a.outlet_id) ?? a.outlet_id,
+      category: prod.category ?? "Uncategorised",
+      item: prod.name,
+      reason: a.reason,
+      since: a.updated_at,
+    });
+  }
+  snoozedItems.sort((x, y) => x.outletName.localeCompare(y.outletName) || x.category.localeCompare(y.category));
+
+  // ── Assemble store cards ─────────────────────────────────────────────────
+  const stores: StoreCard[] = scoped.map((o) => {
+    const loyaltyId = o.loyaltyOutletId;
+    const isOpen = o.isOpen === true;
+    const manualPause = o.pickupStoreId ? override[o.pickupStoreId] === true : false;
+    const todayOrders = loyaltyId ? byDate.get(loyaltyId)?.get(today) ?? 0 : 0;
+    const avgWeekday = loyaltyId ? sameWeekdayAvg(loyaltyId) : 0;
+    const snoozed = o.pickupStoreId ? snoozedByStore.get(o.pickupStoreId) ?? 0 : 0;
+    const openToday = (o.daysOpen ?? []).includes(todayDow === 0 ? 7 : todayDow);
+
+    let alert: StoreCard["alert"] = "none";
+    if (manualPause) alert = "manual-pause";
+    else if (isOpen && todayOrders === 0) alert = "open-no-orders";
+    else if (isOpen && avgWeekday >= 5 && hourNow >= 14 && todayOrders < 0.4 * avgWeekday)
+      alert = "quiet";
+
+    return {
+      outletId: o.id,
+      name: o.name,
+      storeId: o.pickupStoreId,
+      loyaltyId,
+      isOpen,
+      manualPause,
+      openTime: o.openTime,
+      closeTime: o.closeTime,
+      daysOpen: o.daysOpen ?? [],
+      openToday,
+      todayOrders,
+      avgWeekday,
+      lastOrderAt: loyaltyId ? lastAt.get(loyaltyId) ?? null : null,
+      snoozed,
+      menuTotal,
+      alert,
+    };
+  });
+
+  return NextResponse.json({
+    generatedAt: new Date().toISOString(),
+    mytToday: today,
+    mytHour: hourNow,
+    menuTotal,
+    stores,
+    snoozedItems,
+  });
+}


### PR DESCRIPTION
## What

A live **Store / Menu Status** board in the backoffice POS section, benchmarked on Hubbo POS's report of the same name (surfaced while comparing our POS to Hubbo).

### Store status (per outlet)
- Open / Paused / Closed — `Outlet.isOpen` + `app_settings.outlet_open_override` (a manual force-close shows as **Paused**).
- Today's orders vs the **same-weekday average** (averaged only over days the outlet actually traded, so freshly migrated outlets — SA/Tam cut over 15 Jun — show "—" instead of a diluted baseline).
- Operating hours + last-order heartbeat.
- **Headline alarm:** an outlet that's **open but has taken 0 orders today** (red), plus a softer afternoon "quiet" flag.

### Menu status
- Per-outlet snoozed-vs-live counts + a snoozed-item detail table (outlet · category · item · reason · since), with search.
- Sourced from `outlet_product_availability` (the register's long-press "86", which already mirrors to GrabFood).

## Scope / safety
- **Read-only.** New `GET /api/pos/store-menu-status` (auth-gated: admins see all outlets, managers their own) + page + nav entry + POS landing card. No schema changes.

## Verification
- `tsc --noEmit` clean for all changed files.
- Data logic validated against the live DB: snoozed counts match exactly (conezion 15 / shah-alam 3 / tamarind 15); conezion Saturday avg ≈ 100.
- UI not render-verified locally (backoffice is auth-gated) — please eyeball the Vercel preview.

> Note: `pause-till` (timed auto-resume) is intentionally out of scope — no field exists yet; it belongs with the open/close-consolidation work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)