### PR TITLE
fix(inventory): label recipe-card sections "recipe" not "build"

### DIFF
--- a/apps/backoffice/src/app/(admin)/inventory/menus/cards/page.tsx
+++ b/apps/backoffice/src/app/(admin)/inventory/menus/cards/page.tsx
@@ -232,14 +232,14 @@ function RecipeCard({ menu, showCosts, onSaved }: { menu: MenuItem; showCosts: b
         ) : hasTempSplit ? (
           <div className="grid grid-cols-2 gap-x-4 divide-x divide-gray-100">
             <BuildColumn
-              title="Hot build"
+              title="Hot recipe"
               accent="text-orange-600"
               icon={<Flame className="h-3 w-3" />}
               steps={hotSteps}
             />
             <div className="pl-4">
               <BuildColumn
-                title="Iced build"
+                title="Iced recipe"
                 accent="text-sky-600"
                 icon={<Snowflake className="h-3 w-3" />}
                 steps={icedSteps}
@@ -247,7 +247,7 @@ function RecipeCard({ menu, showCosts, onSaved }: { menu: MenuItem; showCosts: b
             </div>
           </div>
         ) : (
-          <BuildColumn title="Build" steps={singleSteps} />
+          <BuildColumn title="Recipe" steps={singleSteps} />
         )}
       </div>
 
@@ -393,7 +393,7 @@ export default function RecipeCardsPage() {
           <h2 className="text-xl font-semibold text-gray-900">Recipe Cards</h2>
         </div>
         <p className="mt-0.5 text-sm text-gray-500">
-          Barista build cards from the Bill of Materials — reference photo, Hot &amp; Iced builds, and plating notes. {filtered.length} of {menus.length} shown.
+          Barista recipe cards from the Bill of Materials — reference photo, Hot &amp; Iced recipes, and plating notes. {filtered.length} of {menus.length} shown.
         </p>
 
         <div className="mt-4 flex flex-col gap-3">


### PR DESCRIPTION
## What

Renames the Recipe Card's user-facing section headers from **build** to **recipe**:

- `Hot build` → **Hot recipe**
- `Iced build` → **Iced recipe**
- single `Build` → **Recipe**
- page subtitle: "Barista **recipe** cards … Hot & Iced **recipes**"

Text-only change. Internal identifiers (`BuildColumn`, `buildSteps`, `BUILD_ORDER`) are unchanged — no behaviour or layout change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01EARY9tqLDV3yvnqngT29Bn)_