### PR TITLE
Round-gap loop: prepare + round-specific measure + cleanup (end-to-end)

### DIFF
--- a/apps/backoffice/src/app/(admin)/loyalty/loops/page.tsx
+++ b/apps/backoffice/src/app/(admin)/loyalty/loops/page.tsx
@@ -283,6 +283,26 @@ export default function LoopsPage() {
         </div>
       )}
 
+      {loopKey === "round_gap" && (
+        <RoundGapPrepareCard
+          busy={busy === "rg"}
+          onPrepare={async (campaign) => {
+            setBusy("rg"); setErr(null); setRunResult(null);
+            try {
+              const res = await fetch("/api/loyalty/loops/round-gap/prepare", {
+                method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify({ campaign }),
+              });
+              const data = await res.json();
+              if (!res.ok) throw new Error(data?.error ?? "Prepare failed");
+              setRunResult(data.message ?? "Prepared.");
+              await load();
+            } catch (e) { setErr(e instanceof Error ? e.message : "Prepare failed"); }
+            finally { setBusy(null); }
+          }}
+          note={runResult}
+        />
+      )}
+
       {opt && <MessagesPanel arms={opt.proposal.arms} />}
 
       {opt && <OptimizerPanel opt={opt} />}
@@ -513,6 +533,42 @@ function MiniStat({ label, value }: { label: string; value: string }) {
     <div>
       <p className="text-[11px] uppercase tracking-wide text-gray-400">{label}</p>
       <p className="text-sm font-semibold tabular-nums text-gray-900">{value}</p>
+    </div>
+  );
+}
+
+// ---- Round-gap prepare: tag audience + auto-create the time-boxed promo ------
+function RoundGapPrepareCard({ busy, onPrepare, note }: { busy: boolean; onPrepare: (campaign: string) => void; note: string | null }) {
+  const campaigns = [
+    { id: "conezion-breakfast", title: "Conezion · Breakfast (7–9am)", offer: "Free coffee with any breakfast — drives food attach, margin-safe (it's a free low-COGS item, not a discount)", audience: "Conezion regulars who skip breakfast" },
+    { id: "shah-alam-evening", title: "Shah Alam · Evening (5–7pm)", offer: "Free coffee with any bite — de-concentrate the midday peak", audience: "Shah Alam regulars who skip evenings" },
+  ];
+  return (
+    <div className="mb-6 rounded-xl border border-gray-200 bg-white p-5 shadow-sm">
+      <div className="mb-1 flex items-center gap-2">
+        <Coins className="h-5 w-5 text-[#A2492C]" />
+        <h2 className="text-lg font-semibold">Prepare a round-gap campaign</h2>
+      </div>
+      <p className="mb-3 text-xs text-gray-500">
+        Auto-tags the audience and creates a time-boxed, tag-restricted promo — no manual promotions to set. Prepares a round you review + send below (10% held back as control; no SMS until you approve).
+      </p>
+      <div className="grid gap-3 md:grid-cols-2">
+        {campaigns.map((c) => (
+          <div key={c.id} className="rounded-lg border border-gray-200 bg-gray-50 p-3">
+            <div className="text-sm font-semibold text-gray-900">{c.title}</div>
+            <p className="mt-0.5 text-xs text-gray-600">{c.offer}</p>
+            <p className="mt-1 text-[11px] text-gray-400">{c.audience}</p>
+            <button
+              disabled={busy}
+              onClick={() => { if (confirm(`Prepare "${c.title}"? This tags the audience + creates the promo. No SMS until you send the round.`)) onPrepare(c.id); }}
+              className="mt-2 inline-flex items-center gap-1.5 rounded-lg bg-[#A2492C] px-3 py-1.5 text-sm font-medium text-white disabled:opacity-50"
+            >
+              {busy ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <FlaskConical className="h-3.5 w-3.5" />} Prepare
+            </button>
+          </div>
+        ))}
+      </div>
+      {note && <p className="mt-3 rounded-lg border border-green-200 bg-green-50 px-3 py-2 text-xs text-green-900">{note}</p>}
     </div>
   );
 }

