### PR TITLE
Fix: Store/Menu Status "No outlet" for company-wide managers

### DIFF
--- a/apps/backoffice/src/app/api/pos/store-menu-status/route.ts
+++ b/apps/backoffice/src/app/api/pos/store-menu-status/route.ts
@@ -67,7 +67,13 @@ export async function GET(request: NextRequest) {
   if (auth.error) return auth.error;
   const user = auth.user;
 
-  const isAdmin = user.role === "OWNER" || user.role === "ADMIN";
+  // Admins — and company-wide managers with no home outlet — see every active
+  // outlet (this board's whole promise is "across all outlets"). A null
+  // outletId means "not pinned to a store", the same convention the sales
+  // dashboard / command board use to treat a manager as company-wide; without
+  // this, such a manager hits the `o.id === null` filter below and gets a bogus
+  // "No outlet" 400. Outlet-scoped users still see only their own outlet.
+  const seesAllOutlets = user.role === "OWNER" || user.role === "ADMIN" || !user.outletId;
 
   const outlets = await prisma.outlet.findMany({
     where: { status: "ACTIVE" },
@@ -83,7 +89,7 @@ export async function GET(request: NextRequest) {
     },
     orderBy: { name: "asc" },
   });
-  const scoped = isAdmin ? outlets : outlets.filter((o) => o.id === user.outletId);
+  const scoped = seesAllOutlets ? outlets : outlets.filter((o) => o.id === user.outletId);
   if (scoped.length === 0) {
     return NextResponse.json({ error: "No outlet" }, { status: 400 });
   }


### PR DESCRIPTION
## Problem
Ariff (and Adam Kelvin) get **"No outlet"** on **Sales › Store / Menu Status**, even though they have the `pickup:settings` grant and can open the page.

## Root cause
The board is meant to be company-wide ("Live: who's open, who's selling, and what's 86'd — **across all outlets**"), but the API only treated OWNER/ADMIN as all-outlet:

```js
const isAdmin = user.role === "OWNER" || user.role === "ADMIN";
const scoped = isAdmin ? outlets : outlets.filter((o) => o.id === user.outletId);
if (scoped.length === 0) return NextResponse.json({ error: "No outlet" }, { status: 400 });
```

Ariff and Adam Kelvin are **MANAGERs with `outletId = null`** (company-wide / area managers). The filter `o.id === null` matches nothing → empty → `400 "No outlet"`. They already see all-outlet data on the **Sales Dashboard / Compare** (the `command`/`sales` routes treat a null outletId as company-wide) — this board was just the outlier.

## Fix
Treat a **null `outletId` as "not pinned to a store" → sees all outlets**, the same convention the rest of the app uses. Outlet-scoped users are unchanged (still their own outlet only).

## Blast radius
Only non-admins with **no home outlet** who can already reach this page (i.e. have `pickup:settings`). In the live data that's exactly **Ariff + Adam Kelvin** — the two intended company-wide managers; the other 5 null-outlet users lack the grant so the nav item isn't even shown to them. Both already have all-outlet visibility elsewhere, so this is consistent, not a new exposure.

## Verification
- typecheck (backoffice) ✅ · eslint (changed file) ✅
- `isAdmin` had no other uses (renamed to `seesAllOutlets`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PfVviAtVbppgRTt5pG3D8j)_