### PR TITLE
feat(reviews): local-rank geogrid — scoreboard for the GBP ranking loop

### DIFF
--- a/apps/backoffice/src/app/(admin)/layout.tsx
+++ b/apps/backoffice/src/app/(admin)/layout.tsx
@@ -38,6 +38,7 @@ import {
   TicketPercent,
   Megaphone,
   MessageSquare,
+  MapPinned,
   Sparkles,
   Building2,
   UserCog,
@@ -330,6 +331,7 @@ const NAV_SECTIONS: NavSection[] = [
         items: [
           { label: "All Reviews", href: "/reviews", icon: <Star className={ICON_SIZE} />, moduleKey: "reviews:list" },
           { label: "Feedback Management", href: "/reviews/feedback", icon: <MessageSquare className={ICON_SIZE} />, moduleKey: "reviews:list" },
+          { label: "Local Rank", href: "/reviews/geogrid", icon: <MapPinned className={ICON_SIZE} />, moduleKey: "reviews:list" },
         ],
       },
       {

--- a/apps/backoffice/src/app/(admin)/reviews/geogrid/page.tsx
+++ b/apps/backoffice/src/app/(admin)/reviews/geogrid/page.tsx
@@ -1,0 +1,239 @@
+"use client";
+
+import { useEffect, useState, useCallback } from "react";
+import Link from "next/link";
+import { Loader2, MapPin, Play, ArrowLeft, TrendingUp } from "lucide-react";
+
+type GridPoint = { row: number; col: number; lat: number; lng: number; rank: number | null };
+type Scan = {
+  id: string;
+  keyword: string;
+  gridSize: number;
+  rangeMiles: number;
+  centerLat: number;
+  centerLng: number;
+  status: string;
+  points: GridPoint[];
+  avgRank: number | null;
+  pctTop3: number | null;
+  foundPoints: number;
+  totalPoints: number;
+  greenRadiusM: number | null;
+  createdAt: string;
+};
+type Outlet = { id: string; name: string };
+
+function rankColor(rank: number | null): { bg: string; fg: string; label: string } {
+  if (rank == null) return { bg: "#9ca3af", fg: "#fff", label: "–" };
+  const label = String(rank);
+  if (rank <= 3) return { bg: "#15803d", fg: "#fff", label };
+  if (rank <= 6) return { bg: "#65a30d", fg: "#fff", label };
+  if (rank <= 10) return { bg: "#eab308", fg: "#1a1a1a", label };
+  if (rank <= 15) return { bg: "#f97316", fg: "#fff", label };
+  return { bg: "#dc2626", fg: "#fff", label };
+}
+
+function miles(m: number | null): string {
+  if (m == null) return "–";
+  return (m / 1609.34).toFixed(2) + " mi";
+}
+
+function Stat({ label, value, sub }: { label: string; value: string; sub?: string }) {
+  return (
+    <div className="rounded-xl border border-border bg-white p-4">
+      <p className="text-xs font-medium text-muted-foreground">{label}</p>
+      <p className="mt-1 text-2xl font-bold text-foreground">{value}</p>
+      {sub && <p className="text-[11px] text-muted-foreground">{sub}</p>}
+    </div>
+  );
+}
+
+export default function GeogridPage() {
+  const [outlets, setOutlets] = useState<Outlet[]>([]);
+  const [outletId, setOutletId] = useState("");
+  const [keyword, setKeyword] = useState("");
+  const [gridSize, setGridSize] = useState(9);
+  const [rangeMiles, setRangeMiles] = useState(0.1);
+  const [scans, setScans] = useState<Scan[]>([]);
+  const [active, setActive] = useState<Scan | null>(null);
+  const [running, setRunning] = useState(false);
+  const [keyConfigured, setKeyConfigured] = useState(true);
+  const [error, setError] = useState("");
+
+  useEffect(() => {
+    fetch("/api/settings/outlets")
+      .then((r) => r.json())
+      .then((d) => {
+        const list: Outlet[] = (Array.isArray(d) ? d : d.outlets ?? []).map((o: Outlet) => ({ id: o.id, name: o.name }));
+        setOutlets(list);
+        if (list[0]) setOutletId(list[0].id);
+      })
+      .catch(() => setOutlets([]));
+  }, []);
+
+  const loadHistory = useCallback(async (oid: string) => {
+    if (!oid) return;
+    const res = await fetch(`/api/geogrid/scan?outletId=${oid}`);
+    const d = await res.json();
+    setScans(d.scans ?? []);
+    setKeyConfigured(d.keyConfigured ?? true);
+    setActive((d.scans ?? [])[0] ?? null);
+  }, []);
+
+  useEffect(() => {
+    loadHistory(outletId);
+  }, [outletId, loadHistory]);
+
+  const run = async () => {
+    setError("");
+    if (!keyword.trim()) {
+      setError("Enter a keyword");
+      return;
+    }
+    setRunning(true);
+    try {
+      const res = await fetch("/api/geogrid/scan", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ outletId, keyword: keyword.trim(), gridSize, rangeMiles }),
+      });
+      const d = await res.json();
+      if (res.ok && d.scan) {
+        setActive(d.scan);
+        await loadHistory(outletId);
+      } else {
+        setError(d.error || "Scan failed");
+      }
+    } catch {
+      setError("Network error");
+    } finally {
+      setRunning(false);
+    }
+  };
+
+  // order active points into rows
+  const grid: GridPoint[][] = [];
+  if (active) {
+    for (let r = 0; r < active.gridSize; r++) {
+      grid.push(active.points.filter((p) => p.row === r).sort((a, b) => a.col - b.col));
+    }
+  }
+
+  return (
+    <div className="mx-auto max-w-5xl px-4 py-6 sm:px-6">
+      <Link href="/reviews" className="mb-1 flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground">
+        <ArrowLeft className="h-3.5 w-3.5" /> Back to Reviews
+      </Link>
+      <h1 className="font-heading text-2xl font-bold text-foreground">Local Rank Geogrid</h1>
+      <p className="text-sm text-muted-foreground">
+        Where you rank for a keyword across the map. Two goals: lift the rank (more green) and widen the green radius.
+      </p>
+
+      {!keyConfigured && (
+        <div className="mt-4 rounded-xl border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-900">
+          Scans are inactive until <span className="font-mono">GOOGLE_PLACES_API_KEY</span> is set and the Places API is enabled on project 23036. History below still works.
+        </div>
+      )}
+
+      {/* Controls */}
+      <div className="mt-5 flex flex-wrap items-end gap-3">
+        <div>
+          <label className="block text-xs font-medium text-muted-foreground">Outlet</label>
+          <select value={outletId} onChange={(e) => setOutletId(e.target.value)} className="mt-1 rounded-lg border border-border bg-white px-3 py-2 text-sm">
+            {outlets.map((o) => (
+              <option key={o.id} value={o.id}>{o.name}</option>
+            ))}
+          </select>
+        </div>
+        <div>
+          <label className="block text-xs font-medium text-muted-foreground">Keyword</label>
+          <input value={keyword} onChange={(e) => setKeyword(e.target.value)} placeholder="e.g. cafe cyberjaya" className="mt-1 w-48 rounded-lg border border-border bg-white px-3 py-2 text-sm outline-none focus:ring-2 focus:ring-ring/50" />
+        </div>
+        <div>
+          <label className="block text-xs font-medium text-muted-foreground">Grid</label>
+          <select value={gridSize} onChange={(e) => setGridSize(Number(e.target.value))} className="mt-1 rounded-lg border border-border bg-white px-3 py-2 text-sm">
+            {[5, 7, 9, 11, 13].map((n) => (
+              <option key={n} value={n}>{n}×{n}</option>
+            ))}
+          </select>
+        </div>
+        <div>
+          <label className="block text-xs font-medium text-muted-foreground">Range (mi)</label>
+          <input type="number" step="0.05" min="0.05" value={rangeMiles} onChange={(e) => setRangeMiles(Number(e.target.value))} className="mt-1 w-24 rounded-lg border border-border bg-white px-3 py-2 text-sm" />
+        </div>
+        <button onClick={run} disabled={running || !outletId} className="flex items-center gap-1.5 rounded-lg bg-brand-dark px-4 py-2 text-sm font-medium text-white hover:bg-brand-dark/90 disabled:opacity-50">
+          {running ? <Loader2 className="h-4 w-4 animate-spin" /> : <Play className="h-4 w-4" />}
+          {running ? "Scanning…" : "Run scan"}
+        </button>
+      </div>
+      {error && <p className="mt-2 text-sm text-red-600">{error}</p>}
+
+      {active ? (
+        <>
+          {/* Metrics — the two goals */}
+          <div className="mt-6 grid grid-cols-2 gap-3 sm:grid-cols-4">
+            <Stat label="Avg rank" value={active.avgRank != null ? active.avgRank.toFixed(1) : "–"} sub="lower is better" />
+            <Stat label="% in top 3" value={`${Math.round(active.pctTop3 ?? 0)}%`} sub="more green = better" />
+            <Stat label="Green radius" value={miles(active.greenRadiusM)} sub="rank ≤3 reach (goal #2)" />
+            <Stat label="Coverage" value={`${active.foundPoints}/${active.totalPoints}`} sub="points ranking ≤20" />
+          </div>
+
+          {/* The grid */}
+          <div className="mt-5 rounded-xl border border-border bg-white p-4">
+            <div className="mb-2 flex items-center gap-2 text-sm text-muted-foreground">
+              <MapPin className="h-4 w-4" />
+              <span className="font-medium text-foreground">&ldquo;{active.keyword}&rdquo;</span> · {active.gridSize}×{active.gridSize} · {active.rangeMiles} mi spacing
+            </div>
+            <div className="grid gap-1.5" style={{ gridTemplateColumns: `repeat(${active.gridSize}, minmax(0, 1fr))`, maxWidth: 520 }}>
+              {grid.flat().map((p) => {
+                const c = rankColor(p.rank);
+                return (
+                  <div key={`${p.row}-${p.col}`} className="flex aspect-square items-center justify-center rounded-full text-xs font-bold" style={{ backgroundColor: c.bg, color: c.fg }} title={`rank ${p.rank ?? ">20"}`}>
+                    {c.label}
+                  </div>
+                );
+              })}
+            </div>
+            <p className="mt-2 text-[11px] text-muted-foreground">
+              Center = your storefront. Rank approximated from the Places API (proxy for the Maps local pack) — use it for trend, not exact position.
+            </p>
+          </div>
+
+          {/* History / trend — the loop */}
+          {scans.length > 1 && (
+            <div className="mt-5 rounded-xl border border-border bg-white p-4">
+              <div className="mb-2 flex items-center gap-2 text-sm font-medium text-foreground">
+                <TrendingUp className="h-4 w-4" /> Trend (are the two goals moving?)
+              </div>
+              <table className="w-full text-sm">
+                <thead>
+                  <tr className="text-left text-xs text-muted-foreground">
+                    <th className="py-1">Date</th><th>Keyword</th><th>Avg rank</th><th>% top 3</th><th>Green radius</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {scans.map((s) => (
+                    <tr key={s.id} className={`border-t border-border ${active.id === s.id ? "bg-muted/40" : ""}`}>
+                      <td className="py-1.5">
+                        <button onClick={() => setActive(s)} className="text-foreground hover:underline">{new Date(s.createdAt).toLocaleDateString()}</button>
+                      </td>
+                      <td className="text-muted-foreground">{s.keyword}</td>
+                      <td>{s.avgRank != null ? s.avgRank.toFixed(1) : "–"}</td>
+                      <td>{Math.round(s.pctTop3 ?? 0)}%</td>
+                      <td>{miles(s.greenRadiusM)}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          )}
+        </>
+      ) : (
+        <div className="mt-6 rounded-xl border border-border bg-white p-10 text-center">
+          <MapPin className="mx-auto h-10 w-10 text-muted-foreground/30" />
+          <p className="mt-3 text-sm text-muted-foreground">No scans yet for this outlet. Enter a keyword and run one.</p>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/backoffice/src/app/api/geogrid/scan/route.ts
+++ b/apps/backoffice/src/app/api/geogrid/scan/route.ts
@@ -1,0 +1,104 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getUserFromHeaders } from "@/lib/auth";
+import { prisma } from "@/lib/prisma";
+import { getLocationGeo } from "@/lib/reviews/gbp";
+import { buildGrid, scanGrid, computeMetrics } from "@/lib/geogrid/places";
+
+export const dynamic = "force-dynamic";
+export const maxDuration = 120;
+
+const METERS_PER_MILE = 1609.34;
+
+// GET /api/geogrid/scan?outletId=...&keyword=... — recent scans (with points) for trend.
+export async function GET(request: NextRequest) {
+  const user = await getUserFromHeaders(request.headers);
+  if (!user) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+
+  const url = new URL(request.url);
+  const outletId = url.searchParams.get("outletId");
+  const keyword = url.searchParams.get("keyword");
+  if (!outletId) return NextResponse.json({ error: "outletId required" }, { status: 400 });
+
+  const scans = await prisma.geoGridScan.findMany({
+    where: { outletId, ...(keyword ? { keyword } : {}) },
+    orderBy: { createdAt: "desc" },
+    take: 12,
+  });
+  return NextResponse.json({ scans, keyConfigured: !!process.env.GOOGLE_PLACES_API_KEY });
+}
+
+// POST /api/geogrid/scan — run a fresh grid scan.
+// Body: { outletId, keyword, gridSize?=9, rangeMiles?=0.1 }
+export async function POST(request: NextRequest) {
+  const user = await getUserFromHeaders(request.headers);
+  if (!user) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+
+  const apiKey = process.env.GOOGLE_PLACES_API_KEY;
+  if (!apiKey) {
+    return NextResponse.json(
+      { error: "GOOGLE_PLACES_API_KEY not configured — set it + enable Places API on project 23036 to run scans." },
+      { status: 400 },
+    );
+  }
+
+  const body = await request.json().catch(() => ({}));
+  const outletId: string = body.outletId;
+  const keyword: string = (body.keyword || "").trim();
+  const gridSize: number = [5, 7, 9, 11, 13].includes(body.gridSize) ? body.gridSize : 9;
+  const rangeMiles: number = typeof body.rangeMiles === "number" && body.rangeMiles > 0 ? body.rangeMiles : 0.1;
+  if (!outletId || !keyword) {
+    return NextResponse.json({ error: "outletId and keyword required" }, { status: 400 });
+  }
+
+  const settings = await prisma.reviewSettings.findUnique({ where: { outletId } });
+  if (!settings?.gbpLocationName) {
+    return NextResponse.json({ error: "Outlet has no GBP location connected" }, { status: 400 });
+  }
+
+  // Resolve centre + target Places id from the GBP location.
+  let geo;
+  try {
+    geo = await getLocationGeo(settings.gbpLocationName);
+  } catch (err) {
+    console.error("[geogrid] location geo failed:", err);
+    return NextResponse.json({ error: "Could not resolve outlet location from Google" }, { status: 502 });
+  }
+  if (geo.lat == null || geo.lng == null) {
+    return NextResponse.json({ error: "Outlet has no lat/lng on its Google profile" }, { status: 400 });
+  }
+
+  const points = buildGrid(geo.lat, geo.lng, gridSize, rangeMiles);
+  const radiusM = Math.min(Math.max(rangeMiles * METERS_PER_MILE, 500), 5000);
+
+  const { points: scanned, failures } = await scanGrid(
+    apiKey,
+    keyword,
+    points,
+    radiusM,
+    geo.placeId,
+    geo.title,
+  );
+  const metrics = computeMetrics(scanned, geo.lat, geo.lng);
+
+  const scan = await prisma.geoGridScan.create({
+    data: {
+      outletId,
+      keyword,
+      gridSize,
+      rangeMiles,
+      centerLat: geo.lat,
+      centerLng: geo.lng,
+      placeId: geo.placeId,
+      status: failures === 0 ? "complete" : failures < points.length ? "partial" : "failed",
+      points: scanned,
+      avgRank: metrics.avgRank,
+      pctTop3: metrics.pctTop3,
+      foundPoints: metrics.foundPoints,
+      totalPoints: metrics.totalPoints,
+      greenRadiusM: metrics.greenRadiusM,
+      createdBy: user.name || user.id,
+    },
+  });
+
+  return NextResponse.json({ scan, failures });
+}

--- a/apps/backoffice/src/lib/geogrid/places.ts
+++ b/apps/backoffice/src/lib/geogrid/places.ts
@@ -1,0 +1,126 @@
+/**
+ * Geogrid engine for the local-rank loop.
+ *
+ * Builds an N×N grid of points around an outlet, asks the Places API "where do
+ * we rank for <keyword> as searched from here" at each point, and rolls the
+ * results into the two loop metrics: average rank (lower = better) and green
+ * radius (how far from the store we still rank top-3 = prominence/reach).
+ *
+ * NOTE: Places searchText with a locationBias circle is an APPROXIMATION of the
+ * real Maps local pack — good for relative rank + trend over time, not an exact
+ * mirror of what a user sees. That's fine for a measure→act→learn loop.
+ */
+
+const MILES_PER_DEG_LAT = 69.0;
+
+export type GridPoint = { row: number; col: number; lat: number; lng: number; rank: number | null };
+
+/** N×N points centred on (lat,lng), spaced `rangeMiles` apart. Row 0 = north. */
+export function buildGrid(centerLat: number, centerLng: number, gridSize: number, rangeMiles: number): GridPoint[] {
+  const latStep = rangeMiles / MILES_PER_DEG_LAT;
+  const lngStep = rangeMiles / (MILES_PER_DEG_LAT * Math.cos((centerLat * Math.PI) / 180));
+  const half = (gridSize - 1) / 2;
+  const points: GridPoint[] = [];
+  for (let row = 0; row < gridSize; row++) {
+    for (let col = 0; col < gridSize; col++) {
+      points.push({
+        row,
+        col,
+        lat: centerLat - (row - half) * latStep, // row 0 → north (higher lat)
+        lng: centerLng + (col - half) * lngStep, // col 0 → west (lower lng)
+        rank: null,
+      });
+    }
+  }
+  return points;
+}
+
+export function distanceMeters(lat1: number, lng1: number, lat2: number, lng2: number): number {
+  const R = 6371000;
+  const dLat = ((lat2 - lat1) * Math.PI) / 180;
+  const dLng = ((lng2 - lng1) * Math.PI) / 180;
+  const a =
+    Math.sin(dLat / 2) ** 2 +
+    Math.cos((lat1 * Math.PI) / 180) * Math.cos((lat2 * Math.PI) / 180) * Math.sin(dLng / 2) ** 2;
+  return 2 * R * Math.asin(Math.sqrt(a));
+}
+
+/** Rank of the target business in Places results for `keyword` at a point, or null if not in top 20. */
+export async function rankAtPoint(
+  apiKey: string,
+  keyword: string,
+  lat: number,
+  lng: number,
+  radiusM: number,
+  targetPlaceId: string | null,
+  targetTitle: string | null,
+): Promise<number | null> {
+  const res = await fetch("https://places.googleapis.com/v1/places:searchText", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "X-Goog-Api-Key": apiKey,
+      "X-Goog-FieldMask": "places.id,places.displayName",
+    },
+    body: JSON.stringify({
+      textQuery: keyword,
+      locationBias: { circle: { center: { latitude: lat, longitude: lng }, radius: radiusM } },
+      maxResultCount: 20,
+    }),
+  });
+  if (!res.ok) {
+    const body = await res.text();
+    throw new Error(`Places searchText error ${res.status}: ${body.slice(0, 300)}`);
+  }
+  const data = await res.json();
+  const places: { id?: string; displayName?: { text?: string } }[] = data.places ?? [];
+  const title = targetTitle?.toLowerCase();
+  const idx = places.findIndex(
+    (p) =>
+      (targetPlaceId && p.id === targetPlaceId) ||
+      (title && p.displayName?.text?.toLowerCase().includes(title)),
+  );
+  return idx >= 0 ? idx + 1 : null;
+}
+
+export function computeMetrics(points: GridPoint[], centerLat: number, centerLng: number) {
+  const ranked = points.filter((p) => p.rank != null) as (GridPoint & { rank: number })[];
+  const top3 = ranked.filter((p) => p.rank <= 3);
+  return {
+    avgRank: ranked.length ? ranked.reduce((s, p) => s + p.rank, 0) / ranked.length : null,
+    pctTop3: points.length ? (top3.length / points.length) * 100 : 0,
+    foundPoints: ranked.length,
+    totalPoints: points.length,
+    greenRadiusM: top3.length
+      ? Math.max(...top3.map((p) => distanceMeters(centerLat, centerLng, p.lat, p.lng)))
+      : 0,
+  };
+}
+
+/** Run all grid points with limited concurrency so we don't hammer the Places API. */
+export async function scanGrid(
+  apiKey: string,
+  keyword: string,
+  points: GridPoint[],
+  radiusM: number,
+  targetPlaceId: string | null,
+  targetTitle: string | null,
+  concurrency = 8,
+): Promise<{ points: GridPoint[]; failures: number }> {
+  let failures = 0;
+  for (let i = 0; i < points.length; i += concurrency) {
+    const batch = points.slice(i, i + concurrency);
+    await Promise.all(
+      batch.map(async (p) => {
+        try {
+          p.rank = await rankAtPoint(apiKey, keyword, p.lat, p.lng, radiusM, targetPlaceId, targetTitle);
+        } catch (err) {
+          failures++;
+          console.error(`[geogrid] point ${p.row},${p.col} failed:`, (err as Error).message);
+          p.rank = null;
+        }
+      }),
+    );
+  }
+  return { points, failures };
+}

--- a/apps/backoffice/src/lib/reviews/gbp.ts
+++ b/apps/backoffice/src/lib/reviews/gbp.ts
@@ -244,3 +244,28 @@ export async function replyToReview(
     throw new Error(`GBP reply error ${res.status}: ${body}`);
   }
 }
+
+const GBP_INFO_BASE = "https://mybusinessbusinessinformation.googleapis.com/v1";
+
+// Resolve an outlet's precise centre (lat/lng) + Google Places id, so a geogrid
+// scan can place its grid and find the business in each point's results.
+export async function getLocationGeo(
+  locationName: string,
+): Promise<{ lat: number; lng: number; placeId: string | null; title: string | null }> {
+  const token = await getAccessToken();
+  const res = await fetch(
+    `${GBP_INFO_BASE}/${locationName}?readMask=latlng,metadata,title`,
+    { headers: { Authorization: `Bearer ${token}` } },
+  );
+  if (!res.ok) {
+    const body = await res.text();
+    throw new Error(`GBP location info error ${res.status}: ${body}`);
+  }
+  const data = await res.json();
+  return {
+    lat: data.latlng?.latitude,
+    lng: data.latlng?.longitude,
+    placeId: data.metadata?.placeId ?? null,
+    title: data.title ?? null,
+  };
+}

--- a/docs/design/gbp-profile-optimizer.md
+++ b/docs/design/gbp-profile-optimizer.md
@@ -1,0 +1,132 @@
+# GBP Profile Optimizer (the real "page ranking" work)
+
+_Office-hours diagnostic — 2026-06-24. Reframes the "page ranking loop"._
+
+## Problem Statement
+The user wants to "loop page ranking" by generating GBP updates optimized with the
+best keywords. Diagnosis reframes this hard:
+
+- **Posts don't move local rank.** Google has said GBP posts ("updates") are not a
+  direct ranking factor — a weak freshness signal at best. `localPosts` is also on
+  Google's deprecation path. A keyword-post loop optimizes a lever that barely moves.
+- **The real relevance levers are the PROFILE FIELDS** — categories, business
+  description, services/products, attributes, photos. And the user's own answer is that
+  these are **thin/stale, set up once and never optimized**. That's the gap worth fixing.
+- **Keyword impressions are measurable; rank and attribution are not.** The Business
+  Profile Performance API exposes the real search terms customers used (monthly
+  impressions) — a great INPUT. But you cannot attribute a rank/impression change to a
+  specific edit. So this is **audit → optimize → periodic refresh**, NOT a tight
+  measure→act→learn loop. Don't dress a publisher up as a loop (the trap from the
+  original ads-conversion-loop doc).
+
+## Demand Evidence
+- Q1 Demand: **"Aspirational — rank higher."** No acute bleed. 3 of 4 outlets are
+  4.5–4.8★ with 40–46 Google reviews; ~100 reviews/30 days — they're being found.
+  (Nilai is the one real exception: 0 reviews / 0.0★, effectively invisible.)
+- Q2 Status quo: **profiles thin/stale** — descriptions/categories/services/photos
+  incomplete or outdated, set once and abandoned.
+- Q3 Owner: **nobody** — no one owns GBP content; that's why it's stale.
+
+Aspirational demand + orphaned ownership ⇒ build the smallest thing that proves value
+with real data, and make it draft+apply so it needs ~no owner. Do NOT build a daily loop.
+
+## Status Quo
+Profiles sit untouched since setup. No keyword data is ever looked at. No posting, no
+description/services upkeep. Nothing breaks loudly — which is exactly why it's neglected.
+
+## Target User
+**Ammar (owner)** — would approve/apply profile changes himself, but only if something
+drafts the optimized description / categories / services for a few-minutes review (not
+research from scratch). The tool has to do the work; the human just says yes.
+
+## Narrowest Wedge
+A **one-time keyword audit + profile gap report** for the 4 outlets: pull real GBP
+keyword impressions + current profile state, AI cross-references to surface concrete
+gaps ("Tamarind's top searches are X/Y/Z; description doesn't mention X; add category A;
+services missing B/C"). Ammar applies the top fixes by hand in GBP. No write-back, no
+loop. Either it reveals real opportunity (→ act, maybe automate) or shows you're fine
+(→ stop, months saved).
+
+## Premises (verify before building)
+1. **Performance API** (`businessprofileperformance.googleapis.com`,
+   `searchkeywords:impressions`) is enabled on the GBP project (My Project 23036) and the
+   existing OAuth scope covers it. (Reviews use the GBP API; performance may need enabling.)
+2. **Business Information API** (`mybusinessbusinessinformation.googleapis.com`) write
+   access for `locations.patch` (description, categories) — services/photos have limited
+   API support and may stay manual.
+3. Profiles really are thin (Q2) — the audit will confirm per outlet.
+4. Posts are NOT a meaningful rank lever (treated as fact; not building a post loop).
+
+## Approaches Considered
+
+### Approach A — One-time keyword audit + profile gap report (days) — RECOMMENDED
+- Pull Performance API keyword impressions per outlet (last ~6 months).
+- Pull current profile (description, categories, services) via Business Information API.
+- AI cross-references → per-outlet report: high-impression terms missing from the
+  profile, weak/wrong categories, thin description, missing services.
+- Output to a simple backoffice page (or one-off doc). Ammar applies top fixes manually.
+- Measure-first: validates the aspirational hunch with real data, zero write risk.
+
+### Approach B — Draft + approve + API write-back + refresh (weeks)
+- Backoffice "GBP Optimizer" panel per outlet: keyword data + current profile +
+  AI-drafted optimized description/categories/services.
+- Ammar approves → description + categories written via `locations.patch`;
+  services/photos surfaced as a manual checklist.
+- Monthly cron re-pulls keyword data, flags drift, says "time to refresh."
+- Coarse outcome MONITORING only (impressions/actions trend per outlet) — explicitly NOT
+  attributed to edits. No fake loop closure on rank.
+
+### Approach C — Autonomous local-SEO agent (months) — REJECT
+- Folds into the marketing agent: continuous profile edits + posts + review replies,
+  Telegram-approved. Rejected: posts don't help, attribution impossible, no acute demand.
+
+## Recommended Approach
+**A first.** It's cheap, measure-first, and directly tests whether the aspirational goal
+has real substance. Build **B only if** A shows consistent gaps AND the keyword data
+shifts enough month-to-month to justify ongoing upkeep. Reject C.
+
+**What flips it:** if A shows profiles are actually well-covered for the terms that
+matter → stop. If A shows big gaps that recur as menu/seasons change → build B.
+
+## Open Questions
+1. Is the Performance API enabled on project 23036, or does it need turning on + scope?
+2. How much can `locations.patch` actually write (categories yes; services? attributes?)
+   vs. what stays a manual GBP-UI checklist.
+3. Nilai (invisible) — is the fix even a keyword problem, or just "get the basics + first
+   reviews live"? It may belong to the reviews loop, not this.
+
+## Success Criteria (measurable)
+- **A:** a per-outlet report exists naming the top search terms and the specific profile
+  gaps; Ammar applies ≥3 concrete fixes per outlet. (Output is the deliverable, not rank.)
+- **B (if built):** description+categories optimized + applied for all 4 outlets; monthly
+  keyword-drift check runs; impressions/actions trend visible per outlet (monitored, not
+  attributed).
+
+## UPDATE 2026-06-24 — Geogrid changes the verdict (it IS a loop)
+User clarified the goal with a **geogrid** screenshot: (1) increase ranking, (2) increase the
+high-rank RADIUS. The geogrid is the measurement I claimed didn't exist — rank-by-location,
+repeatable, comparable over time. So this becomes a genuine measure→act→learn loop.
+
+Honest lever analysis (the grid measures, doesn't move):
+- Each dot = rank for the keyword *searched from that spot*; colour driven by proximity
+  (fixed), relevance (categories/description), prominence (REVIEWS: volume/velocity/recency).
+- Goal #1 (rank↑) = relevance + prominence. Goal #2 (radius↑) = **~80% prominence = reviews**.
+  Far from the store, only authority/reviews keep you ranking. So the engine that widens the
+  green radius is the **reviews loop already built+live** — there's no separate radius loop,
+  just a scoreboard for the reviews engine.
+
+**BUILT (this branch):** in-house geogrid (chosen over renting Local Falcon). `GeoGridScan`
+table (migration 056); `lib/geogrid/places.ts` (buildGrid + Places searchText rankAtPoint +
+metrics: avgRank, pctTop3, greenRadiusM); `/api/geogrid/scan` (run + history); `/reviews/geogrid`
+page (controls + colored N×N grid + the two goal-metrics + scan-history trend); sidebar "Local
+Rank". Ships DARK until GOOGLE_PLACES_API_KEY set + Places API enabled on project 23036.
+Places searchText w/ locationBias circle = PROXY for the Maps local pack (good for trend, not
+exact). Cost ~RM350-400/mo at weekly cadence (81 calls/scan). Cron auto-scan = phase 2.
+
+## The Assignment (one concrete next step)
+**Before any code:** pull ONE outlet's real data and look. For Tamarind, get the GBP
+"searches that showed your business" (top keywords + impressions) and its current
+description + categories + services. Lay the top 5 search terms next to the profile and
+ask: are they actually reflected? If yes for most → the gap is smaller than assumed,
+rethink. If clearly no → that's your proof, and Approach A is worth an afternoon. Look at
+real data for one outlet before building for four.

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -103,6 +103,7 @@ model Outlet {
   reviewSettings    ReviewSettings?
   internalFeedbacks InternalFeedback[]
   reviewReplyDrafts ReviewReplyDraft[]
+  geoGridScans      GeoGridScan[]
   auditReports      AuditReport[]
   recurringExpenses RecurringExpense[]
   bankStatementLines BankStatementLine[]
@@ -1377,6 +1378,31 @@ model ReviewReplyDraft {
 
   @@index([status])
   @@index([outletId])
+}
+
+// Local-rank geogrid scoreboard for the GBP ranking loop. One row per scan
+// (an N×N grid of simulated searches around an outlet for a keyword).
+model GeoGridScan {
+  id           String   @id @default(uuid())
+  outletId     String
+  outlet       Outlet   @relation(fields: [outletId], references: [id])
+  keyword      String
+  gridSize     Int // N for an N×N grid
+  rangeMiles   Float // spacing between points, miles
+  centerLat    Float
+  centerLng    Float
+  placeId      String? // target business Places id
+  status       String   @default("complete") // complete | partial | failed
+  points       Json // [{row,col,lat,lng,rank}] rank null = unranked
+  avgRank      Float? // mean rank over ranked points
+  pctTop3      Float? // % of points ranking 1-3
+  foundPoints  Int      @default(0)
+  totalPoints  Int      @default(0)
+  greenRadiusM Float? // farthest point (m) still ranking ≤3
+  createdAt    DateTime @default(now())
+  createdBy    String?
+
+  @@index([outletId, keyword, createdAt])
 }
 
 // ─── ADS MODULE ─────────────────────────────────────────────

--- a/supabase/migrations/056_geogrid_scans.sql
+++ b/supabase/migrations/056_geogrid_scans.sql
@@ -1,0 +1,29 @@
+-- 056_geogrid_scans.sql
+-- Local-rank geogrid scoreboard for the GBP ranking loop. Each scan runs a
+-- grid of simulated searches (Places API) around an outlet for one keyword and
+-- records the business's rank at every point. Stored over time so the two loop
+-- goals are measurable as a trend: avg rank ↓ (better) and green radius ↑ (rank
+-- well farther from the storefront = more prominence/reviews).
+
+CREATE TABLE IF NOT EXISTS "GeoGridScan" (
+  "id"           text PRIMARY KEY,
+  "outletId"     text NOT NULL REFERENCES "Outlet"("id"),
+  "keyword"      text NOT NULL,
+  "gridSize"     integer NOT NULL,                 -- N for an N×N grid (e.g. 9)
+  "rangeMiles"   double precision NOT NULL,        -- spacing between points, miles
+  "centerLat"    double precision NOT NULL,
+  "centerLng"    double precision NOT NULL,
+  "placeId"      text,                             -- target business Places id
+  "status"       text NOT NULL DEFAULT 'complete', -- complete | partial | failed
+  "points"       jsonb NOT NULL DEFAULT '[]',      -- [{row,col,lat,lng,rank}] rank null = unranked
+  "avgRank"      double precision,                 -- mean rank over ranked points
+  "pctTop3"      double precision,                 -- % of points ranking 1-3
+  "foundPoints"  integer NOT NULL DEFAULT 0,
+  "totalPoints"  integer NOT NULL DEFAULT 0,
+  "greenRadiusM" double precision,                 -- farthest point (m) still ranking ≤3
+  "createdAt"    timestamptz NOT NULL DEFAULT now(),
+  "createdBy"    text
+);
+
+CREATE INDEX IF NOT EXISTS "GeoGridScan_outlet_keyword_idx"
+  ON "GeoGridScan" ("outletId", "keyword", "createdAt");


### PR DESCRIPTION
The measurement layer that makes "page ranking" a real loop: rank-by-location across a grid, repeatable and comparable over time.

## What it measures (your two goals)
- **Avg rank** + **% in top 3** — goal #1, lift the ranking (more green).
- **Green radius** — goal #2, how far from the storefront you still rank top-3. This is ~80% a **reviews/prominence** function, so the engine that widens it is the reviews loop already live — this is its scoreboard.

## What's in it
- **`GeoGridScan`** table (migration 056, manual SQL): one row per scan with the N×N points + metrics, so the trend is visible.
- **`lib/geogrid/places.ts`**: builds an N×N grid around the outlet, calls Places API `searchText` (locationBias circle) per point to find our rank, rolls up avgRank / pctTop3 / greenRadiusM.
- **`getLocationGeo()`**: resolves outlet centre + Places id from the Business Information API.
- **`/api/geogrid/scan`** (run + history) and **`/reviews/geogrid`** page: outlet/keyword/grid/range controls, a colored N×N grid, the two goal-metrics, and a scan-history trend table. Sidebar **Local Rank** link.

## Honest caveats
- **Ships DARK** until `GOOGLE_PLACES_API_KEY` is set + Places API enabled on project 23036 (same gate as the competitor-ranking feature). The page + history render without the key; scans are blocked with a clear banner.
- `searchText` + locationBias is a **proxy** for the Maps local pack — good for relative rank + trend, not an exact mirror.
- Cost ~RM350–400/mo at weekly cadence (81 Places calls/scan). On-demand only for now; cron auto-scan = phase 2.

## Verification
- `tsc` + ESLint clean. Migration applied + confirmed on the live DB. Can't end-to-end test scans until the Places key is set.