### PR TITLE
Reclaim overflowing Cloudinary poster storage (audit + prune + weekly cron)

### DIFF
--- a/apps/backoffice/.gitignore
+++ b/apps/backoffice/.gitignore
@@ -2,3 +2,6 @@
 
 # Grab production secrets (filled from .grab-prod.env.example)
 .grab-prod.env
+
+# Orphan list dumped by scripts/audit-cloudinary-posters.mjs --json
+cloudinary-orphans.json

--- a/apps/backoffice/package.json
+++ b/apps/backoffice/package.json
@@ -10,7 +10,9 @@
     "lint": "eslint",
     "typecheck": "tsc --noEmit",
     "test": "vitest run",
-    "test:watch": "vitest"
+    "test:watch": "vitest",
+    "audit:posters": "node scripts/audit-cloudinary-posters.mjs",
+    "prune:posters": "node scripts/prune-cloudinary-posters.mjs"
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.87.0",

--- a/apps/backoffice/scripts/audit-cloudinary-posters.mjs
+++ b/apps/backoffice/scripts/audit-cloudinary-posters.mjs
@@ -1,0 +1,89 @@
+#!/usr/bin/env node
+/**
+ * Read-only audit of Cloudinary poster storage.
+ *
+ * Reports how many poster assets exist, how many are still referenced by a
+ * splash_posters row, and how much storage is reclaimable (orphans). Makes
+ * NO changes — safe to run anytime. Use this to get the real number before
+ * running prune-cloudinary-posters.mjs.
+ *
+ * Usage:
+ *   node scripts/audit-cloudinary-posters.mjs           # print report
+ *   node scripts/audit-cloudinary-posters.mjs --json     # also dump orphan
+ *                                                        # list to a JSON file
+ *
+ * Requires (from apps/backoffice/.env.local or the shell):
+ *   CLOUDINARY_CLOUD_NAME, CLOUDINARY_API_KEY, CLOUDINARY_API_SECRET,
+ *   NEXT_PUBLIC_LOYALTY_SUPABASE_URL, LOYALTY_SUPABASE_SERVICE_ROLE_KEY
+ */
+import { writeFileSync } from "node:fs";
+import {
+  loadEnv,
+  configureCloudinary,
+  getSupabase,
+  listPosterAssets,
+  loadReferencedUrls,
+  partitionOrphans,
+  sumBytes,
+  formatBytes,
+} from "./lib/cloudinary-posters.mjs";
+
+loadEnv();
+configureCloudinary();
+const sb = getSupabase();
+
+console.log("Scanning Cloudinary posters + Supabase references…\n");
+
+const [assets, refs] = await Promise.all([
+  listPosterAssets(),
+  loadReferencedUrls(sb),
+]);
+const { referenced, orphans } = partitionOrphans(assets, refs);
+
+const totalBytes = sumBytes(assets);
+const orphanBytes = sumBytes(orphans);
+
+console.log("─────────────────────────────────────────────");
+console.log(`Poster assets in Cloudinary : ${assets.length} (${formatBytes(totalBytes)})`);
+console.log(`Still referenced            : ${referenced.length} (${formatBytes(sumBytes(referenced))})`);
+console.log(`Orphaned (reclaimable)      : ${orphans.length} (${formatBytes(orphanBytes)})`);
+if (totalBytes > 0) {
+  console.log(`Reclaimable share           : ${((orphanBytes / totalBytes) * 100).toFixed(1)}% of poster storage`);
+}
+console.log("─────────────────────────────────────────────");
+
+if (orphans.length > 0) {
+  const withDates = orphans.filter((a) => a.createdAt);
+  if (withDates.length > 0) {
+    const sorted = [...withDates].sort((a, b) => a.createdAt.localeCompare(b.createdAt));
+    console.log(`\nOldest orphan: ${sorted[0].createdAt}`);
+    console.log(`Newest orphan: ${sorted[sorted.length - 1].createdAt}`);
+  }
+  console.log("\nSample of orphaned assets (up to 10):");
+  for (const a of orphans.slice(0, 10)) {
+    console.log(`  ${a.publicId}  (${formatBytes(a.bytes)})`);
+  }
+  if (orphans.length > 10) console.log(`  …and ${orphans.length - 10} more.`);
+  console.log("\nNext step: node scripts/prune-cloudinary-posters.mjs   (dry run, safe)");
+} else {
+  console.log("\nNo orphaned poster assets — nothing to reclaim. 🎉");
+}
+
+if (process.argv.includes("--json")) {
+  const out = "cloudinary-orphans.json";
+  writeFileSync(
+    out,
+    JSON.stringify(
+      {
+        generatedAt: new Date().toISOString(),
+        totalAssets: assets.length,
+        orphanCount: orphans.length,
+        reclaimableBytes: orphanBytes,
+        orphans: orphans.map((a) => ({ publicId: a.publicId, bytes: a.bytes, createdAt: a.createdAt })),
+      },
+      null,
+      2,
+    ),
+  );
+  console.log(`\nWrote orphan list → ${out}`);
+}

