### PR TITLE
feat(inventory): hero photo on recipe cards (revert side-by-side)

### DIFF
--- a/apps/backoffice/src/app/(admin)/inventory/menus/cards/page.tsx
+++ b/apps/backoffice/src/app/(admin)/inventory/menus/cards/page.tsx
@@ -168,7 +168,7 @@ function fitPhoto(url: string, ar: string): string {
   const marker = "/image/upload/";
   const at = url.indexOf(marker);
   if (at === -1) return url;
-  const tx = `c_fill,ar_${ar},w_480,q_auto,f_auto`;
+  const tx = `c_fill,ar_${ar},w_640,q_auto,f_auto`;
   return `${url.slice(0, at + marker.length)}${tx}/${url.slice(at + marker.length)}`;
 }
 
@@ -205,27 +205,22 @@ function RecipeCard({ menu, showCosts, onSaved }: { menu: MenuItem; showCosts: b
   };
 
   return (
-    <div className="recipe-card flex break-inside-avoid overflow-hidden rounded-2xl border border-gray-200 bg-white shadow-sm">
-      {/* Left: full-height reference photo (plating expectation) from the
-          customer catalogue by name; graceful placeholder when there's no match. */}
-      <div className="relative w-28 shrink-0 self-stretch bg-[#F5F1EA] sm:w-36">
-        {menu.imageUrl ? (
-          // eslint-disable-next-line @next/next/no-img-element
-          <img
-            src={fitPhoto(menu.imageUrl, "3:4")}
-            alt={`${menu.name} — plating reference`}
-            className="absolute inset-0 h-full w-full object-cover"
-          />
-        ) : (
-          <div className="absolute inset-0 flex flex-col items-center justify-center gap-1 text-[#160800]/25">
-            <Coffee className="h-6 w-6" />
-            <span className="px-1 text-center text-[9px] font-medium uppercase tracking-wide print:hidden">No photo</span>
-          </div>
-        )}
-      </div>
-
-      {/* Right column: name, recipe, packaging, plating, cost */}
-      <div className="flex min-w-0 flex-1 flex-col">
+    <div className="recipe-card flex break-inside-avoid flex-col overflow-hidden rounded-2xl border border-gray-200 bg-white shadow-sm">
+      {/* Hero reference photo (plating expectation) — pulled from the customer
+          catalogue by name; graceful placeholder when there's no match. */}
+      {menu.imageUrl ? (
+        // eslint-disable-next-line @next/next/no-img-element
+        <img
+          src={fitPhoto(menu.imageUrl, "4:3")}
+          alt={`${menu.name} — plating reference`}
+          className="aspect-[4/3] w-full bg-[#F5F1EA] object-cover"
+        />
+      ) : (
+        <div className="flex aspect-[4/3] w-full flex-col items-center justify-center gap-1 bg-[#F5F1EA] text-[#160800]/25">
+          <Coffee className="h-7 w-7" />
+          <span className="text-[10px] font-medium uppercase tracking-wide print:hidden">No reference photo</span>
+        </div>
+      )}
 
       {/* Header band — espresso fill, cream text */}
       <div className="rc-head flex items-start justify-between gap-3 bg-[#160800] px-4 py-3 text-[#F5F1EA]">
@@ -246,14 +241,14 @@ function RecipeCard({ menu, showCosts, onSaved }: { menu: MenuItem; showCosts: b
         {empty ? (
           <p className="py-3 text-center text-gray-400">No recipe yet</p>
         ) : hasTempSplit ? (
-          <div className="space-y-2">
+          <div className="grid grid-cols-2 gap-x-4 divide-x divide-gray-100">
             <BuildColumn
               title="Hot recipe"
               accent="text-orange-600"
               icon={<Flame className="h-3 w-3" />}
               steps={hotSteps}
             />
-            <div className="border-t border-gray-100 pt-2">
+            <div className="pl-4">
               <BuildColumn
                 title="Iced recipe"
                 accent="text-sky-600"
@@ -348,7 +343,6 @@ function RecipeCard({ menu, showCosts, onSaved }: { menu: MenuItem; showCosts: b
           )}
         </div>
       )}
-      </div>
     </div>
   );
 }


### PR DESCRIPTION
## What

Switches the recipe-card reference photo back to a **full-width hero on top** of each card, instead of the side-by-side column shipped in #512.

- Restores the **4:3 edge-to-edge hero** image (Cloudinary `c_fill` crop, `object-cover`).
- Restores the **2-up Hot/Iced build grid** (reads better at full card width than the stacked column).
- Placeholder unchanged when a menu item has no catalogue photo match.

## Why

Owner preference after seeing both layouts live — the hero reads cleaner for the print-and-pin recipe cards.

## Scope

One file, layout-only: `apps/backoffice/src/app/(admin)/inventory/menus/cards/page.tsx` (19 insertions / 25 deletions). No data, API, or schema changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01EARY9tqLDV3yvnqngT29Bn)_