### PR TITLE
Show campaign vouchers in all channels (native + web)

### DIFF
--- a/apps/order/src/app/_VoucherRail.tsx
+++ b/apps/order/src/app/_VoucherRail.tsx
@@ -44,6 +44,7 @@ function expiresLabel(iso: string | null | undefined): string | null {
 function toneFor(v: Voucher): "gold" | "terracotta" {
   if (v.source_type === "welcome" || v.source_type === "birthday") return "gold";
   if (v.source_type === "mystery" || v.source_type === "mission") return "gold";
+  if (v.source_type === "campaign") return "gold";
   return "terracotta";
 }
 
@@ -56,6 +57,7 @@ function eyebrowFor(v: Voucher): string {
     case "referral":          return "Referral";
     case "points_redemption": return "Bean reward";
     case "promo":             return "Promo";
+    case "campaign":          return "Welcome back";
     default:                  return "Reward";
   }
 }
@@ -87,7 +89,7 @@ export function VoucherRail() {
           list.filter(
             (v) =>
               (v.status === "active" || !v.status) &&
-              ["mystery", "manual", "birthday"].includes(v.source_type ?? ""),
+              ["mystery", "manual", "birthday", "campaign"].includes(v.source_type ?? ""),
           ),
         );
       })

--- a/apps/pickup-native/app/index.tsx
+++ b/apps/pickup-native/app/index.tsx
@@ -210,7 +210,7 @@ export default function Home() {
   const walletVouchers = (myVouchersQ.data ?? []).filter(
     (v) =>
       v.status === "active" &&
-      ["mystery", "manual", "birthday"].includes(v.source_type ?? ""),
+      ["mystery", "manual", "birthday", "campaign"].includes(v.source_type ?? ""),
   );
   const claimables     = claimableQ.data ?? [];
   // Home rail surfaces only IN-PROGRESS missions (status === 'active').
@@ -1562,6 +1562,7 @@ function describeVoucherTicket(v: Voucher): TicketDescriptor {
   else if (v.source_type === "mission")       { eyebrow = "Challenge reward"; }
   else if (v.source_type === "mystery")       { eyebrow = "Mystery bonus"; }
   else if (v.source_type === "referral")      { eyebrow = "Referral gift"; }
+  else if (v.source_type === "campaign")      { eyebrow = "Welcome back"; }
 
   const dv = Number(v.discount_value ?? 0);
   if (v.discount_type === "flat" && dv > 0) {

--- a/apps/pickup-native/app/rewards.tsx
+++ b/apps/pickup-native/app/rewards.tsx
@@ -55,6 +55,7 @@ const WALLET_SOURCES: ReadonlyArray<Voucher["source_type"]> = [
   "mystery",
   "manual",
   "birthday",
+  "campaign",
 ];
 
 function mapDiscountTypeForApply(

--- a/apps/pickup-native/lib/rewards-v2.ts
+++ b/apps/pickup-native/lib/rewards-v2.ts
@@ -15,7 +15,7 @@ export type Voucher = {
   icon: string;
   category: "free_item" | "upgrade" | "discount" | "multiplier" | "special";
   status: "active" | "used" | "expired";
-  source_type: "mission" | "mystery" | "birthday" | "referral" | "manual" | "points_redemption" | null;
+  source_type: "mission" | "mystery" | "birthday" | "referral" | "manual" | "points_redemption" | "campaign" | null;
   // Back-reference to whatever issued the voucher — e.g. a
   // mission_assignments.id for source_type='mission'. Lets the Challenge
   // card find its linked wallet voucher and route Use without a picker.
@@ -212,7 +212,7 @@ export async function fetchClaimableVouchers(): Promise<ClaimableVoucher[]> {
 // claimables. Bean-shop + referral are NOT wallet items. The home "Rewards"
 // KPI ALSO counts affordable redeemable catalogue items (countAffordableRewards
 // below); the UNaffordable catalogue is never counted.
-const WALLET_COUNT_SOURCES = ["mystery", "manual", "birthday"];
+const WALLET_COUNT_SOURCES = ["mystery", "manual", "birthday", "campaign"];
 export function countRewardsWaiting(
   vouchers: ReadonlyArray<{ status?: string | null; source_type?: string | null }> | null | undefined,
   claimables: ReadonlyArray<unknown> | null | undefined,

--- a/packages/shared/src/loyalty/active-vouchers.ts
+++ b/packages/shared/src/loyalty/active-vouchers.ts
@@ -21,7 +21,8 @@ export type VoucherSource =
   | "manual"
   | "points_redemption"
   | "welcome"
-  | "promo";
+  | "promo"
+  | "campaign";
 
 /** Discount mechanic on a voucher. Mirrors the DB CHECK constraint
  *  on voucher_templates.discount_type. */

--- a/packages/shared/src/loyalty/rewards-count.ts
+++ b/packages/shared/src/loyalty/rewards-count.ts
@@ -20,7 +20,7 @@
 // (points-shop rewards the member can claim with their current balance) — via a
 // separate countAffordableRewards() term the caller adds on top of this
 // wallet+claimables tally. The UNaffordable catalogue is still never counted.
-const WALLET_COUNT_SOURCES = ["mystery", "manual", "birthday"];
+const WALLET_COUNT_SOURCES = ["mystery", "manual", "birthday", "campaign"];
 
 /** Minimal wallet-voucher shape the count needs. */
 export type CountableVoucher = { status?: string | null; source_type?: string | null };


### PR DESCRIPTION
## What
SMS-loop **campaign** vouchers (`source_type='campaign'`) were hidden in the customer wallet because the wallet allowlist `{mystery, manual, birthday}` excluded them — on **native** (rewards screen + home rail + count) and **web** (`_VoucherRail` + count). POS was unaffected (no source filter).

This adds `campaign` as a recognized wallet source in all the lockstep spots:
- **shared:** `VoucherSource` type, `rewards-count` `WALLET_COUNT_SOURCES`
- **web:** `_VoucherRail` filter + `gold` tone + "Welcome back" eyebrow
- **native:** `rewards.tsx` `WALLET_SOURCES`, `index.tsx` home rail + eyebrow, `lib/rewards-v2.ts` type union + `WALLET_COUNT_SOURCES`

## Ship
- Web (order + backoffice) deploys on merge via Vercel.
- **Native requires an EAS OTA** (`eas update --branch preview`) to take effect on the app.

## Notes
- Typecheck clean: shared, order, pickup-native.
- Context: win-back loop rewards (B1F1 / Free Tea) are issued with `source_type='campaign'`; this makes them visible end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)