### PR TITLE
chore(whatsapp): diagnostic logging for webhook verify-token + force backoffice rebuild

### DIFF
--- a/apps/backoffice/src/app/api/whatsapp/webhook/route.ts
+++ b/apps/backoffice/src/app/api/whatsapp/webhook/route.ts
@@ -30,7 +30,13 @@ export async function GET(request: NextRequest) {
     // Meta expects the raw challenge string echoed back with 200.
     return new NextResponse(challenge ?? "", { status: 200 });
   }
-  console.warn(`[whatsapp:webhook] verify failed mode=${mode} token_match=${token === verifyToken}`);
+  // Observability for webhook-setup debugging. Logs LENGTHS only, never the
+  // token values: env_set/env_len reveal whether WHATSAPP_VERIFY_TOKEN reached
+  // this deployment (env_len=0 ⇒ unset or wrong env-scope in Vercel), got_len is
+  // what the caller sent. Distinguishes "env missing" from "value mismatch".
+  console.warn(
+    `[whatsapp:webhook] verify failed mode=${mode} token_match=${token === verifyToken} env_set=${!!verifyToken} env_len=${verifyToken?.length ?? 0} got_len=${token?.length ?? 0}`,
+  );
   return new NextResponse("Forbidden", { status: 403 });
 }
 


### PR DESCRIPTION
## Why

Meta webhook verification (`GET /api/whatsapp/webhook`) keeps returning `403 token_match=false`, but the production deploy (`dpl_2QqF`, the #493 merge) **predates** the `WHATSAPP_VERIFY_TOKEN` env var being set, and dashboard "Redeploy" of the same commit gets **skipped by the Turbo ignored-build-step** — so no new deployment ever picks up the env var.

## What

- Enhances the verify-failure log to include `env_set` / `env_len` / `got_len` — **lengths only, never the token value**. After this deploys, the next failed handshake tells us unambiguously whether `WHATSAPP_VERIFY_TOKEN` reached the deployment (`env_len=0` ⇒ unset / wrong env-scope) vs. a value mismatch (`env_len>0` + `token_match=false`).
- Touching a backoffice file makes the ignored-build-step **rebuild**, producing a fresh deployment that finally reads the current env vars.

## After merge
Re-run the handshake; read the new log line to pinpoint the env-var fix, then register the webhook in Meta.