### PR TITLE
Redemption loop: home expiring-reward banner (use it before it's gone)

### DIFF
--- a/apps/order/src/app/_ExpiringRewardBanner.tsx
+++ b/apps/order/src/app/_ExpiringRewardBanner.tsx
@@ -1,0 +1,110 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
+import { Clock, ChevronRight } from "lucide-react";
+import { applyWalletVoucherToState, type WalletVoucher } from "@/lib/loyalty/apply-wallet-voucher";
+
+/**
+ * Home "use it before it's gone" banner — the REDEEM half of the reward
+ * loop. Customers earn vouchers (mystery / challenge) but ~9 in 10 never
+ * get used; this surfaces the SOONEST-EXPIRING active voucher above the
+ * fold with urgency + a one-tap "use now" that pre-applies it and drops
+ * the customer on the menu to start the next order.
+ *
+ * Distinct from VoucherRail (a passive wallet list further down): shows
+ * only the single most-urgent reward, only when it expires within the
+ * urgency window, and routes straight into an order with the reward
+ * already applied. Renders nothing otherwise (guests, no expiring reward).
+ */
+
+const URGENCY_DAYS = 7;
+
+type Persisted = { state?: { sessionToken?: string | null } };
+type Voucher = WalletVoucher & { status?: string | null; source_type?: string | null };
+
+function daysLeft(iso: string | null | undefined): number | null {
+  if (!iso) return null;
+  return Math.ceil((new Date(iso).getTime() - Date.now()) / (1000 * 60 * 60 * 24));
+}
+
+function expiryPhrase(d: number): string {
+  if (d <= 0) return "today";
+  if (d === 1) return "tomorrow";
+  return `in ${d} days`;
+}
+
+// Tie-break: a free drink beats a discount; otherwise bigger discount wins.
+function valueRank(v: Voucher): number {
+  if (v.discount_type === "free_item") return 1_000_000;
+  return v.discount_value ?? 0;
+}
+
+export function ExpiringRewardBanner() {
+  const router = useRouter();
+  const [pick, setPick] = useState<Voucher | null>(null);
+
+  useEffect(() => {
+    let token: string | null = null;
+    try {
+      const raw = window.localStorage.getItem("celsius-pickup");
+      if (raw) token = (JSON.parse(raw) as Persisted).state?.sessionToken ?? null;
+    } catch {
+      /* ignore */
+    }
+    if (!token) return;
+    fetch("/api/loyalty/me/vouchers", { headers: { Authorization: `Bearer ${token}` } })
+      .then((r) => (r.ok ? r.json() : []))
+      .then((data) => {
+        const list = (Array.isArray(data) ? data : (data?.vouchers ?? [])) as Voucher[];
+        const soonest = list
+          .filter((v) => v.status === "active" || !v.status)
+          .map((v) => ({ v, d: daysLeft(v.expires_at) }))
+          .filter((x): x is { v: Voucher; d: number } => x.d !== null && x.d >= 0 && x.d <= URGENCY_DAYS)
+          .sort((a, b) => a.d - b.d || valueRank(b.v) - valueRank(a.v))[0];
+        setPick(soonest?.v ?? null);
+      })
+      .catch(() => {
+        /* ignore */
+      });
+  }, []);
+
+  if (!pick) return null;
+  const d = daysLeft(pick.expires_at) ?? 0;
+  const name = pick.title ?? pick.name ?? "reward";
+
+  const onUse = () => {
+    applyWalletVoucherToState(pick);
+    router.push("/menu");
+  };
+
+  return (
+    <button
+      onClick={onUse}
+      aria-label={`Use your ${name} before it expires`}
+      className="mx-4 mt-4 flex items-center gap-3 rounded-2xl active:opacity-90 text-left"
+      style={{ width: "calc(100% - 2rem)", backgroundColor: "#1A0200", padding: 14 }}
+    >
+      <span
+        className="flex items-center justify-center rounded-full flex-shrink-0"
+        style={{ width: 38, height: 38, backgroundColor: "rgba(251,191,36,0.18)" }}
+      >
+        <Clock size={20} color="#FBBF24" strokeWidth={2.2} />
+      </span>
+      <span className="flex-1 min-w-0">
+        <span className="block font-peachi font-bold text-[15px] text-white truncate">
+          Your {name} expires {expiryPhrase(d)}
+        </span>
+        <span className="block text-[12px]" style={{ color: "rgba(251,191,36,0.85)" }}>
+          {d <= 1 ? "Last chance — order now to use it" : "Order now to use it"}
+        </span>
+      </span>
+      <span
+        className="flex items-center justify-center rounded-full flex-shrink-0"
+        style={{ width: 28, height: 28, backgroundColor: "#FBBF24" }}
+      >
+        <ChevronRight size={16} color="#1A0200" />
+      </span>
+    </button>
+  );
+}

--- a/apps/order/src/app/page.tsx
+++ b/apps/order/src/app/page.tsx
@@ -12,6 +12,7 @@ import { ActiveChallengeCard } from "./_ActiveChallengeCard";
 import { VoucherRail } from "./_VoucherRail";
 import { GuestSignInCTA } from "./_GuestSignInCTA";
 import { ActiveOrderTracker } from "./_ActiveOrderTracker";
+import { ExpiringRewardBanner } from "./_ExpiringRewardBanner";
 
 /**
  * Customer home — Next.js Server Component. Plain HTML so iOS Safari
@@ -79,6 +80,12 @@ export default async function HomePage() {
         <PosterCarousel posters={posters} />
         <HeroInfoCard />
       </div>
+
+      {/* Expiring-reward urgency banner — the REDEEM half of the reward
+          loop. Surfaces the soonest-expiring unused voucher above the
+          fold with a one-tap "use now" (pre-applies + routes to menu).
+          Renders nothing for guests / no expiring reward. */}
+      <ExpiringRewardBanner />
 
       {/* Outlet row — under the hero, brand voice. Client component
           reads chosen outlet from localStorage so customers see their

--- a/apps/order/src/app/rewards/_YourVouchers.tsx
+++ b/apps/order/src/app/rewards/_YourVouchers.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
 import { Gift, Sparkles, Coffee, Tag, Ticket, Percent } from "lucide-react";
+import { applyWalletVoucherToState } from "@/lib/loyalty/apply-wallet-voucher";
 
 /**
  * "Your vouchers" — the web mirror of apps/pickup-native's "Yours" wallet
@@ -100,47 +101,10 @@ function themeFor(v: Voucher): {
 }
 
 // Write the chosen wallet voucher into the SPA's persisted state as the
-// applied reward + reserved-voucher banner. Mirrors native VoucherWallet's
-// "Use Now" mapping — carries every discount mechanic so flat/percent/
-// free_item/bogo/combo/override all preview + charge correctly.
-function applyWalletVoucher(v: Voucher) {
-  try {
-    const raw = window.localStorage.getItem("celsius-pickup");
-    const parsed = raw ? JSON.parse(raw) : { state: {} };
-    const state = parsed.state ?? {};
-    // beans_multiplier is applied post-payment, never a cart discount.
-    const discountType =
-      v.discount_type && v.discount_type !== "beans_multiplier" ? v.discount_type : null;
-    state.appliedReward = {
-      id: v.id,
-      name: v.title ?? v.name ?? "Reward",
-      points_required: 0,
-      discount_type: discountType,
-      discount_value: v.discount_value ?? null,
-      max_discount_value: v.max_discount_value ?? null,
-      applicable_categories: v.applicable_categories ?? null,
-      applicable_products: v.applicable_products ?? null,
-      free_product_name: v.free_product_name ?? null,
-      free_product_ids: v.free_product_ids ?? null,
-      min_order_value: v.min_order_value ?? null,
-      bogo_buy_qty: v.bogo_buy_qty ?? undefined,
-      bogo_free_qty: v.bogo_free_qty ?? undefined,
-      combo_price_sen: v.combo_price_sen ?? null,
-      override_price_sen: v.override_price_sen ?? null,
-      voucher_id: v.id, // marks this as a wallet voucher (issued_rewards burn)
-    };
-    state.reservedVoucher = {
-      id: v.id,
-      title: v.title ?? v.name ?? "Reward",
-      category: v.category ?? "special",
-      icon: v.icon ?? "ticket",
-      expires_at: v.expires_at ?? null,
-    };
-    window.localStorage.setItem("celsius-pickup", JSON.stringify({ ...parsed, state }));
-  } catch {
-    /* ignore */
-  }
-}
+// applied reward + reserved-voucher banner — shared with the home
+// expiring-reward banner via applyWalletVoucherToState so both close the
+// loop identically (carries flat/percent/free_item/bogo/combo/override).
+const applyWalletVoucher = applyWalletVoucherToState;
 
 export function YourVouchers() {
   const router = useRouter();

--- a/apps/order/src/lib/loyalty/apply-wallet-voucher.ts
+++ b/apps/order/src/lib/loyalty/apply-wallet-voucher.ts
@@ -1,0 +1,67 @@
+// Shared "Use Now" mapping — writes a wallet voucher into the SPA's
+// persisted state (localStorage "celsius-pickup") as the applied reward +
+// reserved-voucher banner, so cart/checkout preview + charge it correctly.
+//
+// Extracted from the Rewards-tab voucher list so the home expiring-reward
+// banner closes the loop the EXACT same way (no drift): both carry every
+// discount mechanic (flat / percent / free_item / bogo / combo / override).
+
+export type WalletVoucher = {
+  id: string;
+  title?: string | null;
+  name?: string | null;
+  category?: string | null;
+  icon?: string | null;
+  discount_type?: string | null;
+  discount_value?: number | null;
+  max_discount_value?: number | null;
+  applicable_categories?: string[] | null;
+  applicable_products?: string[] | null;
+  free_product_name?: string | null;
+  free_product_ids?: string[] | null;
+  min_order_value?: number | null;
+  bogo_buy_qty?: number | null;
+  bogo_free_qty?: number | null;
+  combo_price_sen?: number | null;
+  override_price_sen?: number | null;
+  expires_at?: string | null;
+};
+
+export function applyWalletVoucherToState(v: WalletVoucher): void {
+  try {
+    const raw = window.localStorage.getItem("celsius-pickup");
+    const parsed = raw ? JSON.parse(raw) : { state: {} };
+    const state = parsed.state ?? {};
+    // beans_multiplier is applied post-payment, never a cart discount.
+    const discountType =
+      v.discount_type && v.discount_type !== "beans_multiplier" ? v.discount_type : null;
+    state.appliedReward = {
+      id: v.id,
+      name: v.title ?? v.name ?? "Reward",
+      points_required: 0,
+      discount_type: discountType,
+      discount_value: v.discount_value ?? null,
+      max_discount_value: v.max_discount_value ?? null,
+      applicable_categories: v.applicable_categories ?? null,
+      applicable_products: v.applicable_products ?? null,
+      free_product_name: v.free_product_name ?? null,
+      free_product_ids: v.free_product_ids ?? null,
+      min_order_value: v.min_order_value ?? null,
+      bogo_buy_qty: v.bogo_buy_qty ?? undefined,
+      bogo_free_qty: v.bogo_free_qty ?? undefined,
+      combo_price_sen: v.combo_price_sen ?? null,
+      override_price_sen: v.override_price_sen ?? null,
+      voucher_id: v.id, // marks this as a wallet voucher (issued_rewards burn)
+    };
+    state.reservedVoucher = {
+      id: v.id,
+      title: v.title ?? v.name ?? "Reward",
+      category: v.category ?? "special",
+      icon: v.icon ?? "ticket",
+      expires_at: v.expires_at ?? null,
+    };
+    window.localStorage.setItem("celsius-pickup", JSON.stringify({ ...parsed, state }));
+  } catch {
+    /* ignore */
+  }
+}


### PR DESCRIPTION
## Why
The **earn** side of the reward loops works, but the **redeem** side is broken — rewards are won and never used:

| | unused (active) | used | redemption |
|---|---|---|---|
| Mystery vouchers | 208 | 37 | ~14% |
| Challenge vouchers | 93 | 8 | ~8% |

**301 free-drink vouchers sitting unused**, **55 expiring within 7 days** — each is a customer with a paid-for reason to come back who isn't.

## What
An above-fold home banner that surfaces the **soonest-expiring active voucher** with urgency copy ("Your Free Coffee expires in 2 days — order now to use it") and a **one-tap 'use now'** that pre-applies the voucher and drops the customer on the menu to start the next order.

- **Distinct from VoucherRail** (passive wallet list further down): shows only the single most-urgent reward, only within a 7-day window, and routes straight into an order with the reward already applied.
- **Covers mystery *and* challenge** — source-agnostic (VoucherRail excludes challenge/'mission' vouchers, so those 93 had no home surface at all).
- Renders nothing for guests / when nothing is expiring.

## How
- New `lib/loyalty/apply-wallet-voucher.ts` — extracted the Rewards-tab 'Use Now' mapping so the banner and `_YourVouchers` apply vouchers **identically** (carries flat/percent/free_item/bogo/combo/override). `_YourVouchers` now delegates to it (de-dups ~40 lines).
- New `_ExpiringRewardBanner.tsx` — fetches the existing `/api/loyalty/me/vouchers`, picks soonest-expiry (tie → higher value), one-tap apply + route to /menu.
- Wired into `page.tsx` just under the hero.

No holdout: withholding an expiring-reward reminder for a drink the customer already earned is user-hostile; measuring redemption-rate before/after instead. Typecheck clean (order). Web only — native parity next if it lands well.

🤖 Generated with [Claude Code](https://claude.com/claude-code)