### PR TITLE
feat(reviews): Nearby Competitor Ranking

### DIFF
--- a/apps/backoffice/src/app/(admin)/reviews/page.tsx
+++ b/apps/backoffice/src/app/(admin)/reviews/page.tsx
@@ -16,6 +16,9 @@ import {
   Check,
   X,
   Send,
+  Trophy,
+  MapPin,
+  RefreshCw,
 } from "lucide-react";
 import Link from "next/link";
 import { useFetch } from "@/lib/use-fetch";
@@ -46,6 +49,26 @@ type Feedback = {
 type DashboardGoogleReview = GoogleReview & { outletName: string; outletId: string };
 type DashboardFeedback = Feedback & { outletName: string };
 
+type Competitor = {
+  placeId: string;
+  name: string;
+  rating: number | null;
+  reviewCount: number;
+  distanceM: number;
+};
+
+type CompetitorData = {
+  capturedAt: string;
+  radiusM: number;
+  selfFound: boolean;
+  selfRating: number | null;
+  selfReviewCount: number | null;
+  rankByReviews: number | null;
+  rankByRating: number | null;
+  totalNearby: number;
+  competitors: Competitor[];
+};
+
 type OutletSummary = {
   outletId: string;
   outletName: string;
@@ -60,6 +83,7 @@ type OutletSummary = {
     feedbacks: Feedback[];
     stats: { total: number; star5: number; star4: number; star3: number; star2: number; star1: number };
   };
+  competitor: CompetitorData | null;
 };
 
 type DashboardResponse = {
@@ -855,6 +879,159 @@ function BatchAutoReplyModal({ onClose }: { onClose: () => void }) {
   );
 }
 
+// ─── Nearby Competitor Ranking ─────────────────────────────
+
+type RankRow = { name: string; rating: number | null; reviewCount: number; distanceM: number; isSelf: boolean };
+
+function CompetitorPanel({
+  outlet,
+  onRefreshed,
+}: {
+  outlet: OutletSummary | null;
+  onRefreshed: () => void;
+}) {
+  const [refreshing, setRefreshing] = useState(false);
+
+  const refresh = async () => {
+    if (!outlet) return;
+    setRefreshing(true);
+    try {
+      await fetch(`/api/reviews/competitors/refresh?outletId=${outlet.outletId}`, { method: "POST" });
+      onRefreshed();
+    } finally {
+      setRefreshing(false);
+    }
+  };
+
+  // No outlet selected — mirror the empty state from the spec.
+  if (!outlet) {
+    return (
+      <div className="mt-4 rounded-xl border border-border bg-white p-8 text-center">
+        <Trophy className="mx-auto h-8 w-8 text-muted-foreground/40" />
+        <p className="mt-3 text-sm font-semibold">Select a location to view competitors</p>
+        <p className="mx-auto mt-1 max-w-md text-xs text-muted-foreground">
+          Nearby competitor rankings are location-specific. Pick an outlet above to see its nearby cafés and market position.
+        </p>
+      </div>
+    );
+  }
+
+  const c = outlet.competitor;
+
+  // Selected but never refreshed yet.
+  if (!c) {
+    return (
+      <div className="mt-4 rounded-xl border border-border bg-white p-6 text-center">
+        <Trophy className="mx-auto h-7 w-7 text-muted-foreground/40" />
+        <p className="mt-2 text-sm font-semibold">No competitor data yet for {outlet.outletName}</p>
+        <p className="mt-1 text-xs text-muted-foreground">Pull nearby cafés from Google to compute this outlet&apos;s ranking.</p>
+        <button
+          onClick={refresh}
+          disabled={refreshing}
+          className="mx-auto mt-3 flex items-center gap-1.5 rounded-lg bg-brand-dark px-4 py-2 text-xs font-medium text-white hover:bg-brand-dark/90 disabled:opacity-50 transition-colors"
+        >
+          {refreshing ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <RefreshCw className="h-3.5 w-3.5" />}
+          Refresh competitors
+        </button>
+      </div>
+    );
+  }
+
+  const radiusKm = (c.radiusM / 1000).toFixed(1).replace(/\.0$/, "");
+
+  // Merge self into the rival list and rank the whole set by review volume.
+  const rows: RankRow[] = [
+    ...c.competitors.map((x) => ({ name: x.name, rating: x.rating, reviewCount: x.reviewCount, distanceM: x.distanceM, isSelf: false })),
+  ];
+  if (c.selfFound) {
+    rows.push({ name: `${outlet.outletName} (You)`, rating: c.selfRating, reviewCount: c.selfReviewCount ?? 0, distanceM: 0, isSelf: true });
+  }
+  rows.sort((a, b) => b.reviewCount - a.reviewCount || (b.rating ?? 0) - (a.rating ?? 0));
+
+  return (
+    <div className="mt-4 grid gap-4 lg:grid-cols-[260px_1fr]">
+      {/* Rank summary */}
+      <div className="rounded-xl border border-border bg-white p-5">
+        <div className="flex items-center justify-between">
+          <div className="flex items-center gap-1.5 text-muted-foreground">
+            <MapPin className="h-4 w-4" />
+            <span className="text-xs font-medium">Within {radiusKm}km</span>
+          </div>
+          <button
+            onClick={refresh}
+            disabled={refreshing}
+            title="Refresh from Google"
+            className="rounded-md p-1.5 text-muted-foreground hover:bg-muted hover:text-foreground disabled:opacity-50"
+          >
+            <RefreshCw className={`h-3.5 w-3.5 ${refreshing ? "animate-spin" : ""}`} />
+          </button>
+        </div>
+
+        {c.selfFound && c.rankByReviews ? (
+          <>
+            <div className="mt-3 flex items-end gap-1.5">
+              <span className="text-4xl font-bold leading-none">#{c.rankByReviews}</span>
+              <span className="mb-1 text-sm text-muted-foreground">of {c.totalNearby}</span>
+            </div>
+            <p className="mt-1 text-xs text-muted-foreground">nearby cafés, by review volume</p>
+            <div className="mt-3 flex items-center gap-4 border-t border-border pt-3 text-sm">
+              <div>
+                <span className="font-bold">#{c.rankByRating ?? "–"}</span>
+                <p className="text-[10px] text-muted-foreground">by rating</p>
+              </div>
+              <div>
+                <span className="font-bold">{c.selfRating?.toFixed(1) ?? "–"}</span>
+                <Star className="ml-0.5 inline h-3 w-3 fill-amber-400 text-amber-400" />
+                <p className="text-[10px] text-muted-foreground">{c.selfReviewCount ?? 0} reviews</p>
+              </div>
+            </div>
+          </>
+        ) : (
+          <div className="mt-3">
+            <p className="text-2xl font-bold">N/A</p>
+            <p className="mt-1 text-xs text-amber-600">
+              Your Google listing wasn&apos;t found within {radiusKm}km — showing nearby cafés only.
+            </p>
+          </div>
+        )}
+        <p className="mt-3 text-[10px] text-muted-foreground">Updated {timeAgo(c.capturedAt)}</p>
+      </div>
+
+      {/* Competitor leaderboard */}
+      <div className="rounded-xl border border-border bg-white p-4">
+        <p className="mb-2 px-1 text-xs font-semibold text-muted-foreground uppercase tracking-wide">
+          Nearby cafés ({c.totalNearby})
+        </p>
+        {rows.length === 0 ? (
+          <p className="px-1 py-6 text-center text-sm text-muted-foreground">No nearby cafés found.</p>
+        ) : (
+          <div className="divide-y divide-border">
+            {rows.map((r, i) => (
+              <div
+                key={`${r.name}-${i}`}
+                className={`flex items-center gap-3 px-1 py-2 ${r.isSelf ? "rounded-lg bg-terracotta/5" : ""}`}
+              >
+                <span className={`w-6 shrink-0 text-center text-sm font-bold ${r.isSelf ? "text-terracotta" : "text-muted-foreground"}`}>
+                  {i + 1}
+                </span>
+                <div className="min-w-0 flex-1">
+                  <p className={`truncate text-sm ${r.isSelf ? "font-semibold text-terracotta" : "font-medium"}`}>{r.name}</p>
+                  {!r.isSelf && <p className="text-[10px] text-muted-foreground">{r.distanceM}m away</p>}
+                </div>
+                <div className="flex items-center gap-1 text-sm">
+                  <span className="font-semibold">{r.rating?.toFixed(1) ?? "–"}</span>
+                  <Star className="h-3 w-3 fill-amber-400 text-amber-400" />
+                </div>
+                <span className="w-16 shrink-0 text-right text-xs text-muted-foreground">{r.reviewCount.toLocaleString()} rev</span>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
 // ─── Dashboard View ────────────────────────────────────────
 
 function DashboardView() {
@@ -874,7 +1051,11 @@ function DashboardView() {
       ? `/api/reviews/dashboard?period=${period}`
       : null;
 
-  const { data, isLoading } = useFetch<DashboardResponse>(fetchUrl);
+  const { data, isLoading, mutate } = useFetch<DashboardResponse>(fetchUrl);
+
+  const selectedOutlet = filterOutletId
+    ? data?.outlets?.find((o) => o.outletId === filterOutletId) ?? null
+    : null;
 
   const periodLabel = period === "day" ? "Today" : period === "week" ? "Last 7 days" : period === "month" ? "Last 30 days" : customFrom ? `${customFrom} to ${customTo || "now"}` : "Custom";
 
@@ -1047,6 +1228,13 @@ function DashboardView() {
           </button>
         </div>
       )}
+
+      {/* Nearby Competitor Ranking */}
+      <div className="mt-6 flex items-center gap-2">
+        <Trophy className="h-4 w-4 text-muted-foreground" />
+        <h2 className="text-sm font-semibold">Nearby Competitor Ranking</h2>
+      </div>
+      <CompetitorPanel outlet={selectedOutlet} onRefreshed={() => mutate()} />
 
       {/* Sub-tabs + toolbar */}
       <div className="mt-6 flex items-center justify-between">

--- a/apps/backoffice/src/app/api/reviews/competitors/refresh/route.ts
+++ b/apps/backoffice/src/app/api/reviews/competitors/refresh/route.ts
@@ -1,0 +1,128 @@
+import { NextRequest, NextResponse } from "next/server";
+import { checkCronAuth } from "@celsius/shared";
+import { getUserFromHeaders } from "@/lib/auth";
+import { prisma } from "@/lib/prisma";
+import {
+  searchNearbyCafes,
+  computeRanking,
+  DEFAULT_RADIUS_M,
+} from "@/lib/reviews/places";
+
+export const dynamic = "force-dynamic";
+export const maxDuration = 60;
+
+/**
+ * GET/POST /api/reviews/competitors/refresh
+ *
+ * Refreshes the Nearby Competitor Ranking cache (CompetitorSnapshot) from
+ * Google Places Nearby Search. Runs on a daily Vercel cron AND from the
+ * "Refresh" button in the Reviews dashboard.
+ *
+ * Auth: Vercel cron bearer (checkCronAuth) OR a logged-in backoffice user.
+ * Query: ?outletId=<id> to refresh a single outlet (used by the button).
+ *
+ * Each active outlet with coordinates gets one Places call. We identify our own
+ * outlet inside the nearby set (by stored Place ID, else name, else proximity)
+ * and, when found, opportunistically backfill ReviewSettings.gbpPlaceId.
+ */
+async function handle(req: NextRequest) {
+  const cron = checkCronAuth(req.headers);
+  if (!cron.ok) {
+    const user = await getUserFromHeaders(req.headers);
+    if (!user) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const onlyOutletId = req.nextUrl.searchParams.get("outletId");
+  const radiusM = Number(req.nextUrl.searchParams.get("radius")) || DEFAULT_RADIUS_M;
+
+  const outlets = await prisma.outlet.findMany({
+    where: {
+      status: "ACTIVE",
+      ...(onlyOutletId ? { id: onlyOutletId } : {}),
+    },
+    include: { reviewSettings: true },
+  });
+
+  const results: Array<{
+    outletId: string;
+    outletName: string;
+    ok: boolean;
+    selfFound?: boolean;
+    rankByReviews?: number | null;
+    totalNearby?: number;
+    error?: string;
+  }> = [];
+
+  for (const outlet of outlets) {
+    if (outlet.lat == null || outlet.lng == null) {
+      results.push({ outletId: outlet.id, outletName: outlet.name, ok: false, error: "No coordinates" });
+      continue;
+    }
+
+    try {
+      const cafes = await searchNearbyCafes(Number(outlet.lat), Number(outlet.lng), radiusM);
+      const ranking = computeRanking(cafes, {
+        selfPlaceId: outlet.reviewSettings?.gbpPlaceId ?? null,
+        selfNameHint: outlet.name,
+      });
+
+      await prisma.competitorSnapshot.upsert({
+        where: { outletId: outlet.id },
+        create: {
+          outletId: outlet.id,
+          capturedAt: new Date(),
+          radiusM,
+          selfFound: ranking.selfFound,
+          selfPlaceId: ranking.selfPlaceId,
+          selfRating: ranking.selfRating,
+          selfReviewCount: ranking.selfReviewCount,
+          rankByReviews: ranking.rankByReviews,
+          rankByRating: ranking.rankByRating,
+          totalNearby: ranking.totalNearby,
+          competitors: ranking.competitors,
+        },
+        update: {
+          capturedAt: new Date(),
+          radiusM,
+          selfFound: ranking.selfFound,
+          selfPlaceId: ranking.selfPlaceId,
+          selfRating: ranking.selfRating,
+          selfReviewCount: ranking.selfReviewCount,
+          rankByReviews: ranking.rankByReviews,
+          rankByRating: ranking.rankByRating,
+          totalNearby: ranking.totalNearby,
+          competitors: ranking.competitors,
+        },
+      });
+
+      // Backfill the Place ID we just resolved so future self-matches are exact.
+      if (ranking.selfFound && ranking.selfPlaceId && !outlet.reviewSettings?.gbpPlaceId && outlet.reviewSettings) {
+        await prisma.reviewSettings.update({
+          where: { outletId: outlet.id },
+          data: { gbpPlaceId: ranking.selfPlaceId },
+        });
+      }
+
+      results.push({
+        outletId: outlet.id,
+        outletName: outlet.name,
+        ok: true,
+        selfFound: ranking.selfFound,
+        rankByReviews: ranking.rankByReviews,
+        totalNearby: ranking.totalNearby,
+      });
+    } catch (e) {
+      results.push({
+        outletId: outlet.id,
+        outletName: outlet.name,
+        ok: false,
+        error: e instanceof Error ? e.message : "Unknown error",
+      });
+    }
+  }
+
+  return NextResponse.json({ refreshed: results.filter((r) => r.ok).length, total: results.length, results });
+}
+
+export const GET = handle;
+export const POST = handle;

--- a/apps/backoffice/src/app/api/reviews/dashboard/route.ts
+++ b/apps/backoffice/src/app/api/reviews/dashboard/route.ts
@@ -57,6 +57,12 @@ export async function GET(request: NextRequest) {
   // Sort outlets: Putrajaya first, Nilai last
   outlets.sort((a, b) => outletSortKey(a.name) - outletSortKey(b.name));
 
+  // Cached Nearby Competitor Ranking (refreshed by the daily cron, not live here)
+  const competitorSnapshots = await prisma.competitorSnapshot.findMany({
+    where: { outletId: { in: outlets.map((o) => o.id) } },
+  });
+  const competitorByOutlet = new Map(competitorSnapshots.map((s) => [s.outletId, s]));
+
   // Fetch Google reviews for all connected outlets in parallel
   const googlePromises = outlets.map(async (outlet) => {
     const settings = outlet.reviewSettings;
@@ -107,6 +113,8 @@ export async function GET(request: NextRequest) {
       if (key in fbStats && key !== "total") (fbStats[key] as number)++;
     }
 
+    const snap = competitorByOutlet.get(outlet.id);
+
     return {
       outletId: outlet.id,
       outletName: outlet.name,
@@ -121,6 +129,19 @@ export async function GET(request: NextRequest) {
         feedbacks: outletFeedbacks,
         stats: fbStats,
       },
+      competitor: snap
+        ? {
+            capturedAt: snap.capturedAt.toISOString(),
+            radiusM: snap.radiusM,
+            selfFound: snap.selfFound,
+            selfRating: snap.selfRating,
+            selfReviewCount: snap.selfReviewCount,
+            rankByReviews: snap.rankByReviews,
+            rankByRating: snap.rankByRating,
+            totalNearby: snap.totalNearby,
+            competitors: snap.competitors,
+          }
+        : null,
     };
   });
 

--- a/apps/backoffice/src/lib/reviews/places.test.ts
+++ b/apps/backoffice/src/lib/reviews/places.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect } from "vitest";
+import { computeRanking, type NearbyCafe } from "./places";
+
+function cafe(partial: Partial<NearbyCafe> & { placeId: string }): NearbyCafe {
+  return {
+    name: partial.placeId,
+    rating: null,
+    reviewCount: 0,
+    distanceM: 0,
+    lat: 0,
+    lng: 0,
+    ...partial,
+  };
+}
+
+// A nearby set where "Celsius" sits in the middle of the pack.
+const SET: NearbyCafe[] = [
+  cafe({ placeId: "rivalA", name: "ZUS Coffee", rating: 4.6, reviewCount: 800, distanceM: 300 }),
+  cafe({ placeId: "self", name: "Celsius Coffee Putrajaya", rating: 4.8, reviewCount: 420, distanceM: 5 }),
+  cafe({ placeId: "rivalB", name: "Random Kopitiam", rating: 4.1, reviewCount: 500, distanceM: 700 }),
+  cafe({ placeId: "rivalC", name: "Tiny Cafe", rating: 4.9, reviewCount: 60, distanceM: 1200 }),
+];
+
+describe("computeRanking", () => {
+  it("matches self by stored place id and ranks by review volume", () => {
+    const r = computeRanking(SET, { selfPlaceId: "self" });
+    expect(r.selfFound).toBe(true);
+    expect(r.totalNearby).toBe(4);
+    // 420 reviews: only ZUS(800) and Kopitiam(500) beat it → rank 3.
+    expect(r.rankByReviews).toBe(3);
+    // 4.8 rating: only Tiny Cafe(4.9) beats it → rank 2.
+    expect(r.rankByRating).toBe(2);
+    // Competitors exclude self, sorted by review volume desc.
+    expect(r.competitors.map((c) => c.placeId)).toEqual(["rivalA", "rivalB", "rivalC"]);
+  });
+
+  it("falls back to name hint when no place id is stored", () => {
+    const r = computeRanking(SET, { selfNameHint: "Celsius Coffee Putrajaya" });
+    expect(r.selfFound).toBe(true);
+    expect(r.selfReviewCount).toBe(420);
+    expect(r.rankByReviews).toBe(3);
+  });
+
+  it("falls back to the café sitting on our coordinates (<=60m)", () => {
+    const r = computeRanking(SET, {}); // no id, no hint
+    expect(r.selfFound).toBe(true);
+    expect(r.selfPlaceId).toBe("self"); // distance 5m wins
+  });
+
+  it("reports selfFound=false but still returns rivals when we're not in the set", () => {
+    const noSelf = SET.filter((c) => c.placeId !== "self").map((c) => ({ ...c, distanceM: c.distanceM + 500 }));
+    const r = computeRanking(noSelf, { selfPlaceId: "self", selfNameHint: "Celsius" });
+    expect(r.selfFound).toBe(false);
+    expect(r.rankByReviews).toBeNull();
+    expect(r.totalNearby).toBe(3);
+    expect(r.competitors).toHaveLength(3);
+  });
+
+  it("ties and a null self rating are handled without crashing", () => {
+    const tie = [
+      cafe({ placeId: "self", name: "Celsius", rating: null, reviewCount: 100, distanceM: 5 }),
+      cafe({ placeId: "x", name: "Other", rating: 4.5, reviewCount: 100, distanceM: 50 }),
+    ];
+    const r = computeRanking(tie, { selfPlaceId: "self" });
+    // Equal review counts → nobody strictly beats us → rank 1.
+    expect(r.rankByReviews).toBe(1);
+    // Null self rating → rating rank is not computed.
+    expect(r.rankByRating).toBeNull();
+  });
+});

--- a/apps/backoffice/src/lib/reviews/places.ts
+++ b/apps/backoffice/src/lib/reviews/places.ts
@@ -1,0 +1,205 @@
+/**
+ * Google Places API (New) — Nearby Search helper for the Reviews module's
+ * "Nearby Competitor Ranking" card.
+ *
+ * The Google Business Profile API gives us our OWN reviews/rating but has no
+ * concept of "who's nearby". To rank an outlet against the cafés around it we
+ * use Places API (New) Nearby Search, which returns each nearby place's
+ * `rating` + `userRatingCount` — an apples-to-apples dataset to rank within.
+ *
+ * Auth: a Places API key (X-Goog-Api-Key), NOT the GBP OAuth credentials.
+ * Set GOOGLE_PLACES_API_KEY (enable "Places API (New)" on the same Google
+ * Cloud project that powers GBP, then mint an API key).
+ *
+ * Cost note: `rating`/`userRatingCount` are Enterprise-SKU fields (~$0.035 per
+ * call). We call this on a daily cron (one call per outlet) and cache the
+ * result in CompetitorSnapshot — never live on dashboard load.
+ */
+
+const PLACES_ENDPOINT = "https://places.googleapis.com/v1/places:searchNearby";
+// Only ask for the fields we rank on — a tighter field mask is cheaper and faster.
+const FIELD_MASK =
+  "places.id,places.displayName,places.rating,places.userRatingCount,places.location";
+
+/** Search radius in metres. 1.5km ≈ the cafés a customer would realistically pick between. */
+export const DEFAULT_RADIUS_M = 1500;
+
+/** A café returned by Nearby Search, normalised for our use. */
+export type NearbyCafe = {
+  placeId: string;
+  name: string;
+  rating: number | null;
+  reviewCount: number;
+  distanceM: number;
+  lat: number;
+  lng: number;
+};
+
+export type CompetitorRanking = {
+  /** Did we find our own outlet inside the nearby set? */
+  selfFound: boolean;
+  selfPlaceId: string | null;
+  selfRating: number | null;
+  selfReviewCount: number | null;
+  /** 1-based rank by review volume (lower = more reviews than rivals). */
+  rankByReviews: number | null;
+  /** 1-based rank by star rating. */
+  rankByRating: number | null;
+  /** Total cafés in the set, INCLUDING our own outlet. */
+  totalNearby: number;
+  /** Rivals only (self excluded), sorted by review volume desc. */
+  competitors: NearbyCafe[];
+};
+
+// ─── Distance ──────────────────────────────────────────────
+
+function haversineMeters(lat1: number, lng1: number, lat2: number, lng2: number): number {
+  const R = 6371000;
+  const toRad = (d: number) => (d * Math.PI) / 180;
+  const dLat = toRad(lat2 - lat1);
+  const dLng = toRad(lng2 - lng1);
+  const a =
+    Math.sin(dLat / 2) ** 2 +
+    Math.cos(toRad(lat1)) * Math.cos(toRad(lat2)) * Math.sin(dLng / 2) ** 2;
+  return 2 * R * Math.asin(Math.min(1, Math.sqrt(a)));
+}
+
+// ─── Nearby Search ─────────────────────────────────────────
+
+/**
+ * Return up to 20 cafés nearest to (lat, lng) within `radiusM`.
+ *
+ * rankPreference=DISTANCE (not POPULARITY) so our own outlet — distance ~0 —
+ * is guaranteed to be in the result set, which is what lets us rank ourselves.
+ */
+export async function searchNearbyCafes(
+  lat: number,
+  lng: number,
+  radiusM: number = DEFAULT_RADIUS_M,
+): Promise<NearbyCafe[]> {
+  const key = process.env.GOOGLE_PLACES_API_KEY;
+  if (!key) {
+    throw new Error("GOOGLE_PLACES_API_KEY not configured");
+  }
+
+  const res = await fetch(PLACES_ENDPOINT, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "X-Goog-Api-Key": key,
+      "X-Goog-FieldMask": FIELD_MASK,
+    },
+    body: JSON.stringify({
+      includedTypes: ["cafe", "coffee_shop"],
+      maxResultCount: 20,
+      rankPreference: "DISTANCE",
+      locationRestriction: {
+        circle: {
+          center: { latitude: lat, longitude: lng },
+          radius: radiusM,
+        },
+      },
+    }),
+  });
+
+  if (!res.ok) {
+    const body = await res.text();
+    throw new Error(`Places API error ${res.status}: ${body}`);
+  }
+
+  const data = (await res.json()) as {
+    places?: Array<{
+      id: string;
+      displayName?: { text?: string };
+      rating?: number;
+      userRatingCount?: number;
+      location?: { latitude?: number; longitude?: number };
+    }>;
+  };
+
+  return (data.places ?? []).map((p) => {
+    const pLat = p.location?.latitude ?? lat;
+    const pLng = p.location?.longitude ?? lng;
+    return {
+      placeId: p.id,
+      name: p.displayName?.text ?? "Unknown café",
+      rating: typeof p.rating === "number" ? p.rating : null,
+      reviewCount: p.userRatingCount ?? 0,
+      lat: pLat,
+      lng: pLng,
+      distanceM: Math.round(haversineMeters(lat, lng, pLat, pLng)),
+    };
+  });
+}
+
+// ─── Ranking ───────────────────────────────────────────────
+
+function normalizeName(s: string): string {
+  return s.toLowerCase().replace(/[^a-z0-9]/g, "");
+}
+
+function sortByReviews(cafes: NearbyCafe[]): NearbyCafe[] {
+  return [...cafes].sort((a, b) => b.reviewCount - a.reviewCount || (b.rating ?? 0) - (a.rating ?? 0));
+}
+
+/**
+ * Identify our own outlet inside the nearby set and rank it.
+ *
+ * Self-match order: stored Place ID → café whose name contains `selfNameHint`
+ * (nearest such, e.g. "celsius") → the café sitting on top of our coordinates
+ * (≤60m). If none match, we still return the competitor list but with no rank.
+ */
+export function computeRanking(
+  cafes: NearbyCafe[],
+  opts: { selfPlaceId?: string | null; selfNameHint?: string },
+): CompetitorRanking {
+  let self: NearbyCafe | undefined;
+
+  if (opts.selfPlaceId) {
+    self = cafes.find((c) => c.placeId === opts.selfPlaceId);
+  }
+  if (!self && opts.selfNameHint) {
+    const hint = normalizeName(opts.selfNameHint);
+    if (hint) {
+      self = cafes
+        .filter((c) => normalizeName(c.name).includes(hint))
+        .sort((a, b) => a.distanceM - b.distanceM)[0];
+    }
+  }
+  if (!self) {
+    const nearest = [...cafes].sort((a, b) => a.distanceM - b.distanceM)[0];
+    if (nearest && nearest.distanceM <= 60) self = nearest;
+  }
+
+  if (!self) {
+    return {
+      selfFound: false,
+      selfPlaceId: null,
+      selfRating: null,
+      selfReviewCount: null,
+      rankByReviews: null,
+      rankByRating: null,
+      totalNearby: cafes.length,
+      competitors: sortByReviews(cafes),
+    };
+  }
+
+  const selfReviews = self.reviewCount;
+  const selfRating = self.rating;
+  const rankByReviews = 1 + cafes.filter((c) => c.reviewCount > selfReviews).length;
+  const rankByRating =
+    selfRating == null
+      ? null
+      : 1 + cafes.filter((c) => (c.rating ?? -1) > selfRating).length;
+
+  return {
+    selfFound: true,
+    selfPlaceId: self.placeId,
+    selfRating,
+    selfReviewCount: selfReviews,
+    rankByReviews,
+    rankByRating,
+    totalNearby: cafes.length,
+    competitors: sortByReviews(cafes.filter((c) => c.placeId !== self!.placeId)),
+  };
+}

--- a/apps/backoffice/vercel.json
+++ b/apps/backoffice/vercel.json
@@ -91,6 +91,10 @@
     {
       "path": "/api/cron/pos-poster-autopilot",
       "schedule": "0 23 * * *"
+    },
+    {
+      "path": "/api/reviews/competitors/refresh",
+      "schedule": "0 4 * * *"
     }
   ]
 }

--- a/packages/db/prisma/migrations/20260621_competitor_snapshots/migration.sql
+++ b/packages/db/prisma/migrations/20260621_competitor_snapshots/migration.sql
@@ -1,0 +1,34 @@
+-- Reviews: Nearby Competitor Ranking cache.
+--
+-- The Reviews module shows where each outlet ranks among the cafés around it
+-- (rating + review volume), sourced from Google Places API (New) Nearby Search.
+-- Places calls cost money and competitor numbers barely move day-to-day, so we
+-- never call Places on dashboard load — a daily cron writes one snapshot per
+-- outlet here and the dashboard reads the cache.
+--
+-- One current row per outlet (unique outletId, upserted by the cron). Applied
+-- via Supabase MCP; this file is the captured history per
+-- docs/database-migrations.md. Table + column names are PascalCase/camelCase to
+-- match the Prisma model CompetitorSnapshot (read through `prisma` in the
+-- dashboard route, same as ReviewSettings).
+
+CREATE TABLE IF NOT EXISTS public."CompetitorSnapshot" (
+  "id"              text PRIMARY KEY,
+  "outletId"        text NOT NULL UNIQUE REFERENCES public."Outlet"("id") ON DELETE CASCADE,
+  "capturedAt"      timestamptz NOT NULL DEFAULT now(),
+  "radiusM"         integer NOT NULL,
+  "selfFound"       boolean NOT NULL DEFAULT false,
+  "selfPlaceId"     text,
+  "selfRating"      double precision,
+  "selfReviewCount" integer,
+  "rankByReviews"   integer,
+  "rankByRating"    integer,
+  "totalNearby"     integer NOT NULL DEFAULT 0,
+  "competitors"     jsonb NOT NULL DEFAULT '[]'::jsonb,
+  "createdAt"       timestamptz NOT NULL DEFAULT now(),
+  "updatedAt"       timestamptz NOT NULL DEFAULT now()
+);
+
+-- Non-sensitive (public competitor ratings), but locked by default: only the
+-- service-role / Prisma direct connection reads it. No PostgREST/anon policies.
+ALTER TABLE public."CompetitorSnapshot" ENABLE ROW LEVEL SECURITY;

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -100,7 +100,8 @@ model Outlet {
   sopOutlets        SopOutlet[]
   checklists        Checklist[]
   sopSchedules      SopSchedule[]
-  reviewSettings    ReviewSettings?
+  reviewSettings     ReviewSettings?
+  competitorSnapshot CompetitorSnapshot?
   internalFeedbacks InternalFeedback[]
   auditReports      AuditReport[]
   recurringExpenses RecurringExpense[]
@@ -1315,6 +1316,26 @@ model ReviewSettings {
   logoUrl         String?
   // Feedback form fields config (JSON array of {question, type, required, active})
   feedbackFields  Json?   @default("[]")
+  createdAt       DateTime @default(now())
+  updatedAt       DateTime @updatedAt
+}
+
+// Cached "Nearby Competitor Ranking" per outlet — one current row, refreshed by
+// the daily cron from Google Places Nearby Search. See lib/reviews/places.ts.
+model CompetitorSnapshot {
+  id              String   @id @default(uuid())
+  outletId        String   @unique
+  outlet          Outlet   @relation(fields: [outletId], references: [id], onDelete: Cascade)
+  capturedAt      DateTime @default(now())
+  radiusM         Int
+  selfFound       Boolean  @default(false)
+  selfPlaceId     String?
+  selfRating      Float?
+  selfReviewCount Int?
+  rankByReviews   Int?
+  rankByRating    Int?
+  totalNearby     Int      @default(0)
+  competitors     Json     @default("[]")
   createdAt       DateTime @default(now())
   updatedAt       DateTime @updatedAt
 }


### PR DESCRIPTION
## What

Adds a **Nearby Competitor Ranking** card to the Reviews module (`/reviews`). For each outlet it pulls the nearest cafés via **Google Places API (New)** Nearby Search and ranks the outlet among them by **review volume** (primary) and **rating** (secondary) — answering "where do we stand vs. the coffee shop next door."

Built from a customer request showing a competitor product's "Nearby Competitor Ranking" card; this is our own version inside the existing module.

## How it works

- **`lib/reviews/places.ts`** — Nearby Search helper (`rankPreference=DISTANCE` so our own listing is always in the 20-result set) + pure `computeRanking` (self-match by stored Place ID → name "celsius" → ≤60m proximity; rank by volume then rating).
- **`api/reviews/competitors/refresh`** — cron + manual-button endpoint. One Places call per active outlet, upserts `CompetitorSnapshot`, opportunistically backfills the empty `ReviewSettings.gbpPlaceId`. Auth = `checkCronAuth` **or** a logged-in backoffice user.
- **`api/reviews/dashboard`** — serves the cached snapshot per outlet (additive; **no** Places call on page load).
- **`reviews/page.tsx`** — location-gated `CompetitorPanel`: rank summary + nearby leaderboard with the outlet highlighted, plus a Refresh action. No outlet selected → "select a location" placeholder.
- **`CompetitorSnapshot`** table — Prisma model + manual SQL migration (`20260621_competitor_snapshots`, applied via Supabase MCP, RLS on, one row/outlet).
- Daily cron `0 4 * * *` in `vercel.json`.

## Cost & caching

`rating`/`userRatingCount` are Enterprise-SKU Places fields (~\$0.035/call). We never call live — a daily cron caches one snapshot per outlet (≈4 calls/day, pennies/month).

## ⚠️ Dark until configured

Requires a Places key (the module currently has only GBP OAuth):
1. Enable **Places API (New)** on the GBP Google Cloud project (My Project 23036) + mint an API key (restricted to Places API New).
2. Set `GOOGLE_PLACES_API_KEY` in the backoffice Vercel env, redeploy.

Then hit **Refresh** or wait for the 4am cron.

## Tests / verification

- `places.test.ts` — 5 cases on the ranking logic (Place-ID/name/proximity self-match, rank-by-volume, rank-by-rating, ties, null rating, self-not-found). All pass.
- `tsc --noEmit` clean for these files.

## Note

This is a **derived proxy** (rank vs. nearby cafés), not Google's actual local-pack/SEO position — no API exposes that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)