### PR TITLE
Round-gap: anchor free-coffee threshold above each round's AOV

### DIFF
--- a/apps/backoffice/src/app/api/loyalty/loops/round-gap/prepare/route.ts
+++ b/apps/backoffice/src/app/api/loyalty/loops/round-gap/prepare/route.ts
@@ -7,25 +7,30 @@ export const maxDuration = 60;
 
 // Curated round-gap campaigns per the office-hours design (docs/design/
 // personalised-round-gap-loop.md). Offer = low-COGS "free coffee when you spend
-// RM20+" (free_item gated by min_order_value) — NOT a discount, and the RM20
-// basket forces a real order beyond a lone coffee (food attach) at the weak
-// round. Margin-safe: the give is ~RM3 coffee COGS, carried by the basket. Each
-// keeps a 10% holdout. The prepare RPC tags the treatment group + auto-creates
-// the time-boxed, tag-restricted, outlet-scoped promo. Status 'prepared' → the
-// operator reviews + sends from the round card (no SMS here).
+// RM<min>+" (free_item gated by min_order_value) — NOT a discount. The min is
+// anchored ~20% ABOVE each round's own AOV (NOT below it), so the free coffee is
+// the lever that pulls the basket UP toward the RM40 target — the original
+// "lift this round 20%" objective. Below-AOV would just leak margin on baskets
+// people already make. Margin-safe: the give is ~RM3 coffee COGS, carried by the
+// larger basket. Each keeps a 10% holdout. The prepare RPC tags the treatment
+// group + auto-creates the time-boxed, tag-restricted, outlet-scoped promo.
+// Status 'prepared' → the operator reviews + sends from the round card.
+//
+// Thresholds (60-day data): Conezion Breakfast AOV RM29 → RM35 (+20%); Shah Alam
+// Evening AOV RM33 → RM40 (+21%, lands on target). Retune as AOV moves.
 const CAMPAIGNS: Record<string, {
   outlet: string; round_start: number; round_end: number;
-  name: string; offer_label: string; message: string;
+  name: string; offer_label: string; message: string; min_order: number;
 }> = {
   "conezion-breakfast": {
-    outlet: "conezion", round_start: 7, round_end: 9,
-    name: "Conezion · Breakfast", offer_label: "Free coffee when you spend RM20+ (7–9am)",
-    message: "Free coffee with breakfast at Celsius Conezion, 7-9am this week. Spend RM20+ and your coffee's on us. Show your number to redeem.",
+    outlet: "conezion", round_start: 7, round_end: 9, min_order: 35,
+    name: "Conezion · Breakfast", offer_label: "Free coffee when you spend RM35+ (7–9am)",
+    message: "Free coffee with breakfast at Celsius Conezion, 7-9am this week. Spend RM35+ and your coffee's on us. Show your number to redeem.",
   },
   "shah-alam-evening": {
-    outlet: "shah-alam", round_start: 17, round_end: 19,
-    name: "Shah Alam · Evening", offer_label: "Free coffee when you spend RM20+ (5–7pm)",
-    message: "Free coffee at Celsius Shah Alam, 5-7pm this week. Spend RM20+ and your coffee's on us. Show your number to redeem.",
+    outlet: "shah-alam", round_start: 17, round_end: 19, min_order: 40,
+    name: "Shah Alam · Evening", offer_label: "Free coffee when you spend RM40+ (5–7pm)",
+    message: "Free coffee at Celsius Shah Alam, 5-7pm this week. Spend RM40+ and your coffee's on us. Show your number to redeem.",
   },
 };
 
@@ -48,6 +53,7 @@ export async function POST(request: NextRequest) {
       p_round_name: cfg.name,
       p_offer_label: cfg.offer_label,
       p_message: cfg.message,
+      p_min_order: cfg.min_order,
     });
     if (error) throw new Error(error.message);
     const row = Array.isArray(data) ? data[0] : data;

--- a/supabase/migrations/044_round_gap_prepare.sql
+++ b/supabase/migrations/044_round_gap_prepare.sql
@@ -16,7 +16,7 @@ DROP FUNCTION IF EXISTS loyalty_round_gap_prepare(text, int, int, text, text, te
 CREATE OR REPLACE FUNCTION loyalty_round_gap_prepare(
   p_outlet text, p_round_start int, p_round_end int,
   p_round_name text, p_offer_label text, p_message text,
-  p_free_category text DEFAULT 'classic', p_min_order numeric DEFAULT 20,
+  p_free_category text DEFAULT 'classic', p_min_order numeric DEFAULT 35,
   p_holdout_pct int DEFAULT 10, p_window_days int DEFAULT 7
 )
 RETURNS TABLE(round_id text, treated int, holdout int, promo_id text, member_tag text)


### PR DESCRIPTION
RM20 was the wrong anchor — it sits **below the median basket**, so ~85% of orders already cleared it. The free coffee mostly rewarded spend customers already made: margin leak, no AOV pull.

**Re-anchored ~20% above each round's own AOV** (60-day data), so the free coffee is the lever that pulls the basket up toward the RM40 target — the original "lift this round 20%" objective:

| Round | AOV | Median | New threshold |
|---|---|---|---|
| Conezion Breakfast | RM29 | RM24 | **RM35** (+20%) |
| Shah Alam Evening | RM33 | RM26 | **RM40** (+21%, = target) |

Higher bar = less leak (only the top ~25–30% already clear it, and they're the highest-value customers) + more stretch (the rest must add to qualify). Give is still ~RM3 coffee COGS, carried by the larger basket.

Thresholds passed per-campaign; RPC default bumped 20→35 to remove the below-AOV footgun. Typecheck clean (only pre-existing `music` generated-type error).

🤖 Generated with [Claude Code](https://claude.com/claude-code)