### PR TITLE
Loops: fix birthday segment (1000-row cap) + idempotent daily run

### DIFF
--- a/apps/backoffice/src/app/(admin)/loyalty/loops/page.tsx
+++ b/apps/backoffice/src/app/(admin)/loyalty/loops/page.tsx
@@ -210,7 +210,7 @@ export default function LoopsPage() {
               const res = await fetch("/api/loyalty/loops/run-triggered", { method: "POST" });
               const data = await res.json();
               if (!res.ok) throw new Error(data?.error ?? "Run failed");
-              const fired = ((data.triggered ?? []) as Array<{ loop: string; sent?: number; failed?: number; error?: string }>).map((t) => `${t.loop}: ${t.sent ?? 0} sent${t.failed ? `, ${t.failed} failed` : ""}${t.error ? ` (${t.error})` : ""}`).join(" · ");
+              const fired = ((data.triggered ?? []) as Array<{ loop: string; sent?: number; failed?: number; error?: string; skipped?: boolean }>).map((t) => t.skipped ? `${t.loop}: already ran today` : `${t.loop}: ${t.sent ?? 0} sent${t.failed ? `, ${t.failed} failed` : ""}${t.error ? ` (${t.error})` : ""}`).join(" · ");
               setRunResult(fired || "Nothing qualified right now.");
               await load();
             } catch (e) { setErr(e instanceof Error ? e.message : "Run failed"); }

--- a/apps/backoffice/src/lib/loyalty/loop-engine.ts
+++ b/apps/backoffice/src/lib/loyalty/loop-engine.ts
@@ -59,18 +59,6 @@ function reachable(rows: Array<{ member_id: string; members: MemberRow | null }>
   return out;
 }
 
-function daysUntilBirthday(iso: string): number {
-  const d = new Date(iso);
-  const now = new Date(Date.now());
-  // Compare at DATE granularity, not timestamp — otherwise today's birthday
-  // (whose 00:00 is already past) rolls to next year and reads as 365, so the
-  // birthdayWithinDays:0 trigger would never fire on the actual day.
-  const today0 = Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate());
-  let next = Date.UTC(now.getUTCFullYear(), d.getUTCMonth(), d.getUTCDate());
-  if (next < today0) next = Date.UTC(now.getUTCFullYear() + 1, d.getUTCMonth(), d.getUTCDate());
-  return Math.round((next - today0) / 86400000);
-}
-
 // ── Reactivation: lapsed members (last visit between min..max days ago).
 async function winbackSegment(o: SegmentOpts): Promise<{ rows: SegmentRow[]; label: string }> {
   const minD = o.minDaysLapsed ?? 30, maxD = o.maxDaysLapsed ?? 60;
@@ -93,12 +81,22 @@ async function welcomeSegment(o: SegmentOpts): Promise<{ rows: SegmentRow[]; lab
 }
 
 // ── Birthday: members whose birthday falls within the next K days.
+// Filtered server-side via the loyalty_birthday_members RPC — member_brands has
+// 20k+ rows, so the old "fetch all + filter in JS" silently hit the 1000-row
+// default cap and missed qualifiers. The RPC matches by MM-DD in MYT.
 async function birthdaySegment(o: SegmentOpts): Promise<{ rows: SegmentRow[]; label: string }> {
-  const k = o.birthdayWithinDays ?? 14;
-  const { data, error } = await supabaseAdmin.from("member_brands").select(MEMBER_SELECT).eq("brand_id", BRAND);
+  const k = o.birthdayWithinDays ?? 0;
+  const { data, error } = await supabaseAdmin.rpc("loyalty_birthday_members", { p_brand: BRAND, p_within_days: k });
   if (error) throw new Error(`birthday segment: ${error.message}`);
-  const rows = reachable((data ?? []) as unknown as Array<{ member_id: string; members: MemberRow | null }>, (m) => !!m.birthday && daysUntilBirthday(m.birthday) <= k);
-  return { rows, label: `Birthdays in next ${k}d` };
+  const seen = new Set<string>();
+  const rows: SegmentRow[] = [];
+  for (const r of (data ?? []) as Array<{ member_id: string; phone: string; member_name: string | null }>) {
+    const phone = (r.phone ?? "").trim();
+    if (!phone || seen.has(phone)) continue; // dedupe by phone (PDPA opt-outs already excluded in the RPC)
+    seen.add(phone);
+    rows.push({ member_id: r.member_id, phone, name: r.member_name ?? null });
+  }
+  return { rows, label: k === 0 ? "Birthdays today" : `Birthdays in next ${k}d` };
 }
 
 // ── Weekly round-gap: active customers of one outlet (nudge to a weak round).
@@ -731,10 +729,23 @@ async function recentlyTargetedPhones(loopKey: LoopKey, cooldownDays: number): P
   return Array.from(new Set(((rows ?? []) as Array<{ phone: string }>).map((r) => r.phone)));
 }
 
