### PR TITLE
Round-gap: personalised (name) + per-segment curated offers

### DIFF
--- a/apps/backoffice/src/app/api/loyalty/loops/round-gap/prepare/route.ts
+++ b/apps/backoffice/src/app/api/loyalty/loops/round-gap/prepare/route.ts
@@ -6,47 +6,54 @@ export const dynamic = "force-dynamic";
 export const maxDuration = 60;
 
 // Curated round-gap campaigns per the office-hours design (docs/design/
-// personalised-round-gap-loop.md). Offer = low-COGS "free coffee when you spend
-// RM<min>+" (free_item gated by min_order_value) — NOT a discount. The min is
-// anchored ~20% ABOVE each round's own AOV (NOT below it), so the free coffee is
-// the lever that pulls the basket UP toward the RM40 target — the original
-// "lift this round 20%" objective. Below-AOV would just leak margin on baskets
-// people already make. Margin-safe: the give is ~RM3 coffee COGS, carried by the
-// larger basket. Each keeps a 10% holdout. The prepare RPC tags the treatment
-// group + auto-creates the time-boxed, tag-restricted, outlet-scoped promo.
-// Status 'prepared' → the operator reviews + sends from the round card.
+// personalised-round-gap-loop.md). Offer = low-COGS "free coffee + min spend"
+// (free_item gated by min_order_value) — NOT a discount; the basket carries the
+// ~RM3 coffee COGS, so it's margin-safe and lifts AOV.
 //
-// Thresholds (60-day data): Conezion Breakfast AOV RM29 → RM35 (+20%); Shah Alam
-// Evening AOV RM33 → RM40 (+21%, lands on target). Retune as AOV moves.
-//
-// AUDIENCE (segment v3): the behavioral round-skippers PLUS the dormant imported
-// StoreHub base for the outlet that never ordered native (~15k tagged Putrajaya /
-// Shah Alam). Each run is capped at `limit` (default 100) and takes the warmest
-// slice first — skippers, then StoreHub-tier imports, then points, then the rest
-// — so this doubles as the "100/day" reactivation drip that bleeds the dormant
-// base into the weak rounds. Imports are one-shot; skippers have a 14-day
-// cooldown. The `source` column lets us read skipper vs import lift separately.
-// Run ONE campaign per day for ~100/day total (or split the limit across both).
+// PERSONALISED + CURATED PER SEGMENT. The audience (segment v3) is the outlet's
+// behavioral round-skippers PLUS its dormant imported StoreHub base that never
+// ordered native (~15k tagged Putrajaya / Shah Alam). Each run is capped at
+// `limit` (default 100, the "100/day" reactivation drip) taking the warmest
+// slice first. Each of those two groups gets its OWN arm — its own copy AND its
+// own offer:
+//   • rg_skipper — a warm regular who skips this round. Goal: shift them into the
+//     round + push AOV → higher bar (Conezion RM35 / Shah Alam RM40, ~20% above
+//     the round's AOV).
+//   • rg_import  — a dormant customer we're winning back. Goal: just get the
+//     first native order → easier bar (RM25, near the overall median).
+// Copy uses {name} (substituted to the member's first name at send time). The
+// prepare RPC tags each arm's members, auto-creates one time-boxed, tag-gated,
+// outlet-scoped promo PER ARM at that arm's min_order, and records the round
+// 'prepared'. Operator reviews + sends from the round card (no SMS here).
+// measureRound reads skipper-vs-import lift separately via the arm.
 const DAILY_LIMIT = 100;
