### PR TITLE
Challenge nudge: holdout A/B (measure AOV/frequency lift)

### DIFF
--- a/apps/order/src/app/api/loyalty/me/cart-challenge/route.ts
+++ b/apps/order/src/app/api/loyalty/me/cart-challenge/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
-import { bestCartChallenge, type CartLine } from "@/lib/loyalty/cart-challenge";
+import { bestCartChallenge, resolveNudgeVariant, type CartLine } from "@/lib/loyalty/cart-challenge";
 
 // POST /api/loyalty/me/cart-challenge
 // Body: { member: loyaltyId, items: [{ product_id, quantity, total_sen }] }
@@ -22,6 +22,14 @@ export async function POST(req: NextRequest) {
           }))
       : [];
     const challenge = await bestCartChallenge(member, items);
+    // Holdout: a random slice of members never see the nudge so we can measure
+    // its incremental lift (treatment vs holdout AOV/completion). Only assign a
+    // variant once there's actually a nudge to withhold.
+    if (challenge && member) {
+      const variant = await resolveNudgeVariant(member);
+      if (variant === "holdout") return NextResponse.json({ challenge: null, variant });
+      return NextResponse.json({ challenge, variant });
+    }
     return NextResponse.json({ challenge });
   } catch (err) {
     console.error("[cart-challenge] route error:", err);

--- a/apps/order/src/lib/loyalty/cart-challenge.ts
+++ b/apps/order/src/lib/loyalty/cart-challenge.ts
@@ -2,6 +2,36 @@ import { getSupabaseAdmin } from "@/lib/supabase/server";
 import { CATEGORY_GROUPS } from "./v2";
 
 export type CartLine = { product_id: string; quantity: number; total_sen: number };
+export type NudgeVariant = "treatment" | "holdout";
+
+/**
+ * Member-level holdout for measuring the nudge's incremental lift. Reads the
+ * `challenge_nudge_holdout` flag ({enabled, pct}); assigns + stores a stable
+ * variant per member on first eligible cart moment (random by pct). Holdout
+ * members never see the nudge — the report compares their AOV/completion to
+ * treatment. Defaults to "treatment" when the flag is off (everyone sees it).
+ */
+export async function resolveNudgeVariant(memberId: string): Promise<NudgeVariant> {
+  try {
+    const supabase = getSupabaseAdmin();
+    const { data: flag } = await supabase
+      .from("app_settings").select("value").eq("key", "challenge_nudge_holdout").maybeSingle();
+    const cfg = (flag?.value ?? {}) as { enabled?: boolean; pct?: number };
+    if (!cfg.enabled) return "treatment";
+    const pct = Math.max(0, Math.min(100, Math.round(cfg.pct ?? 20)));
+    if (pct === 0) return "treatment";
+
+    const { data: row } = await supabase
+      .from("challenge_nudge_assignment").select("variant").eq("member_id", memberId).maybeSingle();
+    if (row?.variant === "treatment" || row?.variant === "holdout") return row.variant;
+
+    const variant: NudgeVariant = Math.random() * 100 < pct ? "holdout" : "treatment";
+    await supabase.from("challenge_nudge_assignment").insert({ member_id: memberId, variant });
+    return variant;
+  } catch {
+    return "treatment"; // never block the nudge on a measurement error
+  }
+}
 
 export type CartChallenge = {
   title: string;       // mission title (internal-ish, e.g. "Make it a Meal")

--- a/docs/design/challenge-nudge-measurement.md
+++ b/docs/design/challenge-nudge-measurement.md
@@ -1,0 +1,44 @@
+# Challenge cart-nudge — measurement (holdout A/B)
+
+Proves whether the cart AOV challenge nudge ("Spend RMx more to unlock …")
+actually lifts AOV/frequency, vs. members who'd have qualified anyway.
+
+## How it works
+- `challenge_nudge_holdout` flag in `app_settings`: `{enabled, pct}` (default
+  `{enabled:true, pct:20}`).
+- On a member's **first eligible cart moment** (there's a nudge to show), the
+  cart-challenge endpoint assigns a stable variant via `resolveNudgeVariant`
+  and stores it in `challenge_nudge_assignment` (random by `pct`).
+- **Holdout** members get `{challenge:null}` — they never see the nudge.
+- **Treatment** members see it. Both groups reached the same nudge-able cart, so
+  the only difference is the nudge → a clean A/B.
+- Turn it off once proven: set the flag `enabled:false` (or `pct:0`) → everyone
+  gets the nudge; assignments are kept for historical comparison.
+
+## Report (run in Supabase / execute_sql)
+```sql
+WITH paid AS (
+  SELECT a.variant, a.member_id, o.id AS order_id, o.subtotal,
+         (SELECT count(*) FROM order_items oi WHERE oi.order_id = o.id) AS items
+  FROM challenge_nudge_assignment a
+  JOIN orders o ON o.loyalty_id = a.member_id
+  WHERE o.total > 0 AND o.created_at >= a.assigned_at
+),
+members AS (SELECT variant, count(*) AS members FROM challenge_nudge_assignment GROUP BY variant)
+SELECT m.variant, m.members,
+  count(p.order_id)                                          AS orders,
+  round(count(p.order_id)::numeric / NULLIF(m.members,0), 2) AS orders_per_member,  -- frequency
+  round(avg(p.subtotal)::numeric, 2)                          AS aov_subtotal,       -- AOV
+  round(100.0 * avg((p.items = 1)::int), 1)                   AS single_item_pct
+FROM members m
+LEFT JOIN paid p ON p.variant = m.variant
+GROUP BY m.variant, m.members
+ORDER BY m.variant;
+```
+
+Read it as: treatment vs holdout on **aov_subtotal** (basket lift) and
+**orders_per_member** (frequency). A positive gap = the nudge is working.
+
+## Caveat
+Low order volume → the gap needs time to reach significance. Let it run a few
+weeks before concluding; don't kill on a handful of orders.

--- a/supabase/migrations/038_challenge_nudge_holdout.sql
+++ b/supabase/migrations/038_challenge_nudge_holdout.sql
@@ -1,0 +1,15 @@
+-- Member-level holdout for the cart AOV challenge nudge, so we can PROVE it
+-- lifts AOV/frequency: a random slice never sees the nudge; the report compares
+-- their order AOV + mission completion against the treatment group. Variant is
+-- stored (not hashed) so the endpoint + report always agree.
+CREATE TABLE IF NOT EXISTS challenge_nudge_assignment (
+  member_id   text PRIMARY KEY,
+  variant     text NOT NULL CHECK (variant IN ('treatment','holdout')),
+  assigned_at timestamptz NOT NULL DEFAULT now()
+);
+
+-- Flag: toggle the holdout + its size. Set enabled=false (or pct=0) to give the
+-- nudge to everyone once it's proven.
+INSERT INTO app_settings (key, value)
+VALUES ('challenge_nudge_holdout', '{"enabled":true,"pct":20}'::jsonb)
+ON CONFLICT (key) DO NOTHING;


### PR DESCRIPTION
Makes the cart AOV challenge nudge provable. Member-level holdout: a random slice (default 20%, flag-controlled) never see the nudge; the report compares treatment vs holdout AOV (subtotal) + orders/member. Variant stored per member (no hash drift). Migration 038 + `resolveNudgeVariant` + report SQL in docs. Flip `challenge_nudge_holdout.enabled=false` to give everyone the nudge once proven.

🤖 Generated with [Claude Code](https://claude.com/claude-code)