### PR TITLE
Basket-targeted in-cart upsell

### DIFF
--- a/apps/order/src/app/api/suggest-pairs/route.ts
+++ b/apps/order/src/app/api/suggest-pairs/route.ts
@@ -1,0 +1,106 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getSupabaseAdmin } from "@/lib/supabase/server";
+import { getMenuData } from "@/lib/menu-data";
+import { triedProductIds } from "@/lib/poster/select-home";
+
+// POST /api/suggest-pairs  — in-cart upsell ("goes well with your order").
+// Body: { cart_product_ids: string[], member?: string }
+//
+// Targeted by the BASKET, not a generic best-seller rail: scores every other
+// available menu item by
+//   • complement  — a drinks-only cart wants a bite (and vice-versa)
+//   • co-purchase — what's actually bought together (get_co_purchased_products)
+//   • untried     — items this member hasn't ordered (discovery → trial → AOV)
+//   • price       — light nudge to the higher-ticket add-on
+// and returns the best 3 (distinct categories). Reuses getMenuData so the
+// candidates are exactly the pickup-available menu (cart-ready shape).
+
+const FOOD_CATEGORIES = new Set([
+  "cakes", "cookies", "croissant", "fries", "nasi-lemak", "noodle", "pasta", "roti-bakar", "sandwiches",
+]);
+
+export async function POST(req: NextRequest) {
+  try {
+    const body = await req.json().catch(() => ({}));
+    const cartIds: string[] = Array.isArray(body?.cart_product_ids)
+      ? body.cart_product_ids.filter((x: unknown): x is string => typeof x === "string")
+      : [];
+    const memberId: string | null = typeof body?.member === "string" ? body.member : null;
+    if (!cartIds.length) return NextResponse.json({ pairs: [] });
+
+    const supabase = getSupabaseAdmin();
+    const menu = await getMenuData();
+    const catOf = new Map(menu.products.map((p) => [p.id, p.categoryId] as const));
+    const isFood = (id: string | undefined | null) => !!id && FOOD_CATEGORIES.has(catOf.get(id) ?? "");
+
+    // Cart kind → bias the suggestion to the complementary kind.
+    const cartFood = cartIds.filter((id) => isFood(id)).length;
+    const cartDrink = cartIds.length - cartFood;
+    const preferFood = cartDrink >= cartFood;
+    const cartAllDrinks = cartFood === 0;
+    const cartAllFood = cartDrink === 0;
+
+    // Co-purchase: how often each candidate is bought with the cart items.
+    const coScore = new Map<string, number>();
+    await Promise.all(
+      cartIds.map(async (pid) => {
+        const { data } = await supabase.rpc("get_co_purchased_products", { for_product_id: pid, limit_count: 20 });
+        for (const row of (data ?? []) as { paired_with: string; co_count: number }[]) {
+          coScore.set(row.paired_with, (coScore.get(row.paired_with) ?? 0) + Number(row.co_count ?? 0));
+        }
+      }),
+    );
+    const maxCo = Math.max(1, ...coScore.values());
+
+    const tried = await triedProductIds(supabase, memberId);
+    const cartSet = new Set(cartIds);
+    const candidates = menu.products.filter((p) => p.isAvailable && !cartSet.has(p.id));
+    const maxPrice = Math.max(1, ...candidates.map((p) => p.basePrice));
+
+    type Scored = { p: (typeof candidates)[number]; score: number; reason: string };
+    const scored: Scored[] = [];
+    for (const p of candidates) {
+      const food = isFood(p.id);
+      // Pure-kind cart → only the complementary kind (drinks cart → a bite).
+      if (cartAllDrinks && !food) continue;
+      if (cartAllFood && food) continue;
+      const co = (coScore.get(p.id) ?? 0) / maxCo;
+      const complement = (preferFood && food) || (!preferFood && !food) ? 1 : 0;
+      const untried = memberId && !tried.has(p.id) ? 1 : 0;
+      const priceN = p.basePrice / maxPrice;
+      const score = 2.0 * co + 1.2 * complement + 0.8 * untried + 0.6 * priceN;
+      if (score <= 0) continue;
+      const reason = co > 0 ? "Often paired together"
+        : complement ? (food ? "Add a bite" : "Add a drink")
+        : untried ? "Haven't tried this" : "You might like";
+      scored.push({ p, score, reason });
+    }
+    scored.sort((a, b) => b.score - a.score);
+
+    // Top 3, spread across distinct categories so it's not three near-dupes.
+    const picked: Scored[] = [];
+    const cats = new Set<string>();
+    for (const s of scored) {
+      if (picked.length >= 3) break;
+      if (cats.has(s.p.categoryId)) continue;
+      picked.push(s); cats.add(s.p.categoryId);
+    }
+    for (const s of scored) {
+      if (picked.length >= 3) break;
+      if (!picked.includes(s)) picked.push(s);
+    }
+
+    return NextResponse.json({
+      pairs: picked.map((s) => ({
+        id: s.p.id,
+        name: s.p.name,
+        basePrice: s.p.basePrice,
+        image: s.p.image,
+        reason: s.reason,
+      })),
+    });
+  } catch (err) {
+    console.error("[suggest-pairs] error:", err);
+    return NextResponse.json({ pairs: [] }, { status: 200 });
+  }
+}

