### PR TITLE
Personalize home carousel by member

### DIFF
--- a/apps/order/src/app/_PosterCarousel.tsx
+++ b/apps/order/src/app/_PosterCarousel.tsx
@@ -37,22 +37,48 @@ function logPosterTap(posterId: string, deeplink: string | null) {
 
 export function PosterCarousel({ posters }: { posters: Poster[] }) {
   const [idx, setIdx] = useState(0);
+  // Server render gives a tight, day-part set (same for everyone, cached). Once
+  // mounted, if the customer is signed in we swap in a PERSONALIZED set
+  // (high-AOV items they haven't tried) from /api/home-posters?member=. Falls
+  // back silently to the server set for guests or on any error.
+  const [list, setList] = useState<Poster[]>(posters);
 
   useEffect(() => {
-    if (posters.length <= 1) return;
+    let loyaltyId: string | null = null;
+    try {
+      const raw = localStorage.getItem("celsius-pickup");
+      if (raw) loyaltyId = (JSON.parse(raw)?.state?.loyaltyId as string | undefined) ?? null;
+    } catch { /* ignore */ }
+    if (!loyaltyId) return;
+    let cancelled = false;
+    fetch(`/api/home-posters?member=${encodeURIComponent(loyaltyId)}`)
+      .then((r) => r.json())
+      .then((j) => {
+        const next = Array.isArray(j?.posters)
+          ? (j.posters as { id: string; imageUrl: string; title: string | null; deeplink: string | null }[])
+              .map((p) => ({ id: p.id, image_url: p.imageUrl, title: p.title, deeplink: p.deeplink }))
+          : [];
+        if (!cancelled && next.length) { setList(next); setIdx(0); }
+      })
+      .catch(() => { /* keep server set */ });
+    return () => { cancelled = true; };
+  }, []);
+
+  useEffect(() => {
+    if (list.length <= 1) return;
     const id = window.setInterval(() => {
-      setIdx((i) => (i + 1) % posters.length);
+      setIdx((i) => (i + 1) % list.length);
     }, 5000);
     return () => window.clearInterval(id);
-  }, [posters.length]);
+  }, [list.length]);
 
