### PR TITLE
Add "Credit a Past Order" — orders-only manual point award

### DIFF
--- a/apps/backoffice/src/app/(admin)/layout.tsx
+++ b/apps/backoffice/src/app/(admin)/layout.tsx
@@ -288,6 +288,7 @@ const NAV_SECTIONS: NavSection[] = [
         label: "Members",
         items: [
           { label: "Manual Grant",  href: "/loyalty/manual-grant",  icon: <HandCoins className={ICON_SIZE} />, moduleKey: "loyalty:rewards" },
+          { label: "Credit Order",  href: "/loyalty/credit-order",  icon: <Coins className={ICON_SIZE} />,     moduleKey: "loyalty:rewards" },
         ],
       },
       {

--- a/apps/backoffice/src/app/(admin)/loyalty/credit-order/page.tsx
+++ b/apps/backoffice/src/app/(admin)/loyalty/credit-order/page.tsx
@@ -1,0 +1,292 @@
+"use client";
+
+import { useState } from "react";
+import { Coins, Search, Check, Receipt } from "lucide-react";
+
+interface Member { id: string; name: string | null; phone: string }
+
+interface OrderPreview {
+  order: {
+    id: string;
+    order_number: string | null;
+    total_rm: number;
+    sst_rm: number;
+    outlet_id: string | null;
+    status: string | null;
+    created_at: string | null;
+  };
+  base_points: number;
+  eligible: boolean;
+  reason: string | null;
+}
+
+const BRAND_ID = "brand-celsius";
+
+export default function CreditOrderPage() {
+  const [orderNumber, setOrderNumber] = useState("");
+  const [looking, setLooking] = useState(false);
+  const [preview, setPreview] = useState<OrderPreview | null>(null);
+  const [lookupError, setLookupError] = useState<string | null>(null);
+
+  const [memberQuery, setMemberQuery] = useState("");
+  const [matches, setMatches] = useState<Member[]>([]);
+  const [searching, setSearching] = useState(false);
+  const [selectedMember, setSelectedMember] = useState<Member | null>(null);
+
+  const [reason, setReason] = useState("");
+  const [awarding, setAwarding] = useState(false);
+  const [result, setResult] = useState<{ ok: boolean; message: string } | null>(null);
+
+  function resetAll() {
+    setPreview(null);
+    setLookupError(null);
+    setSelectedMember(null);
+    setMemberQuery("");
+    setMatches([]);
+    setReason("");
+  }
+
+  async function lookupOrder() {
+    const n = orderNumber.trim();
+    if (!n) return;
+    setLooking(true);
+    setResult(null);
+    resetAll();
+    try {
+      const r = await fetch(`/api/pos/loyalty/credit-order?order_number=${encodeURIComponent(n)}`, {
+        credentials: "include",
+      });
+      const j = await r.json();
+      if (!r.ok) {
+        setLookupError(j.error ?? "Lookup failed");
+        return;
+      }
+      setPreview(j as OrderPreview);
+    } catch (e) {
+      setLookupError(e instanceof Error ? e.message : "Network error");
+    } finally {
+      setLooking(false);
+    }
+  }
+
+  async function searchMembers() {
+    if (memberQuery.trim().length < 3) {
+      setMatches([]);
+      return;
+    }
+    setSearching(true);
+    try {
+      const r = await fetch(
+        `/api/loyalty/members?brand_id=${BRAND_ID}&search=${encodeURIComponent(memberQuery.trim())}&limit=8`,
+        { credentials: "include" },
+      );
+      const json = await r.json();
+      const rows = Array.isArray(json) ? json : json?.members;
+      setMatches(Array.isArray(rows) ? rows.slice(0, 8) : []);
+    } catch {
+      setMatches([]);
+    } finally {
+      setSearching(false);
+    }
+  }
+
+  async function award() {
+    if (!preview?.eligible || !selectedMember) return;
+    setAwarding(true);
+    setResult(null);
+    try {
+      const res = await fetch(`/api/pos/loyalty/credit-order`, {
+        method: "POST",
+        credentials: "include",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          order_number: preview.order.order_number,
+          member_id: selectedMember.id,
+          reason: reason.trim() || undefined,
+        }),
+      });
+      const j = await res.json();
+      if (!res.ok) {
+        setResult({ ok: false, message: j.error ?? "Award failed" });
+        return;
+      }
+      setResult({
+        ok: true,
+        message: `Awarded ${j.points_awarded} Beans to ${selectedMember.name ?? selectedMember.phone} for order ${j.order_number}.`,
+      });
+      // Reset for the next credit.
+      setOrderNumber("");
+      resetAll();
+    } catch (e) {
+      setResult({ ok: false, message: e instanceof Error ? e.message : "Network error" });
+    } finally {
+      setAwarding(false);
+    }
+  }
+
+  const o = preview?.order;
+  const finalPoints = preview ? preview.base_points : 0;
+
+  return (
+    <div className="p-6 space-y-6 max-w-3xl">
+      <div>
+        <h1 className="text-2xl font-semibold flex items-center gap-2">
+          <Coins className="w-6 h-6" />
+          Credit a Past Order
+        </h1>
+        <p className="text-sm text-muted-foreground mt-1 max-w-2xl">
+          Award loyalty Beans for a completed in-store order to a customer who
+          forgot to give their phone at the till. Points are computed from the
+          actual order total — you can&apos;t enter a number. Orders can be
+          credited up to 3 days after the sale. Logged in Points Log with your
+          name.
+        </p>
+      </div>
+
+      {/* Step 1 — order lookup */}
+      <div className="rounded-xl border bg-card p-6 space-y-4">
+        <label className="block">
+          <span className="text-xs font-medium text-muted-foreground block mb-1.5 uppercase tracking-wide">
+            Order / receipt number
+          </span>
+          <div className="relative">
+            <Receipt className="w-4 h-4 absolute left-3 top-1/2 -translate-y-1/2 text-muted-foreground" />
+            <input
+              value={orderNumber}
+              onChange={(e) => setOrderNumber(e.target.value)}
+              onKeyDown={(e) => { if (e.key === "Enter") lookupOrder(); }}
+              className="w-full border rounded-lg pl-10 pr-3 py-2 bg-background"
+              placeholder="e.g. CC-PJ-0123"
+            />
+            <button
+              onClick={lookupOrder}
+              disabled={looking || !orderNumber.trim()}
+              className="absolute right-2 top-1/2 -translate-y-1/2 text-xs px-3 py-1.5 rounded bg-foreground text-background disabled:opacity-50"
+            >
+              {looking ? "Looking…" : "Look up"}
+            </button>
+          </div>
+        </label>
+        {lookupError && <p className="text-xs text-rose-500">{lookupError}</p>}
+
+        {o && (
+          <div className="rounded-lg border p-4 bg-foreground/[0.02] space-y-2 text-sm">
+            <div className="flex justify-between">
+              <span className="text-muted-foreground">Order</span>
+              <span className="font-medium">{o.order_number}</span>
+            </div>
+            <div className="flex justify-between">
+              <span className="text-muted-foreground">Date</span>
+              <span>{o.created_at ? new Date(o.created_at).toLocaleString() : "—"}</span>
+            </div>
+            <div className="flex justify-between">
+              <span className="text-muted-foreground">Amount</span>
+              <span>RM {o.total_rm.toFixed(2)}</span>
+            </div>
+            <div className="flex justify-between border-t pt-2">
+              <span className="text-muted-foreground">Beans to award</span>
+              <span className="font-semibold">
+                {finalPoints} <span className="text-xs font-normal text-muted-foreground">(× member tier on confirm)</span>
+              </span>
+            </div>
+            {!preview?.eligible && (
+              <p className="text-xs text-rose-500 border-t pt-2">{preview?.reason}</p>
+            )}
+          </div>
+        )}
+      </div>
+
+      {/* Step 2 — member + confirm (only when an eligible order is loaded) */}
+      {preview?.eligible && (
+        <div className="rounded-xl border bg-card p-6 space-y-5">
+          <div>
+            <span className="text-xs font-medium text-muted-foreground block mb-1.5 uppercase tracking-wide">
+              Customer
+            </span>
+            {selectedMember ? (
+              <div className="flex items-center justify-between rounded-lg border p-3 bg-foreground/[0.02]">
+                <div>
+                  <div className="font-medium">{selectedMember.name ?? "(no name)"}</div>
+                  <div className="text-xs text-muted-foreground">{selectedMember.phone}</div>
+                </div>
+                <button
+                  onClick={() => { setSelectedMember(null); setMemberQuery(""); setMatches([]); }}
+                  className="text-xs text-muted-foreground hover:text-foreground"
+                >
+                  Change
+                </button>
+              </div>
+            ) : (
+              <div className="relative">
+                <Search className="w-4 h-4 absolute left-3 top-1/2 -translate-y-1/2 text-muted-foreground" />
+                <input
+                  value={memberQuery}
+                  onChange={(e) => setMemberQuery(e.target.value)}
+                  onKeyDown={(e) => { if (e.key === "Enter") searchMembers(); }}
+                  className="w-full border rounded-lg pl-10 pr-3 py-2 bg-background"
+                  placeholder="Phone, name, or member id (min 3 chars)"
+                />
+                <button
+                  onClick={searchMembers}
+                  className="absolute right-2 top-1/2 -translate-y-1/2 text-xs px-2 py-1 rounded bg-foreground text-background"
+                >
+                  Search
+                </button>
+              </div>
+            )}
+            {searching && <div className="text-xs text-muted-foreground mt-2">Searching…</div>}
+            {!selectedMember && matches.length > 0 && (
+              <div className="mt-2 border rounded-lg divide-y max-h-60 overflow-y-auto">
+                {matches.map((m) => (
+                  <button
+                    key={m.id}
+                    onClick={() => { setSelectedMember(m); setMatches([]); }}
+                    className="w-full px-3 py-2.5 text-left hover:bg-muted flex items-center justify-between"
+                  >
+                    <div>
+                      <div className="font-medium text-sm">{m.name ?? "(no name)"}</div>
+                      <div className="text-xs text-muted-foreground">{m.phone}</div>
+                    </div>
+                    <span className="text-xs text-muted-foreground">{m.id.slice(0, 8)}…</span>
+                  </button>
+                ))}
+              </div>
+            )}
+          </div>
+
+          <label className="block">
+            <span className="text-xs font-medium text-muted-foreground block mb-1.5 uppercase tracking-wide">
+              Reason (optional)
+            </span>
+            <input
+              value={reason}
+              onChange={(e) => setReason(e.target.value)}
+              className="w-full border rounded-lg px-3 py-2 bg-background"
+              placeholder="e.g. Customer forgot phone — receipt shown at Putrajaya"
+            />
+            <p className="text-xs text-muted-foreground mt-1.5">
+              Stored in the points ledger alongside your name for audit.
+            </p>
+          </label>
+
+          <div className="flex items-center gap-3 pt-2 border-t">
+            <button
+              onClick={award}
+              disabled={!selectedMember || awarding}
+              className="inline-flex items-center gap-2 px-4 py-2 rounded-lg bg-foreground text-background text-sm font-medium disabled:opacity-50"
+            >
+              <Check className="w-4 h-4" />
+              {awarding ? "Awarding…" : "Award points"}
+            </button>
+          </div>
+        </div>
+      )}
+
+      {result && (
+        <p className={`text-sm ${result.ok ? "text-emerald-500" : "text-rose-500"}`}>
+          {result.message}
+        </p>
+      )}
+    </div>
+  );
+}

