### PR TITLE
Tight, day-part-targeted home carousel (live web home)

### DIFF
--- a/apps/order/src/app/api/home-posters/route.ts
+++ b/apps/order/src/app/api/home-posters/route.ts
@@ -1,84 +1,21 @@
-import { NextRequest, NextResponse } from "next/server";
-import { getSupabaseAdmin } from "@/lib/supabase/server";
+import { NextResponse } from "next/server";
+import { selectHomePosters } from "@/lib/poster/select-home";
 
-// Public endpoint — no auth, called by the pickup app's home page on
-// mount. Returns every currently-active poster for the brand whose
-// schedule window includes now(), so the home hero can render an
-// auto-rotating carousel. Splash on launch still uses /api/splash-poster
-// (singular); this is the multi-result version for in-app surfacing.
-//
-// Cached for 60s on the edge — posters change infrequently and a small
-// stale window beats hammering Supabase on every cold launch.
+// Public endpoint — no auth, called by the native app's home page on mount.
+// Returns the tight, day-part-windowed home carousel (same selector the web
+// home uses, so the two surfaces never drift). Cached 60s on the edge.
 export const revalidate = 60;
 
-// Current MYT day-part round (mirrors /api/pos/posters). A round-less poster
-// shows always; a round-tagged poster only during its round — lets the
-// autopilot rotate the home carousel by day-part once posters are tagged.
-function currentRound(): string {
-  const h = (new Date().getUTCHours() + 8) % 24;
-  if (h >= 8 && h < 10) return "breakfast";
-  if (h >= 10 && h < 12) return "brunch";
-  if (h >= 12 && h < 15) return "lunch";
-  if (h >= 15 && h < 17) return "midday";
-  if (h >= 17 && h < 19) return "evening";
-  if (h >= 19 && h < 21) return "dinner";
-  if (h >= 21 && h < 23) return "supper";
-  return "";
-}
-
-export async function GET(request: NextRequest) {
-  const brandId = request.nextUrl.searchParams.get("brand_id") ?? "brand-celsius";
-
+export async function GET() {
   try {
-    const supabase = getSupabaseAdmin();
-    const now = new Date().toISOString();
-    const round = currentRound();
-
-    const { data, error } = await supabase
-      .from("splash_posters")
-      .select("id, image_url, title, deeplink, duration_ms, starts_at, ends_at, sort_order, round, rounds")
-      .eq("brand_id", brandId)
-      .eq("active", true)
-      // Home carousel only — splash posters stay on the launch screen.
-      .eq("placement", "home")
-      // Operator-controlled sequence first (lower number = appears earlier
-      // in the carousel rotation). NULL sort_order is treated as "unordered"
-      // and falls to the back of the rotation, ordered by recency.
-      .order("sort_order", { ascending: true, nullsFirst: false })
-      .order("updated_at", { ascending: false });
-
-    if (error) {
-      console.error("home-posters fetch error:", error);
-      return NextResponse.json({ posters: [] }, { status: 200 });
-    }
-
-    // Day-part window: a poster shows when the current round is in its `rounds`
-    // set; if `rounds` is empty it falls back to the legacy single `round`
-    // (and a null round = always-on). Done in JS so the multi-round array is
-    // simple to evaluate (PostgREST array-contains + legacy fallback is messy).
-    const inWindow = (p: { round: string | null; rounds: string[] | null }): boolean => {
-      if (p.rounds && p.rounds.length) return round !== "" && p.rounds.includes(round);
-      if (p.round) return p.round === round;
-      return true; // always-on
-    };
-
-    const HOME_CAP = 6; // keep the carousel tight even when many posters qualify
-    const posters = (data ?? [])
-      .filter((p) => {
-        const startOk = !p.starts_at || p.starts_at <= now;
-        const endOk   = !p.ends_at   || p.ends_at   >= now;
-        return startOk && endOk;
-      })
-      .filter((p) => inWindow(p as { round: string | null; rounds: string[] | null }))
-      .slice(0, HOME_CAP)
-      .map((p) => ({
-        id:         p.id as string,
-        imageUrl:   p.image_url as string,
-        title:      (p.title as string | null) ?? null,
-        deeplink:   (p.deeplink as string | null) ?? null,
-        durationMs: (p.duration_ms as number | null) ?? 4500,
-      }));
-
+    const picks = await selectHomePosters({ limit: 3 });
+    const posters = picks.map((p) => ({
+      id: p.id,
+      imageUrl: p.image_url,
+      title: p.title,
+      deeplink: p.deeplink,
+      durationMs: p.duration_ms,
+    }));
     return NextResponse.json({ posters });
   } catch (err) {
     console.error("home-posters route error:", err);

--- a/apps/order/src/app/page.tsx
+++ b/apps/order/src/app/page.tsx
@@ -1,8 +1,8 @@
 import Image from "next/image";
 import Link from "next/link";
 import { ChevronRight } from "lucide-react";
-import { getSupabaseAdmin } from "@/lib/supabase/server";
 import { getMenuData } from "@/lib/menu-data";
+import { selectHomePosters } from "@/lib/poster/select-home";
 import { GlobalCartPill } from "./_GlobalCartPill";
 import { BottomNav } from "./_BottomNav";
 import { PosterCarousel } from "./_PosterCarousel";
@@ -27,39 +27,11 @@ import { ActiveOrderTracker } from "./_ActiveOrderTracker";
 
 export const revalidate = 60;
 
-type HomePoster = {
-  id: string;
-  image_url: string;
-  title: string | null;
-  deeplink: string | null;
-};
-
-async function fetchPosters(): Promise<HomePoster[]> {
-  try {
-    const supabase = getSupabaseAdmin();
-    const now = new Date().toISOString();
-    const { data } = await supabase
-      .from("splash_posters")
-      .select("id, image_url, title, deeplink, starts_at, ends_at, sort_order")
-      .eq("brand_id", "brand-celsius")
-      .eq("active", true)
-      .eq("placement", "home")
-      .order("sort_order", { ascending: true, nullsFirst: false });
-    if (!data) return [];
-    return data
-      .filter((p) => {
-        if (p.starts_at && new Date(p.starts_at).toISOString() > now) return false;
-        if (p.ends_at && new Date(p.ends_at).toISOString() < now) return false;
-        return true;
-      })
-      .map((p) => ({ id: p.id, image_url: p.image_url, title: p.title, deeplink: p.deeplink }));
-  } catch {
-    return [];
-  }
-}
-
 export default async function HomePage() {
-  const [posters, menu] = await Promise.all([fetchPosters(), getMenuData()]);
+  // Tight, day-part-targeted carousel — the shared selector windows by current
+  // round and trims to a few high-AOV picks + a signature drink (same logic the
+  // native app's /api/home-posters uses, so web + native never drift).
+  const [posters, menu] = await Promise.all([selectHomePosters({ limit: 3 }), getMenuData()]);
   const bestSellers = menu.products
     .filter((p) => p.isPopular && p.isAvailable)
     .sort((a, b) => (a.featuredPosition ?? 9999) - (b.featuredPosition ?? 9999))

--- a/apps/order/src/lib/poster/select-home.ts
+++ b/apps/order/src/lib/poster/select-home.ts
@@ -1,0 +1,117 @@
+import { getSupabaseAdmin } from "@/lib/supabase/server";
+
+// Food categories (mirror the autopilot engine + suggest-pairs). Everything
+// else is treated as a drink for the carousel's food/drink balance.
+const FOOD_CATEGORIES = new Set([
+  "cakes", "cookies", "croissant", "fries", "nasi-lemak", "noodle", "pasta", "roti-bakar", "sandwiches",
+]);
+
+// Current MYT day-part round (mirrors the autopilot + readers). "" = late night
+// (only always-on posters show).
+function currentRound(): string {
+  const h = (new Date().getUTCHours() + 8) % 24;
+  if (h >= 8 && h < 10) return "breakfast";
+  if (h >= 10 && h < 12) return "brunch";
+  if (h >= 12 && h < 15) return "lunch";
+  if (h >= 15 && h < 17) return "midday";
+  if (h >= 17 && h < 19) return "evening";
+  if (h >= 19 && h < 21) return "dinner";
+  if (h >= 21 && h < 23) return "supper";
+  return "";
+}
+
+export type HomePoster = {
+  id: string;
+  image_url: string;
+  title: string | null;
+  deeplink: string | null;
+  duration_ms: number;
+};
+
+type Row = {
+  id: string; image_url: string; title: string | null; deeplink: string | null;
+  duration_ms: number | null; starts_at: string | null; ends_at: string | null;
+  round: string | null; rounds: string[] | null; product_id: string | null;
+};
+
+/**
+ * The single source of truth for "which home posters show right now". Used by
+ * BOTH the web home (page.tsx) and the native app (/api/home-posters) so they
+ * never drift.
+ *
+ * Targeted, not spray: returns a TIGHT set — up to `limit` posters for the
+ * current day-part window, balanced to (limit-1) high-AOV food + 1 signature
+ * drink. A passive carousel only gets 1-2 posters of real attention, so we
+ * show few and sharp rather than the whole catalogue.
+ */
+export async function selectHomePosters(opts?: { limit?: number }): Promise<HomePoster[]> {
+  const limit = Math.max(1, opts?.limit ?? 3);
+  try {
+    const supabase = getSupabaseAdmin();
+    const now = new Date().toISOString();
+    const round = currentRound();
+
+    const { data, error } = await supabase
+      .from("splash_posters")
+      .select("id, image_url, title, deeplink, duration_ms, starts_at, ends_at, round, rounds, product_id")
+      .eq("brand_id", "brand-celsius")
+      .eq("active", true)
+      .eq("placement", "home")
+      // Autopilot AOV rank (lower sort_order = stronger). NULLs to the back.
+      .order("sort_order", { ascending: true, nullsFirst: false })
+      .order("updated_at", { ascending: false });
+    if (error || !data) return [];
+    const rows = data as Row[];
+
+    // Day-part window: show when the current round is in `rounds`; empty falls
+    // back to the legacy single `round` (null round = always-on). Plus the
+    // operator schedule window (starts/ends).
+    const eligible = rows.filter((p) => {
+      const startOk = !p.starts_at || p.starts_at <= now;
+      const endOk = !p.ends_at || p.ends_at >= now;
+      if (!startOk || !endOk) return false;
+      if (p.rounds && p.rounds.length) return round !== "" && p.rounds.includes(round);
+      if (p.round) return p.round === round;
+      return true;
+    });
+    if (eligible.length <= limit) return eligible.map(toPoster);
+
+    // Classify food vs drink so the tight set keeps a signature drink.
+    const pids = eligible.map((p) => p.product_id).filter((x): x is string => !!x);
+    const catById = new Map<string, string | null>();
+    if (pids.length) {
+      const { data: prods } = await supabase.from("products").select("id, category").in("id", pids);
+      for (const pr of (prods ?? []) as { id: string; category: string | null }[]) catById.set(pr.id, pr.category);
+    }
+    const isDrink = (p: Row) => {
+      const c = p.product_id ? catById.get(p.product_id) : null;
+      return c ? !FOOD_CATEGORIES.has(c) : false;
+    };
+
+    // Tight pick: top (limit-1) foods + top 1 drink (all already AOV-sorted),
+    // then fill any shortfall from the rest, capped at `limit`, in sort order.
+    const foods = eligible.filter((p) => !isDrink(p));
+    const drinks = eligible.filter((p) => isDrink(p));
+    const keep = new Set<string>([
+      ...foods.slice(0, Math.max(1, limit - 1)).map((p) => p.id),
+      ...drinks.slice(0, 1).map((p) => p.id),
+    ]);
+    for (const p of eligible) {
+      if (keep.size >= limit) break;
+      keep.add(p.id);
+    }
+    return eligible.filter((p) => keep.has(p.id)).slice(0, limit).map(toPoster);
+  } catch {
+    return [];
+  }
+}
+
+function toPoster(p: Row): HomePoster {
+  return {
+    id: p.id,
+    image_url: p.image_url,
+    title: p.title ?? null,
+    deeplink: p.deeplink ?? null,
+    duration_ms: (p.duration_ms as number | null) ?? 5000,
+  };
+}


### PR DESCRIPTION
Fixes the real "too many / not targeted" problem: the **live web home (`page.tsx`) was fetching posters inline with no round/window filter and no cap** — so it showed all ~26 active posters, and the day-part windows (PR #403) never actually applied there. That endpoint (`/api/home-posters`) serves the native app; the web home had its own untrimmed query.

- New shared `selectHomePosters()` — windows by current round, then trims to a **tight set: up to 2 high-AOV foods + 1 signature drink** (a passive carousel only gets 1–2 posters of real attention).
- Both `page.tsx` (web) and `/api/home-posters` (native) now use it, so the two surfaces never drift.
- Verified against live data: at supper it yields Smoked Duck + Crispy Prawn Carbonara + 1 matcha.

This is part 1 of the targeting work (tighten). Part 2 (personalize by member) and part 3 (in-cart upsell) to follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)