### PR TITLE
Round-gap: auto-run daily like the other SMS loops (hide cards, 100/day)

### DIFF
--- a/apps/backoffice/src/app/(admin)/loyalty/loops/page.tsx
+++ b/apps/backoffice/src/app/(admin)/loyalty/loops/page.tsx
@@ -265,7 +265,10 @@ export default function LoopsPage() {
         <div className="mb-4 flex items-start gap-2 rounded-lg border border-green-200 bg-green-50 px-4 py-3 text-sm text-green-900">
           <Repeat className="mt-0.5 h-4 w-4 flex-shrink-0" />
           <span>
-            <strong>Auto-triggered daily.</strong> This loop fires by itself — it auto-issues the voucher + SMS to each new qualifier (birthday today · ~1 day after a 1st visit · just lapsed), no budget or approval. Nothing to do here — just watch the scorecard and rounds below.
+            <strong>Auto-triggered daily.</strong>{" "}
+            {loopKey === "round_gap"
+              ? "This loop fires by itself — each day it auto-prepares + sends the next ~100 SMS (warmest first) with a per-segment offer to fill the weak round, 10% holdout, no approval. Nothing to do here — just watch the scorecard below."
+              : "This loop fires by itself — it auto-issues the voucher + SMS to each new qualifier (birthday today · ~1 day after a 1st visit · just lapsed), no budget or approval. Nothing to do here — just watch the scorecard and rounds below."}
           </span>
         </div>
       )}

--- a/apps/backoffice/src/app/api/cron/loops-trigger/route.ts
+++ b/apps/backoffice/src/app/api/cron/loops-trigger/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { checkCronAuth } from "@celsius/shared";
-import { runTriggeredLoops, autoMeasureDueRounds } from "@/lib/loyalty/loop-engine";
+import { runTriggeredLoops, autoMeasureDueRounds, runRoundGapDaily } from "@/lib/loyalty/loop-engine";
 
 export const dynamic = "force-dynamic";
 export const maxDuration = 300;
