### PR TITLE
Per-outlet people cost on dashboard

### DIFF
--- a/apps/backoffice/src/app/(admin)/dashboard/page.tsx
+++ b/apps/backoffice/src/app/(admin)/dashboard/page.tsx
@@ -35,7 +35,10 @@ type LensData = {
   serving: { company: ServeStat | null; byOutlet: Record<string, ServeStat> } | null;
   cogs: { rm: number; pct: number; gpPct: number } | null;
   wastage: { companyRM: number; byOutlet: Record<string, number> } | null;
-  peopleCost: { label: string; costRM: number; pct: number | null } | null;
+  peopleCost: {
+    label: string; costRM: number; pct: number | null; unassignedRM?: number;
+    byOutlet?: Record<string, { costRM: number; pct: number | null }>;
+  } | null;
   churn: { atRisk: number; winBack: number } | null;
 };
 
@@ -66,6 +69,15 @@ export default function DashboardPage() {
 
   const selected = outlet === "all" ? null : data?.outlets.find((o) => o.id === outlet);
   const view = selected ?? data?.company ?? null;
+
+  // People cost follows the outlet filter: a selected outlet shows only its
+  // directly-assigned staff; "all" shows the company roll-up (incl. HQ/rotating).
+  const people = lenses?.peopleCost ?? null;
+  const peopleView = people
+    ? selected
+      ? people.byOutlet?.[selected.id] ?? { costRM: 0, pct: null }
+      : { costRM: people.costRM, pct: people.pct }
+    : null;
   const rounds = selected ? selected.rounds : data?.company.rounds ?? [];
   const maxRound = Math.max(1, ...rounds.map((r) => r.revenue));
   const channel = data?.company.channel;
@@ -233,9 +245,9 @@ export default function DashboardPage() {
             tone={lenses?.cogs ? (lenses.cogs.pct <= 35 ? "good" : "bad") : "muted"}
             href="/inventory/reports" loading={!lenses} />
           <LensCard icon={Users} label="People cost"
-            value={lenses?.peopleCost?.pct != null ? `${lenses.peopleCost.pct}%` : lenses?.peopleCost ? formatRM(lenses.peopleCost.costRM) : "—"}
-            sub={lenses?.peopleCost ? `${lenses.peopleCost.label} · target 15%` : "no data yet"}
-            tone={lenses?.peopleCost?.pct != null ? (lenses.peopleCost.pct <= 15 ? "good" : "bad") : "muted"}
+            value={peopleView?.pct != null ? `${peopleView.pct}%` : peopleView ? formatRM(peopleView.costRM) : "—"}
+            sub={people ? `${people.label}${selected ? " · assigned staff" : ""} · target 15%` : "no data yet"}
+            tone={peopleView?.pct != null ? (peopleView.pct <= 15 ? "good" : "bad") : "muted"}
             href="/hr/payroll" loading={!lenses} />
           <LensCard icon={Trash2} label="Wastage"
             value={lenses?.wastage ? formatRM(lenses.wastage.companyRM) : "—"}

--- a/apps/backoffice/src/app/api/command/lenses/route.ts
+++ b/apps/backoffice/src/app/api/command/lenses/route.ts
@@ -89,27 +89,66 @@ export async function GET(request: NextRequest) {
   })();
 
   // ── People cost (latest confirmed monthly payroll, vs that month's sales) ─
+  // Company figure = whole payroll vs whole-company sales. Per-outlet figure =
+  // only the staff directly assigned to that outlet (User.outletId) vs that
+  // outlet's sales — HQ / rotating / unassigned staff have no single outlet, so
+  // they sit in `unassignedRM` and the company total, never in one outlet's %.
   const peopleCost = (async () => {
     try {
       const { data: runs } = await supabase
         .from("hr_payroll_runs")
-        .select("period_month, period_year, total_gross, total_employer_cost")
+        .select("id, period_month, period_year, total_gross, total_employer_cost")
         .in("status", ["confirmed", "paid"]).eq("cycle_type", "monthly")
         .order("period_year", { ascending: false }).order("period_month", { ascending: false }).limit(1);
       const run = runs?.[0];
       if (!run) return null;
-      const costRM = (Number(run.total_gross) || 0) + (Number(run.total_employer_cost) || 0);
+      const companyCostRM = (Number(run.total_gross) || 0) + (Number(run.total_employer_cost) || 0);
       const mFrom = new Date(`${run.period_year}-${String(run.period_month).padStart(2, "0")}-01T00:00:00+08:00`);
       const mTo = new Date(Date.UTC(run.period_year, run.period_month, 0, 23, 59, 59)); // last day of month
-      const sales = await Promise.all(outlets.map((o) =>
-        getUnifiedSalesForOutlet({ outletId: o.id, storehubStoreId: o.storehubId, loyaltyOutletId: o.loyaltyOutletId, pickupStoreId: o.pickupStoreId, cutoverAt: o.posNativeCutoverAt }, mFrom, mTo)
-          .then((s) => s.reduce((sum, e) => sum + e.total, 0)).catch(() => 0),
-      ));
-      const monthSales = sales.reduce((a, b) => a + b, 0);
+
+      // Per-outlet sales for the payroll month.
+      const salesByOutlet: Record<string, number> = {};
+      await Promise.all(outlets.map(async (o) => {
+        salesByOutlet[o.id] = await getUnifiedSalesForOutlet({ outletId: o.id, storehubStoreId: o.storehubId, loyaltyOutletId: o.loyaltyOutletId, pickupStoreId: o.pickupStoreId, cutoverAt: o.posNativeCutoverAt }, mFrom, mTo)
+          .then((s) => s.reduce((sum, e) => sum + e.total, 0)).catch(() => 0);
+      }));
+      const monthSales = Object.values(salesByOutlet).reduce((a, b) => a + b, 0);
+
+      // Per-outlet labour cost = payroll items mapped to each staff's assigned outlet.
+      const { data: items } = await supabase
+        .from("hr_payroll_items")
+        .select("user_id, total_gross, epf_employer, socso_employer, eis_employer")
+        .eq("payroll_run_id", run.id);
+      const users = await prisma.user.findMany({
+        where: { id: { in: (items ?? []).map((i) => i.user_id) } },
+        select: { id: true, outletId: true },
+      });
+      const outletByUser = new Map(users.map((u) => [u.id, u.outletId]));
+      const inScope = new Set(outlets.map((o) => o.id));
+      const costByOutlet: Record<string, number> = {};
+      let unassignedRM = 0;
+      for (const it of items ?? []) {
+        const cost = (Number(it.total_gross) || 0) + (Number(it.epf_employer) || 0) + (Number(it.socso_employer) || 0) + (Number(it.eis_employer) || 0);
+        const oid = outletByUser.get(it.user_id);
+        if (oid && inScope.has(oid)) costByOutlet[oid] = (costByOutlet[oid] || 0) + cost;
+        else unassignedRM += cost;
+      }
+      const byOutlet: Record<string, { costRM: number; pct: number | null }> = {};
+      for (const o of outlets) {
+        const c = Math.round(costByOutlet[o.id] || 0);
+        const s = salesByOutlet[o.id] || 0;
+        byOutlet[o.id] = { costRM: c, pct: s > 0 ? Math.round((c / s) * 100) : null };
+      }
+
+      // When the request is already scoped to one outlet (manager view), surface
+      // that outlet's figure at the top level; otherwise show the company roll-up.
+      const scoped = scopeOutletId ? byOutlet[scopeOutletId] : null;
       return {
         label: `${MONTHS[run.period_month - 1]} ${run.period_year}`,
-        costRM: Math.round(costRM),
-        pct: monthSales > 0 ? Math.round((costRM / monthSales) * 100) : null,
+        costRM: scoped ? scoped.costRM : Math.round(companyCostRM),
+        pct: scoped ? scoped.pct : monthSales > 0 ? Math.round((companyCostRM / monthSales) * 100) : null,
+        unassignedRM: Math.round(unassignedRM),
+        byOutlet,
       };
     } catch (e) { console.error("[lenses] peopleCost", e); return null; }
   })();


### PR DESCRIPTION
## What
The dashboard **People cost** lens now follows the outlet filter.

## Why
The lens already scoped *sales* to the selected outlet but kept *labour* company-wide, so filtering to one outlet produced a wildly inflated % (the whole RM85.6k payroll divided by one outlet's sales).

## How
- `/api/command/lenses` returns `peopleCost.byOutlet` — each payroll item mapped to the staff member's assigned outlet (`User.outletId`) over that outlet's payroll-month sales.
- HQ / rotating / unassigned staff (no single outlet) roll into the company total + `unassignedRM`, never into one outlet's %.
- Dashboard card reads the selected outlet's figure, or the company roll-up on "All outlets"; sub-label notes "assigned staff" when scoped.

## Verified
Against Mar 2026 confirmed payroll (latest):

| Outlet | Direct labour | Mar sales | People cost % |
|---|---|---|---|
| Putrajaya | RM15,695 | RM96,168 | 16% |
| Shah Alam | RM18,919 | RM86,259 | 22% |
| Tamarind | RM12,214 | RM67,588 | 18% |
| Unassigned (HQ/rotating) | RM38,795 | — | company-only |

Typecheck + lint clean on changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)