### PR TITLE
feat(reviews): auto-reply positive Google reviews on a daily cron

### DIFF
--- a/apps/backoffice/src/app/api/cron/reviews-auto-reply/route.ts
+++ b/apps/backoffice/src/app/api/cron/reviews-auto-reply/route.ts
@@ -1,0 +1,131 @@
+import { NextRequest, NextResponse } from "next/server";
+import { checkCronAuth } from "@celsius/shared";
+import { prisma } from "@/lib/prisma";
+import { fetchGoogleReviews, replyToReview } from "@/lib/reviews/gbp";
+import { generateReply, POSITIVE_THRESHOLD } from "@/lib/reviews/auto-reply";
+
+export const dynamic = "force-dynamic";
+export const maxDuration = 300;
+
+// Scheduled auto-reply for POSITIVE (4-5★) Google reviews only.
+//
+// Negative reviews (1-3★) are intentionally NOT touched here — they are
+// never generated or posted. They stay on the human-approval path until
+// the risk-classifier work lands (see
+// docs/design/reviews-reply-recovery-loop.md). This is the zero-risk wedge.
+//
+// Idempotent: reviews that already carry a reply (from a prior run or a
+// manual reply) are skipped, so re-running never double-posts.
+const MAX_REPLIES_PER_RUN = 50; // safety cap across all outlets per run
+
+type OutletResult = {
+  outletId: string;
+  outletName: string;
+  candidates: number;
+  posted: number;
+  failed: number;
+  error?: string;
+};
+
+export async function GET(req: NextRequest) {
+  const cronAuth = checkCronAuth(req.headers);
+  if (!cronAuth.ok) {
+    return NextResponse.json({ error: cronAuth.error }, { status: cronAuth.status });
+  }
+
+  const outlets = await prisma.outlet.findMany({
+    where: { status: "ACTIVE" },
+    include: { reviewSettings: true },
+  });
+
+  const connected = outlets.filter(
+    (o) => o.reviewSettings?.gbpAccountId && o.reviewSettings?.gbpLocationName,
+  );
+
+  const results: OutletResult[] = [];
+  let totalPosted = 0;
+  let totalFailed = 0;
+
+  for (const outlet of connected) {
+    if (totalPosted >= MAX_REPLIES_PER_RUN) break;
+    const settings = outlet.reviewSettings!;
+
+    try {
+      const data = await fetchGoogleReviews(
+        settings.gbpAccountId!,
+        settings.gbpLocationName!,
+        50,
+      );
+
+      // Positive AND not yet replied. Negatives are excluded before we ever
+      // call the LLM, so this path can never post to a 1-3★ review.
+      const candidates = data.reviews.filter(
+        (r) => !r.reply && r.rating >= POSITIVE_THRESHOLD,
+      );
+
+      let posted = 0;
+      let failed = 0;
+
+      for (const review of candidates) {
+        if (totalPosted + posted >= MAX_REPLIES_PER_RUN) break;
+        try {
+          const reply = await generateReply({
+            rating: review.rating,
+            reviewer: review.reviewer.name,
+            comment: review.comment,
+            outletName: outlet.name,
+          });
+          if (!reply) {
+            failed++;
+            continue;
+          }
+          await replyToReview(
+            settings.gbpAccountId!,
+            settings.gbpLocationName!,
+            review.id,
+            reply,
+          );
+          posted++;
+        } catch (err) {
+          console.error(
+            `[reviews-auto-reply] failed for review ${review.id} (${outlet.name}):`,
+            err,
+          );
+          failed++;
+        }
+      }
+
+      totalPosted += posted;
+      totalFailed += failed;
+      results.push({
+        outletId: outlet.id,
+        outletName: outlet.name,
+        candidates: candidates.length,
+        posted,
+        failed,
+      });
+    } catch (err) {
+      console.error(
+        `[reviews-auto-reply] fetch failed for outlet ${outlet.name}:`,
+        err,
+      );
+      results.push({
+        outletId: outlet.id,
+        outletName: outlet.name,
+        candidates: 0,
+        posted: 0,
+        failed: 0,
+        error: "fetch_failed",
+      });
+    }
+  }
+
+  return NextResponse.json({
+    ran_at: new Date().toISOString(),
+    outlets_connected: connected.length,
+    max_per_run: MAX_REPLIES_PER_RUN,
+    total_posted: totalPosted,
+    total_failed: totalFailed,
+    results,
+  });
+}

