### PR TITLE
Round-gap: feed dormant imported base into weak rounds (100/day drip)

### DIFF
--- a/apps/backoffice/src/app/api/loyalty/loops/round-gap/prepare/route.ts
+++ b/apps/backoffice/src/app/api/loyalty/loops/round-gap/prepare/route.ts
@@ -18,17 +18,27 @@ export const maxDuration = 60;
 //
 // Thresholds (60-day data): Conezion Breakfast AOV RM29 → RM35 (+20%); Shah Alam
 // Evening AOV RM33 → RM40 (+21%, lands on target). Retune as AOV moves.
+//
+// AUDIENCE (segment v3): the behavioral round-skippers PLUS the dormant imported
+// StoreHub base for the outlet that never ordered native (~15k tagged Putrajaya /
+// Shah Alam). Each run is capped at `limit` (default 100) and takes the warmest
+// slice first — skippers, then StoreHub-tier imports, then points, then the rest
+// — so this doubles as the "100/day" reactivation drip that bleeds the dormant
+// base into the weak rounds. Imports are one-shot; skippers have a 14-day
+// cooldown. The `source` column lets us read skipper vs import lift separately.
+// Run ONE campaign per day for ~100/day total (or split the limit across both).
+const DAILY_LIMIT = 100;
 const CAMPAIGNS: Record<string, {
   outlet: string; round_start: number; round_end: number;
-  name: string; offer_label: string; message: string; min_order: number;
+  name: string; offer_label: string; message: string; min_order: number; limit: number;
 }> = {
   "conezion-breakfast": {
-    outlet: "conezion", round_start: 7, round_end: 9, min_order: 35,
+    outlet: "conezion", round_start: 7, round_end: 9, min_order: 35, limit: DAILY_LIMIT,
     name: "Conezion · Breakfast", offer_label: "Free coffee when you spend RM35+ (7–9am)",
     message: "Free coffee with breakfast at Celsius Conezion, 7-9am this week. Spend RM35+ and your coffee's on us. Show your number to redeem.",
   },
   "shah-alam-evening": {
-    outlet: "shah-alam", round_start: 17, round_end: 19, min_order: 40,
+    outlet: "shah-alam", round_start: 17, round_end: 19, min_order: 40, limit: DAILY_LIMIT,
     name: "Shah Alam · Evening", offer_label: "Free coffee when you spend RM40+ (5–7pm)",
     message: "Free coffee at Celsius Shah Alam, 5-7pm this week. Spend RM40+ and your coffee's on us. Show your number to redeem.",
   },
@@ -54,6 +64,7 @@ export async function POST(request: NextRequest) {
       p_offer_label: cfg.offer_label,
       p_message: cfg.message,
       p_min_order: cfg.min_order,
+      p_limit: cfg.limit,
     });
     if (error) throw new Error(error.message);
     const row = Array.isArray(data) ? data[0] : data;

