### PR TITLE
Pair adds: count checkout conversions, split in-store/native/web

### DIFF
--- a/apps/order/src/app/api/orders/route.ts
+++ b/apps/order/src/app/api/orders/route.ts
@@ -643,6 +643,7 @@ export async function POST(request: NextRequest) {
       specialInstructions?: string;
       quantity:    number;
       totalPrice:  number;
+      isPair?:     boolean;
     };
     const orderItems = (items as AnyItem[]).map((item) => {
       const productId   = item.product?.id ?? item.productId ?? "";
@@ -668,6 +669,10 @@ export async function POST(request: NextRequest) {
         quantity:     item.quantity,
         item_total:   Math.round(item.totalPrice * 100),
         modifiers:    { selections, specialInstructions },
+        // Upsell attribution — true when the customer accepted a "Pair with a
+        // Bite" suggestion. Lets the sales dashboard count purchased pairs and
+        // split them native vs web via orders.source.
+        is_pair:      !!item.isPair,
       };
     });
 

--- a/apps/order/supabase/migrations/021_order_items_pair.sql
+++ b/apps/order/supabase/migrations/021_order_items_pair.sql
@@ -1,0 +1,16 @@
+-- Upsell ("Pair with a Bite") attribution on pickup/app order lines.
+--
+-- The native pickup app stages a suggested pair as its own cart line, but until
+-- now that signal only fired as an Amplitude `cart_add` event (add-to-cart) and
+-- was never persisted — so we could not measure pairs that actually CHECKED OUT.
+-- This flag marks an order line that originated from a pair suggestion, letting
+-- the sales dashboard count purchased upsells and split them native vs web (via
+-- orders.source). Forward-only: existing rows default to false.
+--
+-- Apply to the celsiuscoffee project (kqdcdhpnyuwrxqhbuyfl) via
+-- apply_migration "add_order_items_pair".
+ALTER TABLE public.order_items
+  ADD COLUMN IF NOT EXISTS is_pair boolean NOT NULL DEFAULT false;
+
+COMMENT ON COLUMN public.order_items.is_pair IS
+  'True when this line came from a "Pair with a Bite" upsell suggestion (pickup/app). Counted by the sales dashboard as a purchased pair. Forward-only; legacy rows are false.';

--- a/apps/pickup-native/app/checkout.tsx
+++ b/apps/pickup-native/app/checkout.tsx
@@ -758,6 +758,7 @@ export default function Checkout() {
             priceDelta: m.priceDelta,
           })),
           specialInstructions: i.specialInstructions,
+          isPair: i.isPair ?? false,
         })),
         rewardId: appliedReward?.id ?? null,
         rewardName: appliedReward?.name ?? null,

