### PR TITLE
Loops: campaign scorecard (cross-loop evaluation dashboard)

### DIFF
--- a/apps/backoffice/src/app/(admin)/loyalty/loops/page.tsx
+++ b/apps/backoffice/src/app/(admin)/loyalty/loops/page.tsx
@@ -18,7 +18,7 @@ import { useState, useEffect, useCallback } from "react";
 import Link from "next/link";
 import {
   ArrowLeft, Repeat, RefreshCw, Send, FlaskConical, Loader2,
-  CheckCircle2, AlertTriangle, Trophy, Users, ShieldOff, Coins, Plus, X, Crown, Sparkles, Clock,
+  CheckCircle2, AlertTriangle, Trophy, Users, ShieldOff, Coins, Plus, X, Crown, Sparkles, Clock, BarChart3,
 } from "lucide-react";
 import { cn } from "@/lib/utils";
 
@@ -59,6 +59,12 @@ type Optimizer = {
   candidates: Candidate[]; loops: LoopMeta[];
   send_time_leaderboard: SendTimeEntry[]; send_window_proposal: { window: string; reason: string }; send_windows: string[];
 };
+type LoopEval = {
+  loop_key: string; label: string; rounds: number; sent: number;
+  redemptions: number; redemption_rate: number; avg_lift_pp: number;
+  incremental_orders: number; incremental_margin_rm: number; sms_cost_rm: number; roi: number;
+};
+type Evaluation = { per_loop: LoopEval[]; totals: Omit<LoopEval, "loop_key" | "label"> };
 
 const CHAMPION_MIN_RECIPIENTS = 300;
 
