### PR TITLE
feat(reviews): daily rank scoreboard (the daily review lever)

### DIFF
--- a/apps/backoffice/src/app/(admin)/layout.tsx
+++ b/apps/backoffice/src/app/(admin)/layout.tsx
@@ -332,6 +332,7 @@ const NAV_SECTIONS: NavSection[] = [
           { label: "All Reviews", href: "/reviews", icon: <Star className={ICON_SIZE} />, moduleKey: "reviews:list" },
           { label: "Feedback Management", href: "/reviews/feedback", icon: <MessageSquare className={ICON_SIZE} />, moduleKey: "reviews:list" },
           { label: "Local Rank", href: "/reviews/geogrid", icon: <MapPinned className={ICON_SIZE} />, moduleKey: "reviews:list" },
+          { label: "Rank Scoreboard", href: "/reviews/scoreboard", icon: <Target className={ICON_SIZE} />, moduleKey: "reviews:list" },
         ],
       },
       {

--- a/apps/backoffice/src/app/(admin)/reviews/scoreboard/page.tsx
+++ b/apps/backoffice/src/app/(admin)/reviews/scoreboard/page.tsx
@@ -1,0 +1,147 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import Link from "next/link";
+import { Loader2, ArrowLeft, Star, TrendingUp } from "lucide-react";
+
+type ScoreStatus = "ahead" | "on_track" | "behind" | "no_competitor" | "no_data";
+type ScoreRow = {
+  outletId: string;
+  outletName: string;
+  asOf: string | null;
+  reviewCount: number | null;
+  averageRating: number | null;
+  responseRate: number | null;
+  velocity7d: number | null;
+  velocity30d: number | null;
+  competitorName: string | null;
+  competitorReviews: number | null;
+  gap: number | null;
+  targetPerDay: number | null;
+  status: ScoreStatus;
+};
+
+const STATUS: Record<ScoreStatus, { label: string; bg: string; fg: string }> = {
+  ahead: { label: "Ahead", bg: "#15803d", fg: "#fff" },
+  on_track: { label: "On track", bg: "#65a30d", fg: "#fff" },
+  behind: { label: "Behind", bg: "#dc2626", fg: "#fff" },
+  no_competitor: { label: "Leader", bg: "#0891b2", fg: "#fff" },
+  no_data: { label: "No data yet", bg: "#9ca3af", fg: "#fff" },
+};
+
+const num = (n: number | null, suffix = "") => (n == null ? "n/a" : `${n}${suffix}`);
+
+export default function ScoreboardPage() {
+  const [rows, setRows] = useState<ScoreRow[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [placesConfigured, setPlacesConfigured] = useState(true);
+
+  useEffect(() => {
+    fetch("/api/reviews/scoreboard")
+      .then((r) => r.json())
+      .then((d) => {
+        setRows(d.rows ?? []);
+        setPlacesConfigured(d.placesConfigured ?? true);
+      })
+      .finally(() => setLoading(false));
+  }, []);
+
+  return (
+    <div className="mx-auto max-w-6xl p-4 sm:p-6">
+      <Link href="/reviews/geogrid" className="mb-3 inline-flex items-center gap-1 text-sm text-muted-foreground hover:text-foreground">
+        <ArrowLeft className="h-4 w-4" /> Local Rank Geogrid
+      </Link>
+      <h1 className="font-heading text-2xl font-bold text-foreground">Daily Rank Scoreboard</h1>
+      <p className="mt-1 max-w-3xl text-sm text-muted-foreground">
+        The daily lever: reviews acquired per day vs the rate needed to out-review the nearest prominent
+        competitor. Reviews are the only local-rank input that moves daily. The geogrid confirms the rings
+        weekly. Action when an outlet is behind: ask more happy customers to review (in-store QR plus post-order).
+      </p>
+
+      {!placesConfigured && (
+        <div className="mt-3 rounded-lg border border-amber-300 bg-amber-50 p-3 text-sm text-amber-800">
+          Competitor gaps are inactive until <span className="font-mono">GOOGLE_PLACES_API_KEY</span> is set. Review velocity still tracks.
+        </div>
+      )}
+
+      {loading ? (
+        <div className="mt-8 flex items-center gap-2 text-muted-foreground">
+          <Loader2 className="h-4 w-4 animate-spin" /> Loading…
+        </div>
+      ) : (
+        <div className="mt-4 overflow-x-auto rounded-xl border border-border bg-white">
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="border-b border-border text-left text-xs uppercase tracking-wide text-muted-foreground">
+                <th className="px-3 py-2 font-medium">Outlet</th>
+                <th className="px-3 py-2 font-medium">Reviews</th>
+                <th className="px-3 py-2 font-medium">Response</th>
+                <th className="px-3 py-2 font-medium">Velocity /day</th>
+                <th className="px-3 py-2 font-medium">Chasing</th>
+                <th className="px-3 py-2 font-medium">Gap</th>
+                <th className="px-3 py-2 font-medium">Need /day</th>
+                <th className="px-3 py-2 font-medium">Status</th>
+              </tr>
+            </thead>
+            <tbody>
+              {rows.map((r) => {
+                const st = STATUS[r.status];
+                return (
+                  <tr key={r.outletId} className="border-b border-border last:border-0 align-top">
+                    <td className="px-3 py-3">
+                      <div className="font-medium text-foreground">{r.outletName}</div>
+                      {r.asOf && <div className="text-xs text-muted-foreground">as of {r.asOf}</div>}
+                    </td>
+                    <td className="px-3 py-3 text-foreground">
+                      <div>{num(r.reviewCount)}</div>
+                      {r.averageRating != null && (
+                        <div className="flex items-center gap-0.5 text-xs text-muted-foreground">
+                          <Star className="h-3 w-3 fill-amber-400 text-amber-400" /> {r.averageRating.toFixed(1)}
+                        </div>
+                      )}
+                    </td>
+                    <td className="px-3 py-3 text-foreground">
+                      {r.responseRate == null ? "n/a" : `${Math.round(r.responseRate * 100)}%`}
+                    </td>
+                    <td className="px-3 py-3 text-foreground">
+                      <div className="flex items-center gap-1">
+                        <TrendingUp className="h-3 w-3 text-muted-foreground" /> {num(r.velocity7d)} <span className="text-xs text-muted-foreground">7d</span>
+                      </div>
+                      <div className="text-xs text-muted-foreground">{num(r.velocity30d)} 30d</div>
+                    </td>
+                    <td className="px-3 py-3 text-foreground">
+                      {r.competitorName ? (
+                        <>
+                          <div className="max-w-[10rem] truncate" title={r.competitorName}>{r.competitorName}</div>
+                          <div className="text-xs text-muted-foreground">{num(r.competitorReviews)} reviews</div>
+                        </>
+                      ) : (
+                        <span className="text-muted-foreground">n/a</span>
+                      )}
+                    </td>
+                    <td className="px-3 py-3 text-foreground">
+                      {r.gap == null ? "n/a" : r.gap <= 0 ? <span className="text-emerald-600">+{-r.gap}</span> : <span className="text-red-600">-{r.gap}</span>}
+                    </td>
+                    <td className="px-3 py-3 font-medium text-foreground">{num(r.targetPerDay)}</td>
+                    <td className="px-3 py-3">
+                      <span className="rounded-full px-2 py-0.5 text-xs font-medium" style={{ background: st.bg, color: st.fg }}>
+                        {st.label}
+                      </span>
+                    </td>
+                  </tr>
+                );
+              })}
+              {!rows.length && (
+                <tr>
+                  <td colSpan={8} className="px-3 py-8 text-center text-muted-foreground">
+                    No snapshots yet. The first one runs on the daily cron.
+                  </td>
+                </tr>
+              )}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/backoffice/src/app/api/cron/reviews-daily-snapshot/route.ts
+++ b/apps/backoffice/src/app/api/cron/reviews-daily-snapshot/route.ts
@@ -1,0 +1,101 @@
+import { NextRequest, NextResponse } from "next/server";
+import { checkCronAuth } from "@celsius/shared";
+import { getUserFromHeaders } from "@/lib/auth";
+import { prisma } from "@/lib/prisma";
+import { fetchGoogleReviews } from "@/lib/reviews/gbp";
+import { fetchTopCompetitor } from "@/lib/reviews/competitors";
+import { buildScoreboard } from "@/lib/reviews/scoreboard";
+import { sendMessage } from "@/lib/telegram";
+
+export const dynamic = "force-dynamic";
+export const maxDuration = 300;
+
+// Daily snapshot of each outlet's Google review prominence + the top nearby
+// competitor's review count. Feeds the /reviews/scoreboard "daily rank lever"
+// (reviews/day vs the rate needed to out-review the leader). Idempotent per
+// day via the (outletId, snapshotDate) unique key, so re-running just refreshes
+// today's row.
+export async function GET(req: NextRequest) {
+  // Cron secret OR an authenticated admin (so it can be triggered manually).
+  const cronAuth = checkCronAuth(req.headers);
+  if (!cronAuth.ok) {
+    const user = await getUserFromHeaders(req.headers);
+    if (!user) return NextResponse.json({ error: cronAuth.error }, { status: cronAuth.status });
+  }
+
+  const apiKey = process.env.GOOGLE_PLACES_API_KEY;
+  const today = new Date();
+  today.setUTCHours(0, 0, 0, 0);
+  const now = Date.now();
+  const DAY = 86400000;
+
+  const outlets = await prisma.outlet.findMany({
+    where: { status: "ACTIVE" },
+    include: { reviewSettings: true },
+  });
+  const connected = outlets.filter(
+    (o) => o.reviewSettings?.gbpAccountId && o.reviewSettings?.gbpLocationName,
+  );
+
+  const results: { outlet: string; reviewCount?: number; competitor?: string | null; ok: boolean; error?: string }[] = [];
+
+  for (const outlet of connected) {
+    const s = outlet.reviewSettings!;
+    try {
+      const data = await fetchGoogleReviews(s.gbpAccountId!, s.gbpLocationName!, 50);
+      const recentFetched = data.reviews.length;
+      const recentResponded = data.reviews.filter((r) => r.reply).length;
+      const reviews7d = data.reviews.filter((r) => new Date(r.createdAt).getTime() >= now - 7 * DAY).length;
+      const reviews30d = data.reviews.filter((r) => new Date(r.createdAt).getTime() >= now - 30 * DAY).length;
+
+      let comp = null;
+      if (apiKey && outlet.lat != null && outlet.lng != null) {
+        comp = await fetchTopCompetitor(apiKey, Number(outlet.lat), Number(outlet.lng), s.gbpPlaceId ?? null);
+      }
+
+      const payload = {
+        reviewCount: data.totalReviewCount,
+        averageRating: data.averageRating || null,
+        recentFetched,
+        recentResponded,
+        reviews7d,
+        reviews30d,
+        competitorName: comp?.name ?? null,
+        competitorPlaceId: comp?.placeId ?? null,
+        competitorReviews: comp?.reviews ?? null,
+        competitorRating: comp?.rating ?? null,
+      };
+
+      await prisma.reviewDailySnapshot.upsert({
+        where: { outletId_snapshotDate: { outletId: outlet.id, snapshotDate: today } },
+        create: { outletId: outlet.id, snapshotDate: today, ...payload },
+        update: payload,
+      });
+      results.push({ outlet: outlet.name, reviewCount: data.totalReviewCount, competitor: comp?.name ?? null, ok: true });
+    } catch (err) {
+      results.push({ outlet: outlet.name, ok: false, error: err instanceof Error ? err.message : String(err) });
+    }
+  }
+
+  // Nudge: if any outlet is behind its required daily review rate, tell the owner.
+  let nudged = false;
+  try {
+    const board = await buildScoreboard();
+    const behind = board.filter((r) => r.status === "behind");
+    const chatRaw = process.env.TELEGRAM_OWNER_CHAT_ID;
+    if (behind.length && chatRaw) {
+      const lines = behind.map(
+        (r) => `• ${r.outletName}: ${r.velocity7d}/day now, need ${r.targetPerDay}/day to overtake ${r.competitorName} (gap ${r.gap})`,
+      );
+      const msg =
+        `Local rank, outlets behind on reviews:\n\n${lines.join("\n")}\n\n` +
+        `The lever: ask more happy customers to review (in-store QR plus post-order). Reviews are what move the rank.`;
+      await sendMessage(Number(chatRaw), msg);
+      nudged = true;
+    }
+  } catch (err) {
+    console.error("[reviews-daily-snapshot] nudge failed", err);
+  }
+
+  return NextResponse.json({ snapshotDate: today.toISOString().slice(0, 10), outlets: results, nudged });
+}

--- a/apps/backoffice/src/app/api/reviews/scoreboard/route.ts
+++ b/apps/backoffice/src/app/api/reviews/scoreboard/route.ts
@@ -1,0 +1,15 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getUserFromHeaders } from "@/lib/auth";
+import { buildScoreboard } from "@/lib/reviews/scoreboard";
+
+export const dynamic = "force-dynamic";
+
+// GET /api/reviews/scoreboard — per-outlet daily review lever (velocity, gap,
+// target reviews/day). Computed from ReviewDailySnapshot rows.
+export async function GET(request: NextRequest) {
+  const user = await getUserFromHeaders(request.headers);
+  if (!user) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+
+  const rows = await buildScoreboard();
+  return NextResponse.json({ rows, placesConfigured: !!process.env.GOOGLE_PLACES_API_KEY });
+}

--- a/apps/backoffice/src/lib/reviews/competitors.ts
+++ b/apps/backoffice/src/lib/reviews/competitors.ts
@@ -1,0 +1,68 @@
+/**
+ * Top nearby competitor by review prominence, for the daily rank scoreboard.
+ *
+ * Local rank is mostly proximity (fixed) + prominence (reviews). The outlet
+ * "chases" the most-reviewed nearby cafe: out-review them and the geogrid
+ * rings extend. This pulls that competitor's live review count via the Places
+ * API (the same key the geogrid uses). searchText alone omits review counts,
+ * so we add userRatingCount + rating to the field mask.
+ */
+
+export type TopCompetitor = {
+  name: string;
+  placeId: string;
+  reviews: number;
+  rating: number | null;
+};
+
+/**
+ * The single most-reviewed cafe within `radiusM` of (lat,lng) that is NOT us.
+ * Returns null on API failure or if nothing usable comes back.
+ */
+export async function fetchTopCompetitor(
+  apiKey: string,
+  lat: number,
+  lng: number,
+  ourPlaceId: string | null,
+  radiusM = 2500,
+): Promise<TopCompetitor | null> {
+  let res: Response;
+  try {
+    res = await fetch("https://places.googleapis.com/v1/places:searchText", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "X-Goog-Api-Key": apiKey,
+        "X-Goog-FieldMask": "places.id,places.displayName,places.userRatingCount,places.rating",
+      },
+      body: JSON.stringify({
+        textQuery: "cafe",
+        locationBias: { circle: { center: { latitude: lat, longitude: lng }, radius: radiusM } },
+        maxResultCount: 20,
+      }),
+    });
+  } catch {
+    return null;
+  }
+  if (!res.ok) return null;
+  const data = await res.json();
+  const places = (data.places ?? []) as {
+    id?: string;
+    displayName?: { text?: string };
+    userRatingCount?: number;
+    rating?: number;
+  }[];
+
+  const ranked = places
+    .map((p) => ({
+      name: p.displayName?.text ?? "",
+      placeId: p.id ?? "",
+      reviews: p.userRatingCount ?? 0,
+      rating: typeof p.rating === "number" ? p.rating : null,
+    }))
+    // exclude us: by place id, and by name so our other outlets never count
+    .filter((c) => c.placeId && c.placeId !== ourPlaceId && !/celsius/i.test(c.name))
+    .sort((a, b) => b.reviews - a.reviews);
+
+  return ranked[0] ?? null;
+}

--- a/apps/backoffice/src/lib/reviews/scoreboard.ts
+++ b/apps/backoffice/src/lib/reviews/scoreboard.ts
@@ -1,0 +1,117 @@
+/**
+ * Daily rank scoreboard compute.
+ *
+ * Turns the geogrid KPI into one daily operating number per outlet: reviews
+ * acquired per day vs the rate needed to out-review the nearest prominent
+ * competitor within a target window. Reviews are the only local-rank lever
+ * that moves on a daily cadence; this is its scoreboard. The weekly geogrid
+ * scan remains the output confirmation.
+ *
+ * Reads ReviewDailySnapshot rows (populated by the daily cron) and derives
+ * velocity from snapshot deltas, falling back to createTime-derived counts
+ * until enough history accrues.
+ */
+import { prisma } from "@/lib/prisma";
+
+const HORIZON_DAYS = 90; // window to out-review the leader
+
+export type ScoreStatus = "ahead" | "on_track" | "behind" | "no_competitor" | "no_data";
+
+export type ScoreRow = {
+  outletId: string;
+  outletName: string;
+  asOf: string | null;
+  reviewCount: number | null;
+  averageRating: number | null;
+  responseRate: number | null; // 0..1, recent
+  velocity7d: number | null; // reviews/day
+  velocity30d: number | null;
+  competitorName: string | null;
+  competitorReviews: number | null;
+  gap: number | null; // competitor - us (positive = behind)
+  targetPerDay: number | null; // reviews/day to overtake within HORIZON_DAYS
+  status: ScoreStatus;
+};
+
+const round1 = (n: number) => Math.round(n * 10) / 10;
+const daysBetween = (a: Date, b: Date) => Math.max(1, Math.round((a.getTime() - b.getTime()) / 86400000));
+
+export async function buildScoreboard(): Promise<ScoreRow[]> {
+  const outlets = await prisma.outlet.findMany({
+    where: { status: "ACTIVE" },
+    select: {
+      id: true,
+      name: true,
+      reviewDailySnapshots: { orderBy: { snapshotDate: "desc" }, take: 40 },
+    },
+  });
+
+  const rows: ScoreRow[] = [];
+  for (const o of outlets) {
+    const snaps = o.reviewDailySnapshots;
+    if (!snaps.length) {
+      rows.push({
+        outletId: o.id, outletName: o.name, asOf: null, reviewCount: null, averageRating: null,
+        responseRate: null, velocity7d: null, velocity30d: null, competitorName: null,
+        competitorReviews: null, gap: null, targetPerDay: null, status: "no_data",
+      });
+      continue;
+    }
+    type Snap = (typeof snaps)[number];
+    const latest = snaps[0];
+    const latestDate = new Date(latest.snapshotDate);
+    const pickOlder = (n: number): Snap | null => {
+      const cutoff = latestDate.getTime() - n * 86400000;
+      return snaps.find((s) => new Date(s.snapshotDate).getTime() <= cutoff) ?? null;
+    };
+    const s7 = pickOlder(7);
+    const s30 = pickOlder(30);
+
+    const deltaVel = (older: Snap | null, fallbackCount: number, fallbackDays: number): number =>
+      older
+        ? Math.max(0, (latest.reviewCount - older.reviewCount) / daysBetween(latestDate, new Date(older.snapshotDate)))
+        : fallbackCount / fallbackDays;
+
+    const velocity7d = deltaVel(s7, latest.reviews7d, 7);
+    const velocity30d = deltaVel(s30, latest.reviews30d, 30);
+    const responseRate = latest.recentFetched > 0 ? latest.recentResponded / latest.recentFetched : null;
+
+    const compReviews = latest.competitorReviews ?? null;
+    const gap = compReviews != null ? compReviews - latest.reviewCount : null;
+
+    // competitor's own pace, so the target accounts for them moving too
+    let compVel = 0;
+    if (s7 && s7.competitorReviews != null && latest.competitorReviews != null) {
+      compVel = Math.max(0, (latest.competitorReviews - s7.competitorReviews) / daysBetween(latestDate, new Date(s7.snapshotDate)));
+    }
+
+    let targetPerDay: number | null = null;
+    let status: ScoreStatus;
+    if (gap == null) {
+      status = "no_competitor";
+    } else if (gap <= 0) {
+      targetPerDay = compVel > 0 ? round1(compVel) : 0; // ahead: hold pace
+      status = "ahead";
+    } else {
+      targetPerDay = round1(gap / HORIZON_DAYS + compVel);
+      status = velocity7d >= targetPerDay ? "on_track" : "behind";
+    }
+
+    rows.push({
+      outletId: o.id,
+      outletName: o.name,
+      asOf: latestDate.toISOString().slice(0, 10),
+      reviewCount: latest.reviewCount,
+      averageRating: latest.averageRating ?? null,
+      responseRate,
+      velocity7d: round1(velocity7d),
+      velocity30d: round1(velocity30d),
+      competitorName: latest.competitorName ?? null,
+      competitorReviews: compReviews,
+      gap,
+      targetPerDay,
+      status,
+    });
+  }
+  return rows;
+}

--- a/apps/backoffice/vercel.json
+++ b/apps/backoffice/vercel.json
@@ -103,6 +103,10 @@
     {
       "path": "/api/cron/geogrid-scan",
       "schedule": "0 5 * * 1"
+    },
+    {
+      "path": "/api/cron/reviews-daily-snapshot",
+      "schedule": "0 6 * * *"
     }
   ]
 }

--- a/apps/order/src/app/api/loyalty/me/missions/active/route.ts
+++ b/apps/order/src/app/api/loyalty/me/missions/active/route.ts
@@ -145,6 +145,20 @@ export async function GET(req: NextRequest) {
   const supabase = getSupabaseAdmin();
   const { startIso, endIso } = currentWeekWindow();
 
+  // 0) Self-healing expiry: flip this member's leftover past-week active
+  //    assignments to 'expired'. Weekly assignments used to linger 'active'
+  //    forever, so a single order could complete the same mission for every
+  //    un-expired past week at once (the stale-week stacking bug — one visit
+  //    minting 3× Free Coffee). The order hook's week-window guard already
+  //    blocks crediting them; this keeps the data clean on each visit, matching
+  //    the lazy "opening the screen IS the rotation trigger" model (no cron).
+  await supabase
+    .from("mission_assignments")
+    .update({ status: "expired", expired_at: new Date().toISOString() })
+    .eq("member_id", r.member.memberId)
+    .eq("status", "active")
+    .lt("week_end_at", startIso);
+
   // 1) Fetch existing assignments for the current week.
   const { data: existing } = await supabase
     .from("mission_assignments")

--- a/apps/order/src/lib/loyalty/v2.ts
+++ b/apps/order/src/lib/loyalty/v2.ts
@@ -680,11 +680,19 @@ export async function applyOrderToMission(args: {
     return { completedMissionIds: [] };
   }
 
+  // Week-window guard: only credit this order to assignments whose week
+  // actually contains the order time. Without this, a member accumulates one
+  // active assignment per week and a single order completes the same mission
+  // for EVERY un-expired past week at once (the stale-week stacking bug:
+  // e.g. one order minting 3× Free Coffee for weeks it didn't earn). Pairs
+  // with the daily expiry sweep that flips past-week assignments to 'expired'.
   const { data: assignments } = await supabase
     .from("mission_assignments")
     .select("id, mission_id, progress_current, progress_target")
     .eq("member_id", args.memberId)
-    .eq("status", "active");
+    .eq("status", "active")
+    .lte("week_start_at", args.order.created_at)
+    .gte("week_end_at", args.order.created_at);
 
   if (!assignments || assignments.length === 0) {
     return { completedMissionIds: [] };

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -105,6 +105,7 @@ model Outlet {
   reviewReplyDrafts ReviewReplyDraft[]
   geoGridScans      GeoGridScan[]
   geoGridKeywords   GeoGridKeyword[]
+  reviewDailySnapshots ReviewDailySnapshot[]
   auditReports      AuditReport[]
   recurringExpenses RecurringExpense[]
   bankStatementLines BankStatementLine[]
@@ -1405,6 +1406,30 @@ model GeoGridScan {
   createdBy    String?
 
   @@index([outletId, keyword, createdAt])
+}
+
+// Daily snapshot of our review prominence vs the top nearby competitor.
+// The "daily rank lever": reviews acquired per day vs the rate needed to
+// out-review the leader. Populated by /api/cron/reviews-daily-snapshot.
+model ReviewDailySnapshot {
+  id                String   @id @default(uuid())
+  outletId          String
+  outlet            Outlet   @relation(fields: [outletId], references: [id])
+  snapshotDate      DateTime @db.Date
+  reviewCount       Int // our total Google review count
+  averageRating     Float?
+  recentFetched     Int      @default(0) // # recent reviews fetched (response-rate denominator)
+  recentResponded   Int      @default(0) // of those, # we have replied to
+  reviews7d         Int      @default(0) // reviews created in the last 7 days
+  reviews30d        Int      @default(0) // reviews created in the last 30 days
+  competitorName    String? // top nearby cafe by review count (not us)
+  competitorPlaceId String?
+  competitorReviews Int?
+  competitorRating  Float?
+  createdAt         DateTime @default(now())
+
+  @@unique([outletId, snapshotDate])
+  @@index([outletId, snapshotDate])
 }
 
 // Tracked keyword set per outlet for the automated geogrid loop. Auto-selected


### PR DESCRIPTION
Turns the geogrid KPI into one daily operating number per outlet: **review velocity vs the rate needed to out-review the nearest prominent competitor**. Reviews are the only local-rank input that moves daily; the weekly geogrid scan stays the output confirmation.

## What's in it
- **ReviewDailySnapshot** table — daily snapshot of our review count/rating/response rate + the top nearby competitor's review count (Places `userRatingCount`).
- **/api/cron/reviews-daily-snapshot** (daily 06:00) — snapshots all GBP-connected outlets; sends a Telegram nudge to the owner when an outlet is **behind** its required daily review rate. Also triggerable by an authed admin for manual refresh/seed.
- **lib/reviews/scoreboard.ts** — velocity (from snapshot deltas, createTime fallback for early days), competitor gap, target reviews/day to overtake within 90 days, status (ahead / on track / behind).
- **/reviews/scoreboard** page + **Rank Scoreboard** nav under Reviews.

## Notes
- Schema model added; table applied to live DB via Supabase migration `review_daily_snapshot` (manual SQL, no prisma db push).
- Competitor gaps need `GOOGLE_PLACES_API_KEY` (already set in prod for the geogrid); review velocity tracks regardless.
- tsc + eslint clean. First data lands on the next cron run (or a manual admin trigger).