### PR TITLE
Loops Phase A: every campaign objective is a loop

### DIFF
--- a/apps/backoffice/src/app/(admin)/loyalty/loops/page.tsx
+++ b/apps/backoffice/src/app/(admin)/loyalty/loops/page.tsx
@@ -51,7 +51,8 @@ type LeaderboardEntry = {
   rounds: number; recipients: number; avg_lift_pp: number;
   incr_margin_per_recipient_rm: number; cum_incr_margin_rm: number;
 };
-type Optimizer = { leaderboard: LeaderboardEntry[]; proposal: { arms: ProposalArm[] }; candidates: Candidate[] };
+type LoopMeta = { key: string; label: string; objective: string; defaultHoldoutPct: number; defaultWindowDays: number };
+type Optimizer = { loop_key: string; leaderboard: LeaderboardEntry[]; proposal: { arms: ProposalArm[] }; candidates: Candidate[]; loops: LoopMeta[] };
 
 const CHAMPION_MIN_RECIPIENTS = 300;
 
@@ -92,12 +93,14 @@ export default function LoopsPage() {
   const [err, setErr] = useState<string | null>(null);
   const [busy, setBusy] = useState<string | null>(null);
   const [lastPreview, setLastPreview] = useState<Preview | null>(null);
+  const [loopKey, setLoopKey] = useState("winback");
 
   const load = useCallback(async () => {
     try {
+      const qs = `?loop_key=${encodeURIComponent(loopKey)}`;
       const [rRes, oRes] = await Promise.all([
-        fetch("/api/loyalty/loops"),
-        fetch("/api/loyalty/loops/optimizer"),
+        fetch(`/api/loyalty/loops${qs}`),
+        fetch(`/api/loyalty/loops/optimizer${qs}`),
       ]);
       if (!rRes.ok) throw new Error(`list failed (${rRes.status})`);
       setRounds((await rRes.json()) as Round[]);
@@ -106,8 +109,8 @@ export default function LoopsPage() {
     } catch (e) {
       setErr(e instanceof Error ? e.message : "Failed to load");
     }
-  }, []);
-  useEffect(() => { void load(); }, [load]);
+  }, [loopKey]);
+  useEffect(() => { setRounds(null); setOpt(null); setLastPreview(null); void load(); }, [load]);
 
   return (
     <div className="mx-auto max-w-5xl px-4 py-6">
@@ -120,8 +123,23 @@ export default function LoopsPage() {
         <h1 className="text-2xl font-semibold">Win-back loops</h1>
       </div>
       <p className="mb-4 text-sm text-gray-500">
-        Re-activate lapsed customers, measured honestly against a holdout. The engine proposes each round&apos;s offers and learns which logic wins — the setup sharpens over time.
+        Every campaign is a loop: the engine proposes each round&apos;s offers against a holdout and learns which logic wins — the setup sharpens over time. Pick an objective:
       </p>
+
+      {opt && (
+        <div className="mb-4 flex flex-wrap gap-2">
+          {opt.loops.map((l) => (
+            <button
+              key={l.key}
+              onClick={() => setLoopKey(l.key)}
+              title={l.objective}
+              className={cn("rounded-full border px-3 py-1.5 text-sm", loopKey === l.key ? "border-[#A2492C] bg-[#A2492C] text-white" : "border-gray-200 bg-white text-gray-600 hover:border-gray-300")}
+            >
+              {l.label}
+            </button>
+          ))}
+        </div>
+      )}
 
       <div className="mb-6 flex flex-wrap gap-x-6 gap-y-1 rounded-lg border border-gray-200 bg-gray-50 px-4 py-3 text-sm">
         <span><span className="text-gray-500">SMS budget</span> <strong>set per round</strong> (start {rm(DEFAULT_BUDGET_RM)}, scale up)</span>
@@ -140,6 +158,9 @@ export default function LoopsPage() {
 
       {opt ? (
         <NewRoundCard
+          key={loopKey}
+          loopKey={loopKey}
+          loopMeta={opt.loops.find((l) => l.key === loopKey)}
           proposal={opt.proposal.arms}
           candidates={opt.candidates}
           busy={busy === "prepare"}
@@ -287,19 +308,31 @@ function OptimizerPanel({ opt }: { opt: Optimizer }) {
 // ---- New round (seeded by the optimizer's proposal) -------------------------
 type FormArm = { key: string; label: string; voucher_template_id: string; message: string; role: "champion" | "challenger"; reason: string };
 
-function NewRoundCard({ proposal, candidates, busy, onPrepare }: {
-  proposal: ProposalArm[]; candidates: Candidate[]; busy: boolean; onPrepare: (p: unknown) => void;
+function NewRoundCard({ loopKey, loopMeta, proposal, candidates, busy, onPrepare }: {
+  loopKey: string; loopMeta?: LoopMeta; proposal: ProposalArm[]; candidates: Candidate[]; busy: boolean; onPrepare: (p: unknown) => void;
 }) {
   const [minD, setMinD] = useState(30);
   const [maxD, setMaxD] = useState(60);
-  const [holdout, setHoldout] = useState(20);
-  const [windowD, setWindowD] = useState(7);
+  const [joinedD, setJoinedD] = useState(30);
+  const [bdayD, setBdayD] = useState(14);
+  const [outletId, setOutletId] = useState("");
+  const [activeD, setActiveD] = useState(45);
+  const [holdout, setHoldout] = useState(loopMeta?.defaultHoldoutPct ?? 20);
+  const [windowD, setWindowD] = useState(loopMeta?.defaultWindowDays ?? 7);
   const [budget, setBudget] = useState(DEFAULT_BUDGET_RM);
   const [arms, setArms] = useState<FormArm[]>(proposal.map((a) => ({ ...a })));
 
   const logicOf = (tid: string) => candidates.find((c) => c.voucher_template_id === tid)?.logic ?? "—";
   const maxSms = Math.max(0, Math.floor(budget / SMS_COST_RM));
   const maxRecipients = Math.floor(maxSms / Math.max(0.01, 1 - holdout / 100));
+  const segmentOpts = (): Record<string, unknown> => {
+    switch (loopKey) {
+      case "welcome": return { joinedWithinDays: joinedD };
+      case "birthday": return { birthdayWithinDays: bdayD };
+      case "round_gap": return { outletId, activeWithinDays: activeD };
+      default: return { minDaysLapsed: minD, maxDaysLapsed: maxD };
+    }
+  };
 
   const swapArm = (i: number, tid: string) => {
     const c = candidates.find((x) => x.voucher_template_id === tid);
@@ -321,14 +354,22 @@ function NewRoundCard({ proposal, candidates, busy, onPrepare }: {
       </div>
 
       <div className="mb-2 grid grid-cols-2 gap-4 sm:grid-cols-5">
-        <Field label="Lapsed from (days)"><NumInput v={minD} set={setMinD} /></Field>
-        <Field label="Lapsed to (days)"><NumInput v={maxD} set={setMaxD} /></Field>
+        {loopKey === "winback" && (<>
+          <Field label="Lapsed from (days)"><NumInput v={minD} set={setMinD} /></Field>
+          <Field label="Lapsed to (days)"><NumInput v={maxD} set={setMaxD} /></Field>
+        </>)}
+        {loopKey === "welcome" && <Field label="Joined within (days)"><NumInput v={joinedD} set={setJoinedD} /></Field>}
+        {loopKey === "birthday" && <Field label="Birthday within (days)"><NumInput v={bdayD} set={setBdayD} /></Field>}
+        {loopKey === "round_gap" && (<>
+          <Field label="Outlet ID"><input value={outletId} onChange={(e) => setOutletId(e.target.value)} placeholder="outlet uuid" className="w-full rounded-md border border-gray-200 px-3 py-2 text-sm" /></Field>
+          <Field label="Active within (days)"><NumInput v={activeD} set={setActiveD} /></Field>
+        </>)}
         <Field label="Holdout %"><NumInput v={holdout} set={setHoldout} /></Field>
         <Field label="Attribution window (days)"><NumInput v={windowD} set={setWindowD} /></Field>
         <Field label="SMS budget (RM)"><NumInput v={budget} set={setBudget} /></Field>
       </div>
       <p className="mb-4 text-xs text-gray-500">
-        Budget {rm(budget)} → up to <strong>{maxSms.toLocaleString()}</strong> SMS (~{maxRecipients.toLocaleString()} reached incl. holdout). Caps the round if the lapsed segment is larger. Scale later by raising the budget.
+        Budget {rm(budget)} → up to <strong>{maxSms.toLocaleString()}</strong> SMS (~{maxRecipients.toLocaleString()} reached incl. holdout). Caps the round if the segment is larger. Scale later by raising the budget.
       </p>
 
       <div className="mb-2 flex items-center justify-between">
@@ -366,8 +407,10 @@ function NewRoundCard({ proposal, candidates, busy, onPrepare }: {
       <button
         disabled={busy || arms.length === 0}
         onClick={() => onPrepare({
+          loop_key: loopKey,
           arms: arms.map((a) => ({ key: a.key, label: a.label, voucher_template_id: a.voucher_template_id, message: a.message })),
-          holdoutPct: holdout, minDaysLapsed: minD, maxDaysLapsed: maxD, attributionWindowDays: windowD, maxRecipients,
+          holdoutPct: holdout, attributionWindowDays: windowD, maxRecipients,
+          segment: segmentOpts(),
         })}
         className="mt-4 inline-flex items-center gap-2 rounded-lg bg-[#A2492C] px-4 py-2 text-sm font-medium text-white disabled:opacity-50"
       >

--- a/apps/backoffice/src/app/api/loyalty/loops/optimizer/route.ts
+++ b/apps/backoffice/src/app/api/loyalty/loops/optimizer/route.ts
@@ -1,17 +1,23 @@
 import { NextRequest, NextResponse } from "next/server";
 import { requireAuth } from "@/lib/auth";
-import { getLeaderboard, proposeArms, OFFER_CANDIDATES } from "@/lib/loyalty/loop-engine";
+import { getLeaderboard, proposeArms, OFFER_CANDIDATES, LOOPS, type LoopKey } from "@/lib/loyalty/loop-engine";
 
-// GET /api/loyalty/loops/optimizer — the adaptive layer for the dashboard:
+// GET /api/loyalty/loops/optimizer?loop_key= — the adaptive layer per loop:
 //   - leaderboard: every offer ranked by cumulative incremental margin (learns over time)
 //   - proposal:    the next round's champion + challengers (engine's suggestion)
-//   - candidates:  the full offer space, so the operator can swap an arm
+//   - candidates:  this loop's offer subset, so the operator can swap an arm
+//   - loops:       the registry, so the dashboard can render the objective selector
 export async function GET(request: NextRequest) {
   const auth = await requireAuth(request);
   if (auth.error) return auth.error;
   try {
-    const [leaderboard, proposal] = await Promise.all([getLeaderboard(), proposeArms()]);
-    return NextResponse.json({ leaderboard, proposal, candidates: OFFER_CANDIDATES });
+    const loopKey = (new URL(request.url).searchParams.get("loop_key") ?? "winback") as LoopKey;
+    const def = LOOPS[loopKey];
+    if (!def) return NextResponse.json({ error: `unknown loop: ${loopKey}` }, { status: 400 });
+    const [leaderboard, proposal] = await Promise.all([getLeaderboard(loopKey), proposeArms(loopKey)]);
+    const candidates = OFFER_CANDIDATES.filter((c) => def.candidateKeys.includes(c.key));
+    const loops = Object.values(LOOPS).map((l) => ({ key: l.key, label: l.label, objective: l.objective, defaultHoldoutPct: l.defaultHoldoutPct, defaultWindowDays: l.defaultWindowDays }));
+    return NextResponse.json({ loop_key: loopKey, leaderboard, proposal, candidates, loops });
   } catch (err) {
     const msg = err instanceof Error ? err.message : "Failed to load optimizer";
     return NextResponse.json({ error: msg }, { status: 500 });

--- a/apps/backoffice/src/app/api/loyalty/loops/prepare/route.ts
+++ b/apps/backoffice/src/app/api/loyalty/loops/prepare/route.ts
@@ -1,28 +1,29 @@
 import { NextRequest, NextResponse } from "next/server";
 import { requireAuth } from "@/lib/auth";
-import { prepareWinbackRound, proposeArms, type ArmDef } from "@/lib/loyalty/loop-engine";
+import { prepareRound, proposeArms, type ArmDef, type LoopKey } from "@/lib/loyalty/loop-engine";
 
-// POST /api/loyalty/loops/prepare — build a Win Back round (segment + holdout +
+// POST /api/loyalty/loops/prepare — build a loop round (segment + holdout +
 // arms + auto-issue rewards). Returns a preview for approval. NO SMS sent yet.
-// Arms come from the request body (the dashboard sends the approved set); when
+// loop_key selects the objective (winback/welcome/birthday/round_gap). Arms
+// come from the request body (the dashboard sends the approved set); when
 // omitted, the optimizer proposes them (champion + challengers) — never a frozen
-// template list.
+// template list. segment carries the loop-specific audience controls.
 export async function POST(request: NextRequest) {
   const auth = await requireAuth(request);
   if (auth.error) return auth.error;
   try {
     const body = await request.json().catch(() => ({}));
+    const loopKey: LoopKey = body.loop_key ?? "winback";
     const arms: ArmDef[] = Array.isArray(body.arms) && body.arms.length
       ? body.arms
-      : (await proposeArms()).arms.map((a) => ({ key: a.key, label: a.label, voucher_template_id: a.voucher_template_id, message: a.message }));
-    const preview = await prepareWinbackRound({
+      : (await proposeArms(loopKey)).arms.map((a) => ({ key: a.key, label: a.label, voucher_template_id: a.voucher_template_id, message: a.message }));
+    const preview = await prepareRound(loopKey, {
       arms,
       holdoutPct: body.holdoutPct,
-      minDaysLapsed: body.minDaysLapsed,
-      maxDaysLapsed: body.maxDaysLapsed,
       attributionWindowDays: body.attributionWindowDays,
       suppressPhones: body.suppressPhones,
       maxRecipients: body.maxRecipients,
+      segment: body.segment,
       createdBy: auth.user?.id,
     });
     return NextResponse.json(preview);

--- a/apps/backoffice/src/app/api/loyalty/loops/route.ts
+++ b/apps/backoffice/src/app/api/loyalty/loops/route.ts
@@ -2,17 +2,21 @@ import { NextRequest, NextResponse } from "next/server";
 import { requireAuth } from "@/lib/auth";
 import { supabaseAdmin } from "@/lib/loyalty/supabase";
 
-// GET /api/loyalty/loops — list loop rounds (newest first) with their per-arm
-// stats (populated once measured). Powers the backoffice loop dashboard.
+// GET /api/loyalty/loops?loop_key= — list loop rounds (newest first) with their
+// per-arm stats (populated once measured). Filtered by objective when loop_key
+// is given. Powers the backoffice loop dashboard.
 export async function GET(request: NextRequest) {
   const auth = await requireAuth(request);
   if (auth.error) return auth.error;
   try {
-    const { data, error } = await supabaseAdmin
+    const loopKey = new URL(request.url).searchParams.get("loop_key");
+    let query = supabaseAdmin
       .from("loop_rounds")
       .select("*")
       .order("prepared_at", { ascending: false })
       .limit(50);
+    if (loopKey) query = query.eq("loop_key", loopKey);
+    const { data, error } = await query;
     if (error) return NextResponse.json({ error: error.message }, { status: 500 });
     return NextResponse.json(data ?? []);
   } catch (err) {

--- a/apps/backoffice/src/lib/loyalty/loop-engine.ts
+++ b/apps/backoffice/src/lib/loyalty/loop-engine.ts
@@ -31,29 +31,83 @@ function rid(prefix: string): string {
   return `${prefix}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
 }
 
-// ── Segment: lapsed members (last visit between min..max days ago) with a phone.
-async function lapsedSegment(minDays: number, maxDays: number): Promise<SegmentRow[]> {
-  const sinceMax = new Date(Date.now() - maxDays * 86400000).toISOString();
-  const sinceMin = new Date(Date.now() - minDays * 86400000).toISOString();
+// Segment inputs — each loop reads the few it needs (see LOOPS below).
+export type SegmentOpts = {
+  minDaysLapsed?: number; maxDaysLapsed?: number;   // winback
+  joinedWithinDays?: number;                        // welcome
+  birthdayWithinDays?: number;                      // birthday
+  outletId?: string; activeWithinDays?: number;     // round_gap
+};
 
-  const { data, error } = await supabaseAdmin
-    .from("member_brands")
-    .select("member_id, members!inner(id, phone, name)")
-    .eq("brand_id", BRAND)
-    .gte("last_visit_at", sinceMax)
-    .lt("last_visit_at", sinceMin);
-  if (error) throw new Error(`segment query: ${error.message}`);
+type MemberRow = { id: string; phone: string | null; name: string | null; sms_opt_out: boolean | null; birthday: string | null; preferred_outlet_id: string | null };
+const MEMBER_SELECT = "member_id, members!inner(id, phone, name, sms_opt_out, birthday, preferred_outlet_id)";
 
-  const rows: SegmentRow[] = [];
+// Dedupe by phone, drop unreachable + PDPA opt-outs, apply an optional predicate.
+function reachable(rows: Array<{ member_id: string; members: MemberRow | null }>, pred?: (m: MemberRow) => boolean): SegmentRow[] {
+  const out: SegmentRow[] = [];
   const seen = new Set<string>();
-  for (const r of (data ?? []) as unknown as Array<{ member_id: string; members: { id: string; phone: string | null; name: string | null } }>) {
-    const phone = (r.members?.phone ?? "").trim();
-    if (!phone) continue; // unreachable
-    if (seen.has(phone)) continue; // dedupe by phone
+  for (const r of rows) {
+    const m = r.members;
+    if (!m) continue;
+    if (m.sms_opt_out === true) continue;          // PDPA: never message opt-outs
+    const phone = (m.phone ?? "").trim();
+    if (!phone || seen.has(phone)) continue;
+    if (pred && !pred(m)) continue;
     seen.add(phone);
-    rows.push({ member_id: r.member_id, phone, name: r.members?.name ?? null });
+    out.push({ member_id: r.member_id, phone, name: m.name ?? null });
   }
-  return rows;
+  return out;
+}
+
+function daysUntilBirthday(iso: string): number {
+  const d = new Date(iso);
+  const now = new Date(Date.now());
+  const y = now.getUTCFullYear();
+  let next = new Date(Date.UTC(y, d.getUTCMonth(), d.getUTCDate()));
+  if (next.getTime() < now.getTime()) next = new Date(Date.UTC(y + 1, d.getUTCMonth(), d.getUTCDate()));
+  return Math.ceil((next.getTime() - now.getTime()) / 86400000);
+}
+
+// ── Reactivation: lapsed members (last visit between min..max days ago).
+async function winbackSegment(o: SegmentOpts): Promise<{ rows: SegmentRow[]; label: string }> {
+  const minD = o.minDaysLapsed ?? 30, maxD = o.maxDaysLapsed ?? 60;
+  const sinceMax = new Date(Date.now() - maxD * 86400000).toISOString();
+  const sinceMin = new Date(Date.now() - minD * 86400000).toISOString();
+  const { data, error } = await supabaseAdmin.from("member_brands").select(MEMBER_SELECT)
+    .eq("brand_id", BRAND).gte("last_visit_at", sinceMax).lt("last_visit_at", sinceMin);
+  if (error) throw new Error(`winback segment: ${error.message}`);
+  return { rows: reachable((data ?? []) as unknown as Array<{ member_id: string; members: MemberRow | null }>), label: `Lapsed ${minD}–${maxD}d` };
+}
+
+// ── Welcome: members with a single visit, joined within N days (1st → 2nd).
+async function welcomeSegment(o: SegmentOpts): Promise<{ rows: SegmentRow[]; label: string }> {
+  const days = o.joinedWithinDays ?? 30;
+  const since = new Date(Date.now() - days * 86400000).toISOString();
+  const { data, error } = await supabaseAdmin.from("member_brands").select(MEMBER_SELECT)
+    .eq("brand_id", BRAND).eq("total_visits", 1).gte("joined_at", since);
+  if (error) throw new Error(`welcome segment: ${error.message}`);
+  return { rows: reachable((data ?? []) as unknown as Array<{ member_id: string; members: MemberRow | null }>), label: `New members · 1 visit, joined ≤${days}d` };
+}
+
+// ── Birthday: members whose birthday falls within the next K days.
+async function birthdaySegment(o: SegmentOpts): Promise<{ rows: SegmentRow[]; label: string }> {
+  const k = o.birthdayWithinDays ?? 14;
+  const { data, error } = await supabaseAdmin.from("member_brands").select(MEMBER_SELECT).eq("brand_id", BRAND);
+  if (error) throw new Error(`birthday segment: ${error.message}`);
+  const rows = reachable((data ?? []) as unknown as Array<{ member_id: string; members: MemberRow | null }>, (m) => !!m.birthday && daysUntilBirthday(m.birthday) <= k);
+  return { rows, label: `Birthdays in next ${k}d` };
+}
+
+// ── Weekly round-gap: active customers of one outlet (nudge to a weak round).
+async function roundGapSegment(o: SegmentOpts): Promise<{ rows: SegmentRow[]; label: string }> {
+  if (!o.outletId) throw new Error("round_gap needs an outletId");
+  const days = o.activeWithinDays ?? 45;
+  const since = new Date(Date.now() - days * 86400000).toISOString();
+  const { data, error } = await supabaseAdmin.from("member_brands").select(MEMBER_SELECT)
+    .eq("brand_id", BRAND).gte("last_visit_at", since);
+  if (error) throw new Error(`round_gap segment: ${error.message}`);
+  const rows = reachable((data ?? []) as unknown as Array<{ member_id: string; members: MemberRow | null }>, (m) => m.preferred_outlet_id === o.outletId);
+  return { rows, label: `Outlet actives ≤${days}d` };
 }
 
 // Fisher–Yates with a seeded-ish shuffle (index-varied; Math.random is fine here).
@@ -112,26 +166,25 @@ async function issueReward(memberId: string, templateId: string, roundId: string
 // ── PREPARE ─────────────────────────────────────────────────────────────────
 // Builds the round: segment → holdout + arm split → issue rewards for treatment
 // → log every assignment. Returns a preview for owner approval. No SMS sent.
-export async function prepareWinbackRound(opts: {
+export async function prepareRound(loopKey: LoopKey, opts: {
   arms: ArmDef[];
   holdoutPct?: number;
-  minDaysLapsed?: number;
-  maxDaysLapsed?: number;
   attributionWindowDays?: number;
   createdBy?: string;
   suppressPhones?: string[]; // PDPA opt-outs / recent contacts
   maxRecipients?: number; // cap total segment size to fit an SMS budget (start small, scale later)
+  segment?: SegmentOpts; // loop-specific audience controls
 }) {
-  const holdoutPct = opts.holdoutPct ?? 20;
-  const minD = opts.minDaysLapsed ?? 30;
-  const maxD = opts.maxDaysLapsed ?? 60;
-  const windowDays = opts.attributionWindowDays ?? 7;
+  const def = LOOPS[loopKey];
+  if (!def) throw new Error(`unknown loop: ${loopKey}`);
+  const holdoutPct = opts.holdoutPct ?? def.defaultHoldoutPct;
+  const windowDays = opts.attributionWindowDays ?? def.defaultWindowDays;
   const arms = opts.arms;
   if (!arms.length) throw new Error("at least one arm required");
 
   const suppress = new Set((opts.suppressPhones ?? []).map((p) => p.trim()));
-  let segment = await lapsedSegment(minD, maxD);
-  segment = segment.filter((m) => !suppress.has(m.phone));
+  const seg = await def.segment(opts.segment ?? {});
+  let segment = seg.rows.filter((m) => !suppress.has(m.phone));
   segment = shuffle(segment);
   // Budget cap — take the first N of the shuffled (random) segment so the
   // SMS spend stays within the chosen budget. Scaling later = raise the cap.
@@ -143,7 +196,7 @@ export async function prepareWinbackRound(opts: {
   const { data: last } = await supabaseAdmin
     .from("loop_rounds")
     .select("round_no")
-    .eq("loop_key", "winback")
+    .eq("loop_key", loopKey)
     .order("round_no", { ascending: false })
     .limit(1)
     .maybeSingle();
@@ -155,12 +208,12 @@ export async function prepareWinbackRound(opts: {
   const holdout = segment.slice(0, holdoutN);
   const treatment = segment.slice(holdoutN);
 
-  const segmentLabel = `Lapsed ${minD}–${maxD}d (${segment.length} reachable, ${holdoutPct}% holdout)${capped ? ` · budget-capped from ${rawReach}` : ""}`;
+  const segmentLabel = `${seg.label} (${segment.length} reachable, ${holdoutPct}% holdout)${capped ? ` · budget-capped from ${rawReach}` : ""}`;
 
   await supabaseAdmin.from("loop_rounds").insert({
     id: roundId,
     brand_id: BRAND,
-    loop_key: "winback",
+    loop_key: loopKey,
     round_no: roundNo,
     segment_label: segmentLabel,
     holdout_pct: holdoutPct,
@@ -339,7 +392,7 @@ export async function measureRound(roundId: string) {
 export type OfferCandidate = {
   key: string;
   label: string;
-  logic: "% discount" | "flat discount" | "BOGO";
+  logic: "% discount" | "flat discount" | "BOGO" | "free item";
   voucher_template_id: string;
   message: string;
 };
@@ -355,7 +408,29 @@ export const OFFER_CANDIDATES: OfferCandidate[] = [
   { key: "flat10_min30", label: "RM10 off RM30+", logic: "flat discount", voucher_template_id: "02ca62f1-171d-41d2-b6d6-9ca2d67ca3b9", message: "We miss you at Celsius! Here's RM10 off your next RM30+ order. Tap to use — valid 14 days." },
   { key: "flat15_min50", label: "RM15 off RM50+", logic: "flat discount", voucher_template_id: "3c0288b5-51db-4e82-a583-6ed1dbc351b5", message: "We miss you at Celsius! Here's RM15 off your next RM50+ order. Tap to use — valid 14 days." },
   { key: "b1f1_drinks", label: "Buy 1 Free 1 drinks", logic: "BOGO", voucher_template_id: "ed33eb26-4ead-414d-b1ee-179999a33940", message: "We miss you at Celsius! Buy 1 Free 1 on any drink — bring a friend! Valid 30 days." },
+  { key: "free_drink", label: "Free Tea", logic: "free item", voucher_template_id: "1b9a465a-8411-4299-a2e2-8034f2b0ea45", message: "Happy birthday from Celsius! Your free tea is on us — enjoy. Valid 14 days." },
 ];
+
+// ── Loop registry: each campaign objective is a loop. Same machinery
+// (holdout → optimise offers → auto-issue voucher → measure lift), different
+// audience + candidate subset. Add a loop here and it inherits the whole engine.
+export type LoopKey = "winback" | "welcome" | "birthday" | "round_gap";
+export type LoopDef = {
+  key: LoopKey;
+  label: string;
+  objective: string;
+  defaultHoldoutPct: number;
+  defaultWindowDays: number;
+  candidateKeys: string[]; // which OFFER_CANDIDATES this loop explores
+  segment: (o: SegmentOpts) => Promise<{ rows: SegmentRow[]; label: string }>;
+};
+
+export const LOOPS: Record<LoopKey, LoopDef> = {
+  winback: { key: "winback", label: "Reactivation", objective: "Win back lapsed customers", defaultHoldoutPct: 20, defaultWindowDays: 7, candidateKeys: ["pct10_min25", "pct15_min40", "pct20_min40", "flat5_min25", "flat10_min30", "flat15_min50", "b1f1_drinks"], segment: winbackSegment },
+  welcome: { key: "welcome", label: "Welcome", objective: "Turn the 1st visit into a 2nd", defaultHoldoutPct: 20, defaultWindowDays: 14, candidateKeys: ["pct10_min25", "flat5_min25", "b1f1_drinks", "free_drink"], segment: welcomeSegment },
+  birthday: { key: "birthday", label: "Birthday", objective: "Bring members in on their birthday", defaultHoldoutPct: 15, defaultWindowDays: 14, candidateKeys: ["free_drink", "b1f1_drinks", "pct20_min40"], segment: birthdaySegment },
+  round_gap: { key: "round_gap", label: "Weekly round-gap", objective: "Fill an underperforming day-part", defaultHoldoutPct: 20, defaultWindowDays: 7, candidateKeys: ["pct15_min40", "flat10_min30", "b1f1_drinks"], segment: roundGapSegment },
+};
 
 function toArmDef(c: OfferCandidate): ArmDef {
   return { key: c.key, label: c.label, voucher_template_id: c.voucher_template_id, message: c.message };
@@ -381,11 +456,11 @@ export type LeaderboardEntry = {
 // Aggregate every MEASURED round into a per-offer leaderboard. Incremental
 // margin is measured against each round's OWN holdout, then pooled across
 // rounds (recipient-weighted) so a champion only emerges with real evidence.
-export async function getLeaderboard(): Promise<LeaderboardEntry[]> {
+export async function getLeaderboard(loopKey: LoopKey = "winback"): Promise<LeaderboardEntry[]> {
   const { data: rounds } = await supabaseAdmin
     .from("loop_rounds")
     .select("arms, stats, holdout_pct")
-    .eq("loop_key", "winback")
+    .eq("loop_key", loopKey)
     .eq("status", "measured");
 
   type Agg = { label: string; key: string | null; logic: string | null; n: number; liftW: number; incrMargin: number; rounds: number };
@@ -429,19 +504,21 @@ const CHAMPION_MIN_RECIPIENTS = 300;
 
 // Pick the next round's arms: champion (best proven offer) + challengers
 // (least-tested first, diverse logic) so the search never stalls.
-export async function proposeArms(opts?: { count?: number }): Promise<Proposal> {
+export async function proposeArms(loopKey: LoopKey = "winback", opts?: { count?: number }): Promise<Proposal> {
   const count = Math.max(1, opts?.count ?? 3); // champion + 2 challengers
-  const lb = await getLeaderboard();
+  const lb = await getLeaderboard(loopKey);
   const byTemplate = new Map(lb.map((e) => [e.template_id, e]));
+  // explore only this loop's offer subset
+  const space = OFFER_CANDIDATES.filter((c) => LOOPS[loopKey].candidateKeys.includes(c.key));
 
   const chosen: ProposalArm[] = [];
   const usedTemplates = new Set<string>();
   const usedLogics = new Set<string>();
 
-  // champion: best incremental margin/recipient with enough evidence
-  const champ = lb.find((e) => e.recipients >= CHAMPION_MIN_RECIPIENTS);
+  // champion: best incremental margin/recipient with enough evidence (within this loop's space)
+  const champ = lb.find((e) => e.recipients >= CHAMPION_MIN_RECIPIENTS && space.some((c) => c.voucher_template_id === e.template_id));
   if (champ) {
-    const cand = OFFER_CANDIDATES.find((c) => c.voucher_template_id === champ.template_id);
+    const cand = space.find((c) => c.voucher_template_id === champ.template_id);
     if (cand) {
       const sign = champ.incr_margin_per_recipient_rm >= 0 ? "+" : "";
       chosen.push({ ...toArmDef(cand), role: "champion", reason: `Best so far: ${sign}RM${champ.incr_margin_per_recipient_rm}/recipient, ${sign}${champ.avg_lift_pp}pp over ${champ.recipients.toLocaleString()} sent (${champ.rounds} ${champ.rounds === 1 ? "round" : "rounds"}).` });
@@ -451,7 +528,7 @@ export async function proposeArms(opts?: { count?: number }): Promise<Proposal> 
   }
 
   // challengers: least-tested first, preferring an untested logic for spread.
-  const pool = OFFER_CANDIDATES
+  const pool = space
     .filter((c) => !usedTemplates.has(c.voucher_template_id))
     .sort((a, b) => (byTemplate.get(a.voucher_template_id)?.recipients ?? 0) - (byTemplate.get(b.voucher_template_id)?.recipients ?? 0));
 


### PR DESCRIPTION
Generalizes the engine from hardcoded win-back to a **loop registry** — each objective runs the same machinery (holdout → optimise offers → auto-issue voucher to phone → measure lift → tune) with its own audience.

- **LOOPS registry**: `winback` (Reactivation), `welcome` (1st→2nd), `birthday`, `round_gap` (weekly day-part) — each with its own segment + candidate subset.
- **Segments suppress `sms_opt_out` (PDPA)**: lapsed window · single-visit-joined-recently · upcoming-birthday · outlet-actives.
- `prepareWinbackRound` → `prepareRound(loopKey, {segment})`; `getLeaderboard`/`proposeArms` are loop-keyed (champion/challengers from the loop's offer subset). Free-drink candidate added for welcome/birthday.
- **Routes** take `loop_key` (prepare/optimizer/list); optimizer returns the loop registry for the UI.
- **Dashboard**: objective selector (tabs) + per-loop segment fields; optimizer panel/proposal/rounds are per-loop.

Approve-gated send unchanged. **Phase B** = send-time + scheduler cron; **Phase C** = retire the legacy preset-campaign UI. Typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)