### PR TITLE
Poster day-part windows (multi-round home/splash)

### DIFF
--- a/apps/backoffice/src/app/(admin)/pickup/splash-posters/page.tsx
+++ b/apps/backoffice/src/app/(admin)/pickup/splash-posters/page.tsx
@@ -43,8 +43,11 @@ type Poster = {
   // canonical anchor so AI compose can reopen on a clean image even
   // when composer_state is missing (legacy posters, designer uploads).
   original_bg_url: string | null;
-  // Day-part round for pos-display posters (breakfast..supper). NULL = always.
+  // Legacy single day-part round (breakfast..supper). NULL = always.
   round: string | null;
+  // Day-part WINDOW — the set of rounds this poster appears in. NULL/empty =
+  // fall back to `round` (and a null round = always). Preferred going forward.
+  rounds: string[] | null;
 };
 
 type Form = {
@@ -64,9 +67,28 @@ type Form = {
   // Mirrors poster.original_bg_url — overwritten by Re-crop uploads,
   // preserved across AI compose saves.
   originalBgUrl: string | null;
-  // Day-part round (pos-display only). "" = always.
-  round: string;
+  // Day-part window — set of rounds this poster appears in. [] = always.
+  rounds: string[];
 };
+
+// Day-part rounds for the window picker.
+const ROUND_OPTIONS: { id: string; label: string }[] = [
+  { id: "breakfast", label: "Breakfast" },
+  { id: "brunch",    label: "Brunch" },
+  { id: "lunch",     label: "Lunch" },
+  { id: "midday",    label: "Midday" },
+  { id: "evening",   label: "Evening" },
+  { id: "dinner",    label: "Dinner" },
+  { id: "supper",    label: "Supper" },
+];
+const ROUND_LABEL: Record<string, string> = Object.fromEntries(ROUND_OPTIONS.map((r) => [r.id, r.label]));
+// The eligibility window for a poster: explicit `rounds`, else legacy single
+// `round`, else [] (always-on / every round).
+function posterWindow(p: { round: string | null; rounds: string[] | null }): string[] {
+  if (p.rounds && p.rounds.length) return p.rounds;
+  if (p.round) return [p.round];
+  return [];
+}
 
 // Cache-bust IMG URLs against the poster's updated_at. Browsers
 // otherwise hold the prior bytes after a re-upload (especially for
@@ -152,7 +174,7 @@ const empty: Form = {
   placement: "home",
   composerState: null,
   originalBgUrl: null,
-  round: "",
+  rounds: [],
 };
 
 // ---- Schedule helpers ---------------------------------------------------
@@ -348,7 +370,9 @@ export default function SplashPostersPage() {
       placement: p.placement ?? "home",
       composerState: p.composer_state ?? null,
       originalBgUrl: p.original_bg_url ?? null,
-      round: p.round ?? "",
+      // Pre-fill the window from `rounds`; fall back to a legacy single `round`
+      // so editing an old poster migrates it cleanly to the multi-round model.
+      rounds: p.rounds?.length ? p.rounds : (p.round ? [p.round] : []),
     });
     setDeeplinkMode(null);
     setShowForm(true);