--- a/apps/pickup-native/app/product/[id].tsx
+++ b/apps/pickup-native/app/product/[id].tsx
@@ -400,6 +400,7 @@ export default function ProductScreen() {
           modifiers: pairSelections,
           specialInstructions: undefined,
           totalPrice: pair.price + pairModTotal,
+          isPair: true,
         });
         trackEvent("cart_add", {
           productId:   pair.id,

--- a/apps/pickup-native/lib/api.ts
+++ b/apps/pickup-native/lib/api.ts
@@ -118,6 +118,9 @@ export const api = {
       totalPrice: number;
       modifiers: Array<{ groupName: string; label: string; priceDelta: number }>;
       specialInstructions?: string;
+      /** Line came from a "Pair with a Bite" upsell suggestion. Persisted on
+       *  the order line so the sales dashboard can count purchased pairs. */
+      isPair?: boolean;
     }>;
     // Method id the customer picked in checkout (e.g. "card", "apple_pay",
     // "tng", "boost", "grabpay", "fpx"). Kept as a wide string so we don't

--- a/apps/pickup-native/lib/store.ts
+++ b/apps/pickup-native/lib/store.ts
@@ -27,6 +27,10 @@ export type CartItem = {
   modifiers: ModifierSelection[];
   specialInstructions?: string;
   totalPrice: number;
+  /** True when this line was added from a "Pair with a Bite" upsell
+   *  suggestion (vs. a direct product add). Carried through to the order so
+   *  the sales dashboard can count pairs that actually checked out. */
+  isPair?: boolean;
 };
 
 export type AppliedReward = {

--- a/apps/staff-native/app/(staff)/sales/index.tsx
+++ b/apps/staff-native/app/(staff)/sales/index.tsx
@@ -201,12 +201,19 @@ export default function SalesScreen() {
                 </View>
                 <Text className={`font-body-bold text-[13px] ${g.collectionDeltaPts >= 0 ? "text-[#34d399]" : "text-[#f87171]"}`}>{g.collectionDeltaPts >= 0 ? "+" : ""}{g.collectionDeltaPts}%</Text>
               </View>
-              <View className="mt-3.5 flex-row items-center justify-between border-t border-[#F5F3F00f] pt-3.5">
-                <View>
-                  <Text className="font-body-semi text-xs text-[#F5F3F08a]">Pair adds</Text>
-                  <Text className="mt-0.5 font-display text-lg text-[#F5F3F0]">{numF(g.pairAdds)}<Text className="font-body text-[13px] text-[#F5F3F08a]"> · upsell added to cart</Text></Text>
+              <View className="mt-3.5 border-t border-[#F5F3F00f] pt-3.5">
+                <View className="flex-row items-center justify-between">
+                  <View>
+                    <Text className="font-body-semi text-xs text-[#F5F3F08a]">Pair adds</Text>
+                    <Text className="mt-0.5 font-display text-lg text-[#F5F3F0]">{numF(g.pairAdds)}<Text className="font-body text-[13px] text-[#F5F3F08a]"> · upsells purchased</Text></Text>
+                  </View>
+                  <Text className={`font-body-bold text-[13px] ${deltaUp(g.pairAddsDelta) ? "text-[#34d399]" : "text-[#f87171]"}`}>{deltaStr(g.pairAddsDelta)}</Text>
                 </View>
-                <Text className={`font-body-bold text-[13px] ${deltaUp(g.pairAddsDelta) ? "text-[#34d399]" : "text-[#f87171]"}`}>{deltaStr(g.pairAddsDelta)}</Text>
+                <View className="mt-2.5 flex-row gap-2">
+                  <PairChip label="In-store" v={g.pairInstore} />
+                  <PairChip label="Native" v={g.pairNative} />
+                  <PairChip label="Web" v={g.pairWeb} />
+                </View>
               </View>
             </View>
 
@@ -278,6 +285,14 @@ function Tile({ icon: Icon, color, v, k, delta }: { icon: any; color: string; v:
       <Text className="font-display text-2xl text-[#F5F3F0]">{v}</Text>
       <Text className="mt-1 font-body text-[13px] text-[#F5F3F08a]">{k}</Text>
       <Text className={`mt-1.5 font-body-bold text-[13px] ${deltaUp(delta) ? "text-[#34d399]" : "text-[#f87171]"}`}>{deltaStr(delta)}</Text>
+    </View>
+  );
+}
+function PairChip({ label, v }: { label: string; v: number }) {
+  return (
+    <View className="flex-1 rounded-xl border border-[#F5F3F01a] bg-[#160800] px-3 py-2">
+      <Text className="font-display text-base text-[#F5F3F0]">{numF(v)}</Text>
+      <Text className="mt-0.5 font-body-semi text-[11px] uppercase tracking-wide text-[#F5F3F08a]">{label}</Text>
     </View>
   );
 }

--- a/apps/staff-native/lib/sales/dashboard.ts
+++ b/apps/staff-native/lib/sales/dashboard.ts
@@ -32,6 +32,7 @@ export type SalesDashboard = {
     appSharePct: number; appShareDeltaPts: number;
     capturedOrders: number; collectionRatePct: number; collectionDeltaPts: number;
     pairAdds: number; pairAddsDelta: number | null;
+    pairInstore: number; pairNative: number; pairWeb: number;
   };
   warnings?: string[];
 };

--- a/apps/staff/src/app/api/sales/dashboard/route.ts
+++ b/apps/staff/src/app/api/sales/dashboard/route.ts
@@ -355,25 +355,65 @@ export async function GET(req: NextRequest) {
   const prevNewCustomers = [...prevPhones].filter((p) => !priorAll.has(p)).length;
   const newAppCustomers = [...curAppPhones].filter((p) => !priorApp.has(p) && !prevAppPhones.has(p)).length;
   const prevNewApp = [...prevAppPhones].filter((p) => !priorApp.has(p)).length;
-  // Pair adds (upsell): each pos_pair_events row = a suggested pair the cashier
-  // ADDED to the cart. Count-only queries (head:true) — immune to the PostgREST
-  // row cap. Prev clipped to the same elapsed time (like-for-like).
-  let curPair = 0, prevPair = 0;
+  // Pair adds (upsell) — pairs that actually CHECKED OUT, split 3 ways:
+  //   In-store  → pos_pair_events stamped with an order_id at payment
+  //               (stampPairOrder). Unstamped rows are add-to-cart taps that
+  //               never converted, so they're excluded.
+  //   Native    → order_items.is_pair lines on app orders from app_ios/android.
+  //   Web       → order_items.is_pair lines on app orders from the web PWA.
+  // Prev side clipped to the same elapsed time (like-for-like).
+  const prevPairEnd = Number.isFinite(prevCutoffMs)
+    ? new Date(Math.min(prevCutoffMs, Date.parse(mytDayEndUTC(prev.to)))).toISOString()
+    : mytDayEndUTC(prev.to);
+
+  // ── In-store (POS) — count-only queries (head:true), immune to the row cap.
+  let curPairInstore = 0, prevPairInstore = 0;
   if (posCodes.length) {
-    const prevPairEnd = Number.isFinite(prevCutoffMs)
-      ? new Date(Math.min(prevCutoffMs, Date.parse(mytDayEndUTC(prev.to)))).toISOString()
-      : mytDayEndUTC(prev.to);
     const [pc, pp] = await Promise.all([
       supabaseAdmin.from("pos_pair_events").select("id", { count: "exact", head: true })
-        .in("outlet_id", posCodes)
+        .in("outlet_id", posCodes).not("order_id", "is", null)
         .gte("created_at", mytDayStartUTC(cur.from)).lte("created_at", mytDayEndUTC(cur.to)),
       supabaseAdmin.from("pos_pair_events").select("id", { count: "exact", head: true })
-        .in("outlet_id", posCodes)
+        .in("outlet_id", posCodes).not("order_id", "is", null)
         .gte("created_at", mytDayStartUTC(prev.from)).lte("created_at", prevPairEnd),
     ]);
-    if (pc.error) warn.push(`pos_pair_events: ${pc.error.message}`); else curPair = pc.count || 0;
-    if (pp.error) warn.push(`pos_pair_events(prev): ${pp.error.message}`); else prevPair = pp.count || 0;
+    if (pc.error) warn.push(`pos_pair_events: ${pc.error.message}`); else curPairInstore = pc.count || 0;
+    if (pp.error) warn.push(`pos_pair_events(prev): ${pp.error.message}`); else prevPairInstore = pp.count || 0;
   }
+
+  // ── Pickup app (native vs web) — one is_pair line = one purchased pair.
+  // Forward-only: is_pair is false for orders placed before this shipped.
+  let curPairNative = 0, curPairWeb = 0, prevPairNative = 0, prevPairWeb = 0;
+  if (storeIds.length) {
+    type PairRow = { source: string | null; status: string | null; created_at: Date };
+    const pairRows = await prisma
+      .$queryRaw<PairRow[]>`
+        SELECT o.source, o.status, o.created_at
+        FROM order_items oi
+        JOIN orders o ON o.id = oi.order_id
+        WHERE o.store_id IN (${Prisma.join(storeIds)})
+          AND o.created_at >= ${winStartD} AND o.created_at <= ${winEndD}
+          AND oi.is_pair = true
+      `
+      .catch((e: unknown) => {
+        warn.push(`order_items(pair): ${e instanceof Error ? e.message : "query failed"}`);
+        return [] as PairRow[];
+      });
+    for (const r of pairRows) {
+      if (!isAppSale(r.status)) continue;
+      const ts = r.created_at.toISOString();
+      const d = getMYTDateStr(ts);
+      const isNative = r.source === "app_ios" || r.source === "app_android";
+      if (inCur(d)) {
+        if (isNative) curPairNative++; else curPairWeb++;
+      } else if (inPrev(d) && Date.parse(ts) <= prevCutoffMs) {
+        if (isNative) prevPairNative++; else prevPairWeb++;
+      }
+    }
+  }
+
+  const curPair = curPairInstore + curPairNative + curPairWeb;
+  const prevPair = prevPairInstore + prevPairNative + prevPairWeb;
 
   const curShare = curOrd ? Math.round((curAppOrd / curOrd) * 100) : 0;
   const prevShare = prevOrd ? Math.round((prevAppOrd / prevOrd) * 100) : 0;
@@ -412,6 +452,7 @@ export async function GET(req: NextRequest) {
       capturedOrders: curCapOrd, collectionRatePct: curCapRate,
       collectionDeltaPts: curCapRate - prevCapRate,
       pairAdds: curPair, pairAddsDelta: pctChange(curPair, prevPair),
+      pairInstore: curPairInstore, pairNative: curPairNative, pairWeb: curPairWeb,
     },
     ...(warn.length ? { warnings: warn } : {}),
   }, { headers: { "Cache-Control": "no-store, must-revalidate" } });


### PR DESCRIPTION
## Summary

Redefines the Sales dashboard **"Pair adds"** metric from *"upsell added to cart"* to **"upsells that actually checked out"**, and breaks it into three channels — **In-store (POS)**, **Native app**, and **Web**.

Previously pickup-app pairs were never persisted — the app only fired an Amplitude `cart_add` event on add-to-cart. This adds DB persistence and rewires the metric end-to-end.

## How each bucket is counted

- **In-store** → `pos_pair_events` rows stamped with an `order_id` at payment (`stampPairOrder`). Unstamped add-to-cart taps are excluded (the "checkout only" change).
- **Native** → `order_items.is_pair` lines on orders with `source = app_ios | app_android`.
- **Web** → `order_items.is_pair` lines on web/PWA orders.

Previous-period side stays clipped for like-for-like deltas.

## Changes

- **Migration 021** — `order_items.is_pair` flag (already applied to project `kqdcdhpnyuwrxqhbuyfl`).
- **pickup-native** — tags a "Pair with a Bite" line as `isPair` and carries it cart → `/api/orders` → the order line.
- **/api/orders** — persists `is_pair` on the order line.
- **staff dashboard route** — counts checkout pairs, bucketed in-store / native / web.
- **staff-native** — type + UI: 3-channel breakdown under the Pair adds headline; label now "upsells purchased".

## Notes

- **Forward-only**: pickup pair data starts at rollout (no backfill). Native counts appear once customers update the app; Web (PWA) flows on deploy; In-store has history via existing order-id stamps.
- The dashboard's `order_items` pair query degrades gracefully (warns, counts 0) if the migration is ever missing.
- In-store counts only *cashier* (register) pairs — customer self-adds on the in-store display aren't tied to an order, so they can't be confirmed as checked-out. Reconciling those is a possible follow-up to `stampPairOrder`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UkfoN8uRL2MmGFd7TBYaU9

---
_Generated by [Claude Code](https://claude.ai/code/session_01UkfoN8uRL2MmGFd7TBYaU9)_