### PR TITLE
Engage: manual SMS broadcast uses the active gateway (SMS Niaga)

### DIFF
--- a/apps/backoffice/src/app/(admin)/loyalty/engage/page.tsx
+++ b/apps/backoffice/src/app/(admin)/loyalty/engage/page.tsx
@@ -299,6 +299,7 @@ export default function NotificationsPage() {
 
   // SMS credits & log state
   const [smsBalance, setSmsBalance] = useState<number | null>(null);
+  const [smsProvider, setSmsProvider] = useState<string>("sms123"); // active gateway
   const [smsBalanceLoading, setSmsBalanceLoading] = useState(false);
   const [smsSentThisMonth, setSmsSentThisMonth] = useState(0);
   const [smsLogs, setSmsLogs] = useState<{ id: string; phone: string; message: string; status: string; created_at: string }[]>([]);
@@ -320,6 +321,7 @@ export default function NotificationsPage() {
       .then((data) => {
         if (data) {
           setSmsBalance(data.balance);
+          if (data.provider) setSmsProvider(data.provider);
           setSmsSentThisMonth(data.sent_this_month);
         }
       })
@@ -527,14 +529,16 @@ export default function NotificationsPage() {
 
   const previewText = useMemo(() => {
     if (!fullMessage) return "Your message preview will appear here...";
-    // Show the actual message that will be sent (with RM0 prefix the API adds)
-    const SMS_PREFIX = `RM0 [${formSenderId || "CelsiusCoffee"}] `;
-    let text = fullMessage.startsWith(SMS_PREFIX) ? fullMessage : `${SMS_PREFIX}${fullMessage}`;
+    // Show the actual message that will be sent, with the active gateway's prefix:
+    // SMS Niaga prepends "RM0 <SENDERID>:"; SMS123 uses "RM0 [<SenderID>] ".
+    const sender = formSenderId || "CelsiusCoffee";
+    const SMS_PREFIX = smsProvider === "smsniaga" ? `RM0 ${sender.toUpperCase()}: ` : `RM0 [${sender}] `;
+    let text = fullMessage.startsWith("RM0 ") ? fullMessage : `${SMS_PREFIX}${fullMessage}`;
     variables.forEach((v) => {
       text = text.replaceAll(v.key, v.preview);
     });
     return text;
-  }, [fullMessage, formSenderId]);
+  }, [fullMessage, formSenderId, smsProvider]);
 
   // KPI data
   const totalSent = messages.reduce((acc, m) => acc + (m.sent ?? 0), 0);
@@ -595,7 +599,7 @@ export default function NotificationsPage() {
               <CreditCard className="h-5 w-5 text-green-600" />
             </div>
             <div className="flex-1 min-w-0">
-              <p className="text-xs font-medium text-gray-500 dark:text-neutral-400">SMS credits</p>
+              <p className="text-xs font-medium text-gray-500 dark:text-neutral-400">SMS credits · <span className="uppercase">{smsProvider === "smsniaga" ? "SMS Niaga" : smsProvider}</span></p>
               <div className="flex items-center gap-2">
                 <p className={`font-sans text-xl font-bold ${smsBalance !== null && smsBalance < 100 ? "text-red-500" : "text-gray-900 dark:text-white"}`}>
                   {smsBalance !== null ? Math.floor(smsBalance).toLocaleString() : "—"}
@@ -604,9 +608,13 @@ export default function NotificationsPage() {
                   <RefreshCw className={`h-3.5 w-3.5 ${smsBalanceLoading ? "animate-spin" : ""}`} />
                 </button>
               </div>
-              <a href="https://www.sms123.net" target="_blank" rel="noopener noreferrer" className="text-[10px] font-medium text-[#C2452D] hover:underline inline-flex items-center gap-0.5">
-                Top up on SMS123 <ExternalLink className="h-2.5 w-2.5" />
-              </a>
+              {smsProvider === "sms123" ? (
+                <a href="https://www.sms123.net" target="_blank" rel="noopener noreferrer" className="text-[10px] font-medium text-[#C2452D] hover:underline inline-flex items-center gap-0.5">
+                  Top up on SMS123 <ExternalLink className="h-2.5 w-2.5" />
+                </a>
+              ) : (
+                <span className="text-[10px] text-gray-400">Live gateway · balance managed in SMS Niaga</span>
+              )}
             </div>
           </div>
         </div>
@@ -1394,7 +1402,7 @@ export default function NotificationsPage() {
                         )}
                       >
                         {fullMessage.length}/{charLimit} characters
-                        <span className="text-gray-300"> (auto-prefix: RM0 [{formSenderId || "CelsiusCoffee"}])</span>
+                        <span className="text-gray-300"> (auto-prefix: {smsProvider === "smsniaga" ? `RM0 ${(formSenderId || "CelsiusCoffee").toUpperCase()}:` : `RM0 [${formSenderId || "CelsiusCoffee"}]`})</span>
                       </span>
                       {(formChannel === "sms" || formChannel === "both") && formScheduleType === "now" && smsBalance !== null && (
                         <span className="text-xs text-gray-400">

--- a/apps/backoffice/src/app/api/loyalty/sms/blast/route.ts
+++ b/apps/backoffice/src/app/api/loyalty/sms/blast/route.ts
@@ -41,31 +41,36 @@ export async function POST(request: NextRequest) {
     }
 
     // Check SMS123 balance before sending
-    const apiKey = process.env.SMS123_API_KEY;
-    const email = process.env.SMS123_EMAIL;
-    if (apiKey && email) {
-      try {
-        const params = new URLSearchParams({ apiKey, email });
-        const res = await fetch(`https://www.sms123.net/api/getBalance.php?${params.toString()}`);
-        const data = await res.json();
-        if (data.status === 'ok') {
-          const balance = parseFloat(String(data.balance).replace(/,/g, ''));
-          // Balance is in message credits (1 credit = 1 SMS)
-          if (balance < uniquePhones.length) {
-            return NextResponse.json({
-              error: `Insufficient SMS123 credits. Need ${uniquePhones.length}, have ${Math.floor(balance)}. Top up at sms123.net.`,
-              balance: Math.floor(balance),
-              needed: uniquePhones.length,
-            }, { status: 400 });
-          }
-        }
-      } catch {
-        // Continue even if balance check fails
-      }
-    }
-
     // Active gateway from the backoffice toggle (app_settings → env fallback).
     const provider = await getActiveSmsProvider();
+
+    // Pre-flight credit check is SMS123-specific — only gate the send on it when
+    // SMS123 is the active gateway. (SMS Niaga has its own balance; it rejects
+    // per-message if short, which we record as failures.)
+    if (provider === 'sms123') {
+      const apiKey = process.env.SMS123_API_KEY;
+      const email = process.env.SMS123_EMAIL;
+      if (apiKey && email) {
+        try {
+          const params = new URLSearchParams({ apiKey, email });
+          const res = await fetch(`https://www.sms123.net/api/getBalance.php?${params.toString()}`);
+          const data = await res.json();
+          if (data.status === 'ok') {
+            const balance = parseFloat(String(data.balance).replace(/,/g, ''));
+            // Balance is in message credits (1 credit = 1 SMS)
+            if (balance < uniquePhones.length) {
+              return NextResponse.json({
+                error: `Insufficient SMS123 credits. Need ${uniquePhones.length}, have ${Math.floor(balance)}. Top up at sms123.net.`,
+                balance: Math.floor(balance),
+                needed: uniquePhones.length,
+              }, { status: 400 });
+            }
+          }
+        } catch {
+          // Continue even if balance check fails
+        }
+      }
+    }
 
     // Auto-prepend RM0 [<SenderID>] prefix if not already present.
     // SMS Niaga adds its own "RM0.00 <SenderID>:" at the gateway, so skip ours there.

--- a/apps/backoffice/src/app/api/loyalty/sms/credits/route.ts
+++ b/apps/backoffice/src/app/api/loyalty/sms/credits/route.ts
@@ -12,24 +12,29 @@ export async function GET(request: NextRequest) {
     const { searchParams } = new URL(request.url);
     const brandId = searchParams.get('brand_id') || 'brand-celsius';
 
-    // Fetch real balance from SMS123
-    const apiKey = process.env.SMS123_API_KEY;
-    const email = process.env.SMS123_EMAIL;
-    let sms123Balance: number | null = null;
+    const provider = await getActiveSmsProvider();
 
-    if (apiKey && email) {
-      try {
-        const params = new URLSearchParams({ apiKey, email });
-        const res = await fetch(`https://www.sms123.net/api/getBalance.php?${params.toString()}`, {
-          next: { revalidate: 0 },
-        });
-        const data = await res.json();
-        if (data.status === 'ok' && data.balance != null) {
-          // SMS123 returns formatted numbers like "2,000.00" — strip commas before parsing
-          sms123Balance = parseFloat(String(data.balance).replace(/,/g, ''));
+    // Balance is only meaningful for the active gateway. SMS123 exposes a balance
+    // API; SMS Niaga doesn't have one wired here, so we report null (no false
+    // SMS123 number when SMS Niaga is live).
+    let balance: number | null = null;
+    if (provider === 'sms123') {
+      const apiKey = process.env.SMS123_API_KEY;
+      const email = process.env.SMS123_EMAIL;
+      if (apiKey && email) {
+        try {
+          const params = new URLSearchParams({ apiKey, email });
+          const res = await fetch(`https://www.sms123.net/api/getBalance.php?${params.toString()}`, {
+            next: { revalidate: 0 },
+          });
+          const data = await res.json();
+          if (data.status === 'ok' && data.balance != null) {
+            // SMS123 returns formatted numbers like "2,000.00" — strip commas before parsing
+            balance = parseFloat(String(data.balance).replace(/,/g, ''));
+          }
+        } catch (err) {
+          console.error('Failed to fetch SMS123 balance:', err);
         }
-      } catch (err) {
-        console.error('Failed to fetch SMS123 balance:', err);
       }
     }
 
@@ -54,8 +59,8 @@ export async function GET(request: NextRequest) {
       .limit(50);
 
     return NextResponse.json({
-      balance: sms123Balance,
-      provider: await getActiveSmsProvider(),
+      balance,
+      provider,
       total_sent: totalSent ?? 0,
       sent_this_month: sentThisMonth ?? 0,
       history: history ?? [],


### PR DESCRIPTION
Operator: the manual SMS broadcast composer "not connected to smsniaga when changed" — it showed SMS123 credits/prefix and blocked on "Insufficient SMS123 balance" despite the toggle being on SMS Niaga.

The send path already resolved the active provider; the **balance precheck + UI** were the SMS123-hardwired parts:
- **blast route**: SMS123 balance precheck only runs when SMS123 is the active gateway (SMS Niaga isn't blocked by it).
- **credits route**: only queries SMS123 balance when SMS123 is active; otherwise returns the active provider + `null` balance (no misleading SMS123 number).
- **engage UI**: balance card names the live gateway + hides the SMS123 top-up link on SMS Niaga; preview + auto-prefix hint show SMS Niaga's `RM0 <SENDERID>:` format; the credit gate/warnings only apply to SMS123.

Typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)