### PR TITLE
Loops: send via app_settings provider (fix SMS123 misroute)

### DIFF
--- a/apps/backoffice/src/app/(admin)/loyalty/loops/page.tsx
+++ b/apps/backoffice/src/app/(admin)/loyalty/loops/page.tsx
@@ -189,7 +189,7 @@ export default function LoopsPage() {
               const res = await fetch("/api/loyalty/loops/run-triggered", { method: "POST" });
               const data = await res.json();
               if (!res.ok) throw new Error(data?.error ?? "Run failed");
-              const fired = ((data.triggered ?? []) as Array<{ loop: string; sent?: number }>).map((t) => `${t.loop}: ${t.sent ?? 0} sent`).join(" · ");
+              const fired = ((data.triggered ?? []) as Array<{ loop: string; sent?: number; failed?: number; error?: string }>).map((t) => `${t.loop}: ${t.sent ?? 0} sent${t.failed ? `, ${t.failed} failed` : ""}${t.error ? ` (${t.error})` : ""}`).join(" · ");
               setRunResult(fired || "Nothing qualified right now.");
               await load();
             } catch (e) { setErr(e instanceof Error ? e.message : "Run failed"); }
@@ -334,6 +334,7 @@ export default function LoopsPage() {
               }}
               proposedWindow={opt?.send_window_proposal?.window}
               windows={opt?.send_windows ?? []}
+              triggered={activeTriggered}
             />
           ))}
         </div>
@@ -643,9 +644,9 @@ function NumInput({ v, set }: { v: number; set: (n: number) => void }) {
 }
 
 // ---- Round card -------------------------------------------------------------
