### PR TITLE
Win-back loops: adaptive optimizer (champion + challengers)

### DIFF
--- a/apps/backoffice/src/app/(admin)/loyalty/loops/page.tsx
+++ b/apps/backoffice/src/app/(admin)/loyalty/loops/page.tsx
@@ -1,23 +1,24 @@
 "use client";
 
 // ============================================================================
-// Win-back SMS loop — operator + monitor dashboard.
+// Win-back SMS loop — adaptive optimizer + monitor dashboard.
 //
-// Drives the loop-engine routes end to end:
-//   configure → POST /prepare (segment + 20% holdout + auto-issue vouchers)
-//             → review → POST /send (fire SMS per arm) → wait window
-//             → POST /measure (per-arm conversion + lift vs holdout)
+// Not a fixed template: the engine proposes each round's arms (champion +
+// challengers) from an offer SPACE and a leaderboard built from every past
+// round, so the setup gets better over time. Operator approves each send.
+//   configure → /prepare (segment + holdout + auto-issue vouchers, no SMS)
+//             → review → /send → wait window → /measure → per-arm results
+//             → leaderboard updates → next proposal sharpens.
 //
-// Agreed economics: start small (RM200/round SMS) then scale; scale an arm
-// only at >=3pp order-rate lift over the holdout, margins read at 72% GP.
-// The per-round budget caps recipient count so spend can't run over.
+// Agreed economics: start RM200/round SMS then scale; scale an arm only at
+// >=3pp order-rate lift over the holdout; margins read at 72% GP.
 // ============================================================================
 
 import { useState, useEffect, useCallback } from "react";
 import Link from "next/link";
 import {
   ArrowLeft, Repeat, RefreshCw, Send, FlaskConical, Loader2,
-  CheckCircle2, AlertTriangle, Trophy, Users, ShieldOff, Coins,
+  CheckCircle2, AlertTriangle, Trophy, Users, ShieldOff, Coins, Plus, X, Crown, Sparkles,
 } from "lucide-react";
 import { cn } from "@/lib/utils";
 
@@ -25,79 +26,39 @@ import { cn } from "@/lib/utils";
 const DEFAULT_BUDGET_RM = 200; // round-1 default; raise to scale
 const SUCCESS_BAR_PP = 3;
 const SMS_COST_RM = 0.1;
-const GP = 0.72; // gross-profit rate for margin read
-
-// ---- arm presets (existing voucher_templates) -------------------------------
-type ArmPreset = {
-  key: string;
-  label: string;
-  logic: string;
-  voucher_template_id: string;
-  message: string;
-  on: boolean;
-};
-const ARM_PRESETS: ArmPreset[] = [
-  {
-    key: "pct15", label: "15% off RM40+", logic: "% discount",
-    voucher_template_id: "eb47fd73-42ab-4eb6-ade4-a12f96912d00",
-    message: "We miss you at Celsius! Enjoy 15% off when you spend RM40+. Tap to use — valid 14 days.",
-    on: true,
-  },
-  {
-    key: "flat10", label: "RM10 off RM30+", logic: "flat discount",
-    voucher_template_id: "02ca62f1-171d-41d2-b6d6-9ca2d67ca3b9",
-    message: "We miss you at Celsius! Here's RM10 off your next RM30+ order. Tap to use — valid 14 days.",
-    on: true,
-  },
-  {
-    key: "b1f1", label: "Buy 1 Free 1 drinks", logic: "BOGO",
-    voucher_template_id: "ed33eb26-4ead-414d-b1ee-179999a33940",
-    message: "We miss you at Celsius! Buy 1 Free 1 on any drink — bring a friend! Valid 30 days.",
-    on: true,
-  },
-];
+const GP = 0.72;
 
 // ---- types ------------------------------------------------------------------
 type ArmStat = {
-  arm: string;
-  n: number;
-  conversion_rate: number;
-  redemption_rate: number;
-  lift_pp: number;
-  revenue_rm: number;
-  revenue_per_recipient_rm: number;
+  arm: string; n: number; conversion_rate: number; redemption_rate: number;
+  lift_pp: number; revenue_rm: number; revenue_per_recipient_rm: number;
 };
 type RoundArm = { key: string; label: string; voucher_template_id: string; message: string };
 type Round = {
-  id: string;
-  round_no: number;
-  loop_key: string;
-  segment_label: string;
-  holdout_pct: number;
-  arms: RoundArm[];
-  attribution_window_days: number;
-  status: "prepared" | "sent" | "measured";
-  stats: ArmStat[] | null;
-  prepared_at: string | null;
-  sent_at: string | null;
-  measured_at: string | null;
+  id: string; round_no: number; loop_key: string; segment_label: string;
+  holdout_pct: number; arms: RoundArm[]; attribution_window_days: number;
+  status: "prepared" | "sent" | "measured"; stats: ArmStat[] | null;
+  prepared_at: string | null; sent_at: string | null; measured_at: string | null;
 };
 type Preview = {
-  round_id: string;
-  round_no: number;
-  segment_label: string;
-  total: number;
-  holdout: number;
-  arm_counts: Record<string, number>;
-  est_sms_cost_rm: number;
-  est_reward_cogs_rm: number;
+  round_id: string; round_no: number; segment_label: string; total: number;
+  holdout: number; arm_counts: Record<string, number>; est_sms_cost_rm: number; est_reward_cogs_rm: number;
 };
