### PR TITLE
chore(whatsapp): log verify success + force backoffice redeploy for env vars

### DIFF
--- a/apps/backoffice/src/app/api/whatsapp/webhook/route.ts
+++ b/apps/backoffice/src/app/api/whatsapp/webhook/route.ts
@@ -27,6 +27,7 @@ export async function GET(request: NextRequest) {
 
   const verifyToken = process.env.WHATSAPP_VERIFY_TOKEN;
   if (mode === "subscribe" && !!verifyToken && token === verifyToken) {
+    console.log("[whatsapp:webhook] verify OK — challenge echoed");
     // Meta expects the raw challenge string echoed back with 200.
     return new NextResponse(challenge ?? "", { status: 200 });
   }


### PR DESCRIPTION
Forces a fresh `celsius-backoffice` production build so the `WHATSAPP_*` env vars (now added to the correct project with Production scope) actually load — dashboard redeploys of the same commit get skipped by the Turbo ignored-build-step. Also adds a success log on the webhook verify 200 path. After deploy, the verify handshake should return 200 and logs should show `env_set=true` / `verify OK`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)