### PR TITLE
fix(inventory): show full reference photo on recipe cards

### DIFF
--- a/apps/backoffice/src/app/(admin)/inventory/menus/cards/page.tsx
+++ b/apps/backoffice/src/app/(admin)/inventory/menus/cards/page.tsx
@@ -201,11 +201,10 @@ function RecipeCard({ menu, showCosts, onSaved }: { menu: MenuItem; showCosts: b
         <img
           src={menu.imageUrl}
           alt={`${menu.name} — plating reference`}
-          className="h-36 w-full bg-[#F5F1EA] object-cover"
-          style={{ transform: `scale(${(menu.imageZoom ?? 100) / 100})`, transformOrigin: "center" }}
+          className="h-44 w-full bg-[#F5F1EA] object-contain"
         />
       ) : (
-        <div className="flex h-36 w-full flex-col items-center justify-center gap-1 bg-[#F5F1EA] text-[#160800]/25">
+        <div className="flex h-44 w-full flex-col items-center justify-center gap-1 bg-[#F5F1EA] text-[#160800]/25">
           <Coffee className="h-7 w-7" />
           <span className="text-[10px] font-medium uppercase tracking-wide print:hidden">No reference photo</span>
         </div>

--- a/packages/db/prisma/migrations/20260624_menu_plating_note/migration.sql
+++ b/packages/db/prisma/migrations/20260624_menu_plating_note/migration.sql
@@ -2,6 +2,10 @@
 -- expectation" shown on the barista build card). Additive, nullable — every
 -- existing Menu row is unchanged.
 --
--- Applied to production (celsius-inventory) via Supabase MCP apply_migration.
--- Manual SQL only — never `prisma db push`. See docs/database-migrations.md.
+-- Applied to the PRODUCTION inventory DB: the loyalty Supabase project
+-- (kqdcdhpnyuwrxqhbuyfl) — that is where Prisma's DATABASE_URL points for the
+-- Menu / inventory tables. NOTE: the similarly-named "celsius-inventory" project
+-- (akkwdrllvcpnkzgmclkk) is a stale copy and is NOT what production uses; do not
+-- target it. Applied via Supabase MCP apply_migration. Manual SQL only — never
+-- `prisma db push`. See docs/database-migrations.md.
 ALTER TABLE "Menu" ADD COLUMN IF NOT EXISTS "platingNote" TEXT;


### PR DESCRIPTION
## What

Two fixes:

1. **Reference photo was cropped** — the catalogue photo used `object-cover` plus the catalogue's `image_zoom` scale transform, which double-cropped tall drink photos into the short banner (the glass got cut off, as reported). Now uses **`object-contain`** in a **taller frame** (`h-44`) so the whole item is visible, and the zoom transform is dropped. Placeholder height bumped to match.

2. **Migration comment corrected** — the `20260624_menu_plating_note` migration note said it targeted *celsius-inventory*. Production's `Menu`/inventory tables actually live in the **loyalty** Supabase project (`kqdcdhpnyuwrxqhbuyfl`) — `celsius-inventory` (`akkwdrllvcpnkzgmclkk`) is a stale copy. Comment now points future migrations at the right DB (this was the cause of today's `platingNote` P2022 outage, already hot-fixed on the production DB).

Text/CSS + comment only — no logic or schema change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01EARY9tqLDV3yvnqngT29Bn)_