### PR TITLE
Loops Phase B: scheduled sends + send-time learning

### DIFF
--- a/apps/backoffice/src/app/(admin)/loyalty/loops/page.tsx
+++ b/apps/backoffice/src/app/(admin)/loyalty/loops/page.tsx
@@ -18,7 +18,7 @@ import { useState, useEffect, useCallback } from "react";
 import Link from "next/link";
 import {
   ArrowLeft, Repeat, RefreshCw, Send, FlaskConical, Loader2,
-  CheckCircle2, AlertTriangle, Trophy, Users, ShieldOff, Coins, Plus, X, Crown, Sparkles,
+  CheckCircle2, AlertTriangle, Trophy, Users, ShieldOff, Coins, Plus, X, Crown, Sparkles, Clock,
 } from "lucide-react";
 import { cn } from "@/lib/utils";
 
@@ -39,6 +39,7 @@ type Round = {
   holdout_pct: number; arms: RoundArm[]; attribution_window_days: number;
   status: "prepared" | "sent" | "measured"; stats: ArmStat[] | null;
   prepared_at: string | null; sent_at: string | null; measured_at: string | null;
+  scheduled_send_at: string | null; send_window: string | null;
 };
 type Preview = {
   round_id: string; round_no: number; segment_label: string; total: number;
@@ -52,13 +53,27 @@ type LeaderboardEntry = {
   incr_margin_per_recipient_rm: number; cum_incr_margin_rm: number;
 };
 type LoopMeta = { key: string; label: string; objective: string; defaultHoldoutPct: number; defaultWindowDays: number };
-type Optimizer = { loop_key: string; leaderboard: LeaderboardEntry[]; proposal: { arms: ProposalArm[] }; candidates: Candidate[]; loops: LoopMeta[] };
+type SendTimeEntry = { send_window: string; rounds: number; recipients: number; avg_lift_pp: number; avg_order_rate: number };
+type Optimizer = {
+  loop_key: string; leaderboard: LeaderboardEntry[]; proposal: { arms: ProposalArm[] };
+  candidates: Candidate[]; loops: LoopMeta[];
+  send_time_leaderboard: SendTimeEntry[]; send_window_proposal: { window: string; reason: string }; send_windows: string[];
+};
 
 const CHAMPION_MIN_RECIPIENTS = 300;
 
 // ---- helpers ----------------------------------------------------------------
 function rm(n: number) {
   return `RM${n.toLocaleString("en-MY", { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`;
+}
+function windowLabel(w: string | null | undefined): string {
+  if (!w) return "—";
+  return w.split("_").map((s) => s.charAt(0).toUpperCase() + s.slice(1)).join(" ");
+}
+function defaultLocalDatetime(): string {
+  const d = new Date(Date.now() + 3600000); // ~1h from now
+  const pad = (n: number) => String(n).padStart(2, "0");
+  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}T${pad(d.getHours())}:${pad(d.getMinutes())}`;
 }
 function reachableFromLabel(label: string): number | null {
   const m = label.match(/\(([\d,]+)\s+reachable/);
@@ -227,6 +242,18 @@ export default function LoopsPage() {
                 } catch (e) { setErr(e instanceof Error ? e.message : "Measure failed"); }
                 finally { setBusy(null); }
               }}
+              onSchedule={async (scheduledSendAt, sendWindow) => {
+                setBusy(r.id); setErr(null);
+                try {
+                  const res = await fetch("/api/loyalty/loops/schedule", { method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify({ round_id: r.id, scheduled_send_at: scheduledSendAt, send_window: sendWindow }) });
+                  const data = await res.json();
+                  if (!res.ok) throw new Error(data?.error ?? "Schedule failed");
+                  await load();
+                } catch (e) { setErr(e instanceof Error ? e.message : "Schedule failed"); }
+                finally { setBusy(null); }
+              }}
+              proposedWindow={opt?.send_window_proposal?.window}
+              windows={opt?.send_windows ?? []}
             />
           ))}
         </div>
@@ -301,6 +328,24 @@ function OptimizerPanel({ opt }: { opt: Optimizer }) {
           </div>
         </>
       )}
+
+      {/* Send-time learning — best window + per-window lift (unknown #3). */}
+      <div className="mt-4 border-t border-gray-100 pt-3">
+        <div className="mb-2 flex flex-wrap items-center gap-2 text-sm">
+          <Clock className="h-4 w-4 text-[#A2492C]" />
+          <span className="font-medium">Best send time</span>
+          <span className="text-gray-500">— {windowLabel(opt.send_window_proposal?.window)}. {opt.send_window_proposal?.reason}</span>
+        </div>
+        {opt.send_time_leaderboard.length > 0 && (
+          <div className="flex flex-wrap gap-2">
+            {opt.send_time_leaderboard.map((s) => (
+              <span key={s.send_window} className="rounded bg-gray-100 px-2 py-1 text-xs text-gray-600">
+                {windowLabel(s.send_window)}: {s.avg_lift_pp >= 0 ? "+" : ""}{s.avg_lift_pp}pp ({s.recipients.toLocaleString()})
+              </span>
+            ))}
+          </div>
+        )}
+      </div>
     </div>
   );
 }
@@ -436,10 +481,13 @@ function NumInput({ v, set }: { v: number; set: (n: number) => void }) {
 }
 
 // ---- Round card -------------------------------------------------------------
-function RoundCard({ round, busy, onSend, onMeasure }: {
+function RoundCard({ round, busy, onSend, onMeasure, onSchedule, proposedWindow, windows }: {
   round: Round; busy: boolean; onSend: () => void; onMeasure: () => void;
+  onSchedule: (scheduledSendAt: string, sendWindow: string) => void; proposedWindow?: string; windows: string[];
 }) {
   const est = estSmsCost(round);
+  const [when, setWhen] = useState(() => defaultLocalDatetime());
+  const [win, setWin] = useState(proposedWindow ?? "weekday_evening");
   return (
     <div className="rounded-xl border border-gray-200 bg-white p-5 shadow-sm">
       <div className="mb-3 flex flex-wrap items-center justify-between gap-2">
@@ -467,12 +515,39 @@ function RoundCard({ round, busy, onSend, onMeasure }: {
             <span className="inline-flex items-center gap-1"><Users className="h-3.5 w-3.5" /> vouchers issued, awaiting send</span>
             {est != null && <span>Est. SMS cost: <strong>{rm(est)}</strong></span>}
           </div>
+
+          {round.scheduled_send_at && (
+            <div className="mb-2 inline-flex items-center gap-1 rounded bg-amber-100 px-2 py-1 text-xs text-amber-900">
+              <Clock className="h-3.5 w-3.5" /> Scheduled for {new Date(round.scheduled_send_at).toLocaleString("en-MY")} ({windowLabel(round.send_window)}) — the cron fires it automatically.
+            </div>
+          )}
+
+          {/* Schedule: approve now, engine fires at the chosen window. */}
+          <div className="mb-2 flex flex-wrap items-end gap-2">
+            <label className="text-xs text-gray-600">Send at
+              <input type="datetime-local" value={when} onChange={(e) => setWhen(e.target.value)} className="mt-1 block rounded-md border border-gray-200 px-2 py-1 text-sm" />
+            </label>
+            <label className="text-xs text-gray-600">Window
+              <select value={win} onChange={(e) => setWin(e.target.value)} className="mt-1 block rounded-md border border-gray-200 px-2 py-1 text-sm">
+                {windows.map((w) => <option key={w} value={w}>{windowLabel(w)}</option>)}
+              </select>
+            </label>
+            <button
+              disabled={busy}
+              onClick={() => onSchedule(new Date(when).toISOString(), win)}
+              className="inline-flex items-center gap-2 rounded-lg bg-[#A2492C] px-3 py-2 text-sm font-medium text-white disabled:opacity-50"
+            >
+              {busy ? <Loader2 className="h-4 w-4 animate-spin" /> : <Clock className="h-4 w-4" />} {round.scheduled_send_at ? "Reschedule" : "Schedule send"}
+            </button>
+          </div>
+          {proposedWindow && <p className="mb-2 text-xs text-gray-500">Engine suggests <strong>{windowLabel(proposedWindow)}</strong> as the best-known window.</p>}
+
           <button
             disabled={busy}
-            onClick={() => { if (confirm(`Send SMS for round ${round.round_no}? This fires ${est != null ? `~${rm(est)} of` : ""} live SMS to all treatment arms.`)) onSend(); }}
-            className="inline-flex items-center gap-2 rounded-lg bg-blue-600 px-4 py-2 text-sm font-medium text-white disabled:opacity-50"
+            onClick={() => { if (confirm(`Send SMS NOW for round ${round.round_no}? Fires ${est != null ? `~${rm(est)} of` : ""} live SMS immediately.`)) onSend(); }}
+            className="inline-flex items-center gap-2 rounded-lg border border-blue-600 px-4 py-2 text-sm font-medium text-blue-700 disabled:opacity-50"
           >
-            {busy ? <Loader2 className="h-4 w-4 animate-spin" /> : <Send className="h-4 w-4" />} Approve &amp; send SMS
+            {busy ? <Loader2 className="h-4 w-4 animate-spin" /> : <Send className="h-4 w-4" />} Send now
           </button>
         </div>
       )}

--- a/apps/backoffice/src/app/api/cron/loops-send/route.ts
+++ b/apps/backoffice/src/app/api/cron/loops-send/route.ts
@@ -1,0 +1,21 @@
+import { NextRequest, NextResponse } from "next/server";
+import { checkCronAuth } from "@celsius/shared";
+import { sendDueRounds } from "@/lib/loyalty/loop-engine";
+
+export const dynamic = "force-dynamic";
+export const maxDuration = 300;
+
+// GET /api/cron/loops-send — fires any scheduled loop round whose send time has
+// arrived. Runs every ~15 min (vercel.json). Approve-gated: only sends rounds an
+// operator explicitly scheduled via /api/loyalty/loops/schedule.
+export async function GET(req: NextRequest) {
+  const cronAuth = checkCronAuth(req.headers);
+  if (!cronAuth.ok) return NextResponse.json({ error: cronAuth.error }, { status: cronAuth.status });
+  try {
+    const res = await sendDueRounds();
+    return NextResponse.json(res);
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : "loops-send failed";
+    return NextResponse.json({ error: msg }, { status: 500 });
+  }
+}

--- a/apps/backoffice/src/app/api/loyalty/loops/optimizer/route.ts
+++ b/apps/backoffice/src/app/api/loyalty/loops/optimizer/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { requireAuth } from "@/lib/auth";
-import { getLeaderboard, proposeArms, OFFER_CANDIDATES, LOOPS, type LoopKey } from "@/lib/loyalty/loop-engine";
+import { getLeaderboard, proposeArms, getSendTimeLeaderboard, proposeSendWindow, SEND_WINDOWS, OFFER_CANDIDATES, LOOPS, type LoopKey } from "@/lib/loyalty/loop-engine";
 
 // GET /api/loyalty/loops/optimizer?loop_key= — the adaptive layer per loop:
 //   - leaderboard: every offer ranked by cumulative incremental margin (learns over time)
@@ -14,10 +14,15 @@ export async function GET(request: NextRequest) {
     const loopKey = (new URL(request.url).searchParams.get("loop_key") ?? "winback") as LoopKey;
     const def = LOOPS[loopKey];
     if (!def) return NextResponse.json({ error: `unknown loop: ${loopKey}` }, { status: 400 });
-    const [leaderboard, proposal] = await Promise.all([getLeaderboard(loopKey), proposeArms(loopKey)]);
+    const [leaderboard, proposal, sendTimeLeaderboard, sendWindowProposal] = await Promise.all([
+      getLeaderboard(loopKey), proposeArms(loopKey), getSendTimeLeaderboard(loopKey), proposeSendWindow(loopKey),
+    ]);
     const candidates = OFFER_CANDIDATES.filter((c) => def.candidateKeys.includes(c.key));
     const loops = Object.values(LOOPS).map((l) => ({ key: l.key, label: l.label, objective: l.objective, defaultHoldoutPct: l.defaultHoldoutPct, defaultWindowDays: l.defaultWindowDays }));
-    return NextResponse.json({ loop_key: loopKey, leaderboard, proposal, candidates, loops });
+    return NextResponse.json({
+      loop_key: loopKey, leaderboard, proposal, candidates, loops,
+      send_time_leaderboard: sendTimeLeaderboard, send_window_proposal: sendWindowProposal, send_windows: SEND_WINDOWS,
+    });
   } catch (err) {
     const msg = err instanceof Error ? err.message : "Failed to load optimizer";
     return NextResponse.json({ error: msg }, { status: 500 });

--- a/apps/backoffice/src/app/api/loyalty/loops/schedule/route.ts
+++ b/apps/backoffice/src/app/api/loyalty/loops/schedule/route.ts
@@ -1,0 +1,22 @@
+import { NextRequest, NextResponse } from "next/server";
+import { requireAuth } from "@/lib/auth";
+import { scheduleRound } from "@/lib/loyalty/loop-engine";
+
+// POST /api/loyalty/loops/schedule — approve + schedule a prepared round to
+// fire at a chosen time. The /api/cron/loops-send cron sends it when due.
+// Body: { round_id, scheduled_send_at (ISO), send_window? }.
+export async function POST(request: NextRequest) {
+  const auth = await requireAuth(request);
+  if (auth.error) return auth.error;
+  try {
+    const { round_id, scheduled_send_at, send_window } = await request.json();
+    if (!round_id || !scheduled_send_at) {
+      return NextResponse.json({ error: "round_id and scheduled_send_at required" }, { status: 400 });
+    }
+    const res = await scheduleRound(round_id, scheduled_send_at, send_window ?? null);
+    return NextResponse.json(res);
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : "Failed to schedule round";
+    return NextResponse.json({ error: msg }, { status: 500 });
+  }
+}

--- a/apps/backoffice/src/lib/loyalty/loop-engine.ts
+++ b/apps/backoffice/src/lib/loyalty/loop-engine.ts
@@ -299,9 +299,12 @@ export async function sendRound(roundId: string) {
     if (res.success) sent++; else failed++;
   }
 
+  const sentAt = new Date();
   await supabaseAdmin
     .from("loop_rounds")
-    .update({ status: "sent", sent_at: new Date().toISOString() })
+    // Stamp the window it actually went out in (kept if pre-scheduled) so the
+    // send-time leaderboard can attribute conversion to a time of day.
+    .update({ status: "sent", sent_at: sentAt.toISOString(), send_window: round.send_window ?? deriveWindow(sentAt) })
     .eq("id", roundId);
 
   return { round_id: roundId, sent, failed };
@@ -554,4 +557,104 @@ export async function proposeArms(loopKey: LoopKey = "winback", opts?: { count?:
   }
 
   return { arms: chosen.slice(0, count) };
+}
+
+// ============================================================================
+// SEND-TIME — schedule a round + learn the best window (unknown #3).
+//
+// A round is approved by scheduling it: scheduleRound() sets scheduled_send_at
+// and a derived send_window. The /api/cron/loops-send cron calls sendDueRounds()
+// every few minutes and fires any prepared round whose time has arrived. Over
+// rounds, getSendTimeLeaderboard() pools conversion by window so proposeSendWindow()
+// can suggest the best time — the same champion/challenger idea, on the clock.
+// ============================================================================
+
+// Day-part windows (Malaysia, UTC+8). Coarse on purpose — enough to learn from.
+export const SEND_WINDOWS = [
+  "weekday_morning", "weekday_midday", "weekday_evening",
+  "weekend_morning", "weekend_midday", "weekend_evening",
+] as const;
+
+function deriveWindow(d: Date): string {
+  const myt = new Date(d.getTime() + 8 * 3600000); // shift UTC → UTC+8
+  const day = myt.getUTCDay(); // 0 Sun .. 6 Sat
+  const weekend = day === 0 || day === 6;
+  const h = myt.getUTCHours();
+  const part = h < 12 ? "morning" : h < 17 ? "midday" : "evening";
+  return `${weekend ? "weekend" : "weekday"}_${part}`;
+}
+
+// Approve + schedule a prepared round to fire at a chosen time.
+export async function scheduleRound(roundId: string, scheduledSendAt: string, sendWindow?: string | null) {
+  const { data: round } = await supabaseAdmin.from("loop_rounds").select("status").eq("id", roundId).single();
+  if (!round) throw new Error("round not found");
+  if (round.status !== "prepared") throw new Error(`can only schedule a prepared round (is ${round.status})`);
+  const when = new Date(scheduledSendAt);
+  if (Number.isNaN(when.getTime())) throw new Error("invalid scheduled time");
+  const win = sendWindow ?? deriveWindow(when);
+  const { error } = await supabaseAdmin.from("loop_rounds")
+    .update({ scheduled_send_at: when.toISOString(), send_window: win })
+    .eq("id", roundId);
+  if (error) throw new Error(error.message);
+  return { round_id: roundId, scheduled_send_at: when.toISOString(), send_window: win };
+}
+
+// Cron entrypoint: fire every prepared round whose scheduled time has passed.
+export async function sendDueRounds(nowIso?: string) {
+  const now = nowIso ?? new Date().toISOString();
+  const { data: due } = await supabaseAdmin.from("loop_rounds")
+    .select("id")
+    .eq("status", "prepared")
+    .not("scheduled_send_at", "is", null)
+    .lte("scheduled_send_at", now);
+  const results: Array<{ round_id: string; sent?: number; failed?: number; error?: string }> = [];
+  for (const r of (due ?? []) as Array<{ id: string }>) {
+    try { results.push(await sendRound(r.id)); }
+    catch (e) { results.push({ round_id: r.id, error: e instanceof Error ? e.message : "send failed" }); }
+  }
+  return { fired: results.length, results };
+}
+
+type FullStat = { arm: string; n: number; lift_pp: number; conversion_rate: number };
+export type SendTimeEntry = { send_window: string; rounds: number; recipients: number; avg_lift_pp: number; avg_order_rate: number };
+
+// Pool measured rounds by the window they were sent in → learn the best time.
+export async function getSendTimeLeaderboard(loopKey: LoopKey = "winback"): Promise<SendTimeEntry[]> {
+  const { data: rounds } = await supabaseAdmin.from("loop_rounds")
+    .select("send_window, stats")
+    .eq("loop_key", loopKey).eq("status", "measured").not("send_window", "is", null);
+
+  type Agg = { n: number; liftW: number; orderW: number; rounds: number };
+  const agg = new Map<string, Agg>();
+  for (const r of (rounds ?? []) as Array<{ send_window: string | null; stats: FullStat[] | null }>) {
+    if (!r.send_window || !r.stats) continue;
+    let roundN = 0, liftW = 0, orderW = 0;
+    for (const s of r.stats) {
+      if (s.arm === "holdout") continue;
+      roundN += s.n; liftW += (s.lift_pp ?? 0) * s.n; orderW += (s.conversion_rate ?? 0) * s.n;
+    }
+    if (roundN === 0) continue;
+    const e = agg.get(r.send_window) ?? { n: 0, liftW: 0, orderW: 0, rounds: 0 };
+    e.n += roundN; e.liftW += liftW; e.orderW += orderW; e.rounds += 1;
+    agg.set(r.send_window, e);
+  }
+  const out: SendTimeEntry[] = [...agg.entries()].map(([w, e]) => ({
+    send_window: w, rounds: e.rounds, recipients: e.n,
+    avg_lift_pp: +(e.liftW / Math.max(1, e.n)).toFixed(1),
+    avg_order_rate: +(e.orderW / Math.max(1, e.n)).toFixed(1),
+  }));
+  out.sort((a, b) => b.avg_lift_pp - a.avg_lift_pp);
+  return out;
+}
+
+// Suggest the next send window: best proven (enough evidence) → else explore an
+// untested window → else an F&B-sensible default.
+export async function proposeSendWindow(loopKey: LoopKey = "winback"): Promise<{ window: string; reason: string }> {
+  const lb = await getSendTimeLeaderboard(loopKey);
+  const best = lb.find((e) => e.recipients >= CHAMPION_MIN_RECIPIENTS);
+  if (best) return { window: best.send_window, reason: `Best window so far: ${best.avg_lift_pp >= 0 ? "+" : ""}${best.avg_lift_pp}pp over ${best.recipients.toLocaleString()} sent.` };
+  const tested = new Set(lb.map((e) => e.send_window));
+  const untested = SEND_WINDOWS.find((w) => !tested.has(w));
+  if (untested) return { window: untested, reason: "New window — never tested yet." };
+  return { window: "weekday_evening", reason: "Default — F&B evening peak." };
 }

--- a/apps/backoffice/vercel.json
+++ b/apps/backoffice/vercel.json
@@ -49,6 +49,10 @@
       "schedule": "0 3 * * *"
     },
     {
+      "path": "/api/cron/loops-send",
+      "schedule": "*/15 * * * *"
+    },
+    {
       "path": "/api/cron/finance-eod",
       "schedule": "0 20 * * *"
     },

--- a/supabase/migrations/039_loop_schedule.sql
+++ b/supabase/migrations/039_loop_schedule.sql
@@ -1,0 +1,12 @@
+-- Win-back loops Phase B: scheduled sends + send-time learning.
+-- Each round can be scheduled to fire at a chosen time/window; a cron
+-- (/api/cron/loops-send) sends due rounds. send_window records which
+-- day-part the SMS went out so the engine can learn the best time.
+ALTER TABLE loop_rounds
+  ADD COLUMN IF NOT EXISTS scheduled_send_at timestamptz,
+  ADD COLUMN IF NOT EXISTS send_window text;
+
+-- Cron looks up due rounds by (status, scheduled_send_at); index it.
+CREATE INDEX IF NOT EXISTS idx_loop_rounds_due
+  ON loop_rounds (status, scheduled_send_at)
+  WHERE scheduled_send_at IS NOT NULL;


### PR DESCRIPTION
Closes unknown #3 (best time to send) + adds the scheduler.

- **migration 039**: `loop_rounds` + `scheduled_send_at` + `send_window` (+ due index).
- **engine**: `scheduleRound()` (approve + set fire time, derives day-part window), `sendDueRounds()` (cron fires prepared rounds whose time passed), `getSendTimeLeaderboard()` + `proposeSendWindow()` (pool conversion by window → suggest best — champion/challenger on the clock). `sendRound()` stamps the window it went out in so immediate sends also feed learning.
- **routes**: `/api/loyalty/loops/schedule`; `/api/cron/loops-send` (fail-closed `checkCronAuth`) wired into `vercel.json` (*/15). optimizer returns `send_time_leaderboard` + `send_window_proposal`.
- **dashboard**: prepared rounds get a Send-at + Window picker (pre-filled with the engine's best-known window) → **Schedule send** (cron fires it) + **Send now**; scheduled rounds show their fire time; optimizer panel shows best send time.

**Approve-gated**: the cron only fires rounds an operator explicitly scheduled. Phase C next = retire the legacy preset-campaign UI. Typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)