### PR TITLE
Reward-expiring: real redemption tracking + skip non-stackable tiers

### DIFF
--- a/apps/backoffice/src/lib/loyalty/loop-engine.ts
+++ b/apps/backoffice/src/lib/loyalty/loop-engine.ts
@@ -225,11 +225,31 @@ async function rewardExpiringSegment(o: SegmentOpts): Promise<{ rows: SegmentRow
     for (const m of (data ?? []) as MemberRow[]) memberById.set(m.id, m);
   }
 
+  // Exclude non-stackable-tier members (Black Card / Staff): their flat tier
+  // discount REPLACES any voucher at the till, so they can NEVER redeem the
+  // reward we'd remind them about — reminding is wasted SMS + a guaranteed
+  // non-redemption. (Same rule the POS applies; see evaluate-promotions.)
+  const nonStackable = new Set<string>();
+  const { data: nsTiers } = await supabaseAdmin.from("tiers").select("id").eq("brand_id", BRAND).eq("stackable", false);
+  const nsTierIds = (nsTiers ?? []).map((t: { id: string }) => t.id);
+  if (nsTierIds.length) {
+    for (let i = 0; i < memberIds.length; i += 1000) {
+      const { data } = await supabaseAdmin
+        .from("member_brands")
+        .select("member_id")
+        .eq("brand_id", BRAND)
+        .in("member_id", memberIds.slice(i, i + 1000))
+        .in("current_tier_id", nsTierIds);
+      for (const r of (data ?? []) as { member_id: string }[]) nonStackable.add(r.member_id);
+    }
+  }
+
   const seen = new Set<string>();
   const rows: SegmentRow[] = [];
   for (const [memberId, ir] of byMember) {
     const m = memberById.get(memberId);
     if (!m || m.sms_opt_out === true) continue;
+    if (nonStackable.has(memberId)) continue; // tier wipes the voucher — can't redeem
     const phone = (m.phone ?? "").trim();
     if (!phone || seen.has(phone)) continue;
     seen.add(phone);

--- a/supabase/migrations/051_live_rollup_attributed_redeem.sql
+++ b/supabase/migrations/051_live_rollup_attributed_redeem.sql
@@ -1,0 +1,71 @@
+-- Live rollup v3: count vouchers/redemptions off the ATTRIBUTED voucher
+-- (loop_assignments.issued_reward_id) rather than vouchers issued BY the round.
+-- Reminder loops (reward_expiring, noIssue) attribute an EXISTING voucher, so the
+-- old source_ref_id=round join always returned 0 redeemed. Now redemption is real
+-- for both issued loops AND reminder loops. (round_gap uses a promo, no voucher →
+-- still 0 here; its redemption is tracked separately.) Keeps v2's round-specific
+-- order counting for round_gap.
+CREATE OR REPLACE FUNCTION public.loyalty_loops_live_rollup(p_since_days integer DEFAULT NULL::integer)
+RETURNS TABLE(loop_key text, rounds integer, in_flight integer, sent bigint, vouchers bigint, redeemed bigint, orders bigint, revenue_rm numeric, next_results_at timestamp with time zone)
+LANGUAGE sql STABLE AS $function$
+  WITH r AS (
+    SELECT lr.id, lr.loop_key, lr.status, lr.sent_at, lr.attribution_window_days,
+      (lr.meta->>'round_start')::int AS rs, (lr.meta->>'round_end')::int AS re,
+      CASE lr.meta->>'outlet'
+        WHEN 'conezion' THEN ARRAY['conezion','outlet-con']
+        WHEN 'shah-alam' THEN ARRAY['shah-alam','outlet-sa']
+        WHEN 'tamarind' THEN ARRAY['tamarind','outlet-tam']
+        ELSE ARRAY[lr.meta->>'outlet'] END AS rg_outlets
+    FROM loop_rounds lr
+    WHERE lr.status IN ('sent','measured')
+      AND (p_since_days IS NULL OR lr.sent_at >= now() - (p_since_days || ' days')::interval)
+  ),
+  asg AS (
+    SELECT r.loop_key, count(*) FILTER (WHERE la.sms_status='sent') AS sent
+    FROM r JOIN loop_assignments la ON la.round_id = r.id GROUP BY r.loop_key
+  ),
+  vou AS (
+    SELECT r.loop_key,
+      count(*) FILTER (WHERE la.issued_reward_id IS NOT NULL) AS vouchers,
+      count(*) FILTER (WHERE ir.redeemed_at IS NOT NULL OR ir.status='redeemed') AS redeemed
+    FROM r
+    JOIN loop_assignments la ON la.round_id = r.id AND la.arm <> 'holdout' AND la.sms_status = 'sent'
+    LEFT JOIN issued_rewards ir ON ir.id = la.issued_reward_id
+    GROUP BY r.loop_key
+  ),
+  rnd AS (
+    SELECT loop_key, count(*) AS rounds,
+           count(*) FILTER (WHERE status='sent') AS in_flight,
+           min(sent_at + (attribution_window_days || ' days')::interval) FILTER (WHERE status='sent') AS next_results_at
+    FROM r GROUP BY loop_key
+  ),
+  ord AS (
+    SELECT t.loop_key, count(*) AS orders, coalesce(sum(t.total),0)/100.0 AS revenue_rm
+    FROM (
+      SELECT DISTINCT r.loop_key, o.id::text AS oid, o.total
+      FROM r JOIN loop_assignments la ON la.round_id=r.id AND la.arm<>'holdout' AND la.sms_status='sent'
+             JOIN orders o ON o.customer_phone=la.phone AND o.created_at >= r.sent_at AND o.created_at <= r.sent_at + (r.attribution_window_days||' days')::interval
+      WHERE r.status='sent'
+        AND (r.loop_key <> 'round_gap' OR (
+          o.store_id = ANY(r.rg_outlets)
+          AND extract(hour FROM (o.created_at AT TIME ZONE 'Asia/Kuala_Lumpur'))::int >= r.rs
+          AND extract(hour FROM (o.created_at AT TIME ZONE 'Asia/Kuala_Lumpur'))::int <  r.re ))
+      UNION
+      SELECT DISTINCT r.loop_key, p.id::text, p.total
+      FROM r JOIN loop_assignments la ON la.round_id=r.id AND la.arm<>'holdout' AND la.sms_status='sent'
+             JOIN pos_orders p ON p.customer_phone=la.phone AND p.created_at >= r.sent_at AND p.created_at <= r.sent_at + (r.attribution_window_days||' days')::interval
+      WHERE r.status='sent'
+        AND (r.loop_key <> 'round_gap' OR (
+          p.outlet_id = ANY(r.rg_outlets)
+          AND extract(hour FROM (p.created_at AT TIME ZONE 'Asia/Kuala_Lumpur'))::int >= r.rs
+          AND extract(hour FROM (p.created_at AT TIME ZONE 'Asia/Kuala_Lumpur'))::int <  r.re ))
+    ) t GROUP BY t.loop_key
+  )
+  SELECT rnd.loop_key, rnd.rounds::int, rnd.in_flight::int,
+    coalesce(asg.sent,0), coalesce(vou.vouchers,0), coalesce(vou.redeemed,0),
+    coalesce(ord.orders,0), coalesce(ord.revenue_rm,0), rnd.next_results_at
+  FROM rnd
+  LEFT JOIN asg USING (loop_key)
+  LEFT JOIN vou USING (loop_key)
+  LEFT JOIN ord USING (loop_key);
+$function$;


### PR DESCRIPTION
Traced "8 sent, 2 orders, 0 redeemed" — two fixes:

**(A) Redemption tracking was structurally broken for reminder loops.** The live rollup counted vouchers *issued by the round*, but reward-expiring attributes an **existing** voucher (`src_is_this_round = false` for all). So "redeemed" was always 0. Now it counts redemption off the **attributed voucher** (`loop_assignments.issued_reward_id`) — real for both issued and reminder loops. Verified: reward_expiring now shows its **8 vouchers** (redeemed still 0 — genuinely none used); winback **6** / welcome **3** intact; round_gap 0 (promo, no voucher).

**(B) Skip non-stackable tiers (Black Card / Staff) in the reward-expiring audience.** Their flat tier discount **replaces** any voucher at the till (the same rule `evaluate-promotions` applies), so they can *never* redeem the reward — reminding them is wasted SMS and a guaranteed non-redemption. The one "order" on this loop was a **Black Card** member who ordered twice but couldn't apply his RM10-off voucher.

Typecheck clean. Migration 051 (DB function already applied + verified live).

🤖 Generated with [Claude Code](https://claude.com/claude-code)