### PR TITLE
feat(finance): GrabFood marketing cost in the sourced P&L

### DIFF
--- a/apps/backoffice/src/lib/finance/reports/pnl-sourced.ts
+++ b/apps/backoffice/src/lib/finance/reports/pnl-sourced.ts
@@ -17,6 +17,7 @@
 
 import { getFinanceClient } from "../supabase";
 import { prisma } from "@/lib/prisma";
+import { Prisma } from "@prisma/client";
 import { getDefaultCompanyId } from "../companies";
 import type { PnlReport, PnlLine } from "./pnl";
 
@@ -120,6 +121,49 @@ export async function buildSourcedPnl(input: {
     if (adsSpend) {
       expenseLines.push({ code: "MKT-ADS", name: "Marketing — Digital ads (Google)", amount: adsSpend, parentCode: null });
       totalExpenses += adsSpend;
+    }
+  }
+
+  // Marketing — GrabFood: merchant-funded promo cost (per completed order) +
+  // manually entered GrabAds spend, for THIS company's outlets. GrabFood revenue
+  // is booked GROSS in income (pos-native EOD sends the whole order total to the
+  // grabfood channel without deducting the promo), so the merchant-funded promo
+  // must be recognized as a cost here — it is NOT double-counted. grab_merchant_promo
+  // is the merchant-funded part only (Grab-funded promo is Grab's cost, excluded).
+  // fin_outlet_companies/invoices key outlets by the Outlet UUID, but
+  // pos_orders/grab_ads_spend use the loyalty outlet id (e.g. "outlet-sa") —
+  // bridge UUID → loyaltyOutletId before querying the Grab tables.
+  if (outletIds.length) {
+    const loyaltyRows = await prisma.$queryRaw<{ loyalty_id: string }[]>(Prisma.sql`
+      SELECT "loyaltyOutletId" AS loyalty_id FROM "Outlet"
+      WHERE id IN (${Prisma.join(outletIds)}) AND "loyaltyOutletId" IS NOT NULL
+    `);
+    const loyaltyIds = loyaltyRows.map((r) => r.loyalty_id);
+    if (loyaltyIds.length) {
+      const promoAgg = await prisma.$queryRaw<{ promo_sen: bigint }[]>(Prisma.sql`
+        SELECT COALESCE(SUM(grab_merchant_promo), 0) AS promo_sen
+        FROM pos_orders
+        WHERE source = 'grabfood' AND status = 'completed'
+          AND outlet_id IN (${Prisma.join(loyaltyIds)})
+          AND created_at::date BETWEEN ${start}::date AND ${end}::date
+      `);
+      const grabPromo = round2(Number(promoAgg[0]?.promo_sen ?? 0) / 100);
+      if (grabPromo) {
+        expenseLines.push({ code: "MKT-GRAB-PROMO", name: "Marketing — GrabFood promos", amount: grabPromo, parentCode: null });
+        totalExpenses += grabPromo;
+      }
+
+      const adAgg = await prisma.$queryRaw<{ ad_sen: bigint }[]>(Prisma.sql`
+        SELECT COALESCE(SUM(amount_sen), 0) AS ad_sen
+        FROM grab_ads_spend
+        WHERE outlet_id IN (${Prisma.join(loyaltyIds)})
+          AND period_start BETWEEN ${start}::date AND ${end}::date
+      `);
+      const grabAds = round2(Number(adAgg[0]?.ad_sen ?? 0) / 100);
+      if (grabAds) {
+        expenseLines.push({ code: "MKT-GRAB-ADS", name: "Marketing — GrabAds", amount: grabAds, parentCode: null });
+        totalExpenses += grabAds;
+      }
     }
   }
 


### PR DESCRIPTION
## What
Surfaces GrabFood marketing cost in the management (sourced) **P&L**, mirroring the existing Google Ads marketing line. Two new expense lines, per company:
- **Marketing — GrabFood promos** = Σ `pos_orders.grab_merchant_promo`
- **Marketing — GrabAds** = Σ `grab_ads_spend.amount_sen`

(Follow-up to #372, which captured those figures.)

## Why it's correct (not double-counting)
The `pos-native-eod` ingestor books GrabFood revenue **gross** — `classifySourceOverride('grabfood')` sends the whole order `total` (no promo deducted) to the `grabfood` income channel. So the merchant-funded promo isn't reflected anywhere today; recognising it as a cost here completes the picture. Only the **merchant-funded** portion is included (Grab-funded promo is Grab's cost). GrabAds is manually-entered spend that's nowhere else in the P&L.

## Id-space bridge
`fin_outlet_companies`/`invoices` key outlets by the **Outlet UUID**, but `pos_orders`/`grab_ads_spend` use the **loyalty outlet id** (`outlet-sa`). The new block resolves UUID → `Outlet.loyaltyOutletId` before aggregating, so the cost lands on the right company. Verified the bridge end-to-end against prod (celsius→outlet-sa/nilai, conezion→outlet-con, tamarind→outlet-tam).

## Notes
- Single-file change (`pnl-sourced.ts`); no schema change.
- `tsc` clean; the aggregation SQL runs cleanly (returns 0 until `grab_merchant_promo` populates via #372's deploy and ad-spend is entered).
- Effect: net income for a company with GrabFood activity will drop by its GrabFood marketing cost — that's the correction (revenue was previously booked gross with no offsetting promo cost).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01EsqLcUvzHqo2BA2LToav19)_