### PR TITLE
fix(pos-native): stop the POS app from blocking café music (audio focus)

### DIFF
--- a/apps/pos-native/lib/chime.ts
+++ b/apps/pos-native/lib/chime.ts
@@ -11,10 +11,30 @@
  * native module isn't compiled in. Every call is fire-and-forget + fully
  * crash-safe — a sound must never be able to break the order / print flow.
  */
-import { createAudioPlayer, type AudioPlayer } from "expo-audio";
+import { createAudioPlayer, setAudioModeAsync, type AudioPlayer } from "expo-audio";
 import DeviceSpeaker from "@/modules/device-speaker";
 
 type Sound = "chime" | "alarm";
+
+// Make our cues NON-exclusive so the café's Bluetooth music keeps playing while
+// the POS app is open. expo-audio's default takes exclusive Android audio focus
+// the moment a player exists/plays, which PAUSES every other app's audio for as
+// long as the POS is foregrounded — staff reported music wouldn't play with the
+// app open. "duckOthers" lets a cue briefly dip the music instead of killing it,
+// and never seizes focus. Set once, fire-and-forget, never throws into callers.
+let audioModeReady = false;
+function ensureMixableAudioMode(): void {
+  if (audioModeReady) return;
+  audioModeReady = true;
+  try {
+    void setAudioModeAsync({
+      playsInSilentMode: true,
+      shouldPlayInBackground: false,
+      interruptionMode: "duckOthers",
+      interruptionModeAndroid: "duckOthers",
+    }).catch(() => { /* best-effort: a cue must never break the order flow */ });
+  } catch { /* ignore */ }
+}
 
 const SOURCES: Record<Sound, number> = {
   chime: require("../assets/chime.wav"),
@@ -43,6 +63,7 @@ function getPlayer(sound: Sound): AudioPlayer | null {
  * native DeviceSpeaker module isn't compiled in.
  */
 function playViaExpoAudio(sound: Sound): void {
+  ensureMixableAudioMode();
   const p = getPlayer(sound);
   if (!p) return;
   try {
@@ -75,8 +96,15 @@ function play(sound: Sound): void {
   playViaExpoAudio(sound);
 }
 
-/** Pre-create the players at mount so the first real sound has no decode lag. */
+/** Pre-create the players at mount so the first real sound has no decode lag.
+ *  On the SUNMI the cues play through the native DeviceSpeaker, so creating the
+ *  expo-audio players there is pure overhead AND activates the Android audio
+ *  session that blocked the café music — so we DON'T prime them when the native
+ *  module is present (the expo-audio path is a fallback, primed lazily only if
+ *  native playback ever fails). */
 export function primeSounds(): void {
+  ensureMixableAudioMode();
+  if (DeviceSpeaker) return; // native handles playback — don't touch the audio session
   getPlayer("chime");
   getPlayer("alarm");
 }


### PR DESCRIPTION
## Symptom
Staff report the café's Bluetooth music **won't play while the POS app is open** — and they changed nothing. The trigger: the tills relaunched onto the new OTA bundle, which is when the app's audio init started running on the floor.

## Root cause
`chime.ts`'s `primeSounds()` creates two **expo-audio** players at app launch. expo-audio (~1.1.1) takes **exclusive Android audio focus** when a player is active, which **pauses every other app's audio** for as long as the POS is foregrounded. On the SUNMI those players are never even used — cues play through the **native DeviceSpeaker** — so they do nothing but hijack the audio session and block the music.

## Fix (JS-only → OTA)
1. **`setAudioModeAsync({ interruptionMode/Android: "duckOthers" })`** — our cues never seize focus; a chime briefly *ducks* the music instead of killing it.
2. **Don't create the expo-audio players when the native DeviceSpeaker is present** — so on the SUNMI the expo-audio session is never activated at all (the expo path stays as a lazy fallback if native ever fails).

## Test plan
- [x] `chime.ts` type-clean (CI `typecheck-native` validates the `setAudioModeAsync` API against full deps)
- [ ] Play café music over Bluetooth, open the POS app → music keeps playing
- [ ] New order arrives → chime sounds on the till's built-in speaker; music ducks briefly, then continues
- [ ] Confirm chime/alarm still audible (native DeviceSpeaker path unchanged)

⚠️ Worth a quick on-device check on one till after it picks up this OTA, since audio focus behaviour can't be verified off-device.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01SXF3GNPYGpZzwMWy9AR9DV)_