### PR TITLE
Collection rate: split by channel (in-store / native / web)

### DIFF
--- a/apps/staff-native/app/(staff)/sales/index.tsx
+++ b/apps/staff-native/app/(staff)/sales/index.tsx
@@ -200,12 +200,19 @@ export default function SalesScreen() {
                   <ChannelChip label="Web" v={g.appOrdersWeb} />
                 </View>
               </View>
-              <View className="mt-3.5 flex-row items-center justify-between border-t border-[#F5F3F00f] pt-3.5">
-                <View>
-                  <Text className="font-body-semi text-xs text-[#F5F3F08a]">Collection rate</Text>
-                  <Text className="mt-0.5 font-display text-lg text-[#F5F3F0]">{g.collectionRatePct}%<Text className="font-body text-[13px] text-[#F5F3F08a]"> · {numF(g.capturedOrders)} with phone</Text></Text>
+              <View className="mt-3.5 border-t border-[#F5F3F00f] pt-3.5">
+                <View className="flex-row items-center justify-between">
+                  <View>
+                    <Text className="font-body-semi text-xs text-[#F5F3F08a]">Collection rate</Text>
+                    <Text className="mt-0.5 font-display text-lg text-[#F5F3F0]">{g.collectionRatePct}%<Text className="font-body text-[13px] text-[#F5F3F08a]"> · {numF(g.capturedOrders)} with phone</Text></Text>
+                  </View>
+                  <Text className={`font-body-bold text-[13px] ${g.collectionDeltaPts >= 0 ? "text-[#34d399]" : "text-[#f87171]"}`}>{g.collectionDeltaPts >= 0 ? "+" : ""}{g.collectionDeltaPts}%</Text>
                 </View>
-                <Text className={`font-body-bold text-[13px] ${g.collectionDeltaPts >= 0 ? "text-[#34d399]" : "text-[#f87171]"}`}>{g.collectionDeltaPts >= 0 ? "+" : ""}{g.collectionDeltaPts}%</Text>
+                <View className="mt-2.5 flex-row gap-2">
+                  <ChannelChip label="In-store" v={g.collectionRatePos} suffix="%" />
+                  <ChannelChip label="Native" v={g.collectionRateNative} suffix="%" />
+                  <ChannelChip label="Web" v={g.collectionRateWeb} suffix="%" />
+                </View>
               </View>
               <View className="mt-3.5 border-t border-[#F5F3F00f] pt-3.5">
                 <View className="flex-row items-center justify-between">
@@ -294,10 +301,10 @@ function Tile({ icon: Icon, color, v, k, delta }: { icon: any; color: string; v:
     </View>
   );
 }
-function ChannelChip({ label, v }: { label: string; v: number }) {
+function ChannelChip({ label, v, suffix = "" }: { label: string; v: number; suffix?: string }) {
   return (
     <View className="flex-1 rounded-xl border border-[#F5F3F01a] bg-[#160800] px-3 py-2">
-      <Text className="font-display text-base text-[#F5F3F0]">{numF(v)}</Text>
+      <Text className="font-display text-base text-[#F5F3F0]">{numF(v)}{suffix}</Text>
       <Text className="mt-0.5 font-body-semi text-[11px] uppercase tracking-wide text-[#F5F3F08a]">{label}</Text>
     </View>
   );

--- a/apps/staff-native/lib/sales/dashboard.ts
+++ b/apps/staff-native/lib/sales/dashboard.ts
@@ -32,6 +32,7 @@ export type SalesDashboard = {
     appOrdersNative: number; appOrdersWeb: number;
     appSharePct: number; appShareDeltaPts: number;
     capturedOrders: number; collectionRatePct: number; collectionDeltaPts: number;
+    collectionRatePos: number; collectionRateNative: number; collectionRateWeb: number;
     pairAdds: number; pairAddsDelta: number | null;
     pairInstore: number; pairNative: number; pairWeb: number;
   };

--- a/apps/staff/src/app/api/sales/dashboard/route.ts
+++ b/apps/staff/src/app/api/sales/dashboard/route.ts
@@ -180,6 +180,7 @@ export async function GET(req: NextRequest) {
   let curAppOrd = 0, curPosOrd = 0, prevAppOrd = 0, prevPosOrd = 0;
   let curAppNative = 0, curAppWeb = 0; // app-order split by origin (orders.source)
   let curCapOrd = 0, prevCapOrd = 0; // orders with a customer phone (points captured)
+  let curPosCap = 0, curAppNativeCap = 0, curAppWebCap = 0; // captured, per channel
   const curPosIds: string[] = [];
   const nativeCodes = new Set<string>(); // pos outlet-codes with native sales this period
 
@@ -200,7 +201,7 @@ export async function GET(req: NextRequest) {
     const counts = (r.status || "").toLowerCase() === "completed";
     if (inCur(d)) {
       nativeCodes.add(r.outlet_id);
-      if (r.customer_phone) { curPhones.add(r.customer_phone); curCapOrd++; }
+      if (r.customer_phone) { curPhones.add(r.customer_phone); curCapOrd++; curPosCap++; }
       curPosOrd++;
       curPosIds.push(r.id);
       if (counts) {
@@ -235,8 +236,12 @@ export async function GET(req: NextRequest) {
       curAppOrd++;
       // Native = the iOS/Android binary (orders.source app_ios|app_android);
       // everything else (web, web_qr table, legacy null) counts as Web.
-      if (r.source === "app_ios" || r.source === "app_android") curAppNative++; else curAppWeb++;
-      if (r.customer_phone) { curPhones.add(r.customer_phone); curAppPhones.add(r.customer_phone); curCapOrd++; }
+      const appNative = r.source === "app_ios" || r.source === "app_android";
+      if (appNative) curAppNative++; else curAppWeb++;
+      if (r.customer_phone) {
+        curPhones.add(r.customer_phone); curAppPhones.add(r.customer_phone); curCapOrd++;
+        if (appNative) curAppNativeCap++; else curAppWebCap++;
+      }
       if (counts) {
         curRev += net; curOrd++;
         curByDate[d] = (curByDate[d] || 0) + net;
@@ -428,6 +433,11 @@ export async function GET(req: NextRequest) {
   const prevNativeOrd = prevPosOrd + prevAppOrd;
   const curCapRate = curNativeOrd ? Math.round((curCapOrd / curNativeOrd) * 100) : 0;
   const prevCapRate = prevNativeOrd ? Math.round((prevCapOrd / prevNativeOrd) * 100) : 0;
+  // Same capture rate, split by channel: each channel's captured orders over its
+  // own order count (in-store POS, native app, web/PWA).
+  const curCapRatePos = curPosOrd ? Math.round((curPosCap / curPosOrd) * 100) : 0;
+  const curCapRateNative = curAppNative ? Math.round((curAppNativeCap / curAppNative) * 100) : 0;
+  const curCapRateWeb = curAppWeb ? Math.round((curAppWebCap / curAppWeb) * 100) : 0;
 
   return NextResponse.json({
     outletId: scopeId,
@@ -456,6 +466,7 @@ export async function GET(req: NextRequest) {
       appSharePct: curShare, appShareDeltaPts: curShare - prevShare,
       capturedOrders: curCapOrd, collectionRatePct: curCapRate,
       collectionDeltaPts: curCapRate - prevCapRate,
+      collectionRatePos: curCapRatePos, collectionRateNative: curCapRateNative, collectionRateWeb: curCapRateWeb,
       pairAdds: curPair, pairAddsDelta: pctChange(curPair, prevPair),
       pairInstore: curPairInstore, pairNative: curPairNative, pairWeb: curPairWeb,
     },


### PR DESCRIPTION
## Summary

Splits the Sales dashboard **"Collection rate"** (phone-capture rate, for loyalty points) into its three order channels, each shown as that channel's own captured/total rate:

- **In-store** → POS counter orders (`pos_orders`)
- **Native** → `app_ios | app_android` app orders
- **Web** → web / web_qr / legacy-null app orders

Like the Orders split, this is **dashboard-only** — no migration, no client changes, applies to **all historical data** immediately.

## Changes

- **staff dashboard route** — tracks per-channel captured counts (`curPosCap` / `curAppNativeCap` / `curAppWebCap`) and exposes `collectionRatePos` / `collectionRateNative` / `collectionRateWeb` on `growth`.
- **staff-native** — type + UI: rate chips (In-store / Native / Web, each a `%`) under the Collection rate headline. `ChannelChip` gains an optional `suffix` prop so it can render percentages.

## Notes

- Chips show each channel's **own** capture rate (e.g. POS may capture far less than the app), so they won't average to the headline — the headline stays the blended rate over all native+POS orders. A channel with no orders in the period reads 0%.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UkfoN8uRL2MmGFd7TBYaU9

---
_Generated by [Claude Code](https://claude.ai/code/session_01UkfoN8uRL2MmGFd7TBYaU9)_