### PR TITLE
SMS gateway toggle (SMS Niaga / SMS123) + fix SMS Niaga contract

### DIFF
--- a/apps/backoffice/src/app/(admin)/settings/integrations/page.tsx
+++ b/apps/backoffice/src/app/(admin)/settings/integrations/page.tsx
@@ -308,6 +308,12 @@ export default function IntegrationsPage() {
   const [syncing, setSyncing] = useState(false);
   const [syncMsg, setSyncMsg] = useState<string | null>(null);
 
+  // SMS gateway provider toggle (app_settings.sms_provider)
+  const [smsProvider, setSmsProvider] = useState<string>("");
+  const [smsOpen, setSmsOpen] = useState(false);
+  const [smsSaving, setSmsSaving] = useState(false);
+  const [smsMsg, setSmsMsg] = useState<string | null>(null);
+
   /* ── Load ──────────────────────────────────────────────────────────────── */
 
   const loadOutlets = useCallback(async () => {
@@ -348,7 +354,15 @@ export default function IntegrationsPage() {
     } catch { /* ignore */ }
   }, []);
 
-  useEffect(() => { loadOutlets(); loadPgConfig(); loadQr(); }, [loadOutlets, loadPgConfig, loadQr]);
+  const loadSmsProvider = useCallback(async () => {
+    try {
+      const res = await fetch("/api/settings?key=sms_provider");
+      const data = await res.json();
+      if (typeof data === "string" && data) setSmsProvider(data);
+    } catch { /* ignore */ }
+  }, []);
+
+  useEffect(() => { loadOutlets(); loadPgConfig(); loadQr(); loadSmsProvider(); }, [loadOutlets, loadPgConfig, loadQr, loadSmsProvider]);
 
   /* ── Maybank QR + config sync ──────────────────────────────────────────── */
 
@@ -368,6 +382,26 @@ export default function IntegrationsPage() {
       setQrMsg("Save failed");
     }
     setQrSaving(false);
+  }
+
+  /* ── SMS gateway provider toggle ───────────────────────────────────────── */
+
+  async function saveSmsProvider(next: string) {
+    setSmsProvider(next);
+    setSmsSaving(true);
+    setSmsMsg(null);
+    try {
+      const res = await fetch("/api/settings", {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ key: "sms_provider", value: next }),
+      });
+      if (!res.ok) throw new Error();
+      setSmsMsg("Saved");
+    } catch {
+      setSmsMsg("Save failed");
+    }
+    setSmsSaving(false);
   }
 
   /** Read a File as a data: URL. We store the Maybank poster image
@@ -586,6 +620,60 @@ export default function IntegrationsPage() {
           </div>
         ))}
       </div>
+
+      {/* ── SMS Gateway ─────────────────────────────────────────────────── */}
+      <SectionCard
+        icon={<Smartphone className="h-5 w-5 text-emerald-600" />}
+        iconBg="bg-emerald-50"
+        title="SMS Gateway"
+        subtitle="Choose which provider sends OTP and marketing SMS"
+        badge={
+          <span className="text-[10px] bg-emerald-50 text-emerald-700 px-2 py-0.5 rounded-full font-medium">
+            {smsProvider === "smsniaga" ? "SMS Niaga"
+              : smsProvider === "sms123" ? "SMS123"
+              : smsProvider === "console" ? "Console (dev)"
+              : "Env default"}
+          </span>
+        }
+        open={smsOpen}
+        onToggle={() => setSmsOpen(!smsOpen)}
+      >
+        <div className="mt-4 space-y-3">
+          <p className="text-xs text-gray-500">
+            Switches the active gateway for OTP and loyalty blasts instantly — no redeploy. Applies
+            everywhere via <code className="text-[11px] bg-gray-100 px-1 py-0.5 rounded">app_settings.sms_provider</code>.
+          </p>
+          <div className="grid gap-2">
+            {[
+              { id: "smsniaga", label: "SMS Niaga", note: "manage.smsniaga.com · sender CELSIUSCOFFEE · RM0.10/SMS" },
+              { id: "sms123", label: "SMS123", note: "sms123.net · legacy provider" },
+              { id: "console", label: "Console (dev)", note: "Logs to server console — no SMS sent" },
+            ].map((opt) => {
+              const active = smsProvider === opt.id;
+              return (
+                <button
+                  key={opt.id}
+                  onClick={() => saveSmsProvider(opt.id)}
+                  disabled={smsSaving}
+                  className={`flex items-center justify-between rounded-lg border px-4 py-3 text-left transition-colors disabled:opacity-60 ${active ? "border-emerald-500 bg-emerald-50/50" : "border-gray-200 bg-white hover:bg-gray-50"}`}
+                >
+                  <div className="min-w-0">
+                    <div className="text-sm font-medium text-gray-900">{opt.label}</div>
+                    <div className="text-xs text-gray-500 truncate">{opt.note}</div>
+                  </div>
+                  {active && <CheckCircle2 className="h-4 w-4 text-emerald-600 shrink-0" />}
+                </button>
+              );
+            })}
+          </div>
+          {!smsProvider && (
+            <p className="text-[11px] text-amber-600">
+              No override set — using the <code className="text-[11px] bg-gray-100 px-1 py-0.5 rounded">SMS_PROVIDER</code> env var as default.
+            </p>
+          )}
+          {smsMsg && <p className="text-xs text-gray-500">{smsMsg}</p>}
+        </div>
+      </SectionCard>
 
       {/* ── Payment Methods ─────────────────────────────────────────────── */}
       <SectionCard