--- a/apps/backoffice/src/app/api/pos/loyalty/credit-order/route.ts
+++ b/apps/backoffice/src/app/api/pos/loyalty/credit-order/route.ts
@@ -1,0 +1,249 @@
+import { NextRequest, NextResponse } from "next/server";
+import { supabaseAdmin } from "@/lib/loyalty/supabase";
+import { requireAuth, getUserFromHeaders } from "@/lib/auth";
+
+const BRAND_ID = "brand-celsius";
+
+// How far back a completed register order may be back-credited to a member who
+// forgot to give their phone at the till. Deliberately short to limit abuse —
+// the customer is expected to come back with their receipt soon after.
+const MAX_AGE_DAYS = 3;
+
+/**
+ * Back-credit a PAST in-store order to a member who didn't give their phone
+ * at the till.
+ *
+ * This is the "orders-only" alternative to the blanket points tools
+ * (adjust-points / points-award, which let staff type any number): points here
+ * are ALWAYS computed server-side from a real pos_orders row's spend — staff
+ * can only attach a member to a specific completed order, never invent points.
+ *
+ * The earn math + idempotency mirror /api/pos/loyalty/complete (the live
+ * in-store earn): Beans on the pre-tax net, tier-multiplied, one earn per order
+ * (guarded on an existing 'earn' txn referencing the order). Points only — no
+ * Mystery Bean drop for back-dated credits.
+ *
+ *   GET  ?order_number=CC-...   → preview the order + eligibility (no writes)
+ *   POST { order_number, member_id, reason? } → attribute + award
+ *
+ * Backoffice access only (requireAuth). Every credit lands in point_transactions
+ * with the acting staff + reason in the description, visible in Points Log.
+ */
+
+type PosOrderRow = {
+  id: string;
+  order_number: string | null;
+  total: number | null;
+  sst_amount: number | null;
+  outlet_id: string | null;
+  status: string | null;
+  created_at: string | null;
+  loyalty_phone: string | null;
+  loyalty_points_earned: number | null;
+};
+
+async function getPointsPerRm(): Promise<number> {
+  const { data: setting } = await supabaseAdmin
+    .from("app_settings")
+    .select("value")
+    .eq("key", "points_per_rm")
+    .maybeSingle();
+  return Number((setting?.value as { rate?: number } | null)?.rate ?? 1) || 1;
+}
+
+/** Base Beans for an order's spend BEFORE the member's tier multiplier.
+ *  Mirrors /api/pos/loyalty/complete: earn on (total − SST), floored. */
+function basePointsFor(order: PosOrderRow, pointsPerRm: number): number {
+  const totalSen = Number(order.total ?? 0);
+  const sstSen = Number(order.sst_amount ?? 0);
+  const netSen = Math.max(0, totalSen - sstSen);
+  return Math.floor((netSen / 100) * pointsPerRm);
+}
+
+/** Shared eligibility gate. Returns null when the order can be credited,
+ *  otherwise the reason it can't. */
+async function ineligibleReason(order: PosOrderRow): Promise<string | null> {
+  if (order.status !== "completed") {
+    return "Order is not completed.";
+  }
+  if (order.loyalty_phone) {
+    return "Order is already attributed to a member.";
+  }
+  if (order.created_at) {
+    const ageMs = Date.now() - new Date(order.created_at).getTime();
+    if (ageMs > MAX_AGE_DAYS * 86400000) {
+      return `Order is older than ${MAX_AGE_DAYS} days — too old to credit.`;
+    }
+  }
+  // Belt-and-braces: an earn txn already referencing the order means points
+  // were credited (e.g. via a prior attribution). Never double-award.
+  const { data: existingEarn } = await supabaseAdmin
+    .from("point_transactions")
+    .select("id")
+    .eq("reference_id", order.id)
+    .eq("type", "earn")
+    .limit(1)
+    .maybeSingle();
+  if (existingEarn) {
+    return "Points have already been awarded for this order.";
+  }
+  return null;
+}
+
+async function lookupOrder(orderNumber: string): Promise<PosOrderRow | null> {
+  const { data } = await supabaseAdmin
+    .from("pos_orders")
+    .select("id, order_number, total, sst_amount, outlet_id, status, created_at, loyalty_phone, loyalty_points_earned")
+    .eq("order_number", orderNumber)
+    .maybeSingle();
+  return (data as PosOrderRow | null) ?? null;
+}
+
+// ─── GET: preview ────────────────────────────────────────────────────────────
+export async function GET(request: NextRequest) {
+  const auth = await requireAuth(request);
+  if (auth.error) return auth.error;
+
+  const orderNumber = request.nextUrl.searchParams.get("order_number")?.trim();
+  if (!orderNumber) {
+    return NextResponse.json({ error: "order_number is required" }, { status: 400 });
+  }
+
+  const order = await lookupOrder(orderNumber);
+  if (!order) {
+    return NextResponse.json({ error: "Order not found" }, { status: 404 });
+  }
+
+  const pointsPerRm = await getPointsPerRm();
+  const basePoints = basePointsFor(order, pointsPerRm);
+  const reason = await ineligibleReason(order);
+
+  return NextResponse.json({
+    order: {
+      id: order.id,
+      order_number: order.order_number,
+      total_rm: Number(order.total ?? 0) / 100,
+      sst_rm: Number(order.sst_amount ?? 0) / 100,
+      outlet_id: order.outlet_id,
+      status: order.status,
+      created_at: order.created_at,
+    },
+    // Beans before the member's tier multiplier — the final award applies the
+    // selected member's multiplier on top (shown on confirm).
+    base_points: basePoints,
+    eligible: reason === null,
+    reason,
+  });
+}
+
+// ─── POST: attribute + award ─────────────────────────────────────────────────
+export async function POST(request: NextRequest) {
+  const auth = await requireAuth(request);
+  if (auth.error) return auth.error;
+
+  const caller = await getUserFromHeaders(request.headers);
+  const callerLabel = caller?.name ?? caller?.id ?? "admin";
+
+  const body = (await request.json()) as {
+    order_number?: string;
+    member_id?: string;
+    reason?: string;
+  };
+  const orderNumber = body.order_number?.trim();
+  const memberId = body.member_id?.trim();
+  const note = (body.reason ?? "").trim();
+
+  if (!orderNumber || !memberId) {
+    return NextResponse.json(
+      { error: "order_number and member_id are required" },
+      { status: 400 },
+    );
+  }
+
+  const order = await lookupOrder(orderNumber);
+  if (!order) {
+    return NextResponse.json({ error: "Order not found" }, { status: 404 });
+  }
+
+  // Re-check eligibility at commit time (the preview is advisory; state could
+  // have changed). 409 = caller should refresh.
+  const reason = await ineligibleReason(order);
+  if (reason) {
+    return NextResponse.json({ error: reason }, { status: 409 });
+  }
+
+  // Resolve the member + their tier multiplier (same source as the live earn).
+  const [{ data: memberRow }, { data: mb }] = await Promise.all([
+    supabaseAdmin.from("members").select("id, phone, name").eq("id", memberId).maybeSingle(),
+    supabaseAdmin
+      .from("member_brands")
+      .select("tiers(multiplier)")
+      .eq("member_id", memberId)
+      .eq("brand_id", BRAND_ID)
+      .maybeSingle(),
+  ]);
+  if (!memberRow) {
+    return NextResponse.json({ error: "Member not found" }, { status: 404 });
+  }
+  const member = memberRow as { id: string; phone: string | null; name: string | null };
+  const tierMul =
+    Number((mb as { tiers?: { multiplier?: number | null } | null } | null)?.tiers?.multiplier ?? 1) || 1;
+
+  const pointsPerRm = await getPointsPerRm();
+  const basePoints = basePointsFor(order, pointsPerRm);
+  const points = Math.round(basePoints * tierMul);
+  if (points <= 0) {
+    return NextResponse.json({ error: "Order earns no points." }, { status: 400 });
+  }
+
+  // Award first (idempotent on order via the earn-txn guard above), then
+  // attribute the order. If attribution write fails after the award lands, the
+  // points are already credited and referenced to the order — no double-award
+  // is possible because the earn-txn guard will block any retry.
+  const { error: rpcErr } = await supabaseAdmin.rpc("add_loyalty_points", {
+    p_member_id: memberId,
+    p_brand_id: BRAND_ID,
+    p_points: points,
+    p_outlet_id: order.outlet_id ?? "",
+    p_order_id: order.id,
+    p_multiplier: tierMul,
+    p_description: `Back-credit for order ${order.order_number} by ${callerLabel}${note ? `: ${note}` : ""}`,
+  });
+  if (rpcErr) {
+    console.error("[credit-order] add_loyalty_points failed:", rpcErr.message);
+    return NextResponse.json({ error: "Failed to award points." }, { status: 500 });
+  }
+
+  // Attribute the order to the member (for reporting + so the reconcile cron
+  // never re-processes it) and stamp the earned points.
+  await supabaseAdmin
+    .from("pos_orders")
+    .update({
+      loyalty_phone: member.phone,
+      loyalty_id: member.id,
+      loyalty_points_earned: points,
+    })
+    .eq("id", order.id);
+
+  // Tier re-eval so a member who just crossed a threshold bumps immediately.
+  await supabaseAdmin
+    .rpc("evaluate_member_tier", { p_member_id: memberId, p_brand_id: BRAND_ID })
+    .then(() => {}, () => {});
+
+  // New balance for the response (best-effort).
+  const { data: after } = await supabaseAdmin
+    .from("member_brands")
+    .select("points_balance")
+    .eq("member_id", memberId)
+    .eq("brand_id", BRAND_ID)
+    .maybeSingle();
+
+  return NextResponse.json({
+    ok: true,
+    points_awarded: points,
+    multiplier: tierMul,
+    new_balance: (after as { points_balance?: number } | null)?.points_balance ?? null,
+    order_number: order.order_number,
+    member: { id: member.id, name: member.name, phone: member.phone },
+  });
+}


