### PR TITLE
Round-gap UI: show real campaign messages, hide legacy optimizer/prepare bits

### DIFF
--- a/apps/backoffice/src/app/(admin)/loyalty/loops/page.tsx
+++ b/apps/backoffice/src/app/(admin)/loyalty/loops/page.tsx
@@ -46,7 +46,7 @@ type Preview = {
   holdout: number; arm_counts: Record<string, number>; est_sms_cost_rm: number; est_reward_cogs_rm: number;
 };
 type Candidate = { key: string; label: string; logic: string; voucher_template_id: string; message: string };
-type ProposalArm = { key: string; label: string; voucher_template_id: string; message: string; role: "champion" | "challenger"; reason: string };
+type ProposalArm = { key: string; label: string; voucher_template_id: string; message: string; role: string; reason: string };
 type LeaderboardEntry = {
   template_id: string; key: string | null; label: string; logic: string | null;
   rounds: number; recipients: number; avg_lift_pp: number;
@@ -128,11 +128,16 @@ function StatusBadge({ status }: { status: Round["status"] }) {
   const s = map[status];
   return <span className={cn("rounded-full px-2.5 py-0.5 text-xs font-medium", s.cls)}>{s.label}</span>;
 }
-function RoleBadge({ role }: { role: "champion" | "challenger" }) {
-  return role === "champion" ? (
+function RoleBadge({ role }: { role: string }) {
+  if (role === "champion") return (
     <span className="inline-flex items-center gap-1 rounded bg-green-100 px-1.5 py-0.5 text-xs font-medium text-green-800"><Crown className="h-3 w-3" /> champion</span>
-  ) : (
+  );
+  if (role === "challenger") return (
     <span className="inline-flex items-center gap-1 rounded bg-blue-100 px-1.5 py-0.5 text-xs font-medium text-blue-800"><Sparkles className="h-3 w-3" /> challenger</span>
+  );
+  // round_gap segments (regular / win-back) and any other fixed-campaign role
+  return (
+    <span className="inline-flex items-center gap-1 rounded bg-amber-100 px-1.5 py-0.5 text-xs font-medium text-amber-800"><Sparkles className="h-3 w-3" /> {role}</span>
   );
 }
 
@@ -287,7 +292,7 @@ export default function LoopsPage() {
         </div>
       )}
 
-      {loopKey === "round_gap" && (
+      {loopKey === "round_gap" && !activeTriggered && (
         <RoundGapPrepareCard
           busy={busy === "rg"}
           onPrepare={async (campaign) => {
@@ -309,7 +314,8 @@ export default function LoopsPage() {
 
       {opt && <MessagesPanel arms={opt.proposal.arms} />}
 
-      {opt && <OptimizerPanel opt={opt} />}
+      {/* round_gap runs fixed per-segment campaigns, not the A/B optimizer — hide it */}
+      {opt && loopKey !== "round_gap" && <OptimizerPanel opt={opt} />}
 
       {!activeTriggered && (opt ? (
         <NewRoundCard
@@ -691,7 +697,7 @@ function OptimizerPanel({ opt }: { opt: Optimizer }) {
 }
 
 // ---- New round (seeded by the optimizer's proposal) -------------------------
-type FormArm = { key: string; label: string; voucher_template_id: string; message: string; role: "champion" | "challenger"; reason: string };
+type FormArm = { key: string; label: string; voucher_template_id: string; message: string; role: string; reason: string };
 
 function NewRoundCard({ loopKey, loopMeta, proposal, candidates, busy, onPrepare }: {
   loopKey: string; loopMeta?: LoopMeta; proposal: ProposalArm[]; candidates: Candidate[]; busy: boolean; onPrepare: (p: unknown) => void;

--- a/apps/backoffice/src/app/api/loyalty/loops/optimizer/route.ts
+++ b/apps/backoffice/src/app/api/loyalty/loops/optimizer/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { requireAuth } from "@/lib/auth";
-import { getLeaderboard, proposeArms, getSendTimeLeaderboard, proposeSendWindow, composeMessage, SEND_WINDOWS, OFFER_CANDIDATES, LOOPS, type LoopKey } from "@/lib/loyalty/loop-engine";
+import { getLeaderboard, proposeArms, getSendTimeLeaderboard, proposeSendWindow, composeMessage, SEND_WINDOWS, OFFER_CANDIDATES, LOOPS, ROUND_GAP_CAMPAIGNS, type LoopKey } from "@/lib/loyalty/loop-engine";
 
 // GET /api/loyalty/loops/optimizer?loop_key= — the adaptive layer per loop:
 //   - leaderboard: every offer ranked by cumulative incremental margin (learns over time)
@@ -14,9 +14,23 @@ export async function GET(request: NextRequest) {
     const loopKey = (new URL(request.url).searchParams.get("loop_key") ?? "winback") as LoopKey;
     const def = LOOPS[loopKey];
     if (!def) return NextResponse.json({ error: `unknown loop: ${loopKey}` }, { status: 400 });
-    const [leaderboard, proposal, sendTimeLeaderboard, sendWindowProposal] = await Promise.all([
+    const [leaderboard, proposalRaw, sendTimeLeaderboard, sendWindowProposal] = await Promise.all([
       getLeaderboard(loopKey), proposeArms(loopKey), getSendTimeLeaderboard(loopKey), proposeSendWindow(loopKey),
     ]);
+    // round_gap doesn't use the A/B optimizer — it runs fixed per-segment campaigns
+    // (ROUND_GAP_CAMPAIGNS). Surface THOSE as the "messages going out" so the UI
+    // shows exactly what auto-run sends (per-outlet skipper + win-back free-coffee
+    // copy), not the legacy discount candidate template.
+    const proposal = loopKey === "round_gap"
+      ? { arms: Object.values(ROUND_GAP_CAMPAIGNS).flatMap((cfg) => cfg.arms.map((a) => ({
+          key: `${cfg.outlet}:${a.key}`,
+          label: `${cfg.name} — ${a.label}`,
+          voucher_template_id: "",
+          message: a.message,
+          role: a.key === "rg_import" ? "win-back" : "regular",
+          reason: a.key === "rg_import" ? "dormant customers" : "regulars who skip this round",
+        }))) }
+      : proposalRaw;
     // Curate the swap-list copy for THIS objective — a candidate's message
     // reads as a Welcome/Birthday/etc. SMS, not the win-back default.
     const candidates = OFFER_CANDIDATES


### PR DESCRIPTION
The round-gap tab was showing the **legacy optimizer config** — discount offers ("15% off RM40+", "RM10 off RM30+", "Buy 1 Free 1" with "Celsius misses you! Enjoy {offer}") — instead of the **per-segment free-coffee win-back copy** the auto-run actually sends. The manual Prepare card and the A/B Optimizer panel also still rendered even though round-gap is auto now.

## Fixes
- **optimizer route** — for `round_gap`, surface `ROUND_GAP_CAMPAIGNS` arms as "messages going out": the exact per-outlet **skipper** (RM35/40) + **win-back** (RM25) free-coffee copy with `{name}`. No more legacy discount template.
- **page** — hide `RoundGapPrepareCard` when the loop is auto (`activeTriggered`); hide the A/B `OptimizerPanel` for round_gap (fixed campaigns, no champion/challenger).
- **RoleBadge** — render fixed-campaign roles (`regular` / `win-back`) as a neutral badge; widen `ProposalArm`/`FormArm` role to `string`.

Now the round-gap tab shows exactly what goes out. Typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)