### PR TITLE
feat(reviews): backoffice approval gate for negative reviews

### DIFF
--- a/apps/backoffice/src/app/(admin)/reviews/page.tsx
+++ b/apps/backoffice/src/app/(admin)/reviews/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import {
   Star,
   Search,
@@ -71,6 +71,18 @@ type DashboardResponse = {
   outlets: OutletSummary[];
   allGoogleReviews: DashboardGoogleReview[];
   allFeedbacks: DashboardFeedback[];
+};
+
+type PendingDraft = {
+  id: string;
+  reviewId: string;
+  outletId: string;
+  outletName: string;
+  reviewerName: string | null;
+  rating: number;
+  comment: string | null;
+  draftReply: string;
+  createdAt: string;
 };
 
 // ─── Helpers ───────────────────────────────────────────────
@@ -857,9 +869,140 @@ function BatchAutoReplyModal({ onClose }: { onClose: () => void }) {
 
 // ─── Dashboard View ────────────────────────────────────────
 
+// ─── Negative Review Approval Queue ────────────────────────
+
+function NegativeApprovalQueue({ onCountChange }: { onCountChange?: (n: number) => void }) {
+  const [items, setItems] = useState<PendingDraft[] | null>(null);
+  const [syncing, setSyncing] = useState(false);
+  const [edits, setEdits] = useState<Record<string, string>>({});
+  const [busy, setBusy] = useState<Record<string, "approve" | "reject" | null>>({});
+
+  const load = async (sync: boolean) => {
+    setSyncing(true);
+    try {
+      const res = await fetch(`/api/reviews/negatives${sync ? "?sync=1" : ""}`);
+      const data = await res.json();
+      const pending: PendingDraft[] = data.pending ?? [];
+      setItems(pending);
+      onCountChange?.(pending.length);
+    } catch {
+      setItems([]);
+    } finally {
+      setSyncing(false);
+    }
+  };
+
+  useEffect(() => {
+    load(false);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const decide = async (item: PendingDraft, action: "approve" | "reject") => {
+    setBusy((b) => ({ ...b, [item.id]: action }));
+    try {
+      const res = await fetch("/api/reviews/negatives/decide", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          id: item.id,
+          action,
+          reply: action === "approve" ? (edits[item.id] ?? item.draftReply) : undefined,
+        }),
+      });
+      if (res.ok) {
+        setItems((prev) => {
+          const next = (prev ?? []).filter((x) => x.id !== item.id);
+          onCountChange?.(next.length);
+          return next;
+        });
+      } else {
+        const e = await res.json().catch(() => ({}));
+        alert(e.error || "Failed to save decision");
+      }
+    } finally {
+      setBusy((b) => ({ ...b, [item.id]: null }));
+    }
+  };
+
+  return (
+    <div className="space-y-3">
+      <div className="flex items-center justify-between gap-3 rounded-xl border border-amber-200 bg-amber-50 px-4 py-3">
+        <p className="text-sm text-amber-900">
+          Negative (1-3★) reviews are drafted by AI and{" "}
+          <span className="font-semibold">held here for your approval</span> — nothing posts to Google until you approve it.
+        </p>
+        <button
+          onClick={() => load(true)}
+          disabled={syncing}
+          className="flex shrink-0 items-center gap-1.5 rounded-lg border border-amber-300 bg-white px-3 py-1.5 text-sm font-medium text-amber-900 hover:bg-amber-100 disabled:opacity-50"
+        >
+          {syncing ? <Loader2 className="h-4 w-4 animate-spin" /> : <Sparkles className="h-4 w-4" />}
+          Check Google for new
+        </button>
+      </div>
+
+      {items === null ? (
+        <div className="flex items-center justify-center py-10">
+          <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
+        </div>
+      ) : items.length === 0 ? (
+        <div className="rounded-xl border border-border bg-white p-10 text-center">
+          <Check className="mx-auto h-10 w-10 text-muted-foreground/30" />
+          <p className="mt-3 text-sm text-muted-foreground">No negative reviews waiting for approval</p>
+          <p className="mt-1 text-xs text-muted-foreground">Click “Check Google for new” to pull the latest.</p>
+        </div>
+      ) : (
+        items.map((item) => {
+          const value = edits[item.id] ?? item.draftReply;
+          const itemBusy = busy[item.id];
+          return (
+            <div key={item.id} className="rounded-xl border border-border bg-white p-4">
+              <div className="flex items-center gap-2">
+                <StarRating rating={item.rating} />
+                <span className="text-sm font-medium text-foreground">{item.reviewerName || "Anonymous"}</span>
+              </div>
+              <p className="mt-0.5 text-xs text-muted-foreground">{item.outletName} · {timeAgo(item.createdAt)}</p>
+              {item.comment && (
+                <p className="mt-2 rounded-lg bg-muted/50 p-2 text-sm text-foreground">{item.comment}</p>
+              )}
+              <div className="mt-3">
+                <p className="mb-1 text-xs font-medium text-muted-foreground">AI draft reply (edit before approving)</p>
+                <textarea
+                  value={value}
+                  onChange={(e) => setEdits((m) => ({ ...m, [item.id]: e.target.value }))}
+                  rows={3}
+                  className="w-full rounded-lg border border-border bg-white p-2 text-sm outline-none focus:ring-2 focus:ring-ring/50"
+                />
+              </div>
+              <div className="mt-2 flex items-center gap-2">
+                <button
+                  onClick={() => decide(item, "approve")}
+                  disabled={!!itemBusy || !value.trim()}
+                  className="flex items-center gap-1.5 rounded-lg bg-brand-dark px-3 py-2 text-sm font-medium text-white hover:bg-brand-dark/90 disabled:opacity-50"
+                >
+                  {itemBusy === "approve" ? <Loader2 className="h-4 w-4 animate-spin" /> : <Send className="h-4 w-4" />}
+                  Approve &amp; Post
+                </button>
+                <button
+                  onClick={() => decide(item, "reject")}
+                  disabled={!!itemBusy}
+                  className="flex items-center gap-1.5 rounded-lg border border-border bg-white px-3 py-2 text-sm font-medium text-muted-foreground hover:bg-muted disabled:opacity-50"
+                >
+                  {itemBusy === "reject" ? <Loader2 className="h-4 w-4 animate-spin" /> : <X className="h-4 w-4" />}
+                  Reject
+                </button>
+              </div>
+            </div>
+          );
+        })
+      )}
+    </div>
+  );
+}
+
 function DashboardView() {
   const [period, setPeriod] = useState<"day" | "week" | "month" | "custom">("month");
-  const [dashTab, setDashTab] = useState<"google" | "internal">("google");
+  const [dashTab, setDashTab] = useState<"google" | "internal" | "approvals">("google");
   const [search, setSearch] = useState("");
   const [filterRating, setFilterRating] = useState<number | null>(null);
   const [showFilter, setShowFilter] = useState(false);
@@ -867,6 +1010,14 @@ function DashboardView() {
   const [customTo, setCustomTo] = useState("");
   const [showBatchReply, setShowBatchReply] = useState(false);
   const [filterOutletId, setFilterOutletId] = useState<string | null>(null);
+  const [approvalCount, setApprovalCount] = useState<number | null>(null);
+
+  useEffect(() => {
+    fetch("/api/reviews/negatives")
+      .then((r) => r.json())
+      .then((d) => setApprovalCount(d.pending?.length ?? 0))
+      .catch(() => setApprovalCount(0));
+  }, []);
 
   const fetchUrl = period === "custom" && customFrom
     ? `/api/reviews/dashboard?period=custom&from=${customFrom}${customTo ? `&to=${customTo}` : ""}`
@@ -1067,6 +1218,14 @@ function DashboardView() {
           >
             Feedback ({combinedFeedback.length})
           </button>
+          <button
+            onClick={() => setDashTab("approvals")}
+            className={`px-4 py-2.5 text-sm font-medium border-b-2 transition-colors ${
+              dashTab === "approvals" ? "border-foreground text-foreground" : "border-transparent text-muted-foreground hover:text-foreground"
+            }`}
+          >
+            Needs approval{approvalCount ? ` (${approvalCount})` : ""}
+          </button>
         </div>
         <div className="flex items-center gap-2">
           <div className="relative">
@@ -1114,6 +1273,10 @@ function DashboardView() {
 
       {/* Review list */}
       <div className="mt-4 space-y-3">
+        {dashTab === "approvals" ? (
+          <NegativeApprovalQueue onCountChange={setApprovalCount} />
+        ) : (
+        <>
         {isLoading && (
           <div className="flex items-center justify-center py-10">
             <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
@@ -1163,6 +1326,8 @@ function DashboardView() {
               )
             )}
           </>
+        )}
+        </>
         )}
       </div>
     </>

--- a/apps/backoffice/src/app/api/reviews/negatives/decide/route.ts
+++ b/apps/backoffice/src/app/api/reviews/negatives/decide/route.ts
@@ -1,0 +1,60 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getUserFromHeaders } from "@/lib/auth";
+import { prisma } from "@/lib/prisma";
+import { replyToReview } from "@/lib/reviews/gbp";
+
+export const dynamic = "force-dynamic";
+
+// POST /api/reviews/negatives/decide
+// Body: { id, action: "approve" | "reject", reply? }
+//   - approve: post `reply` (edited) or the stored draft to Google, then mark approved
+//   - reject:  mark rejected, nothing is posted
+export async function POST(request: NextRequest) {
+  const user = await getUserFromHeaders(request.headers);
+  if (!user) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+
+  const { id, action, reply } = await request.json();
+  if (!id || (action !== "approve" && action !== "reject")) {
+    return NextResponse.json({ error: "id and valid action (approve|reject) required" }, { status: 400 });
+  }
+
+  const draft = await prisma.reviewReplyDraft.findUnique({
+    where: { id },
+    include: { outlet: { include: { reviewSettings: true } } },
+  });
+  if (!draft) return NextResponse.json({ error: "Draft not found" }, { status: 404 });
+  if (draft.status !== "pending") {
+    return NextResponse.json({ error: `Already ${draft.status}`, status: draft.status }, { status: 409 });
+  }
+
+  const decidedBy = user.name || user.id;
+
+  if (action === "reject") {
+    await prisma.reviewReplyDraft.update({
+      where: { id },
+      data: { status: "rejected", decidedBy, decidedAt: new Date() },
+    });
+    return NextResponse.json({ id, status: "rejected" });
+  }
+
+  // approve → post to GBP, then record the decision
+  const settings = draft.outlet.reviewSettings;
+  if (!settings?.gbpAccountId || !settings?.gbpLocationName) {
+    return NextResponse.json({ error: "GBP not connected for this outlet" }, { status: 400 });
+  }
+  const finalReply =
+    typeof reply === "string" && reply.trim() ? reply.trim() : draft.draftReply;
+
+  try {
+    await replyToReview(settings.gbpAccountId, settings.gbpLocationName, draft.reviewId, finalReply);
+  } catch (err) {
+    console.error(`[reviews/negatives/decide] GBP post failed for ${draft.reviewId}:`, err);
+    return NextResponse.json({ error: "Failed to post reply to Google" }, { status: 502 });
+  }
+
+  await prisma.reviewReplyDraft.update({
+    where: { id },
+    data: { status: "approved", finalReply, decidedBy, decidedAt: new Date() },
+  });
+  return NextResponse.json({ id, status: "approved", posted: true });
+}

--- a/apps/backoffice/src/app/api/reviews/negatives/route.ts
+++ b/apps/backoffice/src/app/api/reviews/negatives/route.ts
@@ -1,0 +1,125 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getUserFromHeaders } from "@/lib/auth";
+import { prisma } from "@/lib/prisma";
+import { fetchGoogleReviews } from "@/lib/reviews/gbp";
+import { generateReply, POSITIVE_THRESHOLD } from "@/lib/reviews/auto-reply";
+
+export const dynamic = "force-dynamic";
+export const maxDuration = 120;
+
+// Cap LLM calls per sync so a large first-run backlog can't blow up.
+const MAX_NEW_DRAFTS_PER_SYNC = 30;
+
+// GET /api/reviews/negatives[?sync=1]
+// Returns the pending negative-review approval queue.
+// With sync=1, first pulls Google reviews and:
+//   - drafts a reply for each new unreplied NEGATIVE (1-3★) review, and
+//   - marks any pending draft whose review now has a reply as "resolved"
+//     (it was handled elsewhere — e.g. a manual reply).
+export async function GET(request: NextRequest) {
+  const user = await getUserFromHeaders(request.headers);
+  if (!user) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+
+  const sync = new URL(request.url).searchParams.get("sync") === "1";
+  let created = 0;
+  let resolved = 0;
+
+  if (sync) {
+    const outlets = await prisma.outlet.findMany({
+      where: { status: "ACTIVE" },
+      include: { reviewSettings: true },
+    });
+    const connected = outlets.filter(
+      (o) => o.reviewSettings?.gbpAccountId && o.reviewSettings?.gbpLocationName,
+    );
+
+    // Every review we've ever drafted (any status) — so we never double-draft.
+    const existing = await prisma.reviewReplyDraft.findMany({
+      select: { id: true, reviewId: true, status: true },
+    });
+    const seenReviewIds = new Set(existing.map((d) => d.reviewId));
+
+    for (const outlet of connected) {
+      const settings = outlet.reviewSettings!;
+      let reviews;
+      try {
+        const data = await fetchGoogleReviews(
+          settings.gbpAccountId!,
+          settings.gbpLocationName!,
+          50,
+        );
+        reviews = data.reviews;
+      } catch (err) {
+        console.error(`[reviews/negatives] sync fetch failed for ${outlet.name}:`, err);
+        continue;
+      }
+
+      // Resolve pending drafts whose review now carries a reply on Google.
+      const repliedIds = reviews.filter((r) => r.reply).map((r) => r.id);
+      const toResolve = existing.filter(
+        (d) => d.status === "pending" && repliedIds.includes(d.reviewId),
+      );
+      if (toResolve.length) {
+        await prisma.reviewReplyDraft.updateMany({
+          where: { id: { in: toResolve.map((d) => d.id) } },
+          data: { status: "resolved" },
+        });
+        resolved += toResolve.length;
+      }
+
+      // Draft replies for new unreplied negatives we haven't seen before.
+      const newNegatives = reviews.filter(
+        (r) => !r.reply && r.rating < POSITIVE_THRESHOLD && !seenReviewIds.has(r.id),
+      );
+      for (const review of newNegatives) {
+        if (created >= MAX_NEW_DRAFTS_PER_SYNC) break;
+        try {
+          const draft = await generateReply({
+            rating: review.rating,
+            reviewer: review.reviewer.name,
+            comment: review.comment,
+            outletName: outlet.name,
+          });
+          if (!draft) continue;
+          await prisma.reviewReplyDraft.create({
+            data: {
+              reviewId: review.id,
+              outletId: outlet.id,
+              reviewerName: review.reviewer.name,
+              rating: review.rating,
+              comment: review.comment ?? null,
+              draftReply: draft,
+            },
+          });
+          seenReviewIds.add(review.id);
+          created++;
+        } catch (err) {
+          console.error(`[reviews/negatives] draft create failed for ${review.id}:`, err);
+        }
+      }
+    }
+  }
+
+  const pending = await prisma.reviewReplyDraft.findMany({
+    where: { status: "pending" },
+    include: { outlet: { select: { name: true } } },
+    orderBy: { createdAt: "desc" },
+  });
+
+  return NextResponse.json({
+    synced: sync,
+    created,
+    resolved,
+    pending: pending.map((d) => ({
+      id: d.id,
+      reviewId: d.reviewId,
+      outletId: d.outletId,
+      outletName: d.outlet.name,
+      reviewerName: d.reviewerName,
+      rating: d.rating,
+      comment: d.comment,
+      draftReply: d.draftReply,
+      createdAt: d.createdAt,
+    })),
+  });
+}

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -102,6 +102,7 @@ model Outlet {
   sopSchedules      SopSchedule[]
   reviewSettings    ReviewSettings?
   internalFeedbacks InternalFeedback[]
+  reviewReplyDrafts ReviewReplyDraft[]
   auditReports      AuditReport[]
   recurringExpenses RecurringExpense[]
   bankStatementLines BankStatementLine[]
@@ -1331,6 +1332,30 @@ model InternalFeedback {
   createdAt DateTime @default(now())
 
   @@index([outletId, createdAt])
+}
+
+// Backoffice approval gate for NEGATIVE (1-3★) Google reviews.
+// AI drafts a reply, a human approves/rejects it in backoffice, and only
+// then is it posted to GBP. Positives never enter this table — they
+// auto-post via /api/cron/reviews-auto-reply.
+model ReviewReplyDraft {
+  id           String    @id @default(uuid())
+  reviewId     String    @unique // GBP review id
+  outletId     String
+  outlet       Outlet    @relation(fields: [outletId], references: [id])
+  reviewerName String?
+  rating       Int
+  comment      String?
+  draftReply   String // AI-generated draft
+  finalReply   String? // what was actually posted (if edited on approval)
+  status       String    @default("pending") // pending | approved | rejected | resolved
+  decidedBy    String? // user who approved/rejected
+  decidedAt    DateTime?
+  createdAt    DateTime  @default(now())
+  updatedAt    DateTime  @updatedAt
+
+  @@index([status])
+  @@index([outletId])
 }
 
 // ─── ADS MODULE ─────────────────────────────────────────────

--- a/supabase/migrations/053_review_reply_drafts.sql
+++ b/supabase/migrations/053_review_reply_drafts.sql
@@ -1,0 +1,28 @@
+-- 053_review_reply_drafts.sql
+-- Backoffice approval gate for NEGATIVE (1-3 star) Google reviews.
+--
+-- AI drafts a reply, a human approves/rejects it in backoffice, and only then
+-- is it posted to GBP. Positive (4-5 star) reviews never enter this table —
+-- they auto-post via /api/cron/reviews-auto-reply.
+--
+-- Column names are camelCase + quoted to match the Prisma model
+-- (ReviewReplyDraft) — Prisma maps field names to column names verbatim.
+
+CREATE TABLE IF NOT EXISTS "ReviewReplyDraft" (
+  "id"           text PRIMARY KEY,
+  "reviewId"     text NOT NULL UNIQUE,                         -- GBP review id
+  "outletId"     text NOT NULL REFERENCES "Outlet"("id"),
+  "reviewerName" text,
+  "rating"       integer NOT NULL,
+  "comment"      text,
+  "draftReply"   text NOT NULL,                                -- AI-generated draft
+  "finalReply"   text,                                         -- actually-posted text (if edited)
+  "status"       text NOT NULL DEFAULT 'pending',              -- pending | approved | rejected | resolved
+  "decidedBy"    text,
+  "decidedAt"    timestamptz,
+  "createdAt"    timestamptz NOT NULL DEFAULT now(),
+  "updatedAt"    timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS "ReviewReplyDraft_status_idx"   ON "ReviewReplyDraft" ("status");
+CREATE INDEX IF NOT EXISTS "ReviewReplyDraft_outletId_idx" ON "ReviewReplyDraft" ("outletId");


### PR DESCRIPTION
> Re-opened as a clean PR onto `main` (supersedes #485, which auto-closed when its stacked base branch was deleted on merge of #484). Single commit, cherry-picked onto current `main`.

## What
Negative (1–3★) Google reviews are drafted by AI and held in a persistent **"Needs approval"** queue in backoffice. **Nothing posts to Google until a human approves it** — the gated counterpart to the positive auto-reply cron (#484).

## How
- **New table `ReviewReplyDraft`** (migration `053_review_reply_drafts.sql`, applied to the live DB via **manual SQL**, not `prisma db push`). Status `pending|approved|rejected|resolved` + `decidedBy`/`decidedAt` audit.
- **`GET /api/reviews/negatives[?sync=1]`** — returns the pending queue; with `sync`, pulls Google reviews, drafts a reply for each new unreplied negative, and auto-resolves drafts whose review already got a reply elsewhere. LLM calls capped per sync.
- **`POST /api/reviews/negatives/decide`** — `approve` (posts edited/draft text to GBP, marks approved) or `reject` (marks rejected, posts nothing).
- **Reviews page** — new **"Needs approval (N)"** tab; each draft editable, Approve & Post / Reject.

## Safety / scope
- A 1–3★ review can never auto-post — it only leaves the queue on human approval.
- Positives untouched (handled by #484's cron).
- Draft copy currently routes to the area manager; the private recovery line + voucher capture is the next phase (`docs/design/reviews-reply-recovery-loop.md`).

## Verification
- `tsc --noEmit` clean on backoffice.
- Migration applied + confirmed on the live project (`ReviewReplyDraft` created, FK to `Outlet`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)