### PR TITLE
feat(ops-pulse): WhatsApp ops KPI pulse — 11 signals, daily + real-time (shadow)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -50,5 +50,12 @@ WHATSAPP_VERIFY_TOKEN=""           # random string you choose; echoed back durin
 # Real-time KPI breach detection (phone-capture rate, overdue checklists) paged
 # 1:1 over WhatsApp. Design: docs/design/ops-kpi-pulse-loop.md.
 # OPS_PULSE_MODE: off | shadow | armed. Unset ⇒ shadow (read-only: detect+log,
-# no sends). Flip to "armed" only after Phase 1b (OpsAlert ledger + DM sender).
+# no sends). Flip to "armed" only after: (1) the OpsAlert table migration is
+# applied, and (2) the templates below are APPROVED in WhatsApp Manager.
 OPS_PULSE_MODE="shadow"
+# Approved template names for proactive (out-of-24h-window) sends. Each needs ONE
+# body variable ({{1}}) that carries the composed digest text. Until set, the
+# sender falls back to free-form text (delivered only inside a 24h window).
+OPS_PULSE_TPL_DIGEST=""        # manager breach digest, e.g. "ops_breach_digest"
+OPS_PULSE_TPL_ESCALATION=""    # owner escalation, e.g. "ops_escalation"
+OPS_PULSE_TPL_LANG="en"        # template language code

--- a/.env.example
+++ b/.env.example
@@ -63,9 +63,10 @@ OPS_PULSE_TPL_LANG="en"        # template language code
 # (comma-separated). barista_head = barista lead, chef_head = food director.
 # A role only alerts if it has an active template.
 OPS_PULSE_AUDIT_ROLES="barista_head,chef_head"
-# Routing: discipline -> recipient names (comma-separated, matched against
-# User.name; first = primary, owns ack/escalation). Unresolved names fall back
+# Routing: discipline -> recipients (comma-separated). Each entry is a User name
+# (matched against User.name) OR a raw phone number (+60…/01…) for people with no
+# app account. First = primary (owns ack/escalation). Unresolved names fall back
 # to the owner. operations = phone/checklist/reviews/procurement.
 OPS_PULSE_OPS_RECIPIENTS="Ariff,Adam Kelvin"
-OPS_PULSE_BARISTA_RECIPIENTS="Syafiq"
-OPS_PULSE_KITCHEN_RECIPIENTS="Chef Bo"
+OPS_PULSE_BARISTA_RECIPIENTS="Syafiq Kaberi"
+OPS_PULSE_KITCHEN_RECIPIENTS="Ibrahim Zakir"

--- a/.env.example
+++ b/.env.example
@@ -45,3 +45,10 @@ WHATSAPP_ACCESS_TOKEN=""           # permanent System User token (scopes: whatsa
 WHATSAPP_WABA_ID=""                # WhatsApp Business Account id (e.g. 974771538513990) — template management
 WHATSAPP_APP_SECRET=""             # Meta app secret — verifies inbound X-Hub-Signature-256 (App → Settings → Basic)
 WHATSAPP_VERIFY_TOKEN=""           # random string you choose; echoed back during the GET verification handshake
+
+# ── Ops KPI Pulse (internal KPI alerts → ops manager) ───
+# Real-time KPI breach detection (phone-capture rate, overdue checklists) paged
+# 1:1 over WhatsApp. Design: docs/design/ops-kpi-pulse-loop.md.
+# OPS_PULSE_MODE: off | shadow | armed. Unset ⇒ shadow (read-only: detect+log,
+# no sends). Flip to "armed" only after Phase 1b (OpsAlert ledger + DM sender).
+OPS_PULSE_MODE="shadow"

--- a/.env.example
+++ b/.env.example
@@ -59,7 +59,12 @@ OPS_PULSE_MODE="shadow"
 OPS_PULSE_DAILY_MODE="shadow"
 # Signals the fast real-time pulse alerts on (every ~5 min); the rest only appear
 # in the daily digest. Comma-separated. Default: Google reviews + menu snoozed.
-OPS_PULSE_REALTIME_SIGNALS="REVIEW,MENU_SNOOZED,NO_CLOCK_IN"
+OPS_PULSE_REALTIME_SIGNALS="REVIEW,MENU_SNOOZED,NO_CLOCK_IN,POS_NOT_OPEN"
+# Signals that also nudge the on-shift outlet team (not just the discipline lead),
+# because the team does the work — e.g. stock take.
+OPS_PULSE_TEAM_NOTIFY_SIGNALS="STOCK_COUNT"
+# Restock-needed (par-level) alerts held OFF until stock counts are reliable.
+OPS_PULSE_RESTOCK_ENABLED="false"
 # Approved template names for proactive (out-of-24h-window) sends. Each needs ONE
 # body variable ({{1}}) that carries the composed digest text. Until set, the
 # sender falls back to free-form text (delivered only inside a 24h window).

--- a/.env.example
+++ b/.env.example
@@ -59,3 +59,6 @@ OPS_PULSE_MODE="shadow"
 OPS_PULSE_TPL_DIGEST=""        # manager breach digest, e.g. "ops_breach_digest"
 OPS_PULSE_TPL_ESCALATION=""    # owner escalation, e.g. "ops_escalation"
 OPS_PULSE_TPL_LANG="en"        # template language code
+# Audit coverage: AuditTemplate.roleType values to watch for overdue audits
+# (comma-separated). A role only alerts if it has an active template.
+OPS_PULSE_AUDIT_ROLES="barista_head"

--- a/.env.example
+++ b/.env.example
@@ -60,5 +60,6 @@ OPS_PULSE_TPL_DIGEST=""        # manager breach digest, e.g. "ops_breach_digest"
 OPS_PULSE_TPL_ESCALATION=""    # owner escalation, e.g. "ops_escalation"
 OPS_PULSE_TPL_LANG="en"        # template language code
 # Audit coverage: AuditTemplate.roleType values to watch for overdue audits
-# (comma-separated). A role only alerts if it has an active template.
-OPS_PULSE_AUDIT_ROLES="barista_head"
+# (comma-separated). barista_head = barista lead, chef_head = food director.
+# A role only alerts if it has an active template.
+OPS_PULSE_AUDIT_ROLES="barista_head,chef_head"

--- a/.env.example
+++ b/.env.example
@@ -57,6 +57,9 @@ OPS_PULSE_MODE="shadow"
 # Independent of OPS_PULSE_MODE: set this to "armed" to start the daily digest
 # while the real-time path stays in shadow. off | shadow | armed; unset => shadow.
 OPS_PULSE_DAILY_MODE="shadow"
+# Signals the fast real-time pulse alerts on (every ~5 min); the rest only appear
+# in the daily digest. Comma-separated. Default: Google reviews + menu snoozed.
+OPS_PULSE_REALTIME_SIGNALS="REVIEW,MENU_SNOOZED"
 # Approved template names for proactive (out-of-24h-window) sends. Each needs ONE
 # body variable ({{1}}) that carries the composed digest text. Until set, the
 # sender falls back to free-form text (delivered only inside a 24h window).

--- a/.env.example
+++ b/.env.example
@@ -59,7 +59,7 @@ OPS_PULSE_MODE="shadow"
 OPS_PULSE_DAILY_MODE="shadow"
 # Signals the fast real-time pulse alerts on (every ~5 min); the rest only appear
 # in the daily digest. Comma-separated. Default: Google reviews + menu snoozed.
-OPS_PULSE_REALTIME_SIGNALS="REVIEW,MENU_SNOOZED"
+OPS_PULSE_REALTIME_SIGNALS="REVIEW,MENU_SNOOZED,NO_CLOCK_IN"
 # Approved template names for proactive (out-of-24h-window) sends. Each needs ONE
 # body variable ({{1}}) that carries the composed digest text. Until set, the
 # sender falls back to free-form text (delivered only inside a 24h window).

--- a/.env.example
+++ b/.env.example
@@ -59,7 +59,7 @@ OPS_PULSE_MODE="shadow"
 OPS_PULSE_DAILY_MODE="shadow"
 # Signals the fast real-time pulse alerts on (every ~5 min); the rest only appear
 # in the daily digest. Comma-separated. Default: Google reviews + menu snoozed.
-OPS_PULSE_REALTIME_SIGNALS="REVIEW,MENU_SNOOZED,NO_CLOCK_IN,POS_NOT_OPEN"
+OPS_PULSE_REALTIME_SIGNALS="REVIEW,MENU_SNOOZED,NO_CLOCK_IN,POS_NOT_OPEN,CHECKLIST,RECEIVING"
 # Signals that also nudge the on-shift outlet team (not just the discipline lead),
 # because the team does the work — e.g. stock take.
 OPS_PULSE_TEAM_NOTIFY_SIGNALS="STOCK_COUNT"

--- a/.env.example
+++ b/.env.example
@@ -53,11 +53,16 @@ WHATSAPP_VERIFY_TOKEN=""           # random string you choose; echoed back durin
 # no sends). Flip to "armed" only after: (1) the OpsAlert table migration is
 # applied, and (2) the templates below are APPROVED in WhatsApp Manager.
 OPS_PULSE_MODE="shadow"
+# Daily pulse (once-a-day digest per lead — the habit-builder, shipped first).
+# Independent of OPS_PULSE_MODE: set this to "armed" to start the daily digest
+# while the real-time path stays in shadow. off | shadow | armed; unset => shadow.
+OPS_PULSE_DAILY_MODE="shadow"
 # Approved template names for proactive (out-of-24h-window) sends. Each needs ONE
 # body variable ({{1}}) that carries the composed digest text. Until set, the
 # sender falls back to free-form text (delivered only inside a 24h window).
 OPS_PULSE_TPL_DIGEST=""        # manager breach digest, e.g. "ops_breach_digest"
 OPS_PULSE_TPL_ESCALATION=""    # owner escalation, e.g. "ops_escalation"
+OPS_PULSE_TPL_DAILY=""         # daily digest, e.g. "ops_daily_pulse"
 OPS_PULSE_TPL_LANG="en"        # template language code
 # Audit coverage: AuditTemplate.roleType values to watch for overdue audits
 # (comma-separated). barista_head = barista lead, chef_head = food director.

--- a/.env.example
+++ b/.env.example
@@ -63,3 +63,9 @@ OPS_PULSE_TPL_LANG="en"        # template language code
 # (comma-separated). barista_head = barista lead, chef_head = food director.
 # A role only alerts if it has an active template.
 OPS_PULSE_AUDIT_ROLES="barista_head,chef_head"
+# Routing: discipline -> recipient names (comma-separated, matched against
+# User.name; first = primary, owns ack/escalation). Unresolved names fall back
+# to the owner. operations = phone/checklist/reviews/procurement.
+OPS_PULSE_OPS_RECIPIENTS="Ariff,Adam Kelvin"
+OPS_PULSE_BARISTA_RECIPIENTS="Syafiq"
+OPS_PULSE_KITCHEN_RECIPIENTS="Chef Bo"

--- a/.env.example
+++ b/.env.example
@@ -69,4 +69,4 @@ OPS_PULSE_AUDIT_ROLES="barista_head,chef_head"
 # to the owner. operations = phone/checklist/reviews/procurement.
 OPS_PULSE_OPS_RECIPIENTS="Ariff,Adam Kelvin"
 OPS_PULSE_BARISTA_RECIPIENTS="Syafiq Kaberi"
-OPS_PULSE_KITCHEN_RECIPIENTS="Ibrahim Zakir"
+OPS_PULSE_KITCHEN_RECIPIENTS="Chef Bo"

--- a/apps/backoffice/src/app/api/cron/ops-pulse-daily/route.ts
+++ b/apps/backoffice/src/app/api/cron/ops-pulse-daily/route.ts
@@ -1,0 +1,31 @@
+import { NextRequest, NextResponse } from "next/server";
+import { checkCronAuth } from "@celsius/shared";
+import { runDailyPulse } from "@/lib/ops-pulse";
+
+export const dynamic = "force-dynamic";
+export const maxDuration = 60;
+
+/**
+ * GET /api/cron/ops-pulse-daily — the once-a-day Ops Pulse digest.
+ *
+ * Sends each discipline lead one morning roundup of everything outstanding in
+ * their lane (the habit-builder). No ledger, no escalation — just a predictable
+ * daily message. Controlled by OPS_PULSE_DAILY_MODE (off | shadow | armed),
+ * independent of the real-time OPS_PULSE_MODE. Scheduled ~9am MYT (vercel.json).
+ *
+ * Design: docs/design/ops-kpi-pulse-loop.md.
+ */
+export async function GET(req: NextRequest) {
+  const cronAuth = checkCronAuth(req.headers);
+  if (!cronAuth.ok) return NextResponse.json({ error: cronAuth.error }, { status: cronAuth.status });
+
+  try {
+    const result = await runDailyPulse();
+    console.log(`[cron/ops-pulse-daily] mode=${result.mode} items=${result.breachCount} sent=${result.sent}`);
+    return NextResponse.json({ ok: true, ...result });
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : "ops-pulse-daily failed";
+    console.error("[cron/ops-pulse-daily]", msg);
+    return NextResponse.json({ error: msg }, { status: 500 });
+  }
+}

--- a/apps/backoffice/src/app/api/cron/ops-pulse/route.ts
+++ b/apps/backoffice/src/app/api/cron/ops-pulse/route.ts
@@ -1,0 +1,38 @@
+import { NextRequest, NextResponse } from "next/server";
+import { checkCronAuth } from "@celsius/shared";
+import { runOpsPulse } from "@/lib/ops-pulse";
+
+export const dynamic = "force-dynamic";
+export const maxDuration = 60;
+
+/**
+ * GET /api/cron/ops-pulse — the Ops KPI Pulse sweep.
+ *
+ * Phase 1 (SHADOW): detects KPI breaches (POS phone-capture rate, overdue
+ * checklists), resolves the accountable manager, and LOGS what it would page.
+ * It sends nothing and writes nothing — a read-only week to confirm the
+ * detectors fire on real breaches before we arm escalation. Controlled by
+ * OPS_PULSE_MODE (off | shadow | armed); unset ⇒ shadow.
+ *
+ * Scheduled hourly while shadowing (vercel.json). Once armed and backed by the
+ * OpsAlert ledger (which dedupes), this tightens to a 15-minute cadence for
+ * real-time paging.
+ *
+ * Design: docs/design/ops-kpi-pulse-loop.md.
+ */
+export async function GET(req: NextRequest) {
+  const cronAuth = checkCronAuth(req.headers);
+  if (!cronAuth.ok) return NextResponse.json({ error: cronAuth.error }, { status: cronAuth.status });
+
+  try {
+    const result = await runOpsPulse();
+    if (result.breachCount > 0) {
+      console.log(`[cron/ops-pulse] mode=${result.mode} breaches=${result.breachCount} sent=${result.sent}`);
+    }
+    return NextResponse.json({ ok: true, ...result });
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : "ops-pulse failed";
+    console.error("[cron/ops-pulse]", msg);
+    return NextResponse.json({ error: msg }, { status: 500 });
+  }
+}

--- a/apps/backoffice/src/app/api/whatsapp/webhook/route.ts
+++ b/apps/backoffice/src/app/api/whatsapp/webhook/route.ts
@@ -17,6 +17,7 @@
  */
 import { NextRequest, NextResponse } from "next/server";
 import { verifyWhatsAppSignature } from "@/lib/whatsapp";
