### PR TITLE
POS-screen poster autopilot + home drink-balance

### DIFF
--- a/apps/backoffice/src/app/api/cron/pos-poster-autopilot/route.ts
+++ b/apps/backoffice/src/app/api/cron/pos-poster-autopilot/route.ts
@@ -54,13 +54,12 @@ export async function GET(req: NextRequest) {
   const today = mytShift(now);
   const mode = modeFor(today);
 
-  // 1. Plan + apply. HOME only for now — it learns from deeplink-attributed
-  //    AOV (poster_events) and is safe to auto-manage. The pos-display
-  //    autopilot (in-store customer screens) is intentionally DEFERRED: turning
-  //    over the counter screens to auto-rotation is a separate operator
-  //    decision. To enable it, add `{ placement: "pos-display", mode }` back to
-  //    this list. Splash is not auto-managed by the cron either.
+  // 1. Plan + apply for POS + home. POS rotates on the switchback A/B (no
+  //    per-poster conversion signal) and keeps its food-attach push; home runs
+  //    autopilot and learns from deeplink-attributed AOV (poster_events) with a
+  //    reserved-drink quota so its carousel isn't all-food. Splash deferred.
   const placements = [
+    { placement: "pos-display" as const, mode },
     { placement: "home" as const, mode: "autopilot" as const },
   ];
   let applied = 0;

--- a/apps/backoffice/src/lib/pos/poster-autopilot.ts
+++ b/apps/backoffice/src/lib/pos/poster-autopilot.ts
@@ -102,6 +102,13 @@ export type Placement = "pos-display" | "home" | "splash";
 // rotates ~5, splash is a single launch poster (pick the one best one).
 const DEFAULT_TOPK: Record<Placement, number> = { "pos-display": 3, home: 5, splash: 1 };
 
+// Minimum drink (non-food) posters guaranteed in the active set per surface.
+// A pure margin/AOV ranking skews all-food (high-ticket pasta wins every slot),
+// which makes the app home hero read like a food court, not a cafe. Reserving a
+// couple of slots keeps signature drinks (matcha, etc.) in rotation. POS screen
+// keeps its food-attach logic untouched (we WANT to push a bite in-store).
+const RESERVE_DRINKS: Record<Placement, number> = { home: 2, splash: 0, "pos-display": 0 };
+
 // Group key for a poster row: POS rotates by day-part round; app placements
 // usually have no round (one '__all__' group) but support rounds once tagged.
 const GROUP_ALL = "__all__";
@@ -224,13 +231,33 @@ export async function planPosterRotation(
       })
       .sort((a, b) => b.score - a.score);
 
+    // Active set = top-K by score, but guarantee RESERVE_DRINKS drink slots:
+    // swap the lowest-scoring foods in the top-K for the best benched drinks so
+    // the carousel isn't 100% food. No-op when the natural top-K already has
+    // enough drinks, or when the pool has no benched drinks to promote.
+    const activeIds = new Set(ranked.slice(0, topK).map((r) => r.s.po.id));
+    const minDrinks = RESERVE_DRINKS[placement] ?? 0;
+    if (minDrinks > 0) {
+      const top = ranked.slice(0, topK);
+      const need = minDrinks - top.filter((r) => !r.s.isFood).length;
+      if (need > 0) {
+        const benchDrinks = ranked.slice(topK).filter((r) => !r.s.isFood).slice(0, need);
+        const dropFoods = top
+          .filter((r) => r.s.isFood)
+          .sort((a, b) => a.score - b.score)
+          .slice(0, benchDrinks.length);
+        for (const r of dropFoods) activeIds.delete(r.s.po.id);
+        for (const r of benchDrinks) activeIds.add(r.s.po.id);
+      }
+    }
+
     ranked.forEach((r, i) => {
       decisions.push({
         round,
         posterId: r.s.po.id,
         title: r.s.po.title,
         productId: r.s.po.product_id,
-        active: i < topK,
+        active: activeIds.has(r.s.po.id),
         sortOrder: (i + 1) * 10,
         score: Math.round(r.score * 1000) / 1000,
         reason: r.reason,


### PR DESCRIPTION
Two changes on top of the now-live home autopilot:

### 1. POS screen autopilot (the ask)
Re-enables `pos-display` in the daily cron — top 3/round, switchback A/B vs popularity, food-attach push in drink-heavy rounds. Auto-manages the in-store customer screens alongside home.

### 2. Home drink-balance rule
Home/app carousel now **reserves 2 drink slots** in the active set, so a pure margin/AOV ranking doesn't surface an all-food (all-pasta) hero — signature drinks (matcha, etc.) stay in rotation. It swaps the lowest-scoring foods in the top-K for the best benched drinks; no-op when enough drinks already rank or none exist. POS keeps `reserve 0` (we *want* to push a bite on the counter screen).

🤖 Generated with [Claude Code](https://claude.com/claude-code)