--- a/apps/backoffice/src/app/api/loyalty/loops/round-gap/prepare/route.ts
+++ b/apps/backoffice/src/app/api/loyalty/loops/round-gap/prepare/route.ts
@@ -1,0 +1,70 @@
+import { NextRequest, NextResponse } from "next/server";
+import { requireAuth } from "@/lib/auth";
+import { supabaseAdmin } from "@/lib/loyalty/supabase";
+
+export const dynamic = "force-dynamic";
+export const maxDuration = 60;
+
+// Curated round-gap campaigns per the office-hours design (docs/design/
+// personalised-round-gap-loop.md). Offer = low-COGS "free coffee when you spend
+// RM20+" (free_item gated by min_order_value) — NOT a discount, and the RM20
+// basket forces a real order beyond a lone coffee (food attach) at the weak
+// round. Margin-safe: the give is ~RM3 coffee COGS, carried by the basket. Each
+// keeps a 10% holdout. The prepare RPC tags the treatment group + auto-creates
+// the time-boxed, tag-restricted, outlet-scoped promo. Status 'prepared' → the
+// operator reviews + sends from the round card (no SMS here).
+const CAMPAIGNS: Record<string, {
+  outlet: string; round_start: number; round_end: number;
+  name: string; offer_label: string; message: string;
+}> = {
+  "conezion-breakfast": {
+    outlet: "conezion", round_start: 7, round_end: 9,
+    name: "Conezion · Breakfast", offer_label: "Free coffee when you spend RM20+ (7–9am)",
+    message: "Free coffee with breakfast at Celsius Conezion, 7-9am this week — spend RM20+ and your coffee's on us. Show your number to redeem.",
+  },
+  "shah-alam-evening": {
+    outlet: "shah-alam", round_start: 17, round_end: 19,
+    name: "Shah Alam · Evening", offer_label: "Free coffee when you spend RM20+ (5–7pm)",
+    message: "Free coffee at Celsius Shah Alam, 5-7pm this week — spend RM20+ and your coffee's on us. Show your number to redeem.",
+  },
+};
+
+// POST /api/loyalty/loops/round-gap/prepare  { campaign: "conezion-breakfast" }
+// Admin-gated. Creates a 'prepared' round-gap round (segment + tag + auto-promo).
+// Does NOT send — review + approve the round to fire the SMS.
+export async function POST(request: NextRequest) {
+  const auth = await requireAuth(request);
+  if (auth.error) return auth.error;
+  try {
+    const body = await request.json().catch(() => ({}));
+    const cfg = CAMPAIGNS[body?.campaign as string];
+    if (!cfg) {
+      return NextResponse.json({ error: `Unknown campaign. Options: ${Object.keys(CAMPAIGNS).join(", ")}` }, { status: 400 });
+    }
+    const { data, error } = await supabaseAdmin.rpc("loyalty_round_gap_prepare", {
+      p_outlet: cfg.outlet,
+      p_round_start: cfg.round_start,
+      p_round_end: cfg.round_end,
+      p_round_name: cfg.name,
+      p_offer_label: cfg.offer_label,
+      p_message: cfg.message,
+    });
+    if (error) throw new Error(error.message);
+    const row = Array.isArray(data) ? data[0] : data;
+    if (!row?.round_id) {
+      return NextResponse.json({ prepared: false, message: "No eligible customers right now — nothing prepared." });
+    }
+    return NextResponse.json({
+      prepared: true,
+      round_id: row.round_id,
+      treated: row.treated,
+      holdout: row.holdout,
+      promo_id: row.promo_id,
+      member_tag: row.member_tag,
+      message: `Prepared ${cfg.name}: ${row.treated} treated + ${row.holdout} holdout. Review the round below, then Send to fire the SMS.`,
+    });
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : "Failed to prepare round-gap";
+    return NextResponse.json({ error: msg }, { status: 500 });
+  }
+}

