### PR TITLE
Make SMS Test Console provider-aware

### DIFF
--- a/apps/backoffice/src/app/(admin)/loyalty/engage/test/page.tsx
+++ b/apps/backoffice/src/app/(admin)/loyalty/engage/test/page.tsx
@@ -16,16 +16,15 @@ import Link from "next/link";
 
 interface Diagnostics {
   provider: string;
-  provider_raw_length?: number;
-  provider_trimmed_length?: number;
+  configured: boolean;
   api_key_set: boolean;
   api_key_prefix: string | null;
+  sender_id: string;
+  balance: string | null;
+  balance_error: string | null;
   email_set: boolean;
   email_value?: string | null;
-  sender_id: string;
-  sms123_balance: number | null;
-  balance_error: string | null;
-  balance_raw_response?: Record<string, unknown>;
+  endpoint?: string | null;
   recent_test_logs?: TestLog[];
 }
 
@@ -45,6 +44,15 @@ interface SendResult {
   error?: string;
   message_sent: string;
   diagnostics: Diagnostics;
+}
+
+const PROVIDER_LABELS: Record<string, string> = {
+  smsniaga: "SMS Niaga",
+  sms123: "SMS123",
+  console: "Console (dev)",
+};
+function providerLabel(p?: string) {
+  return p ? PROVIDER_LABELS[p] ?? p : "—";
 }
 
 function StatusIcon({ ok }: { ok: boolean }) {
@@ -80,8 +88,6 @@ export default function SmsTestPage() {
     setDiagLoading(false);
   }
 
-  // Load diagnostics on mount (placed after the declaration so hooks
-  // lint can order-check it).
   useEffect(() => {
     loadDiagnostics();
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -103,8 +109,7 @@ export default function SmsTestPage() {
       });
       const data = await res.json();
       setSendResult(data);
-      setDiagnostics(data.diagnostics);
-      // Refresh logs
+      if (data.diagnostics) setDiagnostics(data.diagnostics);
       loadDiagnostics();
     } catch {
       setSendResult({ success: false, error: "Network error", message_sent: "", diagnostics: diagnostics! });
@@ -112,8 +117,14 @@ export default function SmsTestPage() {
     setSending(false);
   }
 
-  const smsPrefix = `RM0 [${senderId || "CelsiusCoffee"}] `;
-  const previewMessage = message.startsWith("RM0 ") ? message : `${smsPrefix}${message}`;
+  const provider = diagnostics?.provider;
+  const isSmsNiaga = provider === "smsniaga";
+  // SMS Niaga prepends "RM0 <SenderID>:" at the gateway; SMS123 needs the app prefix.
+  const previewMessage = isSmsNiaga
+    ? message
+    : message.startsWith("RM0 ")
+      ? message
+      : `RM0 [${senderId || "CelsiusCoffee"}] ${message}`;
 
   return (
     <div className="space-y-6">
@@ -128,7 +139,7 @@ export default function SmsTestPage() {
         <div>
           <h1 className="text-2xl font-bold text-gray-900">SMS Test Console</h1>
           <p className="text-sm text-gray-500 mt-0.5">
-            Diagnose SMS123 configuration and send test messages
+            Diagnose the active SMS gateway and send test messages
           </p>
         </div>
       </div>
@@ -136,15 +147,22 @@ export default function SmsTestPage() {
       {/* Diagnostics Card */}
       <div className="bg-white rounded-xl border border-gray-200 p-6">
         <div className="flex items-center justify-between mb-4">
-          <h2 className="text-lg font-semibold text-gray-900">SMS123 Configuration</h2>
-          <button
-            onClick={loadDiagnostics}
-            disabled={diagLoading}
-            className="flex items-center gap-1.5 text-sm text-gray-600 hover:text-gray-900 transition-colors"
-          >
-            <RefreshCw className={cn("h-4 w-4", diagLoading && "animate-spin")} />
-            Refresh
-          </button>
+          <h2 className="text-lg font-semibold text-gray-900">
+            {diagnostics ? `${providerLabel(provider)} Configuration` : "SMS Configuration"}
+          </h2>
+          <div className="flex items-center gap-3">
+            <Link href="/settings/integrations" className="text-sm text-blue-600 hover:text-blue-800 transition-colors">
+              Change gateway
+            </Link>
+            <button
+              onClick={loadDiagnostics}
+              disabled={diagLoading}
+              className="flex items-center gap-1.5 text-sm text-gray-600 hover:text-gray-900 transition-colors"
+            >
+              <RefreshCw className={cn("h-4 w-4", diagLoading && "animate-spin")} />
+              Refresh
+            </button>
+          </div>
         </div>
 
         {diagLoading && !diagnostics ? (
@@ -154,25 +172,18 @@ export default function SmsTestPage() {
           </div>
         ) : diagnostics ? (
           <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
-            {/* Provider */}
+            {/* Provider (active, from the toggle) */}
             <div className="flex items-center gap-2">
-              <StatusIcon ok={diagnostics.provider === "sms123"} />
-              <span className="text-sm text-gray-600">Provider:</span>
+              <StatusIcon ok={diagnostics.configured} />
+              <span className="text-sm text-gray-600">Active provider:</span>
               <span
                 className={cn(
-                  "text-sm font-mono px-2 py-0.5 rounded",
-                  diagnostics.provider === "sms123"
-                    ? "bg-green-50 text-green-700"
-                    : "bg-red-50 text-red-700"
+                  "text-sm font-medium px-2 py-0.5 rounded",
+                  diagnostics.configured ? "bg-green-50 text-green-700" : "bg-amber-50 text-amber-700"
                 )}
               >
-                {diagnostics.provider}
+                {providerLabel(diagnostics.provider)}
               </span>
-              {diagnostics.provider !== "sms123" && (
-                <span className="text-xs text-red-500">
-                  (should be &quot;sms123&quot;)
-                </span>
-              )}
             </div>
 
             {/* API Key */}
@@ -184,23 +195,23 @@ export default function SmsTestPage() {
               </span>
             </div>
 
-            {/* Email */}
-            <div className="flex items-center gap-2">
-              <StatusIcon ok={diagnostics.email_set} />
-              <span className="text-sm text-gray-600">Email:</span>
-              <span className="text-sm font-mono">
-                {diagnostics.email_set ? diagnostics.email_value || "Set" : "NOT SET"}
-              </span>
-            </div>
+            {/* Email — SMS123 only */}
+            {diagnostics.provider === "sms123" && (
+              <div className="flex items-center gap-2">
+                <StatusIcon ok={diagnostics.email_set} />
+                <span className="text-sm text-gray-600">Email:</span>
+                <span className="text-sm font-mono">
+                  {diagnostics.email_set ? diagnostics.email_value || "Set" : "NOT SET"}
+                </span>
+              </div>
+            )}
 
             {/* Balance */}
             <div className="flex items-center gap-2">
-              <StatusIcon ok={diagnostics.sms123_balance !== null && diagnostics.sms123_balance > 0} />
+              <StatusIcon ok={!!diagnostics.balance && !diagnostics.balance_error} />
               <span className="text-sm text-gray-600">Balance:</span>
               <span className="text-sm font-semibold">
-                {diagnostics.sms123_balance !== null
-                  ? `${diagnostics.sms123_balance.toLocaleString()} credits`
-                  : diagnostics.balance_error || "Unknown"}
+                {diagnostics.balance ?? diagnostics.balance_error ?? "Unknown"}
               </span>
             </div>
 
@@ -211,30 +222,33 @@ export default function SmsTestPage() {
               <span className="text-sm font-mono">{diagnostics.sender_id}</span>
             </div>
 
-            {/* Raw length check */}
-            {diagnostics.provider_raw_length !== undefined &&
-              diagnostics.provider_raw_length !== diagnostics.provider_trimmed_length && (
-                <div className="flex items-center gap-2 col-span-2">
-                  <AlertTriangle className="h-4 w-4 text-amber-500" />
-                  <span className="text-sm text-amber-700">
-                    SMS_PROVIDER env var has trailing whitespace/newline (raw length:{" "}
-                    {diagnostics.provider_raw_length}, trimmed: {diagnostics.provider_trimmed_length})
-                  </span>
-                </div>
-              )}
+            {/* Endpoint */}
+            {diagnostics.endpoint && (
+              <div className="flex items-center gap-2 col-span-1 sm:col-span-2">
+                <CheckCircle2 className="h-4 w-4 text-blue-500" />
+                <span className="text-sm text-gray-600">Endpoint:</span>
+                <span className="text-sm font-mono truncate">{diagnostics.endpoint}</span>
+              </div>
+            )}
           </div>
         ) : (
           <p className="text-sm text-red-500">Failed to load diagnostics</p>
         )}
 
-        {/* Warnings */}
-        {diagnostics && diagnostics.provider !== "sms123" && (
+        {/* Not-configured warning */}
+        {diagnostics && !diagnostics.configured && (
           <div className="mt-4 p-3 rounded-lg bg-amber-50 border border-amber-200 flex items-start gap-2">
             <AlertTriangle className="h-5 w-5 text-amber-600 flex-shrink-0 mt-0.5" />
             <div className="text-sm text-amber-800">
-              <p className="font-medium">SMS_PROVIDER is not set to &quot;sms123&quot;</p>
+              <p className="font-medium">{providerLabel(diagnostics.provider)} isn&apos;t fully configured</p>
               <p className="mt-1">
-                Messages are being logged to console only. Set the <code className="font-mono bg-amber-100 px-1 rounded">SMS_PROVIDER</code> environment variable to <code className="font-mono bg-amber-100 px-1 rounded">sms123</code> in your Vercel project settings to enable real sending.
+                {diagnostics.provider === "smsniaga"
+                  ? "Set SMSNIAGA_API_KEY in the backoffice + order Vercel env."
+                  : diagnostics.provider === "sms123"
+                    ? "Set SMS123_API_KEY and SMS123_EMAIL in Vercel env."
+                    : "Messages are logged to the server console only (no SMS sent)."}{" "}
+                Switch gateways under{" "}
+                <Link href="/settings/integrations" className="underline font-medium">Settings → Integrations</Link>.
               </p>
             </div>
           </div>
@@ -273,8 +287,14 @@ export default function SmsTestPage() {
               value={senderId}
               onChange={(e) => setSenderId(e.target.value)}
               placeholder="CelsiusCoffee"
-              className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+              disabled={isSmsNiaga}
+              className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:ring-2 focus:ring-blue-500 focus:border-blue-500 disabled:bg-gray-50 disabled:text-gray-400"
             />
+            {isSmsNiaga && (
+              <p className="text-xs text-gray-400 mt-1">
+                Ignored on SMS Niaga — the gateway uses your registered Sender ID ({diagnostics?.sender_id}).
+              </p>
+            )}
           </div>
 
           {/* Message */}
@@ -302,6 +322,11 @@ export default function SmsTestPage() {
             <p className="text-sm font-mono text-gray-800 whitespace-pre-wrap break-all">
               {previewMessage}
             </p>
+            {isSmsNiaga && (
+              <p className="text-xs text-gray-400 mt-1">
+                SMS Niaga automatically prepends &quot;RM0 {(diagnostics?.sender_id || "").replace(/ \(.*\)$/, "")}: &quot;.
+              </p>
+            )}
           </div>
 
           {/* Send Button */}

--- a/apps/backoffice/src/app/(admin)/pickup/splash-posters/page.tsx
+++ b/apps/backoffice/src/app/(admin)/pickup/splash-posters/page.tsx
@@ -43,8 +43,11 @@ type Poster = {
   // canonical anchor so AI compose can reopen on a clean image even
   // when composer_state is missing (legacy posters, designer uploads).
   original_bg_url: string | null;
-  // Day-part round for pos-display posters (breakfast..supper). NULL = always.
+  // Legacy single day-part round (breakfast..supper). NULL = always.
   round: string | null;
+  // Day-part WINDOW — the set of rounds this poster appears in. NULL/empty =
+  // fall back to `round` (and a null round = always). Preferred going forward.
+  rounds: string[] | null;
 };
 
 type Form = {
@@ -64,9 +67,28 @@ type Form = {
   // Mirrors poster.original_bg_url — overwritten by Re-crop uploads,
   // preserved across AI compose saves.
   originalBgUrl: string | null;
-  // Day-part round (pos-display only). "" = always.
-  round: string;
+  // Day-part window — set of rounds this poster appears in. [] = always.
+  rounds: string[];
 };
+
+// Day-part rounds for the window picker.
+const ROUND_OPTIONS: { id: string; label: string }[] = [
+  { id: "breakfast", label: "Breakfast" },
+  { id: "brunch",    label: "Brunch" },
+  { id: "lunch",     label: "Lunch" },
+  { id: "midday",    label: "Midday" },
+  { id: "evening",   label: "Evening" },
+  { id: "dinner",    label: "Dinner" },
+  { id: "supper",    label: "Supper" },
+];
+const ROUND_LABEL: Record<string, string> = Object.fromEntries(ROUND_OPTIONS.map((r) => [r.id, r.label]));
+// The eligibility window for a poster: explicit `rounds`, else legacy single
+// `round`, else [] (always-on / every round).
+function posterWindow(p: { round: string | null; rounds: string[] | null }): string[] {
+  if (p.rounds && p.rounds.length) return p.rounds;
+  if (p.round) return [p.round];
+  return [];
+}
 
 // Cache-bust IMG URLs against the poster's updated_at. Browsers
 // otherwise hold the prior bytes after a re-upload (especially for
@@ -152,7 +174,7 @@ const empty: Form = {
   placement: "home",
   composerState: null,
   originalBgUrl: null,
-  round: "",
+  rounds: [],
 };
 
 // ---- Schedule helpers ---------------------------------------------------
@@ -348,7 +370,9 @@ export default function SplashPostersPage() {
       placement: p.placement ?? "home",
       composerState: p.composer_state ?? null,
       originalBgUrl: p.original_bg_url ?? null,
-      round: p.round ?? "",
+      // Pre-fill the window from `rounds`; fall back to a legacy single `round`
+      // so editing an old poster migrates it cleanly to the multi-round model.
+      rounds: p.rounds?.length ? p.rounds : (p.round ? [p.round] : []),
     });
     setDeeplinkMode(null);
     setShowForm(true);
@@ -376,7 +400,7 @@ export default function SplashPostersPage() {
         placement:      p.placement ?? "home",
         composerState:  p.composer_state ?? null,
         originalBgUrl:  p.original_bg_url ?? null,
-        round:          p.round ?? null,
+        rounds:         p.rounds?.length ? p.rounds : (p.round ? [p.round] : null),
       };
       const res = await adminFetch("/api/pickup/splash-posters", {
         method: "POST",
@@ -466,10 +490,11 @@ export default function SplashPostersPage() {
         placement:     form.placement,
         composerState: form.composerState,
         originalBgUrl: form.originalBgUrl,
-        // Round applies to every surface now — the home carousel, splash
-        // launch, and POS screen readers all filter by current day-part
-        // round (round-less = always). Lets the autopilot schedule by round.
-        round:         form.round || null,
+        // Day-part window for every surface (home carousel, splash launch, POS
+        // screen). Empty = always. Stored in `rounds`; `round` is cleared so the
+        // multi-round window is the single source of truth going forward.
+        rounds:        form.rounds.length ? form.rounds : null,
+        round:         null,
       };
       const url = form.id
         ? `/api/pickup/splash-posters?id=${encodeURIComponent(form.id)}`
@@ -642,8 +667,8 @@ export default function SplashPostersPage() {
         ];
         const countFor = (id: string) =>
           id === "all" ? pos.length
-            : id === "always" ? pos.filter((p) => !p.round).length
-              : pos.filter((p) => p.round === id).length;
+            : id === "always" ? pos.filter((p) => posterWindow(p).length === 0).length
+              : pos.filter((p) => posterWindow(p).includes(id)).length;
         return (
           <div className="mb-4 flex flex-wrap gap-1.5">
             {opts.map((r) => {
@@ -678,8 +703,8 @@ export default function SplashPostersPage() {
             roundFilter === "all"
               ? true
               : roundFilter === "always"
-                ? !p.round
-                : p.round === roundFilter,
+                ? posterWindow(p).length === 0
+                : posterWindow(p).includes(roundFilter),
           );
 
         if (loading) {
@@ -754,11 +779,18 @@ export default function SplashPostersPage() {
                   <span className={`rounded-full ${placementColor} px-2 py-0.5 text-[10px] font-semibold text-white`}>
                     {placementLabel}
                   </span>
-                  {p.round && (
-                    <span className="rounded-full bg-orange-500 px-2 py-0.5 text-[10px] font-semibold capitalize text-white">
-                      {p.round}
-                    </span>
-                  )}
+                  {(() => {
+                    const w = posterWindow(p);
+                    if (!w.length) return null;
+                    const label = w.length > 3
+                      ? `${w.length} rounds`
+                      : w.map((r) => ROUND_LABEL[r] ?? r).join(", ");
+                    return (
+                      <span className="rounded-full bg-orange-500 px-2 py-0.5 text-[10px] font-semibold capitalize text-white">
+                        {label}
+                      </span>
+                    );
+                  })()}
                   {/* Schedule status pill — replaces the bare ACTIVE
                       pill with one that conveys the real live state:
                       LIVE NOW, SCHEDULED · Apr 12, EXPIRED · Mar 30,
@@ -961,28 +993,43 @@ export default function SplashPostersPage() {
               </div>
 
               <div>
-                <label className="text-xs font-medium text-gray-700">Round (time of day)</label>
-                <select
-                  value={form.round}
-                  onChange={(e) => setForm((f) => ({ ...f, round: e.target.value }))}
-                  className="mt-1 w-full rounded-lg border border-gray-300 px-3 py-2 text-sm"
-                >
-                  <option value="">Always — show in every round</option>
-                  <option value="breakfast">Breakfast · 8–10AM</option>
-                  <option value="brunch">Brunch · 10AM–12PM</option>
-                  <option value="lunch">Lunch · 12–3PM</option>
-                  <option value="midday">Midday · 3–5PM</option>
-                  <option value="evening">Evening · 5–7PM</option>
-                  <option value="dinner">Dinner · 7–9PM</option>
-                  <option value="supper">Supper · 9–11PM</option>
-                </select>
-                <p className="mt-1 text-[11px] text-gray-500">
-                  {form.placement === "home"
-                    ? "Home carousel only shows this poster during this day-part. "
-                    : form.placement === "splash"
-                      ? "App launch splash only shows this poster during this day-part. "
-                      : "Customer screen only shows this poster during this day-part. "}
-                  &quot;Always&quot; shows in every round.
+                <label className="text-xs font-medium text-gray-700">Rounds (time of day)</label>
+                <p className="mt-0.5 text-[11px] text-gray-500">
+                  Pick the day-parts this poster appears in (a span is fine, e.g.
+                  Lunch→Supper). Leave all off for <span className="font-semibold">Always</span>.
+                </p>
+                <div className="mt-2 flex flex-wrap gap-1.5">
+                  {ROUND_OPTIONS.map((r) => {
+                    const on = form.rounds.includes(r.id);
+                    return (
+                      <button
+                        key={r.id}
+                        type="button"
+                        onClick={() =>
+                          setForm((f) => ({
+                            ...f,
+                            rounds: on
+                              ? f.rounds.filter((x) => x !== r.id)
+                              : [...f.rounds, r.id],
+                          }))
+                        }
+                        className={`rounded-full px-3 py-1 text-xs font-semibold transition-colors ${
+                          on
+                            ? "bg-terracotta text-white"
+                            : "bg-gray-100 text-gray-600 hover:bg-gray-200"
+                        }`}
+                      >
+                        {r.label}
+                      </button>
+                    );
+                  })}
+                </div>
+                <p className="mt-1.5 text-[11px] text-gray-500">
+                  {form.rounds.length === 0
+                    ? "Showing in every round (Always)."
+                    : `Showing only during: ${form.rounds
+                        .map((r) => ROUND_LABEL[r] ?? r)
+                        .join(", ")}.`}
                 </p>
               </div>
 

--- a/apps/backoffice/src/app/api/loyalty/sms/test/route.ts
+++ b/apps/backoffice/src/app/api/loyalty/sms/test/route.ts
@@ -1,9 +1,100 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { sendSMS, getSMSProvider, providerAutoPrependsSender, getActiveSmsProvider } from '@/lib/loyalty/sms';
+import { sendSMS, providerAutoPrependsSender, getActiveSmsProvider } from '@/lib/loyalty/sms';
 import { supabaseAdmin } from '@/lib/loyalty/supabase';
 import { requireAuth } from '@/lib/auth';
 
-// POST /api/loyalty/sms/test — send a single test SMS and return detailed diagnostics
+// Build provider-aware config diagnostics for whichever gateway is active
+// (resolved from the app_settings.sms_provider toggle). Used by both the GET
+// diagnostics endpoint and the POST send response.
+async function buildDiagnostics(provider: string): Promise<Record<string, unknown>> {
+  const d: Record<string, unknown> = {
+    provider,
+    configured: false,
+    api_key_set: false,
+    api_key_prefix: null as string | null,
+    sender_id: '',
+    balance: null as string | null,
+    balance_error: null as string | null,
+    email_set: false,
+    email_value: null as string | null,
+    endpoint: null as string | null,
+  };
+
+  if (provider === 'smsniaga') {
+    const apiKey = process.env.SMSNIAGA_API_KEY;
+    d.api_key_set = !!apiKey;
+    d.api_key_prefix = apiKey ? `${apiKey.slice(0, 4)}...` : null;
+    d.sender_id = process.env.SMSNIAGA_SENDER_ID || 'CELSIUSCOFFEE (account default)';
+    d.endpoint = process.env.SMSNIAGA_API_URL || 'https://manage.smsniaga.com/api/send';
+    d.configured = !!apiKey;
+    if (apiKey) {
+      try {
+        const res = await fetch('https://manage.smsniaga.com/api/balance', {
+          headers: { Authorization: `Bearer ${apiKey}`, Accept: 'application/json' },
+        });
+        const data = await res.json().catch(() => ({}));
+        // { balance: { cents, human: "RM36.80", currency: "MYR" } }
+        if (res.ok && data?.balance?.human) {
+          d.balance = String(data.balance.human);
+        } else {
+          d.balance_error = data?.message || `HTTP ${res.status}`;
+        }
+      } catch (err) {
+        d.balance_error = err instanceof Error ? err.message : 'Failed to fetch balance';
+      }
+    } else {
+      d.balance_error = 'SMSNIAGA_API_KEY not configured';
+    }
+  } else if (provider === 'sms123') {
+    const apiKey = process.env.SMS123_API_KEY;
+    const email = process.env.SMS123_EMAIL;
+    d.api_key_set = !!apiKey;
+    d.api_key_prefix = apiKey ? `${apiKey.slice(0, 4)}...` : null;
+    d.email_set = !!email;
+    d.email_value = email || null;
+    d.sender_id = process.env.SMS123_SENDER_ID || 'CelsiusCoffee (default)';
+    d.endpoint = 'https://www.sms123.net/api/send.php';
+    d.configured = !!(apiKey && email);
+    if (apiKey && email) {
+      try {
+        const params = new URLSearchParams({ apiKey, email });
+        const res = await fetch(`https://www.sms123.net/api/getBalance.php?${params.toString()}`);
+        const text = await res.text();
+        try {
+          const data = JSON.parse(text);
+          if (data.status === 'ok' && data.balance != null) {
+            d.balance = `${parseFloat(String(data.balance).replace(/,/g, '')).toLocaleString()} credits`;
+          } else {
+            d.balance_error = data.statusMsg || 'Unknown error';
+          }
+        } catch {
+          d.balance_error = `Non-JSON response: ${text.slice(0, 120)}`;
+        }
+      } catch (err) {
+        d.balance_error = err instanceof Error ? err.message : 'Request failed';
+      }
+    } else {
+      d.balance_error = 'SMS123_API_KEY or SMS123_EMAIL not configured';
+    }
+  } else {
+    // console (dev)
+    d.configured = true;
+    d.sender_id = '(dev console — logs only)';
+    d.balance = 'n/a (console)';
+  }
+
+  const { data: recentTests } = await supabaseAdmin
+    .from('sms_logs')
+    .select('*')
+    .like('id', 'sms-test-%')
+    .order('created_at', { ascending: false })
+    .limit(10);
+  d.recent_test_logs = recentTests ?? [];
+
+  return d;
+}
+
+// POST /api/loyalty/sms/test — send a single test SMS and return diagnostics
 export async function POST(request: NextRequest) {
   try {
     const auth = await requireAuth(request);
@@ -16,50 +107,20 @@ export async function POST(request: NextRequest) {
     }
 
     const provider = await getActiveSmsProvider();
-    const apiKey = process.env.SMS123_API_KEY;
-    const email = process.env.SMS123_EMAIL;
 
-    // Diagnostics object
-    const diagnostics = {
-      provider,
-      api_key_set: !!apiKey,
-      api_key_prefix: apiKey ? `${apiKey.slice(0, 4)}...` : null,
-      email_set: !!email,
-      sender_id: sender_id || process.env.SMS123_SENDER_ID || 'CelsiusCoffee',
-      sms123_balance: null as number | null,
-      balance_error: null as string | null,
-    };
-
-    // Check SMS123 balance if configured
-    if (apiKey && email) {
-      try {
-        const params = new URLSearchParams({ apiKey, email });
-        const res = await fetch(`https://www.sms123.net/api/getBalance.php?${params.toString()}`);
-        const data = await res.json();
-        if (data.status === 'ok' && data.balance != null) {
-          diagnostics.sms123_balance = parseFloat(String(data.balance).replace(/,/g, ''));
-        } else {
-          diagnostics.balance_error = data.statusMsg || 'Unknown error';
-        }
-      } catch (err) {
-        diagnostics.balance_error = err instanceof Error ? err.message : 'Failed to fetch balance';
-      }
-    }
-
-    // Auto-prepend RM0 prefix.
-    // SMS Niaga adds its own "RM0.00 <SenderID>:" at the gateway, so skip ours there.
+    // Auto-prepend RM0 prefix for providers that need it (SMS123). SMS Niaga
+    // adds its own "RM0 <SenderID>:" at the gateway, so skip ours there.
     const senderLabel = sender_id || 'CelsiusCoffee';
     const SMS_PREFIX = `RM0 [${senderLabel}] `;
     const finalMessage =
       providerAutoPrependsSender(provider) || message.startsWith('RM0 ') ? message : `${SMS_PREFIX}${message}`;
 
-    // Send the test SMS. SMS Niaga needs a registered Sender ID, so don't forward a free-text label.
+    // SMS Niaga needs a registered Sender ID, so don't forward a free-text label.
     const result = await sendSMS(phone, finalMessage, {
       provider,
       ...(!providerAutoPrependsSender(provider) && sender_id ? { senderId: sender_id } : {}),
     });
 
-    // Log to sms_logs
     await supabaseAdmin.from('sms_logs').insert({
       id: `sms-test-${Date.now()}-${Math.random().toString(36).slice(2, 6)}`,
       brand_id: 'brand-celsius',
@@ -67,7 +128,7 @@ export async function POST(request: NextRequest) {
       phone,
       message: finalMessage,
       status: result.success ? 'sent' : 'failed',
-      provider: provider,
+      provider,
       provider_message_id: result.messageId || null,
       error: result.error || null,
     });
@@ -75,7 +136,7 @@ export async function POST(request: NextRequest) {
     return NextResponse.json({
       ...result,
       message_sent: finalMessage,
-      diagnostics,
+      diagnostics: await buildDiagnostics(provider),
     });
   } catch (err) {
     const msg = err instanceof Error ? err.message : 'Internal server error';
@@ -83,65 +144,14 @@ export async function POST(request: NextRequest) {
   }
 }
 
-// GET /api/loyalty/sms/test — return SMS config diagnostics without sending
+// GET /api/loyalty/sms/test — return active-provider config diagnostics (no send)
 export async function GET(request: NextRequest) {
   try {
     const auth = await requireAuth(request);
     if (auth.error) return auth.error;
 
-    const provider = (process.env.SMS_PROVIDER || 'console').trim();
-    const apiKey = process.env.SMS123_API_KEY;
-    const email = process.env.SMS123_EMAIL;
-
-    const diagnostics: Record<string, unknown> = {
-      provider,
-      active_provider: await getActiveSmsProvider(),
-      provider_raw_length: (process.env.SMS_PROVIDER || '').length,
-      provider_trimmed_length: provider.length,
-      api_key_set: !!apiKey,
-      api_key_prefix: apiKey ? `${apiKey.slice(0, 4)}...` : null,
-      email_set: !!email,
-      email_value: email || null,
-      sender_id: process.env.SMS123_SENDER_ID || '(default: CelsiusCoffee)',
-      sms123_balance: null,
-      balance_error: null,
-    };
-
-    // Check SMS123 balance
-    if (apiKey && email) {
-      try {
-        const params = new URLSearchParams({ apiKey, email });
-        const res = await fetch(`https://www.sms123.net/api/getBalance.php?${params.toString()}`);
-        const text = await res.text();
-        try {
-          const data = JSON.parse(text);
-          if (data.status === 'ok' && data.balance != null) {
-            diagnostics.sms123_balance = parseFloat(String(data.balance).replace(/,/g, ''));
-          } else {
-            diagnostics.balance_error = data.statusMsg || 'Unknown error';
-          }
-          diagnostics.balance_raw_response = data;
-        } catch {
-          diagnostics.balance_error = `Non-JSON response: ${text.slice(0, 200)}`;
-        }
-      } catch (err) {
-        diagnostics.balance_error = err instanceof Error ? err.message : 'Request failed';
-      }
-    } else {
-      diagnostics.balance_error = 'SMS123_API_KEY or SMS123_EMAIL not configured';
-    }
-
-    // Recent test SMS logs
-    const { data: recentTests } = await supabaseAdmin
-      .from('sms_logs')
-      .select('*')
-      .like('id', 'sms-test-%')
-      .order('created_at', { ascending: false })
-      .limit(10);
-
-    diagnostics.recent_test_logs = recentTests ?? [];
-
-    return NextResponse.json(diagnostics);
+    const provider = await getActiveSmsProvider();
+    return NextResponse.json(await buildDiagnostics(provider));
   } catch (err) {
     const msg = err instanceof Error ? err.message : 'Internal server error';
     return NextResponse.json({ error: msg }, { status: 500 });

--- a/apps/backoffice/src/app/api/pickup/splash-posters/route.ts
+++ b/apps/backoffice/src/app/api/pickup/splash-posters/route.ts
@@ -52,6 +52,7 @@ export async function POST(request: NextRequest) {
       ends_at:     body.endsAt ?? null,
       placement,
       round:       body.round ?? null,
+      rounds:      Array.isArray(body.rounds) && body.rounds.length ? body.rounds : null,
       composer_state:  body.composerState ?? null,
       original_bg_url: body.originalBgUrl ?? null,
     } as Record<string, unknown>)
@@ -80,6 +81,7 @@ export async function PATCH(request: NextRequest) {
   if ("durationMs"     in body) updates.duration_ms     = body.durationMs;
   if ("active"         in body) updates.active          = Boolean(body.active);
   if ("round"          in body) updates.round           = body.round || null;
+  if ("rounds"         in body) updates.rounds          = Array.isArray(body.rounds) && body.rounds.length ? body.rounds : null;
   if ("startsAt"       in body) updates.starts_at       = body.startsAt;
   if ("endsAt"         in body) updates.ends_at         = body.endsAt;
   if ("composerState"  in body) updates.composer_state  = body.composerState;

--- a/apps/backoffice/src/lib/pos/poster-autopilot.ts
+++ b/apps/backoffice/src/lib/pos/poster-autopilot.ts
@@ -109,9 +109,19 @@ const DEFAULT_TOPK: Record<Placement, number> = { "pos-display": 3, home: 5, spl
 // keeps its food-attach logic untouched (we WANT to push a bite in-store).
 const RESERVE_DRINKS: Record<Placement, number> = { home: 2, splash: 0, "pos-display": 0 };
 
-// Group key for a poster row: POS rotates by day-part round; app placements
-// usually have no round (one '__all__' group) but support rounds once tagged.
-const GROUP_ALL = "__all__";
+// A poster's eligibility window — which day-part rounds it may appear in:
+//   • rounds[] set     → exactly those rounds (the day-part window, e.g. a
+//                        pasta tagged lunch→supper, breakfast food all morning)
+//   • else round (one) → that single round (legacy + POS)
+//   • else (both null) → every round (always-on anchor)
+function windowOf(po: { round: string | null; rounds: string[] | null }): Round[] {
+  if (po.rounds && po.rounds.length) {
+    return po.rounds.filter((r): r is Round => (ROUNDS as string[]).includes(r));
+  }
+  if (po.round && (ROUNDS as string[]).includes(po.round)) return [po.round as Round];
+  if (po.round) return [];
+  return ROUNDS;
+}
 
 /**
  * Build the active/sort_order plan for one placement. Pure read — returns
@@ -134,7 +144,7 @@ export async function planPosterRotation(
 
   let postersQuery = supabase
     .from("splash_posters")
-    .select("id,title,round,product_id")
+    .select("id,title,round,rounds,product_id")
     .eq("brand_id", "brand-celsius")
     .eq("placement", placement);
   // POS posters are always round-tagged; app posters may be round-less.
@@ -166,30 +176,48 @@ export async function planPosterRotation(
     prodById.set(p.id, { name: p.name, category: p.category, price: Number(p.price ?? 0) });
   }
 
-  // Group posters by round (or one '__all__' bucket for round-less app posters).
-  const postersByGroup = new Map<string, { id: string; title: string | null; product_id: string | null; round: string | null }[]>();
+  // Normalise rows once, keeping each poster's eligibility window.
+  type Row = { id: string; title: string | null; product_id: string | null; round: string | null; rounds: string[] | null };
   // eslint-disable-next-line @typescript-eslint/no-explicit-any -- legacy untyped DB row (ratchet: reduce, never add)
-  for (const po of (postersRes.data ?? []) as any[]) {
-    const key = po.round ?? GROUP_ALL;
-    const arr = postersByGroup.get(key) ?? [];
-    arr.push({ id: po.id, title: po.title ?? null, product_id: po.product_id ?? null, round: po.round ?? null });
-    postersByGroup.set(key, arr);
+  const rows: Row[] = ((postersRes.data ?? []) as any[]).map((po) => ({
+    id: po.id,
+    title: po.title ?? null,
+    product_id: po.product_id ?? null,
+    round: po.round ?? null,
+    rounds: (po.rounds ?? null) as string[] | null,
+  }));
+
+  // Bucket posters by the rounds they're eligible to appear in (a poster with a
+  // multi-round window lands in several buckets; an always-on poster in all).
+  const eligibleByRound = new Map<Round, Row[]>();
+  for (const po of rows) {
+    for (const r of windowOf(po)) {
+      const arr = eligibleByRound.get(r) ?? [];
+      arr.push(po);
+      eligibleByRound.set(r, arr);
+    }
   }
 
-  const decisions: PosterDecision[] = [];
-  for (const [groupKey, posters] of postersByGroup) {
-    if (!posters.length) continue;
-    const round = (groupKey === GROUP_ALL ? null : (groupKey as Round));
-    const drinkHeavy = round ? (roundStats[round]?.single_rate ?? 0) >= DRINK_HEAVY_SINGLE_RATE : false;
+  const minDrinks = RESERVE_DRINKS[placement] ?? 0;
+  // active = union of each round's top-K (with a per-round drink reserve so a
+  // round's carousel isn't all-food). A poster wins a slot if it ranks top-K in
+  // ANY round it's eligible for; the reader then shows active ∩ current round.
+  const activeIds = new Set<string>();
+  const bestScore = new Map<string, number>();
 
-    const scored = posters.map((po) => {
+  for (const round of ROUNDS) {
+    const pool = eligibleByRound.get(round);
+    if (!pool || !pool.length) continue;
+    const drinkHeavy = (roundStats[round]?.single_rate ?? 0) >= DRINK_HEAVY_SINGLE_RATE;
+
+    const scored = pool.map((po) => {
       const prod = po.product_id ? prodById.get(po.product_id) : null;
       const priceRM = prod?.price ?? 0;
       // Fallback to a 35%-COGS assumption when a poster isn't linked / cost unknown.
       const costRM = prod ? costByName.get(prod.name.trim().toLowerCase()) ?? priceRM * 0.35 : priceRM * 0.35;
       const marginRM = Math.max(0, priceRM - costRM);
       const isFood = prod?.category ? FOOD_CATEGORIES.has(prod.category) : false;
-      const units = po.product_id ? unitsByRoundProduct.get(`${round ?? ""}|${po.product_id}`) ?? 0 : 0;
+      const units = po.product_id ? unitsByRoundProduct.get(`${round}|${po.product_id}`) ?? 0 : 0;
       const measured = measuredByPoster.get(po.id) ?? { orders: 0, aov: 0 };
       return { po, prod, priceRM, marginRM, isFood, units, measured, attach: isFood && drinkHeavy };
     });
@@ -205,64 +233,49 @@ export async function planPosterRotation(
         const priceN = s.priceRM / maxPrice;
         const unitsN = s.units / maxUnits;
         let score: number;
-        let reason: string;
         if (opts.mode === "control") {
           score = unitsN;
-          reason = "popularity (control)";
         } else {
           const heuristic = 0.45 * marginN + 0.3 * (s.attach ? 1 : 0) + 0.15 * priceN + 0.1 * unitsN;
-          const bits: string[] = [];
-          if (s.attach) bits.push("fills drink-only gap");
-          if (marginN > 0.7) bits.push(`RM${s.marginRM.toFixed(2)} margin`);
-          if (priceN > 0.7) bits.push("premium anchor");
-          if (!s.prod) bits.push("unlinked");
-          // Blend in MEASURED order AOV as attributed orders accrue (app only):
+          // Blend MEASURED order AOV as attributed orders accrue (app only):
           // weight ramps 0→1 over the first ~10 orders, then measured dominates.
           const w = Math.min(s.measured.orders / 10, 1);
-          if (w > 0) {
-            score = w * (s.measured.aov / maxMeasuredAov) + (1 - w) * heuristic;
-            bits.unshift(`measured AOV RM${s.measured.aov.toFixed(2)} (${s.measured.orders} ord)`);
-          } else {
-            score = heuristic;
-          }
-          reason = bits.join(", ") || "balanced";
+          score = w > 0 ? w * (s.measured.aov / maxMeasuredAov) + (1 - w) * heuristic : heuristic;
         }
-        return { s, score, reason };
+        return { s, score };
       })
       .sort((a, b) => b.score - a.score);
 
-    // Active set = top-K by score, but guarantee RESERVE_DRINKS drink slots:
-    // swap the lowest-scoring foods in the top-K for the best benched drinks so
-    // the carousel isn't 100% food. No-op when the natural top-K already has
-    // enough drinks, or when the pool has no benched drinks to promote.
-    const activeIds = new Set(ranked.slice(0, topK).map((r) => r.s.po.id));
-    const minDrinks = RESERVE_DRINKS[placement] ?? 0;
+    // Top-K for this round, with the drink reserve (swap lowest-scoring foods
+    // in the top-K for the best benched drinks). No-op without enough drinks.
+    const chosen = new Set(ranked.slice(0, topK).map((r) => r.s.po.id));
     if (minDrinks > 0) {
       const top = ranked.slice(0, topK);
       const need = minDrinks - top.filter((r) => !r.s.isFood).length;
       if (need > 0) {
         const benchDrinks = ranked.slice(topK).filter((r) => !r.s.isFood).slice(0, need);
-        const dropFoods = top
-          .filter((r) => r.s.isFood)
-          .sort((a, b) => a.score - b.score)
-          .slice(0, benchDrinks.length);
-        for (const r of dropFoods) activeIds.delete(r.s.po.id);
-        for (const r of benchDrinks) activeIds.add(r.s.po.id);
+        const dropFoods = top.filter((r) => r.s.isFood).sort((a, b) => a.score - b.score).slice(0, benchDrinks.length);
+        for (const r of dropFoods) chosen.delete(r.s.po.id);
+        for (const r of benchDrinks) chosen.add(r.s.po.id);
       }
     }
-
-    ranked.forEach((r, i) => {
-      decisions.push({
-        round,
-        posterId: r.s.po.id,
-        title: r.s.po.title,
-        productId: r.s.po.product_id,
-        active: activeIds.has(r.s.po.id),
-        sortOrder: (i + 1) * 10,
-        score: Math.round(r.score * 1000) / 1000,
-        reason: r.reason,
-      });
-    });
+    for (const id of chosen) activeIds.add(id);
+    for (const r of ranked) bestScore.set(r.s.po.id, Math.max(bestScore.get(r.s.po.id) ?? 0, r.score));
   }
+
+  // One decision per poster: active if it won a slot in any eligible round;
+  // sort_order by overall best score (the reader caps + orders the per-round
+  // eligible subset by this, so the strongest posters surface first).
+  const ranked = rows.slice().sort((a, b) => (bestScore.get(b.id) ?? 0) - (bestScore.get(a.id) ?? 0));
+  const decisions: PosterDecision[] = ranked.map((po, i) => ({
+    round: po.round ? (po.round as Round) : null,
+    posterId: po.id,
+    title: po.title,
+    productId: po.product_id,
+    active: activeIds.has(po.id),
+    sortOrder: (i + 1) * 10,
+    score: Math.round((bestScore.get(po.id) ?? 0) * 1000) / 1000,
+    reason: activeIds.has(po.id) ? "top-K in an eligible round" : "benched",
+  }));
   return decisions;
 }

--- a/apps/order/src/app/api/home-posters/route.ts
+++ b/apps/order/src/app/api/home-posters/route.ts
@@ -36,13 +36,11 @@ export async function GET(request: NextRequest) {
 
     const { data, error } = await supabase
       .from("splash_posters")
-      .select("id, image_url, title, deeplink, duration_ms, starts_at, ends_at, sort_order")
+      .select("id, image_url, title, deeplink, duration_ms, starts_at, ends_at, sort_order, round, rounds")
       .eq("brand_id", brandId)
       .eq("active", true)
       // Home carousel only — splash posters stay on the launch screen.
       .eq("placement", "home")
-      // Recurring day-part round: round-less shows always; tagged shows in-round.
-      .or(round ? `round.is.null,round.eq.${round}` : "round.is.null")
       // Operator-controlled sequence first (lower number = appears earlier
       // in the carousel rotation). NULL sort_order is treated as "unordered"
       // and falls to the back of the rotation, ordered by recency.
@@ -54,12 +52,25 @@ export async function GET(request: NextRequest) {
       return NextResponse.json({ posters: [] }, { status: 200 });
     }
 
+    // Day-part window: a poster shows when the current round is in its `rounds`
+    // set; if `rounds` is empty it falls back to the legacy single `round`
+    // (and a null round = always-on). Done in JS so the multi-round array is
+    // simple to evaluate (PostgREST array-contains + legacy fallback is messy).
+    const inWindow = (p: { round: string | null; rounds: string[] | null }): boolean => {
+      if (p.rounds && p.rounds.length) return round !== "" && p.rounds.includes(round);
+      if (p.round) return p.round === round;
+      return true; // always-on
+    };
+
+    const HOME_CAP = 6; // keep the carousel tight even when many posters qualify
     const posters = (data ?? [])
       .filter((p) => {
         const startOk = !p.starts_at || p.starts_at <= now;
         const endOk   = !p.ends_at   || p.ends_at   >= now;
         return startOk && endOk;
       })
+      .filter((p) => inWindow(p as { round: string | null; rounds: string[] | null }))
+      .slice(0, HOME_CAP)
       .map((p) => ({
         id:         p.id as string,
         imageUrl:   p.image_url as string,

--- a/apps/order/src/app/api/splash-poster/route.ts
+++ b/apps/order/src/app/api/splash-poster/route.ts
@@ -32,13 +32,11 @@ export async function GET(request: NextRequest) {
 
     const { data, error } = await supabase
       .from("splash_posters")
-      .select("id, image_url, deeplink, duration_ms, starts_at, ends_at")
+      .select("id, image_url, deeplink, duration_ms, starts_at, ends_at, round, rounds")
       .eq("brand_id", brandId)
       .eq("active", true)
       // Splash surface only — home posters stay on the home carousel.
       .eq("placement", "splash")
-      // Recurring day-part round: round-less shows always; tagged shows in-round.
-      .or(round ? `round.is.null,round.eq.${round}` : "round.is.null")
       .order("updated_at", { ascending: false });
 
     if (error) {
@@ -46,11 +44,19 @@ export async function GET(request: NextRequest) {
       return NextResponse.json({ poster: null }, { status: 200 });
     }
 
-    // Pick the first active poster whose schedule window includes now()
+    // Day-part window: shows when the current round is in `rounds`; empty falls
+    // back to the legacy single `round` (null round = always-on).
+    const inWindow = (p: { round: string | null; rounds: string[] | null }): boolean => {
+      if (p.rounds && p.rounds.length) return round !== "" && p.rounds.includes(round);
+      if (p.round) return p.round === round;
+      return true;
+    };
+
+    // Pick the first active poster in-window whose schedule includes now()
     const poster = (data ?? []).find((p) => {
       const startOk = !p.starts_at || p.starts_at <= now;
       const endOk = !p.ends_at || p.ends_at >= now;
-      return startOk && endOk;
+      return startOk && endOk && inWindow(p as { round: string | null; rounds: string[] | null });
     });
 
     return NextResponse.json({

--- a/apps/order/src/lib/loyalty/v2.ts
+++ b/apps/order/src/lib/loyalty/v2.ts
@@ -548,6 +548,7 @@ function evalGoalOnOrder(goal: Goal, order: OrderForMission): number {
     case "spend_amount":               return order.total_sen;
     case "distinct_outlets":           return 0; // dedup: see evalDedupedGoal
     case "distinct_new_products":      return 0; // dedup: see evalDedupedGoal
+    case "distinct_order_days":        return 0; // dedup: see evalDedupedGoal (one tick per new paid day)
     case "referrals_count":            return 0; // referral mission is config-only; vouchers fire from maybeRewardReferralOnFirstOrder
     default:                            return 0;
   }
@@ -591,6 +592,28 @@ async function evalDedupedGoal(
     const priorIds = new Set<string>((prior ?? []).map((p) => p.product_id as string));
     const hasNew = order.item_ids.some((p) => !priorIds.has(p));
     return hasNew ? 1 : 0;
+  }
+  if (goal.type === "distinct_order_days") {
+    // Frequency goal: +1 the FIRST paid order on each calendar day (MYT),
+    // so progress = number of distinct days the member ordered this week.
+    // Unlike orders_count (which counts every order, completable in one
+    // sitting), this can only be cleared by returning on separate days —
+    // the lever for repeat-visit frequency. Caller already filtered free
+    // orders (applyOrderToMission), so this order is paid.
+    const d = new Date(order.created_at);
+    const dayStr = new Date(d.getTime() + 8 * 3_600_000).toISOString().slice(0, 10); // MYT calendar day
+    const dayStartUtc = new Date(`${dayStr}T00:00:00+08:00`).toISOString();
+    const dayEndUtc   = new Date(`${dayStr}T23:59:59.999+08:00`).toISOString();
+    const { count } = await supabase
+      .from("orders")
+      .select("id", { count: "exact", head: true })
+      .eq("loyalty_id", memberId)
+      .neq("id", order.id)
+      .gt("total", 0)
+      .in("status", ["preparing", "ready", "completed"])
+      .gte("created_at", dayStartUtc)
+      .lte("created_at", dayEndUtc);
+    return (count ?? 0) === 0 ? 1 : 0; // first paid order today → new distinct day
   }
   return 0;
 }
@@ -644,6 +667,15 @@ export async function applyOrderToMission(args: {
 }): Promise<{ completedMissionIds: string[] }> {
   const supabase = getSupabaseAdmin();
 
+  // Paid-only: a fully-free order (RM0 — a reward/voucher redemption) must
+  // NOT advance any mission. Otherwise a redeemed free drink completes the
+  // next mission and mints another free drink — a self-feeding chain (the
+  // Yousef case: free order completed "Try Something New" → 2nd free coffee).
+  // Real money must change hands for a visit/spend/new-product to count.
+  if (args.order.total_sen <= 0) {
+    return { completedMissionIds: [] };
+  }
+
   const { data: assignments } = await supabase
     .from("mission_assignments")
     .select("id, mission_id, progress_current, progress_target")
@@ -666,7 +698,7 @@ export async function applyOrderToMission(args: {
 
     const goal = mission.goal as Goal;
     let inc = evalGoalOnOrder(goal, args.order);
-    if (inc === 0 && (goal.type === "distinct_outlets" || goal.type === "distinct_new_products")) {
+    if (inc === 0 && (goal.type === "distinct_outlets" || goal.type === "distinct_new_products" || goal.type === "distinct_order_days")) {
       inc = await evalDedupedGoal(supabase, args.memberId, goal, args.order);
     }
     if (inc === 0) continue;

--- a/packages/shared/src/loyalty/order-reward.ts
+++ b/packages/shared/src/loyalty/order-reward.ts
@@ -50,6 +50,7 @@ type IssuedRewardRow = {
   applicable_categories: string[] | null;
   applicable_products: string[] | null;
   free_product_name: string | null;
+  source_type: string | null;
 };
 
 /** Resolve a catalog / points-shop reward from voucher_templates (by
@@ -176,7 +177,7 @@ export async function resolveOrderReward(args: {
       .select(`
         member_id, status, expires_at, voucher_template_id, min_order_value,
         discount_type, discount_value,
-        applicable_categories, applicable_products, free_product_name
+        applicable_categories, applicable_products, free_product_name, source_type
       `)
       .eq("id", candidateWalletId)
       .maybeSingle<IssuedRewardRow>();
@@ -201,6 +202,30 @@ export async function resolveOrderReward(args: {
         } else {
           spec = inlineSpecFromIssued(voucher);
         }
+        // Daily cap: at most ONE mission free-drink reward redeemed per member
+        // per day. Members can bank several earned free-drink vouchers, but
+        // only burn one a day — so the rewards pace repeat visits instead of
+        // being cleared in a single sitting (the Yousef case: 2 free coffees
+        // in 4 minutes). Only mission free_item vouchers are capped; mystery /
+        // welcome / points rewards are unaffected. The voucher being applied
+        // isn't marked 'used' until post-payment, so this counts only EARLIER
+        // redemptions today and never blocks itself.
+        if (voucher.source_type === "mission" && voucher.discount_type === "free_item") {
+          const dayStr = new Date(Date.now() + 8 * 3_600_000).toISOString().slice(0, 10); // MYT day
+          const { count } = await supabase
+            .from("issued_rewards")
+            .select("id", { count: "exact", head: true })
+            .eq("member_id", memberId)
+            .eq("source_type", "mission")
+            .eq("discount_type", "free_item")
+            .eq("status", "used")
+            .gte("redeemed_at", new Date(`${dayStr}T00:00:00+08:00`).toISOString())
+            .lte("redeemed_at", new Date(`${dayStr}T23:59:59.999+08:00`).toISOString());
+          if ((count ?? 0) >= 1) {
+            return { ok: false, error: "You've already redeemed a free-drink reward today — your other reward is saved for tomorrow." };
+          }
+        }
+
         const cart = await buildEngineCart(
           supabase,
           items,

--- a/supabase/migrations/037_poster_rounds_window.sql
+++ b/supabase/migrations/037_poster_rounds_window.sql
@@ -1,0 +1,9 @@
+-- Day-part WINDOW for posters: a poster may now appear across a SET of rounds
+-- (e.g. a pasta lunch→supper, breakfast food all morning), not just one 2-hour
+-- slot. NULL/empty `rounds` falls back to the legacy single `round` (and a null
+-- `round` still means always-on). Readers + the autopilot engine prefer
+-- `rounds` when present.
+ALTER TABLE splash_posters ADD COLUMN IF NOT EXISTS rounds text[];
+
+COMMENT ON COLUMN splash_posters.rounds IS
+  'Day-part eligibility window (breakfast..supper). NULL/empty = fall back to single `round` (null round = always-on). Reader shows poster when current round is in this set.';


### PR DESCRIPTION
The **SMS Test Console** (`/loyalty/engage/test`) was hardcoded to SMS123: it showed the `SMS_PROVIDER` env var instead of the active toggle, treated `sms123` as the only "correct" provider (red warnings otherwise), and displayed SMS123-only balance/email/key. After the gateway switch to SMS Niaga it read as wrong.

## Changes
- **Diagnostics route** (`/api/loyalty/sms/test`) resolves the active provider (`app_settings.sms_provider`) and returns per-provider config:
  - **SMS Niaga** — Bearer key status, registered Sender ID, live balance via `GET /api/balance` (`balance.human`, e.g. `RM36.80`), send endpoint.
  - **SMS123** — key + email, credit balance (unchanged behaviour).
  - **console** — dev/no-send.
- **Page** relabels dynamically (`{Provider} Configuration`), shows the active provider, hides SMS123-only fields when not on SMS123, provider-aware message preview (SMS Niaga auto-prefix note; SMS123 `RM0 [label]`), and a **Change gateway** link to Settings → Integrations. Removes the stale "should be sms123" warnings.

## Notes
- Typecheck clean (only the unrelated untracked `api/music` WIP errors, excluded).
- No behaviour change to actual sending — display/diagnostics only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)