--- a/apps/backoffice/scripts/lib/cloudinary-posters.mjs
+++ b/apps/backoffice/scripts/lib/cloudinary-posters.mjs
@@ -1,0 +1,153 @@
+/**
+ * Shared logic for the Cloudinary poster storage tools.
+ *
+ * Posters are the one unbounded source of Cloudinary growth: every upload,
+ * Re-crop and AI-compose save mints a fresh `celsius-coffee/posters/{uuid}`
+ * asset, and nothing ever deletes the old one (DELETE only removes the
+ * Supabase row). Over time orphaned poster assets pile up and eat the plan.
+ *
+ * A poster row can reference a Cloudinary asset in three places:
+ *   - image_url        (the live, displayed image)
+ *   - original_bg_url  (clean pre-flatten bg, anchor for AI re-compose)
+ *   - composer_state.bgUrl
+ *
+ * `duplicate()` copies all three, so MULTIPLE rows can point at the SAME
+ * asset. That's why deletion has to be reference-aware: an asset is only an
+ * orphan when NO row references it. Both the audit and prune tools build on
+ * the helpers here so they share one definition of "orphan".
+ */
+import { v2 as cloudinary } from "cloudinary";
+import { createClient } from "@supabase/supabase-js";
+import { readFileSync } from "node:fs";
+import { resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const BACKOFFICE_ROOT = resolve(HERE, "..", "..");
+
+// Deletes are scoped to this prefix and NOTHING else. Product images live
+// under celsius-coffee/products/ and are referenced by the products table,
+// not splash_posters — sweeping them here would delete in-use assets.
+export const POSTER_PREFIX = "celsius-coffee/posters";
+
+// Minimal .env.local loader — backoffice has no dotenv dep. A real
+// process.env value always wins, so shell / CI exports override the file.
+export function loadEnv() {
+  try {
+    const raw = readFileSync(resolve(BACKOFFICE_ROOT, ".env.local"), "utf8");
+    for (const line of raw.split("\n")) {
+      const t = line.trim();
+      if (!t || t.startsWith("#")) continue;
+      const eq = t.indexOf("=");
+      if (eq === -1) continue;
+      const key = t.slice(0, eq).trim();
+      if (process.env[key] !== undefined) continue;
+      let val = t.slice(eq + 1).trim();
+      if (
+        (val.startsWith('"') && val.endsWith('"')) ||
+        (val.startsWith("'") && val.endsWith("'"))
+      ) {
+        val = val.slice(1, -1);
+      }
+      process.env[key] = val;
+    }
+  } catch {
+    // No .env.local — rely entirely on the process environment.
+  }
+}
+
+function requireEnv(name) {
+  const v = process.env[name];
+  if (!v) {
+    throw new Error(
+      `Missing required env var: ${name}. Set it in apps/backoffice/.env.local or export it.`,
+    );
+  }
+  return v;
+}
+
+export function configureCloudinary() {
+  cloudinary.config({
+    cloud_name: requireEnv("CLOUDINARY_CLOUD_NAME"),
+    api_key:    requireEnv("CLOUDINARY_API_KEY"),
+    api_secret: requireEnv("CLOUDINARY_API_SECRET"),
+    secure:     true,
+  });
+  return cloudinary;
+}
+
+export function getSupabase() {
+  return createClient(
+    requireEnv("NEXT_PUBLIC_LOYALTY_SUPABASE_URL"),
+    requireEnv("LOYALTY_SUPABASE_SERVICE_ROLE_KEY"),
+  );
+}
+
+// List every Cloudinary asset under the posters prefix (paginated — the
+// Admin API caps a page at 500 results).
+export async function listPosterAssets() {
+  const assets = [];
+  let nextCursor;
+  do {
+    const res = await cloudinary.api.resources({
+      resource_type: "image",
+      type:          "upload",
+      prefix:        POSTER_PREFIX,
+      max_results:   500,
+      next_cursor:   nextCursor,
+    });
+    for (const r of res.resources ?? []) {
+      assets.push({
+        publicId:  r.public_id,
+        bytes:     r.bytes ?? 0,
+        createdAt: r.created_at ?? null,
+        url:       r.secure_url ?? "",
+      });
+    }
+    nextCursor = res.next_cursor;
+  } while (nextCursor);
+  return assets;
+}
+
+// Every Cloudinary URL referenced by a poster row (see file header).
+export async function loadReferencedUrls(sb) {
+  const { data, error } = await sb
+    .from("splash_posters")
+    .select("image_url, original_bg_url, composer_state");
+  if (error) throw new Error(`Supabase fetch error: ${error.message}`);
+
+  const refs = [];
+  for (const row of data ?? []) {
+    if (row.image_url) refs.push(row.image_url);
+    if (row.original_bg_url) refs.push(row.original_bg_url);
+    const cs = row.composer_state;
+    if (cs && typeof cs === "object" && typeof cs.bgUrl === "string") {
+      refs.push(cs.bgUrl);
+    }
+  }
+  return refs;
+}
+
+// Split assets into referenced vs orphaned. An asset counts as referenced
+// when its public_id appears anywhere in any referenced URL — robust
+// against version prefixes, inline transformations and cache-bust query
+// strings, all of which leave the public_id intact in the URL path.
+export function partitionOrphans(assets, referencedUrls) {
+  const haystack = referencedUrls.join("\n");
+  const referenced = [];
+  const orphans = [];
+  for (const a of assets) {
+    if (haystack.includes(a.publicId)) referenced.push(a);
+    else orphans.push(a);
+  }
+  return { referenced, orphans };
+}
+
+export const sumBytes = (xs) => xs.reduce((t, a) => t + a.bytes, 0);
+
+export function formatBytes(n) {
+  if (!n) return "0 B";
+  const units = ["B", "KB", "MB", "GB", "TB"];
+  const i = Math.floor(Math.log(n) / Math.log(1024));
+  return `${(n / 1024 ** i).toFixed(i ? 2 : 0)} ${units[i]}`;
+}

--- a/apps/backoffice/scripts/prune-cloudinary-posters.mjs
+++ b/apps/backoffice/scripts/prune-cloudinary-posters.mjs
@@ -1,0 +1,84 @@
+#!/usr/bin/env node
+/**
+ * Delete orphaned Cloudinary poster assets — DRY RUN by default.
+ *
+ * An asset is deleted only if NO splash_posters row references it (across
+ * image_url, original_bg_url and composer_state.bgUrl), so posters created
+ * via duplicate() that share an asset are never broken. Scoped strictly to
+ * the celsius-coffee/posters/ prefix — product images are never touched.
+ *
+ * Usage:
+ *   node scripts/prune-cloudinary-posters.mjs            # DRY RUN (no deletes)
+ *   node scripts/prune-cloudinary-posters.mjs --apply    # actually delete
+ *
+ * Run the audit first to see the number:
+ *   node scripts/audit-cloudinary-posters.mjs
+ */
+import {
+  loadEnv,
+  configureCloudinary,
+  getSupabase,
+  listPosterAssets,
+  loadReferencedUrls,
+  partitionOrphans,
+  sumBytes,
+  formatBytes,
+  POSTER_PREFIX,
+} from "./lib/cloudinary-posters.mjs";
+
+const apply = process.argv.includes("--apply");
+
+loadEnv();
+const cloudinary = configureCloudinary();
+const sb = getSupabase();
+
+console.log(`Scanning for orphaned poster assets… (${apply ? "APPLY" : "DRY RUN"})\n`);
+
+const [assets, refs] = await Promise.all([
+  listPosterAssets(),
+  loadReferencedUrls(sb),
+]);
+const { orphans } = partitionOrphans(assets, refs);
+const orphanBytes = sumBytes(orphans);
+
+if (orphans.length === 0) {
+  console.log("No orphaned poster assets. Nothing to do. 🎉");
+  process.exit(0);
+}
+
+console.log(`${orphans.length} orphaned poster assets — ${formatBytes(orphanBytes)} reclaimable.\n`);
+
+// Defence in depth: never delete anything outside the posters prefix, even
+// if the listing logic ever changes upstream.
+const ids = orphans.map((a) => a.publicId);
+const outOfScope = ids.filter((id) => !id.startsWith(`${POSTER_PREFIX}/`));
+if (outOfScope.length > 0) {
+  console.error("Refusing to run — found assets outside the posters prefix:");
+  for (const id of outOfScope.slice(0, 5)) console.error(`  ${id}`);
+  process.exit(1);
+}
+
+if (!apply) {
+  console.log("DRY RUN — nothing deleted. First 20 that WOULD be deleted:");
+  for (const a of orphans.slice(0, 20)) {
+    console.log(`  ${a.publicId}  (${formatBytes(a.bytes)})`);
+  }
+  if (orphans.length > 20) console.log(`  …and ${orphans.length - 20} more.`);
+  console.log("\nRe-run with --apply to delete them.");
+  process.exit(0);
+}
+
+// Cloudinary's delete_resources caps at 100 public_ids per call.
+let deleted = 0;
+for (let i = 0; i < ids.length; i += 100) {
+  const chunk = ids.slice(i, i + 100);
+  const res = await cloudinary.api.delete_resources(chunk, {
+    resource_type: "image",
+    type:          "upload",
+    invalidate:    true, // purge CDN caches for the removed assets
+  });
+  deleted += Object.values(res.deleted ?? {}).filter((v) => v === "deleted").length;
+  console.log(`  deleted ${deleted}/${ids.length}…`);
+}
+
+console.log(`\n✅ Done. Deleted ${deleted} orphaned poster assets (~${formatBytes(orphanBytes)} reclaimed).`);

--- a/apps/backoffice/scripts/prune-cloudinary-posters.mjs
+++ b/apps/backoffice/scripts/prune-cloudinary-posters.mjs
@@ -38,6 +38,18 @@ const [assets, refs] = await Promise.all([
   listPosterAssets(),
   loadReferencedUrls(sb),
 ]);
+
+// Circuit breaker: if Cloudinary has poster assets but Supabase returned
+// zero references, the query almost certainly failed/misconfigured. Refuse
+// to treat everything as an orphan and mass-delete.
+if (assets.length > 0 && refs.length === 0) {
+  console.error(
+    `Aborting: found ${assets.length} poster assets but 0 references in splash_posters.\n` +
+      "That looks like a failed/misconfigured Supabase query, not a real cleanup.",
+  );
+  process.exit(1);
+}
+
 const { orphans } = partitionOrphans(assets, refs);
 const orphanBytes = sumBytes(orphans);
 

--- a/apps/backoffice/src/app/api/cron/prune-poster-assets/route.ts
+++ b/apps/backoffice/src/app/api/cron/prune-poster-assets/route.ts
@@ -1,0 +1,102 @@
+import { NextRequest, NextResponse } from "next/server";
+import { v2 as cloudinary } from "cloudinary";
+import { getSupabaseAdmin } from "@/lib/pickup/supabase";
+import { checkCronAuth } from "@celsius/shared";
+import {
+  listPosterAssets,
+  loadReferencedUrls,
+  partitionOrphans,
+  selectDeletableOrphans,
+  POSTER_PREFIX,
+} from "@/lib/pickup/cloudinary-posters";
+
+export const dynamic = "force-dynamic";
+export const maxDuration = 60;
+
+/**
+ * GET /api/cron/prune-poster-assets  (Vercel Cron, weekly)
+ *
+ * Reclaims orphaned Cloudinary poster assets. Every poster upload, Re-crop
+ * and AI-compose save mints a fresh celsius-coffee/posters/{uuid} asset and
+ * nothing removes the old one (DELETE drops only the Supabase row), so dead
+ * assets accumulate and overflow the plan. This sweep deletes assets that no
+ * splash_posters row references (across image_url, original_bg_url and
+ * composer_state.bgUrl), so posters sharing an image via duplicate() are
+ * never broken.
+ *
+ * Safety:
+ *   - Scoped strictly to the posters prefix — product images are untouched.
+ *   - GRACE_DAYS window: the upload flow stores the asset in Cloudinary
+ *     before the operator saves the row, so a fresh unreferenced asset may
+ *     be mid-edit, not abandoned. We only delete orphans older than that.
+ *   - Idempotent: a deleted asset stops appearing, so re-runs are no-ops.
+ */
+const GRACE_DAYS = 7;
+
+export async function GET(req: NextRequest) {
+  const cronAuth = checkCronAuth(req.headers);
+  if (!cronAuth.ok) {
+    return NextResponse.json({ error: cronAuth.error }, { status: cronAuth.status });
+  }
+
+  // Fail-closed if Cloudinary isn't configured, rather than half-running.
+  const cloudName = process.env.CLOUDINARY_CLOUD_NAME;
+  const apiKey = process.env.CLOUDINARY_API_KEY;
+  const apiSecret = process.env.CLOUDINARY_API_SECRET;
+  if (!cloudName || !apiKey || !apiSecret) {
+    return NextResponse.json({ error: "Cloudinary not configured" }, { status: 500 });
+  }
+  cloudinary.config({
+    cloud_name: cloudName,
+    api_key: apiKey,
+    api_secret: apiSecret,
+    secure: true,
+  });
+
+  const supabase = getSupabaseAdmin();
+
+  const [assets, refs] = await Promise.all([
+    listPosterAssets(cloudinary),
+    loadReferencedUrls(supabase),
+  ]);
+  const { orphans } = partitionOrphans(assets, refs);
+  const deletable = selectDeletableOrphans(orphans, GRACE_DAYS * 86_400_000);
+
+  // Defence in depth: never touch anything outside the posters prefix, even
+  // if the listing logic ever changes upstream.
+  const bytesById = new Map(deletable.map((a) => [a.publicId, a.bytes]));
+  const ids = deletable
+    .map((a) => a.publicId)
+    .filter((id) => id.startsWith(`${POSTER_PREFIX}/`));
+
+  let deleted = 0;
+  let reclaimedBytes = 0;
+  // Cloudinary's delete_resources caps at 100 public_ids per call.
+  for (let i = 0; i < ids.length; i += 100) {
+    const chunk = ids.slice(i, i + 100);
+    const res = await cloudinary.api.delete_resources(chunk, {
+      resource_type: "image",
+      type: "upload",
+      invalidate: true, // purge CDN caches for the removed assets
+    });
+    for (const [id, status] of Object.entries(res.deleted ?? {})) {
+      if (status === "deleted") {
+        deleted += 1;
+        reclaimedBytes += bytesById.get(id) ?? 0;
+      }
+    }
+  }
+
+  const summary = {
+    scanned: assets.length,
+    orphans: orphans.length,
+    skippedWithinGrace: orphans.length - deletable.length,
+    deleted,
+    reclaimedBytes,
+    graceDays: GRACE_DAYS,
+  };
+  if (deleted > 0) {
+    console.log("[cron/prune-poster-assets]", JSON.stringify(summary));
+  }
+  return NextResponse.json({ ok: true, ...summary });
+}

--- a/apps/backoffice/src/app/api/cron/prune-poster-assets/route.ts
+++ b/apps/backoffice/src/app/api/cron/prune-poster-assets/route.ts
@@ -7,6 +7,7 @@ import {
   loadReferencedUrls,
   partitionOrphans,
   selectDeletableOrphans,
+  referencesLookSafe,
   POSTER_PREFIX,
 } from "@/lib/pickup/cloudinary-posters";
 
@@ -59,6 +60,16 @@ export async function GET(req: NextRequest) {
     listPosterAssets(cloudinary),
     loadReferencedUrls(supabase),
   ]);
