### PR TITLE
fix(backoffice): prefer-const on never-reassigned toDate (unbreak main lint)

### DIFF
--- a/apps/backoffice/src/app/api/command/route.ts
+++ b/apps/backoffice/src/app/api/command/route.ts
@@ -80,7 +80,7 @@ export async function GET(request: NextRequest) {
     const todayMYT = mytNow.toISOString().split("T")[0];
 
     let fromDate: string;
-    let toDate = todayMYT;
+    const toDate = todayMYT;
     if (period === "today") {
       fromDate = todayMYT;
     } else if (period === "week") {


### PR DESCRIPTION
## Problem
`lint (backoffice)` is **failing on `main`**, which blocks CI for **every open PR** (including the loyalty Phase 3 work). The cause is a single `prefer-const` error introduced by the recently-merged Command Center route:

```
apps/backoffice/src/app/api/command/route.ts:83:9
  error  'toDate' is never reassigned. Use 'const' instead  prefer-const
```

`toDate` is assigned once (`= todayMYT`) and only ever read (line 95); only `fromDate` varies per period. So `let` → `const` is correct and safe.

## Fix
One line: `let toDate = todayMYT` → `const toDate = todayMYT`.

This unblocks `lint (backoffice)` on main so other PRs can go green again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PfVviAtVbppgRTt5pG3D8j)_