### PR TITLE
feat(reviews): retire approval tab, configurable recovery URL, fold in QR feedback

### DIFF
--- a/apps/backoffice/src/app/(admin)/reviews/feedback/page.tsx
+++ b/apps/backoffice/src/app/(admin)/reviews/feedback/page.tsx
@@ -17,10 +17,12 @@ import {
 
 type Case = {
   id: string;
+  source: "google" | "qr";
   reviewId: string;
   outletId: string;
   outletName: string;
   reviewerName: string | null;
+  phone: string | null;
   rating: number;
   comment: string | null;
   draftReply: string;
@@ -37,21 +39,23 @@ type Case = {
 };
 
 const FILTERS: { key: string; label: string; match: (s: string) => boolean }[] = [
-  { key: "needs_reply", label: "Needs reply", match: (s) => s === "pending" },
+  { key: "needs_action", label: "Needs action", match: (s) => s === "pending" || s === "open" },
   { key: "awaiting", label: "Awaiting customer", match: (s) => s === "approved" },
   { key: "compensated", label: "Compensated", match: (s) => s === "compensated" },
   { key: "resolved", label: "Resolved", match: (s) => s === "resolved" },
-  { key: "closed", label: "Closed", match: (s) => s === "rejected" || s === "expired" },
+  { key: "closed", label: "Closed", match: (s) => s === "rejected" || s === "expired" || s === "dismissed" },
   { key: "all", label: "All", match: () => true },
 ];
 
 const STATUS_BADGE: Record<string, { label: string; cls: string }> = {
   pending: { label: "Needs reply", cls: "bg-amber-100 text-amber-800" },
+  open: { label: "New feedback", cls: "bg-amber-100 text-amber-800" },
   approved: { label: "Awaiting customer", cls: "bg-blue-100 text-blue-800" },
   compensated: { label: "Compensated", cls: "bg-emerald-100 text-emerald-800" },
   resolved: { label: "Resolved", cls: "bg-neutral-200 text-neutral-700" },
   rejected: { label: "Rejected", cls: "bg-neutral-200 text-neutral-500" },
   expired: { label: "Expired", cls: "bg-neutral-200 text-neutral-500" },
+  dismissed: { label: "Dismissed", cls: "bg-neutral-200 text-neutral-500" },
 };
 
 function StarRow({ rating }: { rating: number }) {
@@ -81,7 +85,7 @@ function timeAgo(d: string | null): string {
 export default function FeedbackManagementPage() {
   const [cases, setCases] = useState<Case[] | null>(null);
   const [syncing, setSyncing] = useState(false);
-  const [filter, setFilter] = useState("needs_reply");
+  const [filter, setFilter] = useState("needs_action");
   const [edits, setEdits] = useState<Record<string, string>>({});
   const [busy, setBusy] = useState<Record<string, boolean>>({});
   const [comp, setComp] = useState<Record<string, { phone: string; name: string }>>({});
@@ -115,7 +119,7 @@ export default function FeedbackManagementPage() {
       const res = await fetch("/api/reviews/negatives/decide", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ id: c.id, action, ...extra }),
+        body: JSON.stringify({ id: c.id, source: c.source, action, ...extra }),
       });
       if (res.ok) {
         await load(false);
@@ -162,7 +166,7 @@ export default function FeedbackManagementPage() {
             <ArrowLeft className="h-3.5 w-3.5" /> Back to Reviews
           </Link>
           <h1 className="font-heading text-2xl font-bold text-foreground">Feedback Management</h1>
-          <p className="text-sm text-muted-foreground">Every negative review, worked through to a compensated customer.</p>
+          <p className="text-sm text-muted-foreground">Every negative Google review and QR feedback, worked through to a compensated customer.</p>
         </div>
         <button
           onClick={() => load(true)}
@@ -218,7 +222,10 @@ export default function FeedbackManagementPage() {
                     </div>
                     <p className="mt-0.5 text-xs text-muted-foreground">{c.outletName} · {timeAgo(c.createdAt)}</p>
                   </div>
-                  <span className={`shrink-0 rounded-full px-2.5 py-1 text-xs font-medium ${badge.cls}`}>{badge.label}</span>
+                  <div className="flex shrink-0 items-center gap-1.5">
+                    <span className="rounded-full bg-neutral-100 px-2 py-1 text-[11px] font-medium text-neutral-600">{c.source === "qr" ? "QR" : "Google"}</span>
+                    <span className={`rounded-full px-2.5 py-1 text-xs font-medium ${badge.cls}`}>{badge.label}</span>
+                  </div>
                 </div>
 
                 {c.comment && (
@@ -337,6 +344,54 @@ export default function FeedbackManagementPage() {
                   </div>
                 )}
 
+                {/* QR FEEDBACK (open) — we already have their phone; compensate directly */}
+                {c.status === "open" && (
+                  <div className="mt-3 space-y-2">
+                    {c.phone ? (
+                      <p className="text-xs text-muted-foreground">Contact: <span className="font-medium text-foreground">{c.phone}</span></p>
+                    ) : (
+                      <p className="text-xs text-amber-700">No phone on this feedback — enter one to compensate.</p>
+                    )}
+                    {compForm ? (
+                      <div className="rounded-lg border border-border p-2">
+                        <div className="flex flex-wrap items-center gap-2">
+                          <input
+                            value={compForm.phone}
+                            onChange={(e) => setComp((m) => ({ ...m, [c.id]: { ...compForm, phone: e.target.value } }))}
+                            placeholder="01XXXXXXXX"
+                            inputMode="tel"
+                            className="w-40 rounded-lg border border-border px-2 py-1.5 text-sm outline-none focus:ring-2 focus:ring-ring/50"
+                          />
+                          <button
+                            onClick={() => act(c, "compensate", { phone: compForm.phone, name: compForm.name })}
+                            disabled={isBusy || !compForm.phone.trim()}
+                            className="flex items-center gap-1.5 rounded-lg bg-emerald-600 px-3 py-1.5 text-sm font-medium text-white hover:bg-emerald-700 disabled:opacity-50"
+                          >
+                            <Gift className="h-4 w-4" /> Issue voucher
+                          </button>
+                        </div>
+                      </div>
+                    ) : (
+                      <div className="flex flex-wrap items-center gap-2">
+                        <button
+                          onClick={() => (c.phone ? act(c, "compensate", {}) : setComp((m) => ({ ...m, [c.id]: { phone: "", name: c.reviewerName ?? "" } })))}
+                          disabled={isBusy}
+                          className="flex items-center gap-1.5 rounded-lg bg-emerald-600 px-3 py-2 text-sm font-medium text-white hover:bg-emerald-700 disabled:opacity-50"
+                        >
+                          <Gift className="h-4 w-4" /> Compensate (free coffee)
+                        </button>
+                        <button
+                          onClick={() => act(c, "dismiss")}
+                          disabled={isBusy}
+                          className="rounded-lg border border-border bg-white px-3 py-2 text-sm font-medium text-muted-foreground hover:bg-muted disabled:opacity-50"
+                        >
+                          Dismiss
+                        </button>
+                      </div>
+                    )}
+                  </div>
+                )}
+
                 {/* COMPENSATED — show capture + resolve */}
                 {c.status === "compensated" && (
                   <div className="mt-3 space-y-2">
@@ -354,7 +409,7 @@ export default function FeedbackManagementPage() {
                 )}
 
                 {/* CLOSED states */}
-                {(c.status === "resolved" || c.status === "rejected" || c.status === "expired") && c.resolvedAt && (
+                {(c.status === "resolved" || c.status === "rejected" || c.status === "expired" || c.status === "dismissed") && c.resolvedAt && (
                   <p className="mt-2 text-xs text-muted-foreground">
                     {badge.label}{c.decidedBy ? ` by ${c.decidedBy}` : ""} · {timeAgo(c.resolvedAt)}
                   </p>

--- a/apps/backoffice/src/app/(admin)/reviews/page.tsx
+++ b/apps/backoffice/src/app/(admin)/reviews/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useState } from "react";
 import {
   Star,
   Search,
@@ -71,18 +71,6 @@ type DashboardResponse = {
   outlets: OutletSummary[];
   allGoogleReviews: DashboardGoogleReview[];
   allFeedbacks: DashboardFeedback[];
-};
-
-type PendingDraft = {
-  id: string;
-  reviewId: string;
-  outletId: string;
-  outletName: string;
-  reviewerName: string | null;
-  rating: number;
-  comment: string | null;
-  draftReply: string;
-  createdAt: string;
 };
 
 // ─── Helpers ───────────────────────────────────────────────
@@ -869,140 +857,9 @@ function BatchAutoReplyModal({ onClose }: { onClose: () => void }) {
 
 // ─── Dashboard View ────────────────────────────────────────
 
-// ─── Negative Review Approval Queue ────────────────────────
-
-function NegativeApprovalQueue({ onCountChange }: { onCountChange?: (n: number) => void }) {
-  const [items, setItems] = useState<PendingDraft[] | null>(null);
-  const [syncing, setSyncing] = useState(false);
-  const [edits, setEdits] = useState<Record<string, string>>({});
-  const [busy, setBusy] = useState<Record<string, "approve" | "reject" | null>>({});
-
-  const load = async (sync: boolean) => {
-    setSyncing(true);
-    try {
-      const res = await fetch(`/api/reviews/negatives${sync ? "?sync=1" : ""}`);
-      const data = await res.json();
-      const pending: PendingDraft[] = data.pending ?? [];
-      setItems(pending);
-      onCountChange?.(pending.length);
-    } catch {
-      setItems([]);
-    } finally {
-      setSyncing(false);
-    }
-  };
-
-  useEffect(() => {
-    load(false);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
-
-  const decide = async (item: PendingDraft, action: "approve" | "reject") => {
-    setBusy((b) => ({ ...b, [item.id]: action }));
-    try {
-      const res = await fetch("/api/reviews/negatives/decide", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          id: item.id,
-          action,
-          reply: action === "approve" ? (edits[item.id] ?? item.draftReply) : undefined,
-        }),
-      });
-      if (res.ok) {
-        setItems((prev) => {
-          const next = (prev ?? []).filter((x) => x.id !== item.id);
-          onCountChange?.(next.length);
-          return next;
-        });
-      } else {
-        const e = await res.json().catch(() => ({}));
-        alert(e.error || "Failed to save decision");
-      }
-    } finally {
-      setBusy((b) => ({ ...b, [item.id]: null }));
-    }
-  };
-
-  return (
-    <div className="space-y-3">
-      <div className="flex items-center justify-between gap-3 rounded-xl border border-amber-200 bg-amber-50 px-4 py-3">
-        <p className="text-sm text-amber-900">
-          Negative (1-3★) reviews are drafted by AI and{" "}
-          <span className="font-semibold">held here for your approval</span> — nothing posts to Google until you approve it.
-        </p>
-        <button
-          onClick={() => load(true)}
-          disabled={syncing}
-          className="flex shrink-0 items-center gap-1.5 rounded-lg border border-amber-300 bg-white px-3 py-1.5 text-sm font-medium text-amber-900 hover:bg-amber-100 disabled:opacity-50"
-        >
-          {syncing ? <Loader2 className="h-4 w-4 animate-spin" /> : <Sparkles className="h-4 w-4" />}
-          Check Google for new
-        </button>
-      </div>
-
-      {items === null ? (
-        <div className="flex items-center justify-center py-10">
-          <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
-        </div>
-      ) : items.length === 0 ? (
-        <div className="rounded-xl border border-border bg-white p-10 text-center">
-          <Check className="mx-auto h-10 w-10 text-muted-foreground/30" />
-          <p className="mt-3 text-sm text-muted-foreground">No negative reviews waiting for approval</p>
-          <p className="mt-1 text-xs text-muted-foreground">Click “Check Google for new” to pull the latest.</p>
-        </div>
-      ) : (
-        items.map((item) => {
-          const value = edits[item.id] ?? item.draftReply;
-          const itemBusy = busy[item.id];
-          return (
-            <div key={item.id} className="rounded-xl border border-border bg-white p-4">
-              <div className="flex items-center gap-2">
-                <StarRating rating={item.rating} />
-                <span className="text-sm font-medium text-foreground">{item.reviewerName || "Anonymous"}</span>
-              </div>
-              <p className="mt-0.5 text-xs text-muted-foreground">{item.outletName} · {timeAgo(item.createdAt)}</p>
-              {item.comment && (
-                <p className="mt-2 rounded-lg bg-muted/50 p-2 text-sm text-foreground">{item.comment}</p>
-              )}
-              <div className="mt-3">
-                <p className="mb-1 text-xs font-medium text-muted-foreground">AI draft reply (edit before approving)</p>
-                <textarea
-                  value={value}
-                  onChange={(e) => setEdits((m) => ({ ...m, [item.id]: e.target.value }))}
-                  rows={3}
-                  className="w-full rounded-lg border border-border bg-white p-2 text-sm outline-none focus:ring-2 focus:ring-ring/50"
-                />
-              </div>
-              <div className="mt-2 flex items-center gap-2">
-                <button
-                  onClick={() => decide(item, "approve")}
-                  disabled={!!itemBusy || !value.trim()}
-                  className="flex items-center gap-1.5 rounded-lg bg-brand-dark px-3 py-2 text-sm font-medium text-white hover:bg-brand-dark/90 disabled:opacity-50"
-                >
-                  {itemBusy === "approve" ? <Loader2 className="h-4 w-4 animate-spin" /> : <Send className="h-4 w-4" />}
-                  Approve &amp; Post
-                </button>
-                <button
-                  onClick={() => decide(item, "reject")}
-                  disabled={!!itemBusy}
-                  className="flex items-center gap-1.5 rounded-lg border border-border bg-white px-3 py-2 text-sm font-medium text-muted-foreground hover:bg-muted disabled:opacity-50"
-                >
-                  {itemBusy === "reject" ? <Loader2 className="h-4 w-4 animate-spin" /> : <X className="h-4 w-4" />}
-                  Reject
-                </button>
-              </div>
-            </div>
-          );
-        })
-      )}
-    </div>
-  );
-}
-
 function DashboardView() {
   const [period, setPeriod] = useState<"day" | "week" | "month" | "custom">("month");
-  const [dashTab, setDashTab] = useState<"google" | "internal" | "approvals">("google");
+  const [dashTab, setDashTab] = useState<"google" | "internal">("google");
   const [search, setSearch] = useState("");
   const [filterRating, setFilterRating] = useState<number | null>(null);
   const [showFilter, setShowFilter] = useState(false);
@@ -1010,14 +867,6 @@ function DashboardView() {
   const [customTo, setCustomTo] = useState("");
   const [showBatchReply, setShowBatchReply] = useState(false);
   const [filterOutletId, setFilterOutletId] = useState<string | null>(null);
-  const [approvalCount, setApprovalCount] = useState<number | null>(null);
-
-  useEffect(() => {
-    fetch("/api/reviews/negatives")
-      .then((r) => r.json())
-      .then((d) => setApprovalCount(d.pending?.length ?? 0))
-      .catch(() => setApprovalCount(0));
-  }, []);
 
   const fetchUrl = period === "custom" && customFrom
     ? `/api/reviews/dashboard?period=custom&from=${customFrom}${customTo ? `&to=${customTo}` : ""}`
@@ -1218,14 +1067,6 @@ function DashboardView() {
           >
             Feedback ({combinedFeedback.length})
           </button>
-          <button
-            onClick={() => setDashTab("approvals")}
-            className={`px-4 py-2.5 text-sm font-medium border-b-2 transition-colors ${
-              dashTab === "approvals" ? "border-foreground text-foreground" : "border-transparent text-muted-foreground hover:text-foreground"
-            }`}
-          >
-            Needs approval{approvalCount ? ` (${approvalCount})` : ""}
-          </button>
         </div>
         <div className="flex items-center gap-2">
           <div className="relative">
@@ -1273,10 +1114,6 @@ function DashboardView() {
 
       {/* Review list */}
       <div className="mt-4 space-y-3">
-        {dashTab === "approvals" ? (
-          <NegativeApprovalQueue onCountChange={setApprovalCount} />
-        ) : (
-        <>
         {isLoading && (
           <div className="flex items-center justify-center py-10">
             <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
@@ -1326,8 +1163,6 @@ function DashboardView() {
               )
             )}
           </>
-        )}
-        </>
         )}
       </div>
     </>

--- a/apps/backoffice/src/app/api/reviews/negatives/decide/route.ts
+++ b/apps/backoffice/src/app/api/reviews/negatives/decide/route.ts
@@ -2,11 +2,17 @@ import { NextRequest, NextResponse } from "next/server";
 import { getUserFromHeaders } from "@/lib/auth";
 import { prisma } from "@/lib/prisma";
 import { replyToReview } from "@/lib/reviews/gbp";
-import { genRecoveryCode, compensateReviewCase } from "@/lib/reviews/recovery";
+import { genRecoveryCode, compensateReviewCase, compensateInternalFeedback } from "@/lib/reviews/recovery";
 
 export const dynamic = "force-dynamic";
 
-const APP_URL = process.env.NEXT_PUBLIC_APP_URL || "https://backoffice.celsiuscoffee.com";
+// Base for the customer recovery link placed in the public reply. Defaults to
+// the backoffice domain; set RECOVERY_URL_BASE to a short vanity URL (e.g.
+// https://celsiuscoffee.com/sorry) once a redirect to /recover/<code> exists,
+// so the link is easy to type off a plain-text Google reply.
+const RECOVERY_URL_BASE =
+  process.env.RECOVERY_URL_BASE ||
+  `${process.env.NEXT_PUBLIC_APP_URL || "https://backoffice.celsiuscoffee.com"}/recover`;
 
 // POST /api/reviews/negatives/decide
 // Body: { id, action, reply?, phone?, name?, note? }
@@ -19,10 +25,40 @@ export async function POST(request: NextRequest) {
   const user = await getUserFromHeaders(request.headers);
   if (!user) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
 
-  const { id, action, reply, phone, name, note } = await request.json();
+  const { id, source, action, reply, phone, name, note } = await request.json();
+  if (!id) return NextResponse.json({ error: "id required" }, { status: 400 });
+
+  const decidedBy = user.name || user.id;
+  const now = new Date();
+
+  // ── QR feedback cases: no Google reply; we already have their phone ───────
+  if (source === "qr") {
+    if (action === "compensate") {
+      const result = await compensateInternalFeedback(
+        id,
+        typeof phone === "string" ? phone : null,
+        typeof name === "string" ? name : null,
+      );
+      if (!result.ok) return NextResponse.json({ error: result.error }, { status: 400 });
+      return NextResponse.json({ id, status: "compensated", ...result });
+    }
+    if (action === "resolve" || action === "dismiss") {
+      const fb = await prisma.internalFeedback.findUnique({ where: { id } });
+      if (!fb) return NextResponse.json({ error: "Feedback not found" }, { status: 404 });
+      const status = action === "resolve" ? "resolved" : "dismissed";
+      await prisma.internalFeedback.update({
+        where: { id },
+        data: { status, resolvedAt: now, resolvedBy: decidedBy, resolutionNote: note ?? null },
+      });
+      return NextResponse.json({ id, status });
+    }
+    return NextResponse.json({ error: "Invalid action for feedback" }, { status: 400 });
+  }
+
+  // ── Google review cases ──────────────────────────────────────────────────
   const VALID = ["approve", "reject", "compensate", "resolve", "expire"];
-  if (!id || !VALID.includes(action)) {
-    return NextResponse.json({ error: "id and valid action required" }, { status: 400 });
+  if (!VALID.includes(action)) {
+    return NextResponse.json({ error: "valid action required" }, { status: 400 });
   }
 
   const draft = await prisma.reviewReplyDraft.findUnique({
@@ -30,9 +66,6 @@ export async function POST(request: NextRequest) {
     include: { outlet: { include: { reviewSettings: true } } },
   });
   if (!draft) return NextResponse.json({ error: "Case not found" }, { status: 404 });
-
-  const decidedBy = user.name || user.id;
-  const now = new Date();
 
   // ── approve / reject: only from the NEW (pending) state ──────────────────
   if (action === "reject") {
@@ -58,7 +91,7 @@ export async function POST(request: NextRequest) {
     const code = genRecoveryCode();
     // Deterministic recovery CTA — the link/code are appended in code, never by
     // the LLM, so they can't be mangled. Google replies are plain text.
-    const finalReply = `${base}\n\nWe'd like to make this right. Please visit ${APP_URL}/recover/${code} so we can reach you personally.`;
+    const finalReply = `${base}\n\nWe'd like to make this right. Please visit ${RECOVERY_URL_BASE}/${code} so we can reach you personally.`;
 
     try {
       await replyToReview(settings.gbpAccountId, settings.gbpLocationName, draft.reviewId, finalReply);

--- a/apps/backoffice/src/app/api/reviews/negatives/route.ts
+++ b/apps/backoffice/src/app/api/reviews/negatives/route.ts
@@ -110,12 +110,37 @@ export async function GET(request: NextRequest) {
     orderBy: { createdAt: "desc" },
   });
 
-  const cases = rows.map((d) => ({
+  type CaseRow = {
+    id: string;
+    source: "google" | "qr";
+    reviewId: string;
+    outletId: string;
+    outletName: string;
+    reviewerName: string | null;
+    phone: string | null;
+    rating: number;
+    comment: string | null;
+    draftReply: string;
+    finalReply: string | null;
+    status: string;
+    recoveryCode: string | null;
+    claimedAt: Date | null;
+    recoveryMemberId: string | null;
+    recoveryRewardId: string | null;
+    redeemedAt: Date | null;
+    resolvedAt: Date | null;
+    decidedBy: string | null;
+    createdAt: Date;
+  };
+
+  const googleCases: CaseRow[] = rows.map((d) => ({
     id: d.id,
+    source: "google",
     reviewId: d.reviewId,
     outletId: d.outletId,
     outletName: d.outlet.name,
     reviewerName: d.reviewerName,
+    phone: null,
     rating: d.rating,
     comment: d.comment,
     draftReply: d.draftReply,
@@ -131,7 +156,44 @@ export async function GET(request: NextRequest) {
     createdAt: d.createdAt,
   }));
 
-  const pending = cases.filter((c) => c.status === "pending");
+  // QR feedback (1-3★) folds into the same board on scope=all. It already has
+  // the customer's phone, so it skips the reply + recovery-code steps.
+  let qrCases: CaseRow[] = [];
+  if (scopeAll) {
+    const fb = await prisma.internalFeedback.findMany({
+      where: { rating: { lte: 3 } },
+      include: { outlet: { select: { name: true } } },
+      orderBy: { createdAt: "desc" },
+      take: 200,
+    });
+    qrCases = fb.map((f) => ({
+      id: f.id,
+      source: "qr",
+      reviewId: f.id,
+      outletId: f.outletId,
+      outletName: f.outlet.name,
+      reviewerName: f.name,
+      phone: f.phone,
+      rating: f.rating,
+      comment: f.feedback,
+      draftReply: "",
+      finalReply: null,
+      status: f.status,
+      recoveryCode: null,
+      claimedAt: f.compensatedAt,
+      recoveryMemberId: f.recoveryMemberId,
+      recoveryRewardId: f.recoveryRewardId,
+      redeemedAt: null,
+      resolvedAt: f.resolvedAt,
+      decidedBy: f.resolvedBy,
+      createdAt: f.createdAt,
+    }));
+  }
+
+  const cases = [...googleCases, ...qrCases].sort(
+    (a, b) => b.createdAt.getTime() - a.createdAt.getTime(),
+  );
+  const pending = googleCases.filter((c) => c.status === "pending");
 
   return NextResponse.json({ synced: sync, created, resolved, pending, cases });
 }

--- a/apps/backoffice/src/lib/reviews/recovery.ts
+++ b/apps/backoffice/src/lib/reviews/recovery.ts
@@ -194,3 +194,55 @@ export async function compensateReviewCase(
 
   return { ok: true, alreadyCompensated: false, memberId: member.id, rewardId };
 }
+
+/**
+ * Compensate an internal QR-feedback case. Unlike a Google review we already
+ * have the customer's phone, so there's no recovery code — a manager issues the
+ * voucher directly. Falls back to the phone stored on the feedback row.
+ */
+export async function compensateInternalFeedback(
+  feedbackId: string,
+  phoneOverride?: string | null,
+  name?: string | null,
+): Promise<CompensateResult> {
+  const fb = await prisma.internalFeedback.findUnique({ where: { id: feedbackId } });
+  if (!fb) return { ok: false, error: "Feedback not found" };
+  if (fb.status === "compensated" || fb.status === "resolved") {
+    return {
+      ok: true,
+      alreadyCompensated: true,
+      memberId: fb.recoveryMemberId ?? "",
+      rewardId: fb.recoveryRewardId,
+    };
+  }
+  if (fb.status !== "open") {
+    return { ok: false, error: `This feedback is ${fb.status}` };
+  }
+
+  const phone = (phoneOverride && phoneOverride.trim()) || fb.phone || "";
+  if (!isValidMyPhone(phone)) {
+    return { ok: false, error: "No valid phone on this feedback — enter one" };
+  }
+
+  const member = await findOrCreateMemberByPhone(phone, name ?? fb.name);
+  if (!member) return { ok: false, error: "Could not create loyalty member" };
+
+  let rewardId: string | null = null;
+  if (!(await hasRecoveryVoucher(member.id))) {
+    const voucher = await issueRecoveryVoucher(member.id, feedbackId);
+    if (!voucher) return { ok: false, error: "Could not issue voucher" };
+    rewardId = voucher.id;
+  }
+
+  await prisma.internalFeedback.update({
+    where: { id: feedbackId },
+    data: {
+      status: "compensated",
+      compensatedAt: new Date(),
+      recoveryMemberId: member.id,
+      recoveryRewardId: rewardId ?? fb.recoveryRewardId,
+    },
+  });
+
+  return { ok: true, alreadyCompensated: false, memberId: member.id, rewardId };
+}

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -1329,9 +1329,18 @@ model InternalFeedback {
   phone     String?
   feedback  String?
   source    String   @default("qr") // "qr" | "manual"
+  // Case lifecycle (managed in the feedback board): open | compensated | resolved | dismissed
+  status           String    @default("open")
+  recoveryMemberId String?
+  recoveryRewardId String?
+  compensatedAt    DateTime?
+  resolvedAt       DateTime?
+  resolvedBy       String?
+  resolutionNote   String?
   createdAt DateTime @default(now())
 
   @@index([outletId, createdAt])
+  @@index([status])
 }
 
 // Backoffice approval gate for NEGATIVE (1-3★) Google reviews.

--- a/supabase/migrations/055_internal_feedback_lifecycle.sql
+++ b/supabase/migrations/055_internal_feedback_lifecycle.sql
@@ -1,0 +1,17 @@
+-- 055_internal_feedback_lifecycle.sql
+-- Bring internal QR feedback (1-3★) into the same negative-feedback case manager
+-- as Google reviews. QR feedback already carries the customer's phone, so it
+-- skips the recovery-code step — a manager can compensate directly.
+--
+-- status lifecycle: open → compensated → resolved, or dismissed.
+
+ALTER TABLE "InternalFeedback"
+  ADD COLUMN IF NOT EXISTS "status"           text NOT NULL DEFAULT 'open',
+  ADD COLUMN IF NOT EXISTS "recoveryMemberId" text,
+  ADD COLUMN IF NOT EXISTS "recoveryRewardId" text,
+  ADD COLUMN IF NOT EXISTS "compensatedAt"    timestamptz,
+  ADD COLUMN IF NOT EXISTS "resolvedAt"       timestamptz,
+  ADD COLUMN IF NOT EXISTS "resolvedBy"       text,
+  ADD COLUMN IF NOT EXISTS "resolutionNote"   text;
+
+CREATE INDEX IF NOT EXISTS "InternalFeedback_status_idx" ON "InternalFeedback" ("status");


### PR DESCRIPTION
Completes the three follow-ups from the feedback-loop work (#484/#486/#487).

## 1. Retire the old approval tab
The in-page "Needs approval" tab on the Reviews page is removed — the **Feedback Management** board (`/reviews/feedback`) is now the single home for negative feedback. Removed `NegativeApprovalQueue` + its state/wiring; the header link points to the board.

## 2. Configurable recovery URL (vanity-domain ready)
New `RECOVERY_URL_BASE` env (defaults to `<NEXT_PUBLIC_APP_URL>/recover`). Set it to a short vanity base (e.g. `https://celsiuscoffee.com/sorry`) once a redirect to `/recover/<code>` exists, so the link is easy to type off a plain-text Google reply. **The final hop (DNS/redirect) is an infra step on your side.**

## 3. Fold internal QR feedback into the board
- Migration `055` (manual SQL, not `prisma db push`): `InternalFeedback` gains `status` + compensation + resolution columns.
- The board now shows **Google and QR cases side by side** with a source chip. QR feedback (1-3★) already has the customer's phone, so it **skips the reply/recovery-code steps** — a manager **Compensates** directly (issues the Free Coffee voucher, tagged to the feedback) or **Dismisses**.
- Status filters are now source-agnostic: **Needs action · Awaiting customer · Compensated · Resolved · Closed**.
- `decide` handles `source=qr` (compensate/resolve/dismiss); the cases endpoint merges QR on `?scope=all` (capped at 200 recent, rating ≤ 3).

## Notes
- Existing QR feedback rows default to `open`, so historical un-actioned complaints now surface as "Needs action" (capped at 200) — that's intentional; dismiss the stale ones.
- `tsc` + ESLint clean (0 errors). Migration applied + confirmed on the live DB.

🤖 Generated with [Claude Code](https://claude.com/claude-code)