--- a/apps/backoffice/src/app/api/reviews/auto-reply/route.ts
+++ b/apps/backoffice/src/app/api/reviews/auto-reply/route.ts
@@ -1,48 +1,8 @@
 import { NextRequest, NextResponse } from "next/server";
-import Anthropic from "@anthropic-ai/sdk";
 import { getUserFromHeaders } from "@/lib/auth";
 import { prisma } from "@/lib/prisma";
 import { fetchGoogleReviews, replyToReview } from "@/lib/reviews/gbp";
-
-const anthropic = new Anthropic({ apiKey: process.env.ANTHROPIC_API_KEY });
-
-const MANAGER_NAME = "Adam";
-const MANAGER_PHONE = "+60 17-657 9149";
-
-// Generate a reply using Claude
-async function generateReply(review: {
-  rating: number;
-  reviewer: string;
-  comment?: string;
-  outletName: string;
-}): Promise<string> {
-  const isPositive = review.rating >= 4; // 4-5 = good (auto-post), 1-3 = bad (approval)
-
-  const prompt = isPositive
-    ? `You are the owner of Celsius Coffee (${review.outletName}), a specialty coffee brand in Malaysia. Write a short, warm reply to this positive Google review. Be genuine, not generic. Thank them specifically for what they mentioned. Keep it 2-3 sentences max. Do not use emojis excessively — 1 max if any.
-
-Reviewer: ${review.reviewer}
-Rating: ${review.rating}/5
-Review: ${review.comment || "(no comment, just a rating)"}
-
-Reply:`
-    : `You are the owner of Celsius Coffee (${review.outletName}), a specialty coffee brand in Malaysia. Write a calm, professional reply to this negative Google review. Be empathetic, acknowledge their concern without being defensive. End with a CTA to contact our Area Manager ${MANAGER_NAME} at ${MANAGER_PHONE} so we can make it right. Keep it 3-4 sentences. Do not use emojis.
-
-Reviewer: ${review.reviewer}
-Rating: ${review.rating}/5
-Review: ${review.comment || "(no comment, just a low rating)"}
-
-Reply:`;
-
-  const response = await anthropic.messages.create({
-    model: "claude-sonnet-4-6",
-    max_tokens: 300,
-    messages: [{ role: "user", content: prompt }],
-  });
-
-  const text = response.content[0];
-  return text.type === "text" ? text.text.trim() : "";
-}
+import { generateReply } from "@/lib/reviews/auto-reply";
 
 // POST /api/reviews/auto-reply
 // Body: { outletId, reviewId, mode: "preview" | "post", batch: true }

--- a/apps/backoffice/src/lib/reviews/auto-reply.ts
+++ b/apps/backoffice/src/lib/reviews/auto-reply.ts
@@ -1,0 +1,54 @@
+/**
+ * Shared review auto-reply generator.
+ *
+ * Used by both the manual button (/api/reviews/auto-reply) and the
+ * scheduled cron (/api/cron/reviews-auto-reply) so the brand-voice prompt
+ * lives in exactly one place and can't drift between the two paths.
+ */
+import Anthropic from "@anthropic-ai/sdk";
+
+const anthropic = new Anthropic({ apiKey: process.env.ANTHROPIC_API_KEY });
+
+// Negative-review escalation contact (used in the negative prompt only).
+export const MANAGER_NAME = "Adam";
+export const MANAGER_PHONE = "+60 17-657 9149";
+
+// 4-5 = positive (safe to auto-post). 1-3 = negative (human-approval path).
+export const POSITIVE_THRESHOLD = 4;
+
+export type ReviewForReply = {
+  rating: number;
+  reviewer: string;
+  comment?: string;
+  outletName: string;
+};
+
+/** Generate a Google review reply in the Celsius owner voice. */
+export async function generateReply(review: ReviewForReply): Promise<string> {
+  const isPositive = review.rating >= POSITIVE_THRESHOLD;
+
+  const prompt = isPositive
+    ? `You are the owner of Celsius Coffee (${review.outletName}), a specialty coffee brand in Malaysia. Write a short, warm reply to this positive Google review. Be genuine, not generic. Thank them specifically for what they mentioned. Keep it 2-3 sentences max. Do not use emojis excessively — 1 max if any.
+
+Reviewer: ${review.reviewer}
+Rating: ${review.rating}/5
+Review: ${review.comment || "(no comment, just a rating)"}
+
+Reply:`
+    : `You are the owner of Celsius Coffee (${review.outletName}), a specialty coffee brand in Malaysia. Write a calm, professional reply to this negative Google review. Be empathetic, acknowledge their concern without being defensive. End with a CTA to contact our Area Manager ${MANAGER_NAME} at ${MANAGER_PHONE} so we can make it right. Keep it 3-4 sentences. Do not use emojis.
+
+Reviewer: ${review.reviewer}
+Rating: ${review.rating}/5
+Review: ${review.comment || "(no comment, just a low rating)"}
+
+Reply:`;
+
+  const response = await anthropic.messages.create({
+    model: "claude-sonnet-4-6",
+    max_tokens: 300,
+    messages: [{ role: "user", content: prompt }],
+  });
+
+  const text = response.content[0];
+  return text.type === "text" ? text.text.trim() : "";
+}