--- a/apps/order/src/app/cart/_CartUpsell.tsx
+++ b/apps/order/src/app/cart/_CartUpsell.tsx
@@ -1,0 +1,78 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import Link from "next/link";
+import Image from "next/image";
+import { Plus } from "lucide-react";
+
+type Pair = { id: string; name: string; basePrice: number; image: string | null; reason: string };
+
+/**
+ * In-cart upsell rail — "Goes well with your order". Targeted by the basket
+ * (drinks cart → a bite, etc.) via /api/suggest-pairs, personalized by member.
+ * Cards link to the product page (one tap to add, same flow as the best-seller
+ * rail). Renders nothing until it has a suggestion, so it never adds noise.
+ */
+export function CartUpsell({ productIds, loyaltyId }: { productIds: string[]; loyaltyId: string | null }) {
+  const [pairs, setPairs] = useState<Pair[]>([]);
+  const key = productIds.slice().sort().join(",");
+
+  useEffect(() => {
+    if (!productIds.length) { setPairs([]); return; }
+    let cancelled = false;
+    fetch("/api/suggest-pairs", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ cart_product_ids: productIds, member: loyaltyId }),
+    })
+      .then((r) => r.json())
+      .then((j) => { if (!cancelled) setPairs(Array.isArray(j?.pairs) ? j.pairs : []); })
+      .catch(() => { if (!cancelled) setPairs([]); });
+    return () => { cancelled = true; };
+    // Re-fetch when the cart contents change (key) or the member resolves.
+  }, [key, loyaltyId]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  if (pairs.length === 0) return null;
+
+  return (
+    <div className="mt-2 mb-4">
+      <p className="uppercase px-4 mb-2" style={{ color: "#1A0200", fontSize: 13, fontWeight: 700, letterSpacing: 1.2 }}>
+        Goes well with your order
+      </p>
+      <div
+        className="flex gap-3 px-4 overflow-x-auto pb-1"
+        style={{ scrollSnapType: "x mandatory", WebkitOverflowScrolling: "touch" }}
+      >
+        {pairs.map((p) => (
+          <Link
+            key={p.id}
+            href={`/product/${p.id}`}
+            className="flex-shrink-0 bg-white overflow-hidden active:opacity-70"
+            style={{ width: 150, borderRadius: 16, border: "1px solid rgba(26,2,0,0.10)", boxShadow: "0 3px 8px rgba(0,0,0,0.06)", scrollSnapAlign: "start" }}
+          >
+            <div className="relative bg-[#F2EDE5]" style={{ width: 150, height: 130 }}>
+              {p.image ? <Image src={p.image} alt={p.name} fill sizes="150px" className="object-cover" /> : null}
+              <span
+                className="absolute uppercase"
+                style={{ top: 8, left: 8, backgroundColor: "rgba(22,8,0,0.82)", color: "#FBBF24", fontSize: 8, fontWeight: 700, letterSpacing: 0.6, padding: "3px 6px", borderRadius: 999 }}
+              >
+                {p.reason}
+              </span>
+            </div>
+            <div style={{ paddingLeft: 10, paddingRight: 10, paddingTop: 8, paddingBottom: 10 }}>
+              <p className="font-peachi font-bold truncate" style={{ color: "#1A0200", fontSize: 13 }}>{p.name}</p>
+              <div className="flex items-center justify-between" style={{ marginTop: 4 }}>
+                <span className="font-peachi font-bold" style={{ color: "#A2492C", fontSize: 14 }}>
+                  RM{p.basePrice.toFixed(2)}
+                </span>
+                <span className="rounded-full flex items-center justify-center" style={{ width: 24, height: 24, backgroundColor: "#160800" }}>
+                  <Plus size={14} color="#FFFFFF" />
+                </span>
+              </div>
+            </div>
+          </Link>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/apps/order/src/app/cart/_CartView.tsx
+++ b/apps/order/src/app/cart/_CartView.tsx
@@ -5,6 +5,7 @@ import Link from "next/link";
 import Image from "next/image";
 import { ArrowLeft, Trash2, Plus, Minus, Gift, X, Coffee, ChevronRight } from "lucide-react";
 import { calcRewardDiscount, formatRewardValue, type AppliedReward } from "@/lib/reward-discount";
+import { CartUpsell } from "./_CartUpsell";
 
 type BestSeller = {
   id: string;
@@ -442,6 +443,10 @@ export function CartView({ bestSellers = [] }: { bestSellers?: BestSeller[] }) {
           </li>
         ))}
       </ul>
+
+      {/* Basket-targeted upsell — "goes well with your order" (drinks → a bite,
+          personalized by member). Reactive to the cart contents. */}
+      <CartUpsell productIds={items.map((i) => i.productId)} loyaltyId={loyaltyId} />
 
       {reward ? (
         <div

--- a/apps/order/src/lib/poster/select-home.ts
+++ b/apps/order/src/lib/poster/select-home.ts
@@ -130,7 +130,8 @@ function toPoster(p: Row): HomePoster {
 
 // Distinct product_ids a member has ordered (last ~100 orders). Best-effort —
 // any failure returns an empty set so the carousel falls back to the AOV order.
-async function triedProductIds(
+// Exported so the in-cart upsell can reuse the same "what they've tried" signal.
+export async function triedProductIds(
   supabase: ReturnType<typeof getSupabaseAdmin>,
   memberId: string | null,
 ): Promise<Set<string>> {


### PR DESCRIPTION
Part 3 of the targeting work — the **active lever** (highest AOV payoff).

Adds a **"Goes well with your order"** rail on the cart (filled state), targeted by the basket:
- Drinks-only cart → suggests a **bite** (and vice-versa) — the core attach play.
- New focused `/api/suggest-pairs`: **complement + co-purchase (`get_co_purchased_products`) + untried-by-member + price**, top 3 across distinct categories.
- Reuses `getMenuData` (pickup menu, cart-ready) + the member-history signal from the home personalizer. **Doesn't touch the live POS suggest-pairs engine** (self-contained, low-risk).
- Reactive to cart changes; cards link to the product page (one-tap add). Renders nothing until it has a suggestion.

Completes the 3-part plan: tighten (#406) → personalize (#407) → in-cart upsell (this).

🤖 Generated with [Claude Code](https://claude.com/claude-code)