### PR TITLE
fix(grab): stop dropping orders when the GrabFood short number recurs

### DIFF
--- a/apps/backoffice/src/lib/grab-ingest.ts
+++ b/apps/backoffice/src/lib/grab-ingest.ts
@@ -116,6 +116,56 @@ export interface IngestOpts {
 }
 
 /**
+ * Candidate order_numbers for a Grab order, in preference order. pos_orders has
+ * a GLOBAL unique constraint on order_number, but GrabFood "short" numbers
+ * (e.g. 445) are only unique per-merchant-per-day and recur — so the clean
+ * GF-<short> collides with an older order. We fall back to the globally-unique
+ * Grab order id (external_id) to disambiguate, so the order is never dropped.
+ */
+function grabOrderNumberCandidates(shortNo: string, orderID: string): string[] {
+  const base = `GF-${shortNo || orderID.slice(0, 6)}`;
+  const tail = orderID.replace(/[^A-Za-z0-9]/g, "").slice(-6).toUpperCase();
+  const out = [base];
+  if (tail) out.push(`${base}-${tail}`);
+  out.push(`GF-${orderID}`); // last resort: external_id is globally unique
+  return out;
+}
+
+export type InsertOrderResult =
+  | { status: "created"; id: string }
+  | { status: "duplicate"; id: string | null }
+  | { status: "error"; error: string };
+
+/**
+ * Insert a grabfood pos_orders row, choosing a unique order_number. On a 23505
+ * we distinguish a REAL duplicate (this external_id already exists → idempotent
+ * no-op) from an order_number collision with a DIFFERENT order (recurring short
+ * number → try the next candidate). Previously a collision was misread as a
+ * duplicate and the order was silently dropped (no docket, no revenue).
+ * `row` must include external_id and must NOT include order_number.
+ */
+export async function insertGrabPosOrder(
+  supabase: SupabaseClient,
+  row: Record<string, unknown>,
+  shortNo: string,
+  orderID: string,
+): Promise<InsertOrderResult> {
+  for (const order_number of grabOrderNumberCandidates(shortNo, orderID)) {
+    const { data, error } = await supabase
+      .from("pos_orders").insert({ ...row, order_number }).select("id").single();
+    if (!error && data) return { status: "created", id: (data as { id: string }).id };
+    if ((error as { code?: string } | null)?.code === "23505") {
+      const { data: dup } = await supabase
+        .from("pos_orders").select("id").eq("external_id", row.external_id as string).maybeSingle();
+      if (dup) return { status: "duplicate", id: (dup as { id: string }).id };
+      continue; // order_number taken by a different order — disambiguate
+    }
+    return { status: "error", error: error?.message || "insert failed" };
+  }
+  return { status: "error", error: "order_number candidates exhausted (all collided)" };
+}
+
+/**
  * Idempotent ingest: update an existing order's status (forward-only), skip a
  * no-items state push, or create the order + items + payment. Safe to call from
  * the webhook or a replay.
@@ -178,33 +228,27 @@ export async function ingestGrabOrder(
     payload.orderType === "DINE_IN" ? "dine_in" :
     payload.orderType === "PICKUP" ? "pickup" : "takeaway";
 
-  // 5. Insert order.
+  // 5. Insert order. order_number carries a GLOBAL unique constraint, but
+  // GrabFood short numbers recur across days — insertGrabPosOrder keeps the
+  // clean GF-<short> when free and disambiguates on collision, so an order is
+  // never silently dropped as a false "duplicate".
   const shortNo = (payload.shortOrderNumber ?? "").replace(/^GF-/i, "");
   const baseNote = extractOrderNote(payload);
   const notes = opts.originTag ? `${opts.originTag}${baseNote ? ` ${baseNote}` : ""}` : baseNote;
-  const { data: order, error: orderErr } = await supabase
-    .from("pos_orders")
-    .insert({
-      external_id: orderID,
-      order_number: `GF-${shortNo || orderID.slice(0, 6)}`,
-      outlet_id: outletId,
-      source: "grabfood",
-      order_type: orderType,
-      status: opts.statusOverride ?? "sent_to_kitchen",
-      subtotal, sst_amount: sst, discount_amount: discount, total,
-      customer_name: payload.receiver?.name || "Grab Customer",
-      customer_phone: payload.receiver?.phones?.[0] || null,
-      notes,
-    })
-    .select("id").single();
-  if (orderErr || !order) {
-    if ((orderErr as { code?: string } | null)?.code === "23505") {
-      const { data: dup } = await supabase
-        .from("pos_orders").select("id").eq("external_id", orderID).maybeSingle();
-      return { action: "duplicate", orderId: dup?.id ?? null };
-    }
-    return { action: "error", error: orderErr?.message || "insert failed" };
-  }
+  const ins = await insertGrabPosOrder(supabase, {
+    external_id: orderID,
+    outlet_id: outletId,
+    source: "grabfood",
+    order_type: orderType,
+    status: opts.statusOverride ?? "sent_to_kitchen",
+    subtotal, sst_amount: sst, discount_amount: discount, total,
+    customer_name: payload.receiver?.name || "Grab Customer",
+    customer_phone: payload.receiver?.phones?.[0] || null,
+    notes,
+  }, shortNo, orderID);
+  if (ins.status === "duplicate") return { action: "duplicate", orderId: ins.id };
+  if (ins.status === "error") return { action: "error", error: ins.error };
+  const order = { id: ins.id };
 
   // 6. Items — resolved from our catalogue by partner id / grab_item_id.
   const candidateIds = Array.from(

--- a/apps/backoffice/src/lib/grab-reconcile.ts
+++ b/apps/backoffice/src/lib/grab-reconcile.ts
@@ -17,7 +17,7 @@
 import { randomUUID } from "crypto";
 import { getSupabaseAdmin } from "@/lib/pickup/supabase";
 import { isGrabConfigured, listOrders } from "@/lib/grab";
-import { ingestGrabOrder, type GrabWebhookPayload } from "@/lib/grab-ingest";
+import { ingestGrabOrder, insertGrabPosOrder, type GrabWebhookPayload } from "@/lib/grab-ingest";
 
 type GrabListOrder = Record<string, unknown>;
 
@@ -236,26 +236,27 @@ export async function reconcileGrabOrders(): Promise<ReconcileSummary> {
       }
 
       // 2. Minimal backfill — order + total + status, so the sale isn't lost.
-      try {
-        const short = extractShort(go).replace(/^GF-/i, "");
-        const totalSen = extractTotalSen(go);
-        const { error } = await db.from("pos_orders").insert({
-          external_id: ext,
-          order_number: `GF-${short || ext.slice(0, 6)}`,
-          outlet_id: o.id,
-          source: "grabfood",
-          order_type: "takeaway",
-          status,
-          subtotal: totalSen, sst_amount: 0, discount_amount: 0, total: totalSen,
-          customer_name: "Grab Customer",
-          notes: "[reconciled] backfilled from Grab order list — item detail unavailable",
-        });
-        if (error && (error as { code?: string }).code !== "23505") throw error;
-        summary.backfilledMinimal++;
-        summary.detail.push({ order: ext, outlet: o.id, via: "minimal", status, totalSen });
-      } catch (e) {
+      // Uses the shared insert helper so a recurring short number disambiguates
+      // its order_number instead of silently colliding (the bug that previously
+      // let this branch "succeed" without persisting a row).
+      const short = extractShort(go).replace(/^GF-/i, "");
+      const totalSen = extractTotalSen(go);
+      const ins = await insertGrabPosOrder(db, {
+        external_id: ext,
+        outlet_id: o.id,
+        source: "grabfood",
+        order_type: "takeaway",
+        status,
+        subtotal: totalSen, sst_amount: 0, discount_amount: 0, total: totalSen,
+        customer_name: "Grab Customer",
+        notes: "[reconciled] backfilled from Grab order list — item detail unavailable",
+      }, short, ext);
+      if (ins.status === "error") {
         summary.errors++;
-        summary.detail.push({ order: ext, error: e instanceof Error ? e.message : String(e) });
+        summary.detail.push({ order: ext, error: ins.error });
+      } else {
+        summary.backfilledMinimal++;
+        summary.detail.push({ order: ext, outlet: o.id, via: "minimal", status, totalSen, dup: ins.status === "duplicate" });
       }
     }
   }


### PR DESCRIPTION
## Root cause of dropped GrabFood orders (incl. GF-445)

Live status check turned up the real bug. `pos_orders.order_number` has a **global unique index** (`pos_orders_order_number_key`), but GrabFood "short" numbers (e.g. `445`) are only unique **per-merchant-per-day** and recur constantly (~1000 possible values). Ingest built `order_number = GF-<short>`, so when a new order's short number already existed, the insert hit a unique violation (`23505`).

Both code paths misread that `23505` as a **"duplicate"** and silently dropped the order — **no kitchen docket, no revenue**:
- **Live webhook** (`grab-ingest.ts`): on `23505` it looked up the new `external_id`, didn't find it, and returned `{ action: "duplicate" }` → order vanished.
- **Reconcile backfill** (`grab-reconcile.ts`): swallowed `23505` as benign and counted it as backfilled **without inserting** — which is why the reconcile kept reporting the *same* `missing=5 / backfill=5` every run.

This is exactly how today's **GF-445** (short `445`, `external_id 001219533752-C8A3HBA2T3JXAA`) collided with a 2026-06-19 `GF-445` (`00144578567-C8A2LTMFEUWDCX`) and disappeared.

## Fix

New shared helper `insertGrabPosOrder()`:
- Keeps the clean `GF-<short>` when it's free.
- On a `23505` where **this** `external_id` isn't already stored, it's an order_number collision with a *different* order → disambiguate using the globally-unique Grab order id (`GF-<short>-<idtail>`, then `GF-<full id>`) and insert. The order is never dropped.
- Treats `23505` as a real duplicate **only** when the same `external_id` already exists (genuine idempotent re-delivery).

`order_number` is just a display alias; `external_id` is the real key. No DB migration — the existing unique constraint stays.

## Impact / verify after deploy
- Future orders with recurring short numbers are no longer dropped.
- The next `*/15` reconcile run backfills the 5 orders currently stuck (incl. GF-445) — verify `pos_orders` gets a `[reconciled]` row for `001219533752-C8A3HBA2T3JXAA` and `grab_reconcile_runs.missing` drops toward 0.

Tests: backoffice `tsc`/`eslint` clean, 69 vitest tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01EsqLcUvzHqo2BA2LToav19)_