### PR TITLE
Wire combo/override discount preview + 2nd native wallet mapping

### DIFF
--- a/apps/order/src/app/rewards/_RewardsView.tsx
+++ b/apps/order/src/app/rewards/_RewardsView.tsx
@@ -21,14 +21,18 @@ type Reward = {
   description?: string;
   points_required?: number;
   discount_type?:
-    | "flat" | "percent" | "free_item" | "bogo" | "fixed_amount" | "percentage" | "none" | null;
+    | "flat" | "percent" | "free_item" | "bogo" | "combo" | "override_price" | "fixed_amount" | "percentage" | "none" | null;
   discount_value?: number | null;
+  max_discount_value?: number | null;
   min_order_value?: number | null;
   applicable_products?: string[] | null;
   applicable_categories?: string[] | null;
   free_product_name?: string | null;
+  free_product_ids?: string[] | null;
   bogo_buy_qty?: number;
   bogo_free_qty?: number;
+  combo_price_sen?: number | null;
+  override_price_sen?: number | null;
 };
 
 // Write the chosen catalog reward into the SPA's persisted state as the
@@ -45,12 +49,16 @@ function applyCatalogReward(r: Reward) {
       points_required: r.points_required ?? 0,
       discount_type: r.discount_type ?? null,
       discount_value: r.discount_value ?? null,
+      max_discount_value: r.max_discount_value ?? null,
       applicable_categories: r.applicable_categories ?? null,
       applicable_products: r.applicable_products ?? null,
       free_product_name: r.free_product_name ?? null,
+      free_product_ids: r.free_product_ids ?? null,
       min_order_value: r.min_order_value ?? null,
       bogo_buy_qty: r.bogo_buy_qty,
       bogo_free_qty: r.bogo_free_qty,
+      combo_price_sen: r.combo_price_sen ?? null,
+      override_price_sen: r.override_price_sen ?? null,
     };
     state.reservedVoucher = {
       id: r.id,

--- a/apps/pickup-native/components/VoucherWallet.tsx
+++ b/apps/pickup-native/components/VoucherWallet.tsx
@@ -62,6 +62,9 @@ function mapDiscountType(
     case "free_item":         return "free_item";
     case "flat":              return "flat";
     case "percent":           return "percent";
+    case "bogo":              return "bogo";
+    case "combo":             return "combo";
+    case "override_price":    return "override_price";
     case "beans_multiplier":  return "none";       // applied post-payment
     default:                  return "none";
   }
@@ -390,6 +393,11 @@ export function VoucherRow({ voucher }: { voucher: Voucher }) {
       applicable_categories: voucher.applicable_categories ?? null,
       applicable_products: voucher.applicable_products ?? null,
       free_product_name: voucher.free_product_name ?? null,
+      free_product_ids: voucher.free_product_ids ?? null,
+      bogo_buy_qty: voucher.bogo_buy_qty ?? undefined,
+      bogo_free_qty: voucher.bogo_free_qty ?? undefined,
+      combo_price_sen: voucher.combo_price_sen ?? null,
+      override_price_sen: voucher.override_price_sen ?? null,
       min_order_value: voucher.min_order_value ?? null,
       voucher_id: voucher.id,    // marks this as a wallet voucher (not a points redemption)
     });

--- a/packages/shared/src/loyalty/active-vouchers.ts
+++ b/packages/shared/src/loyalty/active-vouchers.ts
@@ -80,6 +80,9 @@ export type ActiveVoucher = {
    *  issued_rewards). Without these the cart engine computes a RM0 free item. */
   bogo_buy_qty: number | null;
   bogo_free_qty: number | null;
+  /** Combo bundle price / single-item override price (SEN) — template-only. */
+  combo_price_sen: number | null;
+  override_price_sen: number | null;
   /** Whether this voucher stacks with bean redemptions in the same cart */
   stacks_with_beans: boolean;
   /** Optional per-voucher visual override from the linked reward_kind */
