### PR TITLE
Collection rate: show captured count per channel

### DIFF
--- a/apps/staff-native/app/(staff)/sales/index.tsx
+++ b/apps/staff-native/app/(staff)/sales/index.tsx
@@ -209,9 +209,9 @@ export default function SalesScreen() {
                   <Text className={`font-body-bold text-[13px] ${g.collectionDeltaPts >= 0 ? "text-[#34d399]" : "text-[#f87171]"}`}>{g.collectionDeltaPts >= 0 ? "+" : ""}{g.collectionDeltaPts}%</Text>
                 </View>
                 <View className="mt-2.5 flex-row gap-2">
-                  <ChannelChip label="In-store" v={g.collectionRatePos} suffix="%" />
-                  <ChannelChip label="Native" v={g.collectionRateNative} suffix="%" />
-                  <ChannelChip label="Web" v={g.collectionRateWeb} suffix="%" />
+                  <ChannelChip label="In-store" v={g.collectionRatePos} suffix="%" sub={`${numF(g.capturedPos)} w/ phone`} />
+                  <ChannelChip label="Native" v={g.collectionRateNative} suffix="%" sub={`${numF(g.capturedNative)} w/ phone`} />
+                  <ChannelChip label="Web" v={g.collectionRateWeb} suffix="%" sub={`${numF(g.capturedWeb)} w/ phone`} />
                 </View>
               </View>
               <View className="mt-3.5 border-t border-[#F5F3F00f] pt-3.5">
@@ -301,10 +301,11 @@ function Tile({ icon: Icon, color, v, k, delta }: { icon: any; color: string; v:
     </View>
   );
 }
-function ChannelChip({ label, v, suffix = "" }: { label: string; v: number; suffix?: string }) {
+function ChannelChip({ label, v, suffix = "", sub }: { label: string; v: number; suffix?: string; sub?: string }) {
   return (
     <View className="flex-1 rounded-xl border border-[#F5F3F01a] bg-[#160800] px-3 py-2">
       <Text className="font-display text-base text-[#F5F3F0]">{numF(v)}{suffix}</Text>
+      {sub ? <Text className="font-body text-[11px] text-[#F5F3F057]">{sub}</Text> : null}
       <Text className="mt-0.5 font-body-semi text-[11px] uppercase tracking-wide text-[#F5F3F08a]">{label}</Text>
     </View>
   );

--- a/apps/staff-native/lib/sales/dashboard.ts
+++ b/apps/staff-native/lib/sales/dashboard.ts
@@ -33,6 +33,7 @@ export type SalesDashboard = {
     appSharePct: number; appShareDeltaPts: number;
     capturedOrders: number; collectionRatePct: number; collectionDeltaPts: number;
     collectionRatePos: number; collectionRateNative: number; collectionRateWeb: number;
+    capturedPos: number; capturedNative: number; capturedWeb: number;
     pairAdds: number; pairAddsDelta: number | null;
     pairInstore: number; pairNative: number; pairWeb: number;
   };

--- a/apps/staff/src/app/api/sales/dashboard/route.ts
+++ b/apps/staff/src/app/api/sales/dashboard/route.ts
@@ -467,6 +467,7 @@ export async function GET(req: NextRequest) {
       capturedOrders: curCapOrd, collectionRatePct: curCapRate,
       collectionDeltaPts: curCapRate - prevCapRate,
       collectionRatePos: curCapRatePos, collectionRateNative: curCapRateNative, collectionRateWeb: curCapRateWeb,
+      capturedPos: curPosCap, capturedNative: curAppNativeCap, capturedWeb: curAppWebCap,
       pairAdds: curPair, pairAddsDelta: pctChange(curPair, prevPair),
       pairInstore: curPairInstore, pairNative: curPairNative, pairWeb: curPairWeb,
     },


### PR DESCRIPTION
## Summary

Adds the captured **count** (orders with a phone — the "amount") to each of the three **Collection rate** channel chips, beside the rate %. So each chip now reads e.g. `40%` / `80 w/ phone` / `In-store`.

The per-channel captured counts were already computed in the dashboard route (`curPosCap` / `curAppNativeCap` / `curAppWebCap`) — this just exposes them and renders them.

## Changes

- **staff dashboard route** — exposes `capturedPos` / `capturedNative` / `capturedWeb` on `growth`.
- **staff-native** — type + UI: `ChannelChip` gains an optional `sub` line; the three Collection chips pass the captured count.

Dashboard-only, works on all historical data (same as the rate split).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UkfoN8uRL2MmGFd7TBYaU9

---
_Generated by [Claude Code](https://claude.ai/code/session_01UkfoN8uRL2MmGFd7TBYaU9)_