--- a/apps/backoffice/vercel.json
+++ b/apps/backoffice/vercel.json
@@ -91,6 +91,10 @@
     {
       "path": "/api/cron/pos-poster-autopilot",
       "schedule": "0 23 * * *"
+    },
+    {
+      "path": "/api/cron/reviews-auto-reply",
+      "schedule": "0 4 * * *"
     }
   ]
 }

--- a/docs/design/ads-conversion-loop.md
+++ b/docs/design/ads-conversion-loop.md
@@ -1,0 +1,110 @@
+# Ads Conversion Loop (and why there is no GBP "loop")
+
+_Office-hours diagnostic — 2026-06-23_
+
+## Problem Statement
+We are spending on Google Ads on autopilot (Smart Campaigns / Performance Max) with
+**no wire back to orders**. Money leaves the building; nobody reads the result; nobody
+acts. The request was "build a loop for GBP ranking + Google Ads." Diagnosis splits that
+in two and rejects most of it:
+
+- **Google Ads is the real patient.** There is a live bleed (blind spend).
+- **There is no GBP "loop" worth building.** GBP rank isn't readable via API (proxy only),
+  the levers are slow and un-A/B-able, and the Reviews module already does the
+  highest-leverage thing (review volume / recency / response). GBP is a checklist to
+  execute, not a loop to engineer.
+
+## Demand Evidence
+- Q1: "Already spending blind" — money out, no attribution to orders. (Real bleed, not a hunch.)
+- Q2: "Google auto-pilots it" — Performance Max / Smart Campaigns bids unattended; no one
+  adjusts keywords, budget, or geo.
+- Q3: "Nobody acts on cost-per-order today — that's the gap." No decision-owner exists.
+
+## Status Quo (what happens now)
+Google's ML optimizes bids in real time — but toward whatever conversion signal it's fed.
+If that signal is "clicked Order Now" / "visited site," Google is buying **cheap clicks**,
+not RM40 pickup orders, and it has no idea a Nilai order is worth more than a bounce.
+The loop already exists (Google's); it's pointed at the wrong target and no human reads it.
+
+## Target User (named person, consequence)
+**Ammar (owner-operator).** The loop's first job is to manufacture a weekly decision he
+doesn't make today: read cost-per-order by outlet → move the budget envelope (pause losers,
+scale winners). Not an ops-manager tool yet — the decision muscle has to exist before it
+can be delegated or automated.
+
+## The reframe (core insight)
+> **Don't build a bidder. Feed Google's bidder real POS order value.**
+
+You will not out-optimize Performance Max by hand. You close the loop by making order value
+(by outlet) the conversion signal. Then Google's autopilot optimizes toward actual revenue,
+and a human just reads ROAS and moves the budget. This also sidesteps the Explorer-token
+wall: **conversion tracking via Google's tag + the Ads UI needs zero API access.**
+
+## North Star alignment
+Acquisition (new strangers) is a departure from the frequency/AOV loops (SMS, round-gap).
+It stays aligned **only because the conversion is value-based**: feeding order *value* makes
+Google buy high-AOV-order clickers, not RM12 single-coffee orders. A "count of orders"
+signal would depress AOV. New customers then feed the existing frequency loops downstream
+(new order → SMS win-back → repeat). Value-based conversion is the load-bearing choice.
+
+## Premises (explicit assumptions — verify before building)
+1. **The ad click lands on the web order flow** (order.celsiuscoffee.com with a `gclid`),
+   not only on the Maps listing / call / directions. **If false, the whole design changes**
+   (see Open Questions). This is the #1 thing to verify.
+2. Order-confirmation page can fire a client-side tag with order value + hashed phone/email.
+3. Monthly spend is material enough (> ~RM1k) to justify even Approach A.
+4. Google Ads dev token is Explorer/test tier → **no production API access** (read or write)
+   until Basic access is approved. Affects B, not A.
+
+## Approaches Considered
+
+### Approach A — Fix the signal, no API, no build (days, mostly config) — RECOMMENDED
+- Ads UI: create **"Pickup Order"** conversion, `value = order total`, count = every.
+- Order-confirmation page: fire Google conversion tag + **enhanced conversions**
+  (hashed phone/email) with ringgit value + outlet (custom param or per-outlet action).
+- Performance Max re-optimizes toward revenue per outlet immediately.
+- Free add: set **GOOGLE_PLACES_API_KEY** to wake the already-built Nearby Competitor
+  Ranking → passive weekly proxy-rank trend (the only "GBP" piece worth flipping on).
+- Cadence: 5-min weekly look at the ROAS column. No backoffice build.
+- _Purpose: prove Ads can convert profitably BEFORE investing in an in-house loop._
+
+### Approach B — In-house scorecard + offline conversion import (weeks)
+- Apply for **Basic access** (the real gate).
+- Capture `gclid` on every web order → store on `pos_orders`.
+- Daily edge function (mirror `storehub-sync`): upload offline conversions keyed on gclid
+  with **net** ringgit value — catches tag-missed orders, gives outlet precision.
+- Backoffice **"Acquisition"** panel: spend / cost-per-order / ROAS by outlet & campaign,
+  pulled from Ads API. Command Center alert family: _"Outlet X Ads ROAS < 1."_
+- Still human-in-the-loop: panel makes reallocation a 5-minute weekly call.
+
+### Approach C — Autonomous Ads + GBP agent (months) — REJECT FOR NOW
+- Folds into the parked Marketing AI Agent: proposes budget reallocation, drafts GBP
+  ranking posts, auto-responds to reviews; Ammar approves via Telegram.
+- Rejected: nobody acts on the data today. Don't automate an action no human has taken.
+  Build the muscle (B) first.
+
+## Recommended Approach
+**A now → B after ~3–4 weeks of A → C never until B has run.**
+Flip conditions: if monthly spend is trivial, stop at A and check quarterly. If ads don't
+drive the web order flow (Premise 1 false), A's tagging captures nothing — fall back to a
+coarse spend-vs-outlet-order-lift holdout (SMS-loop style), and B becomes the real wedge.
+
+## Open Questions
+1. **Where does the ad click actually land?** Web order flow (gclid-trackable) vs Maps /
+   call / directions (not tie-able to a `pos_order`). Decides whether A works at all.
+2. What's the actual monthly spend, and per outlet? Determines if any of this is worth it.
+3. Are we even spending on the *right* outlets/hours, or is Performance Max free-roaming?
+4. Does the order-confirmation page already load gtag / any Google tag today?
+
+## Success Criteria (measurable)
+- **A:** within 30 days, blended Ads ROAS (order value ÷ spend) is visible per outlet and
+  trending up vs the pre-tag baseline; ≥1 outlet's campaign paused or scaled on the data.
+- **B:** cost-per-order by outlet visible in backoffice; one budget reallocation executed
+  off the panel; Command Center fires a real low-ROAS alert that you act on.
+
+## The Assignment (one concrete next step)
+**Before any code or config:** open Google Ads → for one campaign, click into the ad and
+follow exactly where the click lands. Write down: does it hit order.celsiuscoffee.com with
+a `?gclid=...` in the URL, or does it go to the Maps listing / a call / directions? That
+single answer decides whether Approach A is "an afternoon of tagging" or "the design has to
+change." Don't build until you've looked.

