### PR TITLE
Round-gap SMS: keep copy single-segment GSM-7 (half the send cost)

### DIFF
--- a/apps/backoffice/src/app/api/loyalty/loops/round-gap/prepare/route.ts
+++ b/apps/backoffice/src/app/api/loyalty/loops/round-gap/prepare/route.ts
@@ -20,12 +20,12 @@ const CAMPAIGNS: Record<string, {
   "conezion-breakfast": {
     outlet: "conezion", round_start: 7, round_end: 9,
     name: "Conezion · Breakfast", offer_label: "Free coffee when you spend RM20+ (7–9am)",
-    message: "Free coffee with breakfast at Celsius Conezion, 7-9am this week — spend RM20+ and your coffee's on us. Show your number to redeem.",
+    message: "Free coffee with breakfast at Celsius Conezion, 7-9am this week. Spend RM20+ and your coffee's on us. Show your number to redeem.",
   },
   "shah-alam-evening": {
     outlet: "shah-alam", round_start: 17, round_end: 19,
     name: "Shah Alam · Evening", offer_label: "Free coffee when you spend RM20+ (5–7pm)",
-    message: "Free coffee at Celsius Shah Alam, 5-7pm this week — spend RM20+ and your coffee's on us. Show your number to redeem.",
+    message: "Free coffee at Celsius Shah Alam, 5-7pm this week. Spend RM20+ and your coffee's on us. Show your number to redeem.",
   },
 };
 


### PR DESCRIPTION
The round-gap SMS copy used an em dash (`—`), which isn't in GSM-7 → forces UCS-2 (70-char segments) → each message splits into **2 segments, doubling cost**. Replaced with a plain sentence break. Both messages now send as one GSM-7 segment (129 / 115 chars + ~19 gateway prefix, under 160).

Pure string-literal change; typecheck unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)