### PR TITLE
Round-gap loop: segment RPC + meta slot (foundation)

### DIFF
--- a/supabase/migrations/042_round_gap_segment.sql
+++ b/supabase/migrations/042_round_gap_segment.sql
@@ -1,0 +1,40 @@
+-- Round-gap audience: home-outlet regulars (from order history, both ID schemes)
+-- who DON'T habitually order at the target round — i.e. incremental for that
+-- day-part. Reachable + active. Uncapped (server-side). Drives the round-gap loop.
+CREATE OR REPLACE FUNCTION loyalty_round_gap_segment(
+  p_outlet text, p_round_start int, p_round_end int,
+  p_active_days int DEFAULT 45, p_history_days int DEFAULT 90, p_max_round_orders int DEFAULT 1
+)
+RETURNS TABLE(member_id text, phone text, member_name text)
+LANGUAGE sql STABLE AS $$
+  WITH ids AS (
+    SELECT CASE p_outlet
+      WHEN 'conezion'  THEN ARRAY['conezion','outlet-con']
+      WHEN 'shah-alam' THEN ARRAY['shah-alam','outlet-sa']
+      WHEN 'tamarind'  THEN ARRAY['tamarind','outlet-tam']
+      ELSE ARRAY[p_outlet] END AS arr
+  ),
+  ord AS (
+    SELECT po.customer_phone AS phone, po.outlet_id AS outlet,
+      extract(hour from (po.created_at AT TIME ZONE 'Asia/Kuala_Lumpur'))::int AS h, po.created_at AS ts
+    FROM pos_orders po WHERE po.customer_phone IS NOT NULL AND po.created_at >= now() - (p_history_days||' days')::interval
+    UNION ALL
+    SELECT o.customer_phone, o.store_id,
+      extract(hour from (o.created_at AT TIME ZONE 'Asia/Kuala_Lumpur'))::int, o.created_at
+    FROM orders o WHERE o.customer_phone IS NOT NULL AND o.created_at >= now() - (p_history_days||' days')::interval
+  ),
+  at_outlet AS (
+    SELECT o.phone, count(*) AS outlet_orders,
+      count(*) FILTER (WHERE o.h >= p_round_start AND o.h < p_round_end) AS round_orders
+    FROM ord o CROSS JOIN ids WHERE o.outlet = ANY(ids.arr) GROUP BY o.phone
+  ),
+  recency AS ( SELECT phone, max(ts) AS last_any FROM ord GROUP BY phone )
+  SELECT DISTINCT m.id::text, m.phone::text, coalesce(m.name,'')::text
+  FROM at_outlet a
+  JOIN recency r ON r.phone = a.phone
+  JOIN members m ON m.phone = a.phone
+  JOIN member_brands mb ON mb.member_id = m.id AND mb.brand_id = 'brand-celsius'
+  WHERE a.outlet_orders >= 2 AND a.round_orders <= p_max_round_orders
+    AND r.last_any >= now() - (p_active_days||' days')::interval
+    AND coalesce(m.sms_opt_out,false) = false AND m.phone IS NOT NULL AND btrim(m.phone) <> '';
+$$;

--- a/supabase/migrations/043_loop_rounds_meta.sql
+++ b/supabase/migrations/043_loop_rounds_meta.sql
@@ -1,0 +1,4 @@
+-- Generic metadata bag for loop rounds — round-gap stashes {outlet, round_start,
+-- round_end, promo_id, member_tag} so it can measure the right day-part and clean
+-- up its auto-created promo + tags after the window.
+ALTER TABLE loop_rounds ADD COLUMN IF NOT EXISTS meta jsonb;


### PR DESCRIPTION
Foundation for the per-outlet round-gap campaign (DB only, no behaviour change yet):
- `loyalty_round_gap_segment` — incremental per-outlet audience (order-history home outlet, skips round-regulars, both ID schemes, uncapped). Verified: Conezion Breakfast = 47, 100% phone-match.
- `loop_rounds.meta` — slot for the round's outlet/round/promo_id/tag.

Next: prepare (tag + auto-promo) → send → round-specific measure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)