### PR TITLE
Loops: realtime scorecard (auto-measure + live refresh)

### DIFF
--- a/apps/backoffice/src/app/(admin)/loyalty/loops/page.tsx
+++ b/apps/backoffice/src/app/(admin)/loyalty/loops/page.tsx
@@ -166,6 +166,19 @@ export default function LoopsPage() {
   }, [evalDays]);
   useEffect(() => { void loadEval(); }, [loadEval]);
 
+  // Realtime: silently refetch the scorecard + rounds every 20s while the tab is
+  // visible, so the dashboard stays live without a manual refresh (rounds flip to
+  // measured / scorecard fills in on their own). Skipped while hidden or busy.
+  useEffect(() => {
+    const tick = () => {
+      if (document.visibilityState !== "visible") return;
+      void load();
+      void loadEval();
+    };
+    const id = setInterval(tick, 20000);
+    return () => clearInterval(id);
+  }, [load, loadEval]);
+
   // Auto-triggered loops run themselves — no manual "New round" form, no budget.
   const activeTriggered = !!opt?.loops.find((l) => l.key === loopKey)?.triggered;
 
@@ -375,6 +388,13 @@ function EvaluationPanel({ data, days, onDays }: { data: Evaluation; days: numbe
       <div className="mb-3 flex flex-wrap items-center gap-2">
         <BarChart3 className="h-5 w-5 text-[#A2492C]" />
         <h2 className="text-lg font-semibold">Campaign scorecard</h2>
+        <span className="inline-flex items-center gap-1 rounded-full bg-green-50 px-2 py-0.5 text-[11px] font-medium text-green-700" title="Auto-updates every 20s">
+          <span className="relative flex h-1.5 w-1.5">
+            <span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-green-400 opacity-75" />
+            <span className="relative inline-flex h-1.5 w-1.5 rounded-full bg-green-500" />
+          </span>
+          Live
+        </span>
         <span className="text-xs text-gray-400">all loops · measured rounds{days ? ` · sent in last ${days}d` : ""}</span>
         <div className="ml-auto flex items-center gap-1">
           {EVAL_PRESETS.map((p) => (

--- a/apps/backoffice/src/app/api/cron/loops-send/route.ts
+++ b/apps/backoffice/src/app/api/cron/loops-send/route.ts
@@ -1,19 +1,22 @@
 import { NextRequest, NextResponse } from "next/server";
 import { checkCronAuth } from "@celsius/shared";
-import { sendDueRounds } from "@/lib/loyalty/loop-engine";
+import { sendDueRounds, autoMeasureDueRounds } from "@/lib/loyalty/loop-engine";
 
 export const dynamic = "force-dynamic";
 export const maxDuration = 300;
 
 // GET /api/cron/loops-send — fires any scheduled loop round whose send time has
-// arrived. Runs every ~15 min (vercel.json). Approve-gated: only sends rounds an
-// operator explicitly scheduled via /api/loyalty/loops/schedule.
+// arrived, then measures any sent round whose attribution window has closed.
+// Runs every ~15 min (vercel.json), so the scorecard updates within minutes of a
+// window closing instead of waiting for the daily trigger cron. Approve-gated:
+// only sends rounds an operator scheduled via /api/loyalty/loops/schedule.
 export async function GET(req: NextRequest) {
   const cronAuth = checkCronAuth(req.headers);
   if (!cronAuth.ok) return NextResponse.json({ error: cronAuth.error }, { status: cronAuth.status });
   try {
-    const res = await sendDueRounds();
-    return NextResponse.json(res);
+    const sent = await sendDueRounds();
+    const measured = await autoMeasureDueRounds();
+    return NextResponse.json({ ...sent, measured: measured.measured });
   } catch (err) {
     const msg = err instanceof Error ? err.message : "loops-send failed";
     return NextResponse.json({ error: msg }, { status: 500 });


### PR DESCRIPTION
Makes the campaign scorecard realtime, two halves:

**Data lands promptly** — measurement ran only in the daily 1am cron, so a round's results could lag up to ~24h after its attribution window closed. The 15-min `loops-send` cron now also runs `autoMeasureDueRounds`, so rounds measure within minutes of their window closing.

**UI stays live** — the dashboard silently refetches the scorecard + rounds every 20s while the tab is visible (no manual Refresh needed), with a "Live" indicator on the scorecard header.

Typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)