@@ -376,7 +400,7 @@ export default function SplashPostersPage() {
         placement:      p.placement ?? "home",
         composerState:  p.composer_state ?? null,
         originalBgUrl:  p.original_bg_url ?? null,
-        round:          p.round ?? null,
+        rounds:         p.rounds?.length ? p.rounds : (p.round ? [p.round] : null),
       };
       const res = await adminFetch("/api/pickup/splash-posters", {
         method: "POST",
@@ -466,10 +490,11 @@ export default function SplashPostersPage() {
         placement:     form.placement,
         composerState: form.composerState,
         originalBgUrl: form.originalBgUrl,
-        // Round applies to every surface now — the home carousel, splash
-        // launch, and POS screen readers all filter by current day-part
-        // round (round-less = always). Lets the autopilot schedule by round.
-        round:         form.round || null,
+        // Day-part window for every surface (home carousel, splash launch, POS
+        // screen). Empty = always. Stored in `rounds`; `round` is cleared so the
+        // multi-round window is the single source of truth going forward.
+        rounds:        form.rounds.length ? form.rounds : null,
+        round:         null,
       };
       const url = form.id
         ? `/api/pickup/splash-posters?id=${encodeURIComponent(form.id)}`
@@ -642,8 +667,8 @@ export default function SplashPostersPage() {
         ];
         const countFor = (id: string) =>
           id === "all" ? pos.length
-            : id === "always" ? pos.filter((p) => !p.round).length
-              : pos.filter((p) => p.round === id).length;
+            : id === "always" ? pos.filter((p) => posterWindow(p).length === 0).length
+              : pos.filter((p) => posterWindow(p).includes(id)).length;
         return (
           <div className="mb-4 flex flex-wrap gap-1.5">
             {opts.map((r) => {
@@ -678,8 +703,8 @@ export default function SplashPostersPage() {
             roundFilter === "all"
               ? true
               : roundFilter === "always"
-                ? !p.round
-                : p.round === roundFilter,
+                ? posterWindow(p).length === 0
+                : posterWindow(p).includes(roundFilter),
           );
 
         if (loading) {
@@ -754,11 +779,18 @@ export default function SplashPostersPage() {
                   <span className={`rounded-full ${placementColor} px-2 py-0.5 text-[10px] font-semibold text-white`}>
                     {placementLabel}
                   </span>
-                  {p.round && (
-                    <span className="rounded-full bg-orange-500 px-2 py-0.5 text-[10px] font-semibold capitalize text-white">
-                      {p.round}
-                    </span>
-                  )}
+                  {(() => {
+                    const w = posterWindow(p);
+                    if (!w.length) return null;
+                    const label = w.length > 3
+                      ? `${w.length} rounds`
+                      : w.map((r) => ROUND_LABEL[r] ?? r).join(", ");
+                    return (
+                      <span className="rounded-full bg-orange-500 px-2 py-0.5 text-[10px] font-semibold capitalize text-white">
+                        {label}
+                      </span>
+                    );
+                  })()}
                   {/* Schedule status pill — replaces the bare ACTIVE
                       pill with one that conveys the real live state:
                       LIVE NOW, SCHEDULED · Apr 12, EXPIRED · Mar 30,
@@ -961,28 +993,43 @@ export default function SplashPostersPage() {
               </div>
 
               <div>
-                <label className="text-xs font-medium text-gray-700">Round (time of day)</label>
-                <select
-                  value={form.round}
-                  onChange={(e) => setForm((f) => ({ ...f, round: e.target.value }))}
-                  className="mt-1 w-full rounded-lg border border-gray-300 px-3 py-2 text-sm"
-                >
-                  <option value="">Always — show in every round</option>
-                  <option value="breakfast">Breakfast · 8–10AM</option>
-                  <option value="brunch">Brunch · 10AM–12PM</option>
-                  <option value="lunch">Lunch · 12–3PM</option>
-                  <option value="midday">Midday · 3–5PM</option>
-                  <option value="evening">Evening · 5–7PM</option>
-                  <option value="dinner">Dinner · 7–9PM</option>
-                  <option value="supper">Supper · 9–11PM</option>
-                </select>
-                <p className="mt-1 text-[11px] text-gray-500">
-                  {form.placement === "home"
-                    ? "Home carousel only shows this poster during this day-part. "
-                    : form.placement === "splash"
-                      ? "App launch splash only shows this poster during this day-part. "
-                      : "Customer screen only shows this poster during this day-part. "}
-                  &quot;Always&quot; shows in every round.
+                <label className="text-xs font-medium text-gray-700">Rounds (time of day)</label>
+                <p className="mt-0.5 text-[11px] text-gray-500">
+                  Pick the day-parts this poster appears in (a span is fine, e.g.
+                  Lunch→Supper). Leave all off for <span className="font-semibold">Always</span>.
+                </p>
+                <div className="mt-2 flex flex-wrap gap-1.5">
+                  {ROUND_OPTIONS.map((r) => {
+                    const on = form.rounds.includes(r.id);
+                    return (
+                      <button
+                        key={r.id}
+                        type="button"
+                        onClick={() =>
+                          setForm((f) => ({
+                            ...f,
+                            rounds: on
+                              ? f.rounds.filter((x) => x !== r.id)
+                              : [...f.rounds, r.id],
+                          }))
+                        }
+                        className={`rounded-full px-3 py-1 text-xs font-semibold transition-colors ${
+                          on
+                            ? "bg-terracotta text-white"
+                            : "bg-gray-100 text-gray-600 hover:bg-gray-200"
+                        }`}
+                      >
+                        {r.label}
+                      </button>
+                    );
+                  })}
+                </div>
+                <p className="mt-1.5 text-[11px] text-gray-500">
+                  {form.rounds.length === 0
+                    ? "Showing in every round (Always)."
+                    : `Showing only during: ${form.rounds
+                        .map((r) => ROUND_LABEL[r] ?? r)
+                        .join(", ")}.`}
                 </p>
               </div>
 

--- a/apps/backoffice/src/app/api/pickup/splash-posters/route.ts
+++ b/apps/backoffice/src/app/api/pickup/splash-posters/route.ts
@@ -52,6 +52,7 @@ export async function POST(request: NextRequest) {
       ends_at:     body.endsAt ?? null,
       placement,
       round:       body.round ?? null,
+      rounds:      Array.isArray(body.rounds) && body.rounds.length ? body.rounds : null,
       composer_state:  body.composerState ?? null,
       original_bg_url: body.originalBgUrl ?? null,
     } as Record<string, unknown>)
@@ -80,6 +81,7 @@ export async function PATCH(request: NextRequest) {
   if ("durationMs"     in body) updates.duration_ms     = body.durationMs;
   if ("active"         in body) updates.active          = Boolean(body.active);
   if ("round"          in body) updates.round           = body.round || null;
+  if ("rounds"         in body) updates.rounds          = Array.isArray(body.rounds) && body.rounds.length ? body.rounds : null;
   if ("startsAt"       in body) updates.starts_at       = body.startsAt;
   if ("endsAt"         in body) updates.ends_at         = body.endsAt;
   if ("composerState"  in body) updates.composer_state  = body.composerState;

--- a/apps/backoffice/src/lib/pos/poster-autopilot.ts
+++ b/apps/backoffice/src/lib/pos/poster-autopilot.ts
@@ -109,9 +109,19 @@ const DEFAULT_TOPK: Record<Placement, number> = { "pos-display": 3, home: 5, spl
 // keeps its food-attach logic untouched (we WANT to push a bite in-store).
 const RESERVE_DRINKS: Record<Placement, number> = { home: 2, splash: 0, "pos-display": 0 };
 
-// Group key for a poster row: POS rotates by day-part round; app placements
-// usually have no round (one '__all__' group) but support rounds once tagged.
-const GROUP_ALL = "__all__";
+// A poster's eligibility window — which day-part rounds it may appear in:
+//   • rounds[] set     → exactly those rounds (the day-part window, e.g. a
+//                        pasta tagged lunch→supper, breakfast food all morning)
+//   • else round (one) → that single round (legacy + POS)
+//   • else (both null) → every round (always-on anchor)
+function windowOf(po: { round: string | null; rounds: string[] | null }): Round[] {
+  if (po.rounds && po.rounds.length) {
+    return po.rounds.filter((r): r is Round => (ROUNDS as string[]).includes(r));
+  }
+  if (po.round && (ROUNDS as string[]).includes(po.round)) return [po.round as Round];
+  if (po.round) return [];
+  return ROUNDS;
+}
 
 /**
  * Build the active/sort_order plan for one placement. Pure read — returns
@@ -134,7 +144,7 @@ export async function planPosterRotation(
 
   let postersQuery = supabase
     .from("splash_posters")
-    .select("id,title,round,product_id")
+    .select("id,title,round,rounds,product_id")
     .eq("brand_id", "brand-celsius")
     .eq("placement", placement);
   // POS posters are always round-tagged; app posters may be round-less.
@@ -166,30 +176,48 @@ export async function planPosterRotation(
     prodById.set(p.id, { name: p.name, category: p.category, price: Number(p.price ?? 0) });
   }
 
-  // Group posters by round (or one '__all__' bucket for round-less app posters).
-  const postersByGroup = new Map<string, { id: string; title: string | null; product_id: string | null; round: string | null }[]>();
+  // Normalise rows once, keeping each poster's eligibility window.
+  type Row = { id: string; title: string | null; product_id: string | null; round: string | null; rounds: string[] | null };
   // eslint-disable-next-line @typescript-eslint/no-explicit-any -- legacy untyped DB row (ratchet: reduce, never add)
-  for (const po of (postersRes.data ?? []) as any[]) {
-    const key = po.round ?? GROUP_ALL;
-    const arr = postersByGroup.get(key) ?? [];
-    arr.push({ id: po.id, title: po.title ?? null, product_id: po.product_id ?? null, round: po.round ?? null });
-    postersByGroup.set(key, arr);
+  const rows: Row[] = ((postersRes.data ?? []) as any[]).map((po) => ({
+    id: po.id,
+    title: po.title ?? null,
+    product_id: po.product_id ?? null,
+    round: po.round ?? null,
+    rounds: (po.rounds ?? null) as string[] | null,
+  }));
+
+  // Bucket posters by the rounds they're eligible to appear in (a poster with a
+  // multi-round window lands in several buckets; an always-on poster in all).
+  const eligibleByRound = new Map<Round, Row[]>();
+  for (const po of rows) {
+    for (const r of windowOf(po)) {
+      const arr = eligibleByRound.get(r) ?? [];
+      arr.push(po);
+      eligibleByRound.set(r, arr);
+    }
   }
 
-  const decisions: PosterDecision[] = [];
-  for (const [groupKey, posters] of postersByGroup) {
-    if (!posters.length) continue;
-    const round = (groupKey === GROUP_ALL ? null : (groupKey as Round));
-    const drinkHeavy = round ? (roundStats[round]?.single_rate ?? 0) >= DRINK_HEAVY_SINGLE_RATE : false;
+  const minDrinks = RESERVE_DRINKS[placement] ?? 0;
+  // active = union of each round's top-K (with a per-round drink reserve so a
+  // round's carousel isn't all-food). A poster wins a slot if it ranks top-K in
+  // ANY round it's eligible for; the reader then shows active ∩ current round.
+  const activeIds = new Set<string>();
+  const bestScore = new Map<string, number>();
 
-    const scored = posters.map((po) => {
+  for (const round of ROUNDS) {
+    const pool = eligibleByRound.get(round);
+    if (!pool || !pool.length) continue;
+    const drinkHeavy = (roundStats[round]?.single_rate ?? 0) >= DRINK_HEAVY_SINGLE_RATE;
+
+    const scored = pool.map((po) => {
       const prod = po.product_id ? prodById.get(po.product_id) : null;
       const priceRM = prod?.price ?? 0;
       // Fallback to a 35%-COGS assumption when a poster isn't linked / cost unknown.
       const costRM = prod ? costByName.get(prod.name.trim().toLowerCase()) ?? priceRM * 0.35 : priceRM * 0.35;
       const marginRM = Math.max(0, priceRM - costRM);
       const isFood = prod?.category ? FOOD_CATEGORIES.has(prod.category) : false;
-      const units = po.product_id ? unitsByRoundProduct.get(`${round ?? ""}|${po.product_id}`) ?? 0 : 0;
+      const units = po.product_id ? unitsByRoundProduct.get(`${round}|${po.product_id}`) ?? 0 : 0;
       const measured = measuredByPoster.get(po.id) ?? { orders: 0, aov: 0 };
       return { po, prod, priceRM, marginRM, isFood, units, measured, attach: isFood && drinkHeavy };
     });
@@ -205,64 +233,49 @@ export async function planPosterRotation(
         const priceN = s.priceRM / maxPrice;
         const unitsN = s.units / maxUnits;
         let score: number;
-        let reason: string;
         if (opts.mode === "control") {
           score = unitsN;
-          reason = "popularity (control)";
         } else {
           const heuristic = 0.45 * marginN + 0.3 * (s.attach ? 1 : 0) + 0.15 * priceN + 0.1 * unitsN;
-          const bits: string[] = [];
-          if (s.attach) bits.push("fills drink-only gap");
-          if (marginN > 0.7) bits.push(`RM${s.marginRM.toFixed(2)} margin`);
-          if (priceN > 0.7) bits.push("premium anchor");
-          if (!s.prod) bits.push("unlinked");
-          // Blend in MEASURED order AOV as attributed orders accrue (app only):
+          // Blend MEASURED order AOV as attributed orders accrue (app only):
           // weight ramps 0→1 over the first ~10 orders, then measured dominates.
           const w = Math.min(s.measured.orders / 10, 1);
-          if (w > 0) {
-            score = w * (s.measured.aov / maxMeasuredAov) + (1 - w) * heuristic;
-            bits.unshift(`measured AOV RM${s.measured.aov.toFixed(2)} (${s.measured.orders} ord)`);
-          } else {
-            score = heuristic;
-          }
-          reason = bits.join(", ") || "balanced";
+          score = w > 0 ? w * (s.measured.aov / maxMeasuredAov) + (1 - w) * heuristic : heuristic;
         }
-        return { s, score, reason };
+        return { s, score };
       })
       .sort((a, b) => b.score - a.score);
 
-    // Active set = top-K by score, but guarantee RESERVE_DRINKS drink slots:
-    // swap the lowest-scoring foods in the top-K for the best benched drinks so
-    // the carousel isn't 100% food. No-op when the natural top-K already has
-    // enough drinks, or when the pool has no benched drinks to promote.
-    const activeIds = new Set(ranked.slice(0, topK).map((r) => r.s.po.id));
-    const minDrinks = RESERVE_DRINKS[placement] ?? 0;
+    // Top-K for this round, with the drink reserve (swap lowest-scoring foods
+    // in the top-K for the best benched drinks). No-op without enough drinks.
+    const chosen = new Set(ranked.slice(0, topK).map((r) => r.s.po.id));
     if (minDrinks > 0) {
       const top = ranked.slice(0, topK);
       const need = minDrinks - top.filter((r) => !r.s.isFood).length;
       if (need > 0) {
         const benchDrinks = ranked.slice(topK).filter((r) => !r.s.isFood).slice(0, need);
-        const dropFoods = top
-          .filter((r) => r.s.isFood)
-          .sort((a, b) => a.score - b.score)
-          .slice(0, benchDrinks.length);
-        for (const r of dropFoods) activeIds.delete(r.s.po.id);
-        for (const r of benchDrinks) activeIds.add(r.s.po.id);
+        const dropFoods = top.filter((r) => r.s.isFood).sort((a, b) => a.score - b.score).slice(0, benchDrinks.length);
+        for (const r of dropFoods) chosen.delete(r.s.po.id);
+        for (const r of benchDrinks) chosen.add(r.s.po.id);
       }
     }
-
-    ranked.forEach((r, i) => {
-      decisions.push({
-        round,
-        posterId: r.s.po.id,
-        title: r.s.po.title,
-        productId: r.s.po.product_id,
-        active: activeIds.has(r.s.po.id),
-        sortOrder: (i + 1) * 10,
-        score: Math.round(r.score * 1000) / 1000,
-        reason: r.reason,
-      });
-    });
+    for (const id of chosen) activeIds.add(id);
+    for (const r of ranked) bestScore.set(r.s.po.id, Math.max(bestScore.get(r.s.po.id) ?? 0, r.score));
   }
+
+  // One decision per poster: active if it won a slot in any eligible round;
+  // sort_order by overall best score (the reader caps + orders the per-round
+  // eligible subset by this, so the strongest posters surface first).
+  const ranked = rows.slice().sort((a, b) => (bestScore.get(b.id) ?? 0) - (bestScore.get(a.id) ?? 0));
+  const decisions: PosterDecision[] = ranked.map((po, i) => ({
+    round: po.round ? (po.round as Round) : null,
+    posterId: po.id,
+    title: po.title,
+    productId: po.product_id,
+    active: activeIds.has(po.id),
+    sortOrder: (i + 1) * 10,
+    score: Math.round((bestScore.get(po.id) ?? 0) * 1000) / 1000,
+    reason: activeIds.has(po.id) ? "top-K in an eligible round" : "benched",
+  }));
   return decisions;
 }

--- a/apps/order/src/app/api/home-posters/route.ts
+++ b/apps/order/src/app/api/home-posters/route.ts
@@ -36,13 +36,11 @@ export async function GET(request: NextRequest) {
 
     const { data, error } = await supabase
       .from("splash_posters")
-      .select("id, image_url, title, deeplink, duration_ms, starts_at, ends_at, sort_order")
+      .select("id, image_url, title, deeplink, duration_ms, starts_at, ends_at, sort_order, round, rounds")
       .eq("brand_id", brandId)
       .eq("active", true)
       // Home carousel only — splash posters stay on the launch screen.
       .eq("placement", "home")
-      // Recurring day-part round: round-less shows always; tagged shows in-round.
-      .or(round ? `round.is.null,round.eq.${round}` : "round.is.null")
       // Operator-controlled sequence first (lower number = appears earlier
       // in the carousel rotation). NULL sort_order is treated as "unordered"
       // and falls to the back of the rotation, ordered by recency.
@@ -54,12 +52,25 @@ export async function GET(request: NextRequest) {
       return NextResponse.json({ posters: [] }, { status: 200 });
     }
 
+    // Day-part window: a poster shows when the current round is in its `rounds`
+    // set; if `rounds` is empty it falls back to the legacy single `round`
+    // (and a null round = always-on). Done in JS so the multi-round array is
+    // simple to evaluate (PostgREST array-contains + legacy fallback is messy).
+    const inWindow = (p: { round: string | null; rounds: string[] | null }): boolean => {
+      if (p.rounds && p.rounds.length) return round !== "" && p.rounds.includes(round);
+      if (p.round) return p.round === round;
+      return true; // always-on
+    };
+
+    const HOME_CAP = 6; // keep the carousel tight even when many posters qualify
     const posters = (data ?? [])
       .filter((p) => {
         const startOk = !p.starts_at || p.starts_at <= now;
         const endOk   = !p.ends_at   || p.ends_at   >= now;
         return startOk && endOk;
       })
+      .filter((p) => inWindow(p as { round: string | null; rounds: string[] | null }))
+      .slice(0, HOME_CAP)
       .map((p) => ({
         id:         p.id as string,
         imageUrl:   p.image_url as string,

--- a/apps/order/src/app/api/splash-poster/route.ts
+++ b/apps/order/src/app/api/splash-poster/route.ts
@@ -32,13 +32,11 @@ export async function GET(request: NextRequest) {
 
     const { data, error } = await supabase
       .from("splash_posters")
-      .select("id, image_url, deeplink, duration_ms, starts_at, ends_at")
+      .select("id, image_url, deeplink, duration_ms, starts_at, ends_at, round, rounds")
       .eq("brand_id", brandId)
       .eq("active", true)
       // Splash surface only — home posters stay on the home carousel.
       .eq("placement", "splash")
-      // Recurring day-part round: round-less shows always; tagged shows in-round.
-      .or(round ? `round.is.null,round.eq.${round}` : "round.is.null")
       .order("updated_at", { ascending: false });
 
     if (error) {
@@ -46,11 +44,19 @@ export async function GET(request: NextRequest) {
       return NextResponse.json({ poster: null }, { status: 200 });
     }
 
-    // Pick the first active poster whose schedule window includes now()
+    // Day-part window: shows when the current round is in `rounds`; empty falls
+    // back to the legacy single `round` (null round = always-on).
+    const inWindow = (p: { round: string | null; rounds: string[] | null }): boolean => {
+      if (p.rounds && p.rounds.length) return round !== "" && p.rounds.includes(round);
+      if (p.round) return p.round === round;
+      return true;
+    };
+
+    // Pick the first active poster in-window whose schedule includes now()
     const poster = (data ?? []).find((p) => {
       const startOk = !p.starts_at || p.starts_at <= now;
       const endOk = !p.ends_at || p.ends_at >= now;
-      return startOk && endOk;
+      return startOk && endOk && inWindow(p as { round: string | null; rounds: string[] | null });
     });
 
     return NextResponse.json({

--- a/supabase/migrations/037_poster_rounds_window.sql
+++ b/supabase/migrations/037_poster_rounds_window.sql
@@ -1,0 +1,9 @@
+-- Day-part WINDOW for posters: a poster may now appear across a SET of rounds
+-- (e.g. a pasta lunch→supper, breakfast food all morning), not just one 2-hour
+-- slot. NULL/empty `rounds` falls back to the legacy single `round` (and a null
+-- `round` still means always-on). Readers + the autopilot engine prefer
+-- `rounds` when present.
+ALTER TABLE splash_posters ADD COLUMN IF NOT EXISTS rounds text[];
+
+COMMENT ON COLUMN splash_posters.rounds IS
+  'Day-part eligibility window (breakfast..supper). NULL/empty = fall back to single `round` (null round = always-on). Reader shows poster when current round is in this set.';


### PR DESCRIPTION
Makes home (and splash) posters **day-part aware across a span of rounds** — the single-slot `round` couldn't express a span, which is why home was stuck on "always".

- **Schema:** `splash_posters.rounds text[]` (migration 037, already applied). Empty → falls back to legacy single `round` (null = always-on).
- **Engine:** ranks **per round** over each round's eligible pool; a poster is active if it wins top-K in *any* eligible round. Drink-reserve per round. POS unchanged.
- **Readers:** home + splash show a poster when the current round is in its window; home carousel capped at 6.
- **CMS:** round picker is now a **multi-select window** (chips); persists `rounds`, migrates legacy single-round posters on edit. API accepts `rounds`.

Home posters already tagged into windows; the 3 moderate-confidence drafts were removed (URLs saved) so the window engine can't auto-surface an unconfirmed mapping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)