-  if (posters.length === 0) {
+  if (list.length === 0) {
     return <div className="relative w-full aspect-[1.07] bg-[#160800]" />;
   }
 
   return (
     <div className="relative w-full aspect-[1.07] bg-[#160800] overflow-hidden">
-      {posters.map((p, i) => (
+      {list.map((p, i) => (
         <Link
           key={p.id}
           href={p.deeplink || "/menu"}
@@ -74,9 +100,9 @@ export function PosterCarousel({ posters }: { posters: Poster[] }) {
           />
         </Link>
       ))}
-      {posters.length > 1 && (
+      {list.length > 1 && (
         <div className="absolute bottom-3 left-0 right-0 flex justify-center gap-1.5 z-10">
-          {posters.map((_, i) => (
+          {list.map((_, i) => (
             <span
               key={i}
               className="rounded-full"

--- a/apps/order/src/app/api/home-posters/route.ts
+++ b/apps/order/src/app/api/home-posters/route.ts
@@ -1,14 +1,16 @@
-import { NextResponse } from "next/server";
+import { NextRequest, NextResponse } from "next/server";
 import { selectHomePosters } from "@/lib/poster/select-home";
 
-// Public endpoint — no auth, called by the native app's home page on mount.
-// Returns the tight, day-part-windowed home carousel (same selector the web
-// home uses, so the two surfaces never drift). Cached 60s on the edge.
+// Public endpoint — no auth, called by the home carousel on mount. Returns the
+// tight, day-part-windowed carousel (same selector the web home uses, so the
+// two surfaces never drift). Pass ?member=<loyaltyId> to personalize (surface
+// high-AOV items the member hasn't tried). Cached 60s per URL on the edge.
 export const revalidate = 60;
 
-export async function GET() {
+export async function GET(request: NextRequest) {
   try {
-    const picks = await selectHomePosters({ limit: 3 });
+    const memberId = request.nextUrl.searchParams.get("member");
+    const picks = await selectHomePosters({ limit: 3, memberId });
     const posters = picks.map((p) => ({
       id: p.id,
       imageUrl: p.image_url,

--- a/apps/order/src/lib/poster/select-home.ts
+++ b/apps/order/src/lib/poster/select-home.ts
@@ -44,8 +44,9 @@ type Row = {
  * drink. A passive carousel only gets 1-2 posters of real attention, so we
  * show few and sharp rather than the whole catalogue.
  */
-export async function selectHomePosters(opts?: { limit?: number }): Promise<HomePoster[]> {
+export async function selectHomePosters(opts?: { limit?: number; memberId?: string | null }): Promise<HomePoster[]> {
   const limit = Math.max(1, opts?.limit ?? 3);
+  const memberId = opts?.memberId ?? null;
   try {
     const supabase = getSupabaseAdmin();
     const now = new Date().toISOString();
@@ -88,10 +89,21 @@ export async function selectHomePosters(opts?: { limit?: number }): Promise<Home
       return c ? !FOOD_CATEGORIES.has(c) : false;
     };
 
-    // Tight pick: top (limit-1) foods + top 1 drink (all already AOV-sorted),
+    // Personalize: surface what the member HASN'T tried first (discovery →
+    // trial → AOV) — a regular who always orders pasta gets shown the items
+    // they haven't had, not their usual. Untried sort ahead of tried; AOV order
+    // is preserved within each group (stable sort over the sort_order list).
+    const tried = await triedProductIds(supabase, memberId);
+    const untriedFirst = (a: Row, b: Row) => {
+      const at = a.product_id && tried.has(a.product_id) ? 1 : 0;
+      const bt = b.product_id && tried.has(b.product_id) ? 1 : 0;
+      return at - bt;
+    };
+
+    // Tight pick: top (limit-1) foods + top 1 drink (untried-first, then AOV),
     // then fill any shortfall from the rest, capped at `limit`, in sort order.
-    const foods = eligible.filter((p) => !isDrink(p));
-    const drinks = eligible.filter((p) => isDrink(p));
+    const foods = eligible.filter((p) => !isDrink(p)).sort(untriedFirst);
+    const drinks = eligible.filter((p) => isDrink(p)).sort(untriedFirst);
     const keep = new Set<string>([
       ...foods.slice(0, Math.max(1, limit - 1)).map((p) => p.id),
       ...drinks.slice(0, 1).map((p) => p.id),
@@ -114,4 +126,34 @@ function toPoster(p: Row): HomePoster {
     deeplink: p.deeplink ?? null,
     duration_ms: (p.duration_ms as number | null) ?? 5000,
   };
+}
+
+// Distinct product_ids a member has ordered (last ~100 orders). Best-effort —
+// any failure returns an empty set so the carousel falls back to the AOV order.
+async function triedProductIds(
+  supabase: ReturnType<typeof getSupabaseAdmin>,
+  memberId: string | null,
+): Promise<Set<string>> {
+  const out = new Set<string>();
+  if (!memberId) return out;
+  try {
+    const { data: orders } = await supabase
+      .from("orders")
+      .select("id")
+      .eq("loyalty_id", memberId)
+      .order("created_at", { ascending: false })
+      .limit(100);
+    const ids = (orders ?? []).map((o: { id: string }) => o.id);
+    if (!ids.length) return out;
+    const { data: items } = await supabase
+      .from("order_items")
+      .select("product_id")
+      .in("order_id", ids);
+    for (const it of (items ?? []) as { product_id: string | null }[]) {
+      if (it.product_id) out.add(it.product_id);
+    }
+  } catch {
+    /* personalization is best-effort */
+  }
+  return out;
 }


### PR DESCRIPTION
Part 2 of the targeting work. When the customer is signed in, the home carousel re-fetches a **personalized** set after mount (`/api/home-posters?member=<loyaltyId>`) and swaps it in:

- Ranks high-AOV items the member **hasn't tried** ahead of their usual (discovery → trial → AOV), within the day-part window + drink balance.
- Uses `orders.loyalty_id → order_items.product_id` (last ~100 orders), best-effort.
- Guests / errors fall back silently to the server-rendered tight set, so the fast cached home render is untouched (no perf regression, brief swap on first paint only).

Shared `selectHomePosters({ memberId })` powers it, so web + native stay in sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)