### PR TITLE
Loops: Birthday vouchers read as a birthday gift in the wallet

### DIFF
--- a/apps/backoffice/src/lib/loyalty/loop-engine.ts
+++ b/apps/backoffice/src/lib/loyalty/loop-engine.ts
@@ -139,7 +139,13 @@ function shuffle<T>(arr: T[]): T[] {
   return a;
 }
 
-async function issueReward(memberId: string, templateId: string, roundId: string): Promise<{ id: string; cogsRm: number } | null> {
+// sourceType tags the voucher's origin on issued_rewards. Most loops use
+// "campaign" (the generic win-back/round-gap bucket), but lifecycle loops pass
+// their own (e.g. Birthday → "birthday") so the native wallet shows the right
+// eyebrow + styling ("Birthday gift", gift icon) instead of a generic
+// "Welcome back" campaign card. Attribution keys off source_ref_id (the round
+// id), NOT source_type, so this is display-only and safe to vary per loop.
+async function issueReward(memberId: string, templateId: string, roundId: string, sourceType: string): Promise<{ id: string; cogsRm: number } | null> {
   const { data: tpl } = await supabaseAdmin
     .from("voucher_templates")
     .select(`id, title, description, icon, category, validity_days, discount_type, discount_value, min_order_value, applicable_categories, applicable_products, free_product_name, stacks_with_beans`)
@@ -159,7 +165,7 @@ async function issueReward(memberId: string, templateId: string, roundId: string
     brand_id: BRAND,
     member_id: memberId,
     voucher_template_id: tpl.id,
-    source_type: "campaign",
+    source_type: sourceType,
     source_ref_id: roundId, // ties the reward to this loop round for attribution
     title: tpl.title,
     description: tpl.description,
@@ -252,6 +258,11 @@ export async function prepareRound(loopKey: LoopKey, opts: {
     created_by: opts.createdBy ?? null,
   });
 
+  // Voucher source bucket per loop — Birthday vouchers read as a birthday
+  // gift in the wallet; every other loop stays in the generic "campaign"
+  // bucket. Display-only (attribution joins on source_ref_id).
+  const sourceType = loopKey === "birthday" ? "birthday" : "campaign";
+
   const armCounts: Record<string, number> = {};
   let rewardCogs = 0;
 
@@ -270,7 +281,7 @@ export async function prepareRound(loopKey: LoopKey, opts: {
   for (let i = 0; i < treatment.length; i++) {
     const m = treatment[i];
     const arm = arms[i % arms.length];
-    const issued = await issueReward(m.member_id, arm.voucher_template_id, roundId);
+    const issued = await issueReward(m.member_id, arm.voucher_template_id, roundId, sourceType);
     if (issued) rewardCogs += issued.cogsRm;
     await supabaseAdmin.from("loop_assignments").insert({
       id: rid("la"),

--- a/apps/pickup-native/app/index.tsx
+++ b/apps/pickup-native/app/index.tsx
@@ -1572,8 +1572,11 @@ function describeVoucherTicket(v: Voucher): TicketDescriptor {
     eyebrow = "Discount";
     headline = `${dv}% off`;
   } else if (v.discount_type === "free_item") {
-    if (v.source_type === "birthday") headline = "Free drink";
-    else if (v.category === "free_item") headline = "Free drink";
+    // Use the voucher's own title — a birthday "Free Coffee" must NOT be
+    // flattened to "Free drink" (it left customers hunting for a coffee
+    // reward the card had renamed). free_product_name wins when set
+    // ("Free Croissant"); otherwise the title already carries the value.
+    headline = v.free_product_name ? `Free ${v.free_product_name}` : v.title;
   } else if (v.discount_type === "beans_multiplier") {
     // "2× Points" rather than "2× Points Boost" — the second word wraps
     // a 144-wide top stub at 19pt Peachi and tips the card taller than


### PR DESCRIPTION
## Problem
The birthday SMS loop (round #1, fired today by `cron:loops-trigger`) issued vouchers correctly — active, redeemable, SMS sent — but tagged them `source_type='campaign'` (the loop engine's generic bucket). In the native app that meant:
- Home card eyebrow read **"Welcome back"** (only `source_type='birthday'` gets "Birthday gift")
- The free-item headline was hard-coded to **"Free drink"**

So a member who got the *"Happy birthday — free coffee"* SMS saw a **"Welcome back / Free drink"** card and couldn't find the promised free coffee, even though it was sitting in her wallet.

## Changes
- **`loop-engine.ts`** — Birthday-loop vouchers now tag `source_type='birthday'` (other loops stay `campaign`). Display-only: attribution joins on `source_ref_id` (the round id), not `source_type`, and both buckets are already wallet-counted.
- **`pickup-native/app/index.tsx`** — free-item home card headline now uses the voucher's own title (`"Free Coffee"`) / `free_product_name` instead of a hard-coded `"Free drink"`.

## Data backfill (already applied to prod)
Today's two already-issued birthday vouchers were flipped `campaign` → `birthday` so current recipients are corrected immediately. The home-card headline correction ships with the next pickup-native build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013e1uxzCiy5Cr8XS9bwCGCY

---
_Generated by [Claude Code](https://claude.ai/code/session_013e1uxzCiy5Cr8XS9bwCGCY)_