+  // Circuit breaker: never mass-delete when the reference query came back
+  // empty while Cloudinary has assets — that signals a failed/misconfigured
+  // query, not that every poster is genuinely orphaned.
+  if (!referencesLookSafe(assets.length, refs.length)) {
+    return NextResponse.json(
+      { error: "Aborting: poster assets exist but zero references loaded" },
+      { status: 500 },
+    );
+  }
+
   const { orphans } = partitionOrphans(assets, refs);
   const deletable = selectDeletableOrphans(orphans, GRACE_DAYS * 86_400_000);
 

--- a/apps/backoffice/src/lib/pickup/cloudinary-posters.test.ts
+++ b/apps/backoffice/src/lib/pickup/cloudinary-posters.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect } from "vitest";
+import {
+  partitionOrphans,
+  selectDeletableOrphans,
+  type PosterAsset,
+} from "./cloudinary-posters";
+
+const asset = (publicId: string, extra: Partial<PosterAsset> = {}): PosterAsset => ({
+  publicId,
+  bytes: 1000,
+  createdAt: null,
+  ...extra,
+});
+
+describe("partitionOrphans", () => {
+  it("treats an asset as referenced when its public_id appears in any URL", () => {
+    const assets = [
+      asset("celsius-coffee/posters/aaa"),
+      asset("celsius-coffee/posters/bbb"),
+    ];
+    const refs = [
+      "https://res.cloudinary.com/x/image/upload/v123/celsius-coffee/posters/aaa.jpg",
+    ];
+    const { referenced, orphans } = partitionOrphans(assets, refs);
+    expect(referenced.map((a) => a.publicId)).toEqual(["celsius-coffee/posters/aaa"]);
+    expect(orphans.map((a) => a.publicId)).toEqual(["celsius-coffee/posters/bbb"]);
+  });
+
+  it("matches despite transformations and cache-bust query strings", () => {
+    const assets = [asset("celsius-coffee/posters/ccc")];
+    const refs = [
+      "https://res.cloudinary.com/x/image/upload/q_auto,f_auto/v9/celsius-coffee/posters/ccc.webp?b=171717",
+    ];
+    expect(partitionOrphans(assets, refs).orphans).toHaveLength(0);
+  });
+
+  it("counts an asset referenced only via composer_state.bgUrl / original_bg_url", () => {
+    // loadReferencedUrls flattens all three fields into the URL list; here
+    // we just prove a non-image_url reference still protects the asset.
+    const assets = [asset("celsius-coffee/posters/ddd")];
+    const refs = ["https://res.cloudinary.com/x/image/upload/celsius-coffee/posters/ddd"];
+    expect(partitionOrphans(assets, refs).orphans).toHaveLength(0);
+  });
+
+  it("flags assets referenced by nothing", () => {
+    const assets = [asset("celsius-coffee/posters/eee")];
+    expect(partitionOrphans(assets, []).orphans).toHaveLength(1);
+  });
+});
+
+describe("selectDeletableOrphans", () => {
+  const now = Date.parse("2026-06-20T00:00:00Z");
+  const graceMs = 7 * 86_400_000;
+
+  it("keeps (does not delete) orphans inside the grace window", () => {
+    const fresh = asset("celsius-coffee/posters/new", {
+      createdAt: "2026-06-19T00:00:00Z", // 1 day old
+    });
+    expect(selectDeletableOrphans([fresh], graceMs, now)).toHaveLength(0);
+  });
+
+  it("deletes orphans older than the grace window", () => {
+    const old = asset("celsius-coffee/posters/old", {
+      createdAt: "2026-06-01T00:00:00Z", // ~19 days old
+    });
+    expect(selectDeletableOrphans([old], graceMs, now)).toHaveLength(1);
+  });
+
+  it("never deletes an orphan with unknown or unparseable age", () => {
+    const noDate = asset("celsius-coffee/posters/x", { createdAt: null });
+    const badDate = asset("celsius-coffee/posters/y", { createdAt: "not-a-date" });
+    expect(selectDeletableOrphans([noDate, badDate], graceMs, now)).toHaveLength(0);
+  });
+});