+// Has this loop already produced a round today (MYT)? Keeps the cadence at one
+// round per loop per day and makes "Run all triggered loops now" idempotent —
+// repeat clicks only fire loops that haven't run yet today (no round-stacking),
+// while a loop that failed/produced nothing earlier still gets retried.
+async function ranToday(loopKey: LoopKey): Promise<boolean> {
+  const MYT = 8 * 3600000;
+  const since = new Date(Math.floor((Date.now() + MYT) / 86400000) * 86400000 - MYT).toISOString();
+  const { data } = await supabaseAdmin
+    .from("loop_rounds").select("id").eq("loop_key", loopKey).gte("prepared_at", since).limit(1);
+  return (data?.length ?? 0) > 0;
+}
+
 // Run one triggered loop: auto-prepare a round over today's new qualifiers,
 // then auto-send. Returns a small summary.
-async function runTriggeredLoop(def: LoopDef): Promise<{ loop: LoopKey; qualified: number; sent?: number; failed?: number; round_id?: string; error?: string }> {
+async function runTriggeredLoop(def: LoopDef): Promise<{ loop: LoopKey; qualified: number; sent?: number; failed?: number; round_id?: string; error?: string; skipped?: boolean }> {
   const trig = def.trigger!;
+  if (await ranToday(def.key)) return { loop: def.key, qualified: 0, skipped: true };
   const arms = (await proposeArms(def.key)).arms.map((a) => ({ key: a.key, label: a.label, voucher_template_id: a.voucher_template_id, message: a.message }));
   const suppressPhones = await recentlyTargetedPhones(def.key, trig.cooldownDays);
   const preview = await prepareRound(def.key, {
@@ -751,8 +762,8 @@ async function runTriggeredLoop(def: LoopDef): Promise<{ loop: LoopKey; qualifie
 }
 
 // Cron entrypoint: fire every triggered loop (skip batch/manual ones).
-export async function runTriggeredLoops(): Promise<Array<{ loop: string; qualified: number; sent?: number; failed?: number; error?: string }>> {
-  const out: Array<{ loop: string; qualified: number; sent?: number; failed?: number; error?: string }> = [];
+export async function runTriggeredLoops(): Promise<Array<{ loop: string; qualified: number; sent?: number; failed?: number; error?: string; skipped?: boolean }>> {
+  const out: Array<{ loop: string; qualified: number; sent?: number; failed?: number; error?: string; skipped?: boolean }> = [];
   for (const def of Object.values(LOOPS)) {
     if (!def.trigger) continue;
     try { out.push(await runTriggeredLoop(def)); }

--- a/supabase/migrations/040_loyalty_birthday_members_rpc.sql
+++ b/supabase/migrations/040_loyalty_birthday_members_rpc.sql
@@ -1,0 +1,23 @@
+-- Birthday segment for the loops engine. member_brands has 20k+ rows; the old
+-- approach (fetch all + filter in JS) silently hit the 1000-row default cap and
+-- missed qualifiers. This filters server-side and returns only the matches.
+-- "Within N days" via MM-DD string match over the next N+1 days (Feb-29 safe).
+-- "Today" uses Asia/Kuala_Lumpur so it aligns with the 9am MYT trigger cron.
+CREATE OR REPLACE FUNCTION loyalty_birthday_members(p_brand text, p_within_days int DEFAULT 0)
+RETURNS TABLE(member_id text, phone text, member_name text)
+LANGUAGE sql STABLE
+AS $$
+  WITH params AS (SELECT (now() AT TIME ZONE 'Asia/Kuala_Lumpur')::date AS today)
+  SELECT mb.member_id::text, m.phone::text, COALESCE(m.name, '')::text
+  FROM member_brands mb
+  JOIN members m ON m.id = mb.member_id
+  CROSS JOIN params
+  WHERE mb.brand_id = p_brand
+    AND COALESCE(m.sms_opt_out, false) = false
+    AND m.phone IS NOT NULL AND btrim(m.phone) <> ''
+    AND m.birthday IS NOT NULL
+    AND EXISTS (
+      SELECT 1 FROM generate_series(0, GREATEST(p_within_days, 0)) AS g(d)
+      WHERE to_char(m.birthday, 'MM-DD') = to_char(params.today + g.d, 'MM-DD')
+    );
+$$;


### PR DESCRIPTION
**Why birthday never fired:** `birthdaySegment` fetched **all** `member_brands` (20,000+ rows) and filtered in JS — Supabase's default **1000-row cap** silently dropped the real birthday qualifiers → empty segment → no round → no SMS. (Welcome/Reactivation filter in the query, so they were unaffected.)

- New `loyalty_birthday_members(brand, within_days)` RPC filters server-side (MM-DD match in MYT, Feb-29 safe), returning only the matches. Verified it returns today's 2. Migration `040`, already applied to the DB.
- `birthdaySegment` now calls the RPC; removed the dead `daysUntilBirthday` helper.

**Also — stop the round-stacking** (operator feedback): `runTriggeredLoop` now skips a loop that already produced a round **today** (MYT). So "Run all triggered loops now" is idempotent — repeat clicks only fire loops that haven't run yet today, while a loop that produced nothing earlier still gets retried. Run-result shows "already ran today".

Typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)