### PR TITLE
Posters: home/splash round scheduling + AOV poster autopilot

### DIFF
--- a/apps/backoffice/src/app/(admin)/pickup/splash-posters/page.tsx
+++ b/apps/backoffice/src/app/(admin)/pickup/splash-posters/page.tsx
@@ -466,7 +466,10 @@ export default function SplashPostersPage() {
         placement:     form.placement,
         composerState: form.composerState,
         originalBgUrl: form.originalBgUrl,
-        round:         form.placement === "pos-display" ? (form.round || null) : null,
+        // Round applies to every surface now — the home carousel, splash
+        // launch, and POS screen readers all filter by current day-part
+        // round (round-less = always). Lets the autopilot schedule by round.
+        round:         form.round || null,
       };
       const url = form.id
         ? `/api/pickup/splash-posters?id=${encodeURIComponent(form.id)}`
@@ -604,7 +607,7 @@ export default function SplashPostersPage() {
             {tabs.map((t) => (
               <button
                 key={t.id}
-                onClick={() => setTab(t.id)}
+                onClick={() => { setTab(t.id); setRoundFilter("all"); }}
                 className={`rounded-md px-3 py-1.5 text-xs font-semibold transition-colors ${
                   tab === t.id
                     ? "bg-white text-gray-900 shadow-sm"
@@ -621,10 +624,11 @@ export default function SplashPostersPage() {
         );
       })()}
 
-      {/* POS-screen round sub-filter — narrow the list to one day-part round
-          so it's easy to arrange that round's posters. View only. */}
-      {!loading && tab === "pos-display" && posters.some((p) => (p.placement ?? "home") === "pos-display") && (() => {
-        const pos = posters.filter((p) => (p.placement ?? "home") === "pos-display");
+      {/* Round sub-filter — narrow the current surface's list to one
+          day-part round so it's easy to arrange that round's posters.
+          Works for every placement (home / splash / POS). View only. */}
+      {!loading && posters.some((p) => (p.placement ?? "home") === tab) && (() => {
+        const pos = posters.filter((p) => (p.placement ?? "home") === tab);
         const opts: { id: string; label: string }[] = [
           { id: "all", label: "All" },
           { id: "always", label: "Always" },
@@ -671,7 +675,7 @@ export default function SplashPostersPage() {
         const filtered = posters
           .filter((p) => (p.placement ?? "home") === tab)
           .filter((p) =>
-            tab !== "pos-display" || roundFilter === "all"
+            roundFilter === "all"
               ? true
               : roundFilter === "always"
                 ? !p.round
@@ -956,28 +960,31 @@ export default function SplashPostersPage() {
                 </p>
               </div>
 
-              {form.placement === "pos-display" && (
-                <div>
-                  <label className="text-xs font-medium text-gray-700">Round (time of day)</label>
-                  <select
-                    value={form.round}
-                    onChange={(e) => setForm((f) => ({ ...f, round: e.target.value }))}
-                    className="mt-1 w-full rounded-lg border border-gray-300 px-3 py-2 text-sm"
-                  >
-                    <option value="">Always — show in every round</option>
-                    <option value="breakfast">Breakfast · 8–10AM</option>
-                    <option value="brunch">Brunch · 10AM–12PM</option>
-                    <option value="lunch">Lunch · 12–3PM</option>
-                    <option value="midday">Midday · 3–5PM</option>
-                    <option value="evening">Evening · 5–7PM</option>
-                    <option value="dinner">Dinner · 7–9PM</option>
-                    <option value="supper">Supper · 9–11PM</option>
-                  </select>
-                  <p className="mt-1 text-[11px] text-gray-500">
-                    Only shows on the customer screen during this day-part. &quot;Always&quot; shows in every round.
-                  </p>
-                </div>
-              )}
+              <div>
+                <label className="text-xs font-medium text-gray-700">Round (time of day)</label>
+                <select
+                  value={form.round}
+                  onChange={(e) => setForm((f) => ({ ...f, round: e.target.value }))}
+                  className="mt-1 w-full rounded-lg border border-gray-300 px-3 py-2 text-sm"
+                >
+                  <option value="">Always — show in every round</option>
+                  <option value="breakfast">Breakfast · 8–10AM</option>
+                  <option value="brunch">Brunch · 10AM–12PM</option>
+                  <option value="lunch">Lunch · 12–3PM</option>
+                  <option value="midday">Midday · 3–5PM</option>
+                  <option value="evening">Evening · 5–7PM</option>
+                  <option value="dinner">Dinner · 7–9PM</option>
+                  <option value="supper">Supper · 9–11PM</option>
+                </select>
+                <p className="mt-1 text-[11px] text-gray-500">
+                  {form.placement === "home"
+                    ? "Home carousel only shows this poster during this day-part. "
+                    : form.placement === "splash"
+                      ? "App launch splash only shows this poster during this day-part. "
+                      : "Customer screen only shows this poster during this day-part. "}
+                  &quot;Always&quot; shows in every round.
+                </p>
+              </div>
 
               <div>
                 <label className="text-xs font-medium text-gray-700">

--- a/apps/backoffice/src/app/api/cron/pos-poster-autopilot/route.ts
+++ b/apps/backoffice/src/app/api/cron/pos-poster-autopilot/route.ts
@@ -1,0 +1,98 @@
+import { NextRequest, NextResponse } from "next/server";
+import { checkCronAuth } from "@celsius/shared";
+import { getSupabaseAdmin } from "@/lib/pickup/supabase";
+import { planPosterRotation } from "@/lib/pos/poster-autopilot";
+
+/**
+ * GET /api/cron/pos-poster-autopilot  (daily ~07:00 MYT)
+ *
+ * Auto-rotates customer-display posters to push AOV: scores each round's
+ * posters (margin + food-attach in drink-heavy rounds + price anchor) and
+ * flips splash_posters.active/sort_order to the best K per round. Gated by
+ * app_settings.pos_poster_autopilot_enabled.
+ *
+ * Switchback A/B: even MYT-day-of-year = "autopilot" (margin/attach), odd =
+ * "control" (popularity). Each run also records YESTERDAY's realised per-round
+ * AOV into pos_poster_perf tagged with yesterday's mode — the holdout that
+ * proves whether the autopilot actually beats popularity (and whether posters
+ * move AOV at all). If it doesn't, we'll see it and back off.
+ */
+
+export const dynamic = "force-dynamic";
+export const maxDuration = 60;
+
+// A Date whose UTC fields equal the MYT (UTC+8) wall clock — used only for
+// calendar-date and day-parity math (never for storing timestamps).
+function mytShift(ms: number): Date {
+  return new Date(ms + 8 * 3600 * 1000);
+}
+function dayOfYear(d: Date): number {
+  const start = Date.UTC(d.getUTCFullYear(), 0, 0);
+  const today = Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), d.getUTCDate());
+  return Math.floor((today - start) / 86400000);
+}
+function isoDate(d: Date): string {
+  return `${d.getUTCFullYear()}-${String(d.getUTCMonth() + 1).padStart(2, "0")}-${String(d.getUTCDate()).padStart(2, "0")}`;
+}
+const modeFor = (d: Date): "autopilot" | "control" => (dayOfYear(d) % 2 === 0 ? "autopilot" : "control");
+
+export async function GET(req: NextRequest) {
+  const auth = checkCronAuth(req.headers);
+  if (!auth.ok) return NextResponse.json({ error: auth.error }, { status: auth.status });
+
+  const supabase = getSupabaseAdmin();
+
+  const { data: flagRow } = await supabase
+    .from("app_settings")
+    .select("value")
+    .eq("key", "pos_poster_autopilot_enabled")
+    .maybeSingle();
+  const enabled = (flagRow?.value as { enabled?: boolean } | null)?.enabled ?? false;
+  if (!enabled) return NextResponse.json({ ok: true, skipped: "disabled" });
+
+  const now = Date.now();
+  const today = mytShift(now);
+  const mode = modeFor(today);
+
+  // 1. Plan + apply for POS + home. POS rotates on the switchback A/B (no
+  //    per-poster conversion signal); home always runs autopilot and learns
+  //    from deeplink-attributed AOV (poster_events). Splash deferred.
+  const placements = [
+    { placement: "pos-display" as const, mode },
+    { placement: "home" as const, mode: "autopilot" as const },
+  ];
+  let applied = 0;
+  const activeByPlacement: Record<string, string[]> = {};
+  for (const cfg of placements) {
+    const decisions = await planPosterRotation({ mode: cfg.mode, placement: cfg.placement });
+    for (const d of decisions) {
+      const { error } = await supabase
+        .from("splash_posters")
+        .update({ active: d.active, sort_order: d.sortOrder } as Record<string, unknown>)
+        .eq("id", d.posterId);
+      if (error) console.error("[cron/pos-poster-autopilot] update", d.posterId, error.message);
+      else applied++;
+      if (d.active) (activeByPlacement[cfg.placement] ??= []).push(d.title ?? d.posterId);
+    }
+  }
+
+  // 2. Record yesterday's realised per-round AOV, tagged with yesterday's mode.
+  const yest = mytShift(now - 24 * 3600 * 1000);
+  const yStr = isoDate(yest);
+  const yMode = modeFor(yest);
+  let logged = 0;
+  const { data: perf } = await supabase.rpc("pos_round_aov_for_date", { p_date: yStr });
+  for (const row of (perf ?? []) as { round: string; orders: number; aov_rm: number }[]) {
+    if (!row.round || row.round === "other") continue;
+    const { error } = await supabase
+      .from("pos_poster_perf")
+      .upsert(
+        { perf_date: yStr, round: row.round, mode: yMode, aov_rm: row.aov_rm, orders: row.orders } as Record<string, unknown>,
+        { onConflict: "perf_date,round" },
+      );
+    if (!error) logged++;
+  }
+
+  console.warn(`[cron/pos-poster-autopilot] mode=${mode} applied=${applied} perf_logged=${logged}`);
+  return NextResponse.json({ ok: true, mode, applied, perfLogged: logged, activeByPlacement });
+}

--- a/apps/backoffice/src/lib/pos/poster-autopilot.ts
+++ b/apps/backoffice/src/lib/pos/poster-autopilot.ts
@@ -1,0 +1,241 @@
+/**
+ * POS poster autopilot — scores each round's customer-display posters by
+ * AOV-lift potential and decides which to make active (and in what order).
+ *
+ * Why a poster lifts AOV (not the same as "popular"):
+ *   • margin RM    — price − BOM ingredient cost; push the high-ringgit-margin item
+ *   • food-attach  — in drink-heavy rounds (high single-item %), a bite grows the basket
+ *   • price anchor — higher-ticket signature items lift AOV directly
+ *   • popularity   — light tie-breaker (and the sole signal in "control" mode)
+ *
+ * "control" mode ranks by popularity only — the switchback A/B baseline the cron
+ * alternates with, so pos_poster_perf can tell whether margin/attach beats
+ * popularity (and whether posters move AOV at all).
+ *
+ * The cron applies the returned decisions by flipping splash_posters.active /
+ * sort_order. The /api/pos/posters reader serves the current round's active set.
+ */
+import { prisma } from "@/lib/prisma";
+import { getSupabaseAdmin } from "@/lib/pickup/supabase";
+
+export type Round = "breakfast" | "brunch" | "lunch" | "midday" | "evening" | "dinner" | "supper";
+export const ROUNDS: Round[] = ["breakfast", "brunch", "lunch", "midday", "evening", "dinner", "supper"];
+
+// Mirrors the suggest-pairs FOOD_CATEGORIES — everything else is a drink.
+const FOOD_CATEGORIES = new Set([
+  "cakes", "cookies", "croissant", "fries", "nasi-lemak", "noodle", "pasta", "roti-bakar", "sandwiches",
+]);
+
+// A round counts as "drink-heavy" (worth pushing a bite) above this single-item rate.
+const DRINK_HEAVY_SINGLE_RATE = 45;
+
+export type PosterDecision = {
+  round: Round | null;
+  posterId: string;
+  title: string | null;
+  productId: string | null;
+  active: boolean;
+  sortOrder: number;
+  score: number;
+  reason: string;
+};
+
+/**
+ * Cheapest-supplier ingredient cost (RM) per lower(menu.name), from the BOM.
+ * Mirrors the Sales-reports cost model (ingredient part only — packaging is
+ * small and channel-dependent, immaterial for ranking). ADHOC = RM0 placeholder.
+ */
+export async function ingredientCostByName(): Promise<Map<string, number>> {
+  const [menus, supplierProducts] = await Promise.all([
+    prisma.menu.findMany({
+      select: {
+        name: true,
+        ingredients: {
+          select: { productId: true, quantityUsed: true, product: { select: { itemType: true } } },
+        },
+      },
+    }),
+    prisma.supplierProduct.findMany({
+      where: { isActive: true },
+      select: {
+        productId: true,
+        price: true,
+        productPackage: { select: { conversionFactor: true } },
+        supplier: { select: { supplierCode: true } },
+      },
+    }),
+  ]);
+
+  const costPerBase = new Map<string, number>();
+  for (const sp of supplierProducts) {
+    if (sp.supplier?.supplierCode === "ADHOC") continue;
+    const price = Number(sp.price);
+    if (price <= 0) continue;
+    const conv = sp.productPackage?.conversionFactor ? Number(sp.productPackage.conversionFactor) : 0;
+    if (conv <= 0) continue;
+    const c = price / conv;
+    const ex = costPerBase.get(sp.productId);
+    if (ex == null || c < ex) costPerBase.set(sp.productId, c);
+  }
+
+  const byName = new Map<string, number>();
+  for (const m of menus) {
+    if (!m.name) continue;
+    let ing = 0;
+    for (const li of m.ingredients) {
+      if (li.product.itemType === "PACKAGING") continue;
+      ing += Number(li.quantityUsed) * (costPerBase.get(li.productId) ?? 0);
+    }
+    byName.set(m.name.trim().toLowerCase(), Math.round(ing * 100) / 100);
+  }
+  return byName;
+}
+
+type Signals = {
+  rounds: Record<string, { aov: number; single_rate: number; orders: number }>;
+  products: { round: string; product_id: string; units: number }[];
+};
+
+export type Placement = "pos-display" | "home" | "splash";
+
+// Default live-slot count per placement: POS shows 3/round, the home carousel
+// rotates ~5, splash is a single launch poster (pick the one best one).
+const DEFAULT_TOPK: Record<Placement, number> = { "pos-display": 3, home: 5, splash: 1 };
+
+// Group key for a poster row: POS rotates by day-part round; app placements
+// usually have no round (one '__all__' group) but support rounds once tagged.
+const GROUP_ALL = "__all__";
+
+/**
+ * Build the active/sort_order plan for one placement. Pure read — returns
+ * decisions; the caller applies them.
+ *
+ * pos-display has no per-poster conversion signal, so it scores purely on the
+ * AOV-lift heuristic (margin + food-attach + price). home/splash posters carry
+ * deeplinks, so once orders are attributed (poster_events → pos_poster_app_perf)
+ * the engine blends each poster's MEASURED order AOV over the heuristic — the
+ * blend weight ramps with attributed orders (cold-start heuristic → measured).
+ */
+export async function planPosterRotation(
+  opts: { mode: "autopilot" | "control"; placement?: Placement; topK?: number; days?: number },
+): Promise<PosterDecision[]> {
+  const placement: Placement = opts.placement ?? "pos-display";
+  const topK = opts.topK ?? DEFAULT_TOPK[placement];
+  const days = opts.days ?? 21;
+  const isApp = placement !== "pos-display";
+  const supabase = getSupabaseAdmin();
+
+  let postersQuery = supabase
+    .from("splash_posters")
+    .select("id,title,round,product_id")
+    .eq("brand_id", "brand-celsius")
+    .eq("placement", placement);
+  // POS posters are always round-tagged; app posters may be round-less.
+  if (placement === "pos-display") postersQuery = postersQuery.not("round", "is", null);
+
+  const [sigRes, postersRes, productsRes, costByName, perfRes] = await Promise.all([
+    supabase.rpc("pos_poster_signals", { p_days: days }),
+    postersQuery,
+    supabase.from("products").select("id,name,category,price").eq("brand_id", "brand-celsius"),
+    ingredientCostByName(),
+    isApp ? supabase.rpc("pos_poster_app_perf", { p_days: 28 }) : Promise.resolve({ data: [] }),
+  ]);
+
+  const sig = (sigRes.data ?? { rounds: {}, products: [] }) as Signals;
+  const roundStats = sig.rounds ?? {};
+  const unitsByRoundProduct = new Map<string, number>();
+  for (const r of sig.products ?? []) unitsByRoundProduct.set(`${r.round}|${r.product_id}`, Number(r.units));
+
+  // Measured per-poster order AOV (app placements only).
+  const measuredByPoster = new Map<string, { orders: number; aov: number }>();
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- legacy untyped DB row (ratchet: reduce, never add)
+  for (const r of ((perfRes as any)?.data ?? []) as any[]) {
+    measuredByPoster.set(String(r.poster_id), { orders: Number(r.orders) || 0, aov: Number(r.attributed_aov) || 0 });
+  }
+
+  const prodById = new Map<string, { name: string; category: string | null; price: number }>();
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- legacy untyped DB row (ratchet: reduce, never add)
+  for (const p of (productsRes.data ?? []) as any[]) {
+    prodById.set(p.id, { name: p.name, category: p.category, price: Number(p.price ?? 0) });
+  }
+
+  // Group posters by round (or one '__all__' bucket for round-less app posters).
+  const postersByGroup = new Map<string, { id: string; title: string | null; product_id: string | null; round: string | null }[]>();
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- legacy untyped DB row (ratchet: reduce, never add)
+  for (const po of (postersRes.data ?? []) as any[]) {
+    const key = po.round ?? GROUP_ALL;
+    const arr = postersByGroup.get(key) ?? [];
+    arr.push({ id: po.id, title: po.title ?? null, product_id: po.product_id ?? null, round: po.round ?? null });
+    postersByGroup.set(key, arr);
+  }
+
+  const decisions: PosterDecision[] = [];
+  for (const [groupKey, posters] of postersByGroup) {
+    if (!posters.length) continue;
+    const round = (groupKey === GROUP_ALL ? null : (groupKey as Round));
+    const drinkHeavy = round ? (roundStats[round]?.single_rate ?? 0) >= DRINK_HEAVY_SINGLE_RATE : false;
+
+    const scored = posters.map((po) => {
+      const prod = po.product_id ? prodById.get(po.product_id) : null;
+      const priceRM = prod?.price ?? 0;
+      // Fallback to a 35%-COGS assumption when a poster isn't linked / cost unknown.
+      const costRM = prod ? costByName.get(prod.name.trim().toLowerCase()) ?? priceRM * 0.35 : priceRM * 0.35;
+      const marginRM = Math.max(0, priceRM - costRM);
+      const isFood = prod?.category ? FOOD_CATEGORIES.has(prod.category) : false;
+      const units = po.product_id ? unitsByRoundProduct.get(`${round ?? ""}|${po.product_id}`) ?? 0 : 0;
+      const measured = measuredByPoster.get(po.id) ?? { orders: 0, aov: 0 };
+      return { po, prod, priceRM, marginRM, isFood, units, measured, attach: isFood && drinkHeavy };
+    });
+
+    const maxMargin = Math.max(1, ...scored.map((s) => s.marginRM));
+    const maxPrice = Math.max(1, ...scored.map((s) => s.priceRM));
+    const maxUnits = Math.max(1, ...scored.map((s) => s.units));
+    const maxMeasuredAov = Math.max(1, ...scored.map((s) => s.measured.aov));
+
+    const ranked = scored
+      .map((s) => {
+        const marginN = s.marginRM / maxMargin;
+        const priceN = s.priceRM / maxPrice;
+        const unitsN = s.units / maxUnits;
+        let score: number;
+        let reason: string;
+        if (opts.mode === "control") {
+          score = unitsN;
+          reason = "popularity (control)";
+        } else {
+          const heuristic = 0.45 * marginN + 0.3 * (s.attach ? 1 : 0) + 0.15 * priceN + 0.1 * unitsN;
+          const bits: string[] = [];
+          if (s.attach) bits.push("fills drink-only gap");
+          if (marginN > 0.7) bits.push(`RM${s.marginRM.toFixed(2)} margin`);
+          if (priceN > 0.7) bits.push("premium anchor");
+          if (!s.prod) bits.push("unlinked");
+          // Blend in MEASURED order AOV as attributed orders accrue (app only):
+          // weight ramps 0→1 over the first ~10 orders, then measured dominates.
+          const w = Math.min(s.measured.orders / 10, 1);
+          if (w > 0) {
+            score = w * (s.measured.aov / maxMeasuredAov) + (1 - w) * heuristic;
+            bits.unshift(`measured AOV RM${s.measured.aov.toFixed(2)} (${s.measured.orders} ord)`);
+          } else {
+            score = heuristic;
+          }
+          reason = bits.join(", ") || "balanced";
+        }
+        return { s, score, reason };
+      })
+      .sort((a, b) => b.score - a.score);
+
+    ranked.forEach((r, i) => {
+      decisions.push({
+        round,
+        posterId: r.s.po.id,
+        title: r.s.po.title,
+        productId: r.s.po.product_id,
+        active: i < topK,
+        sortOrder: (i + 1) * 10,
+        score: Math.round(r.score * 1000) / 1000,
+        reason: r.reason,
+      });
+    });
+  }
+  return decisions;
+}

--- a/apps/order/src/app/_PosterCarousel.tsx
+++ b/apps/order/src/app/_PosterCarousel.tsx
@@ -16,6 +16,25 @@ type Poster = {
   deeplink: string | null;
 };
 
+// Best-effort tap log → /api/poster-tap so the home autopilot can attribute the
+// resulting order's AOV to this poster. keepalive lets it survive the
+// navigation the <Link> triggers; never blocks the tap.
+function logPosterTap(posterId: string, deeplink: string | null) {
+  try {
+    let loyaltyId: string | null = null;
+    const raw = localStorage.getItem("celsius-pickup");
+    if (raw) loyaltyId = (JSON.parse(raw)?.state?.loyaltyId as string | undefined) ?? null;
+    void fetch("/api/poster-tap", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ posterId, placement: "home", deeplink, loyaltyId }),
+      keepalive: true,
+    }).catch(() => {});
+  } catch {
+    /* never block navigation */
+  }
+}
+
 export function PosterCarousel({ posters }: { posters: Poster[] }) {
   const [idx, setIdx] = useState(0);
 
@@ -37,6 +56,7 @@ export function PosterCarousel({ posters }: { posters: Poster[] }) {
         <Link
           key={p.id}
           href={p.deeplink || "/menu"}
+          onClick={() => logPosterTap(p.id, p.deeplink)}
           className="absolute inset-0"
           style={{
             opacity: i === idx ? 1 : 0,

--- a/apps/order/src/app/api/home-posters/route.ts
+++ b/apps/order/src/app/api/home-posters/route.ts
@@ -11,12 +11,28 @@ import { getSupabaseAdmin } from "@/lib/supabase/server";
 // stale window beats hammering Supabase on every cold launch.
 export const revalidate = 60;
 
+// Current MYT day-part round (mirrors /api/pos/posters). A round-less poster
+// shows always; a round-tagged poster only during its round — lets the
+// autopilot rotate the home carousel by day-part once posters are tagged.
+function currentRound(): string {
+  const h = (new Date().getUTCHours() + 8) % 24;
+  if (h >= 8 && h < 10) return "breakfast";
+  if (h >= 10 && h < 12) return "brunch";
+  if (h >= 12 && h < 15) return "lunch";
+  if (h >= 15 && h < 17) return "midday";
+  if (h >= 17 && h < 19) return "evening";
+  if (h >= 19 && h < 21) return "dinner";
+  if (h >= 21 && h < 23) return "supper";
+  return "";
+}
+
 export async function GET(request: NextRequest) {
   const brandId = request.nextUrl.searchParams.get("brand_id") ?? "brand-celsius";
 
   try {
     const supabase = getSupabaseAdmin();
     const now = new Date().toISOString();
+    const round = currentRound();
 
     const { data, error } = await supabase
       .from("splash_posters")
@@ -25,6 +41,8 @@ export async function GET(request: NextRequest) {
       .eq("active", true)
       // Home carousel only — splash posters stay on the launch screen.
       .eq("placement", "home")
+      // Recurring day-part round: round-less shows always; tagged shows in-round.
+      .or(round ? `round.is.null,round.eq.${round}` : "round.is.null")
       // Operator-controlled sequence first (lower number = appears earlier
       // in the carousel rotation). NULL sort_order is treated as "unordered"
       // and falls to the back of the rotation, ordered by recency.

--- a/apps/order/src/app/api/orders/route.ts
+++ b/apps/order/src/app/api/orders/route.ts
@@ -17,6 +17,7 @@ import {
 } from "@/lib/loyalty/promotions";
 import { requireCustomerSession } from "@/lib/customer-jwt";
 import { attributeOrderToCampaign } from "@/lib/push/attribution";
+import { attributeOrderToPoster } from "@/lib/poster/attribution";
 import { getOutletSst } from "@/lib/outlet-sst";
 
 function normalisePhoneForLookup(phone: string): string {
@@ -716,6 +717,15 @@ export async function POST(request: NextRequest) {
     // order so the backoffice campaign stats can show "orders driven"
     // per campaign. Fire-and-forget; never blocks the response.
     void attributeOrderToCampaign({
+      orderId:   order.id,
+      memberId:  loyaltyId ?? null,
+      revenueRm: totalSen / 100,
+    });
+
+    // Poster → order attribution. Tag the most recent unattributed poster tap
+    // for this member (within 24h) so the home autopilot learns which poster
+    // drives the highest-AOV orders. Fire-and-forget.
+    void attributeOrderToPoster({
       orderId:   order.id,
       memberId:  loyaltyId ?? null,
       revenueRm: totalSen / 100,

--- a/apps/order/src/app/api/poster-tap/route.ts
+++ b/apps/order/src/app/api/poster-tap/route.ts
@@ -1,0 +1,61 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getSupabaseAdmin } from "@/lib/supabase/server";
+import { readCustomerSession } from "@/lib/customer-jwt";
+
+/**
+ * POST /api/poster-tap
+ *
+ * Logs a customer tap on a home/splash poster so the pos-poster-autopilot can
+ * learn which poster drives orders / higher AOV. The member is taken from the
+ * customer JWT when present (falls back to the body's loyaltyId). The product is
+ * parsed from the deeplink (/product/<id>). At order creation,
+ * attributeOrderToPoster tags the most recent unattributed tap for the member.
+ *
+ * Best-effort, never throws — a failed log must not affect the customer.
+ */
+
+export const dynamic = "force-dynamic";
+
+const ROUNDS: { key: string; s: number; e: number }[] = [
+  { key: "breakfast", s: 8, e: 10 }, { key: "brunch", s: 10, e: 12 }, { key: "lunch", s: 12, e: 15 },
+  { key: "midday", s: 15, e: 17 }, { key: "evening", s: 17, e: 19 }, { key: "dinner", s: 19, e: 21 },
+  { key: "supper", s: 21, e: 23 },
+];
+function currentRound(): string | null {
+  const h = (new Date().getUTCHours() + 8) % 24; // MYT
+  return ROUNDS.find((r) => h >= r.s && h < r.e)?.key ?? null;
+}
+function productIdFromDeeplink(dl: string | null): string | null {
+  if (!dl) return null;
+  const m = dl.match(/\/product\/([^/?#]+)/);
+  return m ? decodeURIComponent(m[1]) : null;
+}
+
+export async function POST(req: NextRequest) {
+  try {
+    const body = (await req.json().catch(() => ({}))) as {
+      posterId?: string; placement?: string; deeplink?: string; loyaltyId?: string; sessionId?: string;
+    };
+    if (!body?.posterId) return NextResponse.json({ ok: false }, { status: 200 });
+
+    const session = readCustomerSession(req);
+    const loyaltyId =
+      (session as { loyaltyId?: string } | null)?.loyaltyId ??
+      (typeof body.loyaltyId === "string" ? body.loyaltyId : null);
+
+    const supabase = getSupabaseAdmin();
+    await supabase.from("poster_events").insert({
+      poster_id: body.posterId,
+      product_id: productIdFromDeeplink(typeof body.deeplink === "string" ? body.deeplink : null),
+      placement: typeof body.placement === "string" ? body.placement : null,
+      round: currentRound(),
+      loyalty_id: loyaltyId,
+      session_id: typeof body.sessionId === "string" ? body.sessionId : null,
+      event_type: "tap",
+    } as Record<string, unknown>);
+
+    return NextResponse.json({ ok: true });
+  } catch {
+    return NextResponse.json({ ok: false }, { status: 200 });
+  }
+}

--- a/apps/order/src/app/api/splash-poster/route.ts
+++ b/apps/order/src/app/api/splash-poster/route.ts
@@ -7,12 +7,28 @@ import { getSupabaseAdmin } from "@/lib/supabase/server";
 // every time the app cold-starts.
 export const revalidate = 60;
 
+// Current MYT day-part round (mirrors /api/home-posters & /api/pos/posters).
+// A round-less poster shows always; a round-tagged poster only during its
+// round — lets the autopilot schedule the launch splash by day-part.
+function currentRound(): string {
+  const h = (new Date().getUTCHours() + 8) % 24;
+  if (h >= 8 && h < 10) return "breakfast";
+  if (h >= 10 && h < 12) return "brunch";
+  if (h >= 12 && h < 15) return "lunch";
+  if (h >= 15 && h < 17) return "midday";
+  if (h >= 17 && h < 19) return "evening";
+  if (h >= 19 && h < 21) return "dinner";
+  if (h >= 21 && h < 23) return "supper";
+  return "";
+}
+
 export async function GET(request: NextRequest) {
   const brandId = request.nextUrl.searchParams.get("brand_id") ?? "brand-celsius";
 
   try {
     const supabase = getSupabaseAdmin();
     const now = new Date().toISOString();
+    const round = currentRound();
 
     const { data, error } = await supabase
       .from("splash_posters")
@@ -21,6 +37,8 @@ export async function GET(request: NextRequest) {
       .eq("active", true)
       // Splash surface only — home posters stay on the home carousel.
       .eq("placement", "splash")
+      // Recurring day-part round: round-less shows always; tagged shows in-round.
+      .or(round ? `round.is.null,round.eq.${round}` : "round.is.null")
       .order("updated_at", { ascending: false });
 
     if (error) {

--- a/apps/order/src/lib/poster/attribution.ts
+++ b/apps/order/src/lib/poster/attribution.ts
@@ -1,0 +1,49 @@
+import { getSupabaseAdmin } from "@/lib/supabase/server";
+
+/**
+ * Order → poster attribution. Mirrors push attribution (lib/push/attribution.ts):
+ * when an order is created we tag the most recent unattributed poster tap for the
+ * same member within 24h with the order id + revenue. The autopilot
+ * (pos_poster_app_perf) then reads attributed_* to learn which poster drives the
+ * highest-AOV orders and rotates toward it.
+ *
+ * Fire-and-forget — never blocks the order POST.
+ */
+
+const ATTRIBUTION_WINDOW_MS = 24 * 60 * 60 * 1000;
+
+export async function attributeOrderToPoster(args: {
+  orderId: string;
+  memberId: string | null;
+  revenueRm: number;
+}): Promise<void> {
+  if (!args.memberId || !(args.revenueRm > 0)) return;
+  try {
+    const supabase = getSupabaseAdmin();
+    const since = new Date(Date.now() - ATTRIBUTION_WINDOW_MS).toISOString();
+
+    const { data: candidate } = await supabase
+      .from("poster_events")
+      .select("id")
+      .eq("loyalty_id", args.memberId)
+      .eq("event_type", "tap")
+      .is("attributed_order_id", null)
+      .gte("created_at", since)
+      .order("created_at", { ascending: false })
+      .limit(1)
+      .maybeSingle();
+
+    if (!candidate) return;
+
+    await supabase
+      .from("poster_events")
+      .update({
+        attributed_order_id: args.orderId,
+        attributed_revenue: args.revenueRm,
+        attributed_at: new Date().toISOString(),
+      })
+      .eq("id", (candidate as { id: string }).id);
+  } catch (err) {
+    console.error("[poster/attribution] failed to attribute order", args.orderId, err);
+  }
+}

--- a/docs/design/aov-at-pos-loop.md
+++ b/docs/design/aov-at-pos-loop.md
@@ -1,0 +1,116 @@
+# AOV-at-POS Loop (activate the dormant upsell, close the loop)
+
+> Office-hours diagnostic, 2026-06-20. Chosen over the outbound campaign agent because
+> push reaches only **28 of 21,008 members** and SMS is 59% blocked — outbound marketing
+> has flat tyres. The AOV loop hits **100% of buyers** at the till, needs zero reach, and
+> the engine is already built.
+
+## Problem Statement
+
+POS AOV is **RM28.68** vs the **RM40** target (business model). Baskets average **2.12
+units**, and **~44% of orders are a single item** — a drink and nothing else. The
+"Pair with a Bite" suggest-pairs engine exists to fix this but is **dormant**: it fired on
+**24 of 2,178 orders (~1%)** in the last 30 days, and only from the register surface.
+
+## Demand Evidence (live, kqdcdhpnyuwrxqhbuyfl, 30 days to 2026-06-20)
+
+- 2,178 real POS orders; AOV **RM28.68**; **2.12 units/order**.
+- **Single-item orders by round** (the prime attach target):
+  | Round | Orders | AOV | % single-item |
+  |---|---|---|---|
+  | Breakfast | 482 | 28.88 | 38% |
+  | Brunch | 302 | 27.03 | **49%** |
+  | **Lunch** | 374 | **25.66** | **52%** |
+  | Midday | 465 | 29.40 | 45% |
+  | Evening | 338 | 31.03 | 43% |
+- Upsell engine: **63 pair events on 24 orders in 30d (~1% penetration)**, source = `register`
+  only. Customer display and pickup app surfaces are unused.
+- (Volume is ramping — Shah Alam + Tamarind only cut over to POS-native 2026-06-15, so order
+  counts will grow toward the ~90/day/outlet target; the AOV/attach ratios are the signal.)
+
+## Status Quo (what happens now)
+
+Cashier rings a drink. The suggest-pairs prompt almost never shows (1%). Customer pays for
+one drink and leaves. No suggestion on the customer display, none in the pickup-app cart.
+~44% of baskets stay single-item.
+
+## Target User (named person)
+
+> **To confirm with Ammar:** the cashier/barista at the till is the actor for the register
+> wedge. Who owns the POS register UX decisions? (Same person who locked the POS UX
+> improvements.) For the pickup-app surface, the actor is the online customer.
+
+## Narrowest Wedge
+
+Force the suggest-pairs prompt on the register **when the basket is a single item**,
+targeted hardest at **Lunch and Brunch**, with a **one-tap full-price add** (no discount).
+The engine already ranks the suggestion; the gap is it isn't shown. Log impression + add so
+attach-rate is measurable from day one.
+
+## The Loop (steady state)
+
+1. **Sense** — each basket's items + round + outlet → flag single-item / drink-only.
+2. **Act** — surface the ranked attach suggestion at the till (and later display + pickup cart).
+3. **Measure** — attach-rate (shown→added) and AOV lift vs baseline, by round/outlet/suggestion.
+4. **Tune** — the gated `tune_pair_weights()` auto-tuner reweights suggestions toward what
+   actually converts. Loop closes.
+
+## Premises
+
+1. Suggestion units are integers in sen (÷100 = RM). Confirmed (AOV math checks out).
+2. `pos_pair_events` currently logs adds from `register` only; needs an impression event to
+   compute a true attach-rate. (To verify in code.)
+3. A full-price attach beats a discount (North Star: discounts last resort). Combos only if
+   BOM-margin-positive — margin data now available via BOM cost.
+4. The till must stay fast (POS UX: big targets, no friction). One tap, dismissable.
+
+## Approaches Considered
+
+### Approach A — Activate the register prompt (days)
+Show the suggest-pairs prompt whenever basket = 1 item, prominent + one-tap, weighted to
+Lunch/Brunch. Add an impression event to `pos_pair_events` so attach-rate is measurable.
+Pure activation of built code. Ships in days.
+
+### Approach B — Multi-surface + closed measurement loop (weeks)
+A + push suggestions to the **customer display** ("Add a {bite} — RM{x}") and the
+**pickup-app cart**, + a weekly attach-rate/AOV dashboard by round/outlet, + enable the
+gated `tune_pair_weights()` auto-tuner. This is the full self-optimizing loop.
+
+### Approach C — Dynamic bundling & margin-aware pricing (months)
+B + auto-generated combos and price points from BOM margin + demand elasticity, auto-applied
+under a margin floor (the "dynamic menu & pricing" loop). Bigger, riskier (auto-pricing),
+only after B proves the attach-rate loop converts.
+
+## Recommended Approach
+
+**A → B.** A turns on dormant value and proves attach-rate moves; B closes the
+measure+tune loop and adds the high-reach surfaces (display, pickup cart). C waits until B
+shows conversion and a margin floor is defined.
+
+**What would flip it:** if A shows the forced prompt slows the till or annoys cashiers
+without lifting attach-rate, pivot the wedge to the **customer-display** surface (self-serve,
+zero cashier friction) as the primary lever instead of the register prompt.
+
+## Open Questions
+
+- Does `pos_pair_events` log impressions, or only adds? (Decides whether attach-rate is
+  measurable today.) — verify in the suggest-pairs route.
+- Attach target: single-item baskets only, or also drink-only 2-item baskets (drink+drink → add bite)?
+- Customer-display surface: does the current display render arbitrary prompts, or only the
+  round splash posters? (Affects Approach B effort.)
+- Combo vs straight add: do we ever bundle at a small margin-positive discount, or strictly
+  full-price adds?
+
+## Success Criteria (measurable)
+
+- Upsell penetration: **~1% → >60% of single-item orders see a prompt** within one cycle.
+- Attach-rate (shown→added): establish baseline, then **>10%**.
+- AOV: **RM28.68 → RM32+** in 60 days, Lunch round **RM25.66 → RM29+**.
+- Zero measurable till-speed regression (order-to-pay time).
+
+## The Assignment (one concrete next step)
+
+Before building: stand at the busiest till through one **Lunch** round (1–2pm) and watch 20
+single-drink orders. Count how many the cashier *could* have attached a bite to in one
+sentence, and note what the customer was buying. That tells us the realistic attach ceiling
+and which 2–3 pairings to hard-wire first.

--- a/supabase/migrations/035_pos_poster_autopilot.sql
+++ b/supabase/migrations/035_pos_poster_autopilot.sql
@@ -1,0 +1,113 @@
+-- ─────────────────────────────────────────────────────────────────────────
+-- POS poster autopilot — auto-rotate customer-display posters to push AOV
+--
+-- The /api/pos/posters endpoint serves active pos-display posters for the
+-- current day-part round. This migration lets a cron (pos-poster-autopilot)
+-- score the featured product of each round's posters by AOV-lift (margin +
+-- food-attach in drink-heavy rounds + price anchor) and flip active/sort_order
+-- to the best K per round. A switchback A/B (autopilot days vs control/
+-- popularity days) records per-round AOV in pos_poster_perf so the loop can
+-- prove whether posters move AOV — and back off if they don't.
+--
+-- Additive + idempotent. No drops.
+-- ─────────────────────────────────────────────────────────────────────────
+
+-- 1. Link each poster to the product it features (for margin/attach scoring).
+ALTER TABLE splash_posters ADD COLUMN IF NOT EXISTS product_id TEXT;
+COMMENT ON COLUMN splash_posters.product_id IS
+  'Product (products.id) this poster features. Drives pos-poster-autopilot AOV scoring.';
+CREATE INDEX IF NOT EXISTS idx_splash_posters_product_id
+  ON splash_posters (product_id) WHERE product_id IS NOT NULL;
+
+-- 2. Switchback A/B measurement: one row per (date, round) tagged with the mode
+--    that was live that day and the realised AOV. Autopilot must earn its keep.
+CREATE TABLE IF NOT EXISTS pos_poster_perf (
+  id                  uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  perf_date           date NOT NULL,
+  round               text NOT NULL,
+  mode                text NOT NULL,            -- 'autopilot' | 'control'
+  aov_rm              numeric,
+  orders              integer,
+  featured_product_ids text[],
+  created_at          timestamptz NOT NULL DEFAULT now(),
+  UNIQUE (perf_date, round)
+);
+COMMENT ON TABLE pos_poster_perf IS
+  'Daily per-round AOV tagged by autopilot/control mode — the holdout that tells us if posters lift AOV.';
+
+-- 3. Gated off by default; flip to {"enabled": true} to go live.
+INSERT INTO app_settings (key, value, updated_at)
+VALUES ('pos_poster_autopilot_enabled', '{"enabled": false}'::jsonb, now())
+ON CONFLICT (key) DO NOTHING;
+
+-- 4. Scoring signals: per-round AOV / single-item rate + per-round-per-product
+--    units over a trailing window. One call, returned as JSONB.
+CREATE OR REPLACE FUNCTION public.pos_poster_signals(p_days integer DEFAULT 21)
+RETURNS jsonb
+LANGUAGE sql
+STABLE
+AS $$
+  WITH o AS (
+    SELECT id, total,
+      CASE
+        WHEN extract(hour FROM created_at AT TIME ZONE 'Asia/Kuala_Lumpur') BETWEEN 8 AND 9   THEN 'breakfast'
+        WHEN extract(hour FROM created_at AT TIME ZONE 'Asia/Kuala_Lumpur') BETWEEN 10 AND 11  THEN 'brunch'
+        WHEN extract(hour FROM created_at AT TIME ZONE 'Asia/Kuala_Lumpur') BETWEEN 12 AND 14  THEN 'lunch'
+        WHEN extract(hour FROM created_at AT TIME ZONE 'Asia/Kuala_Lumpur') BETWEEN 15 AND 16  THEN 'midday'
+        WHEN extract(hour FROM created_at AT TIME ZONE 'Asia/Kuala_Lumpur') BETWEEN 17 AND 18  THEN 'evening'
+        WHEN extract(hour FROM created_at AT TIME ZONE 'Asia/Kuala_Lumpur') BETWEEN 19 AND 20  THEN 'dinner'
+        WHEN extract(hour FROM created_at AT TIME ZONE 'Asia/Kuala_Lumpur') BETWEEN 21 AND 22  THEN 'supper'
+        ELSE 'other'
+      END AS rnd
+    FROM pos_orders
+    WHERE created_at > now() - make_interval(days => p_days)
+      AND status NOT IN ('cancelled','refunded','void')
+      AND coalesce(refund_of_order_id,'') = ''
+  ),
+  units AS (SELECT order_id, sum(quantity) AS q FROM pos_order_items GROUP BY order_id),
+  round_aov AS (
+    SELECT o.rnd,
+           count(*) AS orders,
+           round(avg(o.total)/100.0, 2) AS aov,
+           round(100.0 * sum(CASE WHEN u.q = 1 THEN 1 ELSE 0 END) / count(*), 1) AS single_rate
+    FROM o JOIN units u ON u.order_id = o.id
+    WHERE o.rnd <> 'other'
+    GROUP BY o.rnd
+  ),
+  prod AS (
+    SELECT o.rnd, oi.product_id, sum(oi.quantity) AS units
+    FROM o JOIN pos_order_items oi ON oi.order_id = o.id
+    WHERE o.rnd <> 'other' AND oi.product_id IS NOT NULL
+    GROUP BY o.rnd, oi.product_id
+  )
+  SELECT jsonb_build_object(
+    'rounds',   (SELECT coalesce(jsonb_object_agg(rnd, jsonb_build_object('orders', orders, 'aov', aov, 'single_rate', single_rate)), '{}'::jsonb) FROM round_aov),
+    'products', (SELECT coalesce(jsonb_agg(jsonb_build_object('round', rnd, 'product_id', product_id, 'units', units)), '[]'::jsonb) FROM prod)
+  );
+$$;
+
+-- 5. Realised AOV per round for a specific MYT calendar date (perf logging).
+CREATE OR REPLACE FUNCTION public.pos_round_aov_for_date(p_date date)
+RETURNS TABLE(round text, orders integer, aov_rm numeric)
+LANGUAGE sql
+STABLE
+AS $$
+  SELECT
+    CASE
+      WHEN extract(hour FROM created_at AT TIME ZONE 'Asia/Kuala_Lumpur') BETWEEN 8 AND 9   THEN 'breakfast'
+      WHEN extract(hour FROM created_at AT TIME ZONE 'Asia/Kuala_Lumpur') BETWEEN 10 AND 11  THEN 'brunch'
+      WHEN extract(hour FROM created_at AT TIME ZONE 'Asia/Kuala_Lumpur') BETWEEN 12 AND 14  THEN 'lunch'
+      WHEN extract(hour FROM created_at AT TIME ZONE 'Asia/Kuala_Lumpur') BETWEEN 15 AND 16  THEN 'midday'
+      WHEN extract(hour FROM created_at AT TIME ZONE 'Asia/Kuala_Lumpur') BETWEEN 17 AND 18  THEN 'evening'
+      WHEN extract(hour FROM created_at AT TIME ZONE 'Asia/Kuala_Lumpur') BETWEEN 19 AND 20  THEN 'dinner'
+      WHEN extract(hour FROM created_at AT TIME ZONE 'Asia/Kuala_Lumpur') BETWEEN 21 AND 22  THEN 'supper'
+      ELSE 'other'
+    END AS round,
+    count(*)::int AS orders,
+    round(avg(total)/100.0, 2) AS aov_rm
+  FROM pos_orders
+  WHERE (created_at AT TIME ZONE 'Asia/Kuala_Lumpur')::date = p_date
+    AND status NOT IN ('cancelled','refunded','void')
+    AND coalesce(refund_of_order_id,'') = ''
+  GROUP BY 1;
+$$;

--- a/supabase/migrations/036_poster_events_attribution.sql
+++ b/supabase/migrations/036_poster_events_attribution.sql
@@ -1,0 +1,54 @@
+-- ─────────────────────────────────────────────────────────────────────────
+-- Poster deeplink attribution — let the autopilot learn which poster actually
+-- drives orders / higher AOV (home + splash app placements).
+--
+-- The app carousel/splash posters deeplink to /product/<id> or /menu. We log a
+-- tap event, then (mirroring push attribution in lib/push/attribution.ts) tag
+-- the next order from that member to the most recent unattributed tap within a
+-- 24h window. That gives real per-poster taps / orders / AOV — a far stronger
+-- signal than the POS switchback. The autopilot blends this measured AOV into
+-- its score as data accrues (cold-start = margin heuristic → measured).
+--
+-- Additive + idempotent.
+-- ─────────────────────────────────────────────────────────────────────────
+
+CREATE TABLE IF NOT EXISTS poster_events (
+  id                  uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  poster_id           text,                          -- splash_posters.id
+  product_id          text,                          -- product the deeplink points to (if any)
+  placement           text,                          -- 'home' | 'splash' | 'pos-display'
+  round               text,
+  loyalty_id          text,                          -- member if known at tap time
+  session_id          text,                          -- anonymous client fallback
+  event_type          text NOT NULL DEFAULT 'tap',   -- 'tap' | 'impression'
+  created_at          timestamptz NOT NULL DEFAULT now(),
+  attributed_order_id text,
+  attributed_revenue  numeric,
+  attributed_at       timestamptz
+);
+COMMENT ON TABLE poster_events IS
+  'Poster taps + last-touch order attribution for app posters. Feeds pos-poster-autopilot measured AOV.';
+
+CREATE INDEX IF NOT EXISTS idx_poster_events_attr_lookup
+  ON poster_events (loyalty_id, attributed_order_id, created_at) WHERE loyalty_id IS NOT NULL;
+CREATE INDEX IF NOT EXISTS idx_poster_events_session_lookup
+  ON poster_events (session_id, attributed_order_id, created_at) WHERE session_id IS NOT NULL;
+CREATE INDEX IF NOT EXISTS idx_poster_events_poster ON poster_events (poster_id, created_at);
+
+-- Per-poster measured performance over a trailing window: taps, attributed
+-- orders, and the AOV of those orders. The autopilot's app learning signal.
+CREATE OR REPLACE FUNCTION public.pos_poster_app_perf(p_days integer DEFAULT 28)
+RETURNS TABLE(poster_id text, taps bigint, orders bigint, attributed_aov numeric)
+LANGUAGE sql
+STABLE
+AS $$
+  SELECT
+    poster_id,
+    count(*) FILTER (WHERE event_type = 'tap')                  AS taps,
+    count(*) FILTER (WHERE attributed_order_id IS NOT NULL)     AS orders,
+    round(avg(attributed_revenue) FILTER (WHERE attributed_order_id IS NOT NULL), 2) AS attributed_aov
+  FROM poster_events
+  WHERE created_at > now() - make_interval(days => p_days)
+    AND poster_id IS NOT NULL
+  GROUP BY poster_id;
+$$;


### PR DESCRIPTION
## What
Brings **round (day-part) scheduling to home & splash posters**, matching pos-display, and lands the **AOV poster autopilot** (gated off).

### Round scheduling (the immediate ask)
- `splash-poster` + `home-posters` readers filter by the current MYT day-part round (`round IS NULL` = always shown; tagged = in-round only).
- CMS poster editor: the **Round picker + filter chips now work on every surface** (home / splash / POS) — previously pos-display only; save persists `round` for all placements.
- Operators can now pin any home/splash poster to Breakfast…Supper.

### AOV poster autopilot (gated off)
- Engine scores posters by AOV-lift (margin + food-attach + price), switchback A/B vs popularity; app placements blend measured order-AOV.
- Deeplink attribution: poster taps → `poster_events`, orders tied to last tap (24h) so the autopilot self-learns which poster drives the highest-AOV orders.
- Migrations `035` (signals/perf) + `036` (`poster_events`) — **already applied to the live DB**, committed here for parity.

## Safety
- Autopilot stays **gated off** (`pos_poster_autopilot_enabled = false`) and its cron is **not** registered in `vercel.json` — manual round scheduling works without it. Enabling auto-rotation is a separate go-live step.
- Both apps typecheck clean. Surgical commit — only the 12 poster-feature files (unrelated working-tree WIP excluded).

🤖 Generated with [Claude Code](https://claude.com/claude-code)