### PR TITLE
feat(whatsapp): Cloud API webhook + send-helper for internal messaging

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -34,3 +34,14 @@ TELEGRAM_BOT_TOKEN=""             # e.g. 8490404757:AAHb4Lk3GlfaGfTXVT50qA0EF6cy
 TELEGRAM_OWNER_CHAT_ID=""         # owner's Telegram chat id (numeric). DM the bot then call getUpdates to find it.
 TELEGRAM_WEBHOOK_SECRET=""        # only needed if using inventory telegram webhook
 CRON_SECRET=""                    # vercel cron bearer token
+
+# ── WhatsApp Cloud API (internal looping / customer messaging) ───
+# Official Meta WhatsApp Business Platform. App "Celsius Coffee Ops" + WABA
+# under the Celsius Coffee HQ business portfolio. Webhook lives at the
+# backoffice route /api/whatsapp/webhook (register that URL in the Meta app).
+# Setup state, ids, and remaining steps: see memory/whatsapp-cloud-api-setup.md.
+WHATSAPP_PHONE_NUMBER_ID=""        # Phone Number ID, Graph path segment (e.g. 1063521080187204)
+WHATSAPP_ACCESS_TOKEN=""           # permanent System User token (scopes: whatsapp_business_messaging + _management)
+WHATSAPP_WABA_ID=""                # WhatsApp Business Account id (e.g. 974771538513990) — template management
+WHATSAPP_APP_SECRET=""             # Meta app secret — verifies inbound X-Hub-Signature-256 (App → Settings → Basic)
+WHATSAPP_VERIFY_TOKEN=""           # random string you choose; echoed back during the GET verification handshake

--- a/apps/backoffice/src/app/api/whatsapp/webhook/route.ts
+++ b/apps/backoffice/src/app/api/whatsapp/webhook/route.ts
@@ -1,0 +1,106 @@
+/**
+ * WhatsApp Cloud API webhook receiver.
+ *
+ * GET  — Meta's verification handshake. Echoes hub.challenge when hub.mode is
+ *        "subscribe" and hub.verify_token matches WHATSAPP_VERIFY_TOKEN. Run
+ *        once when you set the callback URL in the Meta app's WhatsApp config.
+ * POST — inbound messages + delivery/read/failed statuses. Validated against
+ *        X-Hub-Signature-256 (HMAC-SHA256 of the RAW body, keyed on the app
+ *        secret). For now we log; routing inbound messages into a customer
+ *        -service flow / auto-reply is the next extension point (see TODO).
+ *
+ * CSRF: /api/whatsapp/webhook is added to middleware.ts exemptPrefixes — Meta
+ * calls carry no browser Origin header, only the HMAC signature.
+ *
+ * Callback URL to register in Meta:
+ *   https://backoffice.celsiuscoffee.com/api/whatsapp/webhook
+ */
+import { NextRequest, NextResponse } from "next/server";
+import { verifyWhatsAppSignature } from "@/lib/whatsapp";
+
+// GET — webhook verification handshake.
+export async function GET(request: NextRequest) {
+  const params = request.nextUrl.searchParams;
+  const mode = params.get("hub.mode");
+  const token = params.get("hub.verify_token");
+  const challenge = params.get("hub.challenge");
+
+  const verifyToken = process.env.WHATSAPP_VERIFY_TOKEN;
+  if (mode === "subscribe" && !!verifyToken && token === verifyToken) {
+    // Meta expects the raw challenge string echoed back with 200.
+    return new NextResponse(challenge ?? "", { status: 200 });
+  }
+  console.warn(`[whatsapp:webhook] verify failed mode=${mode} token_match=${token === verifyToken}`);
+  return new NextResponse("Forbidden", { status: 403 });
+}
+
+// POST — inbound events (messages + statuses).
+export async function POST(request: NextRequest) {
+  const rawBody = await request.text();
+  const signature = request.headers.get("x-hub-signature-256");
+
+  if (!verifyWhatsAppSignature(rawBody, signature)) {
+    // Reject silently. NEVER echo the expected signature — doing so would leak
+    // it and let an attacker forge webhooks once WHATSAPP_APP_SECRET is set.
+    console.warn(`[whatsapp:webhook] unauthorized sig_present=${!!signature}`);
+    return NextResponse.json({ error: "Invalid signature" }, { status: 401 });
+  }
+
+  let payload: WhatsAppWebhookPayload;
+  try {
+    payload = JSON.parse(rawBody);
+  } catch {
+    return NextResponse.json({ error: "Bad JSON" }, { status: 400 });
+  }
+
+  // Meta delivers a batched envelope: entry[].changes[].value.{messages,statuses}
+  for (const entry of payload.entry ?? []) {
+    for (const change of entry.changes ?? []) {
+      const value = change.value ?? {};
+      for (const msg of value.messages ?? []) {
+        const text = msg.text?.body ?? `<${msg.type}>`;
+        console.log(
+          `[whatsapp:webhook] inbound from=${msg.from} type=${msg.type} text=${JSON.stringify(text)}`,
+        );
+        // TODO: route inbound messages — open/append a customer-service thread,
+        // fire an auto-reply via sendWhatsAppText, or notify staff. The 24-hour
+        // free-form reply window opens the moment this message arrives.
+      }
+      for (const status of value.statuses ?? []) {
+        console.log(
+          `[whatsapp:webhook] status id=${status.id} status=${status.status} recipient=${status.recipient_id ?? "?"}`,
+        );
+      }
+    }
+  }
+
+  // Always 200 fast so Meta doesn't retry. Heavy work should be fire-and-forget.
+  return NextResponse.json({ received: true });
+}
+
+// Minimal shapes for the fields we read. Full schema: Cloud API webhook docs.
+interface WhatsAppWebhookPayload {
+  object?: string;
+  entry?: Array<{
+    id?: string;
+    changes?: Array<{
+      field?: string;
+      value?: {
+        messaging_product?: string;
+        metadata?: { display_phone_number?: string; phone_number_id?: string };
+        messages?: Array<{
+          from: string;
+          id: string;
+          timestamp?: string;
+          type: string;
+          text?: { body?: string };
+        }>;
+        statuses?: Array<{
+          id: string;
+          status: string;
+          recipient_id?: string;
+        }>;
+      };
+    }>;
+  }>;
+}

