### PR TITLE
Loyalty Phase 3c: resolve member lookup natively (drop proxy hop)

### DIFF
--- a/apps/order/src/lib/loyalty/member-direct.ts
+++ b/apps/order/src/lib/loyalty/member-direct.ts
@@ -134,3 +134,17 @@ export async function findOrCreateMember(phone: string): Promise<MemberRow | nul
     total_visits:        (brandRow?.total_visits as number | null)         ?? 0,
   };
 }
+
+/** Resolve a phone to an existing member id WITHOUT creating one. Returns
+ *  null when no member matches any phone variant. Used by the v2 /me/*
+ *  session resolver's fallback when a (legacy) session token carries no
+ *  member_id — replaces a proxy hop to loyalty.celsiuscoffee.com/api/members. */
+export async function lookupMemberIdByPhone(phone: string): Promise<string | null> {
+  const supabase = getSupabaseAdmin();
+  const { data } = await supabase
+    .from("members")
+    .select("id")
+    .in("phone", phoneVariants(phone))
+    .limit(1);
+  return data && data.length > 0 ? (data[0] as { id: string }).id : null;
+}

--- a/apps/order/src/lib/loyalty/v2-auth.ts
+++ b/apps/order/src/lib/loyalty/v2-auth.ts
@@ -3,9 +3,7 @@
 
 import type { NextRequest } from "next/server";
 import { requireCustomerSession } from "@/lib/customer-jwt";
-
-const LOYALTY_BASE = (process.env.LOYALTY_BASE_URL ?? "https://loyalty.celsiuscoffee.com").trim();
-const BRAND_ID     = (process.env.LOYALTY_BRAND_ID  ?? "brand-celsius").trim();
+import { lookupMemberIdByPhone } from "./member-direct";
 
 export type ResolvedMember = {
   memberId: string;
@@ -33,20 +31,19 @@ export async function resolveMember(req: NextRequest): Promise<
     return { member: { memberId: guard.session.sub, phone: guard.session.phone }, error: null };
   }
 
+  // Legacy fallback: a session token minted before member rows were always
+  // created at OTP verify can carry an empty `sub`. Resolve phone → member id
+  // directly against the shared Supabase (same store the rest of the app uses)
+  // instead of proxying to loyalty.celsiuscoffee.com.
   try {
-    const res = await fetch(
-      `${LOYALTY_BASE}/api/members?brand_id=${BRAND_ID}&phone=${encodeURIComponent(guard.session.phone)}`,
-      { headers: { "Content-Type": "application/json" } },
-    );
-    const rows = await res.json();
-    const member = Array.isArray(rows) && rows[0];
-    if (!member?.id) {
+    const memberId = await lookupMemberIdByPhone(guard.session.phone);
+    if (!memberId) {
       return {
         member: null,
         error: Response.json({ error: "Member not found" }, { status: 404 }),
       };
     }
-    return { member: { memberId: member.id as string, phone: guard.session.phone }, error: null };
+    return { member: { memberId, phone: guard.session.phone }, error: null };
   } catch {
     return {
       member: null,


### PR DESCRIPTION
Third API of **Phase 3** (migrating the loyalty app's headless endpoints off the proxy).

## Context
Member **create/register** was already native (`member-direct.findOrCreateMember`, Supabase-direct). The only `/api/members` dependency left on the loyalty app was a **legacy fallback** in `v2-auth.resolveMember()`: when a customer session token carries an empty `sub` (member_id), it resolved the member by phone via `loyalty.celsiuscoffee.com/api/members`.

That fallback is rarely hit now (OTP verify always mints `sub: memberId`), but it's still a `loyalty.celsiuscoffee.com` dependency.

## Change
- Add `member-direct.lookupMemberIdByPhone()` — a **lookup-only** (no create) phone→id resolver against the shared Supabase, reusing the same phone-variant logic as `findOrCreateMember`.
- Point `v2-auth`'s fallback at it; drop the `LOYALTY_BASE`/`BRAND_ID` proxy consts.

**Behaviour unchanged:** still returns `404 "Member not found"` when no member matches (lookup-only preserves that — it does *not* create), and `502` on an unexpected error. Same shared store, so it resolves the same rows the proxy did.

## Phase 3 tracker
- ✅ 3a member-tier, ✅ 3b OTP, **3c members (this)**
- ⬜ 3d promotions engine (`evaluate`/`apply`) — order **and** backoffice/POS, highest blast radius, last

(The remaining `member-tier` reference to `LOYALTY_BASE` is the Phase 3a auto-fallback kill-switch, not a live dependency.)

Not built locally (no `node_modules`) — order CI typecheck/lint/build will confirm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PfVviAtVbppgRTt5pG3D8j)_