### PR TITLE
Orders via app: split native vs web

### DIFF
--- a/apps/staff-native/app/(staff)/sales/index.tsx
+++ b/apps/staff-native/app/(staff)/sales/index.tsx
@@ -187,12 +187,18 @@ export default function SalesScreen() {
                 <Tile icon={UserPlus} color="#34d399" v={numF(g.newCustomers)} k="New customers" delta={g.newCustomersDelta} />
                 <Tile icon={Smartphone} color="#8FB3F0" v={numF(g.newAppCustomers)} k="New app customers" delta={g.newAppDelta} />
               </View>
-              <View className="mt-3.5 flex-row items-center justify-between border-t border-[#F5F3F00f] pt-3.5">
-                <View>
-                  <Text className="font-body-semi text-xs text-[#F5F3F08a]">Orders via app</Text>
-                  <Text className="mt-0.5 font-display text-lg text-[#F5F3F0]">{numF(g.appOrders)}<Text className="font-body text-[13px] text-[#F5F3F08a]"> · {g.appSharePct}% of all</Text></Text>
+              <View className="mt-3.5 border-t border-[#F5F3F00f] pt-3.5">
+                <View className="flex-row items-center justify-between">
+                  <View>
+                    <Text className="font-body-semi text-xs text-[#F5F3F08a]">Orders via app</Text>
+                    <Text className="mt-0.5 font-display text-lg text-[#F5F3F0]">{numF(g.appOrders)}<Text className="font-body text-[13px] text-[#F5F3F08a]"> · {g.appSharePct}% of all</Text></Text>
+                  </View>
+                  <Text className={`font-body-bold text-[13px] ${deltaUp(g.appOrdersDelta) ? "text-[#34d399]" : "text-[#f87171]"}`}>{deltaStr(g.appOrdersDelta)}</Text>
                 </View>
-                <Text className={`font-body-bold text-[13px] ${deltaUp(g.appOrdersDelta) ? "text-[#34d399]" : "text-[#f87171]"}`}>{deltaStr(g.appOrdersDelta)}</Text>
+                <View className="mt-2.5 flex-row gap-2">
+                  <ChannelChip label="Native" v={g.appOrdersNative} />
+                  <ChannelChip label="Web" v={g.appOrdersWeb} />
+                </View>
               </View>
               <View className="mt-3.5 flex-row items-center justify-between border-t border-[#F5F3F00f] pt-3.5">
                 <View>
@@ -210,9 +216,9 @@ export default function SalesScreen() {
                   <Text className={`font-body-bold text-[13px] ${deltaUp(g.pairAddsDelta) ? "text-[#34d399]" : "text-[#f87171]"}`}>{deltaStr(g.pairAddsDelta)}</Text>
                 </View>
                 <View className="mt-2.5 flex-row gap-2">
-                  <PairChip label="In-store" v={g.pairInstore} />
-                  <PairChip label="Native" v={g.pairNative} />
-                  <PairChip label="Web" v={g.pairWeb} />
+                  <ChannelChip label="In-store" v={g.pairInstore} />
+                  <ChannelChip label="Native" v={g.pairNative} />
+                  <ChannelChip label="Web" v={g.pairWeb} />
                 </View>
               </View>
             </View>
@@ -288,7 +294,7 @@ function Tile({ icon: Icon, color, v, k, delta }: { icon: any; color: string; v:
     </View>
   );
 }
-function PairChip({ label, v }: { label: string; v: number }) {
+function ChannelChip({ label, v }: { label: string; v: number }) {
   return (
     <View className="flex-1 rounded-xl border border-[#F5F3F01a] bg-[#160800] px-3 py-2">
       <Text className="font-display text-base text-[#F5F3F0]">{numF(v)}</Text>

--- a/apps/staff-native/lib/sales/dashboard.ts
+++ b/apps/staff-native/lib/sales/dashboard.ts
@@ -29,6 +29,7 @@ export type SalesDashboard = {
     newCustomers: number; newCustomersDelta: number | null;
     newAppCustomers: number; newAppDelta: number | null;
     appOrders: number; appOrdersDelta: number | null;
+    appOrdersNative: number; appOrdersWeb: number;
     appSharePct: number; appShareDeltaPts: number;
     capturedOrders: number; collectionRatePct: number; collectionDeltaPts: number;
     pairAdds: number; pairAddsDelta: number | null;

--- a/apps/staff/src/app/api/sales/dashboard/route.ts
+++ b/apps/staff/src/app/api/sales/dashboard/route.ts
@@ -178,6 +178,7 @@ export async function GET(req: NextRequest) {
   const curPhones = new Set<string>(), prevPhones = new Set<string>();
   const curAppPhones = new Set<string>(), prevAppPhones = new Set<string>();
   let curAppOrd = 0, curPosOrd = 0, prevAppOrd = 0, prevPosOrd = 0;
+  let curAppNative = 0, curAppWeb = 0; // app-order split by origin (orders.source)
   let curCapOrd = 0, prevCapOrd = 0; // orders with a customer phone (points captured)
   const curPosIds: string[] = [];
   const nativeCodes = new Set<string>(); // pos outlet-codes with native sales this period
@@ -232,6 +233,9 @@ export async function GET(req: NextRequest) {
     const counts = (r.status || "").toLowerCase() === "completed";
     if (inCur(d)) {
       curAppOrd++;
+      // Native = the iOS/Android binary (orders.source app_ios|app_android);
+      // everything else (web, web_qr table, legacy null) counts as Web.
+      if (r.source === "app_ios" || r.source === "app_android") curAppNative++; else curAppWeb++;
       if (r.customer_phone) { curPhones.add(r.customer_phone); curAppPhones.add(r.customer_phone); curCapOrd++; }
       if (counts) {
         curRev += net; curOrd++;
@@ -448,6 +452,7 @@ export async function GET(req: NextRequest) {
       newCustomers, newCustomersDelta: pctChange(newCustomers, prevNewCustomers),
       newAppCustomers, newAppDelta: pctChange(newAppCustomers, prevNewApp),
       appOrders: curAppOrd, appOrdersDelta: pctChange(curAppOrd, prevAppOrd),
+      appOrdersNative: curAppNative, appOrdersWeb: curAppWeb,
       appSharePct: curShare, appShareDeltaPts: curShare - prevShare,
       capturedOrders: curCapOrd, collectionRatePct: curCapRate,
       collectionDeltaPts: curCapRate - prevCapRate,


### PR DESCRIPTION
## Summary

Splits the Sales dashboard **"Orders via app"** metric into **Native** vs **Web**, mirroring the Pair adds channel breakdown.

- **Native** → the iOS/Android binary (`orders.source` = `app_ios | app_android`)
- **Web** → everything else (web / web_qr table / legacy null)

Unlike the pairs change, this is **dashboard-only** — `orders.source` has been recorded since migration 018, so the split applies to **all historical data immediately**: no migration, no app/client changes, no forward-only caveat.

## Changes

- **staff dashboard route** — counts `curAppNative` / `curAppWeb` in the app-order loop; exposes `appOrdersNative` / `appOrdersWeb` on `growth`.
- **staff-native** — type + UI: Native / Web chips under the "Orders via app" headline. Renames the `PairChip` component to the generic `ChannelChip` (now shared by both the pair and order splits).

## Notes

- QR-table orders fold into **Web** here (same convention as the pair split). Happy to break QR out as its own bucket if preferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UkfoN8uRL2MmGFd7TBYaU9

---
_Generated by [Claude Code](https://claude.ai/code/session_01UkfoN8uRL2MmGFd7TBYaU9)_