### PR TITLE
fix(loyalty): stop missions completing for already-ended weeks (stale-week stacking)

### DIFF
--- a/apps/order/src/app/api/loyalty/me/missions/active/route.ts
+++ b/apps/order/src/app/api/loyalty/me/missions/active/route.ts
@@ -145,6 +145,20 @@ export async function GET(req: NextRequest) {
   const supabase = getSupabaseAdmin();
   const { startIso, endIso } = currentWeekWindow();
 
+  // 0) Self-healing expiry: flip this member's leftover past-week active
+  //    assignments to 'expired'. Weekly assignments used to linger 'active'
+  //    forever, so a single order could complete the same mission for every
+  //    un-expired past week at once (the stale-week stacking bug — one visit
+  //    minting 3× Free Coffee). The order hook's week-window guard already
+  //    blocks crediting them; this keeps the data clean on each visit, matching
+  //    the lazy "opening the screen IS the rotation trigger" model (no cron).
+  await supabase
+    .from("mission_assignments")
+    .update({ status: "expired", expired_at: new Date().toISOString() })
+    .eq("member_id", r.member.memberId)
+    .eq("status", "active")
+    .lt("week_end_at", startIso);
+
   // 1) Fetch existing assignments for the current week.
   const { data: existing } = await supabase
     .from("mission_assignments")

--- a/apps/order/src/lib/loyalty/v2.ts
+++ b/apps/order/src/lib/loyalty/v2.ts
@@ -680,11 +680,19 @@ export async function applyOrderToMission(args: {
     return { completedMissionIds: [] };
   }
 
+  // Week-window guard: only credit this order to assignments whose week
+  // actually contains the order time. Without this, a member accumulates one
+  // active assignment per week and a single order completes the same mission
+  // for EVERY un-expired past week at once (the stale-week stacking bug:
+  // e.g. one order minting 3× Free Coffee for weeks it didn't earn). Pairs
+  // with the daily expiry sweep that flips past-week assignments to 'expired'.
   const { data: assignments } = await supabase
     .from("mission_assignments")
     .select("id, mission_id, progress_current, progress_target")
     .eq("member_id", args.memberId)
-    .eq("status", "active");
+    .eq("status", "active")
+    .lte("week_start_at", args.order.created_at)
+    .gte("week_end_at", args.order.created_at);
 
   if (!assignments || assignments.length === 0) {
     return { completedMissionIds: [] };


### PR DESCRIPTION
## Problem
The screenshots showed members holding 2-3 identical **Free Coffee** mission vouchers. Root cause: a member accumulates **one `mission_assignment` per week**, and nothing ever expired them (**0 of 834** had ever been marked `expired`). `applyOrderToMission` loaded **all** active assignments with no week filter, so **one qualifying order completed the same mission for every un-expired past week at once**.

Real cases:
- Rahiim: one order on Jun 24 → **3× Free Coffee** ("Group Order" for weeks Jun 22 ✓, Jun 15 ✗, Jun 8 ✗ — all fired at 12:29).
- Burhanudin: "RM50 Bill" from the **Jun 8-14** week completed **Jun 24**.
- System-wide: **33 of 120 mission vouchers (28%)** were minted from already-ended weeks; 14 in the last 7 days.

## Fix (code)
- **`applyOrderToMission` (v2.ts)** — week-window guard: only credit an order to an assignment whose `[week_start_at, week_end_at]` contains the order's `created_at`. Prevents cross-week / out-of-window completion structurally.
- **`missions/active` route** — self-healing expiry: on each visit, flip the member's leftover past-week active assignments to `expired`. Matches the existing lazy "opening the screen IS the rotation trigger" model (no cron needed).

## Data already rectified in prod (manual SQL, reversible status flips)
- **588** stale active assignments → `expired` (stops new minting).
- **30** redundant *unredeemed* vouchers clawed back (`active` → `expired`). Already-used vouchers left untouched.
- Post-state verified: 0 stale active assignments, 0 stale active vouchers.

## Test
- `tsc --noEmit` on apps/order: clean.