--- a/apps/backoffice/src/lib/pickup/cloudinary-posters.test.ts
+++ b/apps/backoffice/src/lib/pickup/cloudinary-posters.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from "vitest";
 import {
   partitionOrphans,
   selectDeletableOrphans,
+  referencesLookSafe,
   type PosterAsset,
 } from "./cloudinary-posters";
 
@@ -70,5 +71,19 @@ describe("selectDeletableOrphans", () => {
     const noDate = asset("celsius-coffee/posters/x", { createdAt: null });
     const badDate = asset("celsius-coffee/posters/y", { createdAt: "not-a-date" });
     expect(selectDeletableOrphans([noDate, badDate], graceMs, now)).toHaveLength(0);
+  });
+});
+
+describe("referencesLookSafe", () => {
+  it("flags the catastrophic case: assets exist but zero references loaded", () => {
+    expect(referencesLookSafe(42, 0)).toBe(false);
+  });
+
+  it("allows a normal run with references present", () => {
+    expect(referencesLookSafe(42, 10)).toBe(true);
+  });
+
+  it("allows an empty Cloudinary (nothing to delete anyway)", () => {
+    expect(referencesLookSafe(0, 0)).toBe(true);
   });
 });

--- a/apps/backoffice/src/lib/pickup/cloudinary-posters.ts
+++ b/apps/backoffice/src/lib/pickup/cloudinary-posters.ts
@@ -122,3 +122,12 @@ export function selectDeletableOrphans(
     return now - created >= graceMs;
   });
 }
