### PR TITLE
Native app: in-cart upsell + personalized home posters

### DIFF
--- a/apps/pickup-native/app/cart.tsx
+++ b/apps/pickup-native/app/cart.tsx
@@ -18,6 +18,7 @@ import { getSetting } from "../lib/settings";
 import { supabase, type Outlet } from "../lib/supabase";
 import { EspressoHeader } from "../components/EspressoHeader";
 import { ProductImage } from "../components/ProductImage";
+import { CartUpsell } from "../components/CartUpsell";
 import { OrderTypeBar } from "@/components/OrderTypeBar";
 
 /**
@@ -437,6 +438,14 @@ export default function Cart() {
               </Pressable>
             ))}
             </View>
+
+            {/* Basket-targeted upsell — "Goes well with your order" (drinks →
+                a bite, personalized by member). Scrolls below the items. */}
+            <CartUpsell
+              productIds={cart.map((i) => i.productId)}
+              loyaltyId={loyaltyId}
+              outletId={outletId}
+            />
             </CartItemsScroll>
 
           {/* Summary + checkout footer. NATIVE: sits OUTSIDE the items

--- a/apps/pickup-native/app/index.tsx
+++ b/apps/pickup-native/app/index.tsx
@@ -338,8 +338,8 @@ export default function Home() {
   // getHomePosters() still provides instant first paint on cold
   // launch; this just makes refresh aggressive.
   const postersQ = useQuery({
-    queryKey: ["home-posters"],
-    queryFn: getHomePosters,
+    queryKey: ["home-posters", loyaltyId],
+    queryFn: () => getHomePosters(loyaltyId),
     staleTime: 30_000,
     refetchOnMount: "always",
     refetchOnWindowFocus: true,

--- a/apps/pickup-native/components/CartUpsell.tsx
+++ b/apps/pickup-native/components/CartUpsell.tsx
@@ -1,0 +1,87 @@
+import { View, Text, Pressable, ScrollView } from "react-native";
+import { router } from "expo-router";
+import { Plus } from "lucide-react-native";
+import { useQuery } from "@tanstack/react-query";
+import * as Haptics from "@/lib/haptics";
+import { ProductImage } from "./ProductImage";
+import { cloudinaryThumb } from "../lib/image";
+import { formatPrice } from "../lib/api";
+import { fetchCartPairs } from "../lib/suggest-pairs";
+
+/**
+ * In-cart upsell rail — "Goes well with your order". Basket-targeted (drinks
+ * cart → a bite) + personalized by member, via the shared pairing engine
+ * (/api/suggest-pairs). Cards open the product page (one tap to add), mirroring
+ * the empty-cart best-seller rail. Renders nothing until it has a suggestion.
+ */
+export function CartUpsell({
+  productIds,
+  loyaltyId,
+  outletId,
+}: {
+  productIds: string[];
+  loyaltyId: string | null;
+  outletId: string | null;
+}) {
+  const key = productIds.slice().sort().join(",");
+  const { data } = useQuery({
+    queryKey: ["cart-pairs", key, loyaltyId],
+    queryFn: () => fetchCartPairs(productIds, loyaltyId, outletId),
+    enabled: productIds.length > 0,
+    staleTime: 60_000,
+  });
+  const pairs = data ?? [];
+  if (pairs.length === 0) return null;
+
+  return (
+    <View className="mt-2 mb-4">
+      <View className="px-4 mb-2">
+        <Text
+          className="text-espresso text-[13px] uppercase"
+          style={{ fontFamily: "SpaceGrotesk_700Bold", letterSpacing: 1.2 }}
+        >
+          Goes well with your order
+        </Text>
+      </View>
+      <ScrollView horizontal showsHorizontalScrollIndicator={false} contentContainerClassName="gap-3 px-4">
+        {pairs.map((p) => (
+          <Pressable
+            key={p.id}
+            onPress={() => {
+              Haptics.selectionAsync();
+              router.push({ pathname: "/product/[id]", params: { id: p.id } });
+            }}
+            className="w-40 bg-surface rounded-2xl border border-border overflow-hidden active:opacity-70"
+            style={{ shadowColor: "#000", shadowOpacity: 0.06, shadowRadius: 8, shadowOffset: { width: 0, height: 3 } }}
+          >
+            <View>
+              <ProductImage uri={cloudinaryThumb(p.image, { size: 160 })} width={160} height={130} />
+              <View className="absolute top-2 left-2 bg-espresso/90 rounded-full px-2 py-0.5">
+                <Text
+                  className="text-amber-400 text-[8px] uppercase"
+                  style={{ fontFamily: "SpaceGrotesk_700Bold", letterSpacing: 0.5 }}
+                  numberOfLines={1}
+                >
+                  {p.discountLabel ?? p.reason}
+                </Text>
+              </View>
+            </View>
+            <View className="px-3 py-2.5">
+              <Text className="text-espresso text-[13px]" style={{ fontFamily: "Peachi-Bold" }} numberOfLines={1}>
+                {p.name}
+              </Text>
+              <View className="flex-row items-center justify-between mt-1">
+                <Text className="text-primary text-[14px]" style={{ fontFamily: "Peachi-Bold" }}>
+                  {formatPrice(p.basePrice)}
+                </Text>
+                <View className="bg-espresso rounded-full items-center justify-center" style={{ width: 24, height: 24 }}>
+                  <Plus size={14} color="#FFFFFF" />
+                </View>
+              </View>
+            </View>
+          </Pressable>
+        ))}
+      </ScrollView>
+    </View>
+  );
+}

--- a/apps/pickup-native/lib/posters.ts
+++ b/apps/pickup-native/lib/posters.ts
@@ -21,21 +21,24 @@ export type HomePoster = {
 // Network race: 4s timeout (longer than the 2.5s we used for cache-
 // first since the network IS now the primary source). If it loses,
 // fall back to whatever's in AsyncStorage. If both fail, return [].
-export async function getHomePosters(): Promise<HomePoster[]> {
+export async function getHomePosters(memberId: string | null = null): Promise<HomePoster[]> {
+  // Personalized sets cache per-member so a guest and a signed-in member don't
+  // overwrite each other's snapshot (guest keeps the legacy base key).
+  const cacheKey = memberId ? `${CACHE_KEY}:${memberId}` : CACHE_KEY;
   let resolved = false;
   let cached: HomePoster[] | null = null;
 
   // Read cache in parallel with the fetch.
   const cacheRead: Promise<HomePoster[] | null> = (async () => {
     try {
-      const raw = await AsyncStorage.getItem(CACHE_KEY);
+      const raw = await AsyncStorage.getItem(cacheKey);
       return raw ? (JSON.parse(raw) as HomePoster[]) : null;
     } catch {
       return null;
     }
   })();
 
-  const network = fetchPosters().then((posters) => {
+  const network = fetchPosters(memberId).then((posters) => {
     resolved = true;
     return posters;
   });
@@ -68,25 +71,24 @@ export async function getHomePosters(): Promise<HomePoster[]> {
   return [];
 }
 
-async function fetchPosters(): Promise<HomePoster[]> {
+async function fetchPosters(memberId: string | null = null): Promise<HomePoster[]> {
+  const cacheKey = memberId ? `${CACHE_KEY}:${memberId}` : CACHE_KEY;
   try {
-    const res = await fetch(
-      `${API_BASE}/api/home-posters?brand_id=brand-celsius`,
-      {
-        headers: {
-          "Content-Type": "application/json",
-          Origin: API_BASE,
-          Referer: API_BASE + "/",
-        },
+    const url = `${API_BASE}/api/home-posters?brand_id=brand-celsius${memberId ? `&member=${encodeURIComponent(memberId)}` : ""}`;
+    const res = await fetch(url, {
+      headers: {
+        "Content-Type": "application/json",
+        Origin: API_BASE,
+        Referer: API_BASE + "/",
       },
-    );
+    });
     if (!res.ok) return [];
     const json = (await res.json()) as { posters: HomePoster[] };
     const posters = json.posters ?? [];
     if (posters.length > 0) {
-      await AsyncStorage.setItem(CACHE_KEY, JSON.stringify(posters)).catch(() => {});
+      await AsyncStorage.setItem(cacheKey, JSON.stringify(posters)).catch(() => {});
     } else {
-      await AsyncStorage.removeItem(CACHE_KEY).catch(() => {});
+      await AsyncStorage.removeItem(cacheKey).catch(() => {});
     }
     return posters;
   } catch {

--- a/apps/pickup-native/lib/suggest-pairs.ts
+++ b/apps/pickup-native/lib/suggest-pairs.ts
@@ -1,0 +1,38 @@
+const API_BASE = "https://order.celsiuscoffee.com";
+
+export type CartPair = {
+  id: string;
+  name: string;
+  basePrice: number;
+  image: string | null;
+  reason: string;
+  discountLabel: string | null;
+};
+
+// In-cart upsell ("Goes well with your order"). Calls the SAME shared pairing
+// engine the web cart + in-store POS use (channel "pickup"), so suggestions
+// stay consistent across surfaces. Origin/Referer headers satisfy the API's
+// CSRF guard (same pattern as posters.ts).
+export async function fetchCartPairs(
+  productIds: string[],
+  member: string | null,
+  outletId: string | null,
+): Promise<CartPair[]> {
+  if (!productIds.length) return [];
+  try {
+    const res = await fetch(`${API_BASE}/api/suggest-pairs`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Origin: API_BASE,
+        Referer: API_BASE + "/cart",
+      },
+      body: JSON.stringify({ cart_product_ids: productIds, member, outlet_id: outletId }),
+    });
+    if (!res.ok) return [];
+    const json = (await res.json()) as { pairs?: CartPair[] };
+    return json.pairs ?? [];
+  } catch {
+    return [];
+  }
+}


### PR DESCRIPTION
Brings the **native app (pickup-native)** to parity with web:

- **Cart upsell:** new `components/CartUpsell` rail ("Goes well with your order") on the filled cart, calling the **shared** `/api/suggest-pairs` (same engine as web + POS) — basket-targeted (drinks → a bite) + personalized by member. Cards open the product page (one tap to add).
- **Home personalization:** `getHomePosters(memberId)` now passes `?member=` (per-member cache), and the home query passes the member — so native gets the personalized tight carousel, matching web.

JS-only change → ships via OTA (`eas update`), no store build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)