--- a/apps/backoffice/src/lib/loyalty/loop-engine.ts
+++ b/apps/backoffice/src/lib/loyalty/loop-engine.ts
@@ -372,6 +372,21 @@ export async function measureRound(roundId: string) {
 
   const windowMs = (round.attribution_window_days as number) * 86400000;
 
+  // Round-gap rounds measure round-specifically: only orders placed AT THE TARGET
+  // OUTLET during the TARGET ROUND (day-part) count as conversions — that's the
+  // behaviour the campaign moves, so lift vs holdout isn't diluted by "any order".
+  const RG_OUTLET_IDS: Record<string, string[]> = {
+    conezion: ["conezion", "outlet-con"],
+    "shah-alam": ["shah-alam", "outlet-sa"],
+    tamarind: ["tamarind", "outlet-tam"],
+  };
+  const meta = (round.meta ?? {}) as { kind?: string; outlet?: string; round_start?: number; round_end?: number; promo_id?: string; member_tag?: string };
+  const rgMeta =
+    meta.kind === "round_gap" && meta.outlet != null && meta.round_start != null && meta.round_end != null
+      ? { round_start: meta.round_start, round_end: meta.round_end, outletIds: RG_OUTLET_IDS[meta.outlet] ?? [meta.outlet] }
+      : null;
+  const mytHour = (iso: string) => new Date(new Date(iso).toLocaleString("en-US", { timeZone: "Asia/Kuala_Lumpur" })).getHours();
+
   type Acc = { n: number; converted: number; redeemed: number; revenueRm: number };
   const byArm: Record<string, Acc> = {};
 
@@ -384,10 +399,20 @@ export async function measureRound(roundId: string) {
 
     // orders by phone in the window (online + POS)
     const [{ data: o1 }, { data: o2 }] = await Promise.all([
-      supabaseAdmin.from("orders").select("total").eq("customer_phone", r.phone).gte("created_at", start).lte("created_at", end),
-      supabaseAdmin.from("pos_orders").select("total").eq("customer_phone", r.phone).gte("created_at", start).lte("created_at", end),
+      supabaseAdmin.from("orders").select("total, created_at, store_id").eq("customer_phone", r.phone).gte("created_at", start).lte("created_at", end),
+      supabaseAdmin.from("pos_orders").select("total, created_at, outlet_id").eq("customer_phone", r.phone).gte("created_at", start).lte("created_at", end),
     ]);
-    const orders = [...(o1 ?? []), ...(o2 ?? [])] as Array<{ total: number | null }>;
+    let orders = [
+      ...((o1 ?? []) as Array<{ total: number | null; created_at: string; store_id: string | null }>).map((o) => ({ total: o.total, created_at: o.created_at, outlet: o.store_id })),
+      ...((o2 ?? []) as Array<{ total: number | null; created_at: string; outlet_id: string | null }>).map((o) => ({ total: o.total, created_at: o.created_at, outlet: o.outlet_id })),
+    ];
+    if (rgMeta) {
+      orders = orders.filter((o) => {
+        if (!o.outlet || !rgMeta.outletIds.includes(o.outlet)) return false;
+        const h = mytHour(o.created_at);
+        return h >= rgMeta.round_start && h < rgMeta.round_end;
+      });
+    }
     if (orders.length) {
       acc.converted++;
       acc.revenueRm += orders.reduce((s, o) => s + (o.total ?? 0), 0) / 100; // total is cents
@@ -424,6 +449,12 @@ export async function measureRound(roundId: string) {
     .from("loop_rounds")
     .update({ status: "measured", measured_at: new Date().toISOString(), stats })
     .eq("id", roundId);
+
+  // Round-gap: once measured, retire the auto-created promo + strip the campaign
+  // tag so the offer can't linger past its window.
+  if (rgMeta && meta.promo_id) {
+    await supabaseAdmin.rpc("loyalty_round_gap_cleanup", { p_promo_id: meta.promo_id, p_tag: meta.member_tag ?? null });
+  }
 
   return { round_id: roundId, holdout_conversion_rate: +(holdoutRate * 100).toFixed(1), stats };
 }

--- a/supabase/migrations/044_round_gap_prepare.sql
+++ b/supabase/migrations/044_round_gap_prepare.sql
@@ -1,0 +1,62 @@
+-- Prepare a round-gap campaign atomically: segment -> 10% holdout split -> tag
+-- treatment -> auto-create the time-boxed, tag-restricted, outlet-scoped promo
+-- -> record loop_round + assignments. Status 'prepared'; no SMS until the
+-- operator approves the round. See round-gap loop (docs/design).
+--
+-- Offer = free_item (free cheapest classic coffee) gated by min_order_value.
+-- This is the primitive the POS promo engine actually supports for "free coffee"
+-- (its bogo is same-set only and ignores free_product_ids — a cross-category
+-- "buy food -> free coffee" bogo silently no-ops at the till). The RM<min>
+-- basket forces an order beyond a lone coffee (food attach) at the weak round;
+-- the give is only ~RM3 coffee COGS, carried by the basket. Margin-safe.
+
+-- Drop any earlier BOGO overload so named-param calls resolve unambiguously.
+DROP FUNCTION IF EXISTS loyalty_round_gap_prepare(text, int, int, text, text, text, text[], text, int, int);
+
+CREATE OR REPLACE FUNCTION loyalty_round_gap_prepare(
+  p_outlet text, p_round_start int, p_round_end int,
+  p_round_name text, p_offer_label text, p_message text,
+  p_free_category text DEFAULT 'classic', p_min_order numeric DEFAULT 20,
+  p_holdout_pct int DEFAULT 10, p_window_days int DEFAULT 7
+)
+RETURNS TABLE(round_id text, treated int, holdout int, promo_id text, member_tag text)
+LANGUAGE plpgsql AS $$
+DECLARE
+  v_tag text := 'rg_' || p_outlet || '_r' || p_round_start || '_' || to_char(now() AT TIME ZONE 'Asia/Kuala_Lumpur','YYYYMMDD');
+  v_round_id text := 'lr-rg-' || substr(md5(random()::text || clock_timestamp()::text), 1, 16);
+  v_promo_id text := 'pr-rg-' || substr(md5(random()::text || clock_timestamp()::text), 1, 16);
+  v_round_no int; v_outlet_ids text[]; v_treated int; v_holdout int;
+BEGIN
+  v_outlet_ids := CASE p_outlet
+    WHEN 'conezion' THEN ARRAY['conezion','outlet-con']
+    WHEN 'shah-alam' THEN ARRAY['shah-alam','outlet-sa']
+    WHEN 'tamarind' THEN ARRAY['tamarind','outlet-tam']
+    ELSE ARRAY[p_outlet] END;
+  CREATE TEMP TABLE _seg ON COMMIT DROP AS
+    SELECT member_id, phone, member_name,
+      CASE WHEN random() < p_holdout_pct::numeric/100 THEN 'holdout' ELSE 'rg' END AS arm
+    FROM loyalty_round_gap_segment(p_outlet, p_round_start, p_round_end);
+  SELECT count(*) FILTER (WHERE arm='rg'), count(*) FILTER (WHERE arm='holdout') INTO v_treated, v_holdout FROM _seg;
+  IF v_treated = 0 THEN RETURN QUERY SELECT NULL::text, 0, 0, NULL::text, NULL::text; RETURN; END IF;
+  UPDATE members m SET tags = (SELECT array(SELECT DISTINCT e FROM unnest(coalesce(m.tags,'{}'::text[]) || ARRAY[v_tag]) e))
+  WHERE m.id IN (SELECT member_id FROM _seg WHERE arm='rg');
+  INSERT INTO promotions(id, brand_id, name, description, trigger_type, discount_type,
+    applicable_categories, min_order_value, eligible_member_tags, outlet_ids,
+    time_start, time_end, valid_from, valid_until, is_active, priority, stackable)
+  VALUES (v_promo_id, 'brand-celsius', p_round_name, 'Round-gap auto promo', 'auto', 'free_item',
+    ARRAY[p_free_category], p_min_order, ARRAY[v_tag], v_outlet_ids,
+    make_time(p_round_start,0,0), make_time(p_round_end,0,0),
+    now(), now() + (p_window_days||' days')::interval, true, 60, false);
+  SELECT coalesce(max(round_no),0)+1 INTO v_round_no FROM loop_rounds WHERE loop_key='round_gap';
+  INSERT INTO loop_rounds(id, brand_id, loop_key, round_no, segment_label, holdout_pct, arms,
+    attribution_window_days, status, created_by, prepared_at, meta)
+  VALUES (v_round_id, 'brand-celsius', 'round_gap', v_round_no,
+    p_round_name || ' (' || v_treated || ' reachable, ' || p_holdout_pct || '% holdout)', p_holdout_pct,
+    jsonb_build_array(jsonb_build_object('key','rg','label',p_offer_label,'message',p_message,'voucher_template_id','','promo_id',v_promo_id)),
+    p_window_days, 'prepared', 'round-gap', now(),
+    jsonb_build_object('kind','round_gap','outlet',p_outlet,'round_start',p_round_start,'round_end',p_round_end,'promo_id',v_promo_id,'member_tag',v_tag));
+  INSERT INTO loop_assignments(id, round_id, member_id, phone, arm, sms_status, assigned_at)
+  SELECT 'la-'||substr(md5(random()::text || clock_timestamp()::text || member_id),1,18), v_round_id, member_id, phone, arm, NULL, now() FROM _seg;
+  RETURN QUERY SELECT v_round_id, v_treated, v_holdout, v_promo_id, v_tag;
+END;
+$$;

--- a/supabase/migrations/045_round_gap_cleanup.sql
+++ b/supabase/migrations/045_round_gap_cleanup.sql
@@ -1,0 +1,14 @@
+-- Post-window cleanup for a round-gap round: deactivate its auto-created promo
+-- and strip the campaign tag from members, so the offer can't linger past the
+-- measured window. Called by measureRound when a round_gap round is measured.
+CREATE OR REPLACE FUNCTION loyalty_round_gap_cleanup(p_promo_id text, p_tag text)
+RETURNS void LANGUAGE plpgsql AS $$
+BEGIN
+  IF p_promo_id IS NOT NULL THEN
+    UPDATE promotions SET is_active = false WHERE id = p_promo_id;
+  END IF;
+  IF p_tag IS NOT NULL THEN
+    UPDATE members SET tags = array_remove(tags, p_tag) WHERE p_tag = ANY(tags);
+  END IF;
+END;
+$$;


### PR DESCRIPTION
End-to-end wiring for the per-outlet round-gap campaign. Builds on #463 (segment RPC + meta slot).

## Flow (all hands-off — no manual promotions)
1. **Prepare** — operator clicks a curated campaign on the round-gap tab → `loyalty_round_gap_prepare` segments, splits a 10% holdout, tags the treatment group, and **auto-creates the promo** (time-boxed, tag-restricted, outlet-scoped). Lands as a `prepared` round.
2. **Review + Send** — reuses the existing round-card Send path (SMS Niaga; holdout skipped). No SMS until approved.
3. **Measure** — `measureRound` is now **round-specific** for round-gap: counts only orders at the target outlet during the target day-part, so lift vs holdout is real.
4. **Cleanup** — on measure, `loyalty_round_gap_cleanup` retires the promo + strips the tag.

## Offer (margin-safe, model-improving)
"Free coffee when you spend RM20+" at the weak round — `free_item` (free cheapest `classic`) gated by `min_order_value`. Not a discount; the RM20 basket forces a real order beyond a lone coffee (food attach). Give is ~RM3 coffee COGS, carried by the basket.

**Correctness note:** the POS `bogo` is same-set only and ignores `free_product_ids` — a cross-category "buy food → free coffee" bogo would silently no-op at the till. `free_item` + `min_order_value` is the supported primitive, verified against `promo-engine.ts`.

Typecheck clean (only pre-existing unrelated `music` generated-type error). First real run stays operator-gated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)