### PR TITLE
Mystery loop: home reveal banner + measurement

### DIFF
--- a/apps/order/src/app/_RewardWaiting.tsx
+++ b/apps/order/src/app/_RewardWaiting.tsx
@@ -1,0 +1,73 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import Link from "next/link";
+import { Gift, ChevronRight } from "lucide-react";
+
+/**
+ * Home "reward waiting" banner — pulls the customer back to an UNREVEALED
+ * mystery reward. Today the reveal only lives on the order screen, so ~1/3 of
+ * wins are never tapped (and an unrevealed win never becomes a voucher, so it
+ * can never be redeemed). This surfaces it prominently on the home and deep-
+ * links to the reveal. Renders nothing when there's nothing to reveal.
+ */
+type Claimable = {
+  id: string;
+  order_id?: string | null;
+  title?: string | null;
+  source_type?: string | null;
+};
+
+type Persisted = { state?: { sessionToken?: string | null } };
+
+export function RewardWaiting() {
+  const [drop, setDrop] = useState<Claimable | null>(null);
+
+  useEffect(() => {
+    let token: string | null = null;
+    try {
+      const raw = localStorage.getItem("celsius-pickup");
+      if (raw) token = (JSON.parse(raw) as Persisted).state?.sessionToken ?? null;
+    } catch { /* ignore */ }
+    if (!token) return;
+    let cancelled = false;
+    fetch("/api/loyalty/me/claimable", { headers: { Authorization: `Bearer ${token}` } })
+      .then((r) => (r.ok ? r.json() : []))
+      .then((data: Claimable[]) => {
+        const pending = (Array.isArray(data) ? data : []).find(
+          (c) => c.source_type === "mystery_pending" && c.order_id,
+        );
+        if (!cancelled) setDrop(pending ?? null);
+      })
+      .catch(() => { /* ignore */ });
+    return () => { cancelled = true; };
+  }, []);
+
+  if (!drop) return null;
+
+  return (
+    <div className="px-4 mt-3">
+      <Link
+        href={`/order/${drop.order_id}`}
+        className="flex items-center gap-3 active:opacity-80"
+        style={{ backgroundColor: "#1A0200", borderRadius: 16, padding: "12px 14px" }}
+      >
+        <span
+          className="flex-shrink-0 rounded-full flex items-center justify-center"
+          style={{ width: 36, height: 36, backgroundColor: "#A2492C" }}
+        >
+          <Gift size={18} color="#FFFFFF" />
+        </span>
+        <div className="flex-1 min-w-0">
+          <p className="uppercase" style={{ color: "#FBBF24", fontSize: 10, fontWeight: 700, letterSpacing: 1.5 }}>
+            Mystery reward
+          </p>
+          <p style={{ color: "#FFFFFF", fontSize: 14, fontWeight: 600 }}>You&apos;ve got a reward to reveal</p>
+        </div>
+        <span className="flex items-center gap-0.5 flex-shrink-0" style={{ color: "#FBBF24", fontSize: 13, fontWeight: 700 }}>
+          Reveal <ChevronRight size={15} />
+        </span>
+      </Link>
+    </div>
+  );
+}

--- a/apps/order/src/app/api/loyalty/me/claimable/route.ts
+++ b/apps/order/src/app/api/loyalty/me/claimable/route.ts
@@ -37,6 +37,7 @@ export async function GET(req: NextRequest) {
 
   const mysteryClaimables = ((drops ?? []) as unknown as DropRow[]).map((d) => ({
     id: d.id,
+    order_id: d.order_id,
     title: d.mystery_pool.label,
     description: "Tap to reveal your reward",
     icon: d.mystery_pool.icon ?? "sparkle",

--- a/apps/order/src/app/page.tsx
+++ b/apps/order/src/app/page.tsx
@@ -6,6 +6,7 @@ import { selectHomePosters } from "@/lib/poster/select-home";
 import { GlobalCartPill } from "./_GlobalCartPill";
 import { BottomNav } from "./_BottomNav";
 import { PosterCarousel } from "./_PosterCarousel";
+import { RewardWaiting } from "./_RewardWaiting";
 import { HeroInfoCard } from "./_HeroInfoCard";
 import { OutletRow } from "./_OutletRow";
 import { ActiveChallengeCard } from "./_ActiveChallengeCard";
@@ -79,6 +80,11 @@ export default async function HomePage() {
         <PosterCarousel posters={posters} />
         <HeroInfoCard />
       </div>
+
+      {/* Reward waiting — pulls the customer to an unrevealed mystery reward
+          (the reveal otherwise only lives on the order screen, so ~1/3 are
+          never tapped). Renders nothing when there's nothing to reveal. */}
+      <RewardWaiting />
 
       {/* Outlet row — under the hero, brand voice. Client component
           reads chosen outlet from localStorage so customers see their

--- a/docs/design/mystery-loop-measurement.md
+++ b/docs/design/mystery-loop-measurement.md
@@ -1,0 +1,31 @@
+# Mystery rewards — loop health (measurement)
+
+Mystery drops fire on every paid order; the goal is that a win **pulls the next
+order**. Two leak points, both measurable.
+
+## Baseline (60 days, measured 2026-06-22)
+| Step | Value | Read |
+|---|---|---|
+| Drops | 946 | every paid order spins |
+| Revealed (tapped) | **67.5%** | ~1/3 never reveal → win stranded |
+| Voucher wins | 339 (242 issued once revealed) | |
+| **Vouchers redeemed** | **14.5%** (35/242) | the loop barely closes |
+| Expired unused | 14 | |
+
+The reveal lives only on the order screen, so a customer who doesn't revisit
+never taps — and an **unrevealed win never becomes a voucher**, so it can never
+be redeemed. That's the upstream leak the home "reward waiting" banner targets
+(deep-links to the reveal). Redemption (14.5%) is the downstream leak — the
+return pull (expiring-reward "order now" urgency) is the next lever.
+
+## Report queries (run in Supabase / execute_sql)
+```sql
+-- Funnel (last 60d)
+SELECT
+  (SELECT count(*) FROM mystery_drops WHERE created_at > now()-interval '60 days') AS drops,
+  (SELECT round(100.0*avg((revealed_at IS NOT NULL)::int),1) FROM mystery_drops WHERE created_at > now()-interval '60 days') AS revealed_pct,
+  (SELECT count(*) FROM issued_rewards WHERE source_type='mystery' AND issued_at > now()-interval '60 days') AS vouchers_issued,
+  (SELECT round(100.0*avg((status='used')::int),1) FROM issued_rewards WHERE source_type='mystery' AND issued_at > now()-interval '60 days') AS redeemed_pct;
+```
+Track `revealed_pct` (should climb with the home reveal banner) and
+`redeemed_pct` (should climb with the return pull).


### PR DESCRIPTION
Mystery loop, part 1. Diagnosis (60d): 946 drops, only **67.5% revealed** (the reveal lives only on the order screen, so ~1/3 of wins are never tapped — and an unrevealed win never becomes a voucher), and **14.5% redemption**.

Fix the upstream leak: a home 'reward waiting' banner surfaces an UNREVEALED mystery reward with a tap-to-reveal CTA, deep-linking to the order's reveal (claimable now exposes `order_id`). Renders nothing when there's nothing to reveal. Report + baseline in `docs/design/mystery-loop-measurement.md`.

Web first. Next: the redemption return-pull (expiring-reward 'order now' urgency) + native parity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)