### PR TITLE
feat(geogrid): self-running adaptive rank loop (keyword auto-select + capped scan)

### DIFF
--- a/apps/backoffice/src/app/(admin)/reviews/geogrid/page.tsx
+++ b/apps/backoffice/src/app/(admin)/reviews/geogrid/page.tsx
@@ -19,6 +19,7 @@ type Scan = {
   foundPoints: number;
   totalPoints: number;
   greenRadiusM: number | null;
+  competitors: { name: string; top3Points: number; avgRank: number }[];
   createdAt: string;
 };
 type Outlet = { id: string; name: string };
@@ -33,9 +34,9 @@ function rankColor(rank: number | null): { bg: string; fg: string; label: string
   return { bg: "#dc2626", fg: "#fff", label };
 }
 
-function miles(m: number | null): string {
+function km(m: number | null): string {
   if (m == null) return "–";
-  return (m / 1609.34).toFixed(2) + " mi";
+  return (m / 1000).toFixed(2) + " km";
 }
 
 function Stat({ label, value, sub }: { label: string; value: string; sub?: string }) {
@@ -53,7 +54,7 @@ export default function GeogridPage() {
   const [outletId, setOutletId] = useState("");
   const [keyword, setKeyword] = useState("");
   const [gridSize, setGridSize] = useState(9);
-  const [rangeMiles, setRangeMiles] = useState(0.1);
+  const [radiusKm, setRadiusKm] = useState(2);
   const [scans, setScans] = useState<Scan[]>([]);
   const [active, setActive] = useState<Scan | null>(null);
   const [running, setRunning] = useState(false);
@@ -91,6 +92,8 @@ export default function GeogridPage() {
       return;
     }
     setRunning(true);
+    // radius (km, store→edge) → spacing (miles) between the gridSize points
+    const rangeMiles = radiusKm / ((gridSize - 1) / 2) / 1.60934;
     try {
       const res = await fetch("/api/geogrid/scan", {
         method: "POST",
@@ -158,8 +161,8 @@ export default function GeogridPage() {
           </select>
         </div>
         <div>
-          <label className="block text-xs font-medium text-muted-foreground">Range (mi)</label>
-          <input type="number" step="0.05" min="0.05" value={rangeMiles} onChange={(e) => setRangeMiles(Number(e.target.value))} className="mt-1 w-24 rounded-lg border border-border bg-white px-3 py-2 text-sm" />
+          <label className="block text-xs font-medium text-muted-foreground">Radius (km)</label>
+          <input type="number" step="0.5" min="0.5" value={radiusKm} onChange={(e) => setRadiusKm(Number(e.target.value))} className="mt-1 w-24 rounded-lg border border-border bg-white px-3 py-2 text-sm" />
         </div>
         <button onClick={run} disabled={running || !outletId} className="flex items-center gap-1.5 rounded-lg bg-brand-dark px-4 py-2 text-sm font-medium text-white hover:bg-brand-dark/90 disabled:opacity-50">
           {running ? <Loader2 className="h-4 w-4 animate-spin" /> : <Play className="h-4 w-4" />}
@@ -174,7 +177,7 @@ export default function GeogridPage() {
           <div className="mt-6 grid grid-cols-2 gap-3 sm:grid-cols-4">
             <Stat label="Avg rank" value={active.avgRank != null ? active.avgRank.toFixed(1) : "–"} sub="lower is better" />
             <Stat label="% in top 3" value={`${Math.round(active.pctTop3 ?? 0)}%`} sub="more green = better" />
-            <Stat label="Green radius" value={miles(active.greenRadiusM)} sub="rank ≤3 reach (goal #2)" />
+            <Stat label="Green radius" value={km(active.greenRadiusM)} sub="rank ≤3 reach (goal #2)" />
             <Stat label="Coverage" value={`${active.foundPoints}/${active.totalPoints}`} sub="points ranking ≤20" />
           </div>
 
@@ -182,7 +185,7 @@ export default function GeogridPage() {
           <div className="mt-5 rounded-xl border border-border bg-white p-4">
             <div className="mb-2 flex items-center gap-2 text-sm text-muted-foreground">
               <MapPin className="h-4 w-4" />
-              <span className="font-medium text-foreground">&ldquo;{active.keyword}&rdquo;</span> · {active.gridSize}×{active.gridSize} · {active.rangeMiles} mi spacing
+              <span className="font-medium text-foreground">&ldquo;{active.keyword}&rdquo;</span> · {active.gridSize}×{active.gridSize} · ~{(active.rangeMiles * ((active.gridSize - 1) / 2) * 1.60934).toFixed(1)} km radius
             </div>
             <div className="grid gap-1.5" style={{ gridTemplateColumns: `repeat(${active.gridSize}, minmax(0, 1fr))`, maxWidth: 520 }}>
               {grid.flat().map((p) => {
@@ -198,6 +201,32 @@ export default function GeogridPage() {
               Center = your storefront. Rank approximated from the Places API (proxy for the Maps local pack) — use it for trend, not exact position.
             </p>
           </div>
+
+          {/* Competitors — who out-ranks us, for reference */}
+          {active.competitors && active.competitors.length > 0 && (
+            <div className="mt-5 rounded-xl border border-border bg-white p-4">
+              <div className="mb-2 text-sm font-medium text-foreground">Top competitors here (for reference)</div>
+              <table className="w-full text-sm">
+                <thead>
+                  <tr className="text-left text-xs text-muted-foreground">
+                    <th className="py-1">Competitor</th><th>In top-3 at</th><th>Avg rank</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {active.competitors.map((c, i) => (
+                    <tr key={i} className="border-t border-border">
+                      <td className="py-1.5">{c.name}</td>
+                      <td>{c.top3Points} / {active.totalPoints} pts</td>
+                      <td>{c.avgRank.toFixed(1)}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+              <p className="mt-2 text-[11px] text-muted-foreground">
+                Who shows above you across the grid. You climb past them with prominence — more reviews, faster.
+              </p>
+            </div>
+          )}
 
           {/* History / trend — the loop */}
           {scans.length > 1 && (
@@ -220,7 +249,7 @@ export default function GeogridPage() {
                       <td className="text-muted-foreground">{s.keyword}</td>
                       <td>{s.avgRank != null ? s.avgRank.toFixed(1) : "–"}</td>
                       <td>{Math.round(s.pctTop3 ?? 0)}%</td>
-                      <td>{miles(s.greenRadiusM)}</td>
+                      <td>{km(s.greenRadiusM)}</td>
                     </tr>
                   ))}
                 </tbody>

--- a/apps/backoffice/src/app/api/cron/geogrid-keywords/route.ts
+++ b/apps/backoffice/src/app/api/cron/geogrid-keywords/route.ts
@@ -1,0 +1,30 @@
+import { NextRequest, NextResponse } from "next/server";
+import { checkCronAuth } from "@celsius/shared";
+import { prisma } from "@/lib/prisma";
+import { refreshKeywords } from "@/lib/geogrid/keywords";
+
+export const dynamic = "force-dynamic";
+export const maxDuration = 120;
+
+// Monthly: auto-select each outlet's tracked geogrid keywords from the GBP
+// Performance API (the terms customers actually searched), branded/nav filtered.
+const TOP_N = Number(process.env.GEOGRID_KEYWORDS_PER_OUTLET || 4);
+
+export async function GET(req: NextRequest) {
+  const auth = checkCronAuth(req.headers);
+  if (!auth.ok) return NextResponse.json({ error: auth.error }, { status: auth.status });
+
+  const outlets = await prisma.outlet.findMany({
+    where: { status: "ACTIVE" },
+    include: { reviewSettings: true },
+  });
+  const connected = outlets.filter((o) => o.reviewSettings?.gbpLocationName);
+
+  const results = [];
+  for (const o of connected) {
+    const r = await refreshKeywords(o.id, TOP_N);
+    results.push({ outlet: o.name, ...r });
+  }
+
+  return NextResponse.json({ ran_at: new Date().toISOString(), topN: TOP_N, results });
+}

--- a/apps/backoffice/src/app/api/cron/geogrid-scan/route.ts
+++ b/apps/backoffice/src/app/api/cron/geogrid-scan/route.ts
@@ -1,0 +1,77 @@
+import { NextRequest, NextResponse } from "next/server";
+import { checkCronAuth } from "@celsius/shared";
+import { prisma } from "@/lib/prisma";
+import { runScan, isDue, needScore } from "@/lib/geogrid/scan-runner";
+
+export const dynamic = "force-dynamic";
+export const maxDuration = 300;
+
+// Weekly adaptive scan. Each active keyword×outlet is scanned only when "due"
+// (working combos ~weekly, at-goal combos ~monthly), worst-ranking first, and
+// only up to the monthly budget cap — so spend lands where rank needs improving.
+const MONTHLY_CAP = Number(process.env.GEOGRID_MONTHLY_SCAN_CAP || 40);
+const GRID_SIZE = Number(process.env.GEOGRID_GRID_SIZE || 9);
+const RANGE_MILES = Number(process.env.GEOGRID_RANGE_MILES || 0.2); // ~1.8km, to see the 2km goal
+
+export async function GET(req: NextRequest) {
+  const auth = checkCronAuth(req.headers);
+  if (!auth.ok) return NextResponse.json({ error: auth.error }, { status: auth.status });
+
+  const apiKey = process.env.GOOGLE_PLACES_API_KEY;
+  if (!apiKey) return NextResponse.json({ skipped: "GOOGLE_PLACES_API_KEY not set" });
+
+  const now = new Date();
+  const monthStart = new Date(now.getFullYear(), now.getMonth(), 1);
+  const scansThisMonth = await prisma.geoGridScan.count({ where: { createdAt: { gte: monthStart } } });
+  let budget = MONTHLY_CAP - scansThisMonth;
+  if (budget <= 0) {
+    return NextResponse.json({ capped: true, monthlyCap: MONTHLY_CAP, scansThisMonth });
+  }
+
+  const keywords = await prisma.geoGridKeyword.findMany({
+    where: { active: true, outlet: { status: "ACTIVE" } },
+    include: { outlet: { select: { name: true } } },
+  });
+
+  // Which combos are due, and how badly they need it (warmest-first).
+  const due: { outletId: string; outletName: string; keyword: string; score: number }[] = [];
+  for (const k of keywords) {
+    const last = await prisma.geoGridScan.findFirst({
+      where: { outletId: k.outletId, keyword: k.keyword },
+      orderBy: { createdAt: "desc" },
+      select: { createdAt: true, pctTop3: true, avgRank: true },
+    });
+    if (isDue(last, now)) {
+      due.push({ outletId: k.outletId, outletName: k.outlet.name, keyword: k.keyword, score: needScore(last) });
+    }
+  }
+  due.sort((a, b) => b.score - a.score);
+
+  const results: { outlet: string; keyword: string; avgRank?: number | null; pctTop3?: number | null; error?: string }[] = [];
+  for (const c of due) {
+    if (budget <= 0) break;
+    try {
+      const { scan } = await runScan({
+        outletId: c.outletId,
+        keyword: c.keyword,
+        gridSize: GRID_SIZE,
+        rangeMiles: RANGE_MILES,
+        apiKey,
+        createdBy: "auto-loop",
+      });
+      results.push({ outlet: c.outletName, keyword: c.keyword, avgRank: scan.avgRank, pctTop3: scan.pctTop3 });
+      budget--;
+    } catch (err) {
+      results.push({ outlet: c.outletName, keyword: c.keyword, error: (err as Error).message });
+    }
+  }
+
+  return NextResponse.json({
+    ran_at: now.toISOString(),
+    monthlyCap: MONTHLY_CAP,
+    dueCombos: due.length,
+    scanned: results.filter((r) => !r.error).length,
+    remainingBudget: Math.max(0, budget),
+    results,
+  });
+}

--- a/apps/backoffice/src/app/api/geogrid/scan/route.ts
+++ b/apps/backoffice/src/app/api/geogrid/scan/route.ts
@@ -1,13 +1,10 @@
 import { NextRequest, NextResponse } from "next/server";
 import { getUserFromHeaders } from "@/lib/auth";
 import { prisma } from "@/lib/prisma";
-import { getLocationGeo } from "@/lib/reviews/gbp";
-import { buildGrid, scanGrid, computeMetrics } from "@/lib/geogrid/places";
+import { runScan, GeoScanError } from "@/lib/geogrid/scan-runner";
 
 export const dynamic = "force-dynamic";
 export const maxDuration = 120;
-
-const METERS_PER_MILE = 1609.34;
 
 // GET /api/geogrid/scan?outletId=...&keyword=... — recent scans (with points) for trend.
 export async function GET(request: NextRequest) {
@@ -50,68 +47,21 @@ export async function POST(request: NextRequest) {
     return NextResponse.json({ error: "outletId and keyword required" }, { status: 400 });
   }
 
-  const outlet = await prisma.outlet.findUnique({
-    where: { id: outletId },
-    include: { reviewSettings: true },
-  });
-  if (!outlet?.reviewSettings?.gbpLocationName) {
-    return NextResponse.json({ error: "Outlet has no GBP location connected" }, { status: 400 });
-  }
-
-  // Resolve centre + target Places id from the GBP location. GBP doesn't always
-  // expose latlng, so fall back to the outlet's own stored coordinates, and to
-  // the outlet name for matching when there's no Place id.
-  let geo: { lat: number | null; lng: number | null; placeId: string | null; title: string | null } = {
-    lat: null, lng: null, placeId: null, title: null,
-  };
   try {
-    geo = await getLocationGeo(outlet.reviewSettings.gbpLocationName);
-  } catch (err) {
-    console.error("[geogrid] GBP location info failed, falling back to outlet coords:", err);
-  }
-
-  const centerLat = geo.lat ?? (outlet.lat != null ? Number(outlet.lat) : null);
-  const centerLng = geo.lng ?? (outlet.lng != null ? Number(outlet.lng) : null);
-  if (centerLat == null || centerLng == null) {
-    return NextResponse.json(
-      { error: "No coordinates for this outlet (set its lat/lng, or fix its Google profile)" },
-      { status: 400 },
-    );
-  }
-  const targetTitle = geo.title ?? outlet.name;
-
-  const points = buildGrid(centerLat, centerLng, gridSize, rangeMiles);
-  const radiusM = Math.min(Math.max(rangeMiles * METERS_PER_MILE, 500), 5000);
-
-  const { points: scanned, failures } = await scanGrid(
-    apiKey,
-    keyword,
-    points,
-    radiusM,
-    geo.placeId,
-    targetTitle,
-  );
-  const metrics = computeMetrics(scanned, centerLat, centerLng);
-
-  const scan = await prisma.geoGridScan.create({
-    data: {
+    const { scan, failures } = await runScan({
       outletId,
       keyword,
       gridSize,
       rangeMiles,
-      centerLat,
-      centerLng,
-      placeId: geo.placeId,
-      status: failures === 0 ? "complete" : failures < points.length ? "partial" : "failed",
-      points: scanned,
-      avgRank: metrics.avgRank,
-      pctTop3: metrics.pctTop3,
-      foundPoints: metrics.foundPoints,
-      totalPoints: metrics.totalPoints,
-      greenRadiusM: metrics.greenRadiusM,
+      apiKey,
       createdBy: user.name || user.id,
-    },
-  });
-
-  return NextResponse.json({ scan, failures });
+    });
+    return NextResponse.json({ scan, failures });
+  } catch (err) {
+    if (err instanceof GeoScanError) {
+      return NextResponse.json({ error: err.message }, { status: err.status });
+    }
+    console.error("[geogrid] scan failed:", err);
+    return NextResponse.json({ error: "Scan failed" }, { status: 500 });
+  }
 }

--- a/apps/backoffice/src/lib/geogrid/keywords.ts
+++ b/apps/backoffice/src/lib/geogrid/keywords.ts
@@ -1,0 +1,56 @@
+/**
+ * Auto-select which keywords each outlet's geogrid tracks, from the GBP
+ * Performance API (the terms customers actually searched). Branded and
+ * navigational/address terms are filtered out — we only track discovery terms.
+ */
+import { prisma } from "@/lib/prisma";
+import { getTopSearchKeywords } from "@/lib/reviews/gbp";
+
+// Branded ("celsius...") = trivially #1, not discovery. Address/navigational =
+// the person already knows us. Drop both; keep category/product/location terms.
+function isBrandedOrNav(keyword: string): boolean {
+  const k = keyword.toLowerCase();
+  if (/celsius|celcius/.test(k)) return true;
+  if (k.length > 45) return true; // full-address strings
+  if (/persiaran|jalan|lorong|lebuh|selangor|\b\d{5}\b/.test(k)) return true;
+  return false;
+}
+
+export async function refreshKeywords(
+  outletId: string,
+  topN = 4,
+): Promise<{ ok: boolean; selected?: string[]; reason?: string }> {
+  const outlet = await prisma.outlet.findUnique({
+    where: { id: outletId },
+    include: { reviewSettings: true },
+  });
+  if (!outlet?.reviewSettings?.gbpLocationName) {
+    return { ok: false, reason: "no GBP location" };
+  }
+
+  let all;
+  try {
+    all = await getTopSearchKeywords(outlet.reviewSettings.gbpLocationName);
+  } catch (err) {
+    return { ok: false, reason: `performance API: ${(err as Error).message}` };
+  }
+
+  const discovery = all.filter((k) => !isBrandedOrNav(k.keyword)).slice(0, topN);
+  if (discovery.length === 0) return { ok: false, reason: "no discovery keywords found" };
+
+  const keep = discovery.map((d) => d.keyword);
+  for (const d of discovery) {
+    await prisma.geoGridKeyword.upsert({
+      where: { outletId_keyword: { outletId, keyword: d.keyword } },
+      update: { active: true, impressions: d.impressions, source: "auto" },
+      create: { outletId, keyword: d.keyword, impressions: d.impressions, source: "auto", active: true },
+    });
+  }
+  // Retire auto keywords that dropped out of the top set (keep manual ones).
+  await prisma.geoGridKeyword.updateMany({
+    where: { outletId, source: "auto", active: true, keyword: { notIn: keep } },
+    data: { active: false },
+  });
+
+  return { ok: true, selected: keep };
+}

--- a/apps/backoffice/src/lib/geogrid/places.ts
+++ b/apps/backoffice/src/lib/geogrid/places.ts
@@ -45,7 +45,10 @@ export function distanceMeters(lat1: number, lng1: number, lat2: number, lng2: n
   return 2 * R * Math.asin(Math.sqrt(a));
 }
 
-/** Rank of the target business in Places results for `keyword` at a point, or null if not in top 20. */
+export type PointResult = { name: string; placeId: string; isUs: boolean };
+export type Competitor = { name: string; top3Points: number; avgRank: number };
+
+/** Our rank + the ranked businesses (for the competitor reference) at one point. */
 export async function rankAtPoint(
   apiKey: string,
   keyword: string,
@@ -54,7 +57,7 @@ export async function rankAtPoint(
   radiusM: number,
   targetPlaceId: string | null,
   targetTitle: string | null,
-): Promise<number | null> {
+): Promise<{ rank: number | null; results: PointResult[] }> {
   const res = await fetch("https://places.googleapis.com/v1/places:searchText", {
     method: "POST",
     headers: {
@@ -75,12 +78,16 @@ export async function rankAtPoint(
   const data = await res.json();
   const places: { id?: string; displayName?: { text?: string } }[] = data.places ?? [];
   const title = targetTitle?.toLowerCase();
-  const idx = places.findIndex(
-    (p) =>
-      (targetPlaceId && p.id === targetPlaceId) ||
-      (title && p.displayName?.text?.toLowerCase().includes(title)),
-  );
-  return idx >= 0 ? idx + 1 : null;
+  const isUs = (p: { id?: string; displayName?: { text?: string } }) =>
+    (!!targetPlaceId && p.id === targetPlaceId) ||
+    (!!title && !!p.displayName?.text?.toLowerCase().includes(title));
+  const idx = places.findIndex(isUs);
+  const results: PointResult[] = places.slice(0, 8).map((p) => ({
+    name: p.displayName?.text ?? "",
+    placeId: p.id ?? "",
+    isUs: isUs(p),
+  }));
+  return { rank: idx >= 0 ? idx + 1 : null, results };
 }
 
 export function computeMetrics(points: GridPoint[], centerLat: number, centerLng: number) {
@@ -97,7 +104,7 @@ export function computeMetrics(points: GridPoint[], centerLat: number, centerLng
   };
 }
 
-/** Run all grid points with limited concurrency so we don't hammer the Places API. */
+/** Run all grid points with limited concurrency, also tallying who out-ranks us. */
 export async function scanGrid(
   apiKey: string,
   keyword: string,
@@ -106,14 +113,26 @@ export async function scanGrid(
   targetPlaceId: string | null,
   targetTitle: string | null,
   concurrency = 8,
-): Promise<{ points: GridPoint[]; failures: number }> {
+): Promise<{ points: GridPoint[]; failures: number; competitors: Competitor[] }> {
   let failures = 0;
+  const tally = new Map<string, { name: string; top3: number; rankSum: number; count: number }>();
+
   for (let i = 0; i < points.length; i += concurrency) {
     const batch = points.slice(i, i + concurrency);
     await Promise.all(
       batch.map(async (p) => {
         try {
-          p.rank = await rankAtPoint(apiKey, keyword, p.lat, p.lng, radiusM, targetPlaceId, targetTitle);
+          const { rank, results } = await rankAtPoint(apiKey, keyword, p.lat, p.lng, radiusM, targetPlaceId, targetTitle);
+          p.rank = rank;
+          results.forEach((r, i2) => {
+            if (r.isUs || !r.name) return;
+            const key = r.placeId || r.name.toLowerCase();
+            const t = tally.get(key) ?? { name: r.name, top3: 0, rankSum: 0, count: 0 };
+            t.count++;
+            t.rankSum += i2 + 1;
+            if (i2 < 3) t.top3++;
+            tally.set(key, t);
+          });
         } catch (err) {
           failures++;
           console.error(`[geogrid] point ${p.row},${p.col} failed:`, (err as Error).message);
@@ -122,5 +141,11 @@ export async function scanGrid(
       }),
     );
   }
-  return { points, failures };
+
+  const competitors: Competitor[] = [...tally.values()]
+    .map((t) => ({ name: t.name, top3Points: t.top3, avgRank: t.count ? t.rankSum / t.count : 0 }))
+    .sort((a, b) => b.top3Points - a.top3Points || a.avgRank - b.avgRank)
+    .slice(0, 6);
+
+  return { points, failures, competitors };
 }

--- a/apps/backoffice/src/lib/geogrid/scan-runner.ts
+++ b/apps/backoffice/src/lib/geogrid/scan-runner.ts
@@ -56,7 +56,7 @@ export async function runScan(opts: {
 
   const points = buildGrid(centerLat, centerLng, gridSize, rangeMiles);
   const radiusM = Math.min(Math.max(rangeMiles * METERS_PER_MILE, 500), 5000);
-  const { points: scanned, failures } = await scanGrid(apiKey, keyword, points, radiusM, geo.placeId, targetTitle);
+  const { points: scanned, failures, competitors } = await scanGrid(apiKey, keyword, points, radiusM, geo.placeId, targetTitle);
   const metrics = computeMetrics(scanned, centerLat, centerLng);
 
   const scan = await prisma.geoGridScan.create({
@@ -75,6 +75,7 @@ export async function runScan(opts: {
       foundPoints: metrics.foundPoints,
       totalPoints: metrics.totalPoints,
       greenRadiusM: metrics.greenRadiusM,
+      competitors,
       createdBy: createdBy ?? null,
     },
   });

--- a/apps/backoffice/src/lib/geogrid/scan-runner.ts
+++ b/apps/backoffice/src/lib/geogrid/scan-runner.ts
@@ -1,0 +1,107 @@
+/**
+ * Shared geogrid scan orchestration (used by the manual route + the auto cron)
+ * and the adaptive cadence logic that decides when each keyword×outlet is due.
+ */
+import { prisma } from "@/lib/prisma";
+import { getLocationGeo } from "@/lib/reviews/gbp";
+import { buildGrid, scanGrid, computeMetrics } from "@/lib/geogrid/places";
+import type { GeoGridScan } from "@prisma/client";
+
+const METERS_PER_MILE = 1609.34;
+
+export class GeoScanError extends Error {
+  status: number;
+  constructor(message: string, status = 400) {
+    super(message);
+    this.status = status;
+  }
+}
+
+/** Resolve the outlet centre + target, run the grid, store the scan. */
+export async function runScan(opts: {
+  outletId: string;
+  keyword: string;
+  gridSize: number;
+  rangeMiles: number;
+  apiKey: string;
+  createdBy?: string;
+}): Promise<{ scan: GeoGridScan; failures: number }> {
+  const { outletId, keyword, gridSize, rangeMiles, apiKey, createdBy } = opts;
+
+  const outlet = await prisma.outlet.findUnique({
+    where: { id: outletId },
+    include: { reviewSettings: true },
+  });
+  if (!outlet?.reviewSettings?.gbpLocationName) {
+    throw new GeoScanError("Outlet has no GBP location connected");
+  }
+
+  // GBP doesn't always expose latlng — fall back to the outlet's own coords,
+  // and to the outlet name for matching when there's no Place id.
+  let geo: { lat: number | null; lng: number | null; placeId: string | null; title: string | null } = {
+    lat: null, lng: null, placeId: null, title: null,
+  };
+  try {
+    geo = await getLocationGeo(outlet.reviewSettings.gbpLocationName);
+  } catch (err) {
+    console.error("[geogrid] GBP location info failed, falling back to outlet coords:", err);
+  }
+
+  const centerLat = geo.lat ?? (outlet.lat != null ? Number(outlet.lat) : null);
+  const centerLng = geo.lng ?? (outlet.lng != null ? Number(outlet.lng) : null);
+  if (centerLat == null || centerLng == null) {
+    throw new GeoScanError("No coordinates for this outlet (set its lat/lng, or fix its Google profile)");
+  }
+  const targetTitle = geo.title ?? outlet.name;
+
+  const points = buildGrid(centerLat, centerLng, gridSize, rangeMiles);
+  const radiusM = Math.min(Math.max(rangeMiles * METERS_PER_MILE, 500), 5000);
+  const { points: scanned, failures } = await scanGrid(apiKey, keyword, points, radiusM, geo.placeId, targetTitle);
+  const metrics = computeMetrics(scanned, centerLat, centerLng);
+
+  const scan = await prisma.geoGridScan.create({
+    data: {
+      outletId,
+      keyword,
+      gridSize,
+      rangeMiles,
+      centerLat,
+      centerLng,
+      placeId: geo.placeId,
+      status: failures === 0 ? "complete" : failures < points.length ? "partial" : "failed",
+      points: scanned,
+      avgRank: metrics.avgRank,
+      pctTop3: metrics.pctTop3,
+      foundPoints: metrics.foundPoints,
+      totalPoints: metrics.totalPoints,
+      greenRadiusM: metrics.greenRadiusM,
+      createdBy: createdBy ?? null,
+    },
+  });
+  return { scan, failures };
+}
+
+// ── Adaptive cadence ────────────────────────────────────────────────────────
+// A combo at goal is checked monthly; one still being worked, weekly. This is
+// what concentrates the scan budget on outlets/keywords that need improvement.
+
+export const AT_GOAL_TOP3_PCT = 70; // ≥70% of grid in top-3 ≈ won
+
+type LastScan = { createdAt: Date; pctTop3: number | null; avgRank: number | null } | null;
+
+export function atGoal(last: LastScan): boolean {
+  return !!last && (last.pctTop3 ?? 0) >= AT_GOAL_TOP3_PCT;
+}
+
+/** At-goal combos re-checked every ~28 days; working combos every ~7; new = now. */
+export function isDue(last: LastScan, now: Date): boolean {
+  if (!last) return true;
+  const days = (now.getTime() - new Date(last.createdAt).getTime()) / 86400000;
+  return atGoal(last) ? days >= 28 : days >= 7;
+}
+
+/** Warmest-first priority: further from goal = higher. */
+export function needScore(last: LastScan): number {
+  if (!last) return 1000;
+  return 100 - (last.pctTop3 ?? 0) + (last.avgRank ?? 20);
+}

--- a/apps/backoffice/src/lib/reviews/gbp.ts
+++ b/apps/backoffice/src/lib/reviews/gbp.ts
@@ -269,3 +269,43 @@ export async function getLocationGeo(
     title: data.title ?? null,
   };
 }
+
+const GBP_PERF_BASE = "https://businessprofileperformance.googleapis.com/v1";
+
+// The actual search terms customers used to find this location, with monthly
+// impressions — the data source for auto-selecting which keywords to track.
+export async function getTopSearchKeywords(
+  locationName: string,
+  monthsBack = 5,
+): Promise<{ keyword: string; impressions: number }[]> {
+  const token = await getAccessToken();
+  const now = new Date();
+  // Use complete months: end = last month, start = end - (monthsBack-1).
+  const end = new Date(now.getFullYear(), now.getMonth() - 1, 1);
+  const start = new Date(end.getFullYear(), end.getMonth() - (monthsBack - 1), 1);
+  const params = new URLSearchParams({
+    "monthlyRange.startMonth.year": String(start.getFullYear()),
+    "monthlyRange.startMonth.month": String(start.getMonth() + 1),
+    "monthlyRange.endMonth.year": String(end.getFullYear()),
+    "monthlyRange.endMonth.month": String(end.getMonth() + 1),
+  });
+  const res = await fetch(
+    `${GBP_PERF_BASE}/${locationName}/searchkeywords/impressions/monthly?${params}`,
+    { headers: { Authorization: `Bearer ${token}` } },
+  );
+  if (!res.ok) {
+    const body = await res.text();
+    throw new Error(`GBP performance error ${res.status}: ${body}`);
+  }
+  const data = await res.json();
+  const rows: { searchKeyword?: string; insightsValue?: { value?: string; threshold?: string } }[] =
+    data.searchKeywordsCounts ?? [];
+  return rows
+    .map((r) => ({
+      keyword: (r.searchKeyword ?? "").trim(),
+      // "value" is the real count; "threshold" means "fewer than N" (low volume).
+      impressions: Number(r.insightsValue?.value ?? r.insightsValue?.threshold ?? 0),
+    }))
+    .filter((r) => r.keyword)
+    .sort((a, b) => b.impressions - a.impressions);
+}

--- a/apps/backoffice/vercel.json
+++ b/apps/backoffice/vercel.json
@@ -95,6 +95,14 @@
     {
       "path": "/api/cron/reviews-auto-reply",
       "schedule": "0 4 * * *"
+    },
+    {
+      "path": "/api/cron/geogrid-keywords",
+      "schedule": "0 6 1 * *"
+    },
+    {
+      "path": "/api/cron/geogrid-scan",
+      "schedule": "0 5 * * 1"
     }
   ]
 }

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -1400,6 +1400,7 @@ model GeoGridScan {
   foundPoints  Int      @default(0)
   totalPoints  Int      @default(0)
   greenRadiusM Float? // farthest point (m) still ranking ≤3
+  competitors  Json     @default("[]") // [{name, top3Points, avgRank}] who out-ranks us
   createdAt    DateTime @default(now())
   createdBy    String?
 

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -104,6 +104,7 @@ model Outlet {
   internalFeedbacks InternalFeedback[]
   reviewReplyDrafts ReviewReplyDraft[]
   geoGridScans      GeoGridScan[]
+  geoGridKeywords   GeoGridKeyword[]
   auditReports      AuditReport[]
   recurringExpenses RecurringExpense[]
   bankStatementLines BankStatementLine[]
@@ -1403,6 +1404,23 @@ model GeoGridScan {
   createdBy    String?
 
   @@index([outletId, keyword, createdAt])
+}
+
+// Tracked keyword set per outlet for the automated geogrid loop. Auto-selected
+// monthly from the GBP Performance API (terms customers actually search).
+model GeoGridKeyword {
+  id          String   @id @default(uuid())
+  outletId    String
+  outlet      Outlet   @relation(fields: [outletId], references: [id])
+  keyword     String
+  source      String   @default("auto") // auto | manual
+  impressions Int? // monthly impressions (importance)
+  active      Boolean  @default(true)
+  createdAt   DateTime @default(now())
+  updatedAt   DateTime @updatedAt
+
+  @@unique([outletId, keyword])
+  @@index([outletId, active])
 }
 
 // ─── ADS MODULE ─────────────────────────────────────────────

--- a/supabase/migrations/057_geogrid_keywords.sql
+++ b/supabase/migrations/057_geogrid_keywords.sql
@@ -1,0 +1,19 @@
+-- 057_geogrid_keywords.sql
+-- Tracked keyword set per outlet for the automated geogrid loop. Keywords are
+-- auto-selected monthly from the GBP Performance API (the terms customers
+-- actually search), branded/navigational terms filtered out. The scan cron
+-- runs these on a need-weighted cadence.
+
+CREATE TABLE IF NOT EXISTS "GeoGridKeyword" (
+  "id"          text PRIMARY KEY,
+  "outletId"    text NOT NULL REFERENCES "Outlet"("id"),
+  "keyword"     text NOT NULL,
+  "source"      text NOT NULL DEFAULT 'auto',  -- auto | manual
+  "impressions" integer,                        -- monthly impressions (importance)
+  "active"      boolean NOT NULL DEFAULT true,
+  "createdAt"   timestamptz NOT NULL DEFAULT now(),
+  "updatedAt"   timestamptz NOT NULL DEFAULT now(),
+  UNIQUE ("outletId", "keyword")
+);
+
+CREATE INDEX IF NOT EXISTS "GeoGridKeyword_outlet_idx" ON "GeoGridKeyword" ("outletId", "active");

--- a/supabase/migrations/058_geogrid_competitors.sql
+++ b/supabase/migrations/058_geogrid_competitors.sql
@@ -1,0 +1,6 @@
+-- 058_geogrid_competitors.sql
+-- Store the competitor leaderboard captured during a scan (who out-ranks us
+-- across the grid) for reference: [{name, top3Points, avgRank}].
+
+ALTER TABLE "GeoGridScan"
+  ADD COLUMN IF NOT EXISTS "competitors" jsonb NOT NULL DEFAULT '[]';


### PR DESCRIPTION
Turns the geogrid from a manual tool into the hands-off loop we scoped.

## What it does
- **Keyword auto-selection** — monthly cron `/api/cron/geogrid-keywords` pulls each outlet's *real* search terms from the GBP Performance API, filters out branded/navigational, and stores the **top-4** as the tracked set (`GeoGridKeyword`, migration 057). Self-refreshing as search behaviour shifts — no manual keyword lists.
- **Adaptive, capped scan** — weekly cron `/api/cron/geogrid-scan` scans each keyword×outlet **only when due**: *working* combos ~weekly, *at-goal* combos (≥70% top-3) ~monthly — **worst-ranking first**, up to a **monthly budget cap** (`GEOGRID_MONTHLY_SCAN_CAP`, default 40 ≈ RM500/mo). Spend concentrates where rank needs improving and **physically can't run away**.
- **Shared runner** — extracted `runScan` + cadence (`isDue`/`needScore`/`atGoal`) into `scan-runner.ts`; the manual scan route reuses it.
- Default auto-scan grid **0.2mi (~1.8km)** so the top-3@2km goal is measurable.

## Budget
~RM500/mo hard cap (warmest-first within it). Real spend likely far lower — the ~3–5k Places calls/mo probably sit inside Google's free monthly allowance. If it ever costs more than it saves (cut ad spend), kill it.

## Activation
The Places key is set, so this runs live once deployed. **Bootstrap:** trigger `/api/cron/geogrid-keywords` once to seed the tracked keyword sets; the weekly scan cron then picks them up.

## Verification
`tsc` + ESLint clean. Migration 057 applied + confirmed on the live DB. The scan path itself is already proven live (manual baselines ran successfully); the crons are thin wrappers over `runScan` + the proven Performance-API call.