### PR TITLE
feat(inventory): reference photo + plating note on Recipe Cards

### DIFF
--- a/apps/backoffice/src/app/(admin)/inventory/menus/cards/page.tsx
+++ b/apps/backoffice/src/app/(admin)/inventory/menus/cards/page.tsx
@@ -5,7 +5,7 @@ import { formatRM } from "@celsius/shared";
 import { useState, type ReactNode } from "react";
 import Link from "next/link";
 import { Input } from "@/components/ui/input";
-import { Coffee, Search, Loader2, Printer, ArrowLeft, X, Flame, Snowflake } from "lucide-react";
+import { Coffee, Search, Loader2, Printer, ArrowLeft, X, Flame, Snowflake, Utensils, Pencil, Check } from "lucide-react";
 import { useFetch } from "@/lib/use-fetch";
 
 /**
@@ -55,6 +55,9 @@ type MenuItem = {
   ingredientCount: number;
   packagingCount: number;
   ingredients: Ingredient[];
+  imageUrl: string | null; // reference photo from the customer catalogue (by name)
+  imageZoom: number; // catalogue display zoom (%) so the ref matches the menu
+  platingNote: string | null; // plating / presentation expectation
 };
 
 // ── Build order ───────────────────────────────────────────────────────────
@@ -157,7 +160,7 @@ function BuildColumn({
   );
 }
 
-function RecipeCard({ menu, showCosts }: { menu: MenuItem; showCosts: boolean }) {
+function RecipeCard({ menu, showCosts, onSaved }: { menu: MenuItem; showCosts: boolean; onSaved?: () => void }) {
   const ingredients = menu.ingredients.filter((i) => i.kind === "ingredient");
   const packaging = menu.ingredients.filter((i) => i.kind === "packaging");
   const hasTempSplit = ingredients.some((i) => i.modifier != null);
@@ -167,8 +170,47 @@ function RecipeCard({ menu, showCosts }: { menu: MenuItem; showCosts: boolean })
   const pkgRows = buildPackaging(packaging);
   const empty = ingredients.length === 0 && packaging.length === 0;
 
+  // Plating note — inline editable, persisted to Menu.platingNote.
+  const [note, setNote] = useState(menu.platingNote ?? "");
+  const [editing, setEditing] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const trimmedNote = note.trim();
+  const saveNote = async () => {
+    setSaving(true);
+    try {
+      const res = await fetch(`/api/inventory/menus/${menu.id}/plating`, {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ platingNote: note }),
+      });
+      if (res.ok) {
+        setEditing(false);
+        onSaved?.();
+      }
+    } finally {
+      setSaving(false);
+    }
+  };
+
   return (
     <div className="recipe-card flex break-inside-avoid flex-col overflow-hidden rounded-2xl border border-gray-200 bg-white shadow-sm">
+      {/* Reference photo (plating expectation) — pulled from the customer
+          catalogue by name; graceful placeholder when there's no match. */}
+      {menu.imageUrl ? (
+        // eslint-disable-next-line @next/next/no-img-element
+        <img
+          src={menu.imageUrl}
+          alt={`${menu.name} — plating reference`}
+          className="h-36 w-full bg-[#F5F1EA] object-cover"
+          style={{ transform: `scale(${(menu.imageZoom ?? 100) / 100})`, transformOrigin: "center" }}
+        />
+      ) : (
+        <div className="flex h-36 w-full flex-col items-center justify-center gap-1 bg-[#F5F1EA] text-[#160800]/25">
+          <Coffee className="h-7 w-7" />
+          <span className="text-[10px] font-medium uppercase tracking-wide print:hidden">No reference photo</span>
+        </div>
+      )}
+
       {/* Header band — espresso fill, cream text */}
       <div className="rc-head flex items-start justify-between gap-3 bg-[#160800] px-4 py-3 text-[#F5F1EA]">
         <div className="min-w-0">