@@ -178,16 +181,16 @@ export async function fetchActiveVouchersForMember(args: {
   // Discount mechanics that live ONLY on voucher_templates (not denormalized
   // onto issued_rewards): BOGO quantities + free_product_ids. The cart engine
   // needs these to compute a bogo / free-item discount.
-  const mechByTemplateId = new Map<string, { bogo_buy_qty: number | null; bogo_free_qty: number | null; free_product_ids: string[] | null }>();
+  const mechByTemplateId = new Map<string, { bogo_buy_qty: number | null; bogo_free_qty: number | null; free_product_ids: string[] | null; max_discount_value: number | null; combo_price_sen: number | null; override_price_sen: number | null }>();
   if (templateIds.length > 0) {
     const { data: tpls } = await args.supabase
       .from("voucher_templates")
-      .select("id, reward_kind_id, bogo_buy_qty, bogo_free_qty, free_product_ids")
+      .select("id, reward_kind_id, bogo_buy_qty, bogo_free_qty, free_product_ids, max_discount_value, combo_price_sen, override_price_sen")
       .in("id", templateIds);
-    type TplRow = { id: string; reward_kind_id: string | null; bogo_buy_qty: number | null; bogo_free_qty: number | null; free_product_ids: string[] | null };
+    type TplRow = { id: string; reward_kind_id: string | null; bogo_buy_qty: number | null; bogo_free_qty: number | null; free_product_ids: string[] | null; max_discount_value: number | null; combo_price_sen: number | null; override_price_sen: number | null };
     const tplRows = (tpls ?? []) as TplRow[];
     for (const t of tplRows) {
-      mechByTemplateId.set(t.id, { bogo_buy_qty: t.bogo_buy_qty, bogo_free_qty: t.bogo_free_qty, free_product_ids: t.free_product_ids });
+      mechByTemplateId.set(t.id, { bogo_buy_qty: t.bogo_buy_qty, bogo_free_qty: t.bogo_free_qty, free_product_ids: t.free_product_ids, max_discount_value: t.max_discount_value, combo_price_sen: t.combo_price_sen, override_price_sen: t.override_price_sen });
     }
     const kindIds = Array.from(new Set(
       tplRows.map((t) => t.reward_kind_id).filter((id): id is string => !!id),
@@ -229,9 +232,8 @@ export async function fetchActiveVouchersForMember(args: {
       redeemed_at: v.redeemed_at,
       discount_type: (v.discount_type as VoucherDiscountType | null) ?? null,
       discount_value: v.discount_value ?? null,
-      // Not denormalised onto issued_rewards — lives only on
-      // voucher_templates / rewards. Always null here.
-      max_discount_value: null,
+      // Resolved from the linked template (only lives there, not on issued_rewards).
+      max_discount_value: mech?.max_discount_value ?? null,
       min_order_value: v.min_order_value ?? null,
       applicable_categories: v.applicable_categories ?? null,
       applicable_products: v.applicable_products ?? null,
@@ -240,6 +242,8 @@ export async function fetchActiveVouchersForMember(args: {
       free_product_ids: mech?.free_product_ids ?? null,
       bogo_buy_qty: mech?.bogo_buy_qty ?? null,
       bogo_free_qty: mech?.bogo_free_qty ?? null,
+      combo_price_sen: mech?.combo_price_sen ?? null,
+      override_price_sen: mech?.override_price_sen ?? null,
       stacks_with_beans: v.stacks_with_beans ?? true,
       kind_color: kind?.color ?? null,
       illustration_url: kind?.illustration_url ?? null,


### PR DESCRIPTION
Follow-up to the rewards-engine QA. **Charge was always correct** (server recomputes authoritatively from the template); these close client **preview** gaps so automated reward issuance reads right in every surface.

- **active-vouchers.ts** resolves `combo_price_sen` / `override_price_sen` / `max_discount_value` from the linked template (combo/override were absent; max_discount was hardcoded null). Fixes combo & override previewing RM0, and supplies the percent cap.
- **pickup-native `VoucherWallet.tsx`** — the *second* wallet→AppliedReward mapping (`VoucherRow` "Use Now", a live path) still downgraded `bogo→none` and dropped mechanic fields. Now mirrors `rewards.tsx`.
- **order `_RewardsView.tsx`** — `applyCatalogReward` carries the new fields + union includes combo/override.

POS was already correct (resolves from template; register descriptor carries all knobs).

**Remaining latent:** native `calcRewardDiscount` doesn't apply the percent `max_discount` cap — harmless today (no capped-% voucher exists), tracked for later.

Ship: web on merge; native via EAS OTA. Typecheck clean (shared, order, pickup-native).

🤖 Generated with [Claude Code](https://claude.com/claude-code)