### PR TITLE
Loops: add Cancel round (revert a prepared round)

### DIFF
--- a/apps/backoffice/src/app/(admin)/loyalty/loops/page.tsx
+++ b/apps/backoffice/src/app/(admin)/loyalty/loops/page.tsx
@@ -282,6 +282,16 @@ export default function LoopsPage() {
                 } catch (e) { setErr(e instanceof Error ? e.message : "Schedule failed"); }
                 finally { setBusy(null); }
               }}
+              onCancel={async () => {
+                setBusy(r.id); setErr(null);
+                try {
+                  const res = await fetch("/api/loyalty/loops/cancel", { method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify({ round_id: r.id }) });
+                  const data = await res.json();
+                  if (!res.ok) throw new Error(data?.error ?? "Cancel failed");
+                  await load();
+                } catch (e) { setErr(e instanceof Error ? e.message : "Cancel failed"); }
+                finally { setBusy(null); }
+              }}
               proposedWindow={opt?.send_window_proposal?.window}
               windows={opt?.send_windows ?? []}
             />
@@ -530,9 +540,9 @@ function NumInput({ v, set }: { v: number; set: (n: number) => void }) {
 }
 
 // ---- Round card -------------------------------------------------------------
-function RoundCard({ round, busy, onSend, onMeasure, onSchedule, proposedWindow, windows }: {
+function RoundCard({ round, busy, onSend, onMeasure, onSchedule, onCancel, proposedWindow, windows }: {
   round: Round; busy: boolean; onSend: () => void; onMeasure: () => void;
-  onSchedule: (scheduledSendAt: string, sendWindow: string) => void; proposedWindow?: string; windows: string[];
+  onSchedule: (scheduledSendAt: string, sendWindow: string) => void; onCancel: () => void; proposedWindow?: string; windows: string[];
 }) {
   const est = estSmsCost(round);
   const [when, setWhen] = useState(() => defaultLocalDatetime());
@@ -597,6 +607,13 @@ function RoundCard({ round, busy, onSend, onMeasure, onSchedule, proposedWindow,
             className="inline-flex items-center gap-2 rounded-lg border border-blue-600 px-4 py-2 text-sm font-medium text-blue-700 disabled:opacity-50"
           >
             {busy ? <Loader2 className="h-4 w-4 animate-spin" /> : <Send className="h-4 w-4" />} Send now
+          </button>
+          <button
+            disabled={busy}
+            onClick={() => { if (confirm(`Cancel round ${round.round_no}? This deletes the un-sent vouchers + the round. No SMS has gone out.`)) onCancel(); }}
+            className="ml-2 inline-flex items-center gap-2 rounded-lg px-3 py-2 text-sm font-medium text-gray-500 hover:text-red-600 disabled:opacity-50"
+          >
+            <X className="h-4 w-4" /> Cancel round
           </button>
         </div>
       )}

--- a/apps/backoffice/src/app/api/loyalty/loops/cancel/route.ts
+++ b/apps/backoffice/src/app/api/loyalty/loops/cancel/route.ts
@@ -1,0 +1,20 @@
+import { NextRequest, NextResponse } from "next/server";
+import { requireAuth } from "@/lib/auth";
+import { cancelRound } from "@/lib/loyalty/loop-engine";
+
+// POST /api/loyalty/loops/cancel — revert a PREPARED round (delete its un-sent
+// vouchers + assignments + the round). Body: { round_id }. Rejects sent/measured
+// rounds (SMS already out).
+export async function POST(request: NextRequest) {
+  const auth = await requireAuth(request);
+  if (auth.error) return auth.error;
+  try {
+    const { round_id } = await request.json();
+    if (!round_id) return NextResponse.json({ error: "round_id required" }, { status: 400 });
+    const res = await cancelRound(round_id);
+    return NextResponse.json(res);
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : "Failed to cancel round";
+    return NextResponse.json({ error: msg }, { status: 500 });
+  }
+}

--- a/apps/backoffice/src/lib/loyalty/loop-engine.ts
+++ b/apps/backoffice/src/lib/loyalty/loop-engine.ts
@@ -767,3 +767,17 @@ export async function autoMeasureDueRounds(): Promise<{ measured: number }> {
   }
   return { measured };
 }
+
+// Revert a PREPARED round — delete the un-sent (active) vouchers it issued, its
+// assignments, and the round itself. Only valid before send: a sent round has
+// live SMS in customers' hands, so it can't be un-done. Redeemed vouchers (rare
+// pre-send) are left intact so order history isn't broken.
+export async function cancelRound(roundId: string): Promise<{ vouchers: number; assignments: number }> {
+  const { data: round } = await supabaseAdmin.from("loop_rounds").select("status").eq("id", roundId).single();
+  if (!round) throw new Error("round not found");
+  if (round.status !== "prepared") throw new Error(`can only cancel a prepared round (this one is '${round.status}')`);
+  const { data: ir } = await supabaseAdmin.from("issued_rewards").delete().eq("source_ref_id", roundId).eq("status", "active").select("id");
+  const { data: la } = await supabaseAdmin.from("loop_assignments").delete().eq("round_id", roundId).select("id");
+  await supabaseAdmin.from("loop_rounds").delete().eq("id", roundId);
+  return { vouchers: (ir ?? []).length, assignments: (la ?? []).length };
+}


### PR DESCRIPTION
A prepared round issues vouchers at prepare time; there was no way to undo it. Added **cancelRound()** — deletes the un-sent (active) vouchers + assignments + the round. Rejects sent/measured rounds (SMS already out), leaves any redeemed voucher intact. New `/api/loyalty/loops/cancel` route + a **"Cancel round"** button on prepared rounds (confirm-gated).

(Also reverted the stray manual reactivation round #1 — 800 un-sent vouchers + 1,000 assignments removed via SQL, 0 redeemed.)

Typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)