--- a/apps/backoffice/src/app/api/cron/campaigns-auto/route.ts
+++ b/apps/backoffice/src/app/api/cron/campaigns-auto/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { supabaseAdmin } from "@/lib/loyalty/supabase";
-import { sendSMS } from "@/lib/loyalty/sms";
+import { sendSMS, providerAutoPrependsSender, getActiveSmsProvider } from "@/lib/loyalty/sms";
 import { checkCronAuth } from "@celsius/shared";
 
 export const dynamic = "force-dynamic";
@@ -297,7 +297,7 @@ export async function GET(req: NextRequest) {
       }
     }
 
-    const provider = (process.env.SMS_PROVIDER || "console").trim();
+    const provider = await getActiveSmsProvider();
     const template = campaign.message!;
     let sent = 0;
     let failed = 0;
@@ -321,12 +321,13 @@ export async function GET(req: NextRequest) {
       const rendered = batch.map((m) =>
         renderMessage(template, { name: m.name, points: m.points_balance })
       );
-      const finalMessages = rendered.map(
-        (body) => `RM0 [${SENDER_LABEL}] ${body}`
+      // SMS Niaga adds its own "RM0.00 <SenderID>:" at the gateway, so skip ours there.
+      const finalMessages = rendered.map((body) =>
+        providerAutoPrependsSender(provider) ? body : `RM0 [${SENDER_LABEL}] ${body}`
       );
 
       const batchResults = await Promise.all(
-        batch.map((m, idx) => sendSMS(m.phone, finalMessages[idx]))
+        batch.map((m, idx) => sendSMS(m.phone, finalMessages[idx], { provider }))
       );
 
       for (let j = 0; j < batch.length; j++) {

--- a/apps/backoffice/src/app/api/loyalty/sms/blast/route.ts
+++ b/apps/backoffice/src/app/api/loyalty/sms/blast/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { supabaseAdmin } from '@/lib/loyalty/supabase';
-import { sendSMS } from '@/lib/loyalty/sms';
+import { sendSMS, providerAutoPrependsSender, getActiveSmsProvider } from '@/lib/loyalty/sms';
 import { requireAuth } from '@/lib/auth';
 
 const BATCH_SIZE = 10; // Send 10 SMS concurrently per batch
@@ -64,10 +64,15 @@ export async function POST(request: NextRequest) {
       }
     }
 
-    // Auto-prepend RM0 [<SenderID>] prefix if not already present
+    // Active gateway from the backoffice toggle (app_settings → env fallback).
+    const provider = await getActiveSmsProvider();
+
+    // Auto-prepend RM0 [<SenderID>] prefix if not already present.
+    // SMS Niaga adds its own "RM0.00 <SenderID>:" at the gateway, so skip ours there.
     const senderLabel = sender_id || 'CelsiusCoffee';
     const SMS_PREFIX = `RM0 [${senderLabel}] `;
-    const baseMessage = message.startsWith('RM0 ') ? message : `${SMS_PREFIX}${message}`;
+    const baseMessage =
+      providerAutoPrependsSender(provider) || message.startsWith('RM0 ') ? message : `${SMS_PREFIX}${message}`;
 
     // Per-recipient template substitution: if the message contains {name} or {points},
     // fetch each member's data and substitute before sending. Without this, customers
@@ -124,7 +129,12 @@ export async function POST(request: NextRequest) {
 
       const batchResults = await Promise.all(
         batch.map((phone, idx) =>
-          sendSMS(phone, batchMessages[idx], sender_id ? { senderId: sender_id } : undefined),
+          sendSMS(phone, batchMessages[idx], {
+            provider,
+            // SMS Niaga requires a registered Sender ID — let the provider use its
+            // configured default rather than forwarding a free-text label.
+            ...(!providerAutoPrependsSender(provider) && sender_id ? { senderId: sender_id } : {}),
+          }),
         ),
       );
 
@@ -143,7 +153,7 @@ export async function POST(request: NextRequest) {
           phone: batch[j],
           message: batchMessages[j],
           status: result.success ? 'sent' : 'failed',
-          provider: (process.env.SMS_PROVIDER || 'console').trim(),
+          provider,
           provider_message_id: result.messageId || null,
           error: result.error || null,
         });

--- a/apps/backoffice/src/app/api/loyalty/sms/credits/route.ts
+++ b/apps/backoffice/src/app/api/loyalty/sms/credits/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { supabaseAdmin } from '@/lib/loyalty/supabase';
 import { requireAuth } from '@/lib/auth';
+import { getActiveSmsProvider } from '@/lib/loyalty/sms';
 
 // GET /api/sms/credits?brand_id=X — get credit balance from SMS123 + usage stats
 export async function GET(request: NextRequest) {
@@ -54,7 +55,7 @@ export async function GET(request: NextRequest) {
 
     return NextResponse.json({
       balance: sms123Balance,
-      provider: process.env.SMS_PROVIDER || 'console',
+      provider: await getActiveSmsProvider(),
       total_sent: totalSent ?? 0,
       sent_this_month: sentThisMonth ?? 0,
       history: history ?? [],

--- a/apps/backoffice/src/app/api/loyalty/sms/send/route.ts
+++ b/apps/backoffice/src/app/api/loyalty/sms/send/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { sendSMS } from '@/lib/loyalty/sms';
+import { sendSMS, providerAutoPrependsSender, getActiveSmsProvider } from '@/lib/loyalty/sms';
 import { requireAuth } from '@/lib/auth';
 
 export async function POST(request: NextRequest) {
@@ -13,12 +13,17 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ success: false, error: 'phone and message required' }, { status: 400 });
     }
 
-    // Auto-prepend RM0 [<SenderID>] prefix if not already present
+    // Active gateway from the backoffice toggle (app_settings → env fallback).
+    const provider = await getActiveSmsProvider();
+
+    // Auto-prepend RM0 [<SenderID>] prefix if not already present.
+    // SMS Niaga adds its own "RM0.00 <SenderID>:" at the gateway, so skip ours there.
     const senderLabel = sender_id || 'CelsiusCoffee';
     const SMS_PREFIX = `RM0 [${senderLabel}] `;
-    const finalMessage = message.startsWith('RM0 ') ? message : `${SMS_PREFIX}${message}`;
+    const finalMessage =
+      providerAutoPrependsSender(provider) || message.startsWith('RM0 ') ? message : `${SMS_PREFIX}${message}`;
 
-    const result = await sendSMS(phone, finalMessage);
+    const result = await sendSMS(phone, finalMessage, { provider });
     return NextResponse.json(result);
   } catch (error) {
     return NextResponse.json({ success: false, error: 'Failed to send SMS' }, { status: 500 });

--- a/apps/backoffice/src/app/api/loyalty/sms/test/route.ts
+++ b/apps/backoffice/src/app/api/loyalty/sms/test/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { sendSMS, getSMSProvider } from '@/lib/loyalty/sms';
+import { sendSMS, getSMSProvider, providerAutoPrependsSender, getActiveSmsProvider } from '@/lib/loyalty/sms';
 import { supabaseAdmin } from '@/lib/loyalty/supabase';
 import { requireAuth } from '@/lib/auth';
 
@@ -15,7 +15,7 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ success: false, error: 'phone and message required' }, { status: 400 });
     }
 
-    const provider = (process.env.SMS_PROVIDER || 'console').trim();
+    const provider = await getActiveSmsProvider();
     const apiKey = process.env.SMS123_API_KEY;
     const email = process.env.SMS123_EMAIL;
 
@@ -46,13 +46,18 @@ export async function POST(request: NextRequest) {
       }
     }
 