--- a/supabase/migrations/046_round_gap_segment_imports.sql
+++ b/supabase/migrations/046_round_gap_segment_imports.sql
@@ -1,0 +1,85 @@
+-- Round-gap segment v3: union the behavioral round-skippers with the imported
+-- StoreHub base for the outlet that has never ordered native (the dormant ~15k).
+-- This points the dormant base at the weak rounds to FILL them. Adds source +
+-- priority (skippers first, then StoreHub-tier imports, then points, then rest)
+-- and de-dupes so nobody is messaged twice (skippers: 14-day cooldown; imports:
+-- one-shot — never re-message a cold import via round-gap).
+DROP FUNCTION IF EXISTS loyalty_round_gap_segment(text, int, int, int, int, int);
+
+CREATE FUNCTION loyalty_round_gap_segment(
+  p_outlet text, p_round_start int, p_round_end int,
+  p_active_days int DEFAULT 45, p_history_days int DEFAULT 90, p_max_round_orders int DEFAULT 1,
+  p_cooldown_days int DEFAULT 14
+)
+RETURNS TABLE(member_id text, phone text, member_name text, source text, priority int)
+LANGUAGE sql STABLE AS $function$
+  WITH ids AS (
+    SELECT CASE p_outlet
+      WHEN 'conezion'  THEN ARRAY['conezion','outlet-con']
+      WHEN 'shah-alam' THEN ARRAY['shah-alam','outlet-sa']
+      WHEN 'tamarind'  THEN ARRAY['tamarind','outlet-tam']
+      ELSE ARRAY[p_outlet] END AS arr
+  ),
+  outlet_tag AS (
+    SELECT CASE p_outlet
+      WHEN 'conezion'  THEN 'Putrajaya'
+      WHEN 'shah-alam' THEN 'Shah Alam'
+      WHEN 'tamarind'  THEN 'Tamarind'
+      ELSE p_outlet END AS tag
+  ),
+  recent AS (   -- messaged by round-gap within cooldown (skipper suppression)
+    SELECT DISTINCT la.member_id::text AS member_id
+    FROM loop_assignments la JOIN loop_rounds lr ON lr.id = la.round_id
+    WHERE lr.loop_key = 'round_gap'
+      AND coalesce(lr.sent_at, lr.prepared_at) >= now() - (p_cooldown_days||' days')::interval
+  ),
+  ever AS (     -- ever messaged by round-gap (import one-shot suppression)
+    SELECT DISTINCT la.member_id::text AS member_id
+    FROM loop_assignments la JOIN loop_rounds lr ON lr.id = la.round_id
+    WHERE lr.loop_key = 'round_gap'
+  ),
+  ord AS (
+    SELECT po.customer_phone AS phone, po.outlet_id AS outlet,
+      extract(hour from (po.created_at AT TIME ZONE 'Asia/Kuala_Lumpur'))::int AS h, po.created_at AS ts
+    FROM pos_orders po WHERE po.customer_phone IS NOT NULL AND po.created_at >= now() - (p_history_days||' days')::interval
+    UNION ALL
+    SELECT o.customer_phone, o.store_id,
+      extract(hour from (o.created_at AT TIME ZONE 'Asia/Kuala_Lumpur'))::int, o.created_at
+    FROM orders o WHERE o.customer_phone IS NOT NULL AND o.created_at >= now() - (p_history_days||' days')::interval
+  ),
+  at_outlet AS (
+    SELECT o.phone, count(*) AS outlet_orders,
+      count(*) FILTER (WHERE o.h >= p_round_start AND o.h < p_round_end) AS round_orders
+    FROM ord o CROSS JOIN ids WHERE o.outlet = ANY(ids.arr)
+    GROUP BY o.phone
+  ),
+  recency AS ( SELECT phone, max(ts) AS last_any FROM ord GROUP BY phone ),
+  skippers AS (   -- (A) outlet regulars who skip this round
+    SELECT DISTINCT m.id::text AS member_id, m.phone::text AS phone, coalesce(m.name,'')::text AS member_name,
+      'skipper'::text AS source, 1 AS priority
+    FROM at_outlet a
+    JOIN recency r ON r.phone = a.phone
+    JOIN members m ON m.phone = a.phone
+    JOIN member_brands mb ON mb.member_id = m.id AND mb.brand_id = 'brand-celsius'
+    WHERE a.outlet_orders >= 2 AND a.round_orders <= p_max_round_orders
+      AND r.last_any >= now() - (p_active_days||' days')::interval
+      AND coalesce(m.sms_opt_out,false) = false AND m.phone IS NOT NULL AND btrim(m.phone) <> ''
+      AND m.id::text NOT IN (SELECT member_id FROM recent)
+  ),
+  imports AS (   -- (B) imported StoreHub base for this outlet, never ordered native
+    SELECT m.id::text AS member_id, m.phone::text AS phone, coalesce(m.name,'')::text AS member_name,
+      'import'::text AS source,
+      CASE WHEN 'SH_Tier_1' = ANY(m.tags) THEN 2
+           WHEN coalesce(mb.points_balance,0) > 0 THEN 3 ELSE 4 END AS priority
+    FROM members m
+    JOIN member_brands mb ON mb.member_id = m.id AND mb.brand_id = 'brand-celsius'
+    CROSS JOIN outlet_tag ot
+    WHERE (mb.total_visits = 0 OR mb.last_visit_at IS NULL)
+      AND ot.tag = ANY(m.tags)
+      AND coalesce(m.sms_opt_out,false) = false AND m.phone IS NOT NULL AND btrim(m.phone) <> ''
+      AND m.id::text NOT IN (SELECT member_id FROM ever)
+  )
+  SELECT u.member_id, u.phone, u.member_name, u.source, u.priority
+  FROM (SELECT * FROM skippers UNION SELECT * FROM imports) u
+  ORDER BY u.priority, u.member_id;
+$function$;