+type Candidate = { key: string; label: string; logic: string; voucher_template_id: string; message: string };
+type ProposalArm = { key: string; label: string; voucher_template_id: string; message: string; role: "champion" | "challenger"; reason: string };
+type LeaderboardEntry = {
+  template_id: string; key: string | null; label: string; logic: string | null;
+  rounds: number; recipients: number; avg_lift_pp: number;
+  incr_margin_per_recipient_rm: number; cum_incr_margin_rm: number;
+};
+type Optimizer = { leaderboard: LeaderboardEntry[]; proposal: { arms: ProposalArm[] }; candidates: Candidate[] };
+
+const CHAMPION_MIN_RECIPIENTS = 300;
 
 // ---- helpers ----------------------------------------------------------------
 function rm(n: number) {
   return `RM${n.toLocaleString("en-MY", { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`;
 }
-// Parse "Lapsed 30–60d (4413 reachable, 20% holdout)" → reachable count.
 function reachableFromLabel(label: string): number | null {
   const m = label.match(/\(([\d,]+)\s+reachable/);
   return m ? parseInt(m[1].replace(/,/g, ""), 10) : null;
@@ -105,10 +66,8 @@ function reachableFromLabel(label: string): number | null {
 function estSmsCost(round: Round): number | null {
   const reach = reachableFromLabel(round.segment_label);
   if (reach == null) return null;
-  const treatment = Math.round(reach * (1 - round.holdout_pct / 100));
-  return +(treatment * SMS_COST_RM).toFixed(2);
+  return +(Math.round(reach * (1 - round.holdout_pct / 100)) * SMS_COST_RM).toFixed(2);
 }
-
 function StatusBadge({ status }: { status: Round["status"] }) {
   const map: Record<Round["status"], { label: string; cls: string }> = {
     prepared: { label: "Prepared — awaiting send", cls: "bg-amber-100 text-amber-800" },
@@ -118,22 +77,34 @@ function StatusBadge({ status }: { status: Round["status"] }) {
   const s = map[status];
   return <span className={cn("rounded-full px-2.5 py-0.5 text-xs font-medium", s.cls)}>{s.label}</span>;
 }
+function RoleBadge({ role }: { role: "champion" | "challenger" }) {
+  return role === "champion" ? (
+    <span className="inline-flex items-center gap-1 rounded bg-green-100 px-1.5 py-0.5 text-xs font-medium text-green-800"><Crown className="h-3 w-3" /> champion</span>
+  ) : (
+    <span className="inline-flex items-center gap-1 rounded bg-blue-100 px-1.5 py-0.5 text-xs font-medium text-blue-800"><Sparkles className="h-3 w-3" /> challenger</span>
+  );
+}
 
 // ============================================================================
 export default function LoopsPage() {
   const [rounds, setRounds] = useState<Round[] | null>(null);
+  const [opt, setOpt] = useState<Optimizer | null>(null);
   const [err, setErr] = useState<string | null>(null);
-  const [busy, setBusy] = useState<string | null>(null); // action-in-flight id
+  const [busy, setBusy] = useState<string | null>(null);
   const [lastPreview, setLastPreview] = useState<Preview | null>(null);
 
   const load = useCallback(async () => {
     try {
-      const res = await fetch("/api/loyalty/loops");
-      if (!res.ok) throw new Error(`list failed (${res.status})`);
-      setRounds((await res.json()) as Round[]);
+      const [rRes, oRes] = await Promise.all([
+        fetch("/api/loyalty/loops"),
+        fetch("/api/loyalty/loops/optimizer"),
+      ]);
+      if (!rRes.ok) throw new Error(`list failed (${rRes.status})`);
+      setRounds((await rRes.json()) as Round[]);
+      if (oRes.ok) setOpt((await oRes.json()) as Optimizer);
       setErr(null);
     } catch (e) {
-      setErr(e instanceof Error ? e.message : "Failed to load rounds");
+      setErr(e instanceof Error ? e.message : "Failed to load");
     }
   }, []);
   useEffect(() => { void load(); }, [load]);
@@ -149,10 +120,9 @@ export default function LoopsPage() {
         <h1 className="text-2xl font-semibold">Win-back loops</h1>
       </div>
       <p className="mb-4 text-sm text-gray-500">
-        Re-activate lapsed customers, measured honestly against a holdout. Each round A/B tests offer logics and keeps the winner.
+        Re-activate lapsed customers, measured honestly against a holdout. The engine proposes each round&apos;s offers and learns which logic wins — the setup sharpens over time.
       </p>
 
-      {/* agreed economics banner */}
       <div className="mb-6 flex flex-wrap gap-x-6 gap-y-1 rounded-lg border border-gray-200 bg-gray-50 px-4 py-3 text-sm">
         <span><span className="text-gray-500">SMS budget</span> <strong>set per round</strong> (start {rm(DEFAULT_BUDGET_RM)}, scale up)</span>
         <span><span className="text-gray-500">Scale an arm at</span> <strong>≥{SUCCESS_BAR_PP}pp lift</strong> vs holdout</span>
@@ -166,23 +136,32 @@ export default function LoopsPage() {
         </div>
       )}
 
-      <NewRoundCard
-        busy={busy === "prepare"}
-        onPrepare={async (payload) => {
-          setBusy("prepare"); setErr(null); setLastPreview(null);
-          try {
-            const res = await fetch("/api/loyalty/loops/prepare", {
-              method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify(payload),
-            });
-            const data = await res.json();
-            if (!res.ok) throw new Error(data?.error ?? "Prepare failed");
-            setLastPreview(data as Preview);
-            await load();
-          } catch (e) {
-            setErr(e instanceof Error ? e.message : "Prepare failed");
-          } finally { setBusy(null); }
-        }}
-      />
+      {opt && <OptimizerPanel opt={opt} />}
+
+      {opt ? (
+        <NewRoundCard
+          proposal={opt.proposal.arms}
+          candidates={opt.candidates}
+          busy={busy === "prepare"}
+          onPrepare={async (payload) => {
+            setBusy("prepare"); setErr(null); setLastPreview(null);
+            try {
+              const res = await fetch("/api/loyalty/loops/prepare", {
+                method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify(payload),
+              });
+              const data = await res.json();
+              if (!res.ok) throw new Error(data?.error ?? "Prepare failed");
+              setLastPreview(data as Preview);
+              await load();
+            } catch (e) { setErr(e instanceof Error ? e.message : "Prepare failed"); }
+            finally { setBusy(null); }
+          }}
+        />
+      ) : (
+        <div className="mb-6 rounded-xl border border-gray-200 bg-white p-8 text-center text-sm text-gray-400 shadow-sm">
+          <Loader2 className="mx-auto h-5 w-5 animate-spin" /> Loading optimizer…
+        </div>
+      )}
 
       {lastPreview && (
         <div className="mb-6 rounded-lg border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-900">
@@ -197,7 +176,6 @@ export default function LoopsPage() {
         </div>
       )}
 
-      {/* rounds */}
       <h2 className="mb-3 mt-2 text-lg font-semibold">Rounds</h2>
       {rounds === null ? (
         <div className="py-10 text-center text-gray-400"><Loader2 className="mx-auto h-5 w-5 animate-spin" /></div>
@@ -207,15 +185,11 @@ export default function LoopsPage() {
         <div className="space-y-4">
           {rounds.map((r) => (
             <RoundCard
-              key={r.id}
-              round={r}
-              busy={busy === r.id}
+              key={r.id} round={r} busy={busy === r.id}
               onSend={async () => {
                 setBusy(r.id); setErr(null);
                 try {
-                  const res = await fetch("/api/loyalty/loops/send", {
-                    method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify({ round_id: r.id }),
-                  });
+                  const res = await fetch("/api/loyalty/loops/send", { method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify({ round_id: r.id }) });
                   const data = await res.json();
                   if (!res.ok) throw new Error(data?.error ?? "Send failed");
                   await load();
@@ -225,9 +199,7 @@ export default function LoopsPage() {
               onMeasure={async () => {
                 setBusy(r.id); setErr(null);
                 try {
-                  const res = await fetch("/api/loyalty/loops/measure", {
-                    method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify({ round_id: r.id }),
-                  });
+                  const res = await fetch("/api/loyalty/loops/measure", { method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify({ round_id: r.id }) });
                   const data = await res.json();
                   if (!res.ok) throw new Error(data?.error ?? "Measure failed");
                   await load();
@@ -246,19 +218,100 @@ export default function LoopsPage() {
   );
 }
 
-// ---- New round configurator -------------------------------------------------
-function NewRoundCard({ busy, onPrepare }: { busy: boolean; onPrepare: (p: unknown) => void }) {
+// ---- Optimizer panel: leaderboard + champion --------------------------------
+function OptimizerPanel({ opt }: { opt: Optimizer }) {
+  const lb = opt.leaderboard;
+  const champion = lb.find((e) => e.recipients >= CHAMPION_MIN_RECIPIENTS) ?? null;
+
+  return (
+    <div className="mb-6 rounded-xl border border-gray-200 bg-white p-5 shadow-sm">
+      <div className="mb-3 flex items-center gap-2">
+        <Trophy className="h-5 w-5 text-[#A2492C]" />
+        <h2 className="text-lg font-semibold">Optimizer</h2>
+      </div>
+
+      {lb.length === 0 ? (
+        <p className="text-sm text-gray-500">
+          No measured rounds yet — the leaderboard fills in after your first round. The engine has proposed a diverse starter set below (one of each logic) to begin exploring.
+        </p>
+      ) : (
+        <>
+          {champion ? (
+            <div className="mb-3 flex items-center gap-2 rounded-lg border border-green-200 bg-green-50 px-3 py-2 text-sm text-green-900">
+              <Crown className="h-4 w-4" /> Champion: <strong>{champion.label}</strong> — {champion.incr_margin_per_recipient_rm >= 0 ? "+" : ""}{rm(champion.incr_margin_per_recipient_rm)}/recipient, {champion.avg_lift_pp >= 0 ? "+" : ""}{champion.avg_lift_pp}pp over {champion.recipients.toLocaleString()} sent.
+            </div>
+          ) : (
+            <div className="mb-3 rounded-lg border border-amber-200 bg-amber-50 px-3 py-2 text-sm text-amber-900">
+              Still exploring — no offer has {CHAMPION_MIN_RECIPIENTS}+ recipients yet, so no champion is crowned. Keep running rounds.
+            </div>
+          )}
+          <div className="overflow-x-auto">
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="border-b border-gray-200 text-left text-xs uppercase tracking-wide text-gray-400">
+                  <th className="py-2 pr-3">Offer</th>
+                  <th className="py-2 pr-3">Logic</th>
+                  <th className="py-2 pr-3 text-right">Rounds</th>
+                  <th className="py-2 pr-3 text-right">Sent</th>
+                  <th className="py-2 pr-3 text-right">Avg lift</th>
+                  <th className="py-2 pr-3 text-right">Incr. margin / recipient</th>
+                </tr>
+              </thead>
+              <tbody>
+                {lb.map((e) => (
+                  <tr key={e.template_id} className={cn("border-b border-gray-100", champion?.template_id === e.template_id && "bg-green-50")}>
+                    <td className="py-2 pr-3 font-medium">
+                      <span className="inline-flex items-center gap-1.5">
+                        {champion?.template_id === e.template_id && <Crown className="h-3.5 w-3.5 text-green-600" />}
+                        {e.label}
+                      </span>
+                    </td>
+                    <td className="py-2 pr-3 text-gray-500">{e.logic ?? "—"}</td>
+                    <td className="py-2 pr-3 text-right tabular-nums">{e.rounds}</td>
+                    <td className="py-2 pr-3 text-right tabular-nums">{e.recipients.toLocaleString()}</td>
+                    <td className={cn("py-2 pr-3 text-right tabular-nums", e.avg_lift_pp >= SUCCESS_BAR_PP ? "text-green-700" : e.avg_lift_pp > 0 ? "text-gray-700" : "text-red-600")}>
+                      {e.avg_lift_pp > 0 ? "+" : ""}{e.avg_lift_pp}pp
+                    </td>
+                    <td className="py-2 pr-3 text-right tabular-nums">{e.incr_margin_per_recipient_rm >= 0 ? "+" : ""}{rm(e.incr_margin_per_recipient_rm)}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </>
+      )}
+    </div>
+  );
+}
+
+// ---- New round (seeded by the optimizer's proposal) -------------------------
+type FormArm = { key: string; label: string; voucher_template_id: string; message: string; role: "champion" | "challenger"; reason: string };
+
+function NewRoundCard({ proposal, candidates, busy, onPrepare }: {
+  proposal: ProposalArm[]; candidates: Candidate[]; busy: boolean; onPrepare: (p: unknown) => void;
+}) {
   const [minD, setMinD] = useState(30);
   const [maxD, setMaxD] = useState(60);
   const [holdout, setHoldout] = useState(20);
   const [windowD, setWindowD] = useState(7);
   const [budget, setBudget] = useState(DEFAULT_BUDGET_RM);
-  const [arms, setArms] = useState<ArmPreset[]>(ARM_PRESETS.map((a) => ({ ...a })));
+  const [arms, setArms] = useState<FormArm[]>(proposal.map((a) => ({ ...a })));
 
-  const activeArms = arms.filter((a) => a.on);
-  // Budget → recipient cap. SMS only hits treatment, so reach = treatment / (1 - holdout).
+  const logicOf = (tid: string) => candidates.find((c) => c.voucher_template_id === tid)?.logic ?? "—";
   const maxSms = Math.max(0, Math.floor(budget / SMS_COST_RM));
   const maxRecipients = Math.floor(maxSms / Math.max(0.01, 1 - holdout / 100));
+
+  const swapArm = (i: number, tid: string) => {
+    const c = candidates.find((x) => x.voucher_template_id === tid);
+    if (!c) return;
+    setArms((prev) => prev.map((a, j) => j === i ? { key: c.key, label: c.label, voucher_template_id: c.voucher_template_id, message: c.message, role: a.role, reason: "Manually selected." } : a));
+  };
+  const addArm = () => {
+    const used = new Set(arms.map((a) => a.voucher_template_id));
+    const next = candidates.find((c) => !used.has(c.voucher_template_id));
+    if (!next) return;
+    setArms((prev) => [...prev, { key: next.key, label: next.label, voucher_template_id: next.voucher_template_id, message: next.message, role: "challenger", reason: "Manually added." }]);
+  };
 
   return (
     <div className="mb-6 rounded-xl border border-gray-200 bg-white p-5 shadow-sm">
@@ -275,39 +328,46 @@ function NewRoundCard({ busy, onPrepare }: { busy: boolean; onPrepare: (p: unkno
         <Field label="SMS budget (RM)"><NumInput v={budget} set={setBudget} /></Field>
       </div>
       <p className="mb-4 text-xs text-gray-500">
-        Budget {rm(budget)} → up to <strong>{maxSms.toLocaleString()}</strong> SMS (~{maxRecipients.toLocaleString()} reached incl. holdout). Caps the round if the lapsed segment is larger. Scale later by raising the budget. Exact cost shown after prepare.
+        Budget {rm(budget)} → up to <strong>{maxSms.toLocaleString()}</strong> SMS (~{maxRecipients.toLocaleString()} reached incl. holdout). Caps the round if the lapsed segment is larger. Scale later by raising the budget.
       </p>
 
-      <div className="mb-2 text-sm font-medium text-gray-700">Offer arms to test ({activeArms.length} on)</div>
+      <div className="mb-2 flex items-center justify-between">
+        <span className="text-sm font-medium text-gray-700">Proposed arms ({arms.length})</span>
+        <button onClick={addArm} className="inline-flex items-center gap-1 text-xs text-[#A2492C] hover:underline"><Plus className="h-3.5 w-3.5" /> add arm</button>
+      </div>
       <div className="space-y-2">
         {arms.map((a, i) => (
-          <div key={a.key} className={cn("rounded-lg border p-3", a.on ? "border-gray-200 bg-white" : "border-gray-100 bg-gray-50 opacity-60")}>
-            <label className="flex cursor-pointer items-center gap-2">
-              <input
-                type="checkbox" checked={a.on}
-                onChange={(e) => setArms((prev) => prev.map((x, j) => j === i ? { ...x, on: e.target.checked } : x))}
-              />
-              <span className="font-medium">{a.label}</span>
-              <span className="rounded bg-gray-100 px-1.5 py-0.5 text-xs text-gray-500">{a.logic}</span>
-            </label>
-            {a.on && (
-              <textarea
-                value={a.message}
-                onChange={(e) => setArms((prev) => prev.map((x, j) => j === i ? { ...x, message: e.target.value } : x))}
-                rows={2}
-                className="mt-2 w-full rounded-md border border-gray-200 p-2 text-sm"
-              />
-            )}
+          <div key={`${a.voucher_template_id}-${i}`} className="rounded-lg border border-gray-200 p-3">
+            <div className="mb-2 flex flex-wrap items-center gap-2">
+              <RoleBadge role={a.role} />
+              <span className="rounded bg-gray-100 px-1.5 py-0.5 text-xs text-gray-500">{logicOf(a.voucher_template_id)}</span>
+              <select
+                value={a.voucher_template_id}
+                onChange={(e) => swapArm(i, e.target.value)}
+                className="rounded-md border border-gray-200 px-2 py-1 text-sm"
+              >
+                {candidates.map((c) => (
+                  <option key={c.voucher_template_id} value={c.voucher_template_id}>{c.label} · {c.logic}</option>
+                ))}
+              </select>
+              <button onClick={() => setArms((prev) => prev.filter((_, j) => j !== i))} className="ml-auto text-gray-400 hover:text-red-600" aria-label="remove arm"><X className="h-4 w-4" /></button>
+            </div>
+            <p className="mb-2 text-xs text-gray-500">{a.reason}</p>
+            <textarea
+              value={a.message}
+              onChange={(e) => setArms((prev) => prev.map((x, j) => j === i ? { ...x, message: e.target.value } : x))}
+              rows={2}
+              className="w-full rounded-md border border-gray-200 p-2 text-sm"
+            />
           </div>
         ))}
       </div>
 
       <button
-        disabled={busy || activeArms.length === 0}
+        disabled={busy || arms.length === 0}
         onClick={() => onPrepare({
-          arms: activeArms.map((a) => ({ key: a.key, label: a.label, voucher_template_id: a.voucher_template_id, message: a.message })),
-          holdoutPct: holdout, minDaysLapsed: minD, maxDaysLapsed: maxD, attributionWindowDays: windowD,
-          maxRecipients,
+          arms: arms.map((a) => ({ key: a.key, label: a.label, voucher_template_id: a.voucher_template_id, message: a.message })),
+          holdoutPct: holdout, minDaysLapsed: minD, maxDaysLapsed: maxD, attributionWindowDays: windowD, maxRecipients,
         })}
         className="mt-4 inline-flex items-center gap-2 rounded-lg bg-[#A2492C] px-4 py-2 text-sm font-medium text-white disabled:opacity-50"
       >
@@ -328,10 +388,7 @@ function Field({ label, children }: { label: string; children: React.ReactNode }
 }
 function NumInput({ v, set }: { v: number; set: (n: number) => void }) {
   return (
-    <input
-      type="number" value={v} onChange={(e) => set(Number(e.target.value))}
-      className="w-full rounded-md border border-gray-200 px-3 py-2 text-sm"
-    />
+    <input type="number" value={v} onChange={(e) => set(Number(e.target.value))} className="w-full rounded-md border border-gray-200 px-3 py-2 text-sm" />
   );
 }
 
@@ -340,7 +397,6 @@ function RoundCard({ round, busy, onSend, onMeasure }: {
   round: Round; busy: boolean; onSend: () => void; onMeasure: () => void;
 }) {
   const est = estSmsCost(round);
-
   return (
     <div className="rounded-xl border border-gray-200 bg-white p-5 shadow-sm">
       <div className="mb-3 flex flex-wrap items-center justify-between gap-2">
@@ -362,7 +418,6 @@ function RoundCard({ round, busy, onSend, onMeasure }: {
         ))}
       </div>
 
-      {/* prepared → send */}
       {round.status === "prepared" && (
         <div className="rounded-lg border border-amber-200 bg-amber-50 p-3">
           <div className="mb-2 flex flex-wrap items-center gap-x-4 gap-y-1 text-sm text-amber-900">
@@ -379,21 +434,15 @@ function RoundCard({ round, busy, onSend, onMeasure }: {
         </div>
       )}
 
-      {/* sent → measure */}
       {round.status === "sent" && (
         <div className="rounded-lg border border-blue-200 bg-blue-50 p-3">
           <div className="mb-2 text-sm text-blue-900">SMS sent{round.sent_at ? ` ${new Date(round.sent_at).toLocaleDateString("en-MY")}` : ""}. Measure after the {round.attribution_window_days}-day window closes.</div>
-          <button
-            disabled={busy}
-            onClick={onMeasure}
-            className="inline-flex items-center gap-2 rounded-lg bg-blue-600 px-4 py-2 text-sm font-medium text-white disabled:opacity-50"
-          >
+          <button disabled={busy} onClick={onMeasure} className="inline-flex items-center gap-2 rounded-lg bg-blue-600 px-4 py-2 text-sm font-medium text-white disabled:opacity-50">
             {busy ? <Loader2 className="h-4 w-4 animate-spin" /> : <CheckCircle2 className="h-4 w-4" />} Measure results
           </button>
         </div>
       )}
 
-      {/* measured → results */}
       {round.status === "measured" && round.stats && <Results round={round} />}
     </div>
   );
@@ -407,15 +456,12 @@ function Results({ round }: { round: Round }) {
   const labelFor = (key: string) => round.arms?.find((a) => a.key === key)?.label ?? key;
 
   const treatment = stats.filter((s) => s.arm !== "holdout").map((s) => {
-    const incrRevPerRecip = s.revenue_per_recipient_rm - baseRevPerRecip;
-    const incrRevenue = incrRevPerRecip * s.n;
-    const incrMargin = incrRevenue * GP;
+    const incrMargin = (s.revenue_per_recipient_rm - baseRevPerRecip) * s.n * GP;
     const smsSpend = s.n * SMS_COST_RM;
     const roi = smsSpend > 0 ? incrMargin / smsSpend : 0;
     const meetsBar = s.lift_pp >= SUCCESS_BAR_PP;
     return { ...s, incrMargin, smsSpend, roi, meetsBar };
   });
-  // winner = best incremental margin among arms that clear the bar
   const winners = treatment.filter((t) => t.meetsBar).sort((a, b) => b.incrMargin - a.incrMargin);
   const winnerArm = winners[0]?.arm ?? null;
 
@@ -462,8 +508,8 @@ function Results({ round }: { round: Round }) {
       <p className="mt-2 text-xs text-gray-400">
         Incremental margin = (arm revenue/recipient − holdout revenue/recipient) × recipients × {Math.round(GP * 100)}% GP. ROI = incremental margin ÷ SMS spend.
         {winnerArm
-          ? ` Winner: ${labelFor(winnerArm)} — clears the ≥${SUCCESS_BAR_PP}pp bar with the best incremental margin. Scale it next round.`
-          : ` No arm cleared the ≥${SUCCESS_BAR_PP}pp bar — hold spend and retest.`}
+          ? ` Round winner: ${labelFor(winnerArm)}. It feeds the leaderboard — if it leads with enough evidence it becomes the champion next round.`
+          : ` No arm cleared the ≥${SUCCESS_BAR_PP}pp bar this round — the optimizer keeps exploring.`}
       </p>
     </div>
   );

--- a/apps/backoffice/src/app/api/loyalty/loops/optimizer/route.ts
+++ b/apps/backoffice/src/app/api/loyalty/loops/optimizer/route.ts
@@ -1,0 +1,19 @@
+import { NextRequest, NextResponse } from "next/server";
+import { requireAuth } from "@/lib/auth";
+import { getLeaderboard, proposeArms, OFFER_CANDIDATES } from "@/lib/loyalty/loop-engine";
+
+// GET /api/loyalty/loops/optimizer — the adaptive layer for the dashboard:
+//   - leaderboard: every offer ranked by cumulative incremental margin (learns over time)
+//   - proposal:    the next round's champion + challengers (engine's suggestion)
+//   - candidates:  the full offer space, so the operator can swap an arm
+export async function GET(request: NextRequest) {
+  const auth = await requireAuth(request);
+  if (auth.error) return auth.error;
+  try {
+    const [leaderboard, proposal] = await Promise.all([getLeaderboard(), proposeArms()]);
+    return NextResponse.json({ leaderboard, proposal, candidates: OFFER_CANDIDATES });
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : "Failed to load optimizer";
+    return NextResponse.json({ error: msg }, { status: 500 });
+  }
+}

--- a/apps/backoffice/src/app/api/loyalty/loops/prepare/route.ts
+++ b/apps/backoffice/src/app/api/loyalty/loops/prepare/route.ts
@@ -1,40 +1,20 @@
 import { NextRequest, NextResponse } from "next/server";
 import { requireAuth } from "@/lib/auth";
-import { prepareWinbackRound, type ArmDef } from "@/lib/loyalty/loop-engine";
-
-// Default Win Back arms — sales-driving offer logics compared head to head
-// (every arm needs a real basket; no claim-and-leave freebies):
-//   % discount · flat discount · BOGO. Override via the request body / the
-//   backoffice "Win-back Loops" page.
-const DEFAULT_ARMS: ArmDef[] = [
-  {
-    key: "pct15",
-    label: "15% off RM40+",
-    voucher_template_id: "eb47fd73-42ab-4eb6-ade4-a12f96912d00",
-    message: "We miss you at Celsius! Enjoy 15% off when you spend RM40+. Tap to use — valid 14 days.",
-  },
-  {
-    key: "flat10",
-    label: "RM10 off RM30+",
-    voucher_template_id: "02ca62f1-171d-41d2-b6d6-9ca2d67ca3b9",
-    message: "We miss you at Celsius! Here's RM10 off your next RM30+ order. Tap to use — valid 14 days.",
-  },
-  {
-    key: "b1f1",
-    label: "Buy 1 Free 1 drinks",
-    voucher_template_id: "ed33eb26-4ead-414d-b1ee-179999a33940",
-    message: "We miss you at Celsius! Buy 1 Free 1 on any drink — bring a friend! Valid 30 days.",
-  },
-];
+import { prepareWinbackRound, proposeArms, type ArmDef } from "@/lib/loyalty/loop-engine";
 
 // POST /api/loyalty/loops/prepare — build a Win Back round (segment + holdout +
 // arms + auto-issue rewards). Returns a preview for approval. NO SMS sent yet.
+// Arms come from the request body (the dashboard sends the approved set); when
+// omitted, the optimizer proposes them (champion + challengers) — never a frozen
+// template list.
 export async function POST(request: NextRequest) {
   const auth = await requireAuth(request);
   if (auth.error) return auth.error;
   try {
     const body = await request.json().catch(() => ({}));
-    const arms: ArmDef[] = Array.isArray(body.arms) && body.arms.length ? body.arms : DEFAULT_ARMS;
+    const arms: ArmDef[] = Array.isArray(body.arms) && body.arms.length
+      ? body.arms
+      : (await proposeArms()).arms.map((a) => ({ key: a.key, label: a.label, voucher_template_id: a.voucher_template_id, message: a.message }));
     const preview = await prepareWinbackRound({
       arms,
       holdoutPct: body.holdoutPct,

--- a/apps/backoffice/src/lib/loyalty/loop-engine.ts
+++ b/apps/backoffice/src/lib/loyalty/loop-engine.ts
@@ -16,6 +16,7 @@ import { sendSMS } from "@/lib/loyalty/sms";
 
 const BRAND = "brand-celsius";
 const SMS_COST_RM = 0.1; // SMS Niaga ~RM0.10/SMS
+const GP = 0.72; // gross-profit rate for incremental-margin read
 
 export type ArmDef = {
   key: string; // e.g. 'free_tea'
@@ -322,4 +323,158 @@ export async function measureRound(roundId: string) {
     .eq("id", roundId);
 
   return { round_id: roundId, holdout_conversion_rate: +(holdoutRate * 100).toFixed(1), stats };
+}
+
+// ============================================================================
+// ADAPTIVE OPTIMIZER — the loop "learns" instead of running a fixed template.
+//
+// Offer SPACE (not 3 frozen arms): a grid across logic × value × threshold.
+// Each round = the current CHAMPION (best cumulative incremental margin with
+// enough evidence) + CHALLENGERS (least-tested / new logics) so the engine
+// keeps exploring. A persistent leaderboard over all measured rounds is what
+// makes it better over time. proposeArms() returns the next round's arm set;
+// the operator approves before any SMS goes out.
+// ============================================================================
+
+export type OfferCandidate = {
+  key: string;
+  label: string;
+  logic: "% discount" | "flat discount" | "BOGO";
+  voucher_template_id: string;
+  message: string;
+};
+
+// The explorable offer space. Extend freely — every new voucher_template added
+// here becomes a candidate the optimizer can test. Round-robin diversity +
+// least-tested-first selection means new entries get explored automatically.
+export const OFFER_CANDIDATES: OfferCandidate[] = [
+  { key: "pct10_min25", label: "10% off RM25+", logic: "% discount", voucher_template_id: "a0000010-0000-4000-8000-000000000010", message: "We miss you at Celsius! Enjoy 10% off when you spend RM25+. Tap to use — valid 14 days." },
+  { key: "pct15_min40", label: "15% off RM40+", logic: "% discount", voucher_template_id: "eb47fd73-42ab-4eb6-ade4-a12f96912d00", message: "We miss you at Celsius! Enjoy 15% off when you spend RM40+. Tap to use — valid 14 days." },
+  { key: "pct20_min40", label: "20% off RM40+", logic: "% discount", voucher_template_id: "a0000020-0000-4000-8000-000000000020", message: "We miss you at Celsius! Enjoy 20% off when you spend RM40+ (max RM12). Tap to use — valid 14 days." },
+  { key: "flat5_min25", label: "RM5 off RM25+", logic: "flat discount", voucher_template_id: "a0000005-0000-4000-8000-000000000005", message: "We miss you at Celsius! Here's RM5 off your next RM25+ order. Tap to use — valid 14 days." },
+  { key: "flat10_min30", label: "RM10 off RM30+", logic: "flat discount", voucher_template_id: "02ca62f1-171d-41d2-b6d6-9ca2d67ca3b9", message: "We miss you at Celsius! Here's RM10 off your next RM30+ order. Tap to use — valid 14 days." },
+  { key: "flat15_min50", label: "RM15 off RM50+", logic: "flat discount", voucher_template_id: "3c0288b5-51db-4e82-a583-6ed1dbc351b5", message: "We miss you at Celsius! Here's RM15 off your next RM50+ order. Tap to use — valid 14 days." },
+  { key: "b1f1_drinks", label: "Buy 1 Free 1 drinks", logic: "BOGO", voucher_template_id: "ed33eb26-4ead-414d-b1ee-179999a33940", message: "We miss you at Celsius! Buy 1 Free 1 on any drink — bring a friend! Valid 30 days." },
+];
+
+function toArmDef(c: OfferCandidate): ArmDef {
+  return { key: c.key, label: c.label, voucher_template_id: c.voucher_template_id, message: c.message };
+}
+
+type StoredArm = { key: string; label: string; voucher_template_id: string; message: string };
+type StoredStat = {
+  arm: string; n: number; lift_pp: number; revenue_per_recipient_rm: number;
+};
+
+export type LeaderboardEntry = {
+  template_id: string;
+  key: string | null;
+  label: string;
+  logic: string | null;
+  rounds: number;
+  recipients: number;
+  avg_lift_pp: number;
+  incr_margin_per_recipient_rm: number;
+  cum_incr_margin_rm: number;
+};
+
+// Aggregate every MEASURED round into a per-offer leaderboard. Incremental
+// margin is measured against each round's OWN holdout, then pooled across
+// rounds (recipient-weighted) so a champion only emerges with real evidence.
+export async function getLeaderboard(): Promise<LeaderboardEntry[]> {
+  const { data: rounds } = await supabaseAdmin
+    .from("loop_rounds")
+    .select("arms, stats, holdout_pct")
+    .eq("loop_key", "winback")
+    .eq("status", "measured");
+
+  type Agg = { label: string; key: string | null; logic: string | null; n: number; liftW: number; incrMargin: number; rounds: number };
+  const agg = new Map<string, Agg>();
+
+  for (const r of (rounds ?? []) as Array<{ arms: StoredArm[] | null; stats: StoredStat[] | null }>) {
+    const stats = r.stats; const arms = r.arms;
+    if (!stats || !arms) continue;
+    const holdout = stats.find((s) => s.arm === "holdout");
+    const baseRev = holdout?.revenue_per_recipient_rm ?? 0;
+    for (const s of stats) {
+      if (s.arm === "holdout") continue;
+      const arm = arms.find((a) => a.key === s.arm);
+      if (!arm) continue;
+      const tid = arm.voucher_template_id;
+      const cand = OFFER_CANDIDATES.find((c) => c.voucher_template_id === tid);
+      const incrMargin = (s.revenue_per_recipient_rm - baseRev) * s.n * GP;
+      const e = agg.get(tid) ?? { label: cand?.label ?? arm.label, key: cand?.key ?? null, logic: cand?.logic ?? null, n: 0, liftW: 0, incrMargin: 0, rounds: 0 };
+      e.n += s.n; e.liftW += s.lift_pp * s.n; e.incrMargin += incrMargin; e.rounds += 1;
+      agg.set(tid, e);
+    }
+  }
+
+  const out: LeaderboardEntry[] = [...agg.entries()].map(([tid, e]) => ({
+    template_id: tid, key: e.key, label: e.label, logic: e.logic, rounds: e.rounds,
+    recipients: e.n,
+    avg_lift_pp: +(e.liftW / Math.max(1, e.n)).toFixed(1),
+    incr_margin_per_recipient_rm: +(e.incrMargin / Math.max(1, e.n)).toFixed(2),
+    cum_incr_margin_rm: +e.incrMargin.toFixed(2),
+  }));
+  out.sort((a, b) => b.incr_margin_per_recipient_rm - a.incr_margin_per_recipient_rm);
+  return out;
+}
+
+export type ProposalArm = ArmDef & { role: "champion" | "challenger"; reason: string };
+export type Proposal = { arms: ProposalArm[] };
+
+// Minimum cumulative recipients before an offer can be crowned champion —
+// guards against declaring a winner off noise from a tiny first round.
+const CHAMPION_MIN_RECIPIENTS = 300;
+
+// Pick the next round's arms: champion (best proven offer) + challengers
+// (least-tested first, diverse logic) so the search never stalls.
+export async function proposeArms(opts?: { count?: number }): Promise<Proposal> {
+  const count = Math.max(1, opts?.count ?? 3); // champion + 2 challengers
+  const lb = await getLeaderboard();
+  const byTemplate = new Map(lb.map((e) => [e.template_id, e]));
+
+  const chosen: ProposalArm[] = [];
+  const usedTemplates = new Set<string>();
+  const usedLogics = new Set<string>();
+
+  // champion: best incremental margin/recipient with enough evidence
+  const champ = lb.find((e) => e.recipients >= CHAMPION_MIN_RECIPIENTS);
+  if (champ) {
+    const cand = OFFER_CANDIDATES.find((c) => c.voucher_template_id === champ.template_id);
+    if (cand) {
+      const sign = champ.incr_margin_per_recipient_rm >= 0 ? "+" : "";
+      chosen.push({ ...toArmDef(cand), role: "champion", reason: `Best so far: ${sign}RM${champ.incr_margin_per_recipient_rm}/recipient, ${sign}${champ.avg_lift_pp}pp over ${champ.recipients.toLocaleString()} sent (${champ.rounds} ${champ.rounds === 1 ? "round" : "rounds"}).` });
+      usedTemplates.add(cand.voucher_template_id);
+      usedLogics.add(cand.logic);
+    }
+  }
+
+  // challengers: least-tested first, preferring an untested logic for spread.
+  const pool = OFFER_CANDIDATES
+    .filter((c) => !usedTemplates.has(c.voucher_template_id))
+    .sort((a, b) => (byTemplate.get(a.voucher_template_id)?.recipients ?? 0) - (byTemplate.get(b.voucher_template_id)?.recipients ?? 0));
+
+  const addChallenger = (c: OfferCandidate) => {
+    const seen = byTemplate.get(c.voucher_template_id);
+    const reason = seen
+      ? `Re-test — ${seen.recipients.toLocaleString()} sent so far, ${seen.avg_lift_pp >= 0 ? "+" : ""}${seen.avg_lift_pp}pp.`
+      : "New logic — never tested yet.";
+    chosen.push({ ...toArmDef(c), role: "challenger", reason });
+    usedTemplates.add(c.voucher_template_id);
+    usedLogics.add(c.logic);
+  };
+
+  // pass 1: diversify logic
+  for (const c of pool) {
+    if (chosen.length >= count) break;
+    if (!usedLogics.has(c.logic)) addChallenger(c);
+  }
+  // pass 2: fill remaining slots regardless of logic
+  for (const c of pool) {
+    if (chosen.length >= count) break;
+    if (!usedTemplates.has(c.voucher_template_id)) addChallenger(c);
+  }
+
+  return { arms: chosen.slice(0, count) };
 }


### PR DESCRIPTION
Replaces the frozen 3-arm template with a **self-improving loop** — engine proposes each round, learns which offer logic wins.

- **loop-engine**: `OFFER_CANDIDATES` (grid: logic × value × threshold), `getLeaderboard()` (pools every measured round's incremental margin per offer vs that round's holdout — learns over time), `proposeArms()` (champion = best proven ≥300 recipients + challengers = least-tested, logic-diverse). 3 new offer-space templates seeded in DB.
- **`/api/loyalty/loops/optimizer`** → `{leaderboard, proposal, candidates}`.
- **prepare route**: no-arms fallback calls `proposeArms()`, never a hardcoded list.
- **dashboard**: Optimizer panel (leaderboard + champion) + New-round form seeded by the proposal (champion/challenger badges + reasons), arms swappable/editable. Approve-gated send unchanged.

Typecheck clean. Backoffice only. (Supersedes #424, which a concurrent branch-switch corrupted.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)