--- a/apps/backoffice/src/lib/whatsapp.ts
+++ b/apps/backoffice/src/lib/whatsapp.ts
@@ -1,0 +1,120 @@
+/**
+ * WhatsApp Cloud API client for Celsius BackOffice.
+ *
+ * Official Meta WhatsApp Business Platform (Cloud API) — used for the internal
+ * "looping": staff alerts, two-way customer-service replies, and POS/inventory
+ * event notifications. App "Celsius Coffee Ops" + WABA under Celsius Coffee HQ.
+ *
+ * Env vars:
+ *   WHATSAPP_PHONE_NUMBER_ID  – sender number's Phone Number ID (Graph path segment)
+ *   WHATSAPP_ACCESS_TOKEN     – permanent System User token (whatsapp_business_messaging)
+ *   WHATSAPP_WABA_ID          – WhatsApp Business Account id (template management)
+ *   WHATSAPP_APP_SECRET       – Meta app secret, verifies inbound X-Hub-Signature-256
+ *   WHATSAPP_VERIFY_TOKEN     – random string echoed back during webhook verification
+ *
+ * Setup state + ids: see memory/whatsapp-cloud-api-setup.md.
+ */
+import { createHmac, timingSafeEqual } from "crypto";
+
+// Graph API version. v23.0 verified working against the Celsius WABA (2026-06).
+const GRAPH_API_VERSION = "v23.0";
+const GRAPH_BASE = `https://graph.facebook.com/${GRAPH_API_VERSION}`;
+
+export function isWhatsAppConfigured(): boolean {
+  return !!(process.env.WHATSAPP_PHONE_NUMBER_ID && process.env.WHATSAPP_ACCESS_TOKEN);
+}
+
+/**
+ * Verify Meta's X-Hub-Signature-256 over the RAW request body, keyed on the app
+ * secret. The header format is "sha256=<hex>". Returns false when unconfigured
+ * or mismatched. Timing-safe so a failed compare never leaks the expected value.
+ */
+export function verifyWhatsAppSignature(
+  rawBody: string,
+  signatureHeader: string | null,
+): boolean {
+  const secret = process.env.WHATSAPP_APP_SECRET;
+  if (!secret || !signatureHeader) return false;
+  const expected = "sha256=" + createHmac("sha256", secret).update(rawBody).digest("hex");
+  // timingSafeEqual throws on length mismatch — guard first.
+  if (signatureHeader.length !== expected.length) return false;
+  try {
+    return timingSafeEqual(Buffer.from(signatureHeader), Buffer.from(expected));
+  } catch {
+    return false;
+  }
+}
+
+export interface WhatsAppSendResult {
+  ok: boolean;
+  status: number;
+  messageId?: string;
+  error?: string;
+}
+
+async function postMessage(body: Record<string, unknown>): Promise<WhatsAppSendResult> {
+  const phoneNumberId = process.env.WHATSAPP_PHONE_NUMBER_ID;
+  const token = process.env.WHATSAPP_ACCESS_TOKEN;
+  if (!phoneNumberId || !token) {
+    return {
+      ok: false,
+      status: 0,
+      error: "WhatsApp not configured (WHATSAPP_PHONE_NUMBER_ID / WHATSAPP_ACCESS_TOKEN)",
+    };
+  }
+  const res = await fetch(`${GRAPH_BASE}/${phoneNumberId}/messages`, {
+    method: "POST",
+    headers: { Authorization: `Bearer ${token}`, "Content-Type": "application/json" },
+    body: JSON.stringify({ messaging_product: "whatsapp", ...body }),
+  });
+  const json = (await res.json().catch(() => ({}))) as {
+    messages?: Array<{ id: string }>;
+    error?: { message?: string };
+  };
+  if (!res.ok) {
+    return { ok: false, status: res.status, error: json.error?.message || `HTTP ${res.status}` };
+  }
+  return { ok: true, status: res.status, messageId: json.messages?.[0]?.id };
+}
+
+/**
+ * Send a free-form text message. ONLY valid inside an open 24-hour customer
+ * service window (the recipient messaged us within the last 24h). For
+ * business-initiated messages outside that window, use sendWhatsAppTemplate.
+ * `to` may be passed in any human format ("+60 12-345 6789") — it's normalised.
+ */
+export function sendWhatsAppText(to: string, body: string): Promise<WhatsAppSendResult> {
+  return postMessage({
+    recipient_type: "individual",
+    to: normalizeMsisdn(to),
+    type: "text",
+    text: { preview_url: false, body },
+  });
+}
+
+/**
+ * Send a pre-approved template message (business-initiated, works outside the
+ * 24h window). `templateName` must be APPROVED in WhatsApp Manager. `components`
+ * carries header/body variable substitutions per the Cloud API template schema.
+ */
+export function sendWhatsAppTemplate(
+  to: string,
+  templateName: string,
+  languageCode = "en",
+  components?: unknown[],
+): Promise<WhatsAppSendResult> {
+  return postMessage({
+    to: normalizeMsisdn(to),
+    type: "template",
+    template: {
+      name: templateName,
+      language: { code: languageCode },
+      ...(components && components.length ? { components } : {}),
+    },
+  });
+}
+
+/** Strip everything but digits so callers can pass "+60 12-345 6789". */
+function normalizeMsisdn(to: string): string {
+  return to.replace(/[^0-9]/g, "");
+}

