### PR TITLE
Fix BOGO discount preview (wallet API + native mapping)

### DIFF
--- a/apps/pickup-native/app/rewards.tsx
+++ b/apps/pickup-native/app/rewards.tsx
@@ -65,6 +65,9 @@ function mapDiscountTypeForApply(
     case "free_item":          return "free_item";
     case "flat":               return "flat";
     case "percent":            return "percent";
+    case "bogo":               return "bogo";
+    case "combo":              return "combo";
+    case "override_price":     return "override_price";
     case "beans_multiplier":   return "none";
     default:                    return "none";
   }
@@ -297,6 +300,11 @@ export default function RewardsTab() {
       applicable_categories: v.applicable_categories ?? null,
       applicable_products: v.applicable_products ?? null,
       free_product_name: v.free_product_name ?? null,
+      free_product_ids: v.free_product_ids ?? null,
+      bogo_buy_qty: v.bogo_buy_qty ?? undefined,
+      bogo_free_qty: v.bogo_free_qty ?? undefined,
+      combo_price_sen: v.combo_price_sen ?? null,
+      override_price_sen: v.override_price_sen ?? null,
       min_order_value: v.min_order_value ?? null,
       voucher_id: v.id,
     });

--- a/apps/pickup-native/lib/rewards-v2.ts
+++ b/apps/pickup-native/lib/rewards-v2.ts
@@ -26,12 +26,19 @@ export type Voucher = {
   stacks_with_beans: boolean;
   // Discount metadata — drives the client-side discount engine when the
   // customer reserves a wallet voucher and proceeds to checkout.
-  discount_type?: "flat" | "percent" | "free_item" | "beans_multiplier" | "none" | null;
+  discount_type?: "flat" | "percent" | "free_item" | "bogo" | "combo" | "override_price" | "beans_multiplier" | "none" | null;
   discount_value?: number | null;
   min_order_value?: number | null;
   applicable_categories?: string[] | null;
   applicable_products?: string[] | null;
   free_product_name?: string | null;
+  // BOGO / combo / override mechanics — resolved from the linked template by
+  // the wallet API (active-vouchers.ts). Needed for the cart discount engine.
+  free_product_ids?: string[] | null;
+  bogo_buy_qty?: number | null;
+  bogo_free_qty?: number | null;
+  combo_price_sen?: number | null;
+  override_price_sen?: number | null;
   // Optional visual overrides — sourced from a linked reward_kind row
   // in the backoffice. When null the native card falls back to the
   // source-bucket theme + Lucide glyph.

--- a/packages/shared/src/loyalty/active-vouchers.ts
+++ b/packages/shared/src/loyalty/active-vouchers.ts
@@ -76,6 +76,10 @@ export type ActiveVoucher = {
   applicable_products: string[] | null;
   free_product_name: string | null;
   free_product_ids: string[] | null;
+  /** BOGO mechanics — resolved from the linked voucher_template (NOT carried on
+   *  issued_rewards). Without these the cart engine computes a RM0 free item. */
+  bogo_buy_qty: number | null;
+  bogo_free_qty: number | null;
   /** Whether this voucher stacks with bean redemptions in the same cart */
   stacks_with_beans: boolean;
   /** Optional per-voucher visual override from the linked reward_kind */
@@ -171,13 +175,20 @@ export async function fetchActiveVouchersForMember(args: {
     rows.map((v) => v.voucher_template_id).filter((id): id is string => !!id),
   ));
   const kindByTemplateId = new Map<string, { color: string | null; illustration_url: string | null }>();
+  // Discount mechanics that live ONLY on voucher_templates (not denormalized
+  // onto issued_rewards): BOGO quantities + free_product_ids. The cart engine
+  // needs these to compute a bogo / free-item discount.
+  const mechByTemplateId = new Map<string, { bogo_buy_qty: number | null; bogo_free_qty: number | null; free_product_ids: string[] | null }>();
   if (templateIds.length > 0) {
     const { data: tpls } = await args.supabase
       .from("voucher_templates")
-      .select("id, reward_kind_id")
+      .select("id, reward_kind_id, bogo_buy_qty, bogo_free_qty, free_product_ids")
       .in("id", templateIds);
-    type TplRow = { id: string; reward_kind_id: string | null };
+    type TplRow = { id: string; reward_kind_id: string | null; bogo_buy_qty: number | null; bogo_free_qty: number | null; free_product_ids: string[] | null };
     const tplRows = (tpls ?? []) as TplRow[];
+    for (const t of tplRows) {
+      mechByTemplateId.set(t.id, { bogo_buy_qty: t.bogo_buy_qty, bogo_free_qty: t.bogo_free_qty, free_product_ids: t.free_product_ids });
+    }
     const kindIds = Array.from(new Set(
       tplRows.map((t) => t.reward_kind_id).filter((id): id is string => !!id),
     ));
@@ -201,6 +212,7 @@ export async function fetchActiveVouchersForMember(args: {
 
   return rows.map((v): ActiveVoucher => {
     const kind = v.voucher_template_id ? kindByTemplateId.get(v.voucher_template_id) : null;
+    const mech = v.voucher_template_id ? mechByTemplateId.get(v.voucher_template_id) : null;
     return {
       id: v.id,
       template_id: v.voucher_template_id ?? null,
@@ -224,8 +236,10 @@ export async function fetchActiveVouchersForMember(args: {
       applicable_categories: v.applicable_categories ?? null,
       applicable_products: v.applicable_products ?? null,
       free_product_name: v.free_product_name ?? null,
-      // Same as max_discount_value — only on the template.
-      free_product_ids: null,
+      // Resolved from the linked template (these live only there, not on issued_rewards).
+      free_product_ids: mech?.free_product_ids ?? null,
+      bogo_buy_qty: mech?.bogo_buy_qty ?? null,
+      bogo_free_qty: mech?.bogo_free_qty ?? null,
       stacks_with_beans: v.stacks_with_beans ?? true,
       kind_color: kind?.color ?? null,
       illustration_url: kind?.illustration_url ?? null,


### PR DESCRIPTION
## Symptom
A "Buy 1 Free 1 Drink" voucher applied in the cart but the total showed **no free-drink discount** (only the Platinum %).

## Severity: preview-only (no overcharge)
The **server charge is authoritative** — `/api/checkout/initiate` ignores the client total and recomputes the reward discount via `resolveOrderReward`, which loads the voucher's **template** (with `bogo_buy_qty`/`bogo_free_qty`) → shared engine `case "bogo"` frees the cheapest drink. So customers were charged correctly; only the **client preview** was wrong.

## Root cause
`fetchActiveVouchersForMember` (`active-vouchers.ts`) returned only the denormalized issued_rewards columns. `bogo_buy_qty`/`bogo_free_qty`/`free_product_ids` live **only on voucher_templates**, so the cart engine got `bogo` with no quantities → RM0.

## Fix
- **shared:** `active-vouchers.ts` resolves `bogo_buy_qty`/`bogo_free_qty`/`free_product_ids` from the linked template (reuses the existing template batch). Fixes web + POS preview.
- **native:** `Voucher` type gains the bogo fields; the wallet→`AppliedReward` mapping passes them; `mapDiscountTypeForApply` no longer downgrades `bogo`→`"none"`.

## Ship
- Web deploys on merge (the API serves the bogo data).
- **Native needs an EAS OTA** to pick up the mapping change.

Typecheck clean: shared, order, pickup-native.

🤖 Generated with [Claude Code](https://claude.com/claude-code)