### PR TITLE
Fix mission time/day filters evaluated in UTC instead of MYT

### DIFF
--- a/apps/order/src/app/challenge/[id]/_ChallengeView.tsx
+++ b/apps/order/src/app/challenge/[id]/_ChallengeView.tsx
@@ -80,32 +80,29 @@ function howToWin(m: Mission): string[] {
         "Every order this week adds up — no single big bill needed.",
         "Discounts and vouchers don't reduce the qualifying amount.",
       ];
-    case "drinks_count":
-    case "cups_count":
-      return [
-        `Order ${goal} drinks before the challenge ends.`,
-        "Drinks can be on the same order or split across visits.",
-        "Both hot and iced count.",
-      ];
-    case "distinct_products":
-    case "distinct_drinks_count":
-      return [
-        `Try ${goal} different items you haven't ordered before.`,
-        "We only count the first time you ever buy a given item.",
-        "Both drinks and food count unless the description says otherwise.",
-      ];
-    case "single_order_items_count":
+    case "single_order_item_count":
       return [
         `Order ${goal}+ items in a single transaction.`,
         "Each individual cup or plate counts as one item.",
         "Mix and match across drinks and food.",
       ];
-    case "drink_and_food":
+    case "distinct_new_products":
       return [
-        "Order at least one drink and one food item in the same order.",
-        "Roti bakar, pastries and cakes all count as food.",
+        `Try ${goal} different items you haven't ordered before.`,
+        "Only the first time you ever buy a given item counts.",
+        "Spread them across visits — they don't need to be one order.",
+      ];
+    case "referrals_count":
+      return [
+        "Share your referral link with a friend.",
+        "You earn the reward when they place their first paid order.",
       ];
     default:
+      // orders_count (with time/day windows), single_order_has_groups and
+      // single_order_group_count carry their specifics in goal.filter /
+      // goal.groups, which aren't on this shape — the mission description
+      // ("Place 2 orders before 11am", "Get a drink, food and a pastry")
+      // states them precisely, so it's the most accurate copy here.
       return m.description ? [m.description] : [];
   }
 }

--- a/apps/order/src/lib/loyalty/v2.ts
+++ b/apps/order/src/lib/loyalty/v2.ts
@@ -507,11 +507,15 @@ function evalGoalOnOrder(goal: Goal, order: OrderForMission): number {
   // the per-referral voucher is issued directly in
   // maybeRewardReferralOnFirstOrder, so the mission's only role is
   // to hold the voucher templates as config.
-  const created = new Date(order.created_at);
-  if (goal.filter?.order_hour_lt !== undefined && created.getHours() >= goal.filter.order_hour_lt) {
+  // Time/day filters are MYT (UTC+8) wall-clock. The server runs in UTC
+  // (Vercel), so shift the instant by +8h and read the UTC fields — same
+  // trick distinct_order_days uses below. Without this, "before 11am" and
+  // "Sat/Sun" were evaluated against UTC, i.e. 8h / one day off.
+  const createdMyt = new Date(new Date(order.created_at).getTime() + 8 * 3_600_000);
+  if (goal.filter?.order_hour_lt !== undefined && createdMyt.getUTCHours() >= goal.filter.order_hour_lt) {
     return 0;
   }
-  if (goal.filter?.order_day_in && !goal.filter.order_day_in.includes(created.getDay())) {
+  if (goal.filter?.order_day_in && !goal.filter.order_day_in.includes(createdMyt.getUTCDay())) {
     return 0;
   }
   switch (goal.type) {

--- a/apps/pickup-native/app/challenge/[id]/index.tsx
+++ b/apps/pickup-native/app/challenge/[id]/index.tsx
@@ -46,32 +46,28 @@ function howToWin(m: ActiveMission): string[] {
         "Every order this week adds up — no single big bill needed.",
         "Discounts and vouchers don't reduce the qualifying amount.",
       ];
-    case "drinks_count":
-    case "cups_count":
-      return [
-        `Order ${m.goal_threshold} drinks before the challenge ends.`,
-        "Drinks can be on the same order or split across visits.",
-        "Both hot and iced count.",
-      ];
-    case "distinct_products":
-    case "distinct_drinks_count":
-      return [
-        `Try ${m.goal_threshold} different items you haven't ordered before.`,
-        "We only count the first time you ever buy a given item.",
-        "Both drinks and food count unless the description says otherwise.",
-      ];
-    case "single_order_items_count":
+    case "single_order_item_count":
       return [
         `Order ${m.goal_threshold}+ items in a single transaction.`,
         "Each individual cup or plate counts as one item.",
         "Mix and match across drinks and food.",
       ];
-    case "drink_and_food":
+    case "distinct_new_products":
       return [
-        "Order at least one drink and one food item in the same order.",
-        "Roti bakar, pastries and cakes all count as food.",
+        `Try ${m.goal_threshold} different items you haven't ordered before.`,
+        "Only the first time you ever buy a given item counts.",
+        "Spread them across visits — they don't need to be one order.",
+      ];
+    case "referrals_count":
+      return [
+        "Share your referral link with a friend.",
+        "You earn the reward when they place their first paid order.",
       ];
     default:
+      // orders_count (with time/day windows), single_order_has_groups and
+      // single_order_group_count carry their specifics in goal.filter /
+      // goal.groups, which aren't on this shape — the mission description
+      // states them precisely, so it's the most accurate copy here.
       return [m.description];
   }
 }


### PR DESCRIPTION
## The bug
`evalGoalOnOrder` read `created.getHours()` / `created.getDay()` in the **server** timezone. Vercel runs in **UTC**, Malaysia is **UTC+8**, so the time/day filters were 8h / one day off:

| Mission | Intended | Actually counted |
|---|---|---|
| **Morning Habit** (`order_hour_lt: 11`) | before 11am MYT | up to ~7pm MYT — morning gate gone |
| **Weekend Run** (`day_in [0,6]`) | Sat/Sun MYT | a Sat order before 8am MYT counted as Friday |
| **Weekday Lift** (`day_in [1-5]`) | Mon–Fri MYT | a Mon order before 8am MYT counted as Sunday |

## Fix
Shift the instant `+8h` and read UTC fields — the same conversion `distinct_order_days` already uses 40 lines down. Verified against boundary cases: every previously-wrong case (11:30am/6pm MYT, pre-8am Sat/Mon) now resolves correctly.

## Also
Re-keyed the challenge-detail `howToWin` copy (web + native) onto the goal types that **actually exist** (`single_order_item_count`, `distinct_new_products`, `referrals_count`). The old cases (`single_order_items_count`, `distinct_products`, `drink_and_food`, `drinks_count`) matched no live mission and silently fell back to the description. Kept the existing `spend_amount` case.

Found during a full audit of all 15 active missions. Typecheck clean on order + pickup-native.

🤖 Generated with [Claude Code](https://claude.com/claude-code)