--- a/docs/design/reviews-reply-recovery-loop.md
+++ b/docs/design/reviews-reply-recovery-loop.md
@@ -1,0 +1,108 @@
+# Reviews Reply + Recovery Loop
+
+_Office-hours diagnostic — 2026-06-23. Supersedes the GBP half of ads-conversion-loop.md._
+
+## Problem Statement
+Google reviews come in across 4 outlets and replies are ad-hoc. Two misses:
+1. **Response rate is left on the table** — it's a real GBP rank lever (see
+   [[project_reviews_goal]]), and most reviews go un-replied.
+2. **Negative reviews dead-end.** An unhappy customer leaves 1★ and we never recover them —
+   no apology, no path back, no capture. They stay anonymous and lost.
+
+This extends the **live** Reviews module (GBP API, 4 outlets, QR gate — see
+[[project_reviews_module]]). Not greenfield.
+
+## What's a loop and what isn't
+- **Review reply + recovery = a real loop.** Closes on a measurable outcome: recovery rate
+  and repeat orders from recovered customers (frequency-aligned, North Star).
+- **"GBP posts to improve rank" = a publisher, not a loop.** Rank isn't API-readable (proxy
+  only), and Google has been deprecating `localPosts` via API — auto-posting may not even be
+  available. Treat as a scheduled publisher (reuse round posters), phase 2, verify API first.
+
+## Status Quo
+Replies written by hand when someone remembers. No sentiment split, no recovery mechanism,
+no capture, no audit trail. Negative reviewers are lost forever.
+
+## Target User
+- **Customers** leaving reviews (positive: want acknowledgement; negative: want it made right).
+- **Adam Kelvin (area manager, recovery owner)** — handles escalated negatives + the private
+  recovery line. **Ammar** — owns the rank outcome.
+
+## Design
+
+### Per-review pipeline
+1. **Ingest** new review (Reviews module already polls GBP) + add reply-state tracking.
+2. **Classify**: star → positive (4–5★) / negative (1–3★). On negatives, run a **risk
+   classifier**: health, safety, injury, food poisoning, legal/lawyer, discrimination,
+   refund demand, severe-anger keywords → **ESCALATE**; everything else → routine.
+3. **Generate + post**:
+   - **Positive (4–5★):** personalized thanks (reference what they praised), brand voice,
+     per-outlet. **Auto-post.** (Biggest rank lever, near-zero risk.)
+   - **Negative routine:** empathetic recovery reply — **no admission of fault, no arguing** —
+     points to the **private recovery line**. **Auto-post** (operator chose full-auto).
+   - **Negative risk-flagged:** **draft only → Telegram to Adam/Ammar** for approve/edit
+     before posting. (The tripwire — see Decision Log.)
+4. **Recovery capture:** the recovery line is a dedicated WhatsApp/form (NOT Adam's personal
+   mobile in public). Reviewer messages it → capture name + number + review/outlet → write to
+   loyalty DB as **recovered-detractor** → issue voucher (reuse existing voucher/promo system)
+   → enroll in SMS win-back ([[project_sms_loop_engineering]]).
+5. **Audit:** every auto-posted reply logged to a backoffice "Reviews Ops" tab (review, reply,
+   timestamp), **editable after the fact**. The warn+allow+audit safety net under full-auto
+   ([[feedback_staff_ops_soft_controls]]).
+6. **Measure (loop closure):** response rate, time-to-reply, % negatives that reach the
+   recovery line, vouchers redeemed, **repeat orders from recovered customers**. Plus the
+   competitor-rank proxy trend from the dark feature ([[project_reviews_competitor_ranking]])
+   as a coarse rank signal.
+
+## Premises (verify before building)
+1. **GBP API allows posting review replies** for these locations (Reviews module reads them;
+   confirm reply-write scope is enabled).
+2. The order/loyalty system can mint a voucher + tag a customer as recovered-detractor.
+3. A dedicated recovery channel (WhatsApp number or a short form) exists or can be stood up.
+4. GBP `localPosts` write is still available via API (for the phase-2 publisher) — likely NOT;
+   verify.
+
+## Approaches Considered
+
+### Approach A — Positive auto-reply + risk-tiered negative recovery (the core loop, ~days–1wk) — RECOMMENDED
+Positives auto-reply now (ships the rank lever immediately). Negatives: risk classifier →
+routine auto-post / risky-to-Telegram, recovery line + voucher capture into loyalty.
+
+### Approach B — Add publisher + ops dashboard + attribution (weeks)
+Scheduled GBP post publisher (if API allows), "Reviews Ops" backoffice dashboard (queue,
+audit log, recovery funnel), recovered-customer → repeat-order attribution, competitor-rank
+trend wired in.
+
+### Approach C — Fold into autonomous marketing agent (months) — defer
+Reply + recovery + GBP posting orchestrated by [[project_marketing_agent]], Telegram-gated.
+
+## Recommended Approach
+**A now → B once recovery volume justifies a dashboard → C later.**
+
+## Decision Log
+- Negative-reply automation: operator chose **full-auto**. Built with a **risk-classifier
+  tripwire** (health/legal/safety/discrimination/refund → human) by default; operator may veto
+  the tripwire for pure full-auto (not recommended).
+- Recovery path: **private recovery line + voucher capture** into loyalty (chosen). Adam's
+  personal mobile is NOT placed in public replies.
+
+## Open Questions
+1. Recovery channel: dedicated WhatsApp Business number vs a short web form? (Form captures
+   number more cleanly; WhatsApp lowers friction.)
+2. Voucher value + guardrail — flat RM off? Margin-safe item (free coffee, low COGS)?
+3. Risk-classifier keyword/severity list — who signs off on the escalation triggers?
+4. Does GBP API still permit programmatic review replies + posts for these 4 locations?
+
+## Success Criteria (measurable)
+- Response rate → ~100% within 30 days (positives auto, negatives within SLA).
+- Median time-to-reply under X hours.
+- ≥ N% of negative reviewers reach the recovery line and get captured into loyalty.
+- ≥ M recovered customers place a repeat order within 60 days (the real North-Star proof).
+- Zero risk-flagged reviews auto-posted (tripwire holds).
+
+## The Assignment (one concrete next step)
+**Before flipping negatives to auto:** run the classifier + drafter in **shadow mode** on the
+last 20 negative reviews across all outlets — generate the reply it *would* have posted, but
+don't post. Read all 20. If none would have made things worse, flip auto on. If even one
+would have (an admission, a misread of a serious complaint), you've just written your
+risk-classifier rules. Watch before you automate the brand's public face.