+type Arm = { key: "rg_skipper" | "rg_import"; label: string; message: string; min_order: number };
 const CAMPAIGNS: Record<string, {
-  outlet: string; round_start: number; round_end: number;
-  name: string; offer_label: string; message: string; min_order: number; limit: number;
+  outlet: string; round_start: number; round_end: number; name: string; limit: number; arms: Arm[];
 }> = {
   "conezion-breakfast": {
-    outlet: "conezion", round_start: 7, round_end: 9, min_order: 35, limit: DAILY_LIMIT,
-    name: "Conezion · Breakfast", offer_label: "Free coffee when you spend RM35+ (7–9am)",
-    message: "Free coffee with breakfast at Celsius Conezion, 7-9am this week. Spend RM35+ and your coffee's on us. Show your number to redeem.",
+    outlet: "conezion", round_start: 7, round_end: 9, name: "Conezion · Breakfast", limit: DAILY_LIMIT,
+    arms: [
+      { key: "rg_skipper", min_order: 35, label: "Regular · free coffee, spend RM35 (7-9am)",
+        message: "Hi {name}! Free coffee at Celsius Conezion breakfast (7-9am) this week, spend RM35. We miss you in the AM! Show your number." },
+      { key: "rg_import", min_order: 25, label: "Win-back · free coffee, spend RM25 (7-9am)",
+        message: "Hi {name}! We miss you at Celsius Conezion. Free coffee at breakfast (7-9am) this week, spend RM25. Show your number." },
+    ],
   },
   "shah-alam-evening": {
-    outlet: "shah-alam", round_start: 17, round_end: 19, min_order: 40, limit: DAILY_LIMIT,
-    name: "Shah Alam · Evening", offer_label: "Free coffee when you spend RM40+ (5–7pm)",
-    message: "Free coffee at Celsius Shah Alam, 5-7pm this week. Spend RM40+ and your coffee's on us. Show your number to redeem.",
+    outlet: "shah-alam", round_start: 17, round_end: 19, name: "Shah Alam · Evening", limit: DAILY_LIMIT,
+    arms: [
+      { key: "rg_skipper", min_order: 40, label: "Regular · free coffee, spend RM40 (5-7pm)",
+        message: "Hi {name}! Free coffee at Celsius Shah Alam (5-7pm) this week, spend RM40. We rarely see you in the evening! Show your number." },
+      { key: "rg_import", min_order: 25, label: "Win-back · free coffee, spend RM25 (5-7pm)",
+        message: "Hi {name}! We miss you at Celsius Shah Alam. Free coffee (5-7pm) this week, spend RM25. Show your number." },
+    ],
   },
 };
 
 // POST /api/loyalty/loops/round-gap/prepare  { campaign: "conezion-breakfast" }
-// Admin-gated. Creates a 'prepared' round-gap round (segment + tag + auto-promo).
-// Does NOT send — review + approve the round to fire the SMS.
+// Admin-gated. Creates a 'prepared' round-gap round (segment + per-arm tag +
+// per-arm auto-promo). Does NOT send — review + approve the round to fire the SMS.
 export async function POST(request: NextRequest) {
   const auth = await requireAuth(request);
   if (auth.error) return auth.error;
@@ -61,9 +68,7 @@ export async function POST(request: NextRequest) {
       p_round_start: cfg.round_start,
       p_round_end: cfg.round_end,
       p_round_name: cfg.name,
-      p_offer_label: cfg.offer_label,
-      p_message: cfg.message,
-      p_min_order: cfg.min_order,
+      p_arms: cfg.arms,
       p_limit: cfg.limit,
     });
     if (error) throw new Error(error.message);
