### PR TITLE
Loops: push-preferred delivery with SMS fallback

### DIFF
--- a/apps/backoffice/src/lib/loyalty/loop-engine.ts
+++ b/apps/backoffice/src/lib/loyalty/loop-engine.ts
@@ -13,6 +13,7 @@
 
 import { supabaseAdmin } from "@/lib/loyalty/supabase";
 import { sendSMS, getActiveSmsProvider } from "@/lib/loyalty/sms";
+import { pushTokensByMember, sendPushToTokens } from "@/lib/loyalty/push";
 
 const BRAND = "brand-celsius";
 const SMS_COST_RM = 0.1; // SMS Niaga ~RM0.10/SMS
@@ -505,11 +506,20 @@ export async function sendRound(roundId: string) {
     }
   }
 
-  let sent = 0;
+  // Push-preferred delivery: a member with a registered device gets a FREE push;
+  // everyone else falls back to (paid) SMS. Same holdout + attribution either
+  // way — only the channel differs. Resolve all treatment members' tokens up
+  // front in one query.
+  const treatmentMemberIds = ((rows ?? []) as Array<{ member_id: string | null }>)
+    .map((r) => r.member_id).filter((x): x is string => !!x);
+  const tokensByMember = await pushTokensByMember(treatmentMemberIds);
+
+  let sentPush = 0;
+  let sentSms = 0;
   let failed = 0;
   let firstError: string | undefined;
   for (const r of (rows ?? []) as Array<{ id: string; phone: string; arm: string; sms_status: string | null; member_id: string | null; issued_reward_id: string | null }>) {
-    if (r.sms_status === "sent") continue; // idempotent
+    if (r.sms_status === "sent") continue; // idempotent (covers push + SMS)
     let message = armMsg[r.arm] ?? "";
     if (!message) { failed++; continue; }
     if (needsName) {
@@ -522,14 +532,22 @@ export async function sendRound(roundId: string) {
         .replace(/\{reward\}/g, (rw?.title ?? "reward").trim())
         .replace(/\{expiry\}/g, expiryPhrase(rw?.expires_at));
     }
-    const res = await sendSMS(r.phone, message, { provider });
-    await supabaseAdmin
-      .from("loop_assignments")
-      // On failure, stash the error in sms_message_id so it's queryable (no
-      // silent fails like the SMS123 misroute).
-      .update({ sms_status: res.success ? "sent" : "failed", sms_message_id: res.success ? (res.messageId ?? null) : (res.error?.slice(0, 200) ?? "failed") })
-      .eq("id", r.id);
-    if (res.success) { sent++; } else { failed++; if (!firstError) firstError = res.error; }
+
+    const tokens = r.member_id ? tokensByMember.get(r.member_id) : undefined;
+    if (tokens && tokens.length) {
+      const pr = await sendPushToTokens(tokens, message);
+      await supabaseAdmin.from("loop_assignments")
+        .update({ channel: "push", sms_status: pr.ok ? "sent" : "failed", sms_message_id: pr.ok ? "push" : `push:${(pr.error ?? "failed").slice(0, 180)}` })
+        .eq("id", r.id);
+      if (pr.ok) { sentPush++; } else { failed++; if (!firstError) firstError = `push: ${pr.error}`; }
+    } else {
+      // On failure, stash the error in sms_message_id so it's queryable.
+      const res = await sendSMS(r.phone, message, { provider });
+      await supabaseAdmin.from("loop_assignments")
+        .update({ channel: "sms", sms_status: res.success ? "sent" : "failed", sms_message_id: res.success ? (res.messageId ?? null) : (res.error?.slice(0, 200) ?? "failed") })
+        .eq("id", r.id);
+      if (res.success) { sentSms++; } else { failed++; if (!firstError) firstError = res.error; }
+    }
   }
 
   const sentAt = new Date();
@@ -540,7 +558,7 @@ export async function sendRound(roundId: string) {
     .update({ status: "sent", sent_at: sentAt.toISOString(), send_window: round.send_window ?? deriveWindow(sentAt) })
     .eq("id", roundId);
 
-  return { round_id: roundId, sent, failed, error: firstError };
+  return { round_id: roundId, sent: sentPush + sentSms, sent_push: sentPush, sent_sms: sentSms, failed, error: firstError };
 }
 
 // ── MEASURE ───────────────────────────────────────────────────────────────────
@@ -1232,6 +1250,9 @@ export async function getEvaluation(opts?: { sinceDays?: number }): Promise<Eval
   }
 
   const toEval = (loop_key: string, a: Acc): LoopEval => {
+    // Conservative: bills every send as SMS. Push sends are free, so this is an
+    // UPPER bound on cost (→ ROI is understated, never overstated). Make it
+    // channel-accurate via loop_assignments.channel once push volume is material.
     const sms = +(a.sent * SMS_COST_RM).toFixed(2);
     return {
       loop_key, label: LOOPS[loop_key as LoopKey]?.label ?? loop_key,

--- a/apps/backoffice/src/lib/loyalty/push.ts
+++ b/apps/backoffice/src/lib/loyalty/push.ts
@@ -1,0 +1,64 @@
+import { supabaseAdmin } from "@/lib/loyalty/supabase";
+
+/**
+ * Minimal Expo push client for the loop engine's push-preferred delivery.
+ *
+ * The Expo push API (exp.host) needs NO credentials to send — you POST the
+ * ExponentPushTokens + messages and it routes to APNs/FCM. So the backoffice
+ * can deliver push directly without the order app's keys. (Mirrors the sender
+ * in apps/order/src/lib/push/send.ts; kept local so this change doesn't touch
+ * the order app's working push module.)
+ *
+ * Tokens live member-scoped in `expo_push_tokens` (same DB).
+ */
+
+const EXPO_PUSH_URL = "https://exp.host/--/api/v2/push/send";
+const PUSH_TITLE = "Celsius Coffee";
+
+/** member_id → valid Expo tokens (a member may have several devices). */
+export async function pushTokensByMember(memberIds: string[]): Promise<Map<string, string[]>> {
+  const map = new Map<string, string[]>();
+  const ids = [...new Set(memberIds.filter(Boolean))];
+  for (let i = 0; i < ids.length; i += 1000) {
+    const { data } = await supabaseAdmin
+      .from("expo_push_tokens")
+      .select("member_id, token")
+      .in("member_id", ids.slice(i, i + 1000));
+    for (const r of (data ?? []) as Array<{ member_id: string | null; token: string | null }>) {
+      if (!r.member_id || !r.token || !r.token.startsWith("ExponentPushToken[")) continue;
+      const arr = map.get(r.member_id) ?? [];
+      arr.push(r.token);
+      map.set(r.member_id, arr);
+    }
+  }
+  return map;
+}
+
+/** Push one message to all of a member's devices. Returns ok if >=1 delivered.
+ *  Best-effort prunes tokens Expo reports as DeviceNotRegistered. */
+export async function sendPushToTokens(tokens: string[], body: string): Promise<{ ok: boolean; error?: string }> {
+  const messages = tokens
+    .filter((t) => t.startsWith("ExponentPushToken["))
+    .map((t) => ({ to: t, title: PUSH_TITLE, body, sound: "default" as const }));
+  if (!messages.length) return { ok: false, error: "no tokens" };
+  try {
+    const res = await fetch(EXPO_PUSH_URL, {
+      method: "POST",
+      headers: { "Content-Type": "application/json", Accept: "application/json" },
+      body: JSON.stringify(messages),
+    });
+    if (!res.ok) return { ok: false, error: `expo HTTP ${res.status}` };
+    const json = (await res.json()) as { data?: Array<{ status: string; details?: { error?: string } }> };
+    const tickets = json.data ?? [];
+    const okCount = tickets.filter((t) => t.status === "ok").length;
+    const dead = tickets
+      .map((t, i) => (t.status !== "ok" && t.details?.error === "DeviceNotRegistered" ? messages[i].to : null))
+      .filter((t): t is string => !!t);
+    if (dead.length) {
+      try { await supabaseAdmin.from("expo_push_tokens").delete().in("token", dead); } catch { /* best-effort */ }
+    }
+    return okCount > 0 ? { ok: true } : { ok: false, error: tickets[0]?.details?.error ?? "push failed" };
+  } catch (e) {
+    return { ok: false, error: e instanceof Error ? e.message : "push error" };
+  }
+}

--- a/supabase/migrations/052_loop_assignment_channel.sql
+++ b/supabase/migrations/052_loop_assignment_channel.sql
@@ -1,0 +1,5 @@
+-- Delivery channel per loop assignment: 'push' (free, device-reachable members)
+-- or 'sms' (the paid fallback). Set by sendRound's push-preferred delivery.
+-- Null on rows that predate push delivery (those were all SMS). Lets the
+-- scorecard split delivery and bill SMS-only once push volume is material.
+alter table loop_assignments add column if not exists channel text;


### PR DESCRIPTION
Per owner ("push-preferred, SMS fallback") — unify the Engage push module and the SMS loop engine.

## Why
The Engage push module reached only **~33 of 21,419 members** (token-registration gap), so its triggers sent ≈0. The loop engine reaches **100%** via paid SMS. Best of both: send a **free push** to members with a registered device, **SMS** to everyone else — cheapest channel per member, one holdout, one attribution path.

## How
- `sendRound` resolves all treatment members' Expo tokens up front (`expo_push_tokens`), then per recipient: **push if reachable**, else **SMS**.
- New `lib/loyalty/push.ts` — token lookup + a credential-free Expo sender (exp.host needs no keys to send, so backoffice can deliver push directly; kept local so the order app's push module is untouched).
- Records `loop_assignments.channel` ('push'|'sms', migration 052) and returns `sent_push`/`sent_sms`.
- Order + redemption attribution is **channel-agnostic**, so ROI/holdout are unaffected — push just makes part of the reach free.

## Scope note
SMS cost in the scorecard still bills every send as SMS — a **conservative upper bound** (push is free → ROI understated, never overstated). At 33 push-reachable that's ~RM3. The new `channel` column makes it exactly SMS-only in a fast follow once push volume grows.

Applies to every loop (winback/welcome/birthday/round_gap/reward_expiring). Migration applied live. Backoffice typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)