-    // Auto-prepend RM0 prefix
+    // Auto-prepend RM0 prefix.
+    // SMS Niaga adds its own "RM0.00 <SenderID>:" at the gateway, so skip ours there.
     const senderLabel = sender_id || 'CelsiusCoffee';
     const SMS_PREFIX = `RM0 [${senderLabel}] `;
-    const finalMessage = message.startsWith('RM0 ') ? message : `${SMS_PREFIX}${message}`;
+    const finalMessage =
+      providerAutoPrependsSender(provider) || message.startsWith('RM0 ') ? message : `${SMS_PREFIX}${message}`;
 
-    // Send the test SMS
-    const result = await sendSMS(phone, finalMessage, sender_id ? { senderId: sender_id } : undefined);
+    // Send the test SMS. SMS Niaga needs a registered Sender ID, so don't forward a free-text label.
+    const result = await sendSMS(phone, finalMessage, {
+      provider,
+      ...(!providerAutoPrependsSender(provider) && sender_id ? { senderId: sender_id } : {}),
+    });
 
     // Log to sms_logs
     await supabaseAdmin.from('sms_logs').insert({
@@ -90,6 +95,7 @@ export async function GET(request: NextRequest) {
 
     const diagnostics: Record<string, unknown> = {
       provider,
+      active_provider: await getActiveSmsProvider(),
       provider_raw_length: (process.env.SMS_PROVIDER || '').length,
       provider_trimmed_length: provider.length,
       api_key_set: !!apiKey,

--- a/apps/backoffice/src/lib/loyalty/sms.ts
+++ b/apps/backoffice/src/lib/loyalty/sms.ts
@@ -1,2 +1,10 @@
-export { sendSMS, getSMSProvider } from "@celsius/shared";
+export { sendSMS, getSMSProvider, providerAutoPrependsSender } from "@celsius/shared";
 export type { SMSProvider } from "@celsius/shared";
+
+import { resolveSmsProvider } from "@celsius/shared";
+import { supabaseAdmin } from "@/lib/loyalty/supabase";
+
+/** Active SMS gateway from the app_settings `sms_provider` toggle (env fallback). */
+export function getActiveSmsProvider() {
+  return resolveSmsProvider(supabaseAdmin);
+}

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -45,8 +45,8 @@ export {
   getProgressPercentage,
   getTimeAgo,
 } from "./format";
-export { sendSMS, getSMSProvider } from "./sms";
-export type { SMSProvider } from "./sms";
+export { sendSMS, getSMSProvider, providerAutoPrependsSender, resolveSmsProvider } from "./sms";
+export type { SMSProvider, SMSProviderName } from "./sms";
 export { filterModifiersForChannel } from "./modifier-channels";
 export type { ModifierChannel, ModifierGroupLike, ModifierOptionLike } from "./modifier-channels";
 // OTP is intentionally NOT re-exported here — it imports node:crypto,

--- a/packages/shared/src/otp.ts
+++ b/packages/shared/src/otp.ts
@@ -11,7 +11,7 @@
 // triggers "Ecmascript file had an error" when the chain reaches
 // middleware via packages/shared/src/index.ts).
 import { timingSafeEqual, randomInt } from 'node:crypto';
-import { sendSMS } from './sms';
+import { sendSMS, resolveSmsProvider, providerAutoPrependsSender } from './sms';
 import type { SupabaseClient } from '@supabase/supabase-js';
 
 /**
@@ -85,12 +85,17 @@ export async function sendOTP(
     return { success: false, error: 'Failed to store OTP' };
   }
 
-  // Send via SMS (must match approved SMS123 templates with RM0 prefix and [CelsiusCoffee] header)
+  // Resolve the active gateway (app_settings toggle → env fallback). SMS123
+  // needs the "RM0 [CelsiusCoffee]" prefix to match approved templates; SMS
+  // Niaga prepends its own "RM0 <SenderID>:" at the gateway, so omit ours there
+  // to avoid a double prefix.
+  const provider = await resolveSmsProvider(supabaseAdmin);
+  const prefix = providerAutoPrependsSender(provider) ? '' : 'RM0 [CelsiusCoffee] ';
   const message = purpose === 'login'
-    ? `RM0 [CelsiusCoffee] Your Celsius Coffee verification code is: ${code}. Valid for 5 minutes.`
-    : `RM0 [CelsiusCoffee] Your Celsius Coffee redemption code is: ${code}. Valid for 5 minutes.`;
+    ? `${prefix}Your Celsius Coffee verification code is: ${code}. Valid for 5 minutes.`
+    : `${prefix}Your Celsius Coffee redemption code is: ${code}. Valid for 5 minutes.`;
 
-  const result = await sendSMS(normalizedPhone, message);
+  const result = await sendSMS(normalizedPhone, message, { provider });
 
   return {
     success: result.success,

--- a/packages/shared/src/sms.ts
+++ b/packages/shared/src/sms.ts
@@ -1,7 +1,16 @@
 // ==========================================
 // SMS Provider Interface
-// Pluggable SMS gateway — swap providers by changing SMS_PROVIDER env var
+// Pluggable SMS gateway. The active provider is resolved at runtime from the
+// `app_settings.sms_provider` row (see resolveSmsProvider) so it can be toggled
+// from the backoffice without a redeploy; the SMS_PROVIDER env var is the
+// fallback default.
 // ==========================================
+
+// Type-only import — erased at compile time, so this never pulls the Supabase
+// client into Edge/middleware bundles.
+import type { SupabaseClient } from '@supabase/supabase-js';
+
+export type SMSProviderName = 'smsniaga' | 'sms123' | 'console';
 
 export interface SMSProvider {
   sendSMS(phone: string, message: string, opts?: { senderId?: string }): Promise<{ success: boolean; messageId?: string; error?: string }>;
@@ -20,58 +29,79 @@ class ConsoleSMSProvider implements SMSProvider {
 // Malaysian SMS gateway — https://smsniaga.com
 class SMSNiagaProvider implements SMSProvider {
   private apiUrl: string;
-  private username: string;
   private apiKey: string;
   private senderId: string;
 
   constructor() {
-    this.apiUrl = process.env.SMSNIAGA_API_URL || 'https://api.smsniaga.com/v1/send';
-    this.username = process.env.SMSNIAGA_USERNAME || '';
+    // SMS Niaga v2 REST API. Auth is a single Bearer token created at
+    // manage.smsniaga.com → Profile → API Token. Endpoint + contract:
+    // https://smsniaga.stoplight.io/docs/api-reference (POST /api/send).
+    this.apiUrl = process.env.SMSNIAGA_API_URL || 'https://manage.smsniaga.com/api/send';
     this.apiKey = process.env.SMSNIAGA_API_KEY || '';
-    this.senderId = process.env.SMSNIAGA_SENDER_ID || 'CelsiusCoffee';
+    // Leave blank to use the account's default registered Sender ID
+    // (e.g. "CELSIUS COFFEE SDN. BHD."). Must match a registered Sender ID.
+    this.senderId = process.env.SMSNIAGA_SENDER_ID || '';
   }
 
+  // SMS Niaga expects MSISDN in 60XXXXXXXXX form (no leading +).
   private formatPhone(phone: string): string {
     let cleaned = phone.replace(/[\s\-()]/g, '');
-    if (cleaned.startsWith('+60')) return cleaned;
-    if (cleaned.startsWith('60')) return `+${cleaned}`;
-    if (cleaned.startsWith('0')) return `+60${cleaned.slice(1)}`;
+    if (cleaned.startsWith('+')) cleaned = cleaned.slice(1);
+    if (cleaned.startsWith('60')) return cleaned;
+    if (cleaned.startsWith('0')) return `60${cleaned.slice(1)}`;
     return cleaned;
   }
 
-  async sendSMS(phone: string, message: string) {
-    if (!this.username || !this.apiKey) {
-      console.error('SMS Niaga: Missing SMSNIAGA_USERNAME or SMSNIAGA_API_KEY');
-      return { success: false, error: 'SMS Niaga credentials not configured' };
+  async sendSMS(phone: string, message: string, opts?: { senderId?: string }) {
+    if (!this.apiKey) {
+      console.error('SMS Niaga: Missing SMSNIAGA_API_KEY');
+      return { success: false, error: 'SMS Niaga API token not configured' };
     }
 
     const to = this.formatPhone(phone);
-    const authToken = Buffer.from(`${this.username}:${this.apiKey}`).toString('base64');
+    const senderId = opts?.senderId || this.senderId;
 
     try {
       const response = await fetch(this.apiUrl, {
         method: 'POST',
         headers: {
-          'Authorization': `Basic ${authToken}`,
+          'Authorization': `Bearer ${this.apiKey}`,
+          'Accept': 'application/json',
           'Content-Type': 'application/json',
         },
         signal: AbortSignal.timeout(10000),
         body: JSON.stringify({
-          to,
-          message,
-          from: this.senderId,
+          body: message,
+          phones: [to],
+          // preview must be 0 to actually send; 1 = dry-run preview only.
+          preview: 0,
+          ...(senderId ? { sender_id: senderId } : {}),
         }),
       });
 
-      if (!response.ok) {
-        const errorText = await response.text().catch(() => 'Unknown error');
-        console.error(`SMS Niaga error (${response.status}): ${errorText}`);
-        return { success: false, error: `SMS Niaga error: ${response.status}` };
+      const rawBody = await response.text();
+      let data: {
+        data?: { uuid?: string; total_charge?: number; credit_balance_after?: string };
+        message?: string;
+        error?: string;
+      } = {};
+      try {
+        data = JSON.parse(rawBody);
+      } catch {
+        // Non-JSON response — keep rawBody for the error string below.
       }
 
-      const data = await response.json();
-      console.log(`SMS Niaga: Message sent successfully (ID: ${data.message_id})`);
-      return { success: true, messageId: data.message_id };
+      if (!response.ok) {
+        const detail = data.message || data.error || `HTTP ${response.status}: ${rawBody.slice(0, 200)}`;
+        console.error(`SMS Niaga error (${response.status}): ${detail}`);
+        return { success: false, error: `SMS Niaga: ${detail}` };
+      }
+
+      const messageId = data.data?.uuid;
+      console.log(
+        `SMS Niaga: sent (uuid: ${messageId}, charge: ${data.data?.total_charge}, balance after: ${data.data?.credit_balance_after})`,
+      );
+      return { success: true, messageId };
     } catch (err) {
       const errorMessage = err instanceof Error ? err.message : 'Unknown error';
       console.error(`SMS Niaga: Failed to send SMS — ${errorMessage}`);
@@ -157,8 +187,9 @@ class SMS123Provider implements SMSProvider {
 }
 
 // ─── Provider Factory ────────────────────────────────
-export function getSMSProvider(): SMSProvider {
-  const provider = (process.env.SMS_PROVIDER || 'console').trim().toLowerCase();
+export function getSMSProvider(name?: string): SMSProvider {
+  // Explicit name (from the app_settings toggle) wins; else fall back to env.
+  const provider = (name || process.env.SMS_PROVIDER || 'console').trim().toLowerCase();
 
   switch (provider) {
     case 'smsniaga':
@@ -174,7 +205,45 @@ export function getSMSProvider(): SMSProvider {
 }
 
 // ─── Convenience function ────────────────────────────
-export async function sendSMS(phone: string, message: string, opts?: { senderId?: string }) {
-  const provider = getSMSProvider();
+// opts.provider overrides which gateway to use (from the app_settings toggle);
+// without it, getSMSProvider falls back to the SMS_PROVIDER env var.
+export async function sendSMS(
+  phone: string,
+  message: string,
+  opts?: { senderId?: string; provider?: string },
+) {
+  const provider = getSMSProvider(opts?.provider);
   return provider.sendSMS(phone, message, opts);
+}
+
+// ─── Sender-prefix behaviour ─────────────────────────
+// SMS Niaga prepends "RM0.00 <SenderID>:" to every message body at the gateway,
+// and only accepts a registered Sender ID. So on SMS Niaga, app code must NOT
+// add its own "RM0 [label]" prefix (it would double up) and must NOT pass a
+// free-text sender label. Other providers (e.g. SMS123) still need the app to
+// add the "RM0 [label]" prefix itself. Pass the active provider name (from the
+// toggle); falls back to the SMS_PROVIDER env var.
+export function providerAutoPrependsSender(provider?: string): boolean {
+  return (provider || process.env.SMS_PROVIDER || 'console').trim().toLowerCase() === 'smsniaga';
+}
+
+// ─── Active-provider resolver ────────────────────────
+// Reads the `app_settings.sms_provider` row (set from the backoffice
+// Integrations toggle) and returns the active gateway name. Falls back to the
+// SMS_PROVIDER env var, then 'console'. Pass the Supabase admin client the
+// caller already holds — keeps this package free of a runtime Supabase import.
+export async function resolveSmsProvider(supabase: SupabaseClient): Promise<SMSProviderName> {
+  try {
+    const { data } = await supabase
+      .from('app_settings')
+      .select('value')
+      .eq('key', 'sms_provider')
+      .maybeSingle();
+    const v = (data?.value ?? '').toString().trim().toLowerCase();
+    if (v === 'smsniaga' || v === 'sms123' || v === 'console') return v;
+  } catch {
+    // fall through to env default
+  }
+  const env = (process.env.SMS_PROVIDER || 'console').trim().toLowerCase();
+  return env === 'smsniaga' || env === 'sms123' ? env : 'console';
 }


### PR DESCRIPTION
## What
Adds a runtime **SMS gateway toggle** and fixes the SMS Niaga integration so it actually works.

### Switch with no redeploy
- New `resolveSmsProvider(supabase)` reads `app_settings.sms_provider` (fallback: `SMS_PROVIDER` env → `console`).
- New **Settings → Integrations → SMS Gateway** card to pick **SMS Niaga / SMS123 / Console**.
- One toggle drives OTP **and** all loyalty sends across backoffice + order (shared DB).

### SMS Niaga contract fix
- `SMSNiagaProvider` now uses the real v2 API: `POST https://manage.smsniaga.com/api/send`, `Authorization: Bearer`, body `{ body, phones[], sender_id, preview:0 }`, response `data.uuid`. (Old `api.smsniaga.com/v1/send` + Basic auth was a wrong guess.)
- Verified live via a `preview:1` call (no send/charge). Registered sender = `CELSIUSCOFFEE`.

### Prefix correctness
- SMS Niaga auto-prepends `RM0 <SenderID>:` at the gateway; `providerAutoPrependsSender()` now gates the app's own `RM0 [label]` prefix + free-text sender per provider (across blast/send/test/campaigns-auto **and** OTP) to avoid double-prefixing.

## To activate after merge
1. Set `SMSNIAGA_API_KEY` (the regenerated token) on **backoffice** + **order** Vercel projects.
2. Flip the toggle to **SMS Niaga**, send a test OTP.

## Notes
- Typecheck clean on shared, backoffice, order (the unrelated untracked `api/music` WIP is excluded).

🤖 Generated with [Claude Code](https://claude.com/claude-code)