+import { handleInboundAck } from "@/lib/ops-pulse/inbound";
 
 // GET — webhook verification handshake.
 export async function GET(request: NextRequest) {
@@ -68,9 +69,19 @@ export async function POST(request: NextRequest) {
         console.log(
           `[whatsapp:webhook] inbound from=${msg.from} type=${msg.type} text=${JSON.stringify(text)}`,
         );
-        // TODO: route inbound messages — open/append a customer-service thread,
-        // fire an auto-reply via sendWhatsAppText, or notify staff. The 24-hour
-        // free-form reply window opens the moment this message arrives.
+        // Ops pulse ack: a manager/owner replying "DONE" (etc.) resolves their
+        // open OpsAlerts. No-op when the sender isn't staff or it's not an ack.
+        // Never let this break the webhook — Meta must still get a fast 200.
+        try {
+          const ack = await handleInboundAck(msg.from, msg.text?.body ?? "");
+          if (ack && ack.resolved > 0) {
+            console.log(`[ops-pulse] ack from=${msg.from} resolved=${ack.resolved} alert(s)`);
+          }
+        } catch (err) {
+          console.error("[ops-pulse] inbound ack failed:", err);
+        }
+        // TODO: route non-ack inbound messages — customer-service thread /
+        // auto-reply. The 24-hour free-form window opens when this arrives.
       }
       for (const status of value.statuses ?? []) {
         console.log(

--- a/apps/backoffice/src/lib/ops-pulse/config.ts
+++ b/apps/backoffice/src/lib/ops-pulse/config.ts
@@ -28,7 +28,7 @@ export function dailyMode(): PulseMode {
 // instant; incidents (checklist, receiving) are good candidates too. Override via
 // OPS_PULSE_REALTIME_SIGNALS (comma-separated).
 export const REALTIME_SIGNALS: Set<string> = new Set(
-  (process.env.OPS_PULSE_REALTIME_SIGNALS || "REVIEW,MENU_SNOOZED,NO_CLOCK_IN,POS_NOT_OPEN")
+  (process.env.OPS_PULSE_REALTIME_SIGNALS || "REVIEW,MENU_SNOOZED,NO_CLOCK_IN,POS_NOT_OPEN,CHECKLIST,RECEIVING")
     .split(",")
     .map((s) => s.trim().toUpperCase())
     .filter(Boolean),

--- a/apps/backoffice/src/lib/ops-pulse/config.ts
+++ b/apps/backoffice/src/lib/ops-pulse/config.ts
@@ -1,14 +1,14 @@
-// Ops Pulse configuration — thresholds + run mode.
+// Ops Pulse configuration — run mode, thresholds, escalation, templates.
 //
-// Defaults are the owner-proposed values from docs/design/ops-kpi-pulse-loop.md
-// (tune during the shadow week). Kept here so there is one place to change them.
+// Defaults are the owner-confirmed values from docs/design/ops-kpi-pulse-loop.md
+// (phone floor 60%, escalation 90 min). Kept here so there is one place to tune.
 
 export type PulseMode = "off" | "shadow" | "armed";
 
 // OPS_PULSE_MODE controls the loop:
 //   off    — cron is a no-op (kill switch).
 //   shadow — DEFAULT. Detect + route + log only. No DB writes, no WhatsApp sends.
-//   armed  — (Phase 1b, not yet wired) would persist OpsAlert + DM the manager.
+//   armed  — persist OpsAlert, DM the manager, escalate to the owner past SLA.
 // Unset ⇒ shadow, so deploying starts the read-only shadow week automatically.
 export function pulseMode(): PulseMode {
   const m = (process.env.OPS_PULSE_MODE || "shadow").trim().toLowerCase();
@@ -28,4 +28,28 @@ export const THRESHOLDS = {
     // Minutes past dueAt before a still-incomplete checklist counts as a breach.
     graceMinutes: 30,
   },
+  review: {
+    // QR feedback is already 1–3★ (4–5★ redirect to Google), so page only the
+    // clearly-bad: rating ≤ this. (1★ = HIGH severity, 2★ = MED, 3★ = skip.)
+    internalMaxRating: 2,
+    // Negative Google reviews awaiting a reply decision are 1–3★ — all worth a nudge.
+    googleMaxRating: 3,
+    // Only page reviews newer than this, so first-arm doesn't burst on old backlog.
+    recencyHours: 72,
+  },
+  escalation: {
+    // Minutes an alert may sit OPEN (unacked) before it escalates to the owner.
+    slaMinutes: 90,
+  },
+} as const;
+
+// Approved WhatsApp template names for proactive (out-of-24h-window) sends.
+// Until a template is APPROVED in WhatsApp Manager and set here, the sender
+// falls back to free-form text — which Meta only delivers inside the recipient's
+// open 24h window (fine for testing, NOT for production paging). Set these
+// before flipping OPS_PULSE_MODE=armed.
+export const TEMPLATES = {
+  managerDigest: process.env.OPS_PULSE_TPL_DIGEST || "",
+  ownerEscalation: process.env.OPS_PULSE_TPL_ESCALATION || "",
+  languageCode: process.env.OPS_PULSE_TPL_LANG || "en",
 } as const;

--- a/apps/backoffice/src/lib/ops-pulse/config.ts
+++ b/apps/backoffice/src/lib/ops-pulse/config.ts
@@ -114,6 +114,7 @@ export const SIGNAL_CATEGORY: Record<string, SignalCategory> = {
   CHECKLIST: "routine",
   AUDIT: "routine", // outlet audits + staff skill training
   STOCK_COUNT: "routine",
+  RESTOCK_NEEDED: "routine",
   PHONE_CAPTURE: "routine",
   REVIEW: "adhoc",
   MENU_SNOOZED: "adhoc",

--- a/apps/backoffice/src/lib/ops-pulse/config.ts
+++ b/apps/backoffice/src/lib/ops-pulse/config.ts
@@ -65,10 +65,14 @@ function splitNames(v: string | undefined, def: string): string[] {
   return (v || def).split(",").map((s) => s.trim()).filter(Boolean);
 }
 
+// Each entry is a User name OR a raw phone number (+60…/01…) for people without
+// an app account. NOTE: "Syafiq Kaberi" and "Ibrahim Zakir" have no User record
+// yet — until they're added (or replaced here with their phone numbers) the
+// barista/kitchen routes fall back to the owner.
 export const RECIPIENTS: Record<string, string[]> = {
   operations: splitNames(process.env.OPS_PULSE_OPS_RECIPIENTS, "Ariff,Adam Kelvin"),
-  barista: splitNames(process.env.OPS_PULSE_BARISTA_RECIPIENTS, "Syafiq"),
-  kitchen: splitNames(process.env.OPS_PULSE_KITCHEN_RECIPIENTS, "Chef Bo"),
+  barista: splitNames(process.env.OPS_PULSE_BARISTA_RECIPIENTS, "Syafiq Kaberi"),
+  kitchen: splitNames(process.env.OPS_PULSE_KITCHEN_RECIPIENTS, "Ibrahim Zakir"),
 };
 
 // Map an auditor roleType to its routing discipline.

--- a/apps/backoffice/src/lib/ops-pulse/config.ts
+++ b/apps/backoffice/src/lib/ops-pulse/config.ts
@@ -43,6 +43,23 @@ export const THRESHOLDS = {
   },
 } as const;
 
+// Audit / training coverage. The schema has NO audit cadence, so we define one:
+// each tracked auditor role should have a COMPLETED report at each active outlet
+// within `cadenceDays`. A role only pulses if it has an active AuditTemplate, so
+// configuring a role that doesn't exist yet is a harmless no-op. Severity is LOW
+// (a reminder/scorecard line — never escalated). Kept separate from THRESHOLDS
+// so `roles` stays a mutable string[] for Prisma `in:` filters.
+export const AUDIT = {
+  // 30 = monthly. Owner-set frequency (7 weekly, 90 quarterly).
+  cadenceDays: 30,
+  // AuditTemplate.roleType values to watch. Confirmed in data: "barista_head".
+  // Override with OPS_PULSE_AUDIT_ROLES (comma-separated, e.g. "barista_head,food_director").
+  roles: (process.env.OPS_PULSE_AUDIT_ROLES || "barista_head")
+    .split(",")
+    .map((s) => s.trim())
+    .filter(Boolean),
+};
+
 // Approved WhatsApp template names for proactive (out-of-24h-window) sends.
 // Until a template is APPROVED in WhatsApp Manager and set here, the sender
 // falls back to free-form text — which Meta only delivers inside the recipient's

--- a/apps/backoffice/src/lib/ops-pulse/config.ts
+++ b/apps/backoffice/src/lib/ops-pulse/config.ts
@@ -15,6 +15,14 @@ export function pulseMode(): PulseMode {
   return m === "off" || m === "armed" ? m : "shadow";
 }
 
+// Controls the DAILY pulse — a once-a-day digest per recipient, the habit-builder
+// shipped first. Independent of OPS_PULSE_MODE so the daily digest can go live
+// while the real-time path stays in shadow. off | shadow | armed; unset ⇒ shadow.
+export function dailyMode(): PulseMode {
+  const m = (process.env.OPS_PULSE_DAILY_MODE || "shadow").trim().toLowerCase();
+  return m === "off" || m === "armed" ? m : "shadow";
+}
+
 export const THRESHOLDS = {
   phoneCapture: {
     // Breach if the day's completed-order phone-capture rate for an outlet is
@@ -110,5 +118,6 @@ export const AUDIT = {
 export const TEMPLATES = {
   managerDigest: process.env.OPS_PULSE_TPL_DIGEST || "",
   ownerEscalation: process.env.OPS_PULSE_TPL_ESCALATION || "",
+  dailyDigest: process.env.OPS_PULSE_TPL_DAILY || "",
   languageCode: process.env.OPS_PULSE_TPL_LANG || "en",
 } as const;

--- a/apps/backoffice/src/lib/ops-pulse/config.ts
+++ b/apps/backoffice/src/lib/ops-pulse/config.ts
@@ -37,11 +37,46 @@ export const THRESHOLDS = {
     // Only page reviews newer than this, so first-arm doesn't burst on old backlog.
     recencyHours: 72,
   },
+  stockCount: {
+    // No SUBMITTED/REVIEWED stock count for an active outlet within this many
+    // days → overdue (procurement).
+    cadenceDays: 7,
+  },
+  receiving: {
+    // Receivings with a discrepancy (DISPUTED/PARTIAL) in this window get paged.
+    recencyDays: 7,
+  },
+  menuSnooze: {
+    // Page an outlet once its snoozed (86'd / out-of-stock) item count reaches this.
+    minItems: 1,
+  },
   escalation: {
     // Minutes an alert may sit OPEN (unacked) before it escalates to the owner.
     slaMinutes: 90,
   },
 } as const;
+
+// ── Routing ──────────────────────────────────────────────────
+// Discipline (routeKey) → recipient names, matched case-insensitively against
+// User.name. Multiple recipients allowed; the FIRST is primary (owns the
+// ledger row's ack/escalation), the rest are co-recipients who also get the
+// digest. Unresolved names fall back to the owner (logged). Override via env.
+function splitNames(v: string | undefined, def: string): string[] {
+  return (v || def).split(",").map((s) => s.trim()).filter(Boolean);
+}
+
+export const RECIPIENTS: Record<string, string[]> = {
+  operations: splitNames(process.env.OPS_PULSE_OPS_RECIPIENTS, "Ariff,Adam Kelvin"),
+  barista: splitNames(process.env.OPS_PULSE_BARISTA_RECIPIENTS, "Syafiq"),
+  kitchen: splitNames(process.env.OPS_PULSE_KITCHEN_RECIPIENTS, "Chef Bo"),
+};
+
+// Map an auditor roleType to its routing discipline.
+export function routeForRole(role: string): "barista" | "kitchen" | "operations" {
+  if (role === "barista_head") return "barista";
+  if (role === "chef_head") return "kitchen";
+  return "operations";
+}
 
 // Audit / training coverage. The schema has NO audit cadence, so we define one:
 // each tracked auditor role should have a COMPLETED report at each active outlet

--- a/apps/backoffice/src/lib/ops-pulse/config.ts
+++ b/apps/backoffice/src/lib/ops-pulse/config.ts
@@ -23,6 +23,17 @@ export function dailyMode(): PulseMode {
   return m === "off" || m === "armed" ? m : "shadow";
 }
 
+// Signals that fire on the FAST real-time pulse (every ~5 min). Everything else
+// surfaces only in the daily digest. Owner: Google reviews + menu-snoozed must be
+// instant; incidents (checklist, receiving) are good candidates too. Override via
+// OPS_PULSE_REALTIME_SIGNALS (comma-separated).
+export const REALTIME_SIGNALS: Set<string> = new Set(
+  (process.env.OPS_PULSE_REALTIME_SIGNALS || "REVIEW,MENU_SNOOZED")
+    .split(",")
+    .map((s) => s.trim().toUpperCase())
+    .filter(Boolean),
+);
+
 export const THRESHOLDS = {
   phoneCapture: {
     // Breach if the day's completed-order phone-capture rate for an outlet is

--- a/apps/backoffice/src/lib/ops-pulse/config.ts
+++ b/apps/backoffice/src/lib/ops-pulse/config.ts
@@ -50,11 +50,14 @@ export const THRESHOLDS = {
 // (a reminder/scorecard line — never escalated). Kept separate from THRESHOLDS
 // so `roles` stays a mutable string[] for Prisma `in:` filters.
 export const AUDIT = {
-  // 30 = monthly. Owner-set frequency (7 weekly, 90 quarterly).
-  cadenceDays: 30,
-  // AuditTemplate.roleType values to watch. Confirmed in data: "barista_head".
-  // Override with OPS_PULSE_AUDIT_ROLES (comma-separated, e.g. "barista_head,food_director").
-  roles: (process.env.OPS_PULSE_AUDIT_ROLES || "barista_head")
+  // Owner-set frequency: 7 = weekly (chosen 2026-06-24), 30 monthly, 90 quarterly.
+  cadenceDays: 7,
+  // AuditTemplate.roleType values to watch (confirmed against live data):
+  //   barista_head — barista lead (Barista Station Audit / Barista Skills)
+  //   chef_head    — food director  (Kitchen Quality Audit / Kitchen Crew Skills)
+  // Coverage counts a COMPLETED report of either the OUTLET or STAFF template for
+  // that role. Override with OPS_PULSE_AUDIT_ROLES (comma-separated).
+  roles: (process.env.OPS_PULSE_AUDIT_ROLES || "barista_head,chef_head")
     .split(",")
     .map((s) => s.trim())
     .filter(Boolean),

--- a/apps/backoffice/src/lib/ops-pulse/config.ts
+++ b/apps/backoffice/src/lib/ops-pulse/config.ts
@@ -28,7 +28,7 @@ export function dailyMode(): PulseMode {
 // instant; incidents (checklist, receiving) are good candidates too. Override via
 // OPS_PULSE_REALTIME_SIGNALS (comma-separated).
 export const REALTIME_SIGNALS: Set<string> = new Set(
-  (process.env.OPS_PULSE_REALTIME_SIGNALS || "REVIEW,MENU_SNOOZED,NO_CLOCK_IN")
+  (process.env.OPS_PULSE_REALTIME_SIGNALS || "REVIEW,MENU_SNOOZED,NO_CLOCK_IN,POS_NOT_OPEN")
     .split(",")
     .map((s) => s.trim().toUpperCase())
     .filter(Boolean),
@@ -73,6 +73,10 @@ export const THRESHOLDS = {
     // Minutes past a published shift's start_time before "no clock-in" counts.
     graceMinutes: 15,
   },
+  posOpen: {
+    // Minutes past an outlet's openTime before "POS not opened" (no till session) counts.
+    graceMinutes: 15,
+  },
   escalation: {
     // Minutes an alert may sit OPEN (unacked) before it escalates to the owner.
     slaMinutes: 90,
@@ -97,6 +101,28 @@ export const RECIPIENTS: Record<string, string[]> = {
   barista: splitNames(process.env.OPS_PULSE_BARISTA_RECIPIENTS, "Syafiq Kaberi"),
   kitchen: splitNames(process.env.OPS_PULSE_KITCHEN_RECIPIENTS, "Chef Bo"),
 };
+
+// Routine vs adhoc taxonomy. Routine = scheduled expectations checked at their
+// due time (clock-in, POS open, checklist, audits, stock, phone capture); adhoc =
+// spontaneous events that fire on occurrence (reviews, 86'd items, receiving
+// disputes). Owner: reviews are adhoc. Used to group the digest.
+export type SignalCategory = "routine" | "adhoc";
+
+export const SIGNAL_CATEGORY: Record<string, SignalCategory> = {
+  NO_CLOCK_IN: "routine",
+  POS_NOT_OPEN: "routine",
+  CHECKLIST: "routine",
+  AUDIT: "routine", // outlet audits + staff skill training
+  STOCK_COUNT: "routine",
+  PHONE_CAPTURE: "routine",
+  REVIEW: "adhoc",
+  MENU_SNOOZED: "adhoc",
+  RECEIVING: "adhoc",
+};
+
+export function categoryFor(signal: string): SignalCategory {
+  return SIGNAL_CATEGORY[signal] ?? "routine";
+}
 
 // Map an auditor roleType to its routing discipline.
 export function routeForRole(role: string): "barista" | "kitchen" | "operations" {

--- a/apps/backoffice/src/lib/ops-pulse/config.ts
+++ b/apps/backoffice/src/lib/ops-pulse/config.ts
@@ -1,0 +1,31 @@
+// Ops Pulse configuration — thresholds + run mode.
+//
+// Defaults are the owner-proposed values from docs/design/ops-kpi-pulse-loop.md
+// (tune during the shadow week). Kept here so there is one place to change them.
+
+export type PulseMode = "off" | "shadow" | "armed";
+
+// OPS_PULSE_MODE controls the loop:
+//   off    — cron is a no-op (kill switch).
+//   shadow — DEFAULT. Detect + route + log only. No DB writes, no WhatsApp sends.
+//   armed  — (Phase 1b, not yet wired) would persist OpsAlert + DM the manager.
+// Unset ⇒ shadow, so deploying starts the read-only shadow week automatically.
+export function pulseMode(): PulseMode {
+  const m = (process.env.OPS_PULSE_MODE || "shadow").trim().toLowerCase();
+  return m === "off" || m === "armed" ? m : "shadow";
+}
+
+export const THRESHOLDS = {
+  phoneCapture: {
+    // Breach if the day's completed-order phone-capture rate for an outlet is
+    // below this. Target is higher (80%); this is the floor that pages someone.
+    floorPct: 60,
+    // Don't judge an outlet until it has at least this many completed orders
+    // today — a 0/3 morning is noise, not a coaching signal.
+    minOrders: 10,
+  },
+  checklist: {
+    // Minutes past dueAt before a still-incomplete checklist counts as a breach.
+    graceMinutes: 30,
+  },
+} as const;

--- a/apps/backoffice/src/lib/ops-pulse/config.ts
+++ b/apps/backoffice/src/lib/ops-pulse/config.ts
@@ -28,7 +28,7 @@ export function dailyMode(): PulseMode {
 // instant; incidents (checklist, receiving) are good candidates too. Override via
 // OPS_PULSE_REALTIME_SIGNALS (comma-separated).
 export const REALTIME_SIGNALS: Set<string> = new Set(
-  (process.env.OPS_PULSE_REALTIME_SIGNALS || "REVIEW,MENU_SNOOZED")
+  (process.env.OPS_PULSE_REALTIME_SIGNALS || "REVIEW,MENU_SNOOZED,NO_CLOCK_IN")
     .split(",")
     .map((s) => s.trim().toUpperCase())
     .filter(Boolean),
@@ -68,6 +68,10 @@ export const THRESHOLDS = {
   menuSnooze: {
     // Page an outlet once its snoozed (86'd / out-of-stock) item count reaches this.
     minItems: 1,
+  },
+  attendance: {
+    // Minutes past a published shift's start_time before "no clock-in" counts.
+    graceMinutes: 15,
   },
   escalation: {
     // Minutes an alert may sit OPEN (unacked) before it escalates to the owner.

--- a/apps/backoffice/src/lib/ops-pulse/config.ts
+++ b/apps/backoffice/src/lib/ops-pulse/config.ts
@@ -65,14 +65,14 @@ function splitNames(v: string | undefined, def: string): string[] {
   return (v || def).split(",").map((s) => s.trim()).filter(Boolean);
 }
 
-// Each entry is a User name OR a raw phone number (+60…/01…) for people without
-// an app account. NOTE: "Syafiq Kaberi" and "Ibrahim Zakir" have no User record
-// yet — until they're added (or replaced here with their phone numbers) the
-// barista/kitchen routes fall back to the owner.
+// Each entry is a User name OR a raw phone number (+60…/01…). Confirmed against
+// the production DB: barista lead = "Syafiq Kaberi" (+601137506488), kitchen =
+// "Chef Bo" (+60126057787) — both active MANAGERs, so name routing resolves and
+// their "DONE" replies attribute correctly.
 export const RECIPIENTS: Record<string, string[]> = {
   operations: splitNames(process.env.OPS_PULSE_OPS_RECIPIENTS, "Ariff,Adam Kelvin"),
   barista: splitNames(process.env.OPS_PULSE_BARISTA_RECIPIENTS, "Syafiq Kaberi"),
-  kitchen: splitNames(process.env.OPS_PULSE_KITCHEN_RECIPIENTS, "Ibrahim Zakir"),
+  kitchen: splitNames(process.env.OPS_PULSE_KITCHEN_RECIPIENTS, "Chef Bo"),
 };
 
 // Map an auditor roleType to its routing discipline.

--- a/apps/backoffice/src/lib/ops-pulse/config.ts
+++ b/apps/backoffice/src/lib/ops-pulse/config.ts
@@ -125,6 +125,21 @@ export function categoryFor(signal: string): SignalCategory {
   return SIGNAL_CATEGORY[signal] ?? "routine";
 }
 
+// Restock-needed is held OFF until stock counts are reliable — par-level alerts
+// are noise while StockBalance is stale (78% of items read below reorder today,
+// because counts aren't being done). Fix stock counts first (the nudge to
+// Ariff/Adam), then flip OPS_PULSE_RESTOCK_ENABLED=true.
+export const RESTOCK_ENABLED = (process.env.OPS_PULSE_RESTOCK_ENABLED || "false").toLowerCase() === "true";
+
+// Signals that ALSO nudge the on-shift outlet team (not just the discipline
+// lead), because the team does the work — e.g. stock take. Comma-separated.
+export const TEAM_NOTIFY_SIGNALS: Set<string> = new Set(
+  (process.env.OPS_PULSE_TEAM_NOTIFY_SIGNALS || "STOCK_COUNT")
+    .split(",")
+    .map((s) => s.trim().toUpperCase())
+    .filter(Boolean),
+);
+
 // Map an auditor roleType to its routing discipline.
 export function routeForRole(role: string): "barista" | "kitchen" | "operations" {
   if (role === "barista_head") return "barista";

--- a/apps/backoffice/src/lib/ops-pulse/detectors.ts
+++ b/apps/backoffice/src/lib/ops-pulse/detectors.ts
@@ -1,0 +1,120 @@
+// Ops Pulse detectors. Each returns the Breaches it found; pure read, no writes.
+//
+// Phase 1 signals:
+//   • PHONE_CAPTURE — % of today's completed POS sales that captured a customer
+//     phone, per outlet, below the floor. Phone is the join key for every
+//     loyalty/marketing loop, so an uncaptured sale is a customer lost to them.
+//   • CHECKLIST     — a scheduled checklist still PENDING/IN_PROGRESS past its
+//     dueAt + grace window, at an active outlet.
+
+import { prisma } from "@/lib/prisma";
+import { THRESHOLDS } from "./config";
+import type { Breach } from "./types";
+
+// Today's MYT (UTC+8) calendar date + the UTC instant of its 00:00. pos_orders
+// store created_at as a timestamp; this mirrors the EOD ingestor's day boundary.
+function mytToday(now: Date): { ymd: string; dayStart: Date } {
+  const ymd = new Date(now.getTime() + 8 * 3_600_000).toISOString().slice(0, 10);
+  return { ymd, dayStart: new Date(`${ymd}T00:00:00+08:00`) };
+}
+
+// pos_orders.outlet_id is the loyalty outlet id, so we join through
+// Outlet.loyaltyOutletId rather than Outlet.id.
+export async function detectPhoneCapture(now: Date): Promise<Breach[]> {
+  const { ymd, dayStart } = mytToday(now);
+
+  const rows = await prisma.$queryRaw<
+    Array<{ outlet_id: string | null; total: number; with_phone: number }>
+  >`
+    SELECT outlet_id,
+           COUNT(*)::int AS total,
+           COUNT(*) FILTER (
+             WHERE customer_phone IS NOT NULL AND length(trim(customer_phone)) > 0
+           )::int AS with_phone
+    FROM pos_orders
+    WHERE status = 'completed'
+      AND refund_of_order_id IS NULL
+      AND created_at >= ${dayStart}
+    GROUP BY outlet_id
+  `;
+  if (rows.length === 0) return [];
+
+  const loyaltyIds = rows.map((r) => r.outlet_id).filter((x): x is string => !!x);
+  if (loyaltyIds.length === 0) return [];
+
+  const outlets = await prisma.outlet.findMany({
+    where: { loyaltyOutletId: { in: loyaltyIds }, status: "ACTIVE" },
+    select: { id: true, name: true, loyaltyOutletId: true },
+  });
+  const byLoyalty = new Map<string, (typeof outlets)[number]>();
+  for (const o of outlets) byLoyalty.set(o.loyaltyOutletId as string, o);
+
+  const { floorPct, minOrders } = THRESHOLDS.phoneCapture;
+  const breaches: Breach[] = [];
+  for (const r of rows) {
+    const outlet = r.outlet_id ? byLoyalty.get(r.outlet_id) : undefined;
+    if (!outlet) continue; // unmapped or inactive outlet
+    if (r.total < minOrders) continue; // sample too small to judge
+    const pct = Math.round((r.with_phone / r.total) * 100);
+    if (pct >= floorPct) continue;
+
+    breaches.push({
+      signal: "PHONE_CAPTURE",
+      outletId: outlet.id,
+      outletName: outlet.name,
+      severity: "MED",
+      dedupeKey: `PHONE_CAPTURE:${outlet.id}:${ymd}`,
+      summary: `Phone capture ${pct}% today (${r.with_phone}/${r.total} sales) — below ${floorPct}% floor`,
+      detail: { pct, withPhone: r.with_phone, total: r.total, floorPct, date: ymd },
+    });
+  }
+  return breaches;
+}
+
+// A scheduled checklist with an explicit dueAt that is still not done, more than
+// graceMinutes past due, at an active outlet. (Shift-only checklists with no
+// dueAt aren't paged here — that needs shift-end resolution; a Phase 2 refinement.)
+export async function detectChecklist(now: Date): Promise<Breach[]> {
+  const cutoff = new Date(now.getTime() - THRESHOLDS.checklist.graceMinutes * 60_000);
+
+  const overdue = await prisma.checklist.findMany({
+    where: {
+      status: { in: ["PENDING", "IN_PROGRESS"] },
+      dueAt: { not: null, lt: cutoff },
+    },
+    select: {
+      id: true,
+      outletId: true,
+      dueAt: true,
+      shift: true,
+      outlet: { select: { name: true, status: true } },
+      sop: { select: { title: true } },
+    },
+    orderBy: { dueAt: "asc" },
+    take: 200, // safety cap; a backlog this deep is itself the alert
+  });
+
+  const breaches: Breach[] = [];
+  for (const c of overdue) {
+    if (c.outlet.status !== "ACTIVE") continue;
+    const dueAt = c.dueAt as Date;
+    const overdueMinutes = Math.round((now.getTime() - dueAt.getTime()) / 60_000);
+    breaches.push({
+      signal: "CHECKLIST",
+      outletId: c.outletId,
+      outletName: c.outlet.name,
+      // An unopened opening checklist (prep/food-safety) is the high-stakes case.
+      severity: c.shift === "OPENING" ? "HIGH" : "MED",
+      dedupeKey: `CHECKLIST:${c.id}`, // each instance is unique
+      summary: `${c.sop.title} (${c.shift.toLowerCase()}) overdue ${overdueMinutes}m — ${c.outlet.name}`,
+      detail: {
+        checklistId: c.id,
+        sopTitle: c.sop.title,
+        shift: c.shift,
+        dueAt: dueAt.toISOString(),
+        overdueMinutes,
+      },
+    });
+  }
+  return breaches;
+}

--- a/apps/backoffice/src/lib/ops-pulse/detectors.ts
+++ b/apps/backoffice/src/lib/ops-pulse/detectors.ts
@@ -166,7 +166,7 @@ export async function detectReviews(now: Date): Promise<Breach[]> {
       severity: f.rating <= 1 ? "HIGH" : "MED",
       routeKey: "operations",
       dedupeKey: `REVIEW:IF:${f.id}`,
-      summary: `${f.rating}★ feedback — ${f.outlet.name}: "${clip(f.feedback)}"`,
+      summary: `${f.rating}★ feedback — ${f.outlet.name}: "${clip(f.feedback, 1000)}"`,
       detail: { source: "internal_feedback", feedbackId: f.id, rating: f.rating },
     });
   }
@@ -196,7 +196,7 @@ export async function detectReviews(now: Date): Promise<Breach[]> {
       severity: d.rating <= 1 ? "HIGH" : "MED",
       routeKey: "operations",
       dedupeKey: `REVIEW:GBP:${d.id}`,
-      summary: `${d.rating}★ Google review awaiting reply — ${d.outlet.name}: "${clip(d.comment)}"`,
+      summary: `${d.rating}★ Google review awaiting reply — ${d.outlet.name}: "${clip(d.comment, 1000)}"`,
       detail: { source: "google_review", draftId: d.id, rating: d.rating },
     });
   }

--- a/apps/backoffice/src/lib/ops-pulse/detectors.ts
+++ b/apps/backoffice/src/lib/ops-pulse/detectors.ts
@@ -118,3 +118,82 @@ export async function detectChecklist(now: Date): Promise<Breach[]> {
   }
   return breaches;
 }
+
+// Trim a free-text review to a one-line preview for the digest.
+function clip(s: string | null | undefined, n = 60): string {
+  const t = (s ?? "").replace(/\s+/g, " ").trim();
+  return t.length <= n ? t : `${t.slice(0, n - 1)}…`;
+}
+
+// Bad reviews still needing attention. Two sources, both reused from the live
+// reviews module rather than re-detected:
+//   • InternalFeedback — QR-gate feedback (already 1–3★); page the ≤2★ that are
+//     still "open".
+//   • ReviewReplyDraft — negative (1–3★) Google reviews still "pending" a reply.
+// Bounded to the recency window so arming doesn't burst on historical backlog;
+// the ledger then dedupes each review to a single page.
+export async function detectReviews(now: Date): Promise<Breach[]> {
+  const { internalMaxRating, googleMaxRating, recencyHours } = THRESHOLDS.review;
+  const since = new Date(now.getTime() - recencyHours * 3_600_000);
+  const breaches: Breach[] = [];
+
+  const feedback = await prisma.internalFeedback.findMany({
+    where: {
+      status: "open",
+      rating: { lte: internalMaxRating },
+      createdAt: { gte: since },
+    },
+    select: {
+      id: true,
+      outletId: true,
+      rating: true,
+      feedback: true,
+      outlet: { select: { name: true, status: true } },
+    },
+    orderBy: { createdAt: "asc" },
+    take: 100,
+  });
+  for (const f of feedback) {
+    if (f.outlet.status !== "ACTIVE") continue;
+    breaches.push({
+      signal: "REVIEW",
+      outletId: f.outletId,
+      outletName: f.outlet.name,
+      severity: f.rating <= 1 ? "HIGH" : "MED",
+      dedupeKey: `REVIEW:IF:${f.id}`,
+      summary: `${f.rating}★ feedback — ${f.outlet.name}: "${clip(f.feedback)}"`,
+      detail: { source: "internal_feedback", feedbackId: f.id, rating: f.rating },
+    });
+  }
+
+  const drafts = await prisma.reviewReplyDraft.findMany({
+    where: {
+      status: "pending",
+      rating: { lte: googleMaxRating },
+      createdAt: { gte: since },
+    },
+    select: {
+      id: true,
+      outletId: true,
+      rating: true,
+      comment: true,
+      outlet: { select: { name: true, status: true } },
+    },
+    orderBy: { createdAt: "asc" },
+    take: 100,
+  });
+  for (const d of drafts) {
+    if (d.outlet.status !== "ACTIVE") continue;
+    breaches.push({
+      signal: "REVIEW",
+      outletId: d.outletId,
+      outletName: d.outlet.name,
+      severity: d.rating <= 1 ? "HIGH" : "MED",
+      dedupeKey: `REVIEW:GBP:${d.id}`,
+      summary: `${d.rating}★ Google review awaiting reply — ${d.outlet.name}: "${clip(d.comment)}"`,
+      detail: { source: "google_review", draftId: d.id, rating: d.rating },
+    });
+  }
+
+  return breaches;
+}

--- a/apps/backoffice/src/lib/ops-pulse/detectors.ts
+++ b/apps/backoffice/src/lib/ops-pulse/detectors.ts
@@ -9,7 +9,8 @@
 
 import { prisma } from "@/lib/prisma";
 import { hrSupabaseAdmin } from "@/lib/hr/supabase";
-import { AUDIT, THRESHOLDS } from "./config";
+import { getSupabaseAdmin } from "@/lib/pickup/supabase";
+import { AUDIT, THRESHOLDS, routeForRole } from "./config";
 import type { Breach } from "./types";
 
 // Today's MYT (UTC+8) calendar date + the UTC instant of its 00:00. pos_orders
@@ -64,6 +65,7 @@ export async function detectPhoneCapture(now: Date): Promise<Breach[]> {
       outletId: outlet.id,
       outletName: outlet.name,
       severity: "MED",
+      routeKey: "operations",
       dedupeKey: `PHONE_CAPTURE:${outlet.id}:${ymd}`,
       summary: `Phone capture ${pct}% today (${r.with_phone}/${r.total} sales) — below ${floorPct}% floor`,
       detail: { pct, withPhone: r.with_phone, total: r.total, floorPct, date: ymd },
@@ -106,6 +108,7 @@ export async function detectChecklist(now: Date): Promise<Breach[]> {
       outletName: c.outlet.name,
       // An unopened opening checklist (prep/food-safety) is the high-stakes case.
       severity: c.shift === "OPENING" ? "HIGH" : "MED",
+      routeKey: "operations",
       dedupeKey: `CHECKLIST:${c.id}`, // each instance is unique
       summary: `${c.sop.title} (${c.shift.toLowerCase()}) overdue ${overdueMinutes}m — ${c.outlet.name}`,
       detail: {
@@ -161,6 +164,7 @@ export async function detectReviews(now: Date): Promise<Breach[]> {
       outletId: f.outletId,
       outletName: f.outlet.name,
       severity: f.rating <= 1 ? "HIGH" : "MED",
+      routeKey: "operations",
       dedupeKey: `REVIEW:IF:${f.id}`,
       summary: `${f.rating}★ feedback — ${f.outlet.name}: "${clip(f.feedback)}"`,
       detail: { source: "internal_feedback", feedbackId: f.id, rating: f.rating },
@@ -190,6 +194,7 @@ export async function detectReviews(now: Date): Promise<Breach[]> {
       outletId: d.outletId,
       outletName: d.outlet.name,
       severity: d.rating <= 1 ? "HIGH" : "MED",
+      routeKey: "operations",
       dedupeKey: `REVIEW:GBP:${d.id}`,
       summary: `${d.rating}★ Google review awaiting reply — ${d.outlet.name}: "${clip(d.comment)}"`,
       detail: { source: "google_review", draftId: d.id, rating: d.rating },
@@ -252,6 +257,7 @@ export async function detectOutletAudit(now: Date): Promise<Breach[]> {
         outletId: o.id,
         outletName: o.name,
         severity: "LOW",
+        routeKey: routeForRole(role),
         dedupeKey: `AUDIT:${role}:${o.id}:${bucket}`,
         summary: `No ${role} audit at ${o.name} in ${AUDIT.cadenceDays}d`,
         detail: { role, cadenceDays: AUDIT.cadenceDays },
@@ -336,6 +342,7 @@ export async function detectSkillTraining(now: Date): Promise<Breach[]> {
         outletId,
         outletName: agg.name,
         severity: "LOW",
+        routeKey: routeForRole(t.roleType),
         dedupeKey: `SKILL:${t.roleType}:${outletId}:${bucket}`,
         summary: `${t.name}: ${agg.trained}/${agg.eligible} staff trained — ${agg.name} (${untrained} to go)`,
         detail: {
@@ -348,6 +355,122 @@ export async function detectSkillTraining(now: Date): Promise<Breach[]> {
         },
       });
     }
+  }
+  return breaches;
+}
+
+// ── Procurement signals (route to operations) ────────────────
+
+// Stock count overdue: an active outlet with no SUBMITTED/REVIEWED StockCount
+// inside the cadence window. LOW severity, deduped per outlet/window.
+export async function detectStockCount(now: Date): Promise<Breach[]> {
+  const cadenceDays = THRESHOLDS.stockCount.cadenceDays;
+  const cutoff = new Date(now.getTime() - cadenceDays * 86_400_000);
+
+  const [outlets, recent] = await Promise.all([
+    prisma.outlet.findMany({ where: { status: "ACTIVE" }, select: { id: true, name: true } }),
+    prisma.stockCount.findMany({
+      where: { status: { in: ["SUBMITTED", "REVIEWED"] }, countDate: { gte: cutoff } },
+      select: { outletId: true },
+    }),
+  ]);
+  const counted = new Set(recent.map((r) => r.outletId));
+
+  const { ymd } = mytToday(now);
+  const bucket = Math.floor(
+    new Date(`${ymd}T00:00:00+08:00`).getTime() / (cadenceDays * 86_400_000),
+  );
+
+  const breaches: Breach[] = [];
+  for (const o of outlets) {
+    if (counted.has(o.id)) continue;
+    breaches.push({
+      signal: "STOCK_COUNT",
+      outletId: o.id,
+      outletName: o.name,
+      severity: "LOW",
+      routeKey: "operations",
+      dedupeKey: `STOCK_COUNT:${o.id}:${bucket}`,
+      summary: `No stock count submitted at ${o.name} in ${cadenceDays}d`,
+      detail: { cadenceDays },
+    });
+  }
+  return breaches;
+}
+
+// Receiving discrepancy: a DISPUTED/PARTIAL goods receipt in the recency window.
+// DISPUTED = MED (active dispute), PARTIAL = LOW. Deduped per receiving.
+export async function detectReceivings(now: Date): Promise<Breach[]> {
+  const cutoff = new Date(now.getTime() - THRESHOLDS.receiving.recencyDays * 86_400_000);
+
+  const rows = await prisma.receiving.findMany({
+    where: { status: { in: ["DISPUTED", "PARTIAL"] }, receivedAt: { gte: cutoff } },
+    select: {
+      id: true,
+      status: true,
+      outletId: true,
+      outlet: { select: { name: true, status: true } },
+    },
+    orderBy: { receivedAt: "desc" },
+    take: 100,
+  });
+
+  const breaches: Breach[] = [];
+  for (const r of rows) {
+    if (r.outlet.status !== "ACTIVE") continue;
+    breaches.push({
+      signal: "RECEIVING",
+      outletId: r.outletId,
+      outletName: r.outlet.name,
+      severity: r.status === "DISPUTED" ? "MED" : "LOW",
+      routeKey: "operations",
+      dedupeKey: `RECEIVING:${r.id}`,
+      summary: `${r.status.toLowerCase()} goods receipt — ${r.outlet.name}`,
+      detail: { receivingId: r.id, status: r.status },
+    });
+  }
+  return breaches;
+}
+
+// Menu snoozed: items 86'd / out-of-stock at an outlet (outlet_product_availability
+// in the loyalty DB; outlet_id is the pickupStoreId slug). A restock/procurement
+// signal. Deduped per outlet/day (the count fluctuates).
+export async function detectMenuSnoozed(now: Date): Promise<Breach[]> {
+  const supabase = getSupabaseAdmin();
+  const { data, error } = await supabase
+    .from("outlet_product_availability")
+    .select("outlet_id")
+    .eq("is_available", false);
+  if (error) throw new Error(`outlet_product_availability: ${error.message}`);
+
+  const countBySlug = new Map<string, number>();
+  for (const row of (data ?? []) as Array<{ outlet_id: string | null }>) {
+    if (!row.outlet_id) continue;
+    countBySlug.set(row.outlet_id, (countBySlug.get(row.outlet_id) ?? 0) + 1);
+  }
+  if (countBySlug.size === 0) return [];
+
+  const outlets = await prisma.outlet.findMany({
+    where: { status: "ACTIVE", pickupStoreId: { in: [...countBySlug.keys()] } },
+    select: { id: true, name: true, pickupStoreId: true },
+  });
+
+  const { ymd } = mytToday(now);
+  const minItems = THRESHOLDS.menuSnooze.minItems;
+  const breaches: Breach[] = [];
+  for (const o of outlets) {
+    const n = o.pickupStoreId ? countBySlug.get(o.pickupStoreId) ?? 0 : 0;
+    if (n < minItems) continue;
+    breaches.push({
+      signal: "MENU_SNOOZED",
+      outletId: o.id,
+      outletName: o.name,
+      severity: "MED",
+      routeKey: "operations",
+      dedupeKey: `MENU_SNOOZED:${o.id}:${ymd}`,
+      summary: `${n} menu item${n === 1 ? "" : "s"} snoozed (86'd) at ${o.name}`,
+      detail: { snoozed: n },
+    });
   }
   return breaches;
 }

--- a/apps/backoffice/src/lib/ops-pulse/detectors.ts
+++ b/apps/backoffice/src/lib/ops-pulse/detectors.ts
@@ -8,7 +8,7 @@
 //     dueAt + grace window, at an active outlet.
 
 import { prisma } from "@/lib/prisma";
-import { THRESHOLDS } from "./config";
+import { AUDIT, THRESHOLDS } from "./config";
 import type { Breach } from "./types";
 
 // Today's MYT (UTC+8) calendar date + the UTC instant of its 00:00. pos_orders
@@ -195,5 +195,67 @@ export async function detectReviews(now: Date): Promise<Breach[]> {
     });
   }
 
+  return breaches;
+}
+
+// Audit/training coverage gap: a tracked auditor role (e.g. barista_head,
+// food_director) with no COMPLETED report at an active outlet inside the cadence
+// window. Low-frequency by nature, so this is a LOW-severity reminder, deduped
+// to once per outlet/role/cadence-window — never escalated (it's lagging, not a
+// now-fix-it incident). A role is only checked if it has an active
+// AuditTemplate, so configuring a not-yet-created role is a harmless no-op.
+export async function detectAudit(now: Date): Promise<Breach[]> {
+  if (AUDIT.roles.length === 0) return [];
+  const cutoff = new Date(now.getTime() - AUDIT.cadenceDays * 86_400_000);
+
+  const [outlets, templates] = await Promise.all([
+    prisma.outlet.findMany({ where: { status: "ACTIVE" }, select: { id: true, name: true } }),
+    prisma.auditTemplate.findMany({
+      where: { isActive: true, roleType: { in: AUDIT.roles } },
+      select: { id: true, roleType: true },
+    }),
+  ]);
+  if (outlets.length === 0 || templates.length === 0) return [];
+
+  const roleByTemplate = new Map<string, string>();
+  for (const t of templates) roleByTemplate.set(t.id, t.roleType);
+  // Only roles that actually have an active template can be "overdue".
+  const activeRoles = [...new Set(templates.map((t) => t.roleType))];
+
+  const recent = await prisma.auditReport.findMany({
+    where: {
+      status: "COMPLETED",
+      templateId: { in: templates.map((t) => t.id) },
+      date: { gte: cutoff },
+    },
+    select: { outletId: true, templateId: true },
+  });
+  const covered = new Set<string>(); // `${outletId}::${roleType}`
+  for (const r of recent) {
+    const role = roleByTemplate.get(r.templateId);
+    if (role) covered.add(`${r.outletId}::${role}`);
+  }
+
+  // Re-alert once per cadence window: a stable bucket index over MYT days.
+  const { ymd } = mytToday(now);
+  const bucket = Math.floor(
+    new Date(`${ymd}T00:00:00+08:00`).getTime() / (AUDIT.cadenceDays * 86_400_000),
+  );
+
+  const breaches: Breach[] = [];
+  for (const o of outlets) {
+    for (const role of activeRoles) {
+      if (covered.has(`${o.id}::${role}`)) continue;
+      breaches.push({
+        signal: "AUDIT",
+        outletId: o.id,
+        outletName: o.name,
+        severity: "LOW",
+        dedupeKey: `AUDIT:${role}:${o.id}:${bucket}`,
+        summary: `No ${role} audit at ${o.name} in ${AUDIT.cadenceDays}d`,
+        detail: { role, cadenceDays: AUDIT.cadenceDays },
+      });
+    }
+  }
   return breaches;
 }

--- a/apps/backoffice/src/lib/ops-pulse/detectors.ts
+++ b/apps/backoffice/src/lib/ops-pulse/detectors.ts
@@ -550,3 +550,48 @@ export async function detectNoClockIn(now: Date): Promise<Breach[]> {
   }
   return breaches;
 }
+
+// POS not opened: an active outlet open today whose openTime + grace has passed
+// with no pos_shifts session opened — the till isn't logged in, so it can't
+// trade. Part of "open-ready". pos_shifts.outlet_id is the loyalty outlet id.
+export async function detectPosNotOpen(now: Date): Promise<Breach[]> {
+  const { ymd, dayStart } = mytToday(now);
+  const mytNow = new Date(now.getTime() + 8 * 3_600_000);
+  const dow = mytNow.getUTCDay() === 0 ? 7 : mytNow.getUTCDay(); // 1=Mon … 7=Sun
+
+  const outlets = await prisma.outlet.findMany({
+    where: { status: "ACTIVE" },
+    select: { id: true, name: true, openTime: true, daysOpen: true, loyaltyOutletId: true },
+  });
+  const grace = THRESHOLDS.posOpen.graceMinutes;
+  const due = outlets.filter((o) => {
+    if (!o.openTime || !o.loyaltyOutletId) return false;
+    if (o.daysOpen && o.daysOpen.length > 0 && !o.daysOpen.includes(dow)) return false; // closed today
+    const open = new Date(`${ymd}T${o.openTime}:00+08:00`);
+    return now.getTime() > open.getTime() + grace * 60_000;
+  });
+  if (due.length === 0) return [];
+
+  const loyaltyIds = due.map((o) => o.loyaltyOutletId as string);
+  const opened = await prisma.$queryRaw<Array<{ outlet_id: string | null }>>`
+    SELECT DISTINCT outlet_id FROM pos_shifts
+    WHERE opened_at >= ${dayStart} AND outlet_id = ANY(${loyaltyIds})
+  `;
+  const openedSet = new Set(opened.map((r) => r.outlet_id).filter((x): x is string => !!x));
+
+  const breaches: Breach[] = [];
+  for (const o of due) {
+    if (o.loyaltyOutletId && openedSet.has(o.loyaltyOutletId)) continue;
+    breaches.push({
+      signal: "POS_NOT_OPEN",
+      outletId: o.id,
+      outletName: o.name,
+      severity: "HIGH",
+      routeKey: "operations",
+      dedupeKey: `POS_NOT_OPEN:${o.id}:${ymd}`,
+      summary: `POS not opened at ${o.name} — opens ${o.openTime}, no till session yet`,
+      detail: { openTime: o.openTime },
+    });
+  }
+  return breaches;
+}

--- a/apps/backoffice/src/lib/ops-pulse/detectors.ts
+++ b/apps/backoffice/src/lib/ops-pulse/detectors.ts
@@ -482,3 +482,71 @@ export async function detectMenuSnoozed(now: Date): Promise<Breach[]> {
   }
   return breaches;
 }
+
+// Staff no-show: a published shift today whose start_time + grace has passed with
+// no clock-in. Leaves the shift understaffed — urgent, routed to operations. The
+// roster (hr_schedule_shifts/hr_schedules) and clock-ins (hr_attendance_logs)
+// live in the same DB as Prisma, so we query them raw. One breach per staff/day.
+export async function detectNoClockIn(now: Date): Promise<Breach[]> {
+  const { ymd } = mytToday(now);
+  const dayStart = new Date(`${ymd}T00:00:00+08:00`);
+  const dayEnd = new Date(dayStart.getTime() + 86_400_000);
+
+  const shifts = await prisma.$queryRaw<
+    Array<{ user_id: string; outlet_id: string | null; start_time: string }>
+  >`
+    SELECT s.user_id, sch.outlet_id, s.start_time::text AS start_time
+    FROM hr_schedule_shifts s
+    JOIN hr_schedules sch ON sch.id = s.schedule_id
+    WHERE s.shift_date = ${ymd}::date
+      AND sch.published_at IS NOT NULL
+  `;
+  if (shifts.length === 0) return [];
+
+  const clockRows = await prisma.$queryRaw<Array<{ user_id: string }>>`
+    SELECT DISTINCT user_id FROM hr_attendance_logs
+    WHERE clock_in >= ${dayStart} AND clock_in < ${dayEnd}
+  `;
+  const clockedIn = new Set(clockRows.map((r) => r.user_id));
+
+  const grace = THRESHOLDS.attendance.graceMinutes;
+  const candidates = shifts.filter((s) => {
+    if (!s.user_id || clockedIn.has(s.user_id)) return false;
+    const start = new Date(`${ymd}T${s.start_time}+08:00`);
+    return now.getTime() > start.getTime() + grace * 60_000;
+  });
+  if (candidates.length === 0) return [];
+
+  const userIds = [...new Set(candidates.map((c) => c.user_id))];
+  const outletIds = [...new Set(candidates.map((c) => c.outlet_id).filter((x): x is string => !!x))];
+  const [users, outlets] = await Promise.all([
+    prisma.user.findMany({ where: { id: { in: userIds } }, select: { id: true, name: true } }),
+    outletIds.length
+      ? prisma.outlet.findMany({ where: { id: { in: outletIds } }, select: { id: true, name: true } })
+      : Promise.resolve([] as Array<{ id: string; name: string }>),
+  ]);
+  const userName = new Map<string, string>();
+  for (const u of users) userName.set(u.id, u.name);
+  const outletName = new Map<string, string>();
+  for (const o of outlets) outletName.set(o.id, o.name);
+
+  // One breach per staff per day (earliest unmatched shift wins).
+  const seen = new Set<string>();
+  const breaches: Breach[] = [];
+  for (const c of candidates) {
+    if (seen.has(c.user_id)) continue;
+    seen.add(c.user_id);
+    const oName = c.outlet_id ? outletName.get(c.outlet_id) ?? c.outlet_id : "—";
+    breaches.push({
+      signal: "NO_CLOCK_IN",
+      outletId: c.outlet_id ?? "",
+      outletName: oName,
+      severity: "MED",
+      routeKey: "operations",
+      dedupeKey: `NO_CLOCK_IN:${c.user_id}:${ymd}`,
+      summary: `${userName.get(c.user_id) ?? c.user_id} did not clock in — scheduled ${c.start_time.slice(0, 5)} at ${oName}`,
+      detail: { userId: c.user_id, scheduledStart: c.start_time, date: ymd },
+    });
+  }
+  return breaches;
+}

--- a/apps/backoffice/src/lib/ops-pulse/detectors.ts
+++ b/apps/backoffice/src/lib/ops-pulse/detectors.ts
@@ -595,3 +595,55 @@ export async function detectPosNotOpen(now: Date): Promise<Breach[]> {
   }
   return breaches;
 }
+
+// Restock needed: products whose on-hand (summed StockBalance) is at/below their
+// reorder point (ParLevel), per active outlet. A routine procurement list — one
+// breach per outlet (count + a sample of items), never a ping per item.
+export async function detectRestockNeeded(now: Date): Promise<Breach[]> {
+  const { ymd } = mytToday(now);
+
+  const pars = await prisma.parLevel.findMany({
+    select: {
+      outletId: true,
+      productId: true,
+      reorderPoint: true,
+      outlet: { select: { name: true, status: true } },
+      product: { select: { name: true } },
+    },
+  });
+  if (pars.length === 0) return [];
+
+  const balances = await prisma.stockBalance.groupBy({
+    by: ["outletId", "productId"],
+    _sum: { quantity: true },
+  });
+  const onHand = new Map<string, number>();
+  for (const b of balances) onHand.set(`${b.outletId}::${b.productId}`, Number(b._sum.quantity ?? 0));
+
+  const byOutlet = new Map<string, { name: string; count: number; items: string[] }>();
+  for (const par of pars) {
+    if (par.outlet.status !== "ACTIVE") continue;
+    const have = onHand.get(`${par.outletId}::${par.productId}`) ?? 0;
+    if (have > Number(par.reorderPoint)) continue;
+    const agg = byOutlet.get(par.outletId) ?? { name: par.outlet.name, count: 0, items: [] as string[] };
+    agg.count += 1;
+    if (agg.items.length < 5) agg.items.push(par.product.name);
+    byOutlet.set(par.outletId, agg);
+  }
+
+  const breaches: Breach[] = [];
+  for (const [outletId, agg] of byOutlet) {
+    const more = agg.count > agg.items.length ? ` +${agg.count - agg.items.length} more` : "";
+    breaches.push({
+      signal: "RESTOCK_NEEDED",
+      outletId,
+      outletName: agg.name,
+      severity: "MED",
+      routeKey: "operations",
+      dedupeKey: `RESTOCK_NEEDED:${outletId}:${ymd}`,
+      summary: `${agg.count} item${agg.count === 1 ? "" : "s"} below reorder at ${agg.name} — restock: ${agg.items.join(", ")}${more}`,
+      detail: { count: agg.count, items: agg.items },
+    });
+  }
+  return breaches;
+}

--- a/apps/backoffice/src/lib/ops-pulse/detectors.ts
+++ b/apps/backoffice/src/lib/ops-pulse/detectors.ts
@@ -457,13 +457,28 @@ export async function detectMenuSnoozed(now: Date): Promise<Breach[]> {
   const supabase = getSupabaseAdmin();
   const { data, error } = await supabase
     .from("outlet_product_availability")
-    .select("outlet_id")
+    .select("outlet_id, product_id")
     .eq("is_available", false);
   if (error) throw new Error(`outlet_product_availability: ${error.message}`);
+  const rows = (data ?? []) as Array<{ outlet_id: string | null; product_id: string | null }>;
+  if (rows.length === 0) return [];
+
+  // Exclude products that are globally off-menu (is_available=false on the
+  // product) — those aren't an outlet 86'ing a live item. Mirrors the store-menu
+  // board's "ignore globally-disabled items".
+  const productIds = [...new Set(rows.map((r) => r.product_id).filter((x): x is string => !!x))];
+  const disabled = new Set<string>();
+  if (productIds.length > 0) {
+    const { data: prods } = await supabase.from("products").select("id, is_available").in("id", productIds);
+    for (const p of (prods ?? []) as Array<{ id: string; is_available: boolean | null }>) {
+      if (p.is_available === false) disabled.add(p.id);
+    }
+  }
 
   const countBySlug = new Map<string, number>();
-  for (const row of (data ?? []) as Array<{ outlet_id: string | null }>) {
+  for (const row of rows) {
     if (!row.outlet_id) continue;
+    if (row.product_id && disabled.has(row.product_id)) continue; // globally off-menu
     countBySlug.set(row.outlet_id, (countBySlug.get(row.outlet_id) ?? 0) + 1);
   }
   if (countBySlug.size === 0) return [];
@@ -510,6 +525,8 @@ export async function detectNoClockIn(now: Date): Promise<Breach[]> {
     JOIN hr_schedules sch ON sch.id = s.schedule_id
     WHERE s.shift_date = ${ymd}::date
       AND sch.published_at IS NOT NULL
+      AND s.start_time IS NOT NULL
+    ORDER BY s.start_time ASC
   `;
   if (shifts.length === 0) return [];
 

--- a/apps/backoffice/src/lib/ops-pulse/detectors.ts
+++ b/apps/backoffice/src/lib/ops-pulse/detectors.ts
@@ -271,8 +271,9 @@ export async function detectOutletAudit(now: Date): Promise<Breach[]> {
 // eligible staff (by HR position) at an outlet have a COMPLETED skill audit
 // vs. how many should. The number trained is the metric. Cross-DB: positions
 // live in hr_employee_profiles (HR Supabase), staff→outlet + reports in Prisma.
-// "Trained" is cumulative (any completed skill audit), re-nudged once per cadence
-// window. LOW severity, never escalated — a scorecard/coaching number.
+// "Trained" means skill-audited WITHIN the cadence window — skill = 1/week/staff,
+// so each eligible staff needs a fresh skill audit every week (not just ever).
+// LOW severity, never escalated — a scorecard/coaching number.
 export async function detectSkillTraining(now: Date): Promise<Breach[]> {
   if (AUDIT.roles.length === 0) return [];
 
@@ -301,6 +302,7 @@ export async function detectSkillTraining(now: Date): Promise<Breach[]> {
   }
 
   const { ymd } = mytToday(now);
+  const cutoff = new Date(now.getTime() - AUDIT.cadenceDays * 86_400_000);
   const bucket = Math.floor(
     new Date(`${ymd}T00:00:00+08:00`).getTime() / (AUDIT.cadenceDays * 86_400_000),
   );
@@ -318,7 +320,12 @@ export async function detectSkillTraining(now: Date): Promise<Breach[]> {
         select: { id: true, outletId: true, outlet: { select: { name: true, status: true } } },
       }),
       prisma.auditReport.findMany({
-        where: { templateId: t.id, status: "COMPLETED", auditeeId: { in: eligibleList } },
+        where: {
+          templateId: t.id,
+          status: "COMPLETED",
+          auditeeId: { in: eligibleList },
+          date: { gte: cutoff }, // skill = 1/week/staff → only THIS week's audits count
+        },
         select: { auditeeId: true },
       }),
     ]);
@@ -344,11 +351,12 @@ export async function detectSkillTraining(now: Date): Promise<Breach[]> {
         severity: "LOW",
         routeKey: routeForRole(t.roleType),
         dedupeKey: `SKILL:${t.roleType}:${outletId}:${bucket}`,
-        summary: `${t.name}: ${agg.trained}/${agg.eligible} staff trained — ${agg.name} (${untrained} to go)`,
+        summary: `${t.name}: ${agg.trained}/${agg.eligible} staff skill-audited this week — ${agg.name} (${untrained} to go)`,
         detail: {
           kind: "skill_training",
           template: t.name,
           role: t.roleType,
+          cadenceDays: AUDIT.cadenceDays,
           eligible: agg.eligible,
           trained: agg.trained,
           untrained,

--- a/apps/backoffice/src/lib/ops-pulse/detectors.ts
+++ b/apps/backoffice/src/lib/ops-pulse/detectors.ts
@@ -8,6 +8,7 @@
 //     dueAt + grace window, at an active outlet.
 
 import { prisma } from "@/lib/prisma";
+import { hrSupabaseAdmin } from "@/lib/hr/supabase";
 import { AUDIT, THRESHOLDS } from "./config";
 import type { Breach } from "./types";
 
@@ -198,20 +199,20 @@ export async function detectReviews(now: Date): Promise<Breach[]> {
   return breaches;
 }
 
-// Audit/training coverage gap: a tracked auditor role (e.g. barista_head,
-// food_director) with no COMPLETED report at an active outlet inside the cadence
-// window. Low-frequency by nature, so this is a LOW-severity reminder, deduped
-// to once per outlet/role/cadence-window — never escalated (it's lagging, not a
-// now-fix-it incident). A role is only checked if it has an active
-// AuditTemplate, so configuring a not-yet-created role is a harmless no-op.
-export async function detectAudit(now: Date): Promise<Breach[]> {
+// OUTLET-audit coverage gap: a tracked role's OUTLET audit (e.g. Barista Station
+// Audit, Kitchen Quality Audit) with no COMPLETED report at an active outlet
+// inside the cadence window (weekly). LOW severity, deduped per
+// outlet/role/window, never escalated (lagging, not a now-fix-it incident). A
+// role is only checked if it has an active OUTLET template. Per-staff SKILL
+// audits are handled separately by detectSkillTraining.
+export async function detectOutletAudit(now: Date): Promise<Breach[]> {
   if (AUDIT.roles.length === 0) return [];
   const cutoff = new Date(now.getTime() - AUDIT.cadenceDays * 86_400_000);
 
   const [outlets, templates] = await Promise.all([
     prisma.outlet.findMany({ where: { status: "ACTIVE" }, select: { id: true, name: true } }),
     prisma.auditTemplate.findMany({
-      where: { isActive: true, roleType: { in: AUDIT.roles } },
+      where: { isActive: true, auditTarget: "OUTLET", roleType: { in: AUDIT.roles } },
       select: { id: true, roleType: true },
     }),
   ]);
@@ -254,6 +255,97 @@ export async function detectAudit(now: Date): Promise<Breach[]> {
         dedupeKey: `AUDIT:${role}:${o.id}:${bucket}`,
         summary: `No ${role} audit at ${o.name} in ${AUDIT.cadenceDays}d`,
         detail: { role, cadenceDays: AUDIT.cadenceDays },
+      });
+    }
+  }
+  return breaches;
+}
+
+// SKILL-audit (training) coverage: for each STAFF skill template, how many
+// eligible staff (by HR position) at an outlet have a COMPLETED skill audit
+// vs. how many should. The number trained is the metric. Cross-DB: positions
+// live in hr_employee_profiles (HR Supabase), staff→outlet + reports in Prisma.
+// "Trained" is cumulative (any completed skill audit), re-nudged once per cadence
+// window. LOW severity, never escalated — a scorecard/coaching number.
+export async function detectSkillTraining(now: Date): Promise<Breach[]> {
+  if (AUDIT.roles.length === 0) return [];
+
+  const templates = await prisma.auditTemplate.findMany({
+    where: { isActive: true, auditTarget: "STAFF", roleType: { in: AUDIT.roles } },
+    select: { id: true, name: true, roleType: true, jobRoleFilter: true },
+  });
+  if (templates.length === 0) return [];
+
+  // Fetch the eligible roster once: HR profiles whose position matches any tracked
+  // template's jobRoleFilter.
+  const positions = [...new Set(templates.flatMap((t) => t.jobRoleFilter))].filter(Boolean);
+  if (positions.length === 0) return [];
+  const { data: profiles, error } = await hrSupabaseAdmin
+    .from("hr_employee_profiles")
+    .select("user_id, position")
+    .in("position", positions);
+  if (error) throw new Error(`hr_employee_profiles: ${error.message}`);
+
+  const idsByPosition = new Map<string, Set<string>>();
+  for (const p of (profiles ?? []) as Array<{ user_id: string | null; position: string | null }>) {
+    if (!p.user_id || !p.position) continue;
+    const set = idsByPosition.get(p.position) ?? new Set<string>();
+    set.add(p.user_id);
+    idsByPosition.set(p.position, set);
+  }
+
+  const { ymd } = mytToday(now);
+  const bucket = Math.floor(
+    new Date(`${ymd}T00:00:00+08:00`).getTime() / (AUDIT.cadenceDays * 86_400_000),
+  );
+
+  const breaches: Breach[] = [];
+  for (const t of templates) {
+    const eligibleIds = new Set<string>();
+    for (const pos of t.jobRoleFilter) for (const id of idsByPosition.get(pos) ?? []) eligibleIds.add(id);
+    if (eligibleIds.size === 0) continue;
+    const eligibleList = [...eligibleIds];
+
+    const [staff, trainedRows] = await Promise.all([
+      prisma.user.findMany({
+        where: { id: { in: eligibleList }, status: "ACTIVE" },
+        select: { id: true, outletId: true, outlet: { select: { name: true, status: true } } },
+      }),
+      prisma.auditReport.findMany({
+        where: { templateId: t.id, status: "COMPLETED", auditeeId: { in: eligibleList } },
+        select: { auditeeId: true },
+      }),
+    ]);
+    const trained = new Set(trainedRows.map((r) => r.auditeeId).filter((x): x is string => !!x));
+
+    // Tally eligible vs trained per active outlet (staff need an outlet to route).
+    const byOutlet = new Map<string, { name: string; eligible: number; trained: number }>();
+    for (const s of staff) {
+      if (!s.outletId || s.outlet?.status !== "ACTIVE") continue;
+      const agg = byOutlet.get(s.outletId) ?? { name: s.outlet?.name ?? s.outletId, eligible: 0, trained: 0 };
+      agg.eligible += 1;
+      if (trained.has(s.id)) agg.trained += 1;
+      byOutlet.set(s.outletId, agg);
+    }
+
+    for (const [outletId, agg] of byOutlet) {
+      const untrained = agg.eligible - agg.trained;
+      if (untrained <= 0) continue;
+      breaches.push({
+        signal: "AUDIT",
+        outletId,
+        outletName: agg.name,
+        severity: "LOW",
+        dedupeKey: `SKILL:${t.roleType}:${outletId}:${bucket}`,
+        summary: `${t.name}: ${agg.trained}/${agg.eligible} staff trained — ${agg.name} (${untrained} to go)`,
+        detail: {
+          kind: "skill_training",
+          template: t.name,
+          role: t.roleType,
+          eligible: agg.eligible,
+          trained: agg.trained,
+          untrained,
+        },
       });
     }
   }

--- a/apps/backoffice/src/lib/ops-pulse/detectors.ts
+++ b/apps/backoffice/src/lib/ops-pulse/detectors.ts
@@ -10,7 +10,7 @@
 import { prisma } from "@/lib/prisma";
 import { hrSupabaseAdmin } from "@/lib/hr/supabase";
 import { getSupabaseAdmin } from "@/lib/pickup/supabase";
-import { AUDIT, THRESHOLDS, routeForRole } from "./config";
+import { AUDIT, THRESHOLDS, routeForRole, RESTOCK_ENABLED } from "./config";
 import type { Breach } from "./types";
 
 // Today's MYT (UTC+8) calendar date + the UTC instant of its 00:00. pos_orders
@@ -375,14 +375,21 @@ export async function detectStockCount(now: Date): Promise<Breach[]> {
   const cadenceDays = THRESHOLDS.stockCount.cadenceDays;
   const cutoff = new Date(now.getTime() - cadenceDays * 86_400_000);
 
-  const [outlets, recent] = await Promise.all([
+  const [outlets, recent, lastCounts] = await Promise.all([
     prisma.outlet.findMany({ where: { status: "ACTIVE" }, select: { id: true, name: true } }),
     prisma.stockCount.findMany({
       where: { status: { in: ["SUBMITTED", "REVIEWED"] }, countDate: { gte: cutoff } },
       select: { outletId: true },
     }),
+    prisma.stockCount.groupBy({
+      by: ["outletId"],
+      where: { status: { in: ["SUBMITTED", "REVIEWED"] } },
+      _max: { countDate: true },
+    }),
   ]);
   const counted = new Set(recent.map((r) => r.outletId));
+  const lastByOutlet = new Map<string, Date | null>();
+  for (const r of lastCounts) lastByOutlet.set(r.outletId, r._max.countDate ?? null);
 
   const { ymd } = mytToday(now);
   const bucket = Math.floor(
@@ -392,15 +399,18 @@ export async function detectStockCount(now: Date): Promise<Breach[]> {
   const breaches: Breach[] = [];
   for (const o of outlets) {
     if (counted.has(o.id)) continue;
+    const last = lastByOutlet.get(o.id) ?? null;
+    const daysSince = last ? Math.floor((now.getTime() - new Date(last).getTime()) / 86_400_000) : null;
+    const when = daysSince === null ? "no count on record" : `${daysSince}d ago`;
     breaches.push({
       signal: "STOCK_COUNT",
       outletId: o.id,
       outletName: o.name,
-      severity: "LOW",
+      severity: "MED",
       routeKey: "operations",
       dedupeKey: `STOCK_COUNT:${o.id}:${bucket}`,
-      summary: `No stock count submitted at ${o.name} in ${cadenceDays}d`,
-      detail: { cadenceDays },
+      summary: `Stock take overdue at ${o.name} — last count ${when}. Please do a stock take today.`,
+      detail: { cadenceDays, daysSince, lastCount: last ? new Date(last).toISOString().slice(0, 10) : null },
     });
   }
   return breaches;
@@ -600,6 +610,8 @@ export async function detectPosNotOpen(now: Date): Promise<Breach[]> {
 // reorder point (ParLevel), per active outlet. A routine procurement list — one
 // breach per outlet (count + a sample of items), never a ping per item.
 export async function detectRestockNeeded(now: Date): Promise<Breach[]> {
+  // Held off until stock counts are reliable (StockBalance is stale today).
+  if (!RESTOCK_ENABLED) return [];
   const { ymd } = mytToday(now);
 
   const pars = await prisma.parLevel.findMany({

--- a/apps/backoffice/src/lib/ops-pulse/inbound.ts
+++ b/apps/backoffice/src/lib/ops-pulse/inbound.ts
@@ -1,0 +1,40 @@
+// Inbound-ack hook for the ops pulse, called from the WhatsApp webhook.
+// When a manager/owner replies to a digest with an ack word ("DONE", "ok",
+// "fixed"…), close their still-open alerts. Matching all of their open alerts
+// is intentional — the digest batches a person's items, so one "DONE" clears
+// the batch. Refine to per-item acks once template quick-reply buttons land.
+
+import { prisma } from "@/lib/prisma";
+import { resolveOpenAlertsForUser } from "./ledger";
+
+const ACK = /\b(done|ok|okay|resolved|settled|fixed|cleared?|handled)\b/i;
+
+function digits(s: string): string {
+  return s.replace(/[^0-9]/g, "");
+}
+
+// Inbound senders are international digits (e.g. 60123456789); stored phones may
+// be +60…/01…. Compare the last 9 digits, which uniquely identify a MY mobile.
+function samePhone(a: string, b: string): boolean {
+  const x = digits(a);
+  const y = digits(b);
+  if (x.length < 8 || y.length < 8) return false;
+  const n = Math.min(9, x.length, y.length);
+  return x.slice(-n) === y.slice(-n);
+}
+
+// Returns the number of alerts resolved, or null when the message wasn't an ack
+// from a known manager/owner. Never throws — caller logs.
+export async function handleInboundAck(from: string, text: string): Promise<{ resolved: number } | null> {
+  if (!from || !ACK.test(text)) return null;
+
+  const staff = await prisma.user.findMany({
+    where: { role: { in: ["MANAGER", "OWNER"] }, status: "ACTIVE", phone: { not: null } },
+    select: { id: true, phone: true },
+  });
+  const user = staff.find((u) => u.phone && samePhone(from, u.phone));
+  if (!user) return null;
+
+  const resolved = await resolveOpenAlertsForUser(user.id);
+  return { resolved };
+}

--- a/apps/backoffice/src/lib/ops-pulse/index.ts
+++ b/apps/backoffice/src/lib/ops-pulse/index.ts
@@ -1,14 +1,17 @@
-// Ops KPI Pulse runner. Orchestrates detect → route → (shadow) log.
+// Ops KPI Pulse runner. Orchestrates detect → route → (shadow) log / (armed)
+// persist + page + escalate. See docs/design/ops-kpi-pulse-loop.md.
 //
-// Phase 1 is SHADOW-ONLY: it never messages anyone and never writes the ledger.
-// It logs each breach it *would* page so the owner can read a week of output and
-// confirm every breach is real before we arm escalation (Phase 1b). See
-// docs/design/ops-kpi-pulse-loop.md → "The Assignment".
+//   shadow — logs each breach it *would* page; no writes, no sends.
+//   armed  — records each breach in the OpsAlert ledger (deduped), DMs the
+//            accountable manager one digest of their NEW items, then escalates
+//            any incident sitting unacked past the SLA to the owner.
 
-import { pulseMode } from "./config";
-import { detectPhoneCapture, detectChecklist } from "./detectors";
-import { resolveAssignee } from "./router";
-import type { Breach, PulseRunResult, RoutedBreach } from "./types";
+import { pulseMode, THRESHOLDS } from "./config";
+import { detectPhoneCapture, detectChecklist, detectReviews } from "./detectors";
+import { resolveAssignee, resolveOwner } from "./router";
+import { findEscalatable, markEscalated, markSent, recordBreach } from "./ledger";
+import { sendManagerDigest, sendOwnerEscalation } from "./sender";
+import type { Assignee, Breach, PulseRunResult, RoutedBreach } from "./types";
 
 // Last-4 only — shadow output goes to plaintext logs / cron responses, so never
 // emit a full number there.
@@ -18,56 +21,110 @@ function maskPhone(p: string | null): string | null {
   return d.length <= 4 ? "****" : `••••${d.slice(-4)}`;
 }
 
+function detectorFailed(name: string) {
+  return (err: unknown) => {
+    console.error(`[ops-pulse] ${name} detector failed:`, err);
+    return [] as Breach[];
+  };
+}
+
 export async function runOpsPulse(now = new Date()): Promise<PulseRunResult> {
   const mode = pulseMode();
   if (mode === "off") {
-    return { mode, ranAt: now.toISOString(), breachCount: 0, routed: [], sent: 0 };
+    return { mode, ranAt: now.toISOString(), breachCount: 0, routed: [], sent: 0, escalated: 0 };
   }
 
-  // Detectors are isolated: one failing must not sink the whole run.
-  const [phone, checklist] = await Promise.all([
-    detectPhoneCapture(now).catch((err) => {
-      console.error("[ops-pulse] phone-capture detector failed:", err);
-      return [] as Breach[];
-    }),
-    detectChecklist(now).catch((err) => {
-      console.error("[ops-pulse] checklist detector failed:", err);
-      return [] as Breach[];
-    }),
+  // Detectors are isolated: one failing must not sink the run.
+  const [phone, checklist, reviews] = await Promise.all([
+    detectPhoneCapture(now).catch(detectorFailed("phone-capture")),
+    detectChecklist(now).catch(detectorFailed("checklist")),
+    detectReviews(now).catch(detectorFailed("reviews")),
   ]);
-  const breaches: Breach[] = [...phone, ...checklist];
+  const breaches: Breach[] = [...phone, ...checklist, ...reviews];
 
   // Resolve the accountable assignee once per outlet.
-  const assigneeByOutlet = new Map<string, Awaited<ReturnType<typeof resolveAssignee>>>();
+  const assigneeByOutlet = new Map<string, Assignee | null>();
   const routed: RoutedBreach[] = [];
   for (const b of breaches) {
     if (!assigneeByOutlet.has(b.outletId)) {
       assigneeByOutlet.set(b.outletId, await resolveAssignee(b.outletId));
     }
-    const a = assigneeByOutlet.get(b.outletId) ?? null;
-    routed.push({ ...b, assignee: a ? { ...a, phone: maskPhone(a.phone) } : null });
+    routed.push({ ...b, assignee: assigneeByOutlet.get(b.outletId) ?? null });
   }
 
-  // Sending is Phase 1b. If someone flips OPS_PULSE_MODE=armed before then,
-  // be loud and stay safe — degrade to shadow rather than silently do nothing.
-  if (mode === "armed") {
-    console.warn("[ops-pulse] mode=armed but the sender/ledger are not wired yet — running as shadow (no sends).");
+  const maskedRouted = (): RoutedBreach[] =>
+    routed.map((r) => ({ ...r, assignee: r.assignee ? { ...r.assignee, phone: maskPhone(r.assignee.phone) } : null }));
+
+  // ── SHADOW: log what we *would* page; never message anyone, never persist. ──
+  if (mode === "shadow") {
+    for (const r of routed) {
+      console.log(
+        "[ops-pulse:shadow]",
+        JSON.stringify({
+          signal: r.signal,
+          severity: r.severity,
+          outlet: r.outletName,
+          wouldNotify: r.assignee
+            ? { name: r.assignee.name, phone: maskPhone(r.assignee.phone), fallbackToOwner: r.assignee.fallback }
+            : null,
+          summary: r.summary,
+        }),
+      );
+    }
+    return { mode, ranAt: now.toISOString(), breachCount: breaches.length, routed: maskedRouted(), sent: 0, escalated: 0 };
   }
 
+  // ── ARMED: persist + page new alerts + escalate stale ones. ──
+  // Record every breach (dedupe in the ledger); bucket the NEW ones per assignee.
+  const newByUser = new Map<string, { phone: string | null; name: string; lines: string[]; alertIds: string[] }>();
   for (const r of routed) {
-    console.log(
-      "[ops-pulse:shadow]",
-      JSON.stringify({
-        signal: r.signal,
-        severity: r.severity,
-        outlet: r.outletName,
-        wouldNotify: r.assignee
-          ? { name: r.assignee.name, phone: r.assignee.phone, fallbackToOwner: r.assignee.fallback }
-          : null,
-        summary: r.summary,
-      }),
-    );
+    const { alert, isNew } = await recordBreach(r, r.assignee);
+    if (!isNew) continue;
+    const key = r.assignee?.userId ?? "__unrouted__";
+    const bucket = newByUser.get(key) ?? {
+      phone: r.assignee?.phone ?? null,
+      name: r.assignee?.name ?? "unrouted",
+      lines: [],
+      alertIds: [],
+    };
+    bucket.lines.push(r.summary);
+    bucket.alertIds.push(alert.id);
+    newByUser.set(key, bucket);
   }
 
-  return { mode: "shadow", ranAt: now.toISOString(), breachCount: breaches.length, routed, sent: 0 };
+  let sent = 0;
+  for (const [key, bucket] of newByUser) {
+    if (!bucket.phone) {
+      console.warn(`[ops-pulse] ${bucket.alertIds.length} new alert(s) for ${key} but no phone on file — not sent`);
+      continue;
+    }
+    const res = await sendManagerDigest(bucket.phone, bucket.lines);
+    // Mark sent even on failure so the escalation timer starts; a failed send is
+    // surfaced via the log and the alert simply stays OPEN to escalate.
+    for (const id of bucket.alertIds) await markSent(id, res.ok ? res.messageId ?? null : null);
+    if (res.ok) sent += 1;
+    else console.error(`[ops-pulse] manager digest to ${bucket.name} failed:`, res.error);
+  }
+
+  // Escalation sweep — incidents unacked past SLA go to the owner, batched.
+  let escalated = 0;
+  const due = await findEscalatable(THRESHOLDS.escalation.slaMinutes, now);
+  if (due.length > 0) {
+    const owner = await resolveOwner();
+    if (owner?.phone) {
+      const res = await sendOwnerEscalation(owner.phone, due.map((a) => a.summary));
+      if (res.ok) {
+        for (const a of due) {
+          await markEscalated(a.id);
+          escalated += 1;
+        }
+      } else {
+        console.error("[ops-pulse] owner escalation failed:", res.error);
+      }
+    } else {
+      console.warn(`[ops-pulse] ${due.length} alert(s) due for escalation but no owner phone on file`);
+    }
+  }
+
+  return { mode, ranAt: now.toISOString(), breachCount: breaches.length, routed: maskedRouted(), sent, escalated };
 }

--- a/apps/backoffice/src/lib/ops-pulse/index.ts
+++ b/apps/backoffice/src/lib/ops-pulse/index.ts
@@ -19,6 +19,7 @@ import {
   detectMenuSnoozed,
   detectNoClockIn,
   detectPosNotOpen,
+  detectRestockNeeded,
 } from "./detectors";
 import { resolveRecipients, resolveOwner } from "./router";
 import { findEscalatable, markEscalated, markSent, recordBreach } from "./ledger";
@@ -52,6 +53,7 @@ async function detectAll(now: Date): Promise<Breach[]> {
     detectMenuSnoozed(now).catch(detectorFailed("menu-snoozed")),
     detectNoClockIn(now).catch(detectorFailed("no-clock-in")),
     detectPosNotOpen(now).catch(detectorFailed("pos-not-open")),
+    detectRestockNeeded(now).catch(detectorFailed("restock-needed")),
   ]);
   return results.flat();
 }

--- a/apps/backoffice/src/lib/ops-pulse/index.ts
+++ b/apps/backoffice/src/lib/ops-pulse/index.ts
@@ -17,6 +17,7 @@ import {
   detectStockCount,
   detectReceivings,
   detectMenuSnoozed,
+  detectNoClockIn,
 } from "./detectors";
 import { resolveRecipients, resolveOwner } from "./router";
 import { findEscalatable, markEscalated, markSent, recordBreach } from "./ledger";
@@ -48,6 +49,7 @@ async function detectAll(now: Date): Promise<Breach[]> {
     detectStockCount(now).catch(detectorFailed("stock-count")),
     detectReceivings(now).catch(detectorFailed("receivings")),
     detectMenuSnoozed(now).catch(detectorFailed("menu-snoozed")),
+    detectNoClockIn(now).catch(detectorFailed("no-clock-in")),
   ]);
   return results.flat();
 }

--- a/apps/backoffice/src/lib/ops-pulse/index.ts
+++ b/apps/backoffice/src/lib/ops-pulse/index.ts
@@ -6,6 +6,7 @@
 //            recipient of its discipline one digest of their NEW items, then
 //            escalates any incident sitting unacked past the SLA to the owner.
 
+import { prisma } from "@/lib/prisma";
 import { pulseMode, THRESHOLDS } from "./config";
 import {
   detectPhoneCapture,
@@ -119,13 +120,24 @@ export async function runOpsPulse(now = new Date()): Promise<PulseRunResult> {
   // send success — a failed send is logged and the alert stays OPEN to escalate.
   for (const id of newAlertIds) await markSent(id, null);
 
-  // Escalation sweep — incidents unacked past SLA go to the owner, batched.
+  // Escalation sweep — unacked incidents + audits/skill past SLA go to the owner,
+  // tagged with the responsible lead so the owner sees WHO isn't getting it done.
   let escalated = 0;
   const due = await findEscalatable(THRESHOLDS.escalation.slaMinutes, now);
   if (due.length > 0) {
     const owner = await resolveOwner();
     if (owner?.phone) {
-      const res = await sendOwnerEscalation(owner.phone, due.map((a) => a.summary));
+      const leadIds = [...new Set(due.map((a) => a.assigneeUserId).filter((x): x is string => !!x))];
+      const leadName = new Map<string, string>();
+      if (leadIds.length > 0) {
+        const leads = await prisma.user.findMany({ where: { id: { in: leadIds } }, select: { id: true, name: true } });
+        for (const l of leads) leadName.set(l.id, l.name);
+      }
+      const lines = due.map((a) => {
+        const n = a.assigneeUserId ? leadName.get(a.assigneeUserId) : undefined;
+        return n ? `${a.summary} — lead: ${n}` : a.summary;
+      });
+      const res = await sendOwnerEscalation(owner.phone, lines);
       if (res.ok) {
         for (const a of due) {
           await markEscalated(a.id);

--- a/apps/backoffice/src/lib/ops-pulse/index.ts
+++ b/apps/backoffice/src/lib/ops-pulse/index.ts
@@ -7,7 +7,13 @@
 //            any incident sitting unacked past the SLA to the owner.
 
 import { pulseMode, THRESHOLDS } from "./config";
-import { detectPhoneCapture, detectChecklist, detectReviews, detectAudit } from "./detectors";
+import {
+  detectPhoneCapture,
+  detectChecklist,
+  detectReviews,
+  detectOutletAudit,
+  detectSkillTraining,
+} from "./detectors";
 import { resolveAssignee, resolveOwner } from "./router";
 import { findEscalatable, markEscalated, markSent, recordBreach } from "./ledger";
 import { sendManagerDigest, sendOwnerEscalation } from "./sender";
@@ -35,13 +41,14 @@ export async function runOpsPulse(now = new Date()): Promise<PulseRunResult> {
   }
 
   // Detectors are isolated: one failing must not sink the run.
-  const [phone, checklist, reviews, audit] = await Promise.all([
+  const [phone, checklist, reviews, outletAudit, skill] = await Promise.all([
     detectPhoneCapture(now).catch(detectorFailed("phone-capture")),
     detectChecklist(now).catch(detectorFailed("checklist")),
     detectReviews(now).catch(detectorFailed("reviews")),
-    detectAudit(now).catch(detectorFailed("audit")),
+    detectOutletAudit(now).catch(detectorFailed("outlet-audit")),
+    detectSkillTraining(now).catch(detectorFailed("skill-training")),
   ]);
-  const breaches: Breach[] = [...phone, ...checklist, ...reviews, ...audit];
+  const breaches: Breach[] = [...phone, ...checklist, ...reviews, ...outletAudit, ...skill];
 
   // Resolve the accountable assignee once per outlet.
   const assigneeByOutlet = new Map<string, Assignee | null>();

--- a/apps/backoffice/src/lib/ops-pulse/index.ts
+++ b/apps/backoffice/src/lib/ops-pulse/index.ts
@@ -7,7 +7,7 @@
 //            escalates any incident sitting unacked past the SLA to the owner.
 
 import { prisma } from "@/lib/prisma";
-import { pulseMode, dailyMode, REALTIME_SIGNALS, THRESHOLDS, categoryFor } from "./config";
+import { pulseMode, dailyMode, REALTIME_SIGNALS, THRESHOLDS, categoryFor, TEAM_NOTIFY_SIGNALS } from "./config";
 import {
   detectPhoneCapture,
   detectChecklist,
@@ -21,7 +21,7 @@ import {
   detectPosNotOpen,
   detectRestockNeeded,
 } from "./detectors";
-import { resolveRecipients, resolveOwner } from "./router";
+import { resolveRecipients, resolveOwner, resolveOutletTeam } from "./router";
 import { findEscalatable, markEscalated, markSent, recordBreach } from "./ledger";
 import { sendManagerDigest, sendOwnerEscalation, sendDailyDigest } from "./sender";
 import type { Assignee, Breach, PulseRunResult, RoutedBreach } from "./types";
@@ -58,15 +58,31 @@ async function detectAll(now: Date): Promise<Breach[]> {
   return results.flat();
 }
 
-// Attach each breach's discipline recipients (resolved once per routeKey).
-async function routeAll(breaches: Breach[]): Promise<RoutedBreach[]> {
+// Attach each breach's recipients: the discipline lead(s) (cached per routeKey)
+// plus — for team-work signals like stock take — the on-shift outlet team.
+async function routeAll(breaches: Breach[], now: Date): Promise<RoutedBreach[]> {
   const recipientsByRoute = new Map<string, Assignee[]>();
+  const teamByOutlet = new Map<string, Assignee[]>();
   const routed: RoutedBreach[] = [];
   for (const b of breaches) {
     if (!recipientsByRoute.has(b.routeKey)) {
       recipientsByRoute.set(b.routeKey, await resolveRecipients(b.routeKey));
     }
-    routed.push({ ...b, assignees: recipientsByRoute.get(b.routeKey) ?? [] });
+    const assignees: Assignee[] = [...(recipientsByRoute.get(b.routeKey) ?? [])];
+    if (TEAM_NOTIFY_SIGNALS.has(b.signal) && b.outletId) {
+      if (!teamByOutlet.has(b.outletId)) {
+        teamByOutlet.set(b.outletId, await resolveOutletTeam(b.outletId, now));
+      }
+      const seen = new Set(assignees.map((a) => a.userId || a.phone));
+      for (const t of teamByOutlet.get(b.outletId) ?? []) {
+        const k = t.userId || t.phone;
+        if (k && !seen.has(k)) {
+          assignees.push(t);
+          seen.add(k);
+        }
+      }
+    }
+    routed.push({ ...b, assignees });
   }
   return routed;
 }
@@ -84,7 +100,7 @@ export async function runOpsPulse(now = new Date()): Promise<PulseRunResult> {
   // Real-time tier only — the fast pulse alerts on the instant signals (reviews,
   // menu-snoozed, …); everything else surfaces in the daily digest.
   const breaches = (await detectAll(now)).filter((b) => REALTIME_SIGNALS.has(b.signal));
-  const routed = await routeAll(breaches);
+  const routed = await routeAll(breaches, now);
 
   // ── SHADOW: log what we *would* page; never message anyone, never persist. ──
   if (mode === "shadow") {
@@ -183,7 +199,7 @@ export async function runDailyPulse(now = new Date()): Promise<PulseRunResult> {
   }
 
   const breaches = await detectAll(now);
-  const routed = await routeAll(breaches);
+  const routed = await routeAll(breaches, now);
 
   // Group ALL current items by recipient, split routine vs adhoc.
   const byUser = new Map<string, { phone: string | null; name: string; routine: string[]; adhoc: string[] }>();

--- a/apps/backoffice/src/lib/ops-pulse/index.ts
+++ b/apps/backoffice/src/lib/ops-pulse/index.ts
@@ -1,0 +1,73 @@
+// Ops KPI Pulse runner. Orchestrates detect → route → (shadow) log.
+//
+// Phase 1 is SHADOW-ONLY: it never messages anyone and never writes the ledger.
+// It logs each breach it *would* page so the owner can read a week of output and
+// confirm every breach is real before we arm escalation (Phase 1b). See
+// docs/design/ops-kpi-pulse-loop.md → "The Assignment".
+
+import { pulseMode } from "./config";
+import { detectPhoneCapture, detectChecklist } from "./detectors";
+import { resolveAssignee } from "./router";
+import type { Breach, PulseRunResult, RoutedBreach } from "./types";
+
+// Last-4 only — shadow output goes to plaintext logs / cron responses, so never
+// emit a full number there.
+function maskPhone(p: string | null): string | null {
+  if (!p) return null;
+  const d = p.replace(/[^0-9]/g, "");
+  return d.length <= 4 ? "****" : `••••${d.slice(-4)}`;
+}
+
+export async function runOpsPulse(now = new Date()): Promise<PulseRunResult> {
+  const mode = pulseMode();
+  if (mode === "off") {
+    return { mode, ranAt: now.toISOString(), breachCount: 0, routed: [], sent: 0 };
+  }
+
+  // Detectors are isolated: one failing must not sink the whole run.
+  const [phone, checklist] = await Promise.all([
+    detectPhoneCapture(now).catch((err) => {
+      console.error("[ops-pulse] phone-capture detector failed:", err);
+      return [] as Breach[];
+    }),
+    detectChecklist(now).catch((err) => {
+      console.error("[ops-pulse] checklist detector failed:", err);
+      return [] as Breach[];
+    }),
+  ]);
+  const breaches: Breach[] = [...phone, ...checklist];
+
+  // Resolve the accountable assignee once per outlet.
+  const assigneeByOutlet = new Map<string, Awaited<ReturnType<typeof resolveAssignee>>>();
+  const routed: RoutedBreach[] = [];
+  for (const b of breaches) {
+    if (!assigneeByOutlet.has(b.outletId)) {
+      assigneeByOutlet.set(b.outletId, await resolveAssignee(b.outletId));
+    }
+    const a = assigneeByOutlet.get(b.outletId) ?? null;
+    routed.push({ ...b, assignee: a ? { ...a, phone: maskPhone(a.phone) } : null });
+  }
+
+  // Sending is Phase 1b. If someone flips OPS_PULSE_MODE=armed before then,
+  // be loud and stay safe — degrade to shadow rather than silently do nothing.
+  if (mode === "armed") {
+    console.warn("[ops-pulse] mode=armed but the sender/ledger are not wired yet — running as shadow (no sends).");
+  }
+
+  for (const r of routed) {
+    console.log(
+      "[ops-pulse:shadow]",
+      JSON.stringify({
+        signal: r.signal,
+        severity: r.severity,
+        outlet: r.outletName,
+        wouldNotify: r.assignee
+          ? { name: r.assignee.name, phone: r.assignee.phone, fallbackToOwner: r.assignee.fallback }
+          : null,
+        summary: r.summary,
+      }),
+    );
+  }
+
+  return { mode: "shadow", ranAt: now.toISOString(), breachCount: breaches.length, routed, sent: 0 };
+}

--- a/apps/backoffice/src/lib/ops-pulse/index.ts
+++ b/apps/backoffice/src/lib/ops-pulse/index.ts
@@ -97,9 +97,11 @@ export async function runOpsPulse(now = new Date()): Promise<PulseRunResult> {
     if (!isNew) continue;
     newAlertIds.add(alert.id);
     for (const a of r.assignees) {
-      const bucket = digestByUser.get(a.userId) ?? { phone: a.phone, name: a.name, lines: [] };
+      // Phone-only recipients have no userId; key the digest by phone/name instead.
+      const key = a.userId || a.phone || a.name;
+      const bucket = digestByUser.get(key) ?? { phone: a.phone, name: a.name, lines: [] };
       bucket.lines.push(r.summary);
-      digestByUser.set(a.userId, bucket);
+      digestByUser.set(key, bucket);
     }
   }
 

--- a/apps/backoffice/src/lib/ops-pulse/index.ts
+++ b/apps/backoffice/src/lib/ops-pulse/index.ts
@@ -2,9 +2,9 @@
 // persist + page + escalate. See docs/design/ops-kpi-pulse-loop.md.
 //
 //   shadow — logs each breach it *would* page; no writes, no sends.
-//   armed  — records each breach in the OpsAlert ledger (deduped), DMs the
-//            accountable manager one digest of their NEW items, then escalates
-//            any incident sitting unacked past the SLA to the owner.
+//   armed  — records each breach in the OpsAlert ledger (deduped), DMs every
+//            recipient of its discipline one digest of their NEW items, then
+//            escalates any incident sitting unacked past the SLA to the owner.
 
 import { pulseMode, THRESHOLDS } from "./config";
 import {
@@ -13,14 +13,16 @@ import {
   detectReviews,
   detectOutletAudit,
   detectSkillTraining,
+  detectStockCount,
+  detectReceivings,
+  detectMenuSnoozed,
 } from "./detectors";
-import { resolveAssignee, resolveOwner } from "./router";
+import { resolveRecipients, resolveOwner } from "./router";
 import { findEscalatable, markEscalated, markSent, recordBreach } from "./ledger";
 import { sendManagerDigest, sendOwnerEscalation } from "./sender";
 import type { Assignee, Breach, PulseRunResult, RoutedBreach } from "./types";
 
-// Last-4 only — shadow output goes to plaintext logs / cron responses, so never
-// emit a full number there.
+// Last-4 only — shadow output goes to plaintext logs / cron responses.
 function maskPhone(p: string | null): string | null {
   if (!p) return null;
   const d = p.replace(/[^0-9]/g, "");
@@ -41,27 +43,30 @@ export async function runOpsPulse(now = new Date()): Promise<PulseRunResult> {
   }
 
   // Detectors are isolated: one failing must not sink the run.
-  const [phone, checklist, reviews, outletAudit, skill] = await Promise.all([
+  const results = await Promise.all([
     detectPhoneCapture(now).catch(detectorFailed("phone-capture")),
     detectChecklist(now).catch(detectorFailed("checklist")),
     detectReviews(now).catch(detectorFailed("reviews")),
     detectOutletAudit(now).catch(detectorFailed("outlet-audit")),
     detectSkillTraining(now).catch(detectorFailed("skill-training")),
+    detectStockCount(now).catch(detectorFailed("stock-count")),
+    detectReceivings(now).catch(detectorFailed("receivings")),
+    detectMenuSnoozed(now).catch(detectorFailed("menu-snoozed")),
   ]);
-  const breaches: Breach[] = [...phone, ...checklist, ...reviews, ...outletAudit, ...skill];
+  const breaches: Breach[] = results.flat();
 
-  // Resolve the accountable assignee once per outlet.
-  const assigneeByOutlet = new Map<string, Assignee | null>();
+  // Resolve recipients once per discipline (routeKey).
+  const recipientsByRoute = new Map<string, Assignee[]>();
   const routed: RoutedBreach[] = [];
   for (const b of breaches) {
-    if (!assigneeByOutlet.has(b.outletId)) {
-      assigneeByOutlet.set(b.outletId, await resolveAssignee(b.outletId));
+    if (!recipientsByRoute.has(b.routeKey)) {
+      recipientsByRoute.set(b.routeKey, await resolveRecipients(b.routeKey));
     }
-    routed.push({ ...b, assignee: assigneeByOutlet.get(b.outletId) ?? null });
+    routed.push({ ...b, assignees: recipientsByRoute.get(b.routeKey) ?? [] });
   }
 
   const maskedRouted = (): RoutedBreach[] =>
-    routed.map((r) => ({ ...r, assignee: r.assignee ? { ...r.assignee, phone: maskPhone(r.assignee.phone) } : null }));
+    routed.map((r) => ({ ...r, assignees: r.assignees.map((a) => ({ ...a, phone: maskPhone(a.phone) })) }));
 
   // ── SHADOW: log what we *would* page; never message anyone, never persist. ──
   if (mode === "shadow") {
@@ -71,10 +76,9 @@ export async function runOpsPulse(now = new Date()): Promise<PulseRunResult> {
         JSON.stringify({
           signal: r.signal,
           severity: r.severity,
+          route: r.routeKey,
           outlet: r.outletName,
-          wouldNotify: r.assignee
-            ? { name: r.assignee.name, phone: maskPhone(r.assignee.phone), fallbackToOwner: r.assignee.fallback }
-            : null,
+          wouldNotify: r.assignees.map((a) => ({ name: a.name, phone: maskPhone(a.phone), fallbackToOwner: a.fallback })),
           summary: r.summary,
         }),
       );
@@ -83,36 +87,35 @@ export async function runOpsPulse(now = new Date()): Promise<PulseRunResult> {
   }
 
   // ── ARMED: persist + page new alerts + escalate stale ones. ──
-  // Record every breach (dedupe in the ledger); bucket the NEW ones per assignee.
-  const newByUser = new Map<string, { phone: string | null; name: string; lines: string[]; alertIds: string[] }>();
+  // Record every breach (dedupe in the ledger); primary = first recipient owns
+  // the row's ack/escalation. Bucket each NEW breach into every recipient's digest.
+  const newAlertIds = new Set<string>();
+  const digestByUser = new Map<string, { phone: string | null; name: string; lines: string[] }>();
   for (const r of routed) {
-    const { alert, isNew } = await recordBreach(r, r.assignee);
+    const primary = r.assignees[0] ?? null;
+    const { alert, isNew } = await recordBreach(r, primary);
     if (!isNew) continue;
-    const key = r.assignee?.userId ?? "__unrouted__";
-    const bucket = newByUser.get(key) ?? {
-      phone: r.assignee?.phone ?? null,
-      name: r.assignee?.name ?? "unrouted",
-      lines: [],
-      alertIds: [],
-    };
-    bucket.lines.push(r.summary);
-    bucket.alertIds.push(alert.id);
-    newByUser.set(key, bucket);
+    newAlertIds.add(alert.id);
+    for (const a of r.assignees) {
+      const bucket = digestByUser.get(a.userId) ?? { phone: a.phone, name: a.name, lines: [] };
+      bucket.lines.push(r.summary);
+      digestByUser.set(a.userId, bucket);
+    }
   }
 
   let sent = 0;
-  for (const [key, bucket] of newByUser) {
+  for (const [userId, bucket] of digestByUser) {
     if (!bucket.phone) {
-      console.warn(`[ops-pulse] ${bucket.alertIds.length} new alert(s) for ${key} but no phone on file — not sent`);
+      console.warn(`[ops-pulse] new alert(s) for ${bucket.name} (${userId}) but no phone on file — not sent`);
       continue;
     }
     const res = await sendManagerDigest(bucket.phone, bucket.lines);
-    // Mark sent even on failure so the escalation timer starts; a failed send is
-    // surfaced via the log and the alert simply stays OPEN to escalate.
-    for (const id of bucket.alertIds) await markSent(id, res.ok ? res.messageId ?? null : null);
     if (res.ok) sent += 1;
-    else console.error(`[ops-pulse] manager digest to ${bucket.name} failed:`, res.error);
+    else console.error(`[ops-pulse] digest to ${bucket.name} failed:`, res.error);
   }
+  // Start the escalation timer on every new alert regardless of per-recipient
+  // send success — a failed send is logged and the alert stays OPEN to escalate.
+  for (const id of newAlertIds) await markSent(id, null);
 
   // Escalation sweep — incidents unacked past SLA go to the owner, batched.
   let escalated = 0;

--- a/apps/backoffice/src/lib/ops-pulse/index.ts
+++ b/apps/backoffice/src/lib/ops-pulse/index.ts
@@ -7,7 +7,7 @@
 //            any incident sitting unacked past the SLA to the owner.
 
 import { pulseMode, THRESHOLDS } from "./config";
-import { detectPhoneCapture, detectChecklist, detectReviews } from "./detectors";
+import { detectPhoneCapture, detectChecklist, detectReviews, detectAudit } from "./detectors";
 import { resolveAssignee, resolveOwner } from "./router";
 import { findEscalatable, markEscalated, markSent, recordBreach } from "./ledger";
 import { sendManagerDigest, sendOwnerEscalation } from "./sender";
@@ -35,12 +35,13 @@ export async function runOpsPulse(now = new Date()): Promise<PulseRunResult> {
   }
 
   // Detectors are isolated: one failing must not sink the run.
-  const [phone, checklist, reviews] = await Promise.all([
+  const [phone, checklist, reviews, audit] = await Promise.all([
     detectPhoneCapture(now).catch(detectorFailed("phone-capture")),
     detectChecklist(now).catch(detectorFailed("checklist")),
     detectReviews(now).catch(detectorFailed("reviews")),
+    detectAudit(now).catch(detectorFailed("audit")),
   ]);
-  const breaches: Breach[] = [...phone, ...checklist, ...reviews];
+  const breaches: Breach[] = [...phone, ...checklist, ...reviews, ...audit];
 
   // Resolve the accountable assignee once per outlet.
   const assigneeByOutlet = new Map<string, Assignee | null>();

--- a/apps/backoffice/src/lib/ops-pulse/index.ts
+++ b/apps/backoffice/src/lib/ops-pulse/index.ts
@@ -7,7 +7,7 @@
 //            escalates any incident sitting unacked past the SLA to the owner.
 
 import { prisma } from "@/lib/prisma";
-import { pulseMode, dailyMode, REALTIME_SIGNALS, THRESHOLDS } from "./config";
+import { pulseMode, dailyMode, REALTIME_SIGNALS, THRESHOLDS, categoryFor } from "./config";
 import {
   detectPhoneCapture,
   detectChecklist,
@@ -18,6 +18,7 @@ import {
   detectReceivings,
   detectMenuSnoozed,
   detectNoClockIn,
+  detectPosNotOpen,
 } from "./detectors";
 import { resolveRecipients, resolveOwner } from "./router";
 import { findEscalatable, markEscalated, markSent, recordBreach } from "./ledger";
@@ -50,6 +51,7 @@ async function detectAll(now: Date): Promise<Breach[]> {
     detectReceivings(now).catch(detectorFailed("receivings")),
     detectMenuSnoozed(now).catch(detectorFailed("menu-snoozed")),
     detectNoClockIn(now).catch(detectorFailed("no-clock-in")),
+    detectPosNotOpen(now).catch(detectorFailed("pos-not-open")),
   ]);
   return results.flat();
 }
@@ -181,22 +183,23 @@ export async function runDailyPulse(now = new Date()): Promise<PulseRunResult> {
   const breaches = await detectAll(now);
   const routed = await routeAll(breaches);
 
-  // Group ALL current items by recipient.
-  const byUser = new Map<string, { phone: string | null; name: string; lines: string[] }>();
+  // Group ALL current items by recipient, split routine vs adhoc.
+  const byUser = new Map<string, { phone: string | null; name: string; routine: string[]; adhoc: string[] }>();
   for (const r of routed) {
+    const cat = categoryFor(r.signal);
     for (const a of r.assignees) {
       const key = a.userId || a.phone || a.name;
-      const bucket = byUser.get(key) ?? { phone: a.phone, name: a.name, lines: [] };
-      bucket.lines.push(r.summary);
+      const bucket = byUser.get(key) ?? { phone: a.phone, name: a.name, routine: [], adhoc: [] };
+      (cat === "adhoc" ? bucket.adhoc : bucket.routine).push(r.summary);
       byUser.set(key, bucket);
     }
   }
 
   if (mode === "shadow") {
-    for (const [, bucket] of byUser) {
+    for (const [, b] of byUser) {
       console.log(
         "[ops-pulse:daily:shadow]",
-        JSON.stringify({ to: bucket.name, phone: maskPhone(bucket.phone), items: bucket.lines.length, lines: bucket.lines }),
+        JSON.stringify({ to: b.name, phone: maskPhone(b.phone), routine: b.routine, adhoc: b.adhoc }),
       );
     }
     return { mode, ranAt: now.toISOString(), breachCount: breaches.length, routed: maskRouted(routed), sent: 0, escalated: 0 };
@@ -204,14 +207,14 @@ export async function runDailyPulse(now = new Date()): Promise<PulseRunResult> {
 
   // ARMED: one daily digest per recipient who has items.
   let sent = 0;
-  for (const [key, bucket] of byUser) {
-    if (!bucket.phone) {
-      console.warn(`[ops-pulse:daily] items for ${bucket.name} (${key}) but no phone on file — not sent`);
+  for (const [key, b] of byUser) {
+    if (!b.phone) {
+      console.warn(`[ops-pulse:daily] items for ${b.name} (${key}) but no phone on file — not sent`);
       continue;
     }
-    const res = await sendDailyDigest(bucket.phone, bucket.lines);
+    const res = await sendDailyDigest(b.phone, b.routine, b.adhoc);
     if (res.ok) sent += 1;
-    else console.error(`[ops-pulse:daily] digest to ${bucket.name} failed:`, res.error);
+    else console.error(`[ops-pulse:daily] digest to ${b.name} failed:`, res.error);
   }
   return { mode, ranAt: now.toISOString(), breachCount: breaches.length, routed: maskRouted(routed), sent, escalated: 0 };
 }

--- a/apps/backoffice/src/lib/ops-pulse/index.ts
+++ b/apps/backoffice/src/lib/ops-pulse/index.ts
@@ -7,7 +7,7 @@
 //            escalates any incident sitting unacked past the SLA to the owner.
 
 import { prisma } from "@/lib/prisma";
-import { pulseMode, THRESHOLDS } from "./config";
+import { pulseMode, dailyMode, THRESHOLDS } from "./config";
 import {
   detectPhoneCapture,
   detectChecklist,
@@ -20,7 +20,7 @@ import {
 } from "./detectors";
 import { resolveRecipients, resolveOwner } from "./router";
 import { findEscalatable, markEscalated, markSent, recordBreach } from "./ledger";
-import { sendManagerDigest, sendOwnerEscalation } from "./sender";
+import { sendManagerDigest, sendOwnerEscalation, sendDailyDigest } from "./sender";
 import type { Assignee, Breach, PulseRunResult, RoutedBreach } from "./types";
 
 // Last-4 only — shadow output goes to plaintext logs / cron responses.
@@ -37,13 +37,8 @@ function detectorFailed(name: string) {
   };
 }
 
-export async function runOpsPulse(now = new Date()): Promise<PulseRunResult> {
-  const mode = pulseMode();
-  if (mode === "off") {
-    return { mode, ranAt: now.toISOString(), breachCount: 0, routed: [], sent: 0, escalated: 0 };
-  }
-
-  // Detectors are isolated: one failing must not sink the run.
+// Run every detector (isolated — one failing can't sink the run) and flatten.
+async function detectAll(now: Date): Promise<Breach[]> {
   const results = await Promise.all([
     detectPhoneCapture(now).catch(detectorFailed("phone-capture")),
     detectChecklist(now).catch(detectorFailed("checklist")),
@@ -54,9 +49,11 @@ export async function runOpsPulse(now = new Date()): Promise<PulseRunResult> {
     detectReceivings(now).catch(detectorFailed("receivings")),
     detectMenuSnoozed(now).catch(detectorFailed("menu-snoozed")),
   ]);
-  const breaches: Breach[] = results.flat();
+  return results.flat();
+}
 
-  // Resolve recipients once per discipline (routeKey).
+// Attach each breach's discipline recipients (resolved once per routeKey).
+async function routeAll(breaches: Breach[]): Promise<RoutedBreach[]> {
   const recipientsByRoute = new Map<string, Assignee[]>();
   const routed: RoutedBreach[] = [];
   for (const b of breaches) {
@@ -65,9 +62,21 @@ export async function runOpsPulse(now = new Date()): Promise<PulseRunResult> {
     }
     routed.push({ ...b, assignees: recipientsByRoute.get(b.routeKey) ?? [] });
   }
+  return routed;
+}
 
-  const maskedRouted = (): RoutedBreach[] =>
-    routed.map((r) => ({ ...r, assignees: r.assignees.map((a) => ({ ...a, phone: maskPhone(a.phone) })) }));
+function maskRouted(routed: RoutedBreach[]): RoutedBreach[] {
+  return routed.map((r) => ({ ...r, assignees: r.assignees.map((a) => ({ ...a, phone: maskPhone(a.phone) })) }));
+}
+
+export async function runOpsPulse(now = new Date()): Promise<PulseRunResult> {
+  const mode = pulseMode();
+  if (mode === "off") {
+    return { mode, ranAt: now.toISOString(), breachCount: 0, routed: [], sent: 0, escalated: 0 };
+  }
+
+  const breaches = await detectAll(now);
+  const routed = await routeAll(breaches);
 
   // ── SHADOW: log what we *would* page; never message anyone, never persist. ──
   if (mode === "shadow") {
@@ -84,7 +93,7 @@ export async function runOpsPulse(now = new Date()): Promise<PulseRunResult> {
         }),
       );
     }
-    return { mode, ranAt: now.toISOString(), breachCount: breaches.length, routed: maskedRouted(), sent: 0, escalated: 0 };
+    return { mode, ranAt: now.toISOString(), breachCount: breaches.length, routed: maskRouted(routed), sent: 0, escalated: 0 };
   }
 
   // ── ARMED: persist + page new alerts + escalate stale ones. ──
@@ -151,5 +160,54 @@ export async function runOpsPulse(now = new Date()): Promise<PulseRunResult> {
     }
   }
 
-  return { mode, ranAt: now.toISOString(), breachCount: breaches.length, routed: maskedRouted(), sent, escalated };
+  return { mode, ranAt: now.toISOString(), breachCount: breaches.length, routed: maskRouted(routed), sent, escalated };
+}
+
+// Daily pulse — once a day, one digest per recipient of EVERYTHING currently
+// outstanding in their lane (full snapshot, not just new items). No ledger, no
+// escalation; the predictable daily cadence is the point — it builds the
+// discipline. Controlled independently by OPS_PULSE_DAILY_MODE, so the daily
+// digest can go live while the real-time path stays in shadow.
+export async function runDailyPulse(now = new Date()): Promise<PulseRunResult> {
+  const mode = dailyMode();
+  if (mode === "off") {
+    return { mode, ranAt: now.toISOString(), breachCount: 0, routed: [], sent: 0, escalated: 0 };
+  }
+
+  const breaches = await detectAll(now);
+  const routed = await routeAll(breaches);
+
+  // Group ALL current items by recipient.
+  const byUser = new Map<string, { phone: string | null; name: string; lines: string[] }>();
+  for (const r of routed) {
+    for (const a of r.assignees) {
+      const key = a.userId || a.phone || a.name;
+      const bucket = byUser.get(key) ?? { phone: a.phone, name: a.name, lines: [] };
+      bucket.lines.push(r.summary);
+      byUser.set(key, bucket);
+    }
+  }
+
+  if (mode === "shadow") {
+    for (const [, bucket] of byUser) {
+      console.log(
+        "[ops-pulse:daily:shadow]",
+        JSON.stringify({ to: bucket.name, phone: maskPhone(bucket.phone), items: bucket.lines.length, lines: bucket.lines }),
+      );
+    }
+    return { mode, ranAt: now.toISOString(), breachCount: breaches.length, routed: maskRouted(routed), sent: 0, escalated: 0 };
+  }
+
+  // ARMED: one daily digest per recipient who has items.
+  let sent = 0;
+  for (const [key, bucket] of byUser) {
+    if (!bucket.phone) {
+      console.warn(`[ops-pulse:daily] items for ${bucket.name} (${key}) but no phone on file — not sent`);
+      continue;
+    }
+    const res = await sendDailyDigest(bucket.phone, bucket.lines);
+    if (res.ok) sent += 1;
+    else console.error(`[ops-pulse:daily] digest to ${bucket.name} failed:`, res.error);
+  }
+  return { mode, ranAt: now.toISOString(), breachCount: breaches.length, routed: maskRouted(routed), sent, escalated: 0 };
 }

--- a/apps/backoffice/src/lib/ops-pulse/index.ts
+++ b/apps/backoffice/src/lib/ops-pulse/index.ts
@@ -7,7 +7,7 @@
 //            escalates any incident sitting unacked past the SLA to the owner.
 
 import { prisma } from "@/lib/prisma";
-import { pulseMode, dailyMode, THRESHOLDS } from "./config";
+import { pulseMode, dailyMode, REALTIME_SIGNALS, THRESHOLDS } from "./config";
 import {
   detectPhoneCapture,
   detectChecklist,
@@ -75,7 +75,9 @@ export async function runOpsPulse(now = new Date()): Promise<PulseRunResult> {
     return { mode, ranAt: now.toISOString(), breachCount: 0, routed: [], sent: 0, escalated: 0 };
   }
 
-  const breaches = await detectAll(now);
+  // Real-time tier only — the fast pulse alerts on the instant signals (reviews,
+  // menu-snoozed, …); everything else surfaces in the daily digest.
+  const breaches = (await detectAll(now)).filter((b) => REALTIME_SIGNALS.has(b.signal));
   const routed = await routeAll(breaches);
 
   // ── SHADOW: log what we *would* page; never message anyone, never persist. ──

--- a/apps/backoffice/src/lib/ops-pulse/ledger.ts
+++ b/apps/backoffice/src/lib/ops-pulse/ledger.ts
@@ -46,7 +46,8 @@ export async function recordBreach(
       summary: breach.summary,
       detail: breach.detail as Prisma.InputJsonValue,
       status: "OPEN",
-      assigneeUserId: assignee?.userId ?? null,
+      // || (not ??) so a phone-only recipient (userId "") stores null, not "".
+      assigneeUserId: assignee?.userId || null,
     },
     select: ALERT_SELECT,
   });

--- a/apps/backoffice/src/lib/ops-pulse/ledger.ts
+++ b/apps/backoffice/src/lib/ops-pulse/ledger.ts
@@ -37,21 +37,35 @@ export async function recordBreach(
   });
   if (existing) return { alert: existing, isNew: false };
 
-  const created = await prisma.opsAlert.create({
-    data: {
-      signal: breach.signal,
-      outletId: breach.outletId,
-      severity: breach.severity,
-      dedupeKey: breach.dedupeKey,
-      summary: breach.summary,
-      detail: breach.detail as Prisma.InputJsonValue,
-      status: "OPEN",
-      // || (not ??) so a phone-only recipient (userId "") stores null, not "".
-      assigneeUserId: assignee?.userId || null,
-    },
-    select: ALERT_SELECT,
-  });
-  return { alert: created, isNew: true };
+  try {
+    const created = await prisma.opsAlert.create({
+      data: {
+        signal: breach.signal,
+        outletId: breach.outletId,
+        severity: breach.severity,
+        dedupeKey: breach.dedupeKey,
+        summary: breach.summary,
+        detail: breach.detail as Prisma.InputJsonValue,
+        status: "OPEN",
+        // || (not ??) so a phone-only recipient (userId "") stores null, not "".
+        assigneeUserId: assignee?.userId || null,
+      },
+      select: ALERT_SELECT,
+    });
+    return { alert: created, isNew: true };
+  } catch (err) {
+    // Concurrent run won the race on the @unique dedupeKey (overlapping cron):
+    // Prisma P2002 = unique-constraint violation. Re-read and treat as not-new
+    // so we never double-page or crash the run.
+    if ((err as { code?: string } | null)?.code === "P2002") {
+      const row = await prisma.opsAlert.findUnique({
+        where: { dedupeKey: breach.dedupeKey },
+        select: ALERT_SELECT,
+      });
+      if (row) return { alert: row, isNew: false };
+    }
+    throw err;
+  }
 }
 
 export async function markSent(id: string, providerMessageId: string | null): Promise<void> {
@@ -69,17 +83,17 @@ export interface EscalatableAlert {
   assigneeUserId: string | null;
 }
 
-// OPEN alerts sent but unacked past the SLA. Escalate the accountability signals
-// the owner wants enforced: CHECKLIST, REVIEW, RECEIVING (incidents) PLUS AUDIT —
-// outlet audits AND staff skill training — because the owner wants proof the work
-// is actually being done. PHONE_CAPTURE / STOCK_COUNT / MENU_SNOOZED stay
-// non-escalating (fluctuating rates that self-clear).
+// OPEN alerts sent but unacked past the SLA. Escalates only signals that
+// actually enter the ledger (the real-time tier): CHECKLIST, REVIEW, RECEIVING,
+// NO_CLOCK_IN, POS_NOT_OPEN. MENU_SNOOZED is real-time but self-clears, so it's
+// excluded. AUDIT/skill escalation is pending the routine-ledger path (they're
+// daily, not real-time, so they aren't persisted here yet).
 export async function findEscalatable(slaMinutes: number, now: Date): Promise<EscalatableAlert[]> {
   const cutoff = new Date(now.getTime() - slaMinutes * 60_000);
   return prisma.opsAlert.findMany({
     where: {
       status: "OPEN",
-      signal: { in: ["CHECKLIST", "REVIEW", "RECEIVING", "AUDIT", "NO_CLOCK_IN", "POS_NOT_OPEN"] },
+      signal: { in: ["CHECKLIST", "REVIEW", "RECEIVING", "NO_CLOCK_IN", "POS_NOT_OPEN"] },
       escalatedAt: null,
       sentAt: { not: null, lt: cutoff },
     },

--- a/apps/backoffice/src/lib/ops-pulse/ledger.ts
+++ b/apps/backoffice/src/lib/ops-pulse/ledger.ts
@@ -66,22 +66,24 @@ export interface EscalatableAlert {
   outletId: string;
   summary: string;
   severity: string;
+  assigneeUserId: string | null;
 }
 
-// OPEN, actionable-incident alerts sent but unacked past the SLA. Only now-fix-it
-// incidents escalate (CHECKLIST, REVIEW, RECEIVING). Excluded on purpose:
-// PHONE_CAPTURE / STOCK_COUNT / MENU_SNOOZED (rates/coaching that self-clear) and
-// AUDIT (lagging) — escalating those on a 90-min timer would cry wolf.
+// OPEN alerts sent but unacked past the SLA. Escalate the accountability signals
+// the owner wants enforced: CHECKLIST, REVIEW, RECEIVING (incidents) PLUS AUDIT —
+// outlet audits AND staff skill training — because the owner wants proof the work
+// is actually being done. PHONE_CAPTURE / STOCK_COUNT / MENU_SNOOZED stay
+// non-escalating (fluctuating rates that self-clear).
 export async function findEscalatable(slaMinutes: number, now: Date): Promise<EscalatableAlert[]> {
   const cutoff = new Date(now.getTime() - slaMinutes * 60_000);
   return prisma.opsAlert.findMany({
     where: {
       status: "OPEN",
-      signal: { in: ["CHECKLIST", "REVIEW", "RECEIVING"] },
+      signal: { in: ["CHECKLIST", "REVIEW", "RECEIVING", "AUDIT"] },
       escalatedAt: null,
       sentAt: { not: null, lt: cutoff },
     },
-    select: { id: true, outletId: true, summary: true, severity: true },
+    select: { id: true, outletId: true, summary: true, severity: true, assigneeUserId: true },
     orderBy: { sentAt: "asc" },
     take: 100,
   });

--- a/apps/backoffice/src/lib/ops-pulse/ledger.ts
+++ b/apps/backoffice/src/lib/ops-pulse/ledger.ts
@@ -79,7 +79,7 @@ export async function findEscalatable(slaMinutes: number, now: Date): Promise<Es
   return prisma.opsAlert.findMany({
     where: {
       status: "OPEN",
-      signal: { in: ["CHECKLIST", "REVIEW", "RECEIVING", "AUDIT", "NO_CLOCK_IN"] },
+      signal: { in: ["CHECKLIST", "REVIEW", "RECEIVING", "AUDIT", "NO_CLOCK_IN", "POS_NOT_OPEN"] },
       escalatedAt: null,
       sentAt: { not: null, lt: cutoff },
     },

--- a/apps/backoffice/src/lib/ops-pulse/ledger.ts
+++ b/apps/backoffice/src/lib/ops-pulse/ledger.ts
@@ -67,16 +67,16 @@ export interface EscalatableAlert {
   severity: string;
 }
 
-// OPEN, actionable-incident alerts that have been sent but sat unacked past the
-// SLA. PHONE_CAPTURE is excluded on purpose — it's a daily rate (coaching), not
-// a now-fix-it incident, and it can self-clear as more sales come in; escalating
-// it to the owner on a 90-min timer would cry wolf.
+// OPEN, actionable-incident alerts sent but unacked past the SLA. Only now-fix-it
+// incidents escalate (CHECKLIST, REVIEW, RECEIVING). Excluded on purpose:
+// PHONE_CAPTURE / STOCK_COUNT / MENU_SNOOZED (rates/coaching that self-clear) and
+// AUDIT (lagging) — escalating those on a 90-min timer would cry wolf.
 export async function findEscalatable(slaMinutes: number, now: Date): Promise<EscalatableAlert[]> {
   const cutoff = new Date(now.getTime() - slaMinutes * 60_000);
   return prisma.opsAlert.findMany({
     where: {
       status: "OPEN",
-      signal: { in: ["CHECKLIST", "REVIEW"] },
+      signal: { in: ["CHECKLIST", "REVIEW", "RECEIVING"] },
       escalatedAt: null,
       sentAt: { not: null, lt: cutoff },
     },

--- a/apps/backoffice/src/lib/ops-pulse/ledger.ts
+++ b/apps/backoffice/src/lib/ops-pulse/ledger.ts
@@ -1,0 +1,105 @@
+// OpsAlert ledger — the armed-mode spine. Dedupes breaches to one alert each,
+// tracks the OPEN → (ESCALATED) → RESOLVED lifecycle, and records delivery.
+// Only touched in armed mode (shadow never writes).
+
+import { prisma } from "@/lib/prisma";
+import { Prisma } from "@prisma/client";
+import type { Assignee, Breach } from "./types";
+
+export interface LedgerAlert {
+  id: string;
+  dedupeKey: string;
+  status: string;
+  assigneeUserId: string | null;
+  summary: string;
+  outletId: string;
+}
+
+const ALERT_SELECT = {
+  id: true,
+  dedupeKey: true,
+  status: true,
+  assigneeUserId: true,
+  summary: true,
+  outletId: true,
+} as const;
+
+// Create the alert on first sight of a dedupeKey; otherwise return the existing
+// row untouched. isNew=true is the "page this now" signal — so a breach is never
+// paged twice.
+export async function recordBreach(
+  breach: Breach,
+  assignee: Assignee | null,
+): Promise<{ alert: LedgerAlert; isNew: boolean }> {
+  const existing = await prisma.opsAlert.findUnique({
+    where: { dedupeKey: breach.dedupeKey },
+    select: ALERT_SELECT,
+  });
+  if (existing) return { alert: existing, isNew: false };
+
+  const created = await prisma.opsAlert.create({
+    data: {
+      signal: breach.signal,
+      outletId: breach.outletId,
+      severity: breach.severity,
+      dedupeKey: breach.dedupeKey,
+      summary: breach.summary,
+      detail: breach.detail as Prisma.InputJsonValue,
+      status: "OPEN",
+      assigneeUserId: assignee?.userId ?? null,
+    },
+    select: ALERT_SELECT,
+  });
+  return { alert: created, isNew: true };
+}
+
+export async function markSent(id: string, providerMessageId: string | null): Promise<void> {
+  await prisma.opsAlert.update({
+    where: { id },
+    data: { sentAt: new Date(), channel: "whatsapp", providerMessageId },
+  });
+}
+
+export interface EscalatableAlert {
+  id: string;
+  outletId: string;
+  summary: string;
+  severity: string;
+}
+
+// OPEN, actionable-incident alerts that have been sent but sat unacked past the
+// SLA. PHONE_CAPTURE is excluded on purpose — it's a daily rate (coaching), not
+// a now-fix-it incident, and it can self-clear as more sales come in; escalating
+// it to the owner on a 90-min timer would cry wolf.
+export async function findEscalatable(slaMinutes: number, now: Date): Promise<EscalatableAlert[]> {
+  const cutoff = new Date(now.getTime() - slaMinutes * 60_000);
+  return prisma.opsAlert.findMany({
+    where: {
+      status: "OPEN",
+      signal: { in: ["CHECKLIST", "REVIEW"] },
+      escalatedAt: null,
+      sentAt: { not: null, lt: cutoff },
+    },
+    select: { id: true, outletId: true, summary: true, severity: true },
+    orderBy: { sentAt: "asc" },
+    take: 100,
+  });
+}
+
+export async function markEscalated(id: string): Promise<void> {
+  await prisma.opsAlert.update({
+    where: { id },
+    data: { status: "ESCALATED", escalatedAt: new Date() },
+  });
+}
+
+// Resolve every still-open alert assigned to a user — called when they reply to
+// a digest (e.g. "DONE"). Returns how many were closed.
+export async function resolveOpenAlertsForUser(userId: string): Promise<number> {
+  const now = new Date();
+  const res = await prisma.opsAlert.updateMany({
+    where: { assigneeUserId: userId, status: { in: ["OPEN", "ESCALATED", "ACKED"] } },
+    data: { status: "RESOLVED", resolvedAt: now, ackedAt: now },
+  });
+  return res.count;
+}

--- a/apps/backoffice/src/lib/ops-pulse/ledger.ts
+++ b/apps/backoffice/src/lib/ops-pulse/ledger.ts
@@ -79,7 +79,7 @@ export async function findEscalatable(slaMinutes: number, now: Date): Promise<Es
   return prisma.opsAlert.findMany({
     where: {
       status: "OPEN",
-      signal: { in: ["CHECKLIST", "REVIEW", "RECEIVING", "AUDIT"] },
+      signal: { in: ["CHECKLIST", "REVIEW", "RECEIVING", "AUDIT", "NO_CLOCK_IN"] },
       escalatedAt: null,
       sentAt: { not: null, lt: cutoff },
     },

--- a/apps/backoffice/src/lib/ops-pulse/router.ts
+++ b/apps/backoffice/src/lib/ops-pulse/router.ts
@@ -1,0 +1,33 @@
+// Routes a breach to the accountable human. The design holds the *manager*
+// in check, so we page the MANAGER who owns the outlet, with the OWNER as the
+// escalation fallback when no outlet-matched manager exists.
+//
+// NOTE: the schema has no outlet→manager mapping (no Outlet.managerId / region
+// hierarchy), so we match on User.outletId / outletIds. With a single ops
+// manager today this is exact; add a mapping before a second manager joins.
+
+import { prisma } from "@/lib/prisma";
+import type { Assignee } from "./types";
+
+export async function resolveAssignee(outletId: string): Promise<Assignee | null> {
+  const manager = await prisma.user.findFirst({
+    where: {
+      role: "MANAGER",
+      status: "ACTIVE",
+      OR: [{ outletId }, { outletIds: { has: outletId } }],
+    },
+    select: { id: true, name: true, phone: true, role: true },
+  });
+  if (manager) {
+    return { userId: manager.id, name: manager.name, phone: manager.phone, role: manager.role, fallback: false };
+  }
+
+  const owner = await prisma.user.findFirst({
+    where: { role: "OWNER", status: "ACTIVE" },
+    select: { id: true, name: true, phone: true, role: true },
+  });
+  if (owner) {
+    return { userId: owner.id, name: owner.name, phone: owner.phone, role: owner.role, fallback: true };
+  }
+  return null;
+}

--- a/apps/backoffice/src/lib/ops-pulse/router.ts
+++ b/apps/backoffice/src/lib/ops-pulse/router.ts
@@ -66,3 +66,26 @@ export async function resolveOwner(): Promise<Assignee | null> {
   if (!owner) return null;
   return { userId: owner.id, name: owner.name, phone: owner.phone, role: owner.role, fallback: false };
 }
+
+// The on-shift OUTLET TEAM today — staff on a published shift at this outlet, for
+// work the team itself does (e.g. stock take). Resolved to active users with a
+// phone. Empty when no roster is published for the outlet today.
+export async function resolveOutletTeam(outletId: string, now: Date): Promise<Assignee[]> {
+  if (!outletId) return [];
+  const ymd = new Date(now.getTime() + 8 * 3_600_000).toISOString().slice(0, 10);
+  const rows = await prisma.$queryRaw<Array<{ user_id: string | null }>>`
+    SELECT DISTINCT s.user_id
+    FROM hr_schedule_shifts s
+    JOIN hr_schedules sch ON sch.id = s.schedule_id
+    WHERE sch.outlet_id = ${outletId}
+      AND sch.published_at IS NOT NULL
+      AND s.shift_date = ${ymd}::date
+  `;
+  const ids = rows.map((r) => r.user_id).filter((x): x is string => !!x);
+  if (ids.length === 0) return [];
+  const users = await prisma.user.findMany({
+    where: { id: { in: ids }, status: "ACTIVE", phone: { not: null } },
+    select: { id: true, name: true, phone: true, role: true },
+  });
+  return users.map((u) => ({ userId: u.id, name: u.name, phone: u.phone, role: u.role, fallback: false }));
+}

--- a/apps/backoffice/src/lib/ops-pulse/router.ts
+++ b/apps/backoffice/src/lib/ops-pulse/router.ts
@@ -21,13 +21,17 @@ export async function resolveAssignee(outletId: string): Promise<Assignee | null
   if (manager) {
     return { userId: manager.id, name: manager.name, phone: manager.phone, role: manager.role, fallback: false };
   }
+  // No outlet-matched manager → fall back to the owner (also the escalation target).
+  const owner = await resolveOwner();
+  return owner ? { ...owner, fallback: true } : null;
+}
 
+// The owner — escalation target and last-resort assignee.
+export async function resolveOwner(): Promise<Assignee | null> {
   const owner = await prisma.user.findFirst({
     where: { role: "OWNER", status: "ACTIVE" },
     select: { id: true, name: true, phone: true, role: true },
   });
-  if (owner) {
-    return { userId: owner.id, name: owner.name, phone: owner.phone, role: owner.role, fallback: true };
-  }
-  return null;
+  if (!owner) return null;
+  return { userId: owner.id, name: owner.name, phone: owner.phone, role: owner.role, fallback: false };
 }

--- a/apps/backoffice/src/lib/ops-pulse/router.ts
+++ b/apps/backoffice/src/lib/ops-pulse/router.ts
@@ -1,32 +1,45 @@
-// Routes a breach to the accountable human. The design holds the *manager*
-// in check, so we page the MANAGER who owns the outlet, with the OWNER as the
-// escalation fallback when no outlet-matched manager exists.
-//
-// NOTE: the schema has no outlet→manager mapping (no Outlet.managerId / region
-// hierarchy), so we match on User.outletId / outletIds. With a single ops
-// manager today this is exact; add a mapping before a second manager joins.
+// Routes a breach to the accountable people by DISCIPLINE (routeKey), not by
+// outlet→manager. Operations/procurement → ops leads; barista/kitchen → the
+// discipline lead. Recipient names come from config (RECIPIENTS) and resolve to
+// active users; unresolved names fall back to the owner so nothing is dropped.
 
 import { prisma } from "@/lib/prisma";
-import type { Assignee } from "./types";
+import { RECIPIENTS } from "./config";
+import type { Assignee, RouteKey } from "./types";
 
-export async function resolveAssignee(outletId: string): Promise<Assignee | null> {
-  const manager = await prisma.user.findFirst({
-    where: {
-      role: "MANAGER",
-      status: "ACTIVE",
-      OR: [{ outletId }, { outletIds: { has: outletId } }],
-    },
+// Resolve a discipline's configured recipient names to active users. First
+// configured name = primary (owns the ledger row's ack/escalation); the rest are
+// co-recipients. Unmatched names are logged and skipped; if none resolve, falls
+// back to the owner.
+export async function resolveRecipients(routeKey: RouteKey): Promise<Assignee[]> {
+  const names = RECIPIENTS[routeKey] ?? [];
+  if (names.length === 0) return ownerFallback(routeKey);
+
+  const users = await prisma.user.findMany({
+    where: { status: "ACTIVE" },
     select: { id: true, name: true, phone: true, role: true },
   });
-  if (manager) {
-    return { userId: manager.id, name: manager.name, phone: manager.phone, role: manager.role, fallback: false };
+  const byName = new Map<string, (typeof users)[number]>();
+  for (const u of users) byName.set(u.name.trim().toLowerCase(), u);
+
+  const matched: Assignee[] = [];
+  for (const n of names) {
+    const u = byName.get(n.trim().toLowerCase());
+    if (u) matched.push({ userId: u.id, name: u.name, phone: u.phone, role: u.role, fallback: false });
+    else console.warn(`[ops-pulse] route "${routeKey}" recipient "${n}" not found among active users — skipped`);
   }
-  // No outlet-matched manager → fall back to the owner (also the escalation target).
-  const owner = await resolveOwner();
-  return owner ? { ...owner, fallback: true } : null;
+  if (matched.length === 0) return ownerFallback(routeKey);
+  return matched;
 }
 
-// The owner — escalation target and last-resort assignee.
+async function ownerFallback(routeKey: string): Promise<Assignee[]> {
+  const owner = await resolveOwner();
+  if (!owner) return [];
+  console.warn(`[ops-pulse] route "${routeKey}" had no resolvable recipients — falling back to owner`);
+  return [{ ...owner, fallback: true }];
+}
+
+// The owner — escalation target and last-resort recipient.
 export async function resolveOwner(): Promise<Assignee | null> {
   const owner = await prisma.user.findFirst({
     where: { role: "OWNER", status: "ACTIVE" },

--- a/apps/backoffice/src/lib/ops-pulse/router.ts
+++ b/apps/backoffice/src/lib/ops-pulse/router.ts
@@ -1,33 +1,51 @@
 // Routes a breach to the accountable people by DISCIPLINE (routeKey), not by
 // outlet→manager. Operations/procurement → ops leads; barista/kitchen → the
-// discipline lead. Recipient names come from config (RECIPIENTS) and resolve to
-// active users; unresolved names fall back to the owner so nothing is dropped.
+// discipline lead. Recipients come from config (RECIPIENTS): each entry is
+// either a User name (resolved to an active user) or a raw phone number (routed
+// directly, for people without an app account). Unresolved names fall back to
+// the owner so nothing is dropped.
 
 import { prisma } from "@/lib/prisma";
 import { RECIPIENTS } from "./config";
 import type { Assignee, RouteKey } from "./types";
 
-// Resolve a discipline's configured recipient names to active users. First
-// configured name = primary (owns the ledger row's ack/escalation); the rest are
-// co-recipients. Unmatched names are logged and skipped; if none resolve, falls
-// back to the owner.
-export async function resolveRecipients(routeKey: RouteKey): Promise<Assignee[]> {
-  const names = RECIPIENTS[routeKey] ?? [];
-  if (names.length === 0) return ownerFallback(routeKey);
+// A config entry that is a phone number (+60…, 01…) rather than a user name.
+function isPhoneEntry(s: string): boolean {
+  return /^\+?[0-9][0-9\s-]{6,}$/.test(s.trim());
+}
 
-  const users = await prisma.user.findMany({
-    where: { status: "ACTIVE" },
-    select: { id: true, name: true, phone: true, role: true },
-  });
-  const byName = new Map<string, (typeof users)[number]>();
-  for (const u of users) byName.set(u.name.trim().toLowerCase(), u);
+// Resolve a discipline's configured recipients. First entry = primary (owns the
+// ledger row's ack/escalation); the rest co-receive the digest. Phone entries
+// route directly (no User, no ack attribution). Unmatched names are logged; if
+// nothing resolves, falls back to the owner.
+export async function resolveRecipients(routeKey: RouteKey): Promise<Assignee[]> {
+  const entries = RECIPIENTS[routeKey] ?? [];
+  if (entries.length === 0) return ownerFallback(routeKey);
 
   const matched: Assignee[] = [];
-  for (const n of names) {
-    const u = byName.get(n.trim().toLowerCase());
-    if (u) matched.push({ userId: u.id, name: u.name, phone: u.phone, role: u.role, fallback: false });
-    else console.warn(`[ops-pulse] route "${routeKey}" recipient "${n}" not found among active users — skipped`);
+  const nameEntries: string[] = [];
+  for (const e of entries) {
+    if (isPhoneEntry(e)) {
+      matched.push({ userId: "", name: e, phone: e.trim(), role: "external", fallback: false });
+    } else {
+      nameEntries.push(e);
+    }
   }
+
+  if (nameEntries.length > 0) {
+    const users = await prisma.user.findMany({
+      where: { status: "ACTIVE" },
+      select: { id: true, name: true, phone: true, role: true },
+    });
+    const byName = new Map<string, (typeof users)[number]>();
+    for (const u of users) byName.set(u.name.trim().toLowerCase(), u);
+    for (const n of nameEntries) {
+      const u = byName.get(n.trim().toLowerCase());
+      if (u) matched.push({ userId: u.id, name: u.name, phone: u.phone, role: u.role, fallback: false });
+      else console.warn(`[ops-pulse] route "${routeKey}" recipient "${n}" not found among active users — skipped`);
+    }
+  }
+
   if (matched.length === 0) return ownerFallback(routeKey);
   return matched;
 }

--- a/apps/backoffice/src/lib/ops-pulse/sender.ts
+++ b/apps/backoffice/src/lib/ops-pulse/sender.ts
@@ -32,6 +32,14 @@ export function composeEscalation(lines: string[]): string {
   return [header, ...lines.map((l) => `• ${l}`)].join("\n");
 }
 
+// The daily roundup — a once-a-day snapshot of everything outstanding in the
+// recipient's lane. The predictable cadence is what builds the discipline.
+export function composeDailyDigest(lines: string[]): string {
+  const n = lines.length;
+  const header = `☀️ Daily Ops Pulse — ${n} open item${n === 1 ? "" : "s"}`;
+  return [header, ...lines.map((l) => `• ${l}`), "", "Clear them today. Reply DONE as you go."].join("\n");
+}
+
 async function sendProactive(
   to: string,
   templateName: string,
@@ -53,4 +61,9 @@ export function sendManagerDigest(phone: string, lines: string[]): Promise<Whats
 export function sendOwnerEscalation(phone: string, lines: string[]): Promise<WhatsAppSendResult> {
   if (!isWhatsAppConfigured()) return Promise.resolve(NOT_CONFIGURED);
   return sendProactive(phone, TEMPLATES.ownerEscalation, composeEscalation(lines));
+}
+
+export function sendDailyDigest(phone: string, lines: string[]): Promise<WhatsAppSendResult> {
+  if (!isWhatsAppConfigured()) return Promise.resolve(NOT_CONFIGURED);
+  return sendProactive(phone, TEMPLATES.dailyDigest, composeDailyDigest(lines));
 }

--- a/apps/backoffice/src/lib/ops-pulse/sender.ts
+++ b/apps/backoffice/src/lib/ops-pulse/sender.ts
@@ -1,0 +1,56 @@
+// WhatsApp delivery for the ops pulse. One digest per recipient.
+//
+// Proactive (business-initiated) messages outside the recipient's 24h window
+// REQUIRE an approved template. When OPS_PULSE_TPL_* is set we send the template
+// (one body variable carrying the composed text); otherwise we fall back to
+// free-form text, which Meta only delivers inside an open window — fine for a
+// test ping to someone who just messaged the bot, NOT for production paging.
+
+import {
+  isWhatsAppConfigured,
+  sendWhatsAppTemplate,
+  sendWhatsAppText,
+  type WhatsAppSendResult,
+} from "@/lib/whatsapp";
+import { TEMPLATES } from "./config";
+
+const NOT_CONFIGURED: WhatsAppSendResult = {
+  ok: false,
+  status: 0,
+  error: "WhatsApp not configured",
+};
+
+export function composeManagerDigest(lines: string[]): string {
+  const n = lines.length;
+  const header = `🔴 Ops Pulse — ${n} item${n === 1 ? "" : "s"} need${n === 1 ? "s" : ""} you`;
+  return [header, ...lines.map((l) => `• ${l}`), "", "Reply DONE when handled."].join("\n");
+}
+
+export function composeEscalation(lines: string[]): string {
+  const n = lines.length;
+  const header = `⚠️ Ops escalation — ${n} item${n === 1 ? "" : "s"} unacked past SLA`;
+  return [header, ...lines.map((l) => `• ${l}`)].join("\n");
+}
+
+async function sendProactive(
+  to: string,
+  templateName: string,
+  body: string,
+): Promise<WhatsAppSendResult> {
+  if (templateName) {
+    return sendWhatsAppTemplate(to, templateName, TEMPLATES.languageCode, [
+      { type: "body", parameters: [{ type: "text", text: body }] },
+    ]);
+  }
+  return sendWhatsAppText(to, body);
+}
+
+export function sendManagerDigest(phone: string, lines: string[]): Promise<WhatsAppSendResult> {
+  if (!isWhatsAppConfigured()) return Promise.resolve(NOT_CONFIGURED);
+  return sendProactive(phone, TEMPLATES.managerDigest, composeManagerDigest(lines));
+}
+
+export function sendOwnerEscalation(phone: string, lines: string[]): Promise<WhatsAppSendResult> {
+  if (!isWhatsAppConfigured()) return Promise.resolve(NOT_CONFIGURED);
+  return sendProactive(phone, TEMPLATES.ownerEscalation, composeEscalation(lines));
+}

--- a/apps/backoffice/src/lib/ops-pulse/sender.ts
+++ b/apps/backoffice/src/lib/ops-pulse/sender.ts
@@ -33,11 +33,15 @@ export function composeEscalation(lines: string[]): string {
 }
 
 // The daily roundup — a once-a-day snapshot of everything outstanding in the
-// recipient's lane. The predictable cadence is what builds the discipline.
-export function composeDailyDigest(lines: string[]): string {
-  const n = lines.length;
-  const header = `☀️ Daily Ops Pulse — ${n} open item${n === 1 ? "" : "s"}`;
-  return [header, ...lines.map((l) => `• ${l}`), "", "Clear them today. Reply DONE as you go."].join("\n");
+// recipient's lane, grouped Routine vs Adhoc. The predictable cadence builds the
+// discipline.
+export function composeDailyDigest(routine: string[], adhoc: string[]): string {
+  const total = routine.length + adhoc.length;
+  const parts = [`☀️ Daily Ops Pulse — ${total} open item${total === 1 ? "" : "s"}`];
+  if (routine.length) parts.push("", "🔁 Routine", ...routine.map((l) => `• ${l}`));
+  if (adhoc.length) parts.push("", "⚡ Adhoc", ...adhoc.map((l) => `• ${l}`));
+  parts.push("", "Clear them today. Reply DONE as you go.");
+  return parts.join("\n");
 }
 
 async function sendProactive(
@@ -63,7 +67,7 @@ export function sendOwnerEscalation(phone: string, lines: string[]): Promise<Wha
   return sendProactive(phone, TEMPLATES.ownerEscalation, composeEscalation(lines));
 }
 
-export function sendDailyDigest(phone: string, lines: string[]): Promise<WhatsAppSendResult> {
+export function sendDailyDigest(phone: string, routine: string[], adhoc: string[]): Promise<WhatsAppSendResult> {
   if (!isWhatsAppConfigured()) return Promise.resolve(NOT_CONFIGURED);
-  return sendProactive(phone, TEMPLATES.dailyDigest, composeDailyDigest(lines));
+  return sendProactive(phone, TEMPLATES.dailyDigest, composeDailyDigest(routine, adhoc));
 }

--- a/apps/backoffice/src/lib/ops-pulse/types.ts
+++ b/apps/backoffice/src/lib/ops-pulse/types.ts
@@ -5,7 +5,7 @@
 // accountable manager and (once armed) sends a 1:1 WhatsApp DM. In shadow mode
 // nothing is sent — we only log what we *would* page, to validate the detectors.
 
-export type OpsSignal = "PHONE_CAPTURE" | "CHECKLIST" | "REVIEW";
+export type OpsSignal = "PHONE_CAPTURE" | "CHECKLIST" | "REVIEW" | "AUDIT";
 
 export type Severity = "LOW" | "MED" | "HIGH";
 

--- a/apps/backoffice/src/lib/ops-pulse/types.ts
+++ b/apps/backoffice/src/lib/ops-pulse/types.ts
@@ -13,7 +13,8 @@ export type OpsSignal =
   | "STOCK_COUNT"
   | "RECEIVING"
   | "MENU_SNOOZED"
-  | "NO_CLOCK_IN";
+  | "NO_CLOCK_IN"
+  | "POS_NOT_OPEN";
 
 export type Severity = "LOW" | "MED" | "HIGH";
 

--- a/apps/backoffice/src/lib/ops-pulse/types.ts
+++ b/apps/backoffice/src/lib/ops-pulse/types.ts
@@ -12,7 +12,8 @@ export type OpsSignal =
   | "AUDIT"
   | "STOCK_COUNT"
   | "RECEIVING"
-  | "MENU_SNOOZED";
+  | "MENU_SNOOZED"
+  | "NO_CLOCK_IN";
 
 export type Severity = "LOW" | "MED" | "HIGH";
 

--- a/apps/backoffice/src/lib/ops-pulse/types.ts
+++ b/apps/backoffice/src/lib/ops-pulse/types.ts
@@ -14,7 +14,8 @@ export type OpsSignal =
   | "RECEIVING"
   | "MENU_SNOOZED"
   | "NO_CLOCK_IN"
-  | "POS_NOT_OPEN";
+  | "POS_NOT_OPEN"
+  | "RESTOCK_NEEDED";
 
 export type Severity = "LOW" | "MED" | "HIGH";
 

--- a/apps/backoffice/src/lib/ops-pulse/types.ts
+++ b/apps/backoffice/src/lib/ops-pulse/types.ts
@@ -1,0 +1,42 @@
+// Shared shapes for the Ops KPI Pulse. See docs/design/ops-kpi-pulse-loop.md.
+//
+// Phase 1 covers two real-time signals — POS phone-capture rate and overdue
+// checklists. The detectors emit `Breach`es; the runner routes each to the
+// accountable manager and (once armed) sends a 1:1 WhatsApp DM. In shadow mode
+// nothing is sent — we only log what we *would* page, to validate the detectors.
+
+export type OpsSignal = "PHONE_CAPTURE" | "CHECKLIST";
+
+export type Severity = "LOW" | "MED" | "HIGH";
+
+export interface Breach {
+  signal: OpsSignal;
+  outletId: string; // Prisma Outlet.id
+  outletName: string;
+  severity: Severity;
+  // Stable per (signal, outlet, period) so the ledger can dedupe once armed.
+  dedupeKey: string;
+  summary: string; // one-line, human-readable
+  detail: Record<string, unknown>;
+}
+
+export interface Assignee {
+  userId: string;
+  name: string;
+  phone: string | null; // masked before it ever leaves the process in shadow
+  role: string;
+  // true when no outlet-matched MANAGER was found and we fell back to the owner.
+  fallback: boolean;
+}
+
+export interface RoutedBreach extends Breach {
+  assignee: Assignee | null;
+}
+
+export interface PulseRunResult {
+  mode: "off" | "shadow" | "armed";
+  ranAt: string;
+  breachCount: number;
+  routed: RoutedBreach[];
+  sent: number; // always 0 until the armed sender lands (Phase 1b)
+}

--- a/apps/backoffice/src/lib/ops-pulse/types.ts
+++ b/apps/backoffice/src/lib/ops-pulse/types.ts
@@ -5,9 +5,11 @@
 // accountable manager and (once armed) sends a 1:1 WhatsApp DM. In shadow mode
 // nothing is sent — we only log what we *would* page, to validate the detectors.
 
-export type OpsSignal = "PHONE_CAPTURE" | "CHECKLIST";
+export type OpsSignal = "PHONE_CAPTURE" | "CHECKLIST" | "REVIEW";
 
 export type Severity = "LOW" | "MED" | "HIGH";
+
+export type OpsAlertStatus = "OPEN" | "ACKED" | "ESCALATED" | "RESOLVED" | "EXPIRED";
 
 export interface Breach {
   signal: OpsSignal;
@@ -38,5 +40,6 @@ export interface PulseRunResult {
   ranAt: string;
   breachCount: number;
   routed: RoutedBreach[];
-  sent: number; // always 0 until the armed sender lands (Phase 1b)
+  sent: number; // manager digests sent this run (0 in shadow)
+  escalated: number; // alerts escalated to the owner this run (0 in shadow)
 }

--- a/apps/backoffice/src/lib/ops-pulse/types.ts
+++ b/apps/backoffice/src/lib/ops-pulse/types.ts
@@ -1,21 +1,33 @@
 // Shared shapes for the Ops KPI Pulse. See docs/design/ops-kpi-pulse-loop.md.
 //
-// Phase 1 covers two real-time signals — POS phone-capture rate and overdue
-// checklists. The detectors emit `Breach`es; the runner routes each to the
-// accountable manager and (once armed) sends a 1:1 WhatsApp DM. In shadow mode
-// nothing is sent — we only log what we *would* page, to validate the detectors.
+// Signals are routed by DISCIPLINE (routeKey), not outlet→manager: operations
+// (phone, checklist, reviews, procurement) → ops leads; barista/kitchen audit +
+// skill → the discipline lead. Detectors stamp routeKey; the router resolves it
+// to recipients.
 
-export type OpsSignal = "PHONE_CAPTURE" | "CHECKLIST" | "REVIEW" | "AUDIT";
+export type OpsSignal =
+  | "PHONE_CAPTURE"
+  | "CHECKLIST"
+  | "REVIEW"
+  | "AUDIT"
+  | "STOCK_COUNT"
+  | "RECEIVING"
+  | "MENU_SNOOZED";
 
 export type Severity = "LOW" | "MED" | "HIGH";
 
 export type OpsAlertStatus = "OPEN" | "ACKED" | "ESCALATED" | "RESOLVED" | "EXPIRED";
+
+// Discipline a breach routes to. operations = ops/procurement leads; barista /
+// kitchen = the skill-discipline lead.
+export type RouteKey = "operations" | "barista" | "kitchen";
 
 export interface Breach {
   signal: OpsSignal;
   outletId: string; // Prisma Outlet.id
   outletName: string;
   severity: Severity;
+  routeKey: RouteKey;
   // Stable per (signal, outlet, period) so the ledger can dedupe once armed.
   dedupeKey: string;
   summary: string; // one-line, human-readable
@@ -27,12 +39,14 @@ export interface Assignee {
   name: string;
   phone: string | null; // masked before it ever leaves the process in shadow
   role: string;
-  // true when no outlet-matched MANAGER was found and we fell back to the owner.
+  // true when this is an owner fallback (no configured recipient resolved).
   fallback: boolean;
 }
 
 export interface RoutedBreach extends Breach {
-  assignee: Assignee | null;
+  // All recipients for this breach. First = primary (owns ack/escalation in the
+  // ledger); the rest are co-recipients who also get the digest.
+  assignees: Assignee[];
 }
 
 export interface PulseRunResult {

--- a/apps/backoffice/vercel.json
+++ b/apps/backoffice/vercel.json
@@ -98,7 +98,7 @@
     },
     {
       "path": "/api/cron/ops-pulse",
-      "schedule": "0 * * * *"
+      "schedule": "*/5 * * * *"
     },
     {
       "path": "/api/cron/ops-pulse-daily",

--- a/apps/backoffice/vercel.json
+++ b/apps/backoffice/vercel.json
@@ -95,6 +95,10 @@
     {
       "path": "/api/cron/reviews-auto-reply",
       "schedule": "0 4 * * *"
+    },
+    {
+      "path": "/api/cron/ops-pulse",
+      "schedule": "0 * * * *"
     }
   ]
 }

--- a/apps/backoffice/vercel.json
+++ b/apps/backoffice/vercel.json
@@ -99,6 +99,10 @@
     {
       "path": "/api/cron/ops-pulse",
       "schedule": "0 * * * *"
+    },
+    {
+      "path": "/api/cron/ops-pulse-daily",
+      "schedule": "0 1 * * *"
     }
   ]
 }

--- a/docs/design/ops-kpi-pulse-loop.md
+++ b/docs/design/ops-kpi-pulse-loop.md
@@ -397,6 +397,12 @@ WhatsApp templates for approval**, and **confirm the manager's + owner's WhatsAp
     `ops_daily_pulse` template → the team gets a daily habit-forming digest with zero migration.
     Once that's a discipline, arm the real-time + escalation path (`OPS_PULSE_MODE=armed`,
     needs the OpsAlert migration + the breach/escalation templates).
+- **2026-06-24 — real-time tier + staff no-show.** Split signals into a fast real-time tier
+  (`OPS_PULSE_REALTIME_SIGNALS`, cron now every 5 min) vs the daily digest. Real-time defaults:
+  **REVIEW, MENU_SNOOZED, NO_CLOCK_IN**. New `detectNoClockIn` — a published `hr_schedule_shifts`
+  shift today whose `start_time` + 15-min grace passed with no `hr_attendance_logs.clock_in`;
+  routed to operations, MED, escalates. (Menu-snooze is truly live; Google reviews are bounded by
+  GBP polling — a frequent negative-review fetch is still needed for true real-time there.)
 - **Go-live checklist for the REAL-TIME path (before `OPS_PULSE_MODE=armed`).** (1) apply the `OpsAlert` migration to the
   DB; (2) get `ops_breach_digest` + `ops_escalation` templates APPROVED and set
   `OPS_PULSE_TPL_*`; (3) confirm manager + owner `User.phone`; (4) bump the cron from hourly to

--- a/docs/design/ops-kpi-pulse-loop.md
+++ b/docs/design/ops-kpi-pulse-loop.md
@@ -329,6 +329,17 @@ WhatsApp templates for approval**, and **confirm the manager's + owner's WhatsAp
   - `apps/backoffice/src/app/api/cron/ops-pulse/route.ts` — `checkCronAuth`-gated cron.
   - `vercel.json` — `/api/cron/ops-pulse` **hourly** while shadowing.
   - `OPS_PULSE_MODE` env (`off|shadow|armed`, unset ⇒ shadow). Deploying starts the shadow week.
-- **Next — Phase 1b (arm).** After a shadow week is reviewed: add the `OpsAlert` ledger
-  (+migration), the WhatsApp DM sender + approved templates, the inbound-ack hook on the
-  existing webhook, the escalation sweep, and flip the cron to a 15-min cadence.
+- **2026-06-24 — Phase 1b (armed path) wired.** Owner confirmed 60% phone floor, 90-min
+  escalation, and **+reviews**. Built (dormant until `OPS_PULSE_MODE=armed`):
+  - `OpsAlert` model (`schema.prisma`) + SQL migration
+    (`packages/db/prisma/migrations/20260624_ops_alert/`).
+  - `detectReviews` — internal QR feedback ≤2★ (open) + negative Google review drafts ≤3★
+    (pending), bounded to a 72h recency window.
+  - `ledger` (dedupe + OPEN→ESCALATED→RESOLVED lifecycle; phone-capture excluded from
+    escalation), `sender` (template-or-text WhatsApp digest), `inbound` (reply "DONE" →
+    resolve), runner armed branch (persist → page new per-manager digest → escalate past SLA),
+    ack hooked into `api/whatsapp/webhook`.
+- **Go-live checklist (before flipping to armed).** (1) apply the `OpsAlert` migration to the
+  DB; (2) get `ops_breach_digest` + `ops_escalation` templates APPROVED and set
+  `OPS_PULSE_TPL_*`; (3) confirm manager + owner `User.phone`; (4) bump the cron from hourly to
+  15-min in `vercel.json`; (5) set `OPS_PULSE_MODE=armed`. Until then it stays in shadow.

--- a/docs/design/ops-kpi-pulse-loop.md
+++ b/docs/design/ops-kpi-pulse-loop.md
@@ -16,11 +16,20 @@ these in real time and, in his words, **"keep the ops manager in check."** That 
 is the whole design. The goal is not *notification*; it's *accountability*.
 
 ## Objective (owner directive 2026-06-24)
-Make the ops manager's misses **visible, owned, and time-bound** — to the manager AND to
-the owner — so a slipped standard cannot quietly stay slipped. North-Star metric for this
-loop: **breach rate trending DOWN and time-to-resolve shrinking, per manager, week over
-week.** If alerts fire forever at a flat rate, the loop is failing and we'll see it in the
-number — that is the point of building it as a loop, not a feed.
+Two things, in the owner's words:
+1. **"Make sure every ops is in check"** — *comprehensive* coverage. The target state watches
+   all four standards (checklist, phone capture, reviews, audit/training), not one. Nothing
+   slips silently anywhere.
+2. **"Use this alert to monitor and remind the management / ops team"** — the day-to-day job
+   is *monitoring + reminding*, not only catching failures after the fact. So every signal
+   gets **two beats**: a **reminder** before/at the deadline (a low-friction nudge — "checklist
+   due in 15 min", "phone-capture running low this shift") and an **alert** after the grace
+   window (a logged, escalatable breach). Remind first; escalate only what the reminder didn't fix.
+
+Underneath both sits one rule that gives it teeth: misses are **visible, owned, and
+time-bound** — to the manager AND to the owner. North-Star metric: **breach rate trending DOWN
+and time-to-resolve shrinking, per manager, week over week.** If alerts fire forever at a flat
+rate, the loop is failing and we'll see it in the number — the point of a loop, not a feed.
 
 ## Status Quo (what happens now)
 - Checklists, audits live in backoffice/staff DB; nobody is paged when one lapses — the daily
@@ -111,6 +120,23 @@ fields (`packages/db/prisma/schema.prisma`):
   event ([[project_reviews_reply_recovery_loop]]); a 1★/risk-flagged review with no decision
   after SLA becomes an `OpsAlert`. Reuse, don't duplicate.
 
+### Alert catalog — proposed defaults (approve or adjust, don't block on these)
+Two beats per signal: **Remind** (nudge, no escalation) → **Alert** (logged breach, escalatable).
+All paged to the outlet's manager; **escalates to the owner** when the alert sits unacked past
+its SLA. Numbers below are my suggested starting values, tuned in the shadow week.
+
+| Signal | Remind (nudge) | Alert (breach) | Severity | Owner escalation SLA |
+|---|---|---|---|---|
+| **Phone capture** | Mid-shift, if rolling capture < 70% | Shift close < **60%** for the outlet | Med | 2 shifts below floor |
+| **Checklist** | 15 min before `dueAt` | **30 min** past `dueAt`, still `PENDING` | High (opening/food-safety), else Med | 90 min past due |
+| **Review** | — (reviews arrive unscheduled) | New `InternalFeedback` ≤ 2★ or risk-flagged GBP negative, **status open** | High if risk-flagged, else Med | 4 h unaddressed (same-day) |
+| **Audit / training** | When the cadence window opens | Cadence window closes with no `COMPLETED` `AuditReport` | Low (lagging) — scorecard line + single reminder, **not** a real-time ping | On the weekly scorecard |
+
+Defaults behind the catalog: **business hours** = outlet operating window (quiet hours queue
+to open); **ack window** = 90 min high / same-day low; **dedupe** = one alert per
+`dedupeKey`; **coalesce** = multiple new breaches in one sweep → one digest per manager, never
+N pings; **morning open-items digest** + **end-of-shift summary** per manager.
+
 ### The engine (mirror the live loop-engine)
 Reuse the proven shape of `apps/backoffice/src/lib/loyalty/loop-engine.ts` +
 `api/cron/loops-send`:
@@ -136,6 +162,20 @@ From `lib/whatsapp.ts`:
   TODO routing hook): match `providerMessageId` / button payload → flip `OpsAlert` to
   `ACKED`/`RESOLVED`, stop the escalation timer.
 
+### Draft WhatsApp templates (submit for approval first — they have lead time)
+Five templates cover everything; each variable is a Cloud API body param. Quick-reply buttons
+open the 24h window so the rest of the exchange is free-form.
+- **`ops_reminder`** (nudge, manager): _"⏰ {{outlet}} — {{what}} due {{when}}. A quick heads-up."_
+- **`ops_breach_digest`** (alert, manager): _"🔴 Ops Pulse — {{outlet}}\n{{count}} item(s) need
+  you:\n{{lines}}"_ · buttons: **[Acknowledge] [Fixing now] [Snooze 1h]**
+- **`ops_escalation`** (owner): _"⚠️ Escalation — {{outlet}}\n{{manager}} hasn't actioned:
+  {{detail}}\nOpen {{duration}}."_ · button: **[View board]**
+- **`ops_scorecard`** (weekly, manager + owner): _"📊 Scorecard — wk {{date}} · {{manager}}\nPhone
+  {{cap}} (tgt {{capTgt}}) · Checklists {{chk}} on-time · Reviews {{revOpen}} open/{{revRec}}
+  recovered · Audits {{audOverdue}} overdue · Alerts {{sent}} sent/{{esc}} escalated"_
+- **`ops_resolved_ack`** (free-form, inside window): plain `sendWhatsAppText` confirmation — no
+  template needed once the manager has replied.
+
 ### The scorecard
 - `GET /api/cron/ops-scorecard` (weekly; daily owner digest optional) aggregates `OpsAlert` +
   raw rates per manager → `ops_scorecard` template to manager **and** owner.
@@ -153,7 +193,7 @@ owner-facing escalation + approve flows** (richer, instant). One ledger, two sen
 - There is effectively **one ops manager** today; routing = `User.role=MANAGER` whose
   `outletId`/`outletIds` covers the breach outlet, **owner as fallback/escalation.** There is
   **no region/area hierarchy** in the schema — fine for one manager, a gap when you add a
-  second (see Open Questions).
+  second (see Decisions #3).
 - `User.phone` is populated and WhatsApp-reachable for the manager and owner.
 - `pos_orders.customer_phone` is the live capture field post-POS-native cutover (it is, per
   `lib/finance/ingestors/pos-native-eod.ts`); legacy `SalesTransaction` has **no** phone and
@@ -179,21 +219,36 @@ severity, drafts the manager message and the owner escalation, learns which aler
 resolved, and tunes thresholds. Same ledger underneath.
 
 ## Recommended Approach
-**A now → B once the loop mechanics are proven on one signal → C later.** The discipline that
-makes this work — the ledger, the ack state machine, the escalation rule, the scorecard — is
-built *once* in A and is identical for all four signals. Adding signals (B) is then cheap.
-Resist shipping all four as a notifier on day one: that's the exact firehose that gets muted.
+The destination is **all four signals in check** (objective #1). The sequence is only how we
+get there without shipping a day-one firehose that gets muted:
 
-## Open Questions
-1. **SLA before escalation to owner** — propose 90 min in business hours. Acceptable?
-2. **Thresholds** — phone-capture floor (propose 80%/outlet/shift)? Checklist grace past
-   `dueAt`? Audit cadence per template?
-3. **One manager or several?** If several are coming, we need an outlet→manager mapping
-   (`Outlet.managerId` or a join table) — the schema has none today.
-4. **Quiet hours** — operating window per outlet, or one global window?
-5. **Scorecard cadence** — weekly to manager + owner; also a short daily owner digest?
-6. **Snooze policy** — can the manager snooze, and does a snooze still surface on the scorecard?
-   (It should — a silenced alert is still a miss.)
+- **Phase 1 (the spine + 2 clean real-time signals) — start here.** `OpsAlert` ledger + engine
+  + escalation sweep + WhatsApp templates, wired to **phone capture + checklist** (the two
+  cleanest real-time signals, with reminder *and* alert beats). Run **one week in shadow** (log
+  what it would page, read it, confirm each breach is real), then arm escalation.
+- **Phase 2 (full coverage).** Add **reviews** (subscribe to the existing recovery pipeline,
+  don't rebuild) + **audit/training** (scorecard line + single reminder, not a real-time ping)
+  + the **weekly scorecard** + the backoffice **Ops Pulse** tab. This is "every ops in check."
+- **Phase 3 (later).** Fold drafting/prioritising/threshold-tuning into the existing
+  `ai-agent/celsius-overview`.
+
+The discipline that makes this a loop — the ledger, the ack state machine, the escalation rule,
+the scorecard — is built **once** in Phase 1 and is identical for all four signals, so Phase 2
+is mostly adding detectors. Comprehensive *coverage*, sequenced *rollout*.
+
+## Decisions — proposed defaults (these are my suggestions; adjust any)
+Owner said "suggest first," so these are decided defaults, not questions. Tune in the shadow week.
+1. **Escalation SLA** → **90 min** business hours (high-severity); same-day for low. ✅ proposed.
+2. **Thresholds** → phone-capture breach < **60%**/outlet/shift (target 80%); checklist grace
+   **30 min** past `dueAt`; audit = cadence window closes unmet. ✅ proposed (per Alert Catalog).
+3. **Routing** → single ops manager today = default assignee for all outlets, owner = escalation.
+   ✅ works now. ⚠️ **the one real gap:** the schema has **no outlet→manager map** (no
+   `Outlet.managerId`, no region hierarchy). The moment a *second* manager exists, we need to
+   add that mapping. Flagging now; not a Phase-1 blocker.
+4. **Quiet hours** → per-outlet operating window; out-of-hours breaches queue and send at open. ✅.
+5. **Scorecard** → **weekly** to manager + owner, plus a short **daily owner digest**. ✅.
+6. **Snooze** → manager may snooze 1h, **but the snooze still counts on the scorecard** — a
+   silenced alert is still a miss. ✅ (this is what stops snooze becoming a mute button).
 
 ## Success Criteria (measurable)
 - Loop ships with the **phone-capture detector** live: breaches logged to `OpsAlert`, paged to
@@ -205,10 +260,10 @@ Resist shipping all four as a notifier on day one: that's the exact firehose tha
   The falling number — not the message stream — is the deliverable.
 
 ## The Assignment (one concrete next step)
-Decide the two things only the owner can: (1) the **escalation SLA** (how long the manager has
-before it lands on your phone — propose 90 min) and (2) the **phone-capture floor** that counts
-as a breach (propose 80% per outlet per shift). Then we wire `OpsAlert` + the phone-capture
-detector + the escalation sweep + the first scorecard — the full loop on one signal. Before
-turning escalation on, run the detector in **shadow mode for one week**: log the breaches it
-*would* have paged, read them, confirm the manager would agree each is real. Watch before you
-arm it.
+Defaults are proposed above — **approve them as-is, or adjust any number** — and I build
+**Phase 1**: the `OpsAlert` ledger + the phone-capture and checklist detectors (reminder +
+alert beats) + the escalation sweep + the WhatsApp templates. It runs **one week in shadow** —
+logging the breaches it *would* have paged so you read them and confirm each is real — and only
+then do we arm escalation. Two lead-time items to kick off in parallel: **submit the five
+WhatsApp templates for approval**, and **confirm the manager's + owner's WhatsApp numbers**
+(`User.phone`). Watch before you arm it.

--- a/docs/design/ops-kpi-pulse-loop.md
+++ b/docs/design/ops-kpi-pulse-loop.md
@@ -198,17 +198,44 @@ So the channel split is:
 - **Alerts → WhatsApp 1:1 DM** to the accountable manager. Supported, keeps the ack buttons,
   and 1:1 is *better* for "keep her in check" anyway — a group diffuses ownership ("someone
   will get it"). Multiple recipients = **fan-out** (send the template to each DM), not a group.
-- **Team visibility / reminders → a shared group on Telegram** (`lib/telegram.ts`, already
-  wired): native group + supergroup support, inline buttons, threaded replies, no 8-cap, no
-  eligibility gate. Post the daily/weekly **scorecard** and a read-only **pulse feed** there.
+- **Team visibility / reminders → a group.** A Telegram group (`lib/telegram.ts`, already
+  wired) is the no-gate, no-cap, buttons-included option that works *today* — but the owner
+  has opted to pursue a **WhatsApp** group via verification instead (see Channel decision below).
 - Shared visibility doesn't actually *need* a group thread: the `OpsAlert` ledger + the Ops
   Pulse board + the scorecard are the shared source of truth; the group is just a convenience surface.
 - (Unofficial WhatsApp-Web automation — Baileys / whatsapp-web.js — *can* post to any group but
   **violates Meta's ToS and risks a number ban**. Not for a business-critical ops system.)
 
-The internal escalation channel today is already **Telegram** (`lib/telegram.ts`), so this
-split reuses what exists: **WhatsApp DMs** for the manager-facing accountable alerts,
-**Telegram group** for the team-facing scorecard/feed, one `OpsAlert` ledger behind both.
+### Channel decision (owner, 2026-06-24)
+Owner wants the pulse delivered **in a WhatsApp group**, will **create a new** one (clears the
+existing-group blocker), and — over a Telegram group or DM fan-out — chose to **pursue
+verification and keep it on WhatsApp.** The number is a **standard WhatsApp Business account
+(no verified badge) today**, so the Groups API is not available yet. Two honest catches:
+
+1. **The badge clears one gate, not necessarily the Groups gate.** Verification removes the
+   Official-Business-Account requirement, but the Groups API *also* reportedly needs a very
+   high messaging tier (~100k business-initiated conversations / 24h) an internal ops workload
+   will never reach — so verification may **still** not unlock groups. **Confirm Groups-API
+   availability with the BSP/Meta before banking on it.** The **8-participant cap** applies
+   regardless (ops + management must be ≤7 to fit one group).
+2. **Verification path + timeline.** Two routes:
+   - **Meta Verified (paid subscription)** — the realistic SMB route. Check **WhatsApp Business
+     app → Settings / Business Tools → Meta Verified**; if the option isn't shown it's **not
+     in your region yet** (rolled out India/Brazil/Indonesia/Colombia first — **confirm
+     Malaysia**). ~3 business days when available.
+   - **Free OBA (notability-based)** — needs press coverage / large social following; granted
+     selectively; **2–8 weeks** and uncertain for an SMB.
+
+**The build does NOT wait on verification.** The loop — `OpsAlert` ledger, detectors,
+escalation, scorecard — is **channel-agnostic**; the sender is one swappable function.
+- **Now:** build the engine, deliver via **WhatsApp 1:1 DM** to the manager (+owner). Works on
+  today's standard number, keeps tap-to-ack buttons, and is the stronger accountability surface.
+- **In parallel:** pursue Meta Verified; confirm Groups-API + tier eligibility with the BSP.
+- **When/if unlocked:** add a **group sender** (new API group, invite link, acks via text reply
+  — groups have no buttons). A one-file change, not a re-architecture.
+
+The group is a *presentation surface*; the loop is the substance. A weeks-long, uncertain
+verification shouldn't stall the ops value DMs can deliver this week.
 
 ## Premises (verify before building)
 - There is effectively **one ops manager** today; routing = `User.role=MANAGER` whose

--- a/docs/design/ops-kpi-pulse-loop.md
+++ b/docs/design/ops-kpi-pulse-loop.md
@@ -315,3 +315,20 @@ logging the breaches it *would* have paged so you read them and confirm each is 
 then do we arm escalation. Two lead-time items to kick off in parallel: **submit the five
 WhatsApp templates for approval**, and **confirm the manager's + owner's WhatsApp numbers**
 (`User.phone`). Watch before you arm it.
+
+## Build log
+- **2026-06-24 — channel = WhatsApp 1:1 DM.** Owner chose 1:1 DMs over a group (WhatsApp
+  Groups API gated behind a verified badge + a messaging tier an internal workload won't reach;
+  group deferred behind verification). DMs work on today's standard number and keep tap-to-ack.
+- **2026-06-24 — Phase 1a (shadow) shipped.** Read-only detect-and-log, **no sends, no schema
+  change**:
+  - `apps/backoffice/src/lib/ops-pulse/` — `config` (mode + thresholds), `detectors`
+    (`detectPhoneCapture` via `pos_orders`, `detectChecklist` via Prisma `Checklist`),
+    `router` (outlet→MANAGER, owner fallback), `index` (`runOpsPulse`, masks phones, logs
+    would-be pages).
+  - `apps/backoffice/src/app/api/cron/ops-pulse/route.ts` — `checkCronAuth`-gated cron.
+  - `vercel.json` — `/api/cron/ops-pulse` **hourly** while shadowing.
+  - `OPS_PULSE_MODE` env (`off|shadow|armed`, unset ⇒ shadow). Deploying starts the shadow week.
+- **Next — Phase 1b (arm).** After a shadow week is reviewed: add the `OpsAlert` ledger
+  (+migration), the WhatsApp DM sender + approved templates, the inbound-ack hook on the
+  existing webhook, the escalation sweep, and flip the cron to a 15-min cadence.

--- a/docs/design/ops-kpi-pulse-loop.md
+++ b/docs/design/ops-kpi-pulse-loop.md
@@ -341,12 +341,13 @@ WhatsApp templates for approval**, and **confirm the manager's + owner's WhatsAp
     ack hooked into `api/whatsapp/webhook`.
 - **2026-06-24 — audit signal added (food director / barista lead).** `detectAudit` flags a
   tracked auditor `roleType` with no `COMPLETED` `AuditReport` at an active outlet inside a
-  cadence window. No audit cadence exists in the schema, so it's defined in config
-  (`AUDIT.cadenceDays`, default 30 = monthly) over a configurable role list
-  (`OPS_PULSE_AUDIT_ROLES`, default `barista_head`). LOW severity, deduped per
-  outlet/role/window, **never escalated** (lagging, not a now-fix-it incident). A role only
-  fires if it has an active `AuditTemplate`. ⚠️ Owner to confirm the **cadence** and the exact
-  **food-director roleType** string (only `barista_head` is visible in the data today).
+  cadence window. No audit cadence exists in the schema, so it's defined in config. Owner
+  confirmed: **weekly cadence (7 days)**; roles resolved against live data —
+  **`barista_head`** (barista lead: Barista Station Audit / Barista Skills) and **`chef_head`**
+  (food director: Kitchen Quality Audit / Kitchen Crew Skills). Coverage counts a COMPLETED
+  OUTLET *or* STAFF report of the role. LOW severity, deduped per outlet/role/window, **never
+  escalated** (lagging, not a now-fix-it incident). A role only fires if it has an active
+  `AuditTemplate`. (`AUDIT.cadenceDays` / `OPS_PULSE_AUDIT_ROLES` to tune.)
 - **Go-live checklist (before flipping to armed).** (1) apply the `OpsAlert` migration to the
   DB; (2) get `ops_breach_digest` + `ops_escalation` templates APPROVED and set
   `OPS_PULSE_TPL_*`; (3) confirm manager + owner `User.phone`; (4) bump the cron from hourly to

--- a/docs/design/ops-kpi-pulse-loop.md
+++ b/docs/design/ops-kpi-pulse-loop.md
@@ -182,12 +182,33 @@ open the 24h window so the rest of the exchange is free-form.
 - A backoffice **"Ops Pulse"** tab (reuse the `loyalty/loops` + Reviews-Ops dashboard pattern):
   live board, history, per-manager trend, SLA breaches.
 
-### Channel note (Telegram vs WhatsApp)
-The internal escalation channel today is **Telegram**, which has native inline buttons +
-callback queries (`lib/telegram.ts`) — richer for ops control and zero template approval.
-WhatsApp is where the managers actually live and what the owner asked for. Recommend:
-**WhatsApp for the manager-facing pulse** (meet them where they are), keep **Telegram for the
-owner-facing escalation + approve flows** (richer, instant). One ledger, two senders.
+### Channels — DM for accountability, group for visibility (and why the group goes on Telegram)
+**Can WhatsApp send to a group?** Technically yes — Meta shipped a **Groups API** for the
+Cloud API (2026) — but it is **not viable for this use case**, for four reasons:
+- **Eligibility gate.** Group messaging reportedly requires an **Official Business Account**
+  (green tick) **and a very high messaging tier (~100k business-initiated conversations / 24h).**
+  An internal ops-alert workload will never reach that — so we likely can't turn it on at all.
+- **Can't use your existing group.** The API can only message groups it **created
+  programmatically**; an ops team's manually-made WhatsApp group can't be retrofitted.
+- **Opt-in + 8-person cap.** Members join via invite link (no force-add), max **8 incl. admin**.
+- **No buttons in groups.** Group messages are text/media/template only — which **kills the
+  tap-to-ack quick-reply** the accountability loop depends on.
+
+So the channel split is:
+- **Alerts → WhatsApp 1:1 DM** to the accountable manager. Supported, keeps the ack buttons,
+  and 1:1 is *better* for "keep her in check" anyway — a group diffuses ownership ("someone
+  will get it"). Multiple recipients = **fan-out** (send the template to each DM), not a group.
+- **Team visibility / reminders → a shared group on Telegram** (`lib/telegram.ts`, already
+  wired): native group + supergroup support, inline buttons, threaded replies, no 8-cap, no
+  eligibility gate. Post the daily/weekly **scorecard** and a read-only **pulse feed** there.
+- Shared visibility doesn't actually *need* a group thread: the `OpsAlert` ledger + the Ops
+  Pulse board + the scorecard are the shared source of truth; the group is just a convenience surface.
+- (Unofficial WhatsApp-Web automation — Baileys / whatsapp-web.js — *can* post to any group but
+  **violates Meta's ToS and risks a number ban**. Not for a business-critical ops system.)
+
+The internal escalation channel today is already **Telegram** (`lib/telegram.ts`), so this
+split reuses what exists: **WhatsApp DMs** for the manager-facing accountable alerts,
+**Telegram group** for the team-facing scorecard/feed, one `OpsAlert` ledger behind both.
 
 ## Premises (verify before building)
 - There is effectively **one ops manager** today; routing = `User.role=MANAGER` whose

--- a/docs/design/ops-kpi-pulse-loop.md
+++ b/docs/design/ops-kpi-pulse-loop.md
@@ -370,6 +370,16 @@ WhatsApp templates for approval**, and **confirm the manager's + owner's WhatsAp
   - **Procurement signals added** → operations: `detectStockCount` (no SUBMITTED/REVIEWED count
     in 7d, LOW), `detectReceivings` (DISPUTED=MED/PARTIAL=LOW in 7d, **escalates**),
     `detectMenuSnoozed` (86'd item count via `outlet_product_availability`, MED).
+- **2026-06-24 — DB correction + recipients confirmed.** The production Prisma DB is the
+  loyalty Supabase project (`kqdcdhpnyuwrxqhbuyfl`); earlier manual spot-checks mistakenly hit a
+  separate `celsius-inventory` project. The **code was always correct** — every detector uses
+  `prisma` / `hrSupabaseAdmin` / `getSupabaseAdmin`, which all point at the real DB. Corrected
+  facts: all four recipients are active **MANAGERs** with phones, each on 5 outlets via
+  `outletIds` — Ariff, Adam Kelvin, **Syafiq Kaberi** (`+601137506488`), **Chef Bo**
+  (`+60126057787`); names resolve, so routing + ack attribute correctly (kitchen route set to
+  "Chef Bo", the account name). Audits/training ARE happening (Barista Station 30, Barista Skills
+  14, Kitchen+Food audits 24, Kitchen Crew Skills 6) — the earlier "0 everywhere" was the stale
+  project. ⚠️ Apply the `OpsAlert` migration to the **loyalty project**, not celsius-inventory.
 - **Go-live checklist (before flipping to armed).** (1) apply the `OpsAlert` migration to the
   DB; (2) get `ops_breach_digest` + `ops_escalation` templates APPROVED and set
   `OPS_PULSE_TPL_*`; (3) confirm manager + owner `User.phone`; (4) bump the cron from hourly to

--- a/docs/design/ops-kpi-pulse-loop.md
+++ b/docs/design/ops-kpi-pulse-loop.md
@@ -403,6 +403,15 @@ WhatsApp templates for approval**, and **confirm the manager's + owner's WhatsAp
   shift today whose `start_time` + 15-min grace passed with no `hr_attendance_logs.clock_in`;
   routed to operations, MED, escalates. (Menu-snooze is truly live; Google reviews are bounded by
   GBP polling — a frequent negative-review fetch is still needed for true real-time there.)
+- **2026-06-24 — POS-open signal + routine/adhoc taxonomy.** `detectPosNotOpen` — an active
+  outlet open today whose `openTime` + 15-min grace passed with no `pos_shifts` session opened
+  (the till isn't logged in → can't trade). HIGH, ops, real-time, escalates; part of "open-ready".
+  Added a **routine vs adhoc** taxonomy (`SIGNAL_CATEGORY`): routine = scheduled expectations
+  (clock-in, POS open, checklist, audit, skill, stock, phone), adhoc = spontaneous events
+  (**reviews**, menu-snoozed, receiving). The daily digest now groups items under 🔁 Routine / ⚡ Adhoc.
+- **Roster-aware sending (next):** `hr_schedule_shifts` is live (110 published shifts/7d, 3 of ~5
+  outlets rostered) — enough to route the open-ready loop to the on-shift person and time sends to
+  shift start/end, falling back to the lead where no roster is published.
 - **Go-live checklist for the REAL-TIME path (before `OPS_PULSE_MODE=armed`).** (1) apply the `OpsAlert` migration to the
   DB; (2) get `ops_breach_digest` + `ops_escalation` templates APPROVED and set
   `OPS_PULSE_TPL_*`; (3) confirm manager + owner `User.phone`; (4) bump the cron from hourly to

--- a/docs/design/ops-kpi-pulse-loop.md
+++ b/docs/design/ops-kpi-pulse-loop.md
@@ -412,6 +412,15 @@ WhatsApp templates for approval**, and **confirm the manager's + owner's WhatsAp
 - **Roster-aware sending (next):** `hr_schedule_shifts` is live (110 published shifts/7d, 3 of ~5
   outlets rostered) — enough to route the open-ready loop to the on-shift person and time sends to
   shift start/end, falling back to the lead where no roster is published.
+- **2026-06-24 — QA pass (PR #510) + fixes.** Independent correctness review validated the SQL
+  joins/columns/enums/MYT math/shadow-safety. Fixed: (C2) `recordBreach` find-then-create race →
+  catch P2002 and treat as not-new (no double-page/crash on overlapping crons); (C1) escalation
+  dead config → promoted **checklist + receiving to real-time** so they enter the ledger and
+  actually escalate, dropped AUDIT from the escalatable set (audit/skill escalation pending the
+  routine-ledger path); (M1) menu-snooze now excludes globally-disabled products (no false 86'd
+  pages); (M3/N1) no-clock-in query guards null `start_time` + orders by start. Real-time tier is
+  now REVIEW, MENU_SNOOZED, NO_CLOCK_IN, POS_NOT_OPEN, CHECKLIST, RECEIVING. CI (GitHub Actions)
+  needs maintainer **"Approve and run"** on the PR; Vercel backoffice preview built clean.
 - **Go-live checklist for the REAL-TIME path (before `OPS_PULSE_MODE=armed`).** (1) apply the `OpsAlert` migration to the
   DB; (2) get `ops_breach_digest` + `ops_escalation` templates APPROVED and set
   `OPS_PULSE_TPL_*`; (3) confirm manager + owner `User.phone`; (4) bump the cron from hourly to

--- a/docs/design/ops-kpi-pulse-loop.md
+++ b/docs/design/ops-kpi-pulse-loop.md
@@ -339,6 +339,14 @@ WhatsApp templates for approval**, and **confirm the manager's + owner's WhatsAp
     escalation), `sender` (template-or-text WhatsApp digest), `inbound` (reply "DONE" →
     resolve), runner armed branch (persist → page new per-manager digest → escalate past SLA),
     ack hooked into `api/whatsapp/webhook`.
+- **2026-06-24 — audit signal added (food director / barista lead).** `detectAudit` flags a
+  tracked auditor `roleType` with no `COMPLETED` `AuditReport` at an active outlet inside a
+  cadence window. No audit cadence exists in the schema, so it's defined in config
+  (`AUDIT.cadenceDays`, default 30 = monthly) over a configurable role list
+  (`OPS_PULSE_AUDIT_ROLES`, default `barista_head`). LOW severity, deduped per
+  outlet/role/window, **never escalated** (lagging, not a now-fix-it incident). A role only
+  fires if it has an active `AuditTemplate`. ⚠️ Owner to confirm the **cadence** and the exact
+  **food-director roleType** string (only `barista_head` is visible in the data today).
 - **Go-live checklist (before flipping to armed).** (1) apply the `OpsAlert` migration to the
   DB; (2) get `ops_breach_digest` + `ops_escalation` templates APPROVED and set
   `OPS_PULSE_TPL_*`; (3) confirm manager + owner `User.phone`; (4) bump the cron from hourly to

--- a/docs/design/ops-kpi-pulse-loop.md
+++ b/docs/design/ops-kpi-pulse-loop.md
@@ -357,6 +357,19 @@ WhatsApp templates for approval**, and **confirm the manager's + owner's WhatsAp
     Barista×29, Kitchen Crew×10) → staff→outlet (`User`) → completed skill `AuditReport`s.
     Reports **trained/eligible per outlet** (currently **0/39 trained**). LOW severity, never
     escalated — a coaching/scorecard number, not an incident.
+- **2026-06-24 — routing redesigned to discipline-based + procurement signals.** Owner set
+  recipients by *type*, not outlet→manager:
+  - **operations** (phone, checklist, reviews, procurement) → **Ariff + Adam Kelvin** (resolved,
+    have phones).
+  - **barista** (barista_head audit + skill) → **Syafiq**; **kitchen** (chef_head) → **Chef Bo**.
+    ⚠️ Neither resolves to an active `User` (the Barista-Lead HR profile points to a missing
+    user; the Kitchen Leads are Haziq/Shairuleen/Ameir, no "Bo"). Routes are config-driven
+    (`OPS_PULSE_*_RECIPIENTS`, matched on `User.name`); **unresolved names fall back to the
+    owner** until confirmed. Detectors stamp `routeKey`; the router resolves names → recipients
+    (first = primary, owns ack/escalation; rest co-receive the digest).
+  - **Procurement signals added** → operations: `detectStockCount` (no SUBMITTED/REVIEWED count
+    in 7d, LOW), `detectReceivings` (DISPUTED=MED/PARTIAL=LOW in 7d, **escalates**),
+    `detectMenuSnoozed` (86'd item count via `outlet_product_availability`, MED).
 - **Go-live checklist (before flipping to armed).** (1) apply the `OpsAlert` migration to the
   DB; (2) get `ops_breach_digest` + `ops_escalation` templates APPROVED and set
   `OPS_PULSE_TPL_*`; (3) confirm manager + owner `User.phone`; (4) bump the cron from hourly to

--- a/docs/design/ops-kpi-pulse-loop.md
+++ b/docs/design/ops-kpi-pulse-loop.md
@@ -1,0 +1,214 @@
+# Ops KPI Pulse — Accountability Loop
+
+_Office-hours diagnostic — 2026-06-24. Owner: Ammar._
+
+## Problem Statement
+Four ops standards slip silently today, each in a different system, each found out
+days late (or never):
+1. An outlet **skips a checklist** (`Checklist.status` stuck `PENDING` past `dueAt`).
+2. A **POS sale captures no customer phone** (`pos_orders.customer_phone` null) — the
+   single most expensive miss, see below.
+3. A **bad review** lands and dead-ends (`InternalFeedback.rating` low / `ReviewReplyDraft`).
+4. A **required audit/training isn't done** (no `COMPLETED` `AuditReport` for the period).
+
+The owner wants WhatsApp (now live — `apps/backoffice/src/lib/whatsapp.ts`) to surface
+these in real time and, in his words, **"keep the ops manager in check."** That last phrase
+is the whole design. The goal is not *notification*; it's *accountability*.
+
+## Objective (owner directive 2026-06-24)
+Make the ops manager's misses **visible, owned, and time-bound** — to the manager AND to
+the owner — so a slipped standard cannot quietly stay slipped. North-Star metric for this
+loop: **breach rate trending DOWN and time-to-resolve shrinking, per manager, week over
+week.** If alerts fire forever at a flat rate, the loop is failing and we'll see it in the
+number — that is the point of building it as a loop, not a feed.
+
+## Status Quo (what happens now)
+- Checklists, audits live in backoffice/staff DB; nobody is paged when one lapses — the daily
+  `reset-checklists` cron just wipes the slate at 16:00 (`apps/staff/.../cron/reset-checklists`).
+- Phone capture is a field on `pos_orders` (native Poster POS, Supabase) that nobody watches.
+- Negative reviews already have a recovery pipeline ([[project_reviews_reply_recovery_loop]])
+  whose risk tier escalates to **Telegram (Adam/Ammar)** — so an internal-alert precedent and
+  channel already exist.
+- The owner finds out about all four by asking, or by a customer/area-manager complaining.
+  Discovery is manual, lagging, and unowned.
+
+## Target User (named)
+- **The ops manager** — the accountable human the loop keeps in check. Single primary
+  assignee today (`User.role = MANAGER`, joined to outlets via `User.outletId` / `outletIds`).
+- **Ammar (owner)** — the escalation target and scorecard reader. The person who today
+  finds out too late. Keeps him up at night: standards slipping at outlets he can't be in.
+
+## Narrowest Wedge
+**One signal — POS phone-capture rate — wired end to end through the full loop machine**
+(detect → route to manager → require ack → auto-escalate to owner → weekly scorecard),
+then clone the engine to the other three. Phone capture is the wedge because it is the only
+signal that is simultaneously: **leading** (predicts revenue, not records it), **100% the
+manager's job** (it's pure cashier behaviour she controls), **continuous** (a clean daily %,
+perfect for a scorecard), and **currently unclosed** (nothing watches it). And it is the
+**join key for every other loop the company is building** — [[project_sms_loop_engineering]]
+states it plainly: *"Phone is the join key."* Every uncaptured phone is a customer made
+permanently invisible to win-back, frequency, birthday, and every attribution number. Fix
+the capture rate and you widen the mouth of the entire marketing funnel.
+
+## What's a loop and what isn't (read this before building)
+Per the house distinction ([[project_reviews_reply_recovery_loop]]):
+- **A "pulse" that pings on every miss is a notifier, not a loop.** It has no closure. Within
+  two weeks the manager filters it like spam and nothing changes. This is the default failure
+  mode and the thing to NOT build.
+- **This becomes a loop** only when it closes on a measured outcome: every breach has an
+  **owner**, an **acknowledgement**, an **escalation if ignored**, and a **resolution state** —
+  and the breach *rate* is tracked so we know the intervention is working. The deliverable is a
+  falling number, not a stream of messages.
+
+## The Lever (the owner's actual question)
+The highest-leverage mechanism here is **not alert volume — it's the accountability state
+machine plus the weekly scorecard.** Three structural choices give the loop teeth; the first
+two are the lever:
+
+1. **Auto-escalate to the owner on silence.** Breach → manager is paged → if not
+   acked/resolved within an SLA (propose 90 min, business hours) → it **escalates to Ammar**.
+   Silence stops being a safe option. This single rule is what converts a nag into a check.
+2. **A weekly manager scorecard, not just incident pings.** Real-time alerts handle the
+   *incident*; the scorecard handles the *pattern* — "this week: checklist 87% (target 95%),
+   phone-capture 62% (target 80%), 2 unaddressed 1★, 1 overdue audit; 3 alerts escalated."
+   The scorecard is the artefact you review *with* the manager. Pings without a scorecard =
+   nagging; a scorecard without pings = too slow. **If only one thing ships, ship the
+   scorecard** — it turns noise into a managed number and a recurring conversation.
+3. **Route to the accountable person, never the location.** A miss pages the manager who owns
+   that outlet, by name, with the outlet named — personal accountability, not a broadcast a
+   cashier ignores.
+
+## Design
+
+### The spine: an alert ledger (new `OpsAlert` model)
+Everything hangs off one table. Without it you have a notifier; with it you have a loop.
+```
+OpsAlert {
+  id, signal (CHECKLIST|PHONE_CAPTURE|REVIEW|AUDIT), outletId,
+  assigneeUserId, severity,
+  dedupeKey @unique,            // e.g. "phone_capture:outlet123:2026-06-24" — one alert, not 50
+  detail (Json),                // value, threshold, offending ids
+  status (OPEN|ACKED|ESCALATED|RESOLVED|EXPIRED),
+  channel, providerMessageId,   // WhatsApp message id, for inbound ack matching
+  sentAt, ackedAt, escalatedAt, resolvedAt, createdAt
+}
+```
+It gives you, in one place: **dedupe** (no firehose), the **ack/escalation state machine**
+(teeth), the **scorecard data** (time-to-ack, time-to-resolve, recurrence, % escalated), and
+an **audit trail**.
+
+### Per-signal detectors (one pure function each)
+A detector returns `{signal, outletId, severity, dedupeKey, detail}[]`. Grounded in real
+fields (`packages/db/prisma/schema.prisma`):
+- **Phone capture** — query Supabase `pos_orders` for the window; breach if capture %
+  (`customer_phone not null`) over the last shift falls below threshold for an outlet.
+  *Continuous rate → also drives the scorecard line directly.*
+- **Checklist** — `Checklist where status=PENDING and dueAt < now` (or `timeSlot`+`SopSchedule.dueMinutes`
+  elapsed). Breach per overdue instance, deduped per outlet+slot.
+- **Audit/training** — no `AuditReport` with `status=COMPLETED` for a (template, outlet) whose
+  cadence window has closed. *Low-frequency → scorecard line, NOT a real-time ping (see below).*
+- **Review** — do **not** rebuild. **Subscribe** to the existing negative-review ESCALATE
+  event ([[project_reviews_reply_recovery_loop]]); a 1★/risk-flagged review with no decision
+  after SLA becomes an `OpsAlert`. Reuse, don't duplicate.
+
+### The engine (mirror the live loop-engine)
+Reuse the proven shape of `apps/backoffice/src/lib/loyalty/loop-engine.ts` +
+`api/cron/loops-send`:
+- `GET /api/cron/ops-pulse` (`checkCronAuth`-gated, in `apps/backoffice/vercel.json`),
+  every 15 min — the cadence `loops-send` already uses; "real-time" here means *within the
+  SLA window*, not per-event.
+- Per run: **run detectors → upsert OpsAlert by `dedupeKey` (dedupe) → route → send → run the
+  escalation sweep** (any `OPEN` past SLA → escalate to owner, set `escalatedAt`).
+- **Quiet hours + caps**: suppress outside operating hours; one **digest per manager** per run
+  (per-incident lines inside it), not N messages. Realtime ≠ spam.
+
+### WhatsApp specifics (the constraints that bite)
+From `lib/whatsapp.ts`:
+- **Proactive alert ⇒ approved template.** A pulse is business-initiated, outside the 24h
+  window, so each alert/digest/escalation needs an **approved template** in WhatsApp Manager
+  (`ops_breach_digest`, `ops_escalation`, `ops_scorecard`). Approval has lead time — start it
+  first. Variables: manager name, metric, outlet, value, threshold, deep link.
+- **The 24h-window trick buys interactivity for free.** The moment the manager taps a
+  **quick-reply button** ("Acknowledge" / "Fixing now" / "Snooze 1h") or texts back, a 24h
+  free-form window opens → `sendWhatsAppText` can run a full ack/resolve conversation for 24h
+  at no template cost. So ship templates *with* quick-reply buttons.
+- **Inbound ack** extends the existing webhook (`api/whatsapp/webhook` — it already has the
+  TODO routing hook): match `providerMessageId` / button payload → flip `OpsAlert` to
+  `ACKED`/`RESOLVED`, stop the escalation timer.
+
+### The scorecard
+- `GET /api/cron/ops-scorecard` (weekly; daily owner digest optional) aggregates `OpsAlert` +
+  raw rates per manager → `ops_scorecard` template to manager **and** owner.
+- A backoffice **"Ops Pulse"** tab (reuse the `loyalty/loops` + Reviews-Ops dashboard pattern):
+  live board, history, per-manager trend, SLA breaches.
+
+### Channel note (Telegram vs WhatsApp)
+The internal escalation channel today is **Telegram**, which has native inline buttons +
+callback queries (`lib/telegram.ts`) — richer for ops control and zero template approval.
+WhatsApp is where the managers actually live and what the owner asked for. Recommend:
+**WhatsApp for the manager-facing pulse** (meet them where they are), keep **Telegram for the
+owner-facing escalation + approve flows** (richer, instant). One ledger, two senders.
+
+## Premises (verify before building)
+- There is effectively **one ops manager** today; routing = `User.role=MANAGER` whose
+  `outletId`/`outletIds` covers the breach outlet, **owner as fallback/escalation.** There is
+  **no region/area hierarchy** in the schema — fine for one manager, a gap when you add a
+  second (see Open Questions).
+- `User.phone` is populated and WhatsApp-reachable for the manager and owner.
+- `pos_orders.customer_phone` is the live capture field post-POS-native cutover (it is, per
+  `lib/finance/ingestors/pos-native-eod.ts`); legacy `SalesTransaction` has **no** phone and
+  is irrelevant to this signal.
+- WhatsApp templates can be approved for these alert types (start the approvals first).
+
+## Approaches Considered
+
+### Approach A — Phone-capture accountability loop, full machine, one signal — RECOMMENDED (~days)
+Build `OpsAlert` + the engine + escalation + scorecard, but wire **only the phone-capture
+detector**. Proves the entire loop (detect → route → ack → escalate → measure) on the
+highest-leverage, cleanest signal. Deliverable: capture-rate breaches paged to the manager,
+escalated to the owner on silence, and a first weekly scorecard with a real number to move.
+
+### Approach B — All four signals on the same engine (~1–2 wks)
+Add the checklist, audit, and review detectors onto the A engine. Checklist and review reuse
+the ledger directly; audit enters as a **scorecard line only** (low-frequency, lagging — a
+real-time ping is noise). Suppression, quiet hours, per-manager digest, the full Ops Pulse tab.
+
+### Approach C — Fold into the AI ops agent (months) — defer
+The existing `api/ai-agent/celsius-overview` (runs 4×/day) proposes the digest, prioritises by
+severity, drafts the manager message and the owner escalation, learns which alerts actually get
+resolved, and tunes thresholds. Same ledger underneath.
+
+## Recommended Approach
+**A now → B once the loop mechanics are proven on one signal → C later.** The discipline that
+makes this work — the ledger, the ack state machine, the escalation rule, the scorecard — is
+built *once* in A and is identical for all four signals. Adding signals (B) is then cheap.
+Resist shipping all four as a notifier on day one: that's the exact firehose that gets muted.
+
+## Open Questions
+1. **SLA before escalation to owner** — propose 90 min in business hours. Acceptable?
+2. **Thresholds** — phone-capture floor (propose 80%/outlet/shift)? Checklist grace past
+   `dueAt`? Audit cadence per template?
+3. **One manager or several?** If several are coming, we need an outlet→manager mapping
+   (`Outlet.managerId` or a join table) — the schema has none today.
+4. **Quiet hours** — operating window per outlet, or one global window?
+5. **Scorecard cadence** — weekly to manager + owner; also a short daily owner digest?
+6. **Snooze policy** — can the manager snooze, and does a snooze still surface on the scorecard?
+   (It should — a silenced alert is still a miss.)
+
+## Success Criteria (measurable)
+- Loop ships with the **phone-capture detector** live: breaches logged to `OpsAlert`, paged to
+  the manager, **auto-escalated to the owner** when unacked past SLA.
+- Every alert has a recorded **ack/resolve state and timestamp** — no breach dead-ends.
+- First **weekly scorecard** delivered to manager + owner with capture %, breach count,
+  time-to-resolve, and % escalated.
+- Over 4–6 weeks: **capture rate up, breach rate down, time-to-resolve down** for that manager.
+  The falling number — not the message stream — is the deliverable.
+
+## The Assignment (one concrete next step)
+Decide the two things only the owner can: (1) the **escalation SLA** (how long the manager has
+before it lands on your phone — propose 90 min) and (2) the **phone-capture floor** that counts
+as a breach (propose 80% per outlet per shift). Then we wire `OpsAlert` + the phone-capture
+detector + the escalation sweep + the first scorecard — the full loop on one signal. Before
+turning escalation on, run the detector in **shadow mode for one week**: log the breaches it
+*would* have paged, read them, confirm the manager would agree each is real. Watch before you
+arm it.

--- a/docs/design/ops-kpi-pulse-loop.md
+++ b/docs/design/ops-kpi-pulse-loop.md
@@ -348,6 +348,15 @@ WhatsApp templates for approval**, and **confirm the manager's + owner's WhatsAp
   OUTLET *or* STAFF report of the role. LOW severity, deduped per outlet/role/window, **never
   escalated** (lagging, not a now-fix-it incident). A role only fires if it has an active
   `AuditTemplate`. (`AUDIT.cadenceDays` / `OPS_PULSE_AUDIT_ROLES` to tune.)
+- **2026-06-24 — audit split: outlet coverage vs. staff training.** Owner clarified the two
+  audit types behave differently:
+  - **Outlet audits = 1×/week per outlet** → `detectOutletAudit` (OUTLET templates: Barista
+    Station Audit, Kitchen Quality Audit), weekly coverage.
+  - **Skill audits = # staff trained** → `detectSkillTraining` (STAFF templates: Barista
+    Skills, Kitchen Crew Skills). Cross-DB join: HR position (`hr_employee_profiles` —
+    Barista×29, Kitchen Crew×10) → staff→outlet (`User`) → completed skill `AuditReport`s.
+    Reports **trained/eligible per outlet** (currently **0/39 trained**). LOW severity, never
+    escalated — a coaching/scorecard number, not an incident.
 - **Go-live checklist (before flipping to armed).** (1) apply the `OpsAlert` migration to the
   DB; (2) get `ops_breach_digest` + `ops_escalation` templates APPROVED and set
   `OPS_PULSE_TPL_*`; (3) confirm manager + owner `User.phone`; (4) bump the cron from hourly to

--- a/docs/design/ops-kpi-pulse-loop.md
+++ b/docs/design/ops-kpi-pulse-loop.md
@@ -387,7 +387,17 @@ WhatsApp templates for approval**, and **confirm the manager's + owner's WhatsAp
   most once per week. Skill coverage is now window-based (audited within 7d, not ever) — skill =
   1/week/staff; outlet audit = 1/week (unchanged). PHONE_CAPTURE / STOCK_COUNT / MENU_SNOOZED
   stay non-escalating.
-- **Go-live checklist (before flipping to armed).** (1) apply the `OpsAlert` migration to the
+- **2026-06-24 — daily pulse (ship first) + full review text.** Added `runDailyPulse` + cron
+  `/api/cron/ops-pulse-daily` (~9am MYT): once a day, each lead gets ONE roundup of everything
+  outstanding in their lane — no ledger, no escalation, just a predictable daily cadence to build
+  the discipline. Controlled by `OPS_PULSE_DAILY_MODE`, **independent** of `OPS_PULSE_MODE`, so the
+  daily digest can go live while real-time stays in shadow — and it needs **no OpsAlert migration**.
+  Review alerts now carry the **full review text** (up to 1000 chars; was a 60-char clip).
+  - **Recommended rollout: daily first.** Set `OPS_PULSE_DAILY_MODE=armed` + approve one
+    `ops_daily_pulse` template → the team gets a daily habit-forming digest with zero migration.
+    Once that's a discipline, arm the real-time + escalation path (`OPS_PULSE_MODE=armed`,
+    needs the OpsAlert migration + the breach/escalation templates).
+- **Go-live checklist for the REAL-TIME path (before `OPS_PULSE_MODE=armed`).** (1) apply the `OpsAlert` migration to the
   DB; (2) get `ops_breach_digest` + `ops_escalation` templates APPROVED and set
   `OPS_PULSE_TPL_*`; (3) confirm manager + owner `User.phone`; (4) bump the cron from hourly to
   15-min in `vercel.json`; (5) set `OPS_PULSE_MODE=armed`. Until then it stays in shadow.

--- a/docs/design/ops-kpi-pulse-loop.md
+++ b/docs/design/ops-kpi-pulse-loop.md
@@ -380,6 +380,13 @@ WhatsApp templates for approval**, and **confirm the manager's + owner's WhatsAp
   "Chef Bo", the account name). Audits/training ARE happening (Barista Station 30, Barista Skills
   14, Kitchen+Food audits 24, Kitchen Crew Skills 6) — the earlier "0 everywhere" was the stale
   project. ⚠️ Apply the `OpsAlert` migration to the **loyalty project**, not celsius-inventory.
+- **2026-06-24 — audit + skill now escalate; skill = 1/week/staff.** Owner wants proof the work
+  is done, so `AUDIT` (outlet audits + staff skill training) joins CHECKLIST/REVIEW/RECEIVING in
+  the escalation set — unacked past SLA → owner, **tagged with the responsible lead's name** so
+  the owner sees *who* isn't getting it done. Weekly dedupe means each overdue audit escalates at
+  most once per week. Skill coverage is now window-based (audited within 7d, not ever) — skill =
+  1/week/staff; outlet audit = 1/week (unchanged). PHONE_CAPTURE / STOCK_COUNT / MENU_SNOOZED
+  stay non-escalating.
 - **Go-live checklist (before flipping to armed).** (1) apply the `OpsAlert` migration to the
   DB; (2) get `ops_breach_digest` + `ops_escalation` templates APPROVED and set
   `OPS_PULSE_TPL_*`; (3) confirm manager + owner `User.phone`; (4) bump the cron from hourly to

--- a/packages/db/prisma/migrations/20260624_ops_alert/migration.sql
+++ b/packages/db/prisma/migrations/20260624_ops_alert/migration.sql
@@ -20,7 +20,7 @@ CREATE TABLE "OpsAlert" (
     "escalatedAt" TIMESTAMP(3),
     "resolvedAt" TIMESTAMP(3),
     "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    "updatedAt" TIMESTAMP(3) NOT NULL,
+    "updatedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
     CONSTRAINT "OpsAlert_pkey" PRIMARY KEY ("id")
 );
 

--- a/packages/db/prisma/migrations/20260624_ops_alert/migration.sql
+++ b/packages/db/prisma/migrations/20260624_ops_alert/migration.sql
@@ -1,0 +1,30 @@
+-- Ops KPI Pulse alert ledger. Captured for reproducibility per
+-- docs/database-migrations.md (never auto-run; apply via Supabase SQL editor /
+-- MCP before flipping OPS_PULSE_MODE=armed). Matches model OpsAlert in
+-- packages/db/prisma/schema.prisma.
+
+CREATE TABLE "OpsAlert" (
+    "id" TEXT NOT NULL,
+    "signal" TEXT NOT NULL,
+    "outletId" TEXT NOT NULL,
+    "severity" TEXT NOT NULL,
+    "dedupeKey" TEXT NOT NULL,
+    "summary" TEXT NOT NULL,
+    "detail" JSONB NOT NULL,
+    "status" TEXT NOT NULL DEFAULT 'OPEN',
+    "assigneeUserId" TEXT,
+    "channel" TEXT,
+    "providerMessageId" TEXT,
+    "sentAt" TIMESTAMP(3),
+    "ackedAt" TIMESTAMP(3),
+    "escalatedAt" TIMESTAMP(3),
+    "resolvedAt" TIMESTAMP(3),
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+    CONSTRAINT "OpsAlert_pkey" PRIMARY KEY ("id")
+);
+
+CREATE UNIQUE INDEX "OpsAlert_dedupeKey_key" ON "OpsAlert"("dedupeKey");
+CREATE INDEX "OpsAlert_status_idx" ON "OpsAlert"("status");
+CREATE INDEX "OpsAlert_assigneeUserId_status_idx" ON "OpsAlert"("assigneeUserId", "status");
+CREATE INDEX "OpsAlert_outletId_idx" ON "OpsAlert"("outletId");

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -1379,6 +1379,37 @@ model ReviewReplyDraft {
   @@index([outletId])
 }
 
+// ─── OPS KPI PULSE ──────────────────────────────────────────
+// Alert ledger for the internal ops pulse (docs/design/ops-kpi-pulse-loop.md).
+// One row per (signal, outlet, period) breach — the spine that dedupes alerts,
+// tracks the ack/escalation lifecycle, and feeds the manager scorecard.
+// Written only in armed mode; shadow mode logs without persisting. Plain scalar
+// FKs (no Prisma relations) — append-only log, no cascade needs. Table created
+// by manual SQL migration; never `prisma db push`.
+model OpsAlert {
+  id                String    @id @default(uuid())
+  signal            String // PHONE_CAPTURE | CHECKLIST | REVIEW
+  outletId          String
+  severity          String // LOW | MED | HIGH
+  dedupeKey         String    @unique
+  summary           String
+  detail            Json
+  status            String    @default("OPEN") // OPEN | ACKED | ESCALATED | RESOLVED | EXPIRED
+  assigneeUserId    String?
+  channel           String?
+  providerMessageId String?
+  sentAt            DateTime?
+  ackedAt           DateTime?
+  escalatedAt       DateTime?
+  resolvedAt        DateTime?
+  createdAt         DateTime  @default(now())
+  updatedAt         DateTime  @updatedAt
+
+  @@index([status])
+  @@index([assigneeUserId, status])
+  @@index([outletId])
+}
+
 // ─── ADS MODULE ─────────────────────────────────────────────
 // Google Ads performance + invoice tracking.
 // MCC: 415-243-7144, child account: 890-356-3535.


### PR DESCRIPTION
## What
An ops-KPI pulse over WhatsApp: detects outlet-operations issues, routes each to the accountable person (and the on-shift team where the team does the work), built to close as a loop (ack → escalate → measure), not just notify. Design + decision log: `docs/design/ops-kpi-pulse-loop.md`.

**Everything is in shadow** (detect + log only) until explicitly armed via env — opening/merging this is safe and read-only.

## Signals (11)
- **Real-time** (every 5 min): POS-not-open, no-clock-in, bad review (full text), menu-snoozed.
- **Daily digest** (~9am, grouped Routine/Adhoc): checklist, phone-capture, outlet audit, skill-training, stock-count (also nudges the on-shift team), receiving dispute.
- **Gated off**: restock-needed (par-level) — held until stock counts are reliable (`StockBalance` is stale today).

## Delivery
- `api/cron/ops-pulse` (*/5) — real-time tier: `OpsAlert` ledger + dedup + escalation to owner.
- `api/cron/ops-pulse-daily` (daily) — one digest per recipient; no ledger, no migration needed.
- Discipline routing: ops → Ariff + Adam Kelvin, barista → Syafiq Kaberi, kitchen → Chef Bo (all resolve, all have phones); stock-take also → on-shift outlet team via the published roster.

## Safety / arming
- `OPS_PULSE_MODE` / `OPS_PULSE_DAILY_MODE` (off|shadow|armed, default **shadow** = read + log, no sends).
- `OPS_PULSE_RESTOCK_ENABLED=false` holds restock.
- New `OpsAlert` model + SQL migration `packages/db/prisma/migrations/20260624_ops_alert/` — **apply to the loyalty Supabase project before arming the real-time path.**
- Proactive sends need approved WhatsApp templates (`OPS_PULSE_TPL_*`).

## Verification
The full typecheck could **not** be run in the authoring environment (Prisma client can't generate — egress-blocked). Code is syntax-clean and hand-checked; **this PR is for CI (typecheck / lint / build) + review.** An independent correctness review is also in progress.

Known refinements (refine-as-we-go): promote checklist + receiving to real-time; wire routine-signal escalation (audit/skill on a longer SLA); build the loop-closers (verify-on-close + weekly scorecard).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_014QegYiiJdvMZXYwrmgtCCx)_