@@ -15,8 +15,9 @@ export async function GET(req: NextRequest) {
   if (!cronAuth.ok) return NextResponse.json({ error: cronAuth.error }, { status: cronAuth.status });
   try {
     const triggered = await runTriggeredLoops();
+    const roundGap = await runRoundGapDaily(); // per-segment promo loop (its own mechanic)
     const measured = await autoMeasureDueRounds();
-    return NextResponse.json({ triggered, measured: measured.measured });
+    return NextResponse.json({ triggered, roundGap, measured: measured.measured });
   } catch (err) {
     const msg = err instanceof Error ? err.message : "loops-trigger failed";
     return NextResponse.json({ error: msg }, { status: 500 });

--- a/apps/backoffice/src/app/api/loyalty/loops/optimizer/route.ts
+++ b/apps/backoffice/src/app/api/loyalty/loops/optimizer/route.ts
@@ -22,7 +22,10 @@ export async function GET(request: NextRequest) {
     const candidates = OFFER_CANDIDATES
       .filter((c) => def.candidateKeys.includes(c.key))
       .map((c) => ({ key: c.key, label: c.label, logic: c.logic, voucher_template_id: c.voucher_template_id, message: composeMessage(loopKey, c) }));
-    const loops = Object.values(LOOPS).map((l) => ({ key: l.key, label: l.label, objective: l.objective, defaultHoldoutPct: l.defaultHoldoutPct, defaultWindowDays: l.defaultWindowDays, triggered: !!l.trigger }));
+    // round_gap has no `trigger` (it runs on its own promo mechanic via
+    // runRoundGapDaily) but IS auto-run daily — so present it as 'triggered'
+    // (cards hidden, scorecard-only) like the lifecycle loops.
+    const loops = Object.values(LOOPS).map((l) => ({ key: l.key, label: l.label, objective: l.objective, defaultHoldoutPct: l.defaultHoldoutPct, defaultWindowDays: l.defaultWindowDays, triggered: !!l.trigger || l.key === "round_gap" }));
     return NextResponse.json({
       loop_key: loopKey, leaderboard, proposal, candidates, loops,
       send_time_leaderboard: sendTimeLeaderboard, send_window_proposal: sendWindowProposal, send_windows: SEND_WINDOWS,

--- a/apps/backoffice/src/app/api/loyalty/loops/round-gap/prepare/route.ts
+++ b/apps/backoffice/src/app/api/loyalty/loops/round-gap/prepare/route.ts
@@ -1,67 +1,24 @@
 import { NextRequest, NextResponse } from "next/server";
 import { requireAuth } from "@/lib/auth";
 import { supabaseAdmin } from "@/lib/loyalty/supabase";
+import { ROUND_GAP_CAMPAIGNS } from "@/lib/loyalty/loop-engine";
 
 export const dynamic = "force-dynamic";
 export const maxDuration = 60;
 
-// Curated round-gap campaigns per the office-hours design (docs/design/
-// personalised-round-gap-loop.md). Offer = low-COGS "free coffee + min spend"
-// (free_item gated by min_order_value) — NOT a discount; the basket carries the
-// ~RM3 coffee COGS, so it's margin-safe and lifts AOV.
-//
-// PERSONALISED + CURATED PER SEGMENT. The audience (segment v3) is the outlet's
-// behavioral round-skippers PLUS its dormant imported StoreHub base that never
-// ordered native (~15k tagged Putrajaya / Shah Alam). Each run is capped at
-// `limit` (default 100, the "100/day" reactivation drip) taking the warmest
-// slice first. Each of those two groups gets its OWN arm — its own copy AND its
-// own offer:
-//   • rg_skipper — a warm regular who skips this round. Goal: shift them into the
-//     round + push AOV → higher bar (Conezion RM35 / Shah Alam RM40, ~20% above
-//     the round's AOV).
-//   • rg_import  — a dormant customer we're winning back. Goal: just get the
-//     first native order → easier bar (RM25, near the overall median).
-// Copy uses {name} (substituted to the member's first name at send time). The
-// prepare RPC tags each arm's members, auto-creates one time-boxed, tag-gated,
-// outlet-scoped promo PER ARM at that arm's min_order, and records the round
-// 'prepared'. Operator reviews + sends from the round card (no SMS here).
-// measureRound reads skipper-vs-import lift separately via the arm.
-const DAILY_LIMIT = 100;
-type Arm = { key: "rg_skipper" | "rg_import"; label: string; message: string; min_order: number };
-const CAMPAIGNS: Record<string, {
-  outlet: string; round_start: number; round_end: number; name: string; limit: number; arms: Arm[];
-}> = {
-  "conezion-breakfast": {
-    outlet: "conezion", round_start: 7, round_end: 9, name: "Conezion · Breakfast", limit: DAILY_LIMIT,
-    arms: [
-      { key: "rg_skipper", min_order: 35, label: "Regular · free coffee, spend RM35 (7-9am)",
-        message: "Hi {name}! Free coffee at Celsius Conezion breakfast (7-9am) this week, spend RM35. We miss you in the AM! Show your number." },
-      { key: "rg_import", min_order: 25, label: "Win-back · free coffee, spend RM25 (7-9am)",
-        message: "Hi {name}! We miss you at Celsius Conezion. Free coffee at breakfast (7-9am) this week, spend RM25. Show your number." },
-    ],
-  },
-  "shah-alam-evening": {
-    outlet: "shah-alam", round_start: 17, round_end: 19, name: "Shah Alam · Evening", limit: DAILY_LIMIT,
-    arms: [
-      { key: "rg_skipper", min_order: 40, label: "Regular · free coffee, spend RM40 (5-7pm)",
-        message: "Hi {name}! Free coffee at Celsius Shah Alam (5-7pm) this week, spend RM40. We rarely see you in the evening! Show your number." },
-      { key: "rg_import", min_order: 25, label: "Win-back · free coffee, spend RM25 (5-7pm)",
-        message: "Hi {name}! We miss you at Celsius Shah Alam. Free coffee (5-7pm) this week, spend RM25. Show your number." },
-    ],
-  },
-};
-
 // POST /api/loyalty/loops/round-gap/prepare  { campaign: "conezion-breakfast" }
-// Admin-gated. Creates a 'prepared' round-gap round (segment + per-arm tag +
-// per-arm auto-promo). Does NOT send — review + approve the round to fire the SMS.
+// Manual prepare for a single round-gap campaign (segment + per-arm tag +
+// per-arm auto-promo). Does NOT send — kept for ad-hoc/catch-up use. Round-gap
+// normally runs itself daily via the cron (runRoundGapDaily); the campaign
+// config (audience, per-segment offers, copy) is the shared ROUND_GAP_CAMPAIGNS.
 export async function POST(request: NextRequest) {
   const auth = await requireAuth(request);
   if (auth.error) return auth.error;
   try {
     const body = await request.json().catch(() => ({}));
-    const cfg = CAMPAIGNS[body?.campaign as string];
+    const cfg = ROUND_GAP_CAMPAIGNS[body?.campaign as string];
     if (!cfg) {
-      return NextResponse.json({ error: `Unknown campaign. Options: ${Object.keys(CAMPAIGNS).join(", ")}` }, { status: 400 });
+      return NextResponse.json({ error: `Unknown campaign. Options: ${Object.keys(ROUND_GAP_CAMPAIGNS).join(", ")}` }, { status: 400 });
     }
     const { data, error } = await supabaseAdmin.rpc("loyalty_round_gap_prepare", {
       p_outlet: cfg.outlet,
@@ -69,7 +26,7 @@ export async function POST(request: NextRequest) {
       p_round_end: cfg.round_end,
       p_round_name: cfg.name,
       p_arms: cfg.arms,
-      p_limit: cfg.limit,
+      p_limit: cfg.daily_limit,
     });
     if (error) throw new Error(error.message);
     const row = Array.isArray(data) ? data[0] : data;
@@ -82,7 +39,7 @@ export async function POST(request: NextRequest) {
       treated: row.treated,
       holdout: row.holdout,
       promos: row.promos,
-      message: `Prepared ${cfg.name}: ${row.treated} treated + ${row.holdout} holdout. Review the round below, then Send to fire the SMS.`,
+      message: `Prepared ${cfg.name}: ${row.treated} treated + ${row.holdout} holdout.`,
     });
   } catch (err) {
     const msg = err instanceof Error ? err.message : "Failed to prepare round-gap";

--- a/apps/backoffice/src/app/api/loyalty/loops/run-triggered/route.ts
+++ b/apps/backoffice/src/app/api/loyalty/loops/run-triggered/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { requireAuth } from "@/lib/auth";
-import { runTriggeredLoops, autoMeasureDueRounds } from "@/lib/loyalty/loop-engine";
+import { runTriggeredLoops, autoMeasureDueRounds, runRoundGapDaily } from "@/lib/loyalty/loop-engine";
 
 export const dynamic = "force-dynamic";
 export const maxDuration = 300; // sending hundreds of SMS sequentially needs headroom
@@ -16,8 +16,9 @@ export async function POST(request: NextRequest) {
     const body = await request.json().catch(() => ({}));
     const force = body?.force === true;
     const triggered = await runTriggeredLoops({ force });
+    const roundGap = await runRoundGapDaily({ force });
     const measured = await autoMeasureDueRounds();
-    return NextResponse.json({ triggered, measured: measured.measured });
+    return NextResponse.json({ triggered, roundGap, measured: measured.measured });
   } catch (err) {
     const msg = err instanceof Error ? err.message : "Failed to run triggered loops";
     return NextResponse.json({ error: msg }, { status: 500 });

--- a/apps/backoffice/src/lib/loyalty/loop-engine.ts
+++ b/apps/backoffice/src/lib/loyalty/loop-engine.ts
@@ -888,6 +888,77 @@ export async function autoMeasureDueRounds(): Promise<{ measured: number }> {
   return { measured };
 }
 
+// ============================================================================
+// ROUND-GAP AUTO-RUN — same daily lifecycle as the triggered loops, but its own
+// mechanic (per-segment promo via loyalty_round_gap_prepare, not vouchers). The
+// daily cron prepares the next capped batch per campaign and auto-sends it, so
+// round-gap "follows the same as the other SMS loops" — no manual round cards.
+// Kill-switch: app_settings.round_gap_auto_enabled = 'false' pauses it.
+// ============================================================================
+export type RoundGapArm = { key: "rg_skipper" | "rg_import"; label: string; message: string; min_order: number };
+export const ROUND_GAP_CAMPAIGNS: Record<string, {
+  outlet: string; round_start: number; round_end: number; name: string; daily_limit: number; arms: RoundGapArm[];
+}> = {
+  "conezion-breakfast": {
+    outlet: "conezion", round_start: 7, round_end: 9, name: "Conezion · Breakfast", daily_limit: 50,
+    arms: [
+      { key: "rg_skipper", min_order: 35, label: "Regular · free coffee, spend RM35 (7-9am)",
+        message: "Hi {name}! Free coffee at Celsius Conezion breakfast (7-9am) this week, spend RM35. We miss you in the AM! Show your number." },
+      { key: "rg_import", min_order: 25, label: "Win-back · free coffee, spend RM25 (7-9am)",
+        message: "Hi {name}! We miss you at Celsius Conezion. Free coffee at breakfast (7-9am) this week, spend RM25. Show your number." },
+    ],
+  },
+  "shah-alam-evening": {
+    outlet: "shah-alam", round_start: 17, round_end: 19, name: "Shah Alam · Evening", daily_limit: 50,
+    arms: [
+      { key: "rg_skipper", min_order: 40, label: "Regular · free coffee, spend RM40 (5-7pm)",
+        message: "Hi {name}! Free coffee at Celsius Shah Alam (5-7pm) this week, spend RM40. We rarely see you in the evening! Show your number." },
+      { key: "rg_import", min_order: 25, label: "Win-back · free coffee, spend RM25 (5-7pm)",
+        message: "Hi {name}! We miss you at Celsius Shah Alam. Free coffee (5-7pm) this week, spend RM25. Show your number." },
+    ],
+  },
+};
+
+// Auto-run the round-gap campaigns: prepare the next capped batch per campaign
+// and send it immediately. Idempotent — skips a campaign already run in the last
+// 20h, so the daily cron (or a manual re-trigger) can't double-send; force
+// bypasses that guard. Holdout + measurement are handled by the prepare RPC +
+// autoMeasureDueRounds, exactly like the other loops.
+export async function runRoundGapDaily(opts?: { force?: boolean }): Promise<Array<{ campaign: string; prepared?: number; sent?: number; failed?: number; skipped?: boolean; error?: string }>> {
+  const out: Array<{ campaign: string; prepared?: number; sent?: number; failed?: number; skipped?: boolean; error?: string }> = [];
+  try {
+    const { data: s } = await supabaseAdmin.from("app_settings").select("value").eq("key", "round_gap_auto_enabled").maybeSingle();
+    if ((s?.value ?? "").toString().trim().toLowerCase() === "false") {
+      return [{ campaign: "all", skipped: true, error: "round_gap_auto_enabled=false" }];
+    }
+  } catch { /* missing setting → default enabled */ }
+
+  const sinceIso = new Date(Date.now() - 20 * 3600 * 1000).toISOString();
+  for (const [key, cfg] of Object.entries(ROUND_GAP_CAMPAIGNS)) {
+    try {
+      if (!opts?.force) {
+        const { data: recent } = await supabaseAdmin
+          .from("loop_rounds").select("id")
+          .eq("loop_key", "round_gap").filter("meta->>outlet", "eq", cfg.outlet)
+          .gte("prepared_at", sinceIso).limit(1);
+        if (recent && recent.length) { out.push({ campaign: key, skipped: true }); continue; }
+      }
+      const { data, error } = await supabaseAdmin.rpc("loyalty_round_gap_prepare", {
+        p_outlet: cfg.outlet, p_round_start: cfg.round_start, p_round_end: cfg.round_end,
+        p_round_name: cfg.name, p_arms: cfg.arms, p_holdout_pct: 10, p_window_days: 7, p_limit: cfg.daily_limit,
+      });
+      if (error) throw new Error(error.message);
+      const row = Array.isArray(data) ? data[0] : data;
+      if (!row?.round_id) { out.push({ campaign: key, prepared: 0 }); continue; } // pool drained
+      const res = await sendRound(row.round_id);
+      out.push({ campaign: key, prepared: row.treated, sent: res.sent, failed: res.failed });
+    } catch (e) {
+      out.push({ campaign: key, error: e instanceof Error ? e.message : "failed" });
+    }
+  }
+  return out;
+}
+
 // Revert a PREPARED round — delete the un-sent (active) vouchers it issued, its
 // assignments, and the round itself. Only valid before send: a sent round has
 // live SMS in customers' hands, so it can't be un-done. Redeemed vouchers (rare

--- a/supabase/migrations/049_round_gap_auto_setting.sql
+++ b/supabase/migrations/049_round_gap_auto_setting.sql
@@ -1,0 +1,7 @@
+-- Kill-switch for the round-gap auto-run (runRoundGapDaily). Default ON; set to
+-- 'false' to pause the daily 100/SMS reactivation drip without a redeploy.
+-- Idempotent data migration (app_settings is key/value).
+UPDATE app_settings SET value='true' WHERE key='round_gap_auto_enabled';
+INSERT INTO app_settings(key, value)
+  SELECT 'round_gap_auto_enabled','true'
+  WHERE NOT EXISTS (SELECT 1 FROM app_settings WHERE key='round_gap_auto_enabled');


### PR DESCRIPTION
Makes round-gap behave like winback/welcome/birthday — **no manual round cards, runs itself daily**.

## Changes
- **`ROUND_GAP_CAMPAIGNS`** moved to `loop-engine` (single source of audience / per-segment offers / copy; the prepare route imports it).
- **`runRoundGapDaily()`** — per campaign, idempotently (20h guard; `force` bypasses) prepares the next capped batch (**50 each = ~100/day**, warmest-first) and auto-sends. Holdout + measurement via the prepare RPC + `autoMeasureDueRounds`. **Kill-switch:** `app_settings.round_gap_auto_enabled='false'` pauses it (no redeploy).
- Wired into the **daily `loops-trigger` cron** and the manual **run-triggered** route.
- `optimizer` marks `round_gap` `triggered=true` → the loops page **hides the round cards** + shows the auto note (scorecard-only), exactly like the lifecycle loops.
- **Migration 049** — kill-switch setting (default ON).

## Data ops done
- Enabled the kill-switch (`round_gap_auto_enabled=true`).
- **Cancelled the two manually-prepared rounds** (Conezion 95, Shah Alam 89) — untagged members, dropped their 4 promos, deleted assignments + rounds — so the cold imports return to the pool and the cron rebuilds at the daily cap. Verified clean (0 prepared / 0 tagged / 0 promos left). Test round (Ammar) untouched.

Typecheck clean (only pre-existing `music` error). Auto-run begins on the next daily cron (~9am MYT); first batch is warmest-first per segment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)