### PR TITLE
feat(reviews): negative-feedback case manager with recovery + voucher

### DIFF
--- a/apps/backoffice/src/app/(admin)/reviews/feedback/page.tsx
+++ b/apps/backoffice/src/app/(admin)/reviews/feedback/page.tsx
@@ -1,0 +1,329 @@
+"use client";
+
+import { useEffect, useState, useCallback } from "react";
+import Link from "next/link";
+import {
+  Loader2,
+  Star,
+  Check,
+  X,
+  Send,
+  Sparkles,
+  ArrowLeft,
+  Gift,
+  Phone,
+} from "lucide-react";
+
+type Case = {
+  id: string;
+  reviewId: string;
+  outletId: string;
+  outletName: string;
+  reviewerName: string | null;
+  rating: number;
+  comment: string | null;
+  draftReply: string;
+  finalReply: string | null;
+  status: string;
+  recoveryCode: string | null;
+  claimedAt: string | null;
+  recoveryMemberId: string | null;
+  recoveryRewardId: string | null;
+  redeemedAt: string | null;
+  resolvedAt: string | null;
+  decidedBy: string | null;
+  createdAt: string;
+};
+
+const FILTERS: { key: string; label: string; match: (s: string) => boolean }[] = [
+  { key: "needs_reply", label: "Needs reply", match: (s) => s === "pending" },
+  { key: "awaiting", label: "Awaiting customer", match: (s) => s === "approved" },
+  { key: "compensated", label: "Compensated", match: (s) => s === "compensated" },
+  { key: "resolved", label: "Resolved", match: (s) => s === "resolved" },
+  { key: "closed", label: "Closed", match: (s) => s === "rejected" || s === "expired" },
+  { key: "all", label: "All", match: () => true },
+];
+
+const STATUS_BADGE: Record<string, { label: string; cls: string }> = {
+  pending: { label: "Needs reply", cls: "bg-amber-100 text-amber-800" },
+  approved: { label: "Awaiting customer", cls: "bg-blue-100 text-blue-800" },
+  compensated: { label: "Compensated", cls: "bg-emerald-100 text-emerald-800" },
+  resolved: { label: "Resolved", cls: "bg-neutral-200 text-neutral-700" },
+  rejected: { label: "Rejected", cls: "bg-neutral-200 text-neutral-500" },
+  expired: { label: "Expired", cls: "bg-neutral-200 text-neutral-500" },
+};
+
+function StarRow({ rating }: { rating: number }) {
+  return (
+    <div className="flex items-center gap-0.5">
+      {[1, 2, 3, 4, 5].map((i) => (
+        <Star
+          key={i}
+          className={`h-3.5 w-3.5 ${i <= rating ? "fill-amber-400 text-amber-400" : "text-neutral-300"}`}
+        />
+      ))}
+    </div>
+  );
+}
+
+function timeAgo(d: string | null): string {
+  if (!d) return "";
+  const diff = Date.now() - new Date(d).getTime();
+  const days = Math.floor(diff / 86400000);
+  if (days > 0) return `${days}d ago`;
+  const hrs = Math.floor(diff / 3600000);
+  if (hrs > 0) return `${hrs}h ago`;
+  const mins = Math.floor(diff / 60000);
+  return `${mins}m ago`;
+}
+
+export default function FeedbackManagementPage() {
+  const [cases, setCases] = useState<Case[] | null>(null);
+  const [syncing, setSyncing] = useState(false);
+  const [filter, setFilter] = useState("needs_reply");
+  const [edits, setEdits] = useState<Record<string, string>>({});
+  const [busy, setBusy] = useState<Record<string, boolean>>({});
+  const [comp, setComp] = useState<Record<string, { phone: string; name: string }>>({});
+
+  const load = useCallback(async (sync: boolean) => {
+    if (sync) setSyncing(true);
+    try {
+      const res = await fetch(`/api/reviews/negatives?scope=all${sync ? "&sync=1" : ""}`);
+      const data = await res.json();
+      setCases(data.cases ?? []);
+    } catch {
+      setCases([]);
+    } finally {
+      setSyncing(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    load(false);
+  }, [load]);
+
+  const act = async (
+    c: Case,
+    action: string,
+    extra?: Record<string, unknown>,
+  ) => {
+    setBusy((b) => ({ ...b, [c.id]: true }));
+    try {
+      const res = await fetch("/api/reviews/negatives/decide", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ id: c.id, action, ...extra }),
+      });
+      if (res.ok) {
+        await load(false);
+        setComp((m) => {
+          const n = { ...m };
+          delete n[c.id];
+          return n;
+        });
+      } else {
+        const e = await res.json().catch(() => ({}));
+        alert(e.error || "Action failed");
+      }
+    } finally {
+      setBusy((b) => ({ ...b, [c.id]: false }));
+    }
+  };
+
+  const counts = (key: string) =>
+    (cases ?? []).filter((c) => FILTERS.find((f) => f.key === key)!.match(c.status)).length;
+
+  const visible = (cases ?? []).filter((c) => FILTERS.find((f) => f.key === filter)!.match(c.status));
+
+  return (
+    <div className="mx-auto max-w-4xl px-4 py-6 sm:px-6">
+      <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+        <div>
+          <Link href="/reviews" className="mb-1 flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground">
+            <ArrowLeft className="h-3.5 w-3.5" /> Back to Reviews
+          </Link>
+          <h1 className="font-heading text-2xl font-bold text-foreground">Feedback Management</h1>
+          <p className="text-sm text-muted-foreground">Every negative review, worked through to a compensated customer.</p>
+        </div>
+        <button
+          onClick={() => load(true)}
+          disabled={syncing}
+          className="flex shrink-0 items-center gap-1.5 rounded-lg bg-terracotta px-3 py-2 text-sm font-medium text-white hover:bg-terracotta/90 disabled:opacity-50"
+        >
+          {syncing ? <Loader2 className="h-4 w-4 animate-spin" /> : <Sparkles className="h-4 w-4" />}
+          Check Google for new
+        </button>
+      </div>
+
+      {/* Filters */}
+      <div className="mt-6 flex flex-wrap gap-2">
+        {FILTERS.map((f) => (
+          <button
+            key={f.key}
+            onClick={() => setFilter(f.key)}
+            className={`rounded-full px-3 py-1.5 text-sm font-medium transition-colors ${
+              filter === f.key
+                ? "bg-brand-dark text-white"
+                : "border border-border bg-white text-muted-foreground hover:bg-muted"
+            }`}
+          >
+            {f.label} ({counts(f.key)})
+          </button>
+        ))}
+      </div>
+
+      {/* List */}
+      <div className="mt-4 space-y-3">
+        {cases === null ? (
+          <div className="flex items-center justify-center py-10">
+            <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
+          </div>
+        ) : visible.length === 0 ? (
+          <div className="rounded-xl border border-border bg-white p-10 text-center">
+            <Check className="mx-auto h-10 w-10 text-muted-foreground/30" />
+            <p className="mt-3 text-sm text-muted-foreground">Nothing here right now.</p>
+          </div>
+        ) : (
+          visible.map((c) => {
+            const badge = STATUS_BADGE[c.status] ?? { label: c.status, cls: "bg-neutral-200 text-neutral-600" };
+            const isBusy = busy[c.id];
+            const draftVal = edits[c.id] ?? c.draftReply;
+            const compForm = comp[c.id];
+            return (
+              <div key={c.id} className="rounded-xl border border-border bg-white p-4">
+                <div className="flex items-start justify-between gap-3">
+                  <div>
+                    <div className="flex items-center gap-2">
+                      <StarRow rating={c.rating} />
+                      <span className="text-sm font-medium text-foreground">{c.reviewerName || "Anonymous"}</span>
+                    </div>
+                    <p className="mt-0.5 text-xs text-muted-foreground">{c.outletName} · {timeAgo(c.createdAt)}</p>
+                  </div>
+                  <span className={`shrink-0 rounded-full px-2.5 py-1 text-xs font-medium ${badge.cls}`}>{badge.label}</span>
+                </div>
+
+                {c.comment && (
+                  <p className="mt-2 rounded-lg bg-muted/50 p-2 text-sm text-foreground">{c.comment}</p>
+                )}
+
+                {/* NEEDS REPLY — editable draft + approve/reject */}
+                {c.status === "pending" && (
+                  <div className="mt-3">
+                    <p className="mb-1 text-xs font-medium text-muted-foreground">AI draft reply (edit before approving)</p>
+                    <textarea
+                      value={draftVal}
+                      onChange={(e) => setEdits((m) => ({ ...m, [c.id]: e.target.value }))}
+                      rows={3}
+                      className="w-full rounded-lg border border-border bg-white p-2 text-sm outline-none focus:ring-2 focus:ring-ring/50"
+                    />
+                    <p className="mt-1 text-[11px] text-muted-foreground">A recovery link is added automatically when you approve.</p>
+                    <div className="mt-2 flex items-center gap-2">
+                      <button
+                        onClick={() => act(c, "approve", { reply: draftVal })}
+                        disabled={isBusy || !draftVal.trim()}
+                        className="flex items-center gap-1.5 rounded-lg bg-brand-dark px-3 py-2 text-sm font-medium text-white hover:bg-brand-dark/90 disabled:opacity-50"
+                      >
+                        {isBusy ? <Loader2 className="h-4 w-4 animate-spin" /> : <Send className="h-4 w-4" />}
+                        Approve &amp; Post
+                      </button>
+                      <button
+                        onClick={() => act(c, "reject")}
+                        disabled={isBusy}
+                        className="flex items-center gap-1.5 rounded-lg border border-border bg-white px-3 py-2 text-sm font-medium text-muted-foreground hover:bg-muted disabled:opacity-50"
+                      >
+                        <X className="h-4 w-4" /> Reject
+                      </button>
+                    </div>
+                  </div>
+                )}
+
+                {/* AWAITING CUSTOMER — code + compensate/resolve/expire */}
+                {c.status === "approved" && (
+                  <div className="mt-3 space-y-2">
+                    <div className="rounded-lg bg-blue-50 px-3 py-2 text-sm text-blue-900">
+                      Reply posted. Recovery code <span className="font-mono font-semibold">{c.recoveryCode}</span> — waiting for the customer to claim their voucher.
+                    </div>
+                    {compForm ? (
+                      <div className="rounded-lg border border-border p-2">
+                        <p className="mb-1.5 text-xs font-medium text-muted-foreground">Got their number directly? Compensate now.</p>
+                        <div className="flex flex-wrap items-center gap-2">
+                          <input
+                            value={compForm.phone}
+                            onChange={(e) => setComp((m) => ({ ...m, [c.id]: { ...compForm, phone: e.target.value } }))}
+                            placeholder="01XXXXXXXX"
+                            inputMode="tel"
+                            className="w-40 rounded-lg border border-border px-2 py-1.5 text-sm outline-none focus:ring-2 focus:ring-ring/50"
+                          />
+                          <input
+                            value={compForm.name}
+                            onChange={(e) => setComp((m) => ({ ...m, [c.id]: { ...compForm, name: e.target.value } }))}
+                            placeholder="Name (optional)"
+                            className="w-36 rounded-lg border border-border px-2 py-1.5 text-sm outline-none focus:ring-2 focus:ring-ring/50"
+                          />
+                          <button
+                            onClick={() => act(c, "compensate", { phone: compForm.phone, name: compForm.name })}
+                            disabled={isBusy || !compForm.phone.trim()}
+                            className="flex items-center gap-1.5 rounded-lg bg-emerald-600 px-3 py-1.5 text-sm font-medium text-white hover:bg-emerald-700 disabled:opacity-50"
+                          >
+                            <Gift className="h-4 w-4" /> Issue voucher
+                          </button>
+                        </div>
+                      </div>
+                    ) : (
+                      <div className="flex flex-wrap items-center gap-2">
+                        <button
+                          onClick={() => setComp((m) => ({ ...m, [c.id]: { phone: "", name: c.reviewerName ?? "" } }))}
+                          disabled={isBusy}
+                          className="flex items-center gap-1.5 rounded-lg border border-emerald-300 bg-white px-3 py-1.5 text-sm font-medium text-emerald-700 hover:bg-emerald-50 disabled:opacity-50"
+                        >
+                          <Phone className="h-4 w-4" /> Compensate manually
+                        </button>
+                        <button
+                          onClick={() => act(c, "resolve")}
+                          disabled={isBusy}
+                          className="rounded-lg border border-border bg-white px-3 py-1.5 text-sm font-medium text-muted-foreground hover:bg-muted disabled:opacity-50"
+                        >
+                          Mark resolved
+                        </button>
+                        <button
+                          onClick={() => act(c, "expire")}
+                          disabled={isBusy}
+                          className="rounded-lg border border-border bg-white px-3 py-1.5 text-sm font-medium text-muted-foreground hover:bg-muted disabled:opacity-50"
+                        >
+                          No response
+                        </button>
+                      </div>
+                    )}
+                  </div>
+                )}
+
+                {/* COMPENSATED — show capture + resolve */}
+                {c.status === "compensated" && (
+                  <div className="mt-3 space-y-2">
+                    <div className="flex items-center gap-1.5 rounded-lg bg-emerald-50 px-3 py-2 text-sm text-emerald-900">
+                      <Gift className="h-4 w-4" /> Customer captured + free coffee issued{c.claimedAt ? ` · ${timeAgo(c.claimedAt)}` : ""}.
+                    </div>
+                    <button
+                      onClick={() => act(c, "resolve")}
+                      disabled={isBusy}
+                      className="rounded-lg bg-brand-dark px-3 py-1.5 text-sm font-medium text-white hover:bg-brand-dark/90 disabled:opacity-50"
+                    >
+                      Mark resolved
+                    </button>
+                  </div>
+                )}
+
+                {/* CLOSED states */}
+                {(c.status === "resolved" || c.status === "rejected" || c.status === "expired") && c.resolvedAt && (
+                  <p className="mt-2 text-xs text-muted-foreground">
+                    {badge.label}{c.decidedBy ? ` by ${c.decidedBy}` : ""} · {timeAgo(c.resolvedAt)}
+                  </p>
+                )}
+              </div>
+            );
+          })
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/backoffice/src/app/(admin)/reviews/feedback/page.tsx
+++ b/apps/backoffice/src/app/(admin)/reviews/feedback/page.tsx
@@ -12,6 +12,7 @@ import {
   ArrowLeft,
   Gift,
   Phone,
+  RefreshCw,
 } from "lucide-react";
 
 type Case = {
@@ -84,6 +85,8 @@ export default function FeedbackManagementPage() {
   const [edits, setEdits] = useState<Record<string, string>>({});
   const [busy, setBusy] = useState<Record<string, boolean>>({});
   const [comp, setComp] = useState<Record<string, { phone: string; name: string }>>({});
+  const [ctx, setCtx] = useState<Record<string, string>>({});
+  const [regen, setRegen] = useState<Record<string, boolean>>({});
 
   const load = useCallback(async (sync: boolean) => {
     if (sync) setSyncing(true);
@@ -127,6 +130,22 @@ export default function FeedbackManagementPage() {
       }
     } finally {
       setBusy((b) => ({ ...b, [c.id]: false }));
+    }
+  };
+
+  const regenerate = async (c: Case) => {
+    setRegen((r) => ({ ...r, [c.id]: true }));
+    try {
+      const res = await fetch("/api/reviews/negatives/regenerate", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ id: c.id, context: ctx[c.id] ?? "" }),
+      });
+      const d = await res.json();
+      if (res.ok && d.draftReply) setEdits((m) => ({ ...m, [c.id]: d.draftReply }));
+      else alert(d.error || "Could not regenerate");
+    } finally {
+      setRegen((r) => ({ ...r, [c.id]: false }));
     }
   };
 
@@ -217,6 +236,27 @@ export default function FeedbackManagementPage() {
                       className="w-full rounded-lg border border-border bg-white p-2 text-sm outline-none focus:ring-2 focus:ring-ring/50"
                     />
                     <p className="mt-1 text-[11px] text-muted-foreground">A recovery link is added automatically when you approve.</p>
+
+                    {/* Approver context → regenerate a more honest, specific reply */}
+                    <div className="mt-2 rounded-lg border border-dashed border-border p-2">
+                      <p className="mb-1 text-xs font-medium text-muted-foreground">What actually happened? (optional — gives a better, less generic reply)</p>
+                      <textarea
+                        value={ctx[c.id] ?? ""}
+                        onChange={(e) => setCtx((m) => ({ ...m, [c.id]: e.target.value }))}
+                        rows={2}
+                        placeholder="e.g. sink was broken so drinks went out in takeaway cups; repair booked for Friday"
+                        className="w-full rounded-lg border border-border bg-white p-2 text-sm outline-none focus:ring-2 focus:ring-ring/50"
+                      />
+                      <button
+                        onClick={() => regenerate(c)}
+                        disabled={regen[c.id]}
+                        className="mt-1.5 flex items-center gap-1.5 rounded-lg border border-border bg-white px-3 py-1.5 text-sm font-medium text-foreground hover:bg-muted disabled:opacity-50"
+                      >
+                        {regen[c.id] ? <Loader2 className="h-4 w-4 animate-spin" /> : <RefreshCw className="h-4 w-4" />}
+                        Regenerate draft
+                      </button>
+                    </div>
+
                     <div className="mt-2 flex items-center gap-2">
                       <button
                         onClick={() => act(c, "approve", { reply: draftVal })}

--- a/apps/backoffice/src/app/(admin)/reviews/page.tsx
+++ b/apps/backoffice/src/app/(admin)/reviews/page.tsx
@@ -1348,6 +1348,13 @@ export default function ReviewsPage() {
         </div>
         <div className="flex items-center gap-3">
           <Link
+            href="/reviews/feedback"
+            className="flex items-center gap-1.5 rounded-lg border border-border bg-white px-3 py-2 text-sm font-medium hover:bg-muted transition-colors"
+          >
+            <MessageSquare className="h-4 w-4" />
+            Feedback management
+          </Link>
+          <Link
             href="/reviews/settings"
             className="flex items-center gap-1.5 rounded-lg border border-border bg-white px-3 py-2 text-sm font-medium hover:bg-muted transition-colors"
           >

--- a/apps/backoffice/src/app/api/recovery/route.ts
+++ b/apps/backoffice/src/app/api/recovery/route.ts
@@ -1,0 +1,73 @@
+import { NextRequest, NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+import { compensateReviewCase, isValidMyPhone } from "@/lib/reviews/recovery";
+import { sendSMS, getActiveSmsProvider, providerAutoPrependsSender } from "@/lib/loyalty/sms";
+
+export const dynamic = "force-dynamic";
+
+// PUBLIC (no auth — the single-use recovery code is the credential).
+// The customer reached this from the recovery link in our reply to their
+// negative Google review.
+
+// GET /api/recovery?code=XXXX — validate a code so the form can show state.
+export async function GET(request: NextRequest) {
+  const code = new URL(request.url).searchParams.get("code")?.trim().toUpperCase();
+  if (!code) return NextResponse.json({ valid: false }, { status: 400 });
+
+  const c = await prisma.reviewReplyDraft.findUnique({
+    where: { recoveryCode: code },
+    include: { outlet: { select: { name: true } } },
+  });
+  if (!c) return NextResponse.json({ valid: false });
+
+  const claimed = c.status === "compensated" || c.status === "resolved";
+  const usable = c.status === "approved";
+  return NextResponse.json({
+    valid: usable || claimed,
+    claimed,
+    usable,
+    outletName: c.outlet.name,
+  });
+}
+
+// POST /api/recovery — { code, phone, name } → capture + voucher.
+export async function POST(request: NextRequest) {
+  const body = await request.json().catch(() => ({}));
+  const code = typeof body.code === "string" ? body.code.trim().toUpperCase() : "";
+  const phone = typeof body.phone === "string" ? body.phone.trim() : "";
+  const name = typeof body.name === "string" ? body.name.trim() : "";
+
+  if (!code) return NextResponse.json({ ok: false, error: "Missing code" }, { status: 400 });
+  if (!isValidMyPhone(phone)) {
+    return NextResponse.json({ ok: false, error: "Enter a valid Malaysian mobile number" }, { status: 400 });
+  }
+
+  const c = await prisma.reviewReplyDraft.findUnique({ where: { recoveryCode: code } });
+  if (!c) return NextResponse.json({ ok: false, error: "That code isn't valid" }, { status: 404 });
+  if (c.status === "compensated" || c.status === "resolved") {
+    return NextResponse.json({ ok: true, alreadyClaimed: true, message: "You've already claimed this — see you soon!" });
+  }
+  if (c.status !== "approved") {
+    return NextResponse.json({ ok: false, error: "This code is no longer active" }, { status: 410 });
+  }
+
+  const result = await compensateReviewCase(c.id, phone, name || null);
+  if (!result.ok) return NextResponse.json({ ok: false, error: result.error }, { status: 400 });
+
+  // Best-effort SMS — on-screen confirmation is the primary delivery, so a
+  // flaky provider never blocks the claim.
+  try {
+    const provider = await getActiveSmsProvider();
+    const text = "Thank you for giving Celsius another chance — a free coffee is in your account. Show this at the till. We're sorry, and we'll do better.";
+    const msg = providerAutoPrependsSender(provider) ? text : `RM0 [CelsiusCoffee] ${text}`;
+    await sendSMS(phone, msg, { provider });
+  } catch (err) {
+    console.error("[recovery] SMS send failed (non-fatal):", err);
+  }
+
+  return NextResponse.json({
+    ok: true,
+    alreadyClaimed: result.alreadyCompensated,
+    message: "Your free coffee is in your account — just give your phone number at the till.",
+  });
+}

--- a/apps/backoffice/src/app/api/reviews/negatives/decide/route.ts
+++ b/apps/backoffice/src/app/api/reviews/negatives/decide/route.ts
@@ -2,59 +2,114 @@ import { NextRequest, NextResponse } from "next/server";
 import { getUserFromHeaders } from "@/lib/auth";
 import { prisma } from "@/lib/prisma";
 import { replyToReview } from "@/lib/reviews/gbp";
+import { genRecoveryCode, compensateReviewCase } from "@/lib/reviews/recovery";
 
 export const dynamic = "force-dynamic";
 
+const APP_URL = process.env.NEXT_PUBLIC_APP_URL || "https://backoffice.celsiuscoffee.com";
+
 // POST /api/reviews/negatives/decide
-// Body: { id, action: "approve" | "reject", reply? }
-//   - approve: post `reply` (edited) or the stored draft to Google, then mark approved
-//   - reject:  mark rejected, nothing is posted
+// Body: { id, action, reply?, phone?, name?, note? }
+//   approve     — post reply (+ recovery code CTA) to GBP, status → approved
+//   reject      — status → rejected, nothing posted
+//   compensate  — manager has the customer's phone offline: capture + voucher
+//   resolve     — close the case as made-whole
+//   expire      — recovery code went unclaimed; close as unrecovered
 export async function POST(request: NextRequest) {
   const user = await getUserFromHeaders(request.headers);
   if (!user) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
 
-  const { id, action, reply } = await request.json();
-  if (!id || (action !== "approve" && action !== "reject")) {
-    return NextResponse.json({ error: "id and valid action (approve|reject) required" }, { status: 400 });
+  const { id, action, reply, phone, name, note } = await request.json();
+  const VALID = ["approve", "reject", "compensate", "resolve", "expire"];
+  if (!id || !VALID.includes(action)) {
+    return NextResponse.json({ error: "id and valid action required" }, { status: 400 });
   }
 
   const draft = await prisma.reviewReplyDraft.findUnique({
     where: { id },
     include: { outlet: { include: { reviewSettings: true } } },
   });
-  if (!draft) return NextResponse.json({ error: "Draft not found" }, { status: 404 });
-  if (draft.status !== "pending") {
-    return NextResponse.json({ error: `Already ${draft.status}`, status: draft.status }, { status: 409 });
-  }
+  if (!draft) return NextResponse.json({ error: "Case not found" }, { status: 404 });
 
   const decidedBy = user.name || user.id;
+  const now = new Date();
 
+  // ── approve / reject: only from the NEW (pending) state ──────────────────
   if (action === "reject") {
+    if (draft.status !== "pending") {
+      return NextResponse.json({ error: `Already ${draft.status}` }, { status: 409 });
+    }
     await prisma.reviewReplyDraft.update({
       where: { id },
-      data: { status: "rejected", decidedBy, decidedAt: new Date() },
+      data: { status: "rejected", decidedBy, decidedAt: now },
     });
     return NextResponse.json({ id, status: "rejected" });
   }
 
-  // approve → post to GBP, then record the decision
-  const settings = draft.outlet.reviewSettings;
-  if (!settings?.gbpAccountId || !settings?.gbpLocationName) {
-    return NextResponse.json({ error: "GBP not connected for this outlet" }, { status: 400 });
-  }
-  const finalReply =
-    typeof reply === "string" && reply.trim() ? reply.trim() : draft.draftReply;
+  if (action === "approve") {
+    if (draft.status !== "pending") {
+      return NextResponse.json({ error: `Already ${draft.status}` }, { status: 409 });
+    }
+    const settings = draft.outlet.reviewSettings;
+    if (!settings?.gbpAccountId || !settings?.gbpLocationName) {
+      return NextResponse.json({ error: "GBP not connected for this outlet" }, { status: 400 });
+    }
+    const base = typeof reply === "string" && reply.trim() ? reply.trim() : draft.draftReply;
+    const code = genRecoveryCode();
+    // Deterministic recovery CTA — the link/code are appended in code, never by
+    // the LLM, so they can't be mangled. Google replies are plain text.
+    const finalReply = `${base}\n\nWe'd like to make this right. Please visit ${APP_URL}/recover/${code} so we can reach you personally.`;
 
-  try {
-    await replyToReview(settings.gbpAccountId, settings.gbpLocationName, draft.reviewId, finalReply);
-  } catch (err) {
-    console.error(`[reviews/negatives/decide] GBP post failed for ${draft.reviewId}:`, err);
-    return NextResponse.json({ error: "Failed to post reply to Google" }, { status: 502 });
+    try {
+      await replyToReview(settings.gbpAccountId, settings.gbpLocationName, draft.reviewId, finalReply);
+    } catch (err) {
+      console.error(`[decide] GBP post failed for ${draft.reviewId}:`, err);
+      return NextResponse.json({ error: "Failed to post reply to Google" }, { status: 502 });
+    }
+
+    await prisma.reviewReplyDraft.update({
+      where: { id },
+      data: {
+        status: "approved",
+        finalReply,
+        recoveryCode: code,
+        recoveryCodeAt: now,
+        decidedBy,
+        decidedAt: now,
+      },
+    });
+    return NextResponse.json({ id, status: "approved", posted: true, recoveryCode: code });
   }
 
+  // ── compensate: manager captured the phone offline ──────────────────────
+  if (action === "compensate") {
+    if (typeof phone !== "string" || !phone.trim()) {
+      return NextResponse.json({ error: "phone required" }, { status: 400 });
+    }
+    const result = await compensateReviewCase(id, phone, typeof name === "string" ? name : null);
+    if (!result.ok) return NextResponse.json({ error: result.error }, { status: 400 });
+    return NextResponse.json({ id, status: "compensated", ...result });
+  }
+
+  // ── resolve / expire: close the case ────────────────────────────────────
+  if (action === "resolve") {
+    if (!["approved", "compensated"].includes(draft.status)) {
+      return NextResponse.json({ error: `Cannot resolve a ${draft.status} case` }, { status: 409 });
+    }
+    await prisma.reviewReplyDraft.update({
+      where: { id },
+      data: { status: "resolved", resolvedAt: now, resolvedBy: decidedBy, resolutionNote: note ?? null },
+    });
+    return NextResponse.json({ id, status: "resolved" });
+  }
+
+  // expire
+  if (draft.status !== "approved") {
+    return NextResponse.json({ error: `Cannot expire a ${draft.status} case` }, { status: 409 });
+  }
   await prisma.reviewReplyDraft.update({
     where: { id },
-    data: { status: "approved", finalReply, decidedBy, decidedAt: new Date() },
+    data: { status: "expired", resolvedAt: now, resolvedBy: decidedBy, resolutionNote: note ?? null },
   });
-  return NextResponse.json({ id, status: "approved", posted: true });
+  return NextResponse.json({ id, status: "expired" });
 }

--- a/apps/backoffice/src/app/api/reviews/negatives/regenerate/route.ts
+++ b/apps/backoffice/src/app/api/reviews/negatives/regenerate/route.ts
@@ -1,0 +1,41 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getUserFromHeaders } from "@/lib/auth";
+import { prisma } from "@/lib/prisma";
+import { generateReply } from "@/lib/reviews/auto-reply";
+
+export const dynamic = "force-dynamic";
+export const maxDuration = 60;
+
+// POST /api/reviews/negatives/regenerate
+// Body: { id, context } — recompute a PENDING draft, folding in the approver's
+// notes about what actually happened so the reply is honest + specific.
+export async function POST(request: NextRequest) {
+  const user = await getUserFromHeaders(request.headers);
+  if (!user) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+
+  const { id, context } = await request.json();
+  if (!id) return NextResponse.json({ error: "id required" }, { status: 400 });
+
+  const draft = await prisma.reviewReplyDraft.findUnique({
+    where: { id },
+    include: { outlet: { select: { name: true } } },
+  });
+  if (!draft) return NextResponse.json({ error: "Case not found" }, { status: 404 });
+  if (draft.status !== "pending") {
+    return NextResponse.json({ error: "Can only regenerate before approval" }, { status: 409 });
+  }
+
+  const reply = await generateReply({
+    rating: draft.rating,
+    reviewer: draft.reviewerName ?? "there",
+    comment: draft.comment ?? undefined,
+    outletName: draft.outlet.name,
+    context: typeof context === "string" ? context : undefined,
+  });
+  if (!reply) {
+    return NextResponse.json({ error: "Could not generate a reply" }, { status: 502 });
+  }
+
+  await prisma.reviewReplyDraft.update({ where: { id }, data: { draftReply: reply } });
+  return NextResponse.json({ id, draftReply: reply });
+}

--- a/apps/backoffice/src/app/api/reviews/negatives/route.ts
+++ b/apps/backoffice/src/app/api/reviews/negatives/route.ts
@@ -100,26 +100,38 @@ export async function GET(request: NextRequest) {
     }
   }
 
-  const pending = await prisma.reviewReplyDraft.findMany({
-    where: { status: "pending" },
+  // scope=all → the full case board (every status). Default → pending only,
+  // which keeps the existing "Needs approval" tab working unchanged.
+  const scopeAll = new URL(request.url).searchParams.get("scope") === "all";
+
+  const rows = await prisma.reviewReplyDraft.findMany({
+    where: scopeAll ? {} : { status: "pending" },
     include: { outlet: { select: { name: true } } },
     orderBy: { createdAt: "desc" },
   });
 
-  return NextResponse.json({
-    synced: sync,
-    created,
-    resolved,
-    pending: pending.map((d) => ({
-      id: d.id,
-      reviewId: d.reviewId,
-      outletId: d.outletId,
-      outletName: d.outlet.name,
-      reviewerName: d.reviewerName,
-      rating: d.rating,
-      comment: d.comment,
-      draftReply: d.draftReply,
-      createdAt: d.createdAt,
-    })),
-  });
+  const cases = rows.map((d) => ({
+    id: d.id,
+    reviewId: d.reviewId,
+    outletId: d.outletId,
+    outletName: d.outlet.name,
+    reviewerName: d.reviewerName,
+    rating: d.rating,
+    comment: d.comment,
+    draftReply: d.draftReply,
+    finalReply: d.finalReply,
+    status: d.status,
+    recoveryCode: d.recoveryCode,
+    claimedAt: d.claimedAt,
+    recoveryMemberId: d.recoveryMemberId,
+    recoveryRewardId: d.recoveryRewardId,
+    redeemedAt: d.redeemedAt,
+    resolvedAt: d.resolvedAt,
+    decidedBy: d.decidedBy,
+    createdAt: d.createdAt,
+  }));
+
+  const pending = cases.filter((c) => c.status === "pending");
+
+  return NextResponse.json({ synced: sync, created, resolved, pending, cases });
 }

--- a/apps/backoffice/src/app/recover/[code]/page.tsx
+++ b/apps/backoffice/src/app/recover/[code]/page.tsx
@@ -1,0 +1,133 @@
+"use client";
+
+import { use, useEffect, useState } from "react";
+
+type CodeState =
+  | { phase: "loading" }
+  | { phase: "form"; outletName: string }
+  | { phase: "claimed" }
+  | { phase: "invalid" }
+  | { phase: "done"; message: string };
+
+export default function RecoverPage({ params }: { params: Promise<{ code: string }> }) {
+  const { code } = use(params);
+  const [state, setState] = useState<CodeState>({ phase: "loading" });
+  const [name, setName] = useState("");
+  const [phone, setPhone] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState("");
+
+  useEffect(() => {
+    let active = true;
+    fetch(`/api/recovery?code=${encodeURIComponent(code)}`)
+      .then((r) => r.json())
+      .then((d) => {
+        if (!active) return;
+        if (d.claimed) setState({ phase: "claimed" });
+        else if (d.usable) setState({ phase: "form", outletName: d.outletName ?? "Celsius Coffee" });
+        else setState({ phase: "invalid" });
+      })
+      .catch(() => active && setState({ phase: "invalid" }));
+    return () => {
+      active = false;
+    };
+  }, [code]);
+
+  const submit = async () => {
+    setError("");
+    setSubmitting(true);
+    try {
+      const res = await fetch("/api/recovery", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ code, name, phone }),
+      });
+      const d = await res.json();
+      if (res.ok && d.ok) {
+        setState({ phase: "done", message: d.message || "Thank you — your voucher is in your account." });
+      } else {
+        setError(d.error || "Something went wrong. Please try again.");
+      }
+    } catch {
+      setError("Network error. Please try again.");
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <div className="min-h-screen bg-[#F5F1EA] flex items-center justify-center p-4">
+      <div className="w-full max-w-sm rounded-2xl bg-white p-6 shadow-sm">
+        <div className="text-center">
+          <p className="font-heading text-2xl font-bold text-[#1A0200]">Celsius Coffee</p>
+          <div className="mx-auto mt-3 h-px w-12 bg-[#D2965C]" />
+        </div>
+
+        {state.phase === "loading" && (
+          <p className="mt-6 text-center text-sm text-neutral-500">Checking your link…</p>
+        )}
+
+        {state.phase === "invalid" && (
+          <div className="mt-6 text-center">
+            <p className="text-base font-semibold text-[#1A0200]">This link isn't valid</p>
+            <p className="mt-2 text-sm text-neutral-500">
+              The recovery link may have expired or been mistyped. Please reply to our message on Google and we'll sort it out.
+            </p>
+          </div>
+        )}
+
+        {state.phase === "claimed" && (
+          <div className="mt-6 text-center">
+            <p className="text-base font-semibold text-[#1A0200]">You're all set</p>
+            <p className="mt-2 text-sm text-neutral-500">
+              You've already claimed this — your free coffee is in your account. See you soon.
+            </p>
+          </div>
+        )}
+
+        {state.phase === "done" && (
+          <div className="mt-6 text-center">
+            <div className="mx-auto flex h-12 w-12 items-center justify-center rounded-full bg-[#1A0200] text-white text-xl">✓</div>
+            <p className="mt-3 text-base font-semibold text-[#1A0200]">Thank you</p>
+            <p className="mt-2 text-sm text-neutral-600">{state.message}</p>
+          </div>
+        )}
+
+        {state.phase === "form" && (
+          <div className="mt-6">
+            <p className="text-center text-sm text-neutral-600">
+              We're sorry your visit to <span className="font-medium text-[#1A0200]">{state.outletName}</span> fell short.
+              Leave your number and we'll put <span className="font-medium text-[#1A0200]">a free coffee</span> in your account to make it right.
+            </p>
+            <div className="mt-5 space-y-3">
+              <input
+                value={name}
+                onChange={(e) => setName(e.target.value)}
+                placeholder="Your name (optional)"
+                className="w-full rounded-lg border border-neutral-200 px-3 py-2.5 text-sm outline-none focus:border-[#1A0200]"
+              />
+              <input
+                value={phone}
+                onChange={(e) => setPhone(e.target.value)}
+                inputMode="tel"
+                placeholder="Mobile number (e.g. 0123456789)"
+                className="w-full rounded-lg border border-neutral-200 px-3 py-2.5 text-sm outline-none focus:border-[#1A0200]"
+              />
+              {error && <p className="text-sm text-red-600">{error}</p>}
+              <button
+                onClick={submit}
+                disabled={submitting || !phone.trim()}
+                className="w-full rounded-lg bg-[#1A0200] py-3 text-sm font-semibold text-white disabled:opacity-50"
+              >
+                {submitting ? "Sending…" : "Claim my free coffee"}
+              </button>
+              <p className="text-center text-[11px] text-neutral-400">
+                By continuing you agree to join Celsius rewards so we can send your voucher.
+              </p>
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/backoffice/src/app/recover/[code]/page.tsx
+++ b/apps/backoffice/src/app/recover/[code]/page.tsx
@@ -69,18 +69,18 @@ export default function RecoverPage({ params }: { params: Promise<{ code: string
 
         {state.phase === "invalid" && (
           <div className="mt-6 text-center">
-            <p className="text-base font-semibold text-[#1A0200]">This link isn't valid</p>
+            <p className="text-base font-semibold text-[#1A0200]">This link isn’t valid</p>
             <p className="mt-2 text-sm text-neutral-500">
-              The recovery link may have expired or been mistyped. Please reply to our message on Google and we'll sort it out.
+              The recovery link may have expired or been mistyped. Please reply to our message on Google and we’ll sort it out.
             </p>
           </div>
         )}
 
         {state.phase === "claimed" && (
           <div className="mt-6 text-center">
-            <p className="text-base font-semibold text-[#1A0200]">You're all set</p>
+            <p className="text-base font-semibold text-[#1A0200]">You’re all set</p>
             <p className="mt-2 text-sm text-neutral-500">
-              You've already claimed this — your free coffee is in your account. See you soon.
+              You’ve already claimed this — your free coffee is in your account. See you soon.
             </p>
           </div>
         )}
@@ -96,8 +96,8 @@ export default function RecoverPage({ params }: { params: Promise<{ code: string
         {state.phase === "form" && (
           <div className="mt-6">
             <p className="text-center text-sm text-neutral-600">
-              We're sorry your visit to <span className="font-medium text-[#1A0200]">{state.outletName}</span> fell short.
-              Leave your number and we'll put <span className="font-medium text-[#1A0200]">a free coffee</span> in your account to make it right.
+              We’re sorry your visit to <span className="font-medium text-[#1A0200]">{state.outletName}</span> fell short.
+              Leave your number and we’ll put <span className="font-medium text-[#1A0200]">a free coffee</span> in your account to make it right.
             </p>
             <div className="mt-5 space-y-3">
               <input

--- a/apps/backoffice/src/lib/loyalty/loop-engine.ts
+++ b/apps/backoffice/src/lib/loyalty/loop-engine.ts
@@ -306,7 +306,7 @@ function shuffle<T>(arr: T[]): T[] {
 // eyebrow + styling ("Birthday gift", gift icon) instead of a generic
 // "Welcome back" campaign card. Attribution keys off source_ref_id (the round
 // id), NOT source_type, so this is display-only and safe to vary per loop.
-async function issueReward(memberId: string, templateId: string, roundId: string, sourceType: string): Promise<{ id: string; cogsRm: number } | null> {
+export async function issueReward(memberId: string, templateId: string, roundId: string, sourceType: string): Promise<{ id: string; cogsRm: number } | null> {
   const { data: tpl } = await supabaseAdmin
     .from("voucher_templates")
     .select(`id, title, description, icon, category, validity_days, discount_type, discount_value, min_order_value, applicable_categories, applicable_products, free_product_name, stacks_with_beans`)

--- a/apps/backoffice/src/lib/reviews/auto-reply.ts
+++ b/apps/backoffice/src/lib/reviews/auto-reply.ts
@@ -9,10 +9,6 @@ import Anthropic from "@anthropic-ai/sdk";
 
 const anthropic = new Anthropic({ apiKey: process.env.ANTHROPIC_API_KEY });
 
-// Negative-review escalation contact (used in the negative prompt only).
-export const MANAGER_NAME = "Adam";
-export const MANAGER_PHONE = "+60 17-657 9149";
-
 // 4-5 = positive (safe to auto-post). 1-3 = negative (human-approval path).
 export const POSITIVE_THRESHOLD = 4;
 
@@ -21,25 +17,38 @@ export type ReviewForReply = {
   reviewer: string;
   comment?: string;
   outletName: string;
+  context?: string; // approver's notes on what actually happened — for regeneration
 };
 
 /** Generate a Google review reply in the Celsius owner voice. */
 export async function generateReply(review: ReviewForReply): Promise<string> {
   const isPositive = review.rating >= POSITIVE_THRESHOLD;
 
+  const contextBlock = review.context?.trim()
+    ? `\nWhat actually happened (context from our team — use it to respond honestly and specifically; name the cause and any fix that's coming, but never make excuses):\n${review.context.trim()}\n`
+    : "";
+
   const prompt = isPositive
-    ? `You are the owner of Celsius Coffee (${review.outletName}), a specialty coffee brand in Malaysia. Write a short, warm reply to this positive Google review. Be genuine, not generic. Thank them specifically for what they mentioned. Keep it 2-3 sentences max. Do not use emojis excessively — 1 max if any.
+    ? `You are the owner of Celsius Coffee (${review.outletName}), a specialty coffee café in Malaysia, replying to a happy Google review. Write a short, warm, genuine thank-you — like a real person, not a brand. Vary your opening (do not always start with "Thank you"). Mention something specific they said. 1-2 short sentences. At most one emoji, usually none.
 
 Reviewer: ${review.reviewer}
 Rating: ${review.rating}/5
 Review: ${review.comment || "(no comment, just a rating)"}
 
 Reply:`
-    : `You are the owner of Celsius Coffee (${review.outletName}), a specialty coffee brand in Malaysia. Write a calm, professional reply to this negative Google review. Be empathetic, acknowledge their concern without being defensive. End with a CTA to contact our Area Manager ${MANAGER_NAME} at ${MANAGER_PHONE} so we can make it right. Keep it 3-4 sentences. Do not use emojis.
+    : `You are the owner of Celsius Coffee (${review.outletName}), a specialty coffee café in Malaysia, replying personally to a critical Google review. Write like a real owner who genuinely cares — NOT a corporate template.
 
+Rules:
+- Do NOT open with "Dear ${review.reviewer}, thank you for taking the time to share your feedback" or any stock phrase. Vary the opening and sound human.
+- Respond to the SPECIFIC things they raised (name the actual issues). No generic platitudes like "fell short of the standards we hold ourselves to".
+- Be warm and accountable; don't be defensive and don't over-apologise.
+- Format as 2-3 SHORT paragraphs separated by a blank line. No wall of text.
+- Do NOT include any phone number, contact details, or "get in touch" line — that is appended separately afterwards.
+- No emojis. Keep it tight: 3-5 short sentences total.
+${contextBlock}
 Reviewer: ${review.reviewer}
 Rating: ${review.rating}/5
-Review: ${review.comment || "(no comment, just a low rating)"}
+Their review: ${review.comment || "(no comment, just a low rating)"}
 
 Reply:`;
 

--- a/apps/backoffice/src/lib/reviews/recovery.ts
+++ b/apps/backoffice/src/lib/reviews/recovery.ts
@@ -1,0 +1,196 @@
+/**
+ * Service-recovery helpers for the negative-review case manager.
+ *
+ * A negative review's approved reply carries a single-use recovery code. The
+ * customer enters it on the public form, which captures their phone into
+ * loyalty and issues a voucher TAGGED to the originating review (source_ref_id
+ * = caseId), so every free item traces back to a specific approved complaint.
+ */
+import { supabaseAdmin } from "@/lib/loyalty/supabase";
+import { issueReward } from "@/lib/loyalty/loop-engine";
+import { prisma } from "@/lib/prisma";
+
+const BRAND = "brand-celsius";
+
+// Free Coffee — low-COGS, margin-safe (voucher_templates).
+export const RECOVERY_VOUCHER_TEMPLATE = "206b5fbf-c12a-44e5-ad30-85a9e8a81439";
+
+// No ambiguous chars (0/O/1/I/L) so a customer can read it off a plain-text
+// Google reply and type it without confusion.
+const CODE_ALPHABET = "ABCDEFGHJKMNPQRSTUVWXYZ23456789";
+
+export function genRecoveryCode(len = 6): string {
+  let out = "";
+  for (let i = 0; i < len; i++) {
+    out += CODE_ALPHABET[Math.floor(Math.random() * CODE_ALPHABET.length)];
+  }
+  return out;
+}
+
+function phoneVariants(phone: string): string[] {
+  const d = phone.replace(/\D/g, "");
+  const variants: string[] = [phone];
+  if (d.startsWith("60")) variants.push(`+${d}`, d, `0${d.slice(2)}`);
+  else if (d.startsWith("0")) variants.push(`+6${d}`, `6${d}`, d);
+  else variants.push(`+60${d}`, `60${d}`, `0${d}`);
+  return [...new Set(variants)];
+}
+
+function canonicalisePhone(phone: string): string {
+  const d = phone.replace(/\D/g, "");
+  if (d.startsWith("60")) return `+${d}`;
+  if (d.startsWith("0")) return `+6${d}`;
+  return `+60${d}`;
+}
+
+/** Basic sanity check for a Malaysian mobile (after stripping non-digits). */
+export function isValidMyPhone(phone: string): boolean {
+  const d = phone.replace(/\D/g, "");
+  // 01XXXXXXXX (10-11 digits) or 601XXXXXXXX
+  return /^(0|60)1\d{7,9}$/.test(d);
+}
+
+/**
+ * Find a member by any phone variant, else create one. Mirrors the order app's
+ * findOrCreateMember row shape so a recovered customer is indistinguishable
+ * from any other signup. Fills name on create / when previously blank.
+ */
+export async function findOrCreateMemberByPhone(
+  phone: string,
+  name?: string | null,
+): Promise<{ id: string; isNew: boolean } | null> {
+  const variants = phoneVariants(phone);
+
+  const { data: existing } = await supabaseAdmin
+    .from("members")
+    .select("id, name")
+    .in("phone", variants)
+    .limit(1);
+
+  let memberId: string;
+  let isNew = false;
+
+  if (existing && existing.length > 0) {
+    memberId = (existing[0] as { id: string }).id;
+    if (name && !(existing[0] as { name: string | null }).name) {
+      await supabaseAdmin.from("members").update({ name }).eq("id", memberId);
+    }
+  } else {
+    const newId = `member-${Date.now()}-${Math.random().toString(36).slice(2, 6)}`;
+    const { data: inserted, error } = await supabaseAdmin
+      .from("members")
+      .insert({
+        id: newId,
+        phone: canonicalisePhone(phone),
+        name: name ?? null,
+        email: null,
+        birthday: null,
+        sms_opt_out: false,
+        consent_at: new Date().toISOString(),
+      })
+      .select("id")
+      .single();
+    if (error || !inserted) {
+      console.error("[recovery] member insert failed", error?.message);
+      return null;
+    }
+    memberId = (inserted as { id: string }).id;
+    isNew = true;
+  }
+
+  // Ensure brand enrollment (idempotent).
+  const { data: brandRow } = await supabaseAdmin
+    .from("member_brands")
+    .select("id")
+    .eq("member_id", memberId)
+    .eq("brand_id", BRAND)
+    .maybeSingle();
+  if (!brandRow) {
+    await supabaseAdmin.from("member_brands").insert({
+      id: `mb-${Date.now()}-${Math.random().toString(36).slice(2, 6)}`,
+      member_id: memberId,
+      brand_id: BRAND,
+      points_balance: 0,
+      total_points_earned: 0,
+      total_points_redeemed: 0,
+      total_visits: 0,
+      total_spent: 0,
+    });
+  }
+
+  return { id: memberId, isNew };
+}
+
+/** Has this member already been issued a recovery voucher? (one-per-member gate) */
+export async function hasRecoveryVoucher(memberId: string): Promise<boolean> {
+  const { data } = await supabaseAdmin
+    .from("issued_rewards")
+    .select("id")
+    .eq("member_id", memberId)
+    .eq("source_type", "recovery")
+    .limit(1);
+  return !!(data && data.length > 0);
+}
+
+/** Issue the recovery voucher, tagged to the case (review) for audit + dedup. */
+export async function issueRecoveryVoucher(
+  memberId: string,
+  caseId: string,
+): Promise<{ id: string } | null> {
+  const res = await issueReward(memberId, RECOVERY_VOUCHER_TEMPLATE, caseId, "recovery");
+  return res ? { id: res.id } : null;
+}
+
+export type CompensateResult =
+  | { ok: true; alreadyCompensated: boolean; memberId: string; rewardId: string | null }
+  | { ok: false; error: string };
+
+/**
+ * Capture a customer into loyalty + issue the recovery voucher for a case, then
+ * move the case to "compensated". Shared by the public recovery form (claimed
+ * via code) and the manager's manual-compensate action. Idempotent: a case
+ * already compensated/resolved returns its existing linkage; a member who
+ * already holds a recovery voucher isn't double-issued.
+ */
+export async function compensateReviewCase(
+  caseId: string,
+  phone: string,
+  name?: string | null,
+): Promise<CompensateResult> {
+  const c = await prisma.reviewReplyDraft.findUnique({ where: { id: caseId } });
+  if (!c) return { ok: false, error: "Case not found" };
+  if (c.status === "compensated" || c.status === "resolved") {
+    return {
+      ok: true,
+      alreadyCompensated: true,
+      memberId: c.recoveryMemberId ?? "",
+      rewardId: c.recoveryRewardId,
+    };
+  }
+  if (c.status !== "approved") {
+    return { ok: false, error: `This case is ${c.status}, not awaiting recovery` };
+  }
+  if (!isValidMyPhone(phone)) return { ok: false, error: "Enter a valid Malaysian mobile number" };
+
+  const member = await findOrCreateMemberByPhone(phone, name);
+  if (!member) return { ok: false, error: "Could not create loyalty member" };
+
+  let rewardId: string | null = null;
+  if (!(await hasRecoveryVoucher(member.id))) {
+    const voucher = await issueRecoveryVoucher(member.id, caseId);
+    if (!voucher) return { ok: false, error: "Could not issue voucher" };
+    rewardId = voucher.id;
+  }
+
+  await prisma.reviewReplyDraft.update({
+    where: { id: caseId },
+    data: {
+      status: "compensated",
+      claimedAt: new Date(),
+      recoveryMemberId: member.id,
+      recoveryRewardId: rewardId ?? c.recoveryRewardId,
+    },
+  });
+
+  return { ok: true, alreadyCompensated: false, memberId: member.id, rewardId };
+}

--- a/apps/backoffice/src/middleware.ts
+++ b/apps/backoffice/src/middleware.ts
@@ -66,6 +66,7 @@ export async function middleware(request: NextRequest) {
     pathname === "/reset-password" ||
     pathname.startsWith("/r/") ||
     pathname.startsWith("/review/") ||
+    pathname.startsWith("/recover/") ||
     pathname.startsWith("/api/") ||
     pathname.startsWith("/_next") ||
     pathname === "/favicon.ico" ||

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -1348,9 +1348,21 @@ model ReviewReplyDraft {
   comment      String?
   draftReply   String // AI-generated draft
   finalReply   String? // what was actually posted (if edited on approval)
-  status       String    @default("pending") // pending | approved | rejected | resolved
+  // pending(new) | approved(awaiting customer) | compensated | resolved | rejected | expired
+  status       String    @default("pending")
   decidedBy    String? // user who approved/rejected
   decidedAt    DateTime?
+  // Recovery: single-use code in the approved reply → public form → voucher
+  recoveryCode     String?   @unique
+  recoveryCodeAt   DateTime?
+  claimedAt        DateTime? // customer submitted the recovery form
+  recoveryMemberId String? // loyalty member captured
+  recoveryRewardId String? // issued voucher (tagged to this review)
+  redeemedAt       DateTime? // voucher actually used — true recovery
+  // Resolution
+  resolvedAt     DateTime?
+  resolvedBy     String?
+  resolutionNote String?
   createdAt    DateTime  @default(now())
   updatedAt    DateTime  @updatedAt
 

--- a/supabase/migrations/054_review_case_lifecycle.sql
+++ b/supabase/migrations/054_review_case_lifecycle.sql
@@ -1,0 +1,30 @@
+-- 054_review_case_lifecycle.sql
+-- Grow ReviewReplyDraft from a reply-draft into a full negative-review CASE
+-- record, tracked through to compensation/resolution.
+--
+-- status lifecycle (text, no DB constraint — kept flexible):
+--   pending     → NEW, AI-drafted, awaiting manager
+--   approved    → reply posted + recovery code live, AWAITING CUSTOMER
+--   compensated → customer claimed the code, captured into loyalty + voucher issued
+--   resolved    → made whole (voucher redeemed, or manager closed)
+--   rejected    → manager declined (fake / no action)
+--   expired     → recovery code never claimed
+--
+-- Recovery: the approved public reply carries a single-use "recoveryCode".
+-- The customer enters it on the public recovery form, which captures their
+-- phone into loyalty and issues a voucher tagged to this review (misuse gate).
+
+ALTER TABLE "ReviewReplyDraft"
+  ADD COLUMN IF NOT EXISTS "recoveryCode"     text,
+  ADD COLUMN IF NOT EXISTS "recoveryCodeAt"   timestamptz,
+  ADD COLUMN IF NOT EXISTS "claimedAt"        timestamptz,
+  ADD COLUMN IF NOT EXISTS "recoveryMemberId" text,
+  ADD COLUMN IF NOT EXISTS "recoveryRewardId" text,
+  ADD COLUMN IF NOT EXISTS "redeemedAt"       timestamptz,
+  ADD COLUMN IF NOT EXISTS "resolvedAt"       timestamptz,
+  ADD COLUMN IF NOT EXISTS "resolvedBy"       text,
+  ADD COLUMN IF NOT EXISTS "resolutionNote"   text;
+
+-- Single-use codes. NULLs are distinct in Postgres, so un-coded rows are fine.
+CREATE UNIQUE INDEX IF NOT EXISTS "ReviewReplyDraft_recoveryCode_key"
+  ON "ReviewReplyDraft" ("recoveryCode");


### PR DESCRIPTION
Builds on #484 (positive auto-reply) and #486 (negative approval gate). Turns the negative-review gate into a **one-page case manager** that drives every 1–3★ review to a compensated customer.

## Lifecycle
```
pending(new) → approved(awaiting customer) → compensated → resolved
               ↘ rejected             ↘ expired (code unclaimed)
```
A case stays **open until the customer is made whole** (compensated), then resolved.

## What's in it
- **`/reviews/feedback`** — one board: status filters + counts, editable AI drafts, and per-case actions (Approve & Post · Reject · Compensate manually · Mark resolved · No response). Linked from the Reviews header.
- **Recovery, gated against misuse** — approving a negative review mints a **single-use recovery code** and appends a deterministic recovery link to the posted reply (built in code, never by the LLM — Google replies are plain text). No code → no voucher; one use; one review.
- **Public claim form `/recover/[code]`** (no auth — the code is the credential): captures name + phone → `findOrCreateMember` → issues the **Free Coffee** voucher **tagged to the originating review** (`source_type=recovery`, `source_ref_id=caseId`) → best-effort SMS. **One voucher per member** (dedup).
- **`/api/reviews/negatives/decide`** now handles approve / reject / compensate / resolve / expire; **`/api/recovery`** is the public claim endpoint; cases list gains `?scope=all`.

## Data / infra
- Migration `054_review_case_lifecycle.sql` — extends `ReviewReplyDraft` with recovery + resolution columns. **Applied to the live DB via manual SQL** (not `prisma db push`).
- Reuses `issueReward` (now exported) so recovery vouchers render like every other loop voucher.
- `/recover/` added to the middleware public allowlist.

## Safety
- A 1–3★ review never auto-posts and never auto-compensates — a human approves the reply, and a voucher only issues against a valid single-use code (or a manager's explicit manual action). Every voucher is auditable back to its review.

## Verification
- `tsc --noEmit` clean on backoffice.
- Migration applied + confirmed on the live project.

Internal QR feedback can fold into the same board as a fast-follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)