### PR DESCRIPTION
## What & why
Lets backoffice staff award loyalty Beans to a customer who **forgot to give their phone at the till**, without the blanket-points risk of the existing tools.

Today the only manual point tools are `adjust-points` and `points-award` — both let staff type **any** number. This feature is **orders-only**: points are always computed server-side from a real `pos_orders` row, so staff can only attach a member to a **specific completed order**, never invent points.

## How it works
Reuses the live in-store earn (`/api/pos/loyalty/complete`) machinery so the math + idempotency are identical.

**New API — `GET`/`POST /api/pos/loyalty/credit-order`** (backoffice auth only):
- `GET ?order_number=…` → previews the order (date, amount, computed Beans) + eligibility. No writes.
- `POST { order_number, member_id, reason? }` → attributes the member to the order and awards via the same `add_loyalty_points` RPC: Beans on **pre-tax net × tier multiplier**, **idempotent on the order** (guarded on an existing `earn` txn — no double-award).

**Guardrails:**
- Order must be `completed`, **not already attributed** (`loyalty_phone` null), **no prior earn** txn, and **within 3 days** of the sale.
- **Points only** — no Mystery Bean drop for back-dated credits.
- **Audit:** acting staff + reason are written into the `point_transactions` description → visible in **Points Log**.

**New page — `/loyalty/credit-order`** (Loyalty › Members, next to Manual Grant): look up order → confirm details → search/select member → award.

## Decisions (per request)
- **Access:** backoffice access only (standard `requireAuth`; not exposed in POS-native or staff app).
- **Age limit:** 3 days.
- **Mystery drop:** points only.

## Verification
- typecheck (backoffice) ✅ · eslint (new files + nav) 0 errors ✅ · test 202 ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PfVviAtVbppgRTt5pG3D8j)_