+
+// Circuit breaker against catastrophic mass-deletion. If Cloudinary holds
+// poster assets but the Supabase reference query came back EMPTY, the query
+// almost certainly failed or is misconfigured (wrong project, renamed
+// table, outage) rather than every poster genuinely being orphaned. In that
+// case every asset would look like an orphan — refuse to proceed instead.
+export function referencesLookSafe(assetCount: number, referenceCount: number): boolean {
+  return !(assetCount > 0 && referenceCount === 0);
+}

--- a/apps/backoffice/src/lib/pickup/cloudinary-posters.ts
+++ b/apps/backoffice/src/lib/pickup/cloudinary-posters.ts
@@ -1,0 +1,124 @@
+/**
+ * Orphan-detection for Cloudinary poster assets — the canonical logic used
+ * by the prune cron (api/cron/prune-poster-assets).
+ *
+ * Posters are the one unbounded source of Cloudinary growth: every upload,
+ * Re-crop and AI-compose save mints a fresh `celsius-coffee/posters/{uuid}`
+ * asset, and nothing removes the old one (DELETE drops only the Supabase
+ * row). A poster row can reference an asset in THREE places:
+ *   - image_url        (the live, displayed image)
+ *   - original_bg_url  (clean pre-flatten bg, anchor for AI re-compose)
+ *   - composer_state.bgUrl
+ *
+ * `duplicate()` copies all three, so multiple rows can share one asset —
+ * an asset is therefore only an orphan when NO row references it.
+ *
+ * NOTE: the manual CLI tools in apps/backoffice/scripts/lib/cloudinary-posters.mjs
+ * mirror this logic. If you add a Cloudinary URL field to splash_posters,
+ * update BOTH or a sweep could delete an in-use asset.
+ */
+import type { SupabaseClient } from "@supabase/supabase-js";
+
+// Deletes are scoped to this prefix and nothing else. Product images live
+// under celsius-coffee/products/ and are referenced by the products table,
+// not splash_posters — sweeping them here would delete in-use assets.
+export const POSTER_PREFIX = "celsius-coffee/posters";
+
+export type PosterAsset = {
+  publicId: string;
+  bytes: number;
+  createdAt: string | null;
+};
+
+// Minimal shape of the Cloudinary v2 Admin API we depend on — keeps this
+// module unit-testable without importing the SDK.
+export interface CloudinaryResourceLister {
+  api: {
+    resources(options: Record<string, unknown>): Promise<{
+      resources?: Array<{ public_id: string; bytes?: number; created_at?: string }>;
+      next_cursor?: string;
+    }>;
+  };
+}
+
+// List every Cloudinary asset under the posters prefix (paginated — the
+// Admin API caps a page at 500 results).
+export async function listPosterAssets(
+  cloudinary: CloudinaryResourceLister,
+): Promise<PosterAsset[]> {
+  const assets: PosterAsset[] = [];
+  let nextCursor: string | undefined;
+  do {
+    const res = await cloudinary.api.resources({
+      resource_type: "image",
+      type: "upload",
+      prefix: POSTER_PREFIX,
+      max_results: 500,
+      next_cursor: nextCursor,
+    });
+    for (const r of res.resources ?? []) {
+      assets.push({
+        publicId: r.public_id,
+        bytes: r.bytes ?? 0,
+        createdAt: r.created_at ?? null,
+      });
+    }
+    nextCursor = res.next_cursor;
+  } while (nextCursor);
+  return assets;
+}
+
+// Every Cloudinary URL referenced by a poster row (see file header).
+export async function loadReferencedUrls(sb: SupabaseClient): Promise<string[]> {
+  const { data, error } = await sb
+    .from("splash_posters")
+    .select("image_url, original_bg_url, composer_state");
+  if (error) throw new Error(`Supabase fetch error: ${error.message}`);
+
+  const refs: string[] = [];
+  for (const row of (data ?? []) as Array<Record<string, unknown>>) {
+    if (typeof row.image_url === "string") refs.push(row.image_url);
+    if (typeof row.original_bg_url === "string") refs.push(row.original_bg_url);
+    const cs = row.composer_state;
+    if (cs && typeof cs === "object" && typeof (cs as { bgUrl?: unknown }).bgUrl === "string") {
+      refs.push((cs as { bgUrl: string }).bgUrl);
+    }
+  }
+  return refs;
+}
+
+// Split assets into referenced vs orphaned. An asset counts as referenced
+// when its public_id appears anywhere in any referenced URL — robust
+// against version prefixes, inline transformations and cache-bust query
+// strings, all of which leave the public_id intact in the URL path.
+export function partitionOrphans(
+  assets: PosterAsset[],
+  referencedUrls: string[],
+): { referenced: PosterAsset[]; orphans: PosterAsset[] } {
+  const haystack = referencedUrls.join("\n");
+  const referenced: PosterAsset[] = [];
+  const orphans: PosterAsset[] = [];
+  for (const a of assets) {
+    if (a.publicId && haystack.includes(a.publicId)) referenced.push(a);
+    else orphans.push(a);
+  }
+  return { referenced, orphans };
+}
+
+// Orphans younger than the grace window are NOT eligible for automated
+// deletion. The poster upload flow stores an image in Cloudinary BEFORE the
+// operator clicks Save, so a brand-new asset is briefly unreferenced while
+// it's mid-edit — deleting it would destroy an image about to be saved.
+// Assets with an unknown/unparseable age are never auto-deleted (conservative).
+export function selectDeletableOrphans(
+  orphans: PosterAsset[],
+  graceMs: number,
+  now: number = Date.now(),
+): PosterAsset[] {
+  return orphans.filter((a) => {
+    if (!a.createdAt) return false;
+    const created = Date.parse(a.createdAt);
+    if (Number.isNaN(created)) return false;
+    return now - created >= graceMs;
+  });
+}