--- a/supabase/migrations/047_round_gap_prepare_limit.sql
+++ b/supabase/migrations/047_round_gap_prepare_limit.sql
@@ -1,0 +1,58 @@
+-- Add a per-run cap (p_limit, default 100) to round-gap prepare so a run sends at
+-- most N SMS, taking the highest-priority slice of the segment (skippers first,
+-- then tier/points imports). This is what powers the "100/day" reactivation drip
+-- over the dormant imported base. Drop old signature first to avoid an overload.
+DROP FUNCTION IF EXISTS loyalty_round_gap_prepare(text, int, int, text, text, text, text, numeric, int, int);
+
+CREATE FUNCTION loyalty_round_gap_prepare(
+  p_outlet text, p_round_start int, p_round_end int,
+  p_round_name text, p_offer_label text, p_message text,
+  p_free_category text DEFAULT 'classic', p_min_order numeric DEFAULT 35,
+  p_holdout_pct int DEFAULT 10, p_window_days int DEFAULT 7, p_limit int DEFAULT 100
+)
+RETURNS TABLE(round_id text, treated int, holdout int, promo_id text, member_tag text)
+LANGUAGE plpgsql AS $$
+DECLARE
+  v_tag text := 'rg_' || p_outlet || '_r' || p_round_start || '_' || to_char(now() AT TIME ZONE 'Asia/Kuala_Lumpur','YYYYMMDD');
+  v_round_id text := 'lr-rg-' || substr(md5(random()::text || clock_timestamp()::text), 1, 16);
+  v_promo_id text := 'pr-rg-' || substr(md5(random()::text || clock_timestamp()::text), 1, 16);
+  v_round_no int; v_outlet_ids text[]; v_treated int; v_holdout int;
+BEGIN
+  v_outlet_ids := CASE p_outlet
+    WHEN 'conezion' THEN ARRAY['conezion','outlet-con']
+    WHEN 'shah-alam' THEN ARRAY['shah-alam','outlet-sa']
+    WHEN 'tamarind' THEN ARRAY['tamarind','outlet-tam']
+    ELSE ARRAY[p_outlet] END;
+  CREATE TEMP TABLE _seg ON COMMIT DROP AS
+    SELECT member_id, phone, member_name,
+      CASE WHEN random() < p_holdout_pct::numeric/100 THEN 'holdout' ELSE 'rg' END AS arm
+    FROM (
+      SELECT member_id, phone, member_name
+      FROM loyalty_round_gap_segment(p_outlet, p_round_start, p_round_end)
+      ORDER BY priority, random()
+      LIMIT p_limit
+    ) seg;
+  SELECT count(*) FILTER (WHERE arm='rg'), count(*) FILTER (WHERE arm='holdout') INTO v_treated, v_holdout FROM _seg;
+  IF v_treated = 0 THEN RETURN QUERY SELECT NULL::text, 0, 0, NULL::text, NULL::text; RETURN; END IF;
+  UPDATE members m SET tags = (SELECT array(SELECT DISTINCT e FROM unnest(coalesce(m.tags,'{}'::text[]) || ARRAY[v_tag]) e))
+  WHERE m.id IN (SELECT member_id FROM _seg WHERE arm='rg');
+  INSERT INTO promotions(id, brand_id, name, description, trigger_type, discount_type,
+    applicable_categories, min_order_value, eligible_member_tags, outlet_ids,
+    time_start, time_end, valid_from, valid_until, is_active, priority, stackable)
+  VALUES (v_promo_id, 'brand-celsius', p_round_name, 'Round-gap auto promo', 'auto', 'free_item',
+    ARRAY[p_free_category], p_min_order, ARRAY[v_tag], v_outlet_ids,
+    make_time(p_round_start,0,0), make_time(p_round_end,0,0),
+    now(), now() + (p_window_days||' days')::interval, true, 60, false);
+  SELECT coalesce(max(round_no),0)+1 INTO v_round_no FROM loop_rounds WHERE loop_key='round_gap';
+  INSERT INTO loop_rounds(id, brand_id, loop_key, round_no, segment_label, holdout_pct, arms,
+    attribution_window_days, status, created_by, prepared_at, meta)
+  VALUES (v_round_id, 'brand-celsius', 'round_gap', v_round_no,
+    p_round_name || ' (' || v_treated || ' reachable, ' || p_holdout_pct || '% holdout)', p_holdout_pct,
+    jsonb_build_array(jsonb_build_object('key','rg','label',p_offer_label,'message',p_message,'voucher_template_id','','promo_id',v_promo_id)),
+    p_window_days, 'prepared', 'round-gap', now(),
+    jsonb_build_object('kind','round_gap','outlet',p_outlet,'round_start',p_round_start,'round_end',p_round_end,'promo_id',v_promo_id,'member_tag',v_tag));
+  INSERT INTO loop_assignments(id, round_id, member_id, phone, arm, sms_status, assigned_at)
+  SELECT 'la-'||substr(md5(random()::text || clock_timestamp()::text || member_id),1,18), v_round_id, member_id, phone, arm, NULL, now() FROM _seg;
+  RETURN QUERY SELECT v_round_id, v_treated, v_holdout, v_promo_id, v_tag;
+END;
+$$;


### PR DESCRIPTION
The "20k" is really **~15k imported StoreHub customers** (tagged Putrajaya / Shah Alam) who never ordered on the native POS. Instead of a separate reactivation loop, this points them at the weak rounds via the round-gap loop that's already live — reactivation that *also* fills the rounds we're trying to lift.

## Changes
- **Segment v3** — unions the behavioral round-skippers with the outlet's never-ordered imports. Adds `source` + `priority`: skippers first, then StoreHub-tier imports, then points>0, then the rest. De-dupes so nobody's hit twice (skippers 14-day cooldown; **imports one-shot**). The `source` column lets us measure skipper vs import lift separately.
- **`p_limit` (default 100)** on prepare — each run takes the warmest 100 of the segment. This is the **100/day** drip; run one campaign/day for ~100/day total. Conezion now has ~7.9k import audience, Shah Alam ~7.3k.
- **Offer unchanged** (free_item + min RM35/40). The time-boxed promo forces redemption at the target round, so the round-specific measure stays correct even for reactivated imports.

## Verified (read-only)
- Conezion 100-cap = 47 skippers + 1 tier + 52 points-imports (warmest first) ✓
- Both RPCs resolve with no overload ambiguity; fake-outlet prepare mutates nothing ✓
- Typecheck clean (only pre-existing `music` generated-type error)

New forward migrations (042/044 already merged; append-only). First real Prepare+Send stays operator-gated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)