--- a/apps/backoffice/src/middleware.ts
+++ b/apps/backoffice/src/middleware.ts
@@ -37,6 +37,10 @@ export async function middleware(request: NextRequest) {
       // Compat alias: Grab's portal has this store's webhook at the non-/pos
       // path. Same handler (api/grab/webhook/route re-exports the /pos one).
       "/api/grab/webhook",
+      // WhatsApp Cloud API webhook — Meta posts inbound messages/statuses with
+      // no browser Origin, authenticated by X-Hub-Signature-256 (verified in
+      // the route against WHATSAPP_APP_SECRET).
+      "/api/whatsapp/webhook",
     ],
   });
   if (csrfFail) {


### PR DESCRIPTION
## What

First slice of the official Meta **WhatsApp Business Cloud API** integration — the "internal looping" (staff alerts, two-way customer-service replies, POS/inventory event notifications). App **Celsius Coffee Ops** + WABA under the Celsius Coffee HQ business portfolio.

## Changes

- **`lib/whatsapp.ts`** *(new)* — `verifyWhatsAppSignature()` (X-Hub-Signature-256 over raw body, timing-safe), `sendWhatsAppText()` (free-form, 24h-window only), `sendWhatsAppTemplate()` (business-initiated). Graph API v23.0.
- **`api/whatsapp/webhook/route.ts`** *(new)* — `GET` verification handshake (echoes `hub.challenge`) + `POST` inbound handler with HMAC validation; logs inbound messages/statuses, `TODO` for routing into a CS flow. Mirrors the existing Grab webhook conventions.
- **`middleware.ts`** — adds `/api/whatsapp/webhook` to the CSRF `exemptPrefixes` (Meta calls carry no browser Origin, only the HMAC signature).
- **`.env.example`** — documents the 5 `WHATSAPP_*` env vars.

## Verification

- `tsc --noEmit` (backoffice) passes.
- Meta-side already proven live: real inbound→outbound round-trip confirmed via Graph API on number `+60 11-5459 5369` (PNID `1063521080187204`, WABA `974771538513990`).

## Deploy / go-live steps (post-merge)

1. Env vars are set in Vercel (backoffice): `WHATSAPP_PHONE_NUMBER_ID`, `WHATSAPP_WABA_ID`, `WHATSAPP_ACCESS_TOKEN`, `WHATSAPP_APP_SECRET`, `WHATSAPP_VERIFY_TOKEN`.
2. After production deploy, register the webhook in the Meta app → callback `https://backoffice.celsiuscoffee.com/api/whatsapp/webhook`, same verify token, subscribe the `messages` field.
3. Then wire `sendWhatsAppText`/`sendWhatsAppTemplate` into POS/inventory events + submit the first utility template.

🤖 Generated with [Claude Code](https://claude.com/claude-code)