### PR TITLE
Cart AOV challenge nudge (spend RMx more to unlock reward)

### DIFF
--- a/apps/order/src/app/api/loyalty/me/cart-challenge/route.ts
+++ b/apps/order/src/app/api/loyalty/me/cart-challenge/route.ts
@@ -1,0 +1,30 @@
+import { NextRequest, NextResponse } from "next/server";
+import { bestCartChallenge, type CartLine } from "@/lib/loyalty/cart-challenge";
+
+// POST /api/loyalty/me/cart-challenge
+// Body: { member: loyaltyId, items: [{ product_id, quantity, total_sen }] }
+//
+// Returns the single best AOV challenge to nudge for this member + basket:
+// "Spend RM12 more to unlock Free Coffee" / "Add a bite to unlock Free Tea".
+// Drives bigger baskets at the decision moment. Null when nothing's close.
+export async function POST(req: NextRequest) {
+  try {
+    const body = await req.json().catch(() => ({}));
+    const member = typeof body?.member === "string" ? body.member : null;
+    const items: CartLine[] = Array.isArray(body?.items)
+      ? body.items
+          .filter((x: unknown): x is { product_id: string; quantity?: unknown; total_sen?: unknown } =>
+            !!x && typeof (x as { product_id?: unknown }).product_id === "string")
+          .map((x: { product_id: string; quantity?: unknown; total_sen?: unknown }) => ({
+            product_id: x.product_id,
+            quantity: Number(x.quantity) || 1,
+            total_sen: Number(x.total_sen) || 0,
+          }))
+      : [];
+    const challenge = await bestCartChallenge(member, items);
+    return NextResponse.json({ challenge });
+  } catch (err) {
+    console.error("[cart-challenge] route error:", err);
+    return NextResponse.json({ challenge: null }, { status: 200 });
+  }
+}