-function RoundCard({ round, busy, onSend, onMeasure, onSchedule, onCancel, proposedWindow, windows }: {
+function RoundCard({ round, busy, onSend, onMeasure, onSchedule, onCancel, proposedWindow, windows, triggered }: {
   round: Round; busy: boolean; onSend: () => void; onMeasure: () => void;
-  onSchedule: (scheduledSendAt: string, sendWindow: string) => void; onCancel: () => void; proposedWindow?: string; windows: string[];
+  onSchedule: (scheduledSendAt: string, sendWindow: string) => void; onCancel: () => void; proposedWindow?: string; windows: string[]; triggered?: boolean;
 }) {
   const est = estSmsCost(round);
   const [when, setWhen] = useState(() => defaultLocalDatetime());
@@ -723,10 +724,16 @@ function RoundCard({ round, busy, onSend, onMeasure, onSchedule, onCancel, propo
 
       {round.status === "sent" && (
         <div className="rounded-lg border border-blue-200 bg-blue-50 p-3">
-          <div className="mb-2 text-sm text-blue-900">SMS sent{round.sent_at ? ` ${new Date(round.sent_at).toLocaleDateString("en-MY")}` : ""}. Measure after the {round.attribution_window_days}-day window closes.</div>
-          <button disabled={busy} onClick={onMeasure} className="inline-flex items-center gap-2 rounded-lg bg-blue-600 px-4 py-2 text-sm font-medium text-white disabled:opacity-50">
-            {busy ? <Loader2 className="h-4 w-4 animate-spin" /> : <CheckCircle2 className="h-4 w-4" />} Measure results
-          </button>
+          {triggered ? (
+            <div className="text-sm text-blue-900">SMS sent{round.sent_at ? ` ${new Date(round.sent_at).toLocaleDateString("en-MY")}` : ""}. <strong>Auto-measures</strong> when the {round.attribution_window_days}-day window closes — nothing to do.</div>
+          ) : (
+            <>
+              <div className="mb-2 text-sm text-blue-900">SMS sent{round.sent_at ? ` ${new Date(round.sent_at).toLocaleDateString("en-MY")}` : ""}. Auto-measures when the {round.attribution_window_days}-day window closes, or measure now:</div>
+              <button disabled={busy} onClick={onMeasure} className="inline-flex items-center gap-2 rounded-lg bg-blue-600 px-4 py-2 text-sm font-medium text-white disabled:opacity-50">
+                {busy ? <Loader2 className="h-4 w-4 animate-spin" /> : <CheckCircle2 className="h-4 w-4" />} Measure results
+              </button>
+            </>
+          )}
         </div>
       )}
 

--- a/apps/backoffice/src/lib/loyalty/loop-engine.ts
+++ b/apps/backoffice/src/lib/loyalty/loop-engine.ts
@@ -12,7 +12,7 @@
 // ============================================================================
 
 import { supabaseAdmin } from "@/lib/loyalty/supabase";
-import { sendSMS } from "@/lib/loyalty/sms";
+import { sendSMS, getActiveSmsProvider } from "@/lib/loyalty/sms";
 
 const BRAND = "brand-celsius";
 const SMS_COST_RM = 0.1; // SMS Niaga ~RM0.10/SMS
@@ -286,6 +286,10 @@ export async function sendRound(roundId: string) {
   if (!round) throw new Error("round not found");
   if (round.status === "sent" || round.status === "measured") throw new Error(`round already ${round.status}`);
 
+  // Honor the app_settings SMS toggle (smsniaga) — sendSMS otherwise falls back
+  // to the env default (sms123), which fails marketing blasts.
+  const provider = await getActiveSmsProvider();
+
   const armMsg: Record<string, string> = {};
   for (const a of (round.arms as ArmDef[])) armMsg[a.key] = a.message;
 
@@ -297,16 +301,19 @@ export async function sendRound(roundId: string) {
 
   let sent = 0;
   let failed = 0;
+  let firstError: string | undefined;
   for (const r of (rows ?? []) as Array<{ id: string; phone: string; arm: string; sms_status: string | null }>) {
     if (r.sms_status === "sent") continue; // idempotent
     const message = armMsg[r.arm] ?? "";
     if (!message) { failed++; continue; }
-    const res = await sendSMS(r.phone, message); // provider resolved from app_settings toggle
+    const res = await sendSMS(r.phone, message, { provider });
     await supabaseAdmin
       .from("loop_assignments")
-      .update({ sms_status: res.success ? "sent" : "failed", sms_message_id: res.messageId ?? null })
+      // On failure, stash the error in sms_message_id so it's queryable (no
+      // silent fails like the SMS123 misroute).
+      .update({ sms_status: res.success ? "sent" : "failed", sms_message_id: res.success ? (res.messageId ?? null) : (res.error?.slice(0, 200) ?? "failed") })
       .eq("id", r.id);
-    if (res.success) sent++; else failed++;
+    if (res.success) { sent++; } else { failed++; if (!firstError) firstError = res.error; }
   }
 
   const sentAt = new Date();
@@ -317,7 +324,7 @@ export async function sendRound(roundId: string) {
     .update({ status: "sent", sent_at: sentAt.toISOString(), send_window: round.send_window ?? deriveWindow(sentAt) })
     .eq("id", roundId);
 
-  return { round_id: roundId, sent, failed };
+  return { round_id: roundId, sent, failed, error: firstError };
 }
 
 // ── MEASURE ───────────────────────────────────────────────────────────────────
@@ -723,7 +730,7 @@ async function recentlyTargetedPhones(loopKey: LoopKey, cooldownDays: number): P
 
 // Run one triggered loop: auto-prepare a round over today's new qualifiers,
 // then auto-send. Returns a small summary.
-async function runTriggeredLoop(def: LoopDef): Promise<{ loop: LoopKey; qualified: number; sent?: number; failed?: number; round_id?: string }> {
+async function runTriggeredLoop(def: LoopDef): Promise<{ loop: LoopKey; qualified: number; sent?: number; failed?: number; round_id?: string; error?: string }> {
   const trig = def.trigger!;
   const arms = (await proposeArms(def.key)).arms.map((a) => ({ key: a.key, label: a.label, voucher_template_id: a.voucher_template_id, message: a.message }));
   const suppressPhones = await recentlyTargetedPhones(def.key, trig.cooldownDays);
@@ -737,7 +744,7 @@ async function runTriggeredLoop(def: LoopDef): Promise<{ loop: LoopKey; qualifie
   });
   if (!preview.round_id || preview.total === 0) return { loop: def.key, qualified: 0 };
   const res = await sendRound(preview.round_id);
-  return { loop: def.key, qualified: preview.total, sent: res.sent, failed: res.failed, round_id: preview.round_id };
+  return { loop: def.key, qualified: preview.total, sent: res.sent, failed: res.failed, round_id: preview.round_id, error: res.error };
 }
 
 // Cron entrypoint: fire every triggered loop (skip batch/manual ones).


### PR DESCRIPTION
**Root cause of the failed first fire:** sendRound called sendSMS() without a provider → used the env default **SMS123** instead of the app_settings toggle (**smsniaga**). SMS123 rejects marketing blasts → all 161 sends failed silently (vouchers issued, no SMS).

- sendRound now resolves the active provider (getActiveSmsProvider → app_settings.sms_provider) + passes it to every send.
- No more silent failures: send error stashed on loop_assignments + returned from sendRound/runTriggeredLoop; "Run now" result shows failed + error.
- Auto loops drop the manual "Measure results" button (auto-measures).

Failed round + 161 un-sent vouchers already cleaned up. After deploy, re-fire is clean. Typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)