### PR TITLE
fix(reviews): scoreboard chases the geogrid rank-rival, not the biggest venue

### DIFF
--- a/apps/backoffice/src/app/api/cron/reviews-daily-snapshot/route.ts
+++ b/apps/backoffice/src/app/api/cron/reviews-daily-snapshot/route.ts
@@ -3,7 +3,7 @@ import { checkCronAuth } from "@celsius/shared";
 import { getUserFromHeaders } from "@/lib/auth";
 import { prisma } from "@/lib/prisma";
 import { fetchGoogleReviews } from "@/lib/reviews/gbp";
-import { fetchTopCompetitor } from "@/lib/reviews/competitors";
+import { fetchCompetitorByName, fetchNextAheadCompetitor } from "@/lib/reviews/competitors";
 import { buildScoreboard } from "@/lib/reviews/scoreboard";
 import { sendMessage } from "@/lib/telegram";
 
@@ -48,9 +48,22 @@ export async function GET(req: NextRequest) {
       const reviews7d = data.reviews.filter((r) => new Date(r.createdAt).getTime() >= now - 7 * DAY).length;
       const reviews30d = data.reviews.filter((r) => new Date(r.createdAt).getTime() >= now - 30 * DAY).length;
 
+      // Chase target: the geogrid's actual rank-rival (whoever out-ranks us in
+      // the local pack), falling back to the nearest cafe just ahead of us in
+      // review count. Avoids pointing at giant unrelated venues.
       let comp = null;
       if (apiKey && outlet.lat != null && outlet.lng != null) {
-        comp = await fetchTopCompetitor(apiKey, Number(outlet.lat), Number(outlet.lng), s.gbpPlaceId ?? null);
+        const lat = Number(outlet.lat);
+        const lng = Number(outlet.lng);
+        const scan = await prisma.geoGridScan.findFirst({
+          where: { outletId: outlet.id },
+          orderBy: { createdAt: "desc" },
+          select: { competitors: true },
+        });
+        const rivals = (scan?.competitors as { name?: string }[] | null) ?? [];
+        const rivalName = rivals.find((r) => r.name && !/celsius/i.test(r.name))?.name;
+        if (rivalName) comp = await fetchCompetitorByName(apiKey, rivalName, lat, lng);
+        if (!comp) comp = await fetchNextAheadCompetitor(apiKey, lat, lng, data.totalReviewCount, s.gbpPlaceId ?? null);
       }
 
       const payload = {

--- a/apps/backoffice/src/lib/reviews/competitors.ts
+++ b/apps/backoffice/src/lib/reviews/competitors.ts
@@ -1,31 +1,32 @@
 /**
- * Top nearby competitor by review prominence, for the daily rank scoreboard.
+ * The competitor an outlet "chases" for the daily rank scoreboard.
  *
- * Local rank is mostly proximity (fixed) + prominence (reviews). The outlet
- * "chases" the most-reviewed nearby cafe: out-review them and the geogrid
- * rings extend. This pulls that competitor's live review count via the Places
- * API (the same key the geogrid uses). searchText alone omits review counts,
- * so we add userRatingCount + rating to the field mask.
+ * Local rank is mostly proximity (fixed) + prominence (reviews), so the right
+ * chase target is whoever actually OUT-RANKS us in the local pack, not just the
+ * biggest venue nearby. Primary source is the geogrid's rank-rival (the place
+ * that beats us across the grid). Fallback, when there's no geogrid signal, is
+ * the nearest cafe just ahead of us in review count (a realistic next overtake)
+ * rather than the absolute leader.
+ *
+ * Review counts come from the Places API (same key as the geogrid). searchText
+ * omits review counts by default, so we add userRatingCount + rating to the
+ * field mask.
  */
 
-export type TopCompetitor = {
+export type CompetitorRef = {
   name: string;
   placeId: string;
   reviews: number;
   rating: number | null;
 };
 
-/**
- * The single most-reviewed cafe within `radiusM` of (lat,lng) that is NOT us.
- * Returns null on API failure or if nothing usable comes back.
- */
-export async function fetchTopCompetitor(
+async function searchCafes(
   apiKey: string,
+  textQuery: string,
   lat: number,
   lng: number,
-  ourPlaceId: string | null,
-  radiusM = 2500,
-): Promise<TopCompetitor | null> {
+  radiusM: number,
+): Promise<CompetitorRef[]> {
   let res: Response;
   try {
     res = await fetch("https://places.googleapis.com/v1/places:searchText", {
@@ -36,33 +37,63 @@ export async function fetchTopCompetitor(
         "X-Goog-FieldMask": "places.id,places.displayName,places.userRatingCount,places.rating",
       },
       body: JSON.stringify({
-        textQuery: "cafe",
+        textQuery,
         locationBias: { circle: { center: { latitude: lat, longitude: lng }, radius: radiusM } },
         maxResultCount: 20,
       }),
     });
   } catch {
-    return null;
+    return [];
   }
-  if (!res.ok) return null;
+  if (!res.ok) return [];
   const data = await res.json();
-  const places = (data.places ?? []) as {
+  return ((data.places ?? []) as {
     id?: string;
     displayName?: { text?: string };
     userRatingCount?: number;
     rating?: number;
-  }[];
-
-  const ranked = places
+  }[])
     .map((p) => ({
       name: p.displayName?.text ?? "",
       placeId: p.id ?? "",
       reviews: p.userRatingCount ?? 0,
       rating: typeof p.rating === "number" ? p.rating : null,
     }))
-    // exclude us: by place id, and by name so our other outlets never count
-    .filter((c) => c.placeId && c.placeId !== ourPlaceId && !/celsius/i.test(c.name))
-    .sort((a, b) => b.reviews - a.reviews);
+    .filter((c) => c.placeId && c.name);
+}
 
-  return ranked[0] ?? null;
+/** Look up a SPECIFIC named competitor's review count (the geogrid rank-rival). */
+export async function fetchCompetitorByName(
+  apiKey: string,
+  name: string,
+  lat: number,
+  lng: number,
+  radiusM = 4000,
+): Promise<CompetitorRef | null> {
+  const results = await searchCafes(apiKey, name, lat, lng, radiusM);
+  if (!results.length) return null;
+  const key = name.toLowerCase().slice(0, 14);
+  return results.find((r) => r.name.toLowerCase().includes(key)) ?? results[0];
+}
+
+/**
+ * Fallback chase target: the nearby cafe with the smallest review lead over us
+ * (the next realistic overtake). If we already lead everyone nearby, returns the
+ * strongest nearby cafe as a reference so the row still has a competitor.
+ */
+export async function fetchNextAheadCompetitor(
+  apiKey: string,
+  lat: number,
+  lng: number,
+  ourReviews: number,
+  ourPlaceId: string | null,
+  radiusM = 2500,
+): Promise<CompetitorRef | null> {
+  const cafes = (await searchCafes(apiKey, "cafe", lat, lng, radiusM)).filter(
+    (c) => c.placeId !== ourPlaceId && !/celsius/i.test(c.name),
+  );
+  if (!cafes.length) return null;
+  const ahead = cafes.filter((c) => c.reviews > ourReviews).sort((a, b) => a.reviews - b.reviews);
+  if (ahead.length) return ahead[0];
+  return [...cafes].sort((a, b) => b.reviews - a.reviews)[0] ?? null;
 }


### PR DESCRIPTION
The scoreboard pointed each outlet at the single most-reviewed nearby place, which surfaced giant unrelated venues (Nilai was "chasing" Gastrohub at 5,304 reviews, an absurd 57/day target).

Now the chase target is the **geogrid's actual rank-rival** (whoever out-ranks us across the grid: Putrajaya → INaRA, Tamarind → Duer/BINGS), with a fallback to the **nearest cafe just ahead of us** in review count when there's no geogrid signal. Both are comparable cafes, so the gap and reviews/day target are realistic and KPI-aligned.

tsc + eslint clean.