@@ -76,8 +81,7 @@ export async function POST(request: NextRequest) {
       round_id: row.round_id,
       treated: row.treated,
       holdout: row.holdout,
-      promo_id: row.promo_id,
-      member_tag: row.member_tag,
+      promos: row.promos,
       message: `Prepared ${cfg.name}: ${row.treated} treated + ${row.holdout} holdout. Review the round below, then Send to fire the SMS.`,
     });
   } catch (err) {

--- a/apps/backoffice/src/lib/loyalty/loop-engine.ts
+++ b/apps/backoffice/src/lib/loyalty/loop-engine.ts
@@ -325,17 +325,37 @@ export async function sendRound(roundId: string) {
 
   const { data: rows } = await supabaseAdmin
     .from("loop_assignments")
-    .select("id, phone, arm, sms_status")
+    .select("id, phone, arm, sms_status, member_id")
     .eq("round_id", roundId)
     .neq("arm", "holdout");
+
+  // Per-recipient {name} personalisation: substitute the member's FIRST name
+  // (short, to stay within one GSM-7 segment). Only fetch names if any arm copy
+  // actually uses {name}, so loops without it pay nothing.
+  const needsName = Object.values(armMsg).some((m) => m.includes("{name}"));
+  const firstNameById = new Map<string, string>();
+  if (needsName) {
+    const ids = [...new Set(((rows ?? []) as Array<{ member_id: string | null }>).map((r) => r.member_id).filter(Boolean))] as string[];
+    for (let i = 0; i < ids.length; i += 1000) {
+      const { data: ms } = await supabaseAdmin.from("members").select("id, name").in("id", ids.slice(i, i + 1000));
+      for (const m of (ms ?? []) as Array<{ id: string; name: string | null }>) {
+        const first = (m.name ?? "").trim().split(/\s+/)[0];
+        if (first) firstNameById.set(m.id, first);
+      }
+    }
+  }
 
   let sent = 0;
   let failed = 0;
   let firstError: string | undefined;
-  for (const r of (rows ?? []) as Array<{ id: string; phone: string; arm: string; sms_status: string | null }>) {
+  for (const r of (rows ?? []) as Array<{ id: string; phone: string; arm: string; sms_status: string | null; member_id: string | null }>) {
     if (r.sms_status === "sent") continue; // idempotent
-    const message = armMsg[r.arm] ?? "";
+    let message = armMsg[r.arm] ?? "";
     if (!message) { failed++; continue; }
+    if (needsName) {
+      const first = (r.member_id && firstNameById.get(r.member_id)) || "there";
+      message = message.replace(/\{name\}/g, first);
+    }
     const res = await sendSMS(r.phone, message, { provider });
     await supabaseAdmin
       .from("loop_assignments")
@@ -380,7 +400,11 @@ export async function measureRound(roundId: string) {
     "shah-alam": ["shah-alam", "outlet-sa"],
     tamarind: ["tamarind", "outlet-tam"],
   };
-  const meta = (round.meta ?? {}) as { kind?: string; outlet?: string; round_start?: number; round_end?: number; promo_id?: string; member_tag?: string };
+  const meta = (round.meta ?? {}) as {
+    kind?: string; outlet?: string; round_start?: number; round_end?: number;
+    promo_id?: string; member_tag?: string; // legacy single-promo rounds
+    promos?: Array<{ promo_id?: string; tag?: string }>; // per-arm offers (v5+)
+  };
   const rgMeta =
     meta.kind === "round_gap" && meta.outlet != null && meta.round_start != null && meta.round_end != null
       ? { round_start: meta.round_start, round_end: meta.round_end, outletIds: RG_OUTLET_IDS[meta.outlet] ?? [meta.outlet] }
@@ -450,10 +474,18 @@ export async function measureRound(roundId: string) {
     .update({ status: "measured", measured_at: new Date().toISOString(), stats })
     .eq("id", roundId);
 
-  // Round-gap: once measured, retire the auto-created promo + strip the campaign
-  // tag so the offer can't linger past its window.
-  if (rgMeta && meta.promo_id) {
-    await supabaseAdmin.rpc("loyalty_round_gap_cleanup", { p_promo_id: meta.promo_id, p_tag: meta.member_tag ?? null });
+  // Round-gap: once measured, retire every auto-created promo + strip its tag so
+  // no offer lingers past its window. v5 rounds carry one promo per arm
+  // (meta.promos); legacy rounds carried a single (meta.promo_id, meta.member_tag).
+  if (rgMeta) {
+    const toClean = meta.promos?.length
+      ? meta.promos.map((p) => ({ promo_id: p.promo_id, tag: p.tag }))
+      : meta.promo_id
+        ? [{ promo_id: meta.promo_id, tag: meta.member_tag }]
+        : [];
+    for (const c of toClean) {
+      await supabaseAdmin.rpc("loyalty_round_gap_cleanup", { p_promo_id: c.promo_id ?? null, p_tag: c.tag ?? null });
+    }
   }
 
   return { round_id: roundId, holdout_conversion_rate: +(holdoutRate * 100).toFixed(1), stats };

--- a/supabase/migrations/048_round_gap_prepare_per_arm_offers.sql
+++ b/supabase/migrations/048_round_gap_prepare_per_arm_offers.sql
@@ -1,0 +1,74 @@
+-- Round-gap prepare v5: curated per-segment OFFER + copy. p_arms is an array of
+-- { key:'rg_skipper'|'rg_import', label, message, min_order }. Each arm that has
+-- members gets its OWN tag + promo at its OWN min_order (skipper = AOV-push bar;
+-- cold import = easier reactivation bar). Members tagged by their arm; holdout
+-- gets nothing. meta.promos carries every {arm,tag,promo_id} for cleanup, and
+-- round.arms = p_arms so sendRound fires the curated copy and measureRound reads
+-- per-source lift. Drop the v4 signature first to avoid an overload.
+DROP FUNCTION IF EXISTS loyalty_round_gap_prepare(text, int, int, text, jsonb, text, numeric, int, int, int);
+
+CREATE FUNCTION loyalty_round_gap_prepare(
+  p_outlet text, p_round_start int, p_round_end int,
+  p_round_name text, p_arms jsonb,
+  p_free_category text DEFAULT 'classic',
+  p_holdout_pct int DEFAULT 10, p_window_days int DEFAULT 7, p_limit int DEFAULT 100
+)
+RETURNS TABLE(round_id text, treated int, holdout int, promos jsonb)
+LANGUAGE plpgsql AS $$
+DECLARE
+  v_round_id text := 'lr-rg-' || substr(md5(random()::text || clock_timestamp()::text), 1, 16);
+  v_round_no int; v_outlet_ids text[]; v_treated int; v_holdout int;
+  v_date text := to_char(now() AT TIME ZONE 'Asia/Kuala_Lumpur','YYYYMMDD');
+  v_arm jsonb; v_armkey text; v_armtag text; v_armpromo text; v_armmin numeric; v_n int;
+  v_promos jsonb := '[]'::jsonb;
+BEGIN
+  v_outlet_ids := CASE p_outlet
+    WHEN 'conezion' THEN ARRAY['conezion','outlet-con']
+    WHEN 'shah-alam' THEN ARRAY['shah-alam','outlet-sa']
+    WHEN 'tamarind' THEN ARRAY['tamarind','outlet-tam']
+    ELSE ARRAY[p_outlet] END;
+  CREATE TEMP TABLE _seg ON COMMIT DROP AS
+    SELECT member_id, phone, member_name,
+      CASE WHEN random() < p_holdout_pct::numeric/100 THEN 'holdout' ELSE 'rg_'||source END AS arm
+    FROM (
+      SELECT member_id, phone, member_name, source
+      FROM loyalty_round_gap_segment(p_outlet, p_round_start, p_round_end)
+      ORDER BY priority, random()
+      LIMIT p_limit
+    ) seg;
+  SELECT count(*) FILTER (WHERE arm <> 'holdout'), count(*) FILTER (WHERE arm='holdout') INTO v_treated, v_holdout FROM _seg;
+  IF v_treated = 0 THEN RETURN QUERY SELECT NULL::text, 0, 0, '[]'::jsonb; RETURN; END IF;
+
+  FOR v_arm IN SELECT * FROM jsonb_array_elements(p_arms) LOOP
+    v_armkey := v_arm->>'key';
+    SELECT count(*) INTO v_n FROM _seg WHERE arm = v_armkey;
+    IF v_n > 0 THEN
+      v_armtag := 'rg_'||p_outlet||'_'||replace(v_armkey,'rg_','')||'_'||v_date;
+      v_armpromo := 'pr-rg-'||substr(md5(random()::text||clock_timestamp()::text||v_armkey),1,14);
+      v_armmin := coalesce(nullif(v_arm->>'min_order','')::numeric, 35);
+      INSERT INTO promotions(id, brand_id, name, description, trigger_type, discount_type,
+        applicable_categories, min_order_value, eligible_member_tags, outlet_ids,
+        time_start, time_end, valid_from, valid_until, is_active, priority, stackable)
+      VALUES (v_armpromo, 'brand-celsius', p_round_name||' · '||replace(v_armkey,'rg_',''),
+        'Round-gap auto promo', 'auto', 'free_item',
+        ARRAY[p_free_category], v_armmin, ARRAY[v_armtag], v_outlet_ids,
+        make_time(p_round_start,0,0), make_time(p_round_end,0,0),
+        now(), now() + (p_window_days||' days')::interval, true, 60, false);
+      UPDATE members m SET tags = (SELECT array(SELECT DISTINCT e FROM unnest(coalesce(m.tags,'{}'::text[]) || ARRAY[v_armtag]) e))
+      WHERE m.id IN (SELECT member_id FROM _seg WHERE arm = v_armkey);
+      v_promos := v_promos || jsonb_build_object('arm',v_armkey,'tag',v_armtag,'promo_id',v_armpromo,'min_order',v_armmin);
+    END IF;
+  END LOOP;
+
+  SELECT coalesce(max(round_no),0)+1 INTO v_round_no FROM loop_rounds WHERE loop_key='round_gap';
+  INSERT INTO loop_rounds(id, brand_id, loop_key, round_no, segment_label, holdout_pct, arms,
+    attribution_window_days, status, created_by, prepared_at, meta)
+  VALUES (v_round_id, 'brand-celsius', 'round_gap', v_round_no,
+    p_round_name || ' (' || v_treated || ' reachable, ' || p_holdout_pct || '% holdout)', p_holdout_pct,
+    p_arms, p_window_days, 'prepared', 'round-gap', now(),
+    jsonb_build_object('kind','round_gap','outlet',p_outlet,'round_start',p_round_start,'round_end',p_round_end,'promos',v_promos));
+  INSERT INTO loop_assignments(id, round_id, member_id, phone, arm, sms_status, assigned_at)
+  SELECT 'la-'||substr(md5(random()::text || clock_timestamp()::text || member_id),1,18), v_round_id, member_id, phone, arm, NULL, now() FROM _seg;
+  RETURN QUERY SELECT v_round_id, v_treated, v_holdout, v_promos;
+END;
+$$;


### PR DESCRIPTION
A generic blast to 15k cold numbers underperforms. This tailors **both the copy and the offer** per segment — using the `source` tag (skipper vs import) the segment already carries.

## Changes
- **Prepare v5** takes `p_arms [{key, label, message, min_order}]`. Each arm that has members gets its **own tag + own promo at its own bar**:
  - `rg_skipper` — warm regular who skips the round → AOV-push bar (RM35 / RM40)
  - `rg_import` — dormant imported customer → easier win-back bar (RM25)
  - `meta.promos` carries every `{arm,tag,promo_id}`; `round.arms = p_arms`.
- **`sendRound`** substitutes `{name}` → member's **first name** per recipient (short, keeps it single-segment GSM-7); no-op for loops without `{name}`.
- **`measureRound`** retires every per-arm promo + tag on measure (backward-compat for legacy single-promo rounds). Per-arm assignments → **skipper-vs-import lift reads out separately**.
- **Route** — curated copy per outlet/segment, each with its own bar.

## Verified end-to-end (live, then torn down)
`prepare(conezion, limit 50)` → 44 skipper + 1 import + 5 holdout; 2 promos `free_item` min **35.00** / **25.00**, both tag-gated + time-boxed 07:00–09:00; holdout correctly untagged. Test round + promos + tags then fully deleted (all counters 0). Typecheck clean (only pre-existing `music` error).

First real Prepare+Send stays operator-gated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)