@@ -226,6 +268,45 @@ function RecipeCard({ menu, showCosts }: { menu: MenuItem; showCosts: boolean })
         </div>
       )}
 
+      {/* Plating expectation — editable; only prints when a note is set. */}
+      <div className={`border-t border-gray-100 px-4 py-2 text-[11px] ${trimmedNote && !editing ? "" : "print:hidden"}`}>
+        <div className="mb-0.5 flex items-center justify-between">
+          <p className="flex items-center gap-1 text-[9px] font-bold uppercase tracking-wide text-emerald-700">
+            <Utensils className="h-3 w-3" /> Plating
+          </p>
+          {!editing && trimmedNote && (
+            <button onClick={() => setEditing(true)} title="Edit plating note" className="text-gray-400 hover:text-terracotta print:hidden">
+              <Pencil className="h-3 w-3" />
+            </button>
+          )}
+        </div>
+        {editing ? (
+          <div className="print:hidden">
+            <textarea
+              value={note}
+              onChange={(e) => setNote(e.target.value)}
+              rows={3}
+              placeholder="How it should look / be served — e.g. foam art, dust cocoa, wooden board + napkin"
+              className="w-full resize-y rounded border border-gray-200 p-2 text-[11px] text-gray-700 focus:border-terracotta focus:outline-none"
+            />
+            <div className="mt-1 flex items-center justify-end gap-1">
+              <button onClick={() => { setNote(menu.platingNote ?? ""); setEditing(false); }} disabled={saving} className="rounded px-2 py-1 text-[10px] text-gray-500 hover:bg-gray-100">
+                Cancel
+              </button>
+              <button onClick={saveNote} disabled={saving} className="flex items-center gap-1 rounded bg-green-600 px-2 py-1 text-[10px] font-medium text-white hover:bg-green-700">
+                {saving ? <Loader2 className="h-3 w-3 animate-spin" /> : <Check className="h-3 w-3" />} Save
+              </button>
+            </div>
+          </div>
+        ) : trimmedNote ? (
+          <p className="whitespace-pre-line text-gray-700">{trimmedNote}</p>
+        ) : (
+          <button onClick={() => setEditing(true)} className="text-gray-400 hover:text-terracotta print:hidden">
+            + Add plating note
+          </button>
+        )}
+      </div>
+
       {/* Cost summary (off by default — toggle on for costing) */}
       {showCosts && (menu.ingredientCost > 0 || menu.cogs > 0) && (
         <div className="border-t border-gray-100 bg-gray-50/70 px-4 py-2 text-[11px]">
@@ -256,7 +337,7 @@ function RecipeCard({ menu, showCosts }: { menu: MenuItem; showCosts: boolean })
 }
 
 export default function RecipeCardsPage() {
-  const { data: menus = [], isLoading: loading } = useFetch<MenuItem[]>("/api/inventory/menus");
+  const { data: menus = [], isLoading: loading, mutate: reload } = useFetch<MenuItem[]>("/api/inventory/menus");
   const [search, setSearch] = useState("");
   const [catFilter, setCatFilter] = useState<string[]>([]);
   const [onlyWithRecipe, setOnlyWithRecipe] = useState(true);
@@ -312,7 +393,7 @@ export default function RecipeCardsPage() {
           <h2 className="text-xl font-semibold text-gray-900">Recipe Cards</h2>
         </div>
         <p className="mt-0.5 text-sm text-gray-500">
-          Barista build cards from the Bill of Materials — Hot &amp; Iced builds side by side. {filtered.length} of {menus.length} shown.
+          Barista build cards from the Bill of Materials — reference photo, Hot &amp; Iced builds, and plating notes. {filtered.length} of {menus.length} shown.
         </p>
 
         <div className="mt-4 flex flex-col gap-3">
@@ -373,7 +454,7 @@ export default function RecipeCardsPage() {
       ) : (
         <div className="rc-grid mt-5 grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3 print:mt-0">
           {filtered.map((menu) => (
-            <RecipeCard key={menu.id} menu={menu} showCosts={showCosts} />
+            <RecipeCard key={menu.id} menu={menu} showCosts={showCosts} onSaved={reload} />
           ))}
         </div>
       )}

--- a/apps/backoffice/src/app/api/inventory/menus/[id]/plating/route.ts
+++ b/apps/backoffice/src/app/api/inventory/menus/[id]/plating/route.ts
@@ -1,0 +1,29 @@
+import { NextRequest, NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+import { requireAuth } from "@/lib/auth";
+
+/**
+ * PUT /api/inventory/menus/[id]/plating
+ *
+ * Set or clear a menu item's plating / presentation note — the "plating
+ * expectation" shown on its Recipe Card. Body: { platingNote: string | null }.
+ * Blank/empty clears the note.
+ */
+export async function PUT(
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const auth = await requireAuth(req);
+  if (auth.error) return auth.error;
+  const { id } = await params;
+
+  const body = await req.json().catch(() => ({}));
+  const raw = typeof body.platingNote === "string" ? body.platingNote.trim() : "";
+  const platingNote = raw.length > 0 ? raw.slice(0, 2000) : null;
+
+  const menu = await prisma.menu.findUnique({ where: { id } });
+  if (!menu) return NextResponse.json({ error: "Menu not found" }, { status: 404 });
+
+  await prisma.menu.update({ where: { id }, data: { platingNote } });
+  return NextResponse.json({ id, platingNote });
+}

--- a/apps/backoffice/src/app/api/inventory/menus/route.ts
+++ b/apps/backoffice/src/app/api/inventory/menus/route.ts
@@ -1,11 +1,37 @@
 import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
 import { requireAuth } from "@/lib/auth";
+import { getSupabaseAdmin } from "@/lib/pickup/supabase";
+
+// Reference photos live in the customer-facing catalogue (the loyalty project's
+// `products` table), keyed by product name. Pull them so each Recipe Card can
+// show the plating reference next to its build. Best-effort: if the catalogue
+// is unreachable, cards simply render without a photo.
+type CatalogImage = { imageUrl: string; imageZoom: number };
+async function loadCatalogImages(): Promise<Map<string, CatalogImage>> {
+  const map = new Map<string, CatalogImage>();
+  try {
+    const supabase = getSupabaseAdmin();
+    const { data } = await supabase
+      .from("products")
+      .select("name, image_url, image_zoom")
+      .eq("brand_id", "brand-celsius");
+    for (const row of (data ?? []) as { name?: string; image_url?: string; image_zoom?: number }[]) {
+      const key = (row.name ?? "").trim().toLowerCase();
+      const url = (row.image_url ?? "").trim();
+      if (!key || !url || map.has(key)) continue;
+      map.set(key, { imageUrl: url, imageZoom: Number(row.image_zoom) || 100 });
+    }
+  } catch {
+    // Photos are optional enrichment — never fail the menus payload over them.
+  }
+  return map;
+}
 
 export async function GET(request: NextRequest) {
   const auth = await requireAuth(request);
   if (auth.error) return auth.error;
-  const [menus, supplierProducts, packagingRules] = await Promise.all([
+  const [menus, supplierProducts, packagingRules, catalogImages] = await Promise.all([
     prisma.menu.findMany({
       include: {
         ingredients: {
@@ -32,6 +58,7 @@ export async function GET(request: NextRequest) {
         product: { select: { name: true, sku: true, baseUom: true } },
       },
     }),
+    loadCatalogImages(),
   ]);
 
   // Build cost-per-base-unit map (cheapest non-zero supplier price / conversion factor)
@@ -173,11 +200,15 @@ export async function GET(request: NextRequest) {
     const allIn = [matrix.hot.dineIn, matrix.hot.takeaway, matrix.iced.dineIn, matrix.iced.takeaway];
     const worst = allIn.reduce((a, b) => (b.cogs > a.cogs ? b : a));
 
+    const photo = catalogImages.get(m.name.trim().toLowerCase());
     return {
       id: m.id,
       name: m.name,
       category: m.category ?? "",
       sellingPrice,
+      imageUrl: photo?.imageUrl ?? null,
+      imageZoom: photo?.imageZoom ?? 100,
+      platingNote: m.platingNote ?? null,
       ingredientCost: round2(ingredientTotal),
       matrix,
       hasIcedHotSplit,

--- a/packages/db/prisma/migrations/20260624_menu_plating_note/migration.sql
+++ b/packages/db/prisma/migrations/20260624_menu_plating_note/migration.sql
@@ -1,0 +1,7 @@
+-- Recipe Cards: per-menu-item plating / presentation note (the "plating
+-- expectation" shown on the barista build card). Additive, nullable — every
+-- existing Menu row is unchanged.
+--
+-- Applied to production (celsius-inventory) via Supabase MCP apply_migration.
+-- Manual SQL only — never `prisma db push`. See docs/database-migrations.md.
+ALTER TABLE "Menu" ADD COLUMN IF NOT EXISTS "platingNote" TEXT;

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -829,6 +829,9 @@ model Menu {
   category     String?
   sellingPrice Decimal?
   storehubId   String   @unique
+  // Plating / presentation note shown on the Recipe Card — the "this is how it
+  // should look / be served" expectation for baristas. Free text, nullable.
+  platingNote  String?
   isActive     Boolean  @default(true)
   lastSyncedAt DateTime @default(now())
   createdAt    DateTime @default(now())


### PR DESCRIPTION
## What

Adds the **plating expectation** to each barista build card on the Recipe Cards page (`/inventory/menus/cards`): a **reference photo** and an editable **plating note**.

Follow-up to #504 (the Recipe Cards page itself).

## Reference photo — reuses your existing catalogue photos

Menu items (Prisma `Menu`, StoreHub-synced) have no photos, but the **customer-facing catalogue** (the loyalty project's `products` table, managed at `/pickup/menu`) already does. So `/api/inventory/menus` now joins that catalogue **by name** and attaches `image_url` (+ `image_zoom`) per item — the card shows the same hero shot customers see.

- Best-effort: the catalogue lookup is wrapped so a missing/unreachable catalogue never fails the menus payload — those cards just show a clean placeholder.
- Coverage today: **~84 of 101** menu items match a catalogue photo. Misses are mostly non-platable (freeflow, "google review", bottled-retail variants).
- No uploads, no new image hosting — pure reuse.

## Plating note — the presentation standard, in words

- New nullable column **`Menu.platingNote`** (additive migration, applied to `celsius-inventory` via Supabase MCP per `docs/database-migrations.md`; SQL captured under `packages/db/prisma/migrations/`).
- Inline editor on each card + **`PUT /api/inventory/menus/[id]/plating`**.
- Only prints when a note is set (the editor / "add note" affordances are `print:hidden`).

## Notes for review

- Presentation-only: **no costing logic changed**. The photo + note are enrichment over the existing BOM data.
- The migration is already applied to production (additive nullable `TEXT` column — existing rows unchanged; Prisma ignores unknown columns, so the currently-deployed app is unaffected until this merges).
- `<img>` is used for the catalogue photo (matches the existing `/pickup/menu` page) with an eslint-disable for `@next/next/no-img-element`.
- ⚠️ Couldn't run a green `tsc`/lint in the dev container (`react`/`next`/`@prisma/client` aren't installed — same limitation as #504). Verified by error-code parity: the three changed files show only the environmental module-not-found / react-family codes, no logic-level errors. CI's `typecheck (backoffice)` + `lint (backoffice)` are the authoritative gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01EARY9tqLDV3yvnqngT29Bn)_