### PR TITLE
Win-back loops: adaptive optimizer (champion + challengers)

### DIFF
--- a/apps/pickup-native/app/cart.tsx
+++ b/apps/pickup-native/app/cart.tsx
@@ -19,6 +19,7 @@ import { supabase, type Outlet } from "../lib/supabase";
 import { EspressoHeader } from "../components/EspressoHeader";
 import { ProductImage } from "../components/ProductImage";
 import { CartUpsell } from "../components/CartUpsell";
+import { CartChallengeNudge } from "../components/CartChallengeNudge";
 import { OrderTypeBar } from "@/components/OrderTypeBar";
 
 /**
@@ -438,6 +439,14 @@ export default function Cart() {
               </Pressable>
             ))}
             </View>
+
+            {/* AOV challenge nudge — "Spend RM12 more to unlock Free Coffee".
+                Closest single-order mission for this basket; sits above the
+                upsell rail which suggests what to add. */}
+            <CartChallengeNudge
+              items={cart.map((i) => ({ product_id: i.productId, quantity: i.quantity, total_sen: Math.round(i.totalPrice * 100) }))}
+              loyaltyId={loyaltyId}
+            />
 
             {/* Basket-targeted upsell — "Goes well with your order" (drinks →
                 a bite, personalized by member). Scrolls below the items. */}

--- a/apps/pickup-native/components/CartChallengeNudge.tsx
+++ b/apps/pickup-native/components/CartChallengeNudge.tsx
@@ -1,0 +1,53 @@
+import { View, Text } from "react-native";
+import { Gift, Check } from "lucide-react-native";
+import { useQuery } from "@tanstack/react-query";
+import { fetchCartChallenge } from "../lib/cart-challenge";
+
+/**
+ * AOV challenge nudge at the cart — "Spend RM12 more to unlock Free Coffee".
+ * Surfaces the member's closest-to-complete single-order mission so a bigger
+ * basket completes a reward now. Sits above the upsell rail (which suggests
+ * what to add). Renders nothing when nothing's close.
+ */
+export function CartChallengeNudge({
+  items,
+  loyaltyId,
+}: {
+  items: { product_id: string; quantity: number; total_sen: number }[];
+  loyaltyId: string | null;
+}) {
+  const key = items.map((i) => `${i.product_id}:${i.quantity}:${i.total_sen}`).sort().join("|");
+  const { data } = useQuery({
+    queryKey: ["cart-challenge", key, loyaltyId],
+    queryFn: () => fetchCartChallenge(items, loyaltyId),
+    enabled: !!loyaltyId && items.length > 0,
+    staleTime: 30_000,
+  });
+  const c = data ?? null;
+  if (!c) return null;
+
+  return (
+    <View className="px-4 mb-3">
+      <View className="flex-row items-center bg-espresso" style={{ borderRadius: 14, padding: 11, gap: 10 }}>
+        <View
+          className="items-center justify-center rounded-full"
+          style={{ width: 30, height: 30, backgroundColor: c.met ? "#16A34A" : "#A2492C" }}
+        >
+          {c.met ? <Check size={16} color="#FFFFFF" /> : <Gift size={16} color="#FFFFFF" />}
+        </View>
+        <View style={{ flex: 1 }}>
+          <Text className="text-white" style={{ fontSize: 13, fontFamily: "SpaceGrotesk_500Medium" }}>
+            {c.message}
+          </Text>
+          {!c.met && (
+            <View style={{ marginTop: 6, height: 4, borderRadius: 999, backgroundColor: "rgba(255,255,255,0.18)" }}>
+              <View
+                style={{ width: `${Math.round(c.progressPct * 100)}%`, height: 4, borderRadius: 999, backgroundColor: "#FBBF24" }}
+              />
+            </View>
+          )}
+        </View>
+      </View>
+    </View>
+  );
+}

--- a/apps/pickup-native/lib/cart-challenge.ts
+++ b/apps/pickup-native/lib/cart-challenge.ts
@@ -1,0 +1,35 @@
+const API_BASE = "https://order.celsiuscoffee.com";
+
+export type CartChallenge = {
+  title: string;
+  reward: string;
+  message: string;
+  met: boolean;
+  progressPct: number;
+};
+
+// AOV challenge nudge for the cart — "Spend RM12 more to unlock Free Coffee".
+// Hits the shared /api/loyalty/me/cart-challenge (same logic as web). Origin/
+// Referer headers satisfy the API's CSRF guard (same pattern as posters.ts).
+export async function fetchCartChallenge(
+  items: { product_id: string; quantity: number; total_sen: number }[],
+  member: string | null,
+): Promise<CartChallenge | null> {
+  if (!member || !items.length) return null;
+  try {
+    const res = await fetch(`${API_BASE}/api/loyalty/me/cart-challenge`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Origin: API_BASE,
+        Referer: API_BASE + "/cart",
+      },
+      body: JSON.stringify({ member, items }),
+    });
+    if (!res.ok) return null;
+    const json = (await res.json()) as { challenge?: CartChallenge | null };
+    return json.challenge ?? null;
+  } catch {
+    return null;
+  }
+}


### PR DESCRIPTION
Self-improving loop: OFFER_CANDIDATES grid + getLeaderboard (learns over time) + proposeArms (champion + challengers). New /api/loyalty/loops/optimizer; prepare route falls back to proposeArms; dashboard seeded by the proposal (swappable/editable), approve-gated send unchanged. Typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)