--- a/apps/order/src/app/cart/_CartChallengeNudge.tsx
+++ b/apps/order/src/app/cart/_CartChallengeNudge.tsx
@@ -1,0 +1,60 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { Gift, Check } from "lucide-react";
+
+type Challenge = { title: string; reward: string; message: string; met: boolean; progressPct: number };
+
+/**
+ * AOV challenge nudge at the cart — "Spend RM12 more to unlock Free Coffee".
+ * Surfaces the member's closest-to-complete single-order mission so building a
+ * bigger basket completes a reward right now. Pairs with the upsell rail below
+ * (which suggests the items to get there). Renders nothing when nothing's close.
+ */
+export function CartChallengeNudge({
+  items,
+  loyaltyId,
+}: {
+  items: { product_id: string; quantity: number; total_sen: number }[];
+  loyaltyId: string | null;
+}) {
+  const [c, setC] = useState<Challenge | null>(null);
+  const key = items.map((i) => `${i.product_id}:${i.quantity}:${i.total_sen}`).sort().join("|");
+
+  useEffect(() => {
+    if (!loyaltyId || !items.length) { setC(null); return; }
+    let cancelled = false;
+    fetch("/api/loyalty/me/cart-challenge", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ member: loyaltyId, items }),
+    })
+      .then((r) => r.json())
+      .then((j) => { if (!cancelled) setC(j?.challenge ?? null); })
+      .catch(() => { if (!cancelled) setC(null); });
+    return () => { cancelled = true; };
+  }, [key, loyaltyId]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  if (!c) return null;
+
+  return (
+    <div className="px-4 mb-3">
+      <div className="flex items-center gap-2.5" style={{ backgroundColor: "#160800", borderRadius: 14, padding: "10px 14px" }}>
+        <span
+          className="flex-shrink-0 rounded-full flex items-center justify-center"
+          style={{ width: 30, height: 30, backgroundColor: c.met ? "#16a34a" : "#A2492C" }}
+        >
+          {c.met ? <Check size={16} color="#FFFFFF" /> : <Gift size={16} color="#FFFFFF" />}
+        </span>
+        <div className="flex-1 min-w-0">
+          <p style={{ color: "#FFFFFF", fontSize: 13, fontWeight: 600 }}>{c.message}</p>
+          {!c.met && (
+            <div style={{ marginTop: 5, height: 4, borderRadius: 999, backgroundColor: "rgba(255,255,255,0.18)" }}>
+              <div style={{ width: `${Math.round(c.progressPct * 100)}%`, height: 4, borderRadius: 999, backgroundColor: "#FBBF24" }} />
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/order/src/app/cart/_CartView.tsx
+++ b/apps/order/src/app/cart/_CartView.tsx
@@ -6,6 +6,7 @@ import Image from "next/image";
 import { ArrowLeft, Trash2, Plus, Minus, Gift, X, Coffee, ChevronRight } from "lucide-react";
 import { calcRewardDiscount, formatRewardValue, type AppliedReward } from "@/lib/reward-discount";
 import { CartUpsell } from "./_CartUpsell";
+import { CartChallengeNudge } from "./_CartChallengeNudge";
 
 type BestSeller = {
   id: string;
@@ -443,6 +444,14 @@ export function CartView({ bestSellers = [] }: { bestSellers?: BestSeller[] }) {
           </li>
         ))}
       </ul>
+
+      {/* AOV challenge nudge — "Spend RM12 more to unlock Free Coffee". Shows
+          the member's closest single-order mission so a bigger basket completes
+          a reward now. Sits above the upsell rail, which suggests what to add. */}
+      <CartChallengeNudge
+        items={items.map((i) => ({ product_id: i.productId, quantity: i.quantity, total_sen: Math.round(i.totalPrice * 100) }))}
+        loyaltyId={loyaltyId}
+      />
 
       {/* Basket-targeted upsell — "goes well with your order" (drinks → a bite,
           personalized by member). Reactive to the cart contents. */}

--- a/apps/order/src/lib/loyalty/cart-challenge.ts
+++ b/apps/order/src/lib/loyalty/cart-challenge.ts
@@ -1,0 +1,134 @@
+import { getSupabaseAdmin } from "@/lib/supabase/server";
+import { CATEGORY_GROUPS } from "./v2";
+
+export type CartLine = { product_id: string; quantity: number; total_sen: number };
+
+export type CartChallenge = {
+  title: string;       // mission title (internal-ish, e.g. "Make it a Meal")
+  reward: string;      // reward voucher title, e.g. "Free Coffee"
+  message: string;     // "Spend RM12 more to unlock Free Coffee"
+  met: boolean;        // the current cart already qualifies
+  progressPct: number; // 0..1
+};
+
+// Friendly nouns for the "add ___" nudge.
+const GROUP_ADD: Record<string, string> = { drinks: "a drink", food: "a bite", pastry: "a pastry" };
+const GROUP_NOUN: Record<string, string> = { drinks: "drink", food: "food item", pastry: "pastry" };
+
+// Only SINGLE-ORDER goals can be completed by THIS basket → nudgeable at the cart.
+const SINGLE_ORDER_TYPES = new Set([
+  "single_order_total_at_least", "single_order_item_count",
+  "single_order_group_count", "single_order_has_groups",
+]);
+
+// Don't nudge a mission the basket is less than this fraction toward (avoids
+// "Spend RM80 more" on a tiny cart). We show the CLOSEST qualifying one.
+const FLOOR = 0.3;
+
+type Goal = { type: string; threshold?: number; group?: string; groups?: string[] };
+
+/**
+ * The single best AOV challenge to nudge at the cart for this member + basket:
+ * among their ACTIVE single-order missions, the closest-to-complete one, with
+ * a "spend RMx more / add N more → reward" message. Reuses the engine's
+ * CATEGORY_GROUPS so the nudge matches what actually completes the mission.
+ */
+export async function bestCartChallenge(memberId: string | null, lines: CartLine[]): Promise<CartChallenge | null> {
+  if (!memberId || !lines.length) return null;
+  try {
+    const supabase = getSupabaseAdmin();
+
+    const { data: assigns } = await supabase
+      .from("mission_assignments")
+      .select("mission_id")
+      .eq("member_id", memberId)
+      .eq("status", "active");
+    const missionIds = [...new Set((assigns ?? []).map((a) => (a as { mission_id: string }).mission_id))];
+    if (!missionIds.length) return null;
+
+    const { data: missionRows } = await supabase
+      .from("reward_missions")
+      .select("id, title, goal, reward_voucher_template_ids")
+      .in("id", missionIds)
+      .eq("is_active", true);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- legacy untyped DB row
+    const missions = ((missionRows ?? []) as any[]).filter((m) => SINGLE_ORDER_TYPES.has((m.goal as Goal)?.type));
+    if (!missions.length) return null;
+
+    const pids = [...new Set(lines.map((l) => l.product_id))];
+    const tplIds = [...new Set(missions.flatMap((m) => (m.reward_voucher_template_ids ?? []) as string[]))];
+    const [prodRes, tplRes] = await Promise.all([
+      supabase.from("products").select("id, category").in("id", pids),
+      tplIds.length
+        ? supabase.from("voucher_templates").select("id, title").in("id", tplIds)
+        : Promise.resolve({ data: [] as { id: string; title: string }[] }),
+    ]);
+    const catOf = new Map(((prodRes.data ?? []) as { id: string; category: string | null }[]).map((p) => [p.id, p.category]));
+    const tplTitle = new Map(((tplRes.data ?? []) as { id: string; title: string }[]).map((t) => [t.id, t.title]));
+
+    // Cart aggregates.
+    const subtotalSen = lines.reduce((s, l) => s + (l.total_sen || 0), 0);
+    const itemCount = lines.reduce((s, l) => s + (l.quantity || 0), 0);
+    const groupQty = new Map<string, number>();
+    for (const l of lines) {
+      const cat = catOf.get(l.product_id);
+      if (!cat) continue;
+      for (const [g, list] of Object.entries(CATEGORY_GROUPS)) {
+        if (list.includes(cat)) groupQty.set(g, (groupQty.get(g) ?? 0) + (l.quantity || 0));
+      }
+    }
+
+    const out: CartChallenge[] = [];
+    for (const m of missions) {
+      const goal = m.goal as Goal;
+      const reward = (m.reward_voucher_template_ids?.[0] && tplTitle.get(m.reward_voucher_template_ids[0])) || "a reward";
+      const title = (m.title as string) ?? "Challenge";
+      let met = false;
+      let pct = 0;
+      let message = "";
+
+      if (goal.type === "single_order_total_at_least") {
+        const thr = goal.threshold ?? 0;
+        pct = thr ? Math.min(1, subtotalSen / thr) : 0;
+        met = subtotalSen >= thr;
+        const gapRm = Math.max(0, Math.ceil((thr - subtotalSen) / 100));
+        message = met ? `This order unlocks ${reward}` : `Spend RM${gapRm} more to unlock ${reward}`;
+      } else if (goal.type === "single_order_item_count") {
+        const thr = goal.threshold ?? 0;
+        pct = thr ? Math.min(1, itemCount / thr) : 0;
+        met = itemCount >= thr;
+        const gap = Math.max(0, thr - itemCount);
+        message = met ? `This order unlocks ${reward}` : `Add ${gap} more item${gap === 1 ? "" : "s"} to unlock ${reward}`;
+      } else if (goal.type === "single_order_group_count") {
+        const g = goal.group ?? "";
+        const thr = goal.threshold ?? 0;
+        const have = groupQty.get(g) ?? 0;
+        pct = thr ? Math.min(1, have / thr) : 0;
+        met = have >= thr;
+        const gap = Math.max(0, thr - have);
+        const noun = GROUP_NOUN[g] ?? g;
+        message = met ? `This order unlocks ${reward}` : `Add ${gap} more ${noun}${gap === 1 ? "" : "s"} to unlock ${reward}`;
+      } else if (goal.type === "single_order_has_groups") {
+        const groups = goal.groups ?? [];
+        if (!groups.length) continue;
+        const missing = groups.filter((g) => (groupQty.get(g) ?? 0) === 0);
+        pct = (groups.length - missing.length) / groups.length;
+        met = missing.length === 0;
+        message = met
+          ? `This order unlocks ${reward}`
+          : `Add ${missing.map((g) => GROUP_ADD[g] ?? `a ${g}`).join(" + ")} to unlock ${reward}`;
+      } else {
+        continue;
+      }
+      out.push({ title, reward, message, met, progressPct: pct });
+    }
+
+    const unmet = out.filter((c) => !c.met && c.progressPct >= FLOOR).sort((a, b) => b.progressPct - a.progressPct);
+    if (unmet.length) return unmet[0];
+    const metOnes = out.filter((c) => c.met).sort((a, b) => b.progressPct - a.progressPct);
+    return metOnes[0] ?? null;
+  } catch (e) {
+    console.error("[cart-challenge] error:", e);
+    return null;
+  }
+}

--- a/apps/order/src/lib/loyalty/v2.ts
+++ b/apps/order/src/lib/loyalty/v2.ts
@@ -483,7 +483,7 @@ type OrderForMission = {
 // Group fine-grained product categories into the broad buckets the
 // challenge engine cares about. New menu categories can be added here
 // without touching mission seed JSON.
-const CATEGORY_GROUPS: Record<string, ReadonlyArray<string>> = {
+export const CATEGORY_GROUPS: Record<string, ReadonlyArray<string>> = {
   drinks: [
     "classic", "flavoured", "mocha", "artisan-choc", "artisan-matcha",
     "fruit-tea", "gourmet-tea", "mocktails",


### PR DESCRIPTION
First piece of the challenges loop: surface the member's closest-to-complete **single-order** mission at the cart — "Spend RM12 more to unlock Free Coffee" / "Add a bite to unlock Free Tea" — so building a bigger basket completes a reward right now. This was the #1 missing AOV lever (challenges existed but were never surfaced at the decision moment).

- New `/api/loyalty/me/cart-challenge` scores the member's ACTIVE single-order missions (total_at_least / item_count / group_count / has_groups) against the live cart, returns the closest unmet nudge (or a 'this order unlocks X' confirmation). Reuses the engine's `CATEGORY_GROUPS` so the nudge matches what actually completes.
- Banner sits above the upsell rail (which suggests what to add to get there). Web only for now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)