### PR TITLE
fix(reviews): no em-dashes in auto-reply copy

### DIFF
--- a/apps/backoffice/src/lib/reviews/auto-reply.ts
+++ b/apps/backoffice/src/lib/reviews/auto-reply.ts
@@ -25,18 +25,18 @@ export async function generateReply(review: ReviewForReply): Promise<string> {
   const isPositive = review.rating >= POSITIVE_THRESHOLD;
 
   const contextBlock = review.context?.trim()
-    ? `\nWhat actually happened (context from our team — use it to respond honestly and specifically; name the cause and any fix that's coming, but never make excuses):\n${review.context.trim()}\n`
+    ? `\nWhat actually happened (context from our team, use it to respond honestly and specifically; name the cause and any fix that's coming, but never make excuses):\n${review.context.trim()}\n`
     : "";
 
   const prompt = isPositive
-    ? `You are the owner of Celsius Coffee (${review.outletName}), a specialty coffee café in Malaysia, replying to a happy Google review. Write a warm, genuine, professional thank-you — like a real person, not a brand. Open with "Hi ${review.reviewer}," and mention something specific they enjoyed. Keep it 1-2 short sentences. At most one emoji, usually none.
+    ? `You are the owner of Celsius Coffee (${review.outletName}), a specialty coffee café in Malaysia, replying to a happy Google review. Write a warm, genuine, professional thank-you that sounds like a real person, not a brand. Open with "Hi ${review.reviewer}," and mention something specific they enjoyed. Keep it 1-2 short sentences. At most one emoji, usually none. Do NOT use em-dashes or en-dashes (long dashes) anywhere; use commas, periods, or the word "and" instead.
 
 Reviewer: ${review.reviewer}
 Rating: ${review.rating}/5
 Review: ${review.comment || "(no comment, just a rating)"}
 
 Reply:`
-    : `You are the owner of Celsius Coffee (${review.outletName}), a specialty coffee café in Malaysia, replying personally to a critical Google review. Match the warm, professional, accountable voice from this real reply of ours — copy the TONE, never the content:
+    : `You are the owner of Celsius Coffee (${review.outletName}), a specialty coffee café in Malaysia, replying personally to a critical Google review. Match the warm, professional, accountable voice from this real reply of ours (copy the TONE, never the content):
 
 "Hi [Name], thank you so much for your honest feedback. We're truly sorry to hear your visit didn't meet expectations. Every guest deserves to feel welcomed and respected. We've already shared your comments with our team, and we're committed to doing better."
 
@@ -45,12 +45,12 @@ Write a reply that is PROFESSIONAL yet genuinely EMPATHETIC.
 Rules:
 - Open with "Hi ${review.reviewer}," then a sincere thank-you for their feedback.
 - Avoid stiff corporate clichés ("fell short of the standards we hold ourselves to") AND avoid sounding too casual or slangy ("that's on us", "no excuses", "honestly").
-- Acknowledge the SPECIFIC issues they raised with sincere empathy — name what actually went wrong.
-- Be accountable and reassuring: note that we've shared it with the team or are looking into it — but only where that reads as genuine, not a hollow promise.
+- Acknowledge the SPECIFIC issues they raised with sincere empathy, naming what actually went wrong.
+- Be accountable and reassuring: note that we've shared it with the team or are looking into it, but only where that reads as genuine, not a hollow promise.
 - Keep a polished, warm, respectful tone throughout.
 - Format as 2-4 SHORT paragraphs separated by a blank line. No wall of text.
-- Do NOT include any phone number, contact details, or "get in touch" line — that is appended separately afterwards.
-- No emojis. Keep it concise: 4-6 sentences.
+- Do NOT include any phone number, contact details, or "get in touch" line; that is appended separately afterwards.
+- No emojis. Do NOT use em-dashes or en-dashes (long dashes) anywhere; use commas, periods, or the word "and" instead. Keep it concise: 4-6 sentences.
 ${contextBlock}
 Reviewer: ${review.reviewer}
 Rating: ${review.rating}/5

--- a/apps/backoffice/src/lib/reviews/auto-reply.ts
+++ b/apps/backoffice/src/lib/reviews/auto-reply.ts
@@ -29,7 +29,7 @@ export async function generateReply(review: ReviewForReply): Promise<string> {
     : "";
 
   const prompt = isPositive
-    ? `You are the owner of Celsius Coffee (${review.outletName}), a specialty coffee café in Malaysia, replying to a happy Google review. Write a warm, genuine, professional thank-you that sounds like a real person, not a brand. Open with "Hi ${review.reviewer}," and mention something specific they enjoyed. Keep it 1-2 short sentences. At most one emoji, usually none. Do NOT use em-dashes or en-dashes (long dashes) anywhere; use commas, periods, or the word "and" instead.
+    ? `You are the owner of Celsius Coffee (${review.outletName}), a specialty coffee café in Malaysia, replying to a happy Google review. Write a friendly yet professional reply that sounds like a real person, not a brand. Open with "Hi ${review.reviewer}," sincerely thank them, mention something specific they enjoyed, and warmly invite them back. Keep it 2-3 short sentences, polished and warm. At most one emoji, usually none. Do NOT use em-dashes or en-dashes (long dashes) anywhere; use commas, periods, or the word "and" instead.
 
 Reviewer: ${review.reviewer}
 Rating: ${review.rating}/5


### PR DESCRIPTION
Owner feedback: review replies shouldn't use em-dashes or en-dashes (reads AI-generated / off-brand). Added an explicit no-dash rule to both reply prompts and stripped dashes from the prompt's own instructions. Verified fresh generations return zero em/en-dashes. tsc clean.

Saved as a standing memory rule (applies to all generated copy, not just reviews).