### PR DESCRIPTION
## What
Positive (≥4★) Google reviews now get an auto-generated owner-voice reply posted to GBP **automatically** (daily cron), instead of only when someone clicks the manual button. Response rate + recency are GBP rank levers — this is the zero-risk half of the reviews reply+recovery loop.

## How
- **New cron** `/api/cron/reviews-auto-reply` (`checkCronAuth`, scheduled `0 4 * * *` UTC = 12pm MYT).
- **Positives only** — filters `rating >= 4` *before* the LLM call, so a 1–3★ review can never be generated or posted by this path.
- **Idempotent** — skips any review that already has a reply, so re-runs never double-post.
- **Capped** at 50 replies/run across all connected outlets.
- Extracted the brand-voice prompt into `lib/reviews/auto-reply.ts` so the manual button and the cron share one prompt and can't drift.

## Safety / scope
- Negative (1–3★) reviews are **untouched** here — they go to a backoffice approval gate (built separately).
- Reuses existing GBP credentials + `CRON_SECRET`; no new env vars.
- Posted replies are visible in the existing Reviews dashboard and can be overwritten via the manual reply button.
- **First run clears the backlog**: replies to all currently-unreplied positives (≤50) at once.

## Verification
- `tsc --noEmit` clean on backoffice (after clearing a pre-existing stale `.next/dev/types` artifact unrelated to this change).

Design doc: `docs/design/reviews-reply-recovery-loop.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)