### PR TITLE
fix(checkout): apply % promo/tier discount on modifier-inclusive price

### DIFF
--- a/apps/order/src/app/api/checkout/initiate/route.ts
+++ b/apps/order/src/app/api/checkout/initiate/route.ts
@@ -373,11 +373,23 @@ export async function POST(request: NextRequest) {
     // here. Customer-typed promo codes were removed end-to-end. Voucher
     // (legacy) and reward discounts stay separate since they predate
     // the engine.
-    const cartLinesBare = typedItems.map((item) => ({
-      product_id: (item.product?.id ?? item.product_id) as string,
-      quantity: item.quantity,
-      unit_price: priceMap.get((item.product?.id ?? item.product_id) as string) ?? 0,
-    }));
+    const cartLinesBare = typedItems.map((item) => {
+      const pid = (item.product?.id ?? item.product_id) as string;
+      // Per-unit price INCLUDING modifier upcharges (e.g. Iced +RM1), matching
+      // serverSubtotalSen above. The promo/tier engine discounts on this, so a
+      // % perk applies to what the customer actually pays. Using the bare
+      // catalogue price here under-discounted % perks by (percent × modifier)
+      // — Black Card 50% on an Iced (+RM1) drink lost RM0.50, charging RM14.40
+      // where the quote showed RM13.90.
+      const modifierDeltaRm = (item.modifiers?.selections ?? []).reduce(
+        (sum, s) => sum + Math.max(0, s.priceDelta ?? 0), 0,
+      );
+      return {
+        product_id: pid,
+        quantity: item.quantity,
+        unit_price: (priceMap.get(pid) ?? 0) + modifierDeltaRm,
+      };
+    });
     // Categories needed for category-gated combos. Same pattern as
     // /api/orders — server-side lookup so the client can't spoof.
     const productIdsForCategory = Array.from(

--- a/apps/order/src/app/api/orders/route.ts
+++ b/apps/order/src/app/api/orders/route.ts
@@ -470,15 +470,24 @@ export async function POST(request: NextRequest) {
       quantity: number;
       basePrice?: number;
       totalPrice?: number;
+      modifiers?: unknown;
     };
     const cartLinesBare = (items as IncomingItem[]).map((i) => {
       const pid = i.product?.id ?? i.productId ?? i.product_id ?? "";
       // Use the authoritative DB price (not client basePrice) so a crafted
       // basePrice can't inflate a percentage-off promo discount.
-      const unit = pricedMap.get(pid) ?? (i.basePrice != null
+      const base = pricedMap.get(pid) ?? (i.basePrice != null
         ? i.basePrice
         : (i.totalPrice ?? 0) / Math.max(1, i.quantity));
-      return { product_id: pid, quantity: i.quantity, unit_price: unit };
+      // Add modifier upcharges so a % perk (e.g. Black Card 50%) discounts the
+      // price the customer actually pays — bare base price under-discounted by
+      // percent×modifier. Handle both shapes (native array / PWA {selections}),
+      // same as serverSubtotalSen above.
+      const mods = Array.isArray(i.modifiers)
+        ? (i.modifiers as Array<{ priceDelta?: number }>)
+        : (((i.modifiers as { selections?: Array<{ priceDelta?: number }> } | null)?.selections) ?? []);
+      const modifierDeltaRm = mods.reduce((s, m) => s + Math.max(0, m.priceDelta ?? 0), 0);
+      return { product_id: pid, quantity: i.quantity, unit_price: base + modifierDeltaRm };
     });
     // Batch-look-up product categories so the loyalty evaluator can
     // honor category-gated combos ("any classic drink + any roti


### PR DESCRIPTION
## Why
Reported: a Black Card (50% off) member was quoted **RM13.90** but charged **RM14.40** (order C-3851). 

## Root cause
The percentage tier perk was computed on the **bare catalogue price**, excluding modifier upcharges. The promo engine's cart lines used `priceMap` base price (Latte RM11.90), while the order subtotal + charge correctly included the +RM1 "Iced" modifier (RM12.90). So Black Card 50% discounted 50%×RM26.80 = RM13.40 instead of 50%×RM27.80 = RM13.90 — short by exactly **percent × modifier** (50% × RM1 = RM0.50). The customer's RM13.90 was correct; the charge was RM0.50 too high.

## Fix
Both charge paths (`checkout/initiate`, `/api/orders`) now add the per-unit modifier delta into the promo-engine `unit_price`, matching `serverSubtotalSen`. So % discounts apply to what the customer actually pays.

Quote (`/api/checkout/quote`) is preview-only and its payload carries no modifier data — the **charge** is now correct, which is what matters; quote consistency is a separate client-side follow-up if needed.

## Blast radius
~54 orders / ~RM14.14 total overcharged over 120 days (worst RM1.50). Small, but a real correctness/trust issue — now prevented going forward.

`tsc --noEmit` clean on apps/order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)