### PR TITLE
Fix spend_amount challenge progress showing raw sen (0/8000)

### DIFF
--- a/apps/order/src/app/_ActiveChallengeCard.tsx
+++ b/apps/order/src/app/_ActiveChallengeCard.tsx
@@ -61,7 +61,7 @@ export function ActiveChallengeCard() {
   if (!mission) return null;
 
   const progressLabel =
-    mission.goal_type === "single_order_total_at_least"
+    mission.goal_type === "single_order_total_at_least" || mission.goal_type === "spend_amount"
       ? `RM${Math.floor((mission.progress_current ?? 0) / 100)}/RM${Math.floor((mission.goal_threshold ?? 0) / 100)}`
       : `${mission.progress_current ?? 0}/${mission.goal_threshold ?? 0}`;
 

--- a/apps/order/src/app/challenge/[id]/_ChallengeView.tsx
+++ b/apps/order/src/app/challenge/[id]/_ChallengeView.tsx
@@ -40,7 +40,7 @@ const THEME = {
 function progressLabel(m: Mission): string {
   const cur = m.progress_current ?? 0;
   const goal = m.goal_threshold ?? 0;
-  if (m.goal_type === "single_order_total_at_least") {
+  if (m.goal_type === "single_order_total_at_least" || m.goal_type === "spend_amount") {
     return `RM${Math.floor(cur / 100)} of RM${Math.floor(goal / 100)}`;
   }
   return `${cur} of ${goal}`;
@@ -49,7 +49,7 @@ function progressLabel(m: Mission): string {
 function remainingHint(m: Mission): string {
   const remaining = Math.max(0, (m.goal_threshold ?? 0) - (m.progress_current ?? 0));
   if (remaining === 0) return "You're done — claim your reward!";
-  if (m.goal_type === "single_order_total_at_least") {
+  if (m.goal_type === "single_order_total_at_least" || m.goal_type === "spend_amount") {
     return `RM${Math.ceil(remaining / 100)} more to unlock`;
   }
   return remaining === 1 ? "1 more to unlock" : `${remaining} more to unlock`;
@@ -72,6 +72,12 @@ function howToWin(m: Mission): string[] {
       return [
         `Spend at least RM${Math.floor(goal / 100)} in a single order.`,
         "Add-ons, sides and pastries all count toward the total.",
+        "Discounts and vouchers don't reduce the qualifying amount.",
+      ];
+    case "spend_amount":
+      return [
+        `Spend RM${Math.floor(goal / 100)} in total this week.`,
+        "Every order this week adds up — no single big bill needed.",
         "Discounts and vouchers don't reduce the qualifying amount.",
       ];
     case "drinks_count":

--- a/apps/order/src/app/rewards/_ActiveChallenges.tsx
+++ b/apps/order/src/app/rewards/_ActiveChallenges.tsx
@@ -39,7 +39,8 @@ const THEME = {
 type Persisted = { state?: { sessionToken?: string | null } };
 
 function progressLabel(m: Mission): string {
-  if (m.goal_type === "single_order_total_at_least") {
+  // Both these goals store sen → show as RM (e.g. RM0/RM80), not raw 0/8000.
+  if (m.goal_type === "single_order_total_at_least" || m.goal_type === "spend_amount") {
     return `RM${Math.floor((m.progress_current ?? 0) / 100)}/RM${Math.floor((m.goal_threshold ?? 0) / 100)}`;
   }
   return `${m.progress_current ?? 0}/${m.goal_threshold ?? 0}`;

--- a/apps/pickup-native/app/challenge/[id]/index.tsx
+++ b/apps/pickup-native/app/challenge/[id]/index.tsx
@@ -40,6 +40,12 @@ function howToWin(m: ActiveMission): string[] {
         "Add-ons, sides and pastries all count toward the total.",
         "Discounts and vouchers don't reduce the qualifying amount.",
       ];
+    case "spend_amount":
+      return [
+        `Spend RM${Math.floor(m.goal_threshold / 100)} in total this week.`,
+        "Every order this week adds up — no single big bill needed.",
+        "Discounts and vouchers don't reduce the qualifying amount.",
+      ];
     case "drinks_count":
     case "cups_count":
       return [
@@ -71,7 +77,7 @@ function howToWin(m: ActiveMission): string[] {
 }
 
 function progressLabel(m: ActiveMission): string {
-  if (m.goal_type === "single_order_total_at_least") {
+  if (m.goal_type === "single_order_total_at_least" || m.goal_type === "spend_amount") {
     return `RM${Math.floor(m.progress_current / 100)} of RM${Math.floor(m.goal_threshold / 100)}`;
   }
   return `${m.progress_current} of ${m.goal_threshold}`;
@@ -80,7 +86,7 @@ function progressLabel(m: ActiveMission): string {
 function remainingHint(m: ActiveMission): string {
   const remaining = Math.max(0, m.goal_threshold - m.progress_current);
   if (remaining === 0) return "You're done — claim your reward!";
-  if (m.goal_type === "single_order_total_at_least") {
+  if (m.goal_type === "single_order_total_at_least" || m.goal_type === "spend_amount") {
     return `RM${Math.ceil(remaining / 100)} more to unlock`;
   }
   return remaining === 1 ? "1 more to unlock" : `${remaining} more to unlock`;

--- a/apps/pickup-native/app/challenge/[id]/swap.tsx
+++ b/apps/pickup-native/app/challenge/[id]/swap.tsx
@@ -30,6 +30,8 @@ function formatGoal(option: SwapOption): string {
   switch (option.goal_type) {
     case "single_order_total_at_least":
       return `Spend RM${Math.floor(option.goal_threshold / 100)} in one order`;
+    case "spend_amount":
+      return `Spend RM${Math.floor(option.goal_threshold / 100)} this week`;
     case "drinks_count":
     case "cups_count":
       return option.goal_threshold === 1

--- a/apps/pickup-native/app/index.tsx
+++ b/apps/pickup-native/app/index.tsx
@@ -844,12 +844,12 @@ export default function Home() {
                 numberOfLines={1}
               >
                 Active challenge · {
-                  // `single_order_total_at_least` stores the threshold in
-                  // sen (e.g. RM100 → 10000) — render it as Ringgit so
-                  // the customer doesn't see a giant "0/10000" instead
-                  // of "RM0/RM100". Matches the formatting compactProgressLabel
-                  // uses on the rewards tab + the challenge detail page.
-                  activeMission.goal_type === "single_order_total_at_least"
+                  // `single_order_total_at_least` AND `spend_amount` store the
+                  // threshold in sen (e.g. RM100 → 10000, RM80 → 8000) — render
+                  // as Ringgit so the customer doesn't see a giant "0/8000"
+                  // instead of "RM0/RM80". Matches compactProgressLabel on the
+                  // rewards tab + the challenge detail page.
+                  activeMission.goal_type === "single_order_total_at_least" || activeMission.goal_type === "spend_amount"
                     ? `RM${Math.floor(activeMission.progress_current / 100)}/RM${Math.floor(activeMission.goal_threshold / 100)}`
                     : `${activeMission.progress_current}/${activeMission.goal_threshold}`
                 }

--- a/apps/pickup-native/app/rewards.tsx
+++ b/apps/pickup-native/app/rewards.tsx
@@ -134,7 +134,7 @@ function formatMissionExpiry(iso: string): string {
 function compactProgressLabel(m: ActiveMission): string {
   const cur = m.progress_current;
   const tgt = m.goal_threshold;
-  if (m.goal_type === "single_order_total_at_least") {
+  if (m.goal_type === "single_order_total_at_least" || m.goal_type === "spend_amount") {
     return `RM${Math.floor(cur / 100)}/${Math.floor(tgt / 100)}`;
   }
   return `${cur}/${tgt}`;


### PR DESCRIPTION
**Bug:** 'Weekly RM80' challenge showed `0/8000` instead of `RM0/RM80`.

`spend_amount` goals store their threshold in sen (8000 = RM80), same as `single_order_total_at_least` — but only the latter was RM-formatted. `spend_amount` fell through to the raw `current/threshold` default.

**Fix (display-only):** format `spend_amount` as RM at every surface — rewards list, home teaser, challenge detail (progress label + how-to-win + remaining hint), and the swap screen, on both web (apps/order) and native (apps/pickup-native). The engine already accumulates `order.total_sen` correctly, so progress was right — only the label was wrong.

Typecheck clean on order + pickup-native.

🤖 Generated with [Claude Code](https://claude.com/claude-code)