### PR TITLE
Loyalty Phase 3b: serve OTP natively (drop proxy hop)

### DIFF
--- a/apps/order/src/app/api/loyalty/otp/send/route.ts
+++ b/apps/order/src/app/api/loyalty/otp/send/route.ts
@@ -1,8 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { supabaseAdmin } from "@/lib/supabase";
-
-// .trim() guards against accidental trailing newlines in env var values
-const LOYALTY_BASE = (process.env.LOYALTY_BASE_URL ?? "https://loyalty.celsiuscoffee.com").trim();
+import { sendOTP } from "@/lib/otp";
+import { checkRateLimit, RATE_LIMITS } from "@/lib/rate-limit";
 
 // Match every common stored shape — "+60123456789", "60123456789", "0123456789",
 // "123456789", etc. — so the existing-member lookup doesn't miss a customer
@@ -47,32 +46,37 @@ async function isReturningCustomer(phone: string): Promise<boolean> {
   return (count ?? 0) > 0;
 }
 
-// POST /api/loyalty/otp/send — proxy to loyalty app
+// POST /api/loyalty/otp/send — legacy alias for /api/otp/send.
+//
+// Resolves natively (shared OTP store + SMS via @/lib/otp) instead of proxying
+// to the loyalty app, so it no longer depends on loyalty.celsiuscoffee.com.
+// Current clients call /api/otp/send directly; this stays as a thin back-compat
+// endpoint for any older build still on the old path. The OTP store is the same
+// shared Supabase the native route uses, so codes are interchangeable.
 export async function POST(request: NextRequest) {
   try {
     const { phone } = await request.json();
     if (!phone) return NextResponse.json({ success: false, error: "Phone required" }, { status: 400 });
 
-    // Probe the customer's account state in parallel with the OTP send so
-    // we don't add latency to the SMS dispatch. The response carries
-    // `is_new_member` so the OTP screen can conditionally render the
-    // referral-code field.
-    const [proxyRes, returning] = await Promise.all([
-      fetch(`${LOYALTY_BASE}/api/otp/send`, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ phone, purpose: "login" }),
-      }),
+    // Rate-limit by phone (the loyalty endpoint used to enforce this).
+    const rate = await checkRateLimit(phone, RATE_LIMITS.OTP_SEND);
+    if (!rate.allowed) {
+      return NextResponse.json(
+        { success: false, error: `Too many OTP requests. Try again in ${Math.ceil((rate.retryAfter || 300) / 60)} minutes.` },
+        { status: 429 },
+      );
+    }
+
+    // Probe the customer's account state in parallel with the OTP send so we
+    // don't add latency to the SMS dispatch. `is_new_member` drives the OTP
+    // screen's referral-code field visibility.
+    const [data, returning] = await Promise.all([
+      sendOTP(phone, "login"),
       isReturningCustomer(phone).catch(() => false),
     ]);
-
-    const data = await proxyRes.json();
-    return NextResponse.json(
-      { ...data, is_new_member: !returning },
-      { status: proxyRes.status },
-    );
+    return NextResponse.json({ ...data, is_new_member: !returning });
   } catch (err) {
-    console.error("Loyalty OTP send error:", err);
+    console.error("OTP send error:", err);
     return NextResponse.json({ success: false, error: "Failed to send OTP" }, { status: 500 });
   }
 }

--- a/apps/order/src/app/api/loyalty/otp/verify/route.ts
+++ b/apps/order/src/app/api/loyalty/otp/verify/route.ts
@@ -1,34 +1,34 @@
 import { NextRequest, NextResponse } from "next/server";
+import { verifyOTP } from "@/lib/otp";
+import { checkRateLimit, RATE_LIMITS } from "@/lib/rate-limit";
 import { ensureNewMemberRewards } from "@/lib/loyalty/welcome";
 import { findOrCreateMember } from "@/lib/loyalty/member-direct";
 
-// .trim() guards against accidental trailing newlines in env var values
-const LOYALTY_BASE = (process.env.LOYALTY_BASE_URL ?? "https://loyalty.celsiuscoffee.com").trim();
-
-// POST /api/loyalty/otp/verify — verify OTP then fetch/create member
+// POST /api/loyalty/otp/verify — legacy alias for /api/otp/verify.
 //