--- a/apps/backoffice/vercel.json
+++ b/apps/backoffice/vercel.json
@@ -67,6 +67,10 @@
     {
       "path": "/api/cron/grab-reconcile",
       "schedule": "*/15 * * * *"
+    },
+    {
+      "path": "/api/cron/prune-poster-assets",
+      "schedule": "30 3 * * 1"
     }
   ]
 }

--- a/apps/order/scripts/restore-image-urls.mjs
+++ b/apps/order/scripts/restore-image-urls.mjs
@@ -23,14 +23,15 @@ config({ path: resolve(__dirname, '../.env.local') });
 const SUPABASE_URL = process.env.NEXT_PUBLIC_SUPABASE_URL;
 const SUPABASE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY;
 
-if (!SUPABASE_URL || !SUPABASE_KEY) {
-  console.error('Missing NEXT_PUBLIC_SUPABASE_URL or SUPABASE_SERVICE_ROLE_KEY');
+// Read from env (.env.local) — never hardcode secrets in source.
+const CLOUDINARY_CLOUD = process.env.CLOUDINARY_CLOUD_NAME;
+const CLOUDINARY_API_KEY = process.env.CLOUDINARY_API_KEY;
+const CLOUDINARY_API_SECRET = process.env.CLOUDINARY_API_SECRET;
+
+if (!SUPABASE_URL || !SUPABASE_KEY || !CLOUDINARY_CLOUD || !CLOUDINARY_API_KEY || !CLOUDINARY_API_SECRET) {
+  console.error('Missing required env vars: NEXT_PUBLIC_SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY, CLOUDINARY_CLOUD_NAME, CLOUDINARY_API_KEY, CLOUDINARY_API_SECRET');
   process.exit(1);
 }
-
-const CLOUDINARY_CLOUD = 'dxxzt7k6i';
-const CLOUDINARY_API_KEY = '657996329467423';
-const CLOUDINARY_API_SECRET = 'pt5FZsyXdPKU1KPsNmJAPlGc2zs';
 
 const supabase = createClient(SUPABASE_URL, SUPABASE_KEY);
 


### PR DESCRIPTION
## Why
Cloudinary (our image store, not our DB) was overflowing. Root cause: **posters are an unbounded leak** — every poster upload, Re-crop and AI-compose save mints a fresh `celsius-coffee/posters/{uuid}` asset, and nothing ever removes the old one (DELETE drops only the Supabase row). Orphaned poster assets accumulate forever. Product images are fine (they overwrite in place). The fix is cleanup + automation, not a platform migration.

## What
- **Audit tool** (`npm run audit:posters`) — read-only report of total vs referenced vs reclaimable poster assets.
- **Prune tool** (`npm run prune:posters`, `-- --apply` to delete) — dry-run by default; scoped strictly to the posters prefix.
- **Weekly cron** (`/api/cron/prune-poster-assets`, Mon 03:30 sin1) — automated steady-state sweep using the existing fail-closed `checkCronAuth`.
- **Shared orphan logic** (`src/lib/pickup/cloudinary-posters.ts`) with unit tests.
- **Security fix** — `apps/order/scripts/restore-image-urls.mjs` now reads Cloudinary creds from env instead of hardcoded secrets in source.

## Safety
- **Reference-aware**: an asset is deleted only when *no* `splash_posters` row references it across `image_url`, `original_bg_url`, and `composer_state.bgUrl` — so posters that share an image via `duplicate()` are never broken.
- **7-day grace window**: the upload flow stores an asset before the operator saves the row, so fresh unreferenced assets (mid-edit) are never auto-deleted.
- **Circuit breaker**: aborts if Cloudinary has assets but the reference query returns zero rows (guards against a failed/misconfigured query mass-deleting everything).
- **Prefix-scoped** with defence-in-depth filter — product images are never touched.
- Fail-closed auth + fail-closed on missing Cloudinary env. Idempotent.

## Verification
- 10 unit tests for the orphan match, grace window, and circuit breaker; full suite 76/76 green.
- `tsc --noEmit` clean, `eslint` clean.

## Post-merge required (manual)
1. **Rotate the leaked Cloudinary keys** — the old hardcoded secret remains in git history, so treat it as compromised.
2. **Set `CLOUDINARY_*` env vars on the backoffice Vercel project** — the cron needs them.
3. **Recommended rollout**: run the manual `prune:posters -- --apply` once under human supervision for the big initial cleanup, then let the weekly cron handle the trickle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ErZGLRw1HCKvy8kyY3ydyE

---
_Generated by [Claude Code](https://claude.ai/code/session_01ErZGLRw1HCKvy8kyY3ydyE)_