### PR TITLE
Loops: Force run now (bypass once-a-day guard)

### DIFF
--- a/apps/backoffice/src/app/(admin)/loyalty/loops/page.tsx
+++ b/apps/backoffice/src/app/(admin)/loyalty/loops/page.tsx
@@ -165,6 +165,20 @@ export default function LoopsPage() {
   }, [loopKey]);
   useEffect(() => { setRounds(null); setOpt(null); setLastPreview(null); void load(); }, [load]);
 
+  // Fire all triggered loops on demand. force=true ignores the once-a-day guard.
+  const runNow = async (force: boolean) => {
+    setBusy("run"); setErr(null); setRunResult(null);
+    try {
+      const res = await fetch("/api/loyalty/loops/run-triggered", { method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify({ force }) });
+      const data = await res.json();
+      if (!res.ok) throw new Error(data?.error ?? "Run failed");
+      const fired = ((data.triggered ?? []) as Array<{ loop: string; sent?: number; failed?: number; error?: string; skipped?: boolean }>).map((t) => t.skipped ? `${t.loop}: already ran today` : `${t.loop}: ${t.sent ?? 0} sent${t.failed ? `, ${t.failed} failed` : ""}${t.error ? ` (${t.error})` : ""}`).join(" · ");
+      setRunResult(fired || "Nothing qualified right now.");
+      await load();
+    } catch (e) { setErr(e instanceof Error ? e.message : "Run failed"); }
+    finally { setBusy(null); }
+  };
+
   // Scorecard rollup is fetched separately so the date filter only refetches it.
   const loadEval = useCallback(async () => {
     try {
@@ -213,22 +227,23 @@ export default function LoopsPage() {
           disabled={busy === "run"}
           onClick={async () => {
             if (!confirm("Fire all auto-triggered loops NOW? This sends LIVE SMS to everyone who currently qualifies (Reactivation / Welcome / Birthday).")) return;
-            setBusy("run"); setErr(null); setRunResult(null);
-            try {
-              const res = await fetch("/api/loyalty/loops/run-triggered", { method: "POST" });
-              const data = await res.json();
-              if (!res.ok) throw new Error(data?.error ?? "Run failed");
-              const fired = ((data.triggered ?? []) as Array<{ loop: string; sent?: number; failed?: number; error?: string; skipped?: boolean }>).map((t) => t.skipped ? `${t.loop}: already ran today` : `${t.loop}: ${t.sent ?? 0} sent${t.failed ? `, ${t.failed} failed` : ""}${t.error ? ` (${t.error})` : ""}`).join(" · ");
-              setRunResult(fired || "Nothing qualified right now.");
-              await load();
-            } catch (e) { setErr(e instanceof Error ? e.message : "Run failed"); }
-            finally { setBusy(null); }
+            await runNow(false);
           }}
           className="inline-flex items-center gap-2 rounded-lg bg-[#A2492C] px-4 py-2 text-sm font-medium text-white disabled:opacity-50"
         >
           {busy === "run" ? <Loader2 className="h-4 w-4 animate-spin" /> : <Send className="h-4 w-4" />} Run all triggered loops now
         </button>
-        <span className="text-xs text-gray-500">{runResult ?? "Fires Reactivation + Welcome + Birthday immediately. They also run automatically at 9am daily."}</span>
+        <button
+          disabled={busy === "run"}
+          onClick={async () => {
+            if (!confirm("FORCE run NOW? Ignores the once-a-day guard and fires every triggered loop's current qualifiers immediately. Already-messaged customers are still protected by the cooldown. Sends LIVE SMS.")) return;
+            await runNow(true);
+          }}
+          className="inline-flex items-center gap-2 rounded-lg border border-[#A2492C] px-3 py-2 text-sm font-medium text-[#A2492C] disabled:opacity-50"
+        >
+          {busy === "run" ? <Loader2 className="h-4 w-4 animate-spin" /> : <RefreshCw className="h-4 w-4" />} Force run now
+        </button>
+        <span className="text-xs text-gray-500">{runResult ?? "Fires Reactivation + Welcome + Birthday immediately (also auto at 9am daily). “Force” ignores the once-a-day skip — use after changing a segment."}</span>
       </div>
 
       {opt && (

--- a/apps/backoffice/src/app/api/loyalty/loops/run-triggered/route.ts
+++ b/apps/backoffice/src/app/api/loyalty/loops/run-triggered/route.ts
@@ -9,7 +9,10 @@ export async function POST(request: NextRequest) {
   const auth = await requireAuth(request);
   if (auth.error) return auth.error;
   try {
-    const triggered = await runTriggeredLoops();
+    // force:true bypasses the once-a-day guard (cooldown still applies).
+    const body = await request.json().catch(() => ({}));
+    const force = body?.force === true;
+    const triggered = await runTriggeredLoops({ force });
     const measured = await autoMeasureDueRounds();
     return NextResponse.json({ triggered, measured: measured.measured });
   } catch (err) {

--- a/apps/backoffice/src/lib/loyalty/loop-engine.ts
+++ b/apps/backoffice/src/lib/loyalty/loop-engine.ts
@@ -743,9 +743,12 @@ async function ranToday(loopKey: LoopKey): Promise<boolean> {
 
 // Run one triggered loop: auto-prepare a round over today's new qualifiers,
 // then auto-send. Returns a small summary.
-async function runTriggeredLoop(def: LoopDef): Promise<{ loop: LoopKey; qualified: number; sent?: number; failed?: number; round_id?: string; error?: string; skipped?: boolean }> {
+async function runTriggeredLoop(def: LoopDef, force = false): Promise<{ loop: LoopKey; qualified: number; sent?: number; failed?: number; round_id?: string; error?: string; skipped?: boolean }> {
   const trig = def.trigger!;
-  if (await ranToday(def.key)) return { loop: def.key, qualified: 0, skipped: true };
+  // Once-a-day guard — unless the operator forces a run (e.g. after widening a
+  // segment and wanting it out now). Cooldown still protects already-messaged
+  // customers, so a forced run only reaches genuinely new qualifiers.
+  if (!force && await ranToday(def.key)) return { loop: def.key, qualified: 0, skipped: true };
   const arms = (await proposeArms(def.key)).arms.map((a) => ({ key: a.key, label: a.label, voucher_template_id: a.voucher_template_id, message: a.message }));
   const suppressPhones = await recentlyTargetedPhones(def.key, trig.cooldownDays);
   const preview = await prepareRound(def.key, {
@@ -762,11 +765,11 @@ async function runTriggeredLoop(def: LoopDef): Promise<{ loop: LoopKey; qualifie
 }
 
 // Cron entrypoint: fire every triggered loop (skip batch/manual ones).
-export async function runTriggeredLoops(): Promise<Array<{ loop: string; qualified: number; sent?: number; failed?: number; error?: string; skipped?: boolean }>> {
+export async function runTriggeredLoops(opts?: { force?: boolean }): Promise<Array<{ loop: string; qualified: number; sent?: number; failed?: number; error?: string; skipped?: boolean }>> {
   const out: Array<{ loop: string; qualified: number; sent?: number; failed?: number; error?: string; skipped?: boolean }> = [];
   for (const def of Object.values(LOOPS)) {
     if (!def.trigger) continue;
-    try { out.push(await runTriggeredLoop(def)); }
+    try { out.push(await runTriggeredLoop(def, opts?.force)); }
     catch (e) { out.push({ loop: def.key, qualified: 0, error: e instanceof Error ? e.message : "trigger failed" }); }
   }
   return out;


### PR DESCRIPTION
Operator wants the just-widened Reactivation (30–60d, ~1,271) to fire **now**, but today's Reactivation already ran so the once-a-day guard skips it.

Added a **force** path:
- `runTriggeredLoops({ force })` skips the `ranToday` check; `run-triggered` reads `force` from the POST body.
- Dashboard gets a confirm-gated **"Force run now"** button beside the normal one.

Cooldown still applies, so a forced run only reaches genuinely **new** qualifiers (today's already-messaged 78 are protected). A force-run now fires: Reactivation ~1,271 (30–60d), Birthday 2, Welcome 0 (cooldown).

Typecheck clean. Rebased on #451 (30–60d).

🤖 Generated with [Claude Code](https://claude.com/claude-code)