@@ -126,6 +132,7 @@ function RoleBadge({ role }: { role: "champion" | "challenger" }) {
 export default function LoopsPage() {
   const [rounds, setRounds] = useState<Round[] | null>(null);
   const [opt, setOpt] = useState<Optimizer | null>(null);
+  const [evalData, setEvalData] = useState<Evaluation | null>(null);
   const [err, setErr] = useState<string | null>(null);
   const [busy, setBusy] = useState<string | null>(null);
   const [lastPreview, setLastPreview] = useState<Preview | null>(null);
@@ -134,13 +141,15 @@ export default function LoopsPage() {
   const load = useCallback(async () => {
     try {
       const qs = `?loop_key=${encodeURIComponent(loopKey)}`;
-      const [rRes, oRes] = await Promise.all([
+      const [rRes, oRes, sRes] = await Promise.all([
         fetch(`/api/loyalty/loops${qs}`),
         fetch(`/api/loyalty/loops/optimizer${qs}`),
+        fetch(`/api/loyalty/loops/summary`),
       ]);
       if (!rRes.ok) throw new Error(`list failed (${rRes.status})`);
       setRounds((await rRes.json()) as Round[]);
       if (oRes.ok) setOpt((await oRes.json()) as Optimizer);
+      if (sRes.ok) setEvalData((await sRes.json()) as Evaluation);
       setErr(null);
     } catch (e) {
       setErr(e instanceof Error ? e.message : "Failed to load");
@@ -161,6 +170,8 @@ export default function LoopsPage() {
       <p className="mb-4 text-sm text-gray-500">
         Every campaign is a loop: the engine proposes each round&apos;s offers against a holdout and learns which logic wins — the setup sharpens over time. Pick an objective:
       </p>
+
+      {evalData && <EvaluationPanel data={evalData} />}
 
       {opt && (
         <div className="mb-4 flex flex-wrap gap-2">
@@ -302,6 +313,69 @@ export default function LoopsPage() {
       <button onClick={() => void load()} className="mt-6 inline-flex items-center gap-1.5 text-sm text-gray-500 hover:text-gray-800">
         <RefreshCw className="h-3.5 w-3.5" /> Refresh
       </button>
+    </div>
+  );
+}
+
+// ---- Evaluation overview: cross-loop scorecard ------------------------------
+function Kpi({ label, value, sub, highlight }: { label: string; value: string; sub?: string; highlight?: boolean }) {
+  return (
+    <div className={cn("rounded-lg border p-3", highlight ? "border-[#A2492C]/30 bg-[#A2492C]/5" : "border-gray-200 bg-gray-50")}>
+      <p className="text-xs text-gray-500">{label}</p>
+      <p className="mt-0.5 text-xl font-semibold tabular-nums">{value}</p>
+      {sub && <p className="text-xs text-gray-400">{sub}</p>}
+    </div>
+  );
+}
+function EvaluationPanel({ data }: { data: Evaluation }) {
+  const t = data.totals;
+  return (
+    <div className="mb-6 rounded-xl border border-gray-200 bg-white p-5 shadow-sm">
+      <div className="mb-3 flex items-center gap-2">
+        <BarChart3 className="h-5 w-5 text-[#A2492C]" />
+        <h2 className="text-lg font-semibold">Campaign scorecard</h2>
+        <span className="text-xs text-gray-400">all loops · measured rounds</span>
+      </div>
+      {t.rounds === 0 ? (
+        <p className="text-sm text-gray-500">No measured rounds yet — your scorecard fills in here once rounds complete their attribution window (incremental orders, margin and ROI vs the holdout).</p>
+      ) : (
+        <>
+          <div className="mb-4 grid grid-cols-2 gap-3 sm:grid-cols-4">
+            <Kpi label="SMS sent" value={t.sent.toLocaleString()} sub={`${rm(t.sms_cost_rm)} spent`} />
+            <Kpi label="Redemption" value={`${t.redemption_rate}%`} sub={`${t.redemptions.toLocaleString()} redeemed`} />
+            <Kpi label="Incremental orders" value={`+${t.incremental_orders.toLocaleString()}`} sub="vs holdout" />
+            <Kpi label="Incremental margin" value={rm(t.incremental_margin_rm)} sub={`ROI ${t.roi > 0 ? `${t.roi}×` : "—"}`} highlight />
+          </div>
+          <div className="overflow-x-auto">
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="border-b border-gray-200 text-left text-xs uppercase tracking-wide text-gray-400">
+                  <th className="py-2 pr-3">Loop</th>
+                  <th className="py-2 pr-3 text-right">Rounds</th>
+                  <th className="py-2 pr-3 text-right">Sent</th>
+                  <th className="py-2 pr-3 text-right">Redeemed</th>
+                  <th className="py-2 pr-3 text-right">Avg lift</th>
+                  <th className="py-2 pr-3 text-right">Incr. margin</th>
+                  <th className="py-2 pr-3 text-right">ROI</th>
+                </tr>
+              </thead>
+              <tbody>
+                {data.per_loop.map((l) => (
+                  <tr key={l.loop_key} className="border-b border-gray-100">
+                    <td className="py-2 pr-3 font-medium">{l.label}</td>
+                    <td className="py-2 pr-3 text-right tabular-nums">{l.rounds}</td>
+                    <td className="py-2 pr-3 text-right tabular-nums">{l.sent.toLocaleString()}</td>
+                    <td className="py-2 pr-3 text-right tabular-nums">{l.redemption_rate}%</td>
+                    <td className={cn("py-2 pr-3 text-right tabular-nums", l.avg_lift_pp >= SUCCESS_BAR_PP ? "text-green-700" : l.avg_lift_pp > 0 ? "text-gray-700" : "text-red-600")}>{l.avg_lift_pp > 0 ? "+" : ""}{l.avg_lift_pp}pp</td>
+                    <td className="py-2 pr-3 text-right tabular-nums">{rm(l.incremental_margin_rm)}</td>
+                    <td className="py-2 pr-3 text-right tabular-nums">{l.roi > 0 ? `${l.roi}×` : "—"}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </>
+      )}
     </div>
   );
 }

--- a/apps/backoffice/src/app/api/loyalty/loops/summary/route.ts
+++ b/apps/backoffice/src/app/api/loyalty/loops/summary/route.ts
@@ -1,0 +1,16 @@
+import { NextRequest, NextResponse } from "next/server";
+import { requireAuth } from "@/lib/auth";
+import { getEvaluation } from "@/lib/loyalty/loop-engine";
+
+// GET /api/loyalty/loops/summary — cross-loop evaluation rollup for the
+// campaigns overview dashboard (grand totals + per-loop breakdown).
+export async function GET(request: NextRequest) {
+  const auth = await requireAuth(request);
+  if (auth.error) return auth.error;
+  try {
+    return NextResponse.json(await getEvaluation());
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : "Failed to load evaluation";
+    return NextResponse.json({ error: msg }, { status: 500 });
+  }
+}

--- a/apps/backoffice/src/lib/loyalty/loop-engine.ts
+++ b/apps/backoffice/src/lib/loyalty/loop-engine.ts
@@ -781,3 +781,65 @@ export async function cancelRound(roundId: string): Promise<{ vouchers: number; 
   await supabaseAdmin.from("loop_rounds").delete().eq("id", roundId);
   return { vouchers: (ir ?? []).length, assignments: (la ?? []).length };
 }
+
+// ============================================================================
+// EVALUATION — cross-loop rollup for the campaigns overview dashboard.
+// Pools every MEASURED round across all loops into a grand total + per-loop
+// breakdown: SMS sent/cost, redemptions, incremental orders + margin vs the
+// holdout, and ROI. Answers "is the whole programme working?" at a glance.
+// ============================================================================
+type EvalStat = { arm: string; n: number; lift_pp: number; redemption_rate: number; revenue_per_recipient_rm: number };
+export type LoopEval = {
+  loop_key: string; label: string; rounds: number; sent: number;
+  redemptions: number; redemption_rate: number; avg_lift_pp: number;
+  incremental_orders: number; incremental_margin_rm: number; sms_cost_rm: number; roi: number;
+};
+export type Evaluation = { per_loop: LoopEval[]; totals: Omit<LoopEval, "loop_key" | "label"> };
+
+export async function getEvaluation(): Promise<Evaluation> {
+  const { data: rounds } = await supabaseAdmin
+    .from("loop_rounds").select("loop_key, stats").eq("status", "measured");
+
+  type Acc = { rounds: number; sent: number; redemptions: number; liftW: number; incrOrders: number; incrMargin: number };
+  const blank = (): Acc => ({ rounds: 0, sent: 0, redemptions: 0, liftW: 0, incrOrders: 0, incrMargin: 0 });
+  const byLoop = new Map<string, Acc>();
+
+  for (const r of (rounds ?? []) as Array<{ loop_key: string; stats: EvalStat[] | null }>) {
+    if (!r.stats) continue;
+    const baseRev = r.stats.find((s) => s.arm === "holdout")?.revenue_per_recipient_rm ?? 0;
+    const acc = byLoop.get(r.loop_key) ?? blank();
+    let counted = false;
+    for (const s of r.stats) {
+      if (s.arm === "holdout") continue;
+      counted = true;
+      acc.sent += s.n;
+      acc.redemptions += Math.round(s.n * (s.redemption_rate ?? 0) / 100);
+      acc.liftW += (s.lift_pp ?? 0) * s.n;
+      acc.incrOrders += s.n * (s.lift_pp ?? 0) / 100;
+      acc.incrMargin += ((s.revenue_per_recipient_rm ?? 0) - baseRev) * s.n * GP;
+    }
+    if (counted) acc.rounds += 1;
+    byLoop.set(r.loop_key, acc);
+  }
+
+  const toEval = (loop_key: string, a: Acc): LoopEval => {
+    const sms = +(a.sent * SMS_COST_RM).toFixed(2);
+    return {
+      loop_key, label: LOOPS[loop_key as LoopKey]?.label ?? loop_key,
+      rounds: a.rounds, sent: a.sent, redemptions: a.redemptions,
+      redemption_rate: +(a.sent ? (a.redemptions / a.sent) * 100 : 0).toFixed(1),
+      avg_lift_pp: +(a.sent ? a.liftW / a.sent : 0).toFixed(1),
+      incremental_orders: Math.round(a.incrOrders),
+      incremental_margin_rm: +a.incrMargin.toFixed(2),
+      sms_cost_rm: sms,
+      roi: sms > 0 ? +(a.incrMargin / sms).toFixed(1) : 0,
+    };
+  };
+
+  const per_loop = [...byLoop.entries()].map(([k, a]) => toEval(k, a)).sort((x, y) => y.incremental_margin_rm - x.incremental_margin_rm);
+  const tAcc = blank();
+  for (const a of byLoop.values()) { tAcc.rounds += a.rounds; tAcc.sent += a.sent; tAcc.redemptions += a.redemptions; tAcc.liftW += a.liftW; tAcc.incrOrders += a.incrOrders; tAcc.incrMargin += a.incrMargin; }
+  const { loop_key: _k, label: _l, ...totals } = toEval("__totals__", tAcc);
+  void _k; void _l;
+  return { per_loop, totals };
+}


### PR DESCRIPTION
An evaluation overview at the top of the campaigns page — judge the whole programme at a glance.

- **engine `getEvaluation()`**: pools every measured round across all loops → grand totals + per-loop rollup (SMS sent/cost, redemptions, incremental orders + margin vs holdout, ROI).
- **`GET /api/loyalty/loops/summary`**.
- **"Campaign scorecard" panel**: 4 KPI cards (SMS sent/spend · redemption % · incremental orders · incremental margin + ROI) + a per-loop table. Empty state until rounds complete their attribution window.

Typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)