### PR TITLE
feat(reviews): Feedback Management in sidebar + professional-empathetic reply voice

### DIFF
--- a/apps/backoffice/src/app/(admin)/layout.tsx
+++ b/apps/backoffice/src/app/(admin)/layout.tsx
@@ -329,6 +329,7 @@ const NAV_SECTIONS: NavSection[] = [
         label: "Reviews",
         items: [
           { label: "All Reviews", href: "/reviews", icon: <Star className={ICON_SIZE} />, moduleKey: "reviews:list" },
+          { label: "Feedback Management", href: "/reviews/feedback", icon: <MessageSquare className={ICON_SIZE} />, moduleKey: "reviews:list" },
         ],
       },
       {

--- a/apps/backoffice/src/lib/reviews/auto-reply.ts
+++ b/apps/backoffice/src/lib/reviews/auto-reply.ts
@@ -29,22 +29,28 @@ export async function generateReply(review: ReviewForReply): Promise<string> {
     : "";
 
   const prompt = isPositive
-    ? `You are the owner of Celsius Coffee (${review.outletName}), a specialty coffee café in Malaysia, replying to a happy Google review. Write a short, warm, genuine thank-you — like a real person, not a brand. Vary your opening (do not always start with "Thank you"). Mention something specific they said. 1-2 short sentences. At most one emoji, usually none.
+    ? `You are the owner of Celsius Coffee (${review.outletName}), a specialty coffee café in Malaysia, replying to a happy Google review. Write a warm, genuine, professional thank-you — like a real person, not a brand. Open with "Hi ${review.reviewer}," and mention something specific they enjoyed. Keep it 1-2 short sentences. At most one emoji, usually none.
 
 Reviewer: ${review.reviewer}
 Rating: ${review.rating}/5
 Review: ${review.comment || "(no comment, just a rating)"}
 
 Reply:`
-    : `You are the owner of Celsius Coffee (${review.outletName}), a specialty coffee café in Malaysia, replying personally to a critical Google review. Write like a real owner who genuinely cares — NOT a corporate template.
+    : `You are the owner of Celsius Coffee (${review.outletName}), a specialty coffee café in Malaysia, replying personally to a critical Google review. Match the warm, professional, accountable voice from this real reply of ours — copy the TONE, never the content:
+
+"Hi [Name], thank you so much for your honest feedback. We're truly sorry to hear your visit didn't meet expectations. Every guest deserves to feel welcomed and respected. We've already shared your comments with our team, and we're committed to doing better."
+
+Write a reply that is PROFESSIONAL yet genuinely EMPATHETIC.
 
 Rules:
-- Do NOT open with "Dear ${review.reviewer}, thank you for taking the time to share your feedback" or any stock phrase. Vary the opening and sound human.
-- Respond to the SPECIFIC things they raised (name the actual issues). No generic platitudes like "fell short of the standards we hold ourselves to".
-- Be warm and accountable; don't be defensive and don't over-apologise.
-- Format as 2-3 SHORT paragraphs separated by a blank line. No wall of text.
+- Open with "Hi ${review.reviewer}," then a sincere thank-you for their feedback.
+- Avoid stiff corporate clichés ("fell short of the standards we hold ourselves to") AND avoid sounding too casual or slangy ("that's on us", "no excuses", "honestly").
+- Acknowledge the SPECIFIC issues they raised with sincere empathy — name what actually went wrong.
+- Be accountable and reassuring: note that we've shared it with the team or are looking into it — but only where that reads as genuine, not a hollow promise.
+- Keep a polished, warm, respectful tone throughout.
+- Format as 2-4 SHORT paragraphs separated by a blank line. No wall of text.
 - Do NOT include any phone number, contact details, or "get in touch" line — that is appended separately afterwards.
-- No emojis. Keep it tight: 3-5 short sentences total.
+- No emojis. Keep it concise: 4-6 sentences.
 ${contextBlock}
 Reviewer: ${review.reviewer}
 Rating: ${review.rating}/5


### PR DESCRIPTION
## What
1. **Sidebar nav** — adds **Feedback Management** under Marketing → Reviews (next to All Reviews), so the board isn't only reachable via the Reviews-page header.
2. **Reply voice** — retunes the AI reply prompt to be **professional yet genuinely empathetic**, anchored to your own best past reply (the Farihainie one: *"Hi [name], thank you so much for your honest feedback… we've shared your comments with our team…"*).

## Why
The previous prompt swung too casual ("that one's on us", "I don't have an excuse"). This matches the established Celsius voice: warm, polished, accountable. Opens "Hi <name>,", names the specific issues, notes we've shared it with the team, keeps blank-line spacing — and still steers away from the stiff "fell short of the standards we hold ourselves to" cliché.

Verified with a live generation on real reviews (Raagini 1★, Daphne 1★, Nabihah 3★ with context) — output reads professional + empathetic.

After deploy I'll regenerate the existing pending drafts so the board reflects the new voice.

`tsc` + ESLint clean.