### PR TITLE
Reward-expiring loop: auto-run daily, no budget cap

### DIFF
--- a/apps/backoffice/src/lib/loyalty/loop-engine.ts
+++ b/apps/backoffice/src/lib/loyalty/loop-engine.ts
@@ -688,7 +688,7 @@ export const LOOPS: Record<LoopKey, LoopDef> = {
   // Reminder loop (manual/operator-gated — no trigger): pull members back to
   // redeem a voucher they ALREADY won before it expires. noIssue → attributes
   // the existing voucher; {reward}/{expiry} filled per-recipient in sendRound.
-  reward_expiring: { key: "reward_expiring", label: "Reward expiring", objective: "Redeem an unused voucher before it expires", defaultHoldoutPct: 20, defaultWindowDays: 7, candidateKeys: [], noIssue: true, messageTemplate: "Your {reward} at Celsius expires {expiry}! Show your number at any outlet to redeem before it's gone.", segment: rewardExpiringSegment },
+  reward_expiring: { key: "reward_expiring", label: "Reward expiring", objective: "Redeem an unused voucher before it expires", defaultHoldoutPct: 20, defaultWindowDays: 7, candidateKeys: [], noIssue: true, messageTemplate: "Your {reward} at Celsius expires {expiry}! Show your number at any outlet to redeem before it's gone.", trigger: { holdoutPct: 20, cooldownDays: 7, segmentOpts: { expiringWithinDays: 7 } }, segment: rewardExpiringSegment },
 };
 
 // Curated SMS per (loop × offer): slot the offer phrase into the loop's
@@ -967,7 +967,15 @@ async function runTriggeredLoop(def: LoopDef, force = false): Promise<{ loop: Lo
   // segment and wanting it out now). Cooldown still protects already-messaged
   // customers, so a forced run only reaches genuinely new qualifiers.
   if (!force && await ranToday(def.key)) return { loop: def.key, qualified: 0, skipped: true };
-  const arms = (await proposeArms(def.key)).arms.map((a) => ({ key: a.key, label: a.label, voucher_template_id: a.voucher_template_id, message: a.message }));
+  // Optimizer-driven loops build arms from their offer candidates; fixed-message
+  // reminder loops (e.g. reward_expiring, candidateKeys: []) have none, so use the
+  // loop's messageTemplate as a single arm ({reward}/{expiry}/{name} fill at send).
+  const proposed = def.candidateKeys.length > 0
+    ? (await proposeArms(def.key)).arms.map((a) => ({ key: a.key, label: a.label, voucher_template_id: a.voucher_template_id, message: a.message }))
+    : [];
+  const arms = proposed.length > 0
+    ? proposed
+    : [{ key: "reminder", label: def.label, voucher_template_id: "", message: def.messageTemplate }];
   const suppressPhones = await recentlyTargetedPhones(def.key, trig.cooldownDays);
   const preview = await prepareRound(def.key, {
     arms,


### PR DESCRIPTION
Per request — the reward-expiring reminder shouldn't need a budget or manual trigger; just automate it like the other loops.

- **`LOOPS.reward_expiring` gets a `trigger`** (holdout 20%, 7-day cooldown, voucher expiring within 7 days) → `runTriggeredLoops` (daily `loops-trigger` cron) now fires it. **No `maxRecipients` = no budget cap** — reminds every qualifier minus holdout/cooldown (~55/week today).
- **`runTriggeredLoop` falls back to the loop's `messageTemplate`** as a single arm when there are no offer candidates (reward_expiring is `noIssue` / `candidateKeys: []`), so the `{reward}`/`{expiry}` reminder sends correctly.
- UI: it now presents as triggered (cards hidden, scorecard-only) like the rest.

Auto-runs at the next daily cron (~9am MYT). Typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)