-// Step 1 (OTP code validation) still proxies to the loyalty app
-// because the SMS gateway lives there. Step 2/3 (member lookup +
-// auto-register) NOW write to Supabase directly via
-// findOrCreateMember — the loyalty proxy used to silently drop
-// email/birthday and produce a different row shape from
-// backoffice-admin signups, which was the root cause of the
-// "Complete profile" pill resurfacing across mounts.
+// OTP code validation now runs natively (shared OTP store via @/lib/otp)
+// instead of proxying to the loyalty app, so it no longer depends on
+// loyalty.celsiuscoffee.com. Member lookup/create + welcome rewards are
+// unchanged (Supabase-direct via findOrCreateMember). Current clients call
+// /api/otp/verify directly; this stays as a thin back-compat endpoint.
 export async function POST(request: NextRequest) {
   try {
     const { phone, code } = await request.json();
     if (!phone || !code) return NextResponse.json({ success: false, error: "Phone and code required" }, { status: 400 });
 
-    // Step 1: Verify OTP (still via loyalty app — SMS gateway lives there)
-    const verifyRes = await fetch(`${LOYALTY_BASE}/api/otp/verify`, {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ phone, code, purpose: "login" }),
-    });
-    const verifyData = await verifyRes.json();
+    // Rate-limit by phone (the loyalty endpoint used to enforce this).
+    const rate = await checkRateLimit(phone, RATE_LIMITS.OTP_VERIFY);
+    if (!rate.allowed) {
+      return NextResponse.json(
+        { success: false, error: `Too many verification attempts. Try again in ${Math.ceil((rate.retryAfter || 300) / 60)} minutes.` },
+        { status: 429 },
+      );
+    }
 
-    if (!verifyData.success) {
-      return NextResponse.json({ success: false, error: verifyData.error ?? "Invalid or expired code" });
+    // Step 1: Verify the OTP code natively against the shared store.
+    const valid = await verifyOTP(phone, code, "login");
+    if (!valid) {
+      return NextResponse.json({ success: false, error: "Invalid or expired code" });
     }
 
     // Step 2/3: Find or create the member row in Supabase directly.


### PR DESCRIPTION
Second API of **Phase 3** (migrating the loyalty app's headless endpoints off the proxy so it can be turned off).

## Context — OTP was already 95% migrated
The order app already has a **complete native OTP implementation** (`/api/otp/send` + `/api/otp/verify`) built on the **shared** OTP store and SMS provider in `@celsius/shared` — and that's what **every current client uses** (pickup-native and order web both call `/api/otp/*`). The order app's Supabase **is** the loyalty DB (it calls `evaluate_member_tier` and reads `members`), so the native OTP store is the *same* store the loyalty app used.

The only thing still touching `loyalty.celsiuscoffee.com` for OTP was the legacy `/api/loyalty/otp/*` proxy — which has **no callers left in the repo** (only a stale code comment references it).

## Change
Rewire the two proxy routes to resolve OTP **natively** (`sendOTP`/`verifyOTP` from `@/lib/otp`) instead of fetching the loyalty app:
- `POST /api/loyalty/otp/send` → `sendOTP(...)` + the existing `is_new_member` probe
- `POST /api/loyalty/otp/verify` → `verifyOTP(...)` + the existing `findOrCreateMember` + welcome-rewards

**Response shapes are unchanged**, and the per-phone **rate-limit** the loyalty endpoint used to enforce is preserved.

## Why rewire instead of delete (careful, no-break)
Kept the endpoints as thin back-compat aliases so a **not-yet-updated native app build** still on `/api/loyalty/otp/*` can't 404 on OTP login — it now just works without the loyalty hop. Same shared store, so codes are interchangeable with `/api/otp/*`.

## Net
OTP no longer depends on `loyalty.celsiuscoffee.com`. Remaining Phase 3: **3c members** (`/api/members` via `v2-auth`), **3d promotions** (`evaluate`/`apply`, order + POS).

Not built locally (no `node_modules`) — order CI typecheck/lint/build will confirm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PfVviAtVbppgRTt5pG3D8j)_