### PR TITLE
geogrid: per-point competitor breakdown + outer-ring rivals callout

### DIFF
--- a/apps/backoffice/src/app/(admin)/reviews/geogrid/page.tsx
+++ b/apps/backoffice/src/app/(admin)/reviews/geogrid/page.tsx
@@ -4,7 +4,8 @@ import { useEffect, useState, useCallback } from "react";
 import Link from "next/link";
 import { Loader2, MapPin, Play, ArrowLeft, TrendingUp } from "lucide-react";
 
-type GridPoint = { row: number; col: number; lat: number; lng: number; rank: number | null };
+type PointResult = { name: string; placeId: string; isUs: boolean };
+type GridPoint = { row: number; col: number; lat: number; lng: number; rank: number | null; results?: PointResult[] };
 type Scan = {
   id: string;
   keyword: string;
@@ -91,6 +92,7 @@ export default function GeogridPage() {
   const [radiusKm, setRadiusKm] = useState(2);
   const [scans, setScans] = useState<Scan[]>([]);
   const [active, setActive] = useState<Scan | null>(null);
+  const [selectedPoint, setSelectedPoint] = useState<GridPoint | null>(null);
   const [running, setRunning] = useState(false);
   const [keyConfigured, setKeyConfigured] = useState(true);
   const [error, setError] = useState("");
@@ -118,6 +120,11 @@ export default function GeogridPage() {
   useEffect(() => {
     loadHistory(outletId);
   }, [outletId, loadHistory]);
+
+  // Clear the per-point detail whenever the displayed scan changes.
+  useEffect(() => {
+    setSelectedPoint(null);
+  }, [active?.id]);
 
   const run = async () => {
     setError("");
@@ -259,16 +266,63 @@ export default function GeogridPage() {
             <div className="grid gap-1.5" style={{ gridTemplateColumns: `repeat(${active.gridSize}, minmax(0, 1fr))`, maxWidth: 520 }}>
               {grid.flat().map((p) => {
                 const c = rankColor(p.rank);
+                const hasDetail = !!(p.results && p.results.length);
+                const isSelected = selectedPoint?.row === p.row && selectedPoint?.col === p.col;
                 return (
-                  <div key={`${p.row}-${p.col}`} className="flex aspect-square items-center justify-center rounded-full text-xs font-bold" style={{ backgroundColor: c.bg, color: c.fg }} title={`rank ${p.rank ?? ">20"}`}>
+                  <button
+                    key={`${p.row}-${p.col}`}
+                    type="button"
+                    onClick={() => setSelectedPoint(isSelected ? null : p)}
+                    disabled={!hasDetail}
+                    className={`flex aspect-square items-center justify-center rounded-full text-xs font-bold transition ${hasDetail ? "cursor-pointer hover:opacity-90" : "cursor-default"} ${isSelected ? "ring-2 ring-brand-dark ring-offset-2" : ""}`}
+                    style={{ backgroundColor: c.bg, color: c.fg }}
+                    title={hasDetail ? `rank ${p.rank ?? ">20"} — click for competitors here` : `rank ${p.rank ?? ">20"}`}
+                  >
                     {c.label}
-                  </div>
+                  </button>
                 );
               })}
             </div>
             <p className="mt-2 text-[11px] text-muted-foreground">
               Center = your storefront. Rank approximated from the Places API (proxy for the Maps local pack) — use it for trend, not exact position.
+              {grid.flat().some((p) => p.results?.length) && " Click any point to see who ranks there."}
             </p>
+
+            {/* Per-point detail — who ranks at the clicked grid cell */}
+            {selectedPoint && (
+              <div className="mt-4 rounded-xl border border-border bg-muted/30 p-4">
+                <div className="mb-2 flex items-center justify-between">
+                  <div className="text-sm font-medium text-foreground">
+                    Ranking at this point
+                    <span className="ml-2 text-xs font-normal text-muted-foreground">
+                      ~{(distM(active.centerLat, active.centerLng, selectedPoint.lat, selectedPoint.lng) / 1000).toFixed(2)} km from storefront
+                      {selectedPoint.rank != null ? ` · you rank #${selectedPoint.rank}` : " · you’re not in the top 20"}
+                    </span>
+                  </div>
+                  <button onClick={() => setSelectedPoint(null)} className="text-xs text-muted-foreground hover:text-foreground">
+                    Close
+                  </button>
+                </div>
+                {selectedPoint.results && selectedPoint.results.length > 0 ? (
+                  <ol className="space-y-1">
+                    {selectedPoint.results.map((r, i) => (
+                      <li
+                        key={r.placeId || `${r.name}-${i}`}
+                        className={`flex items-center gap-2 rounded-lg px-2 py-1.5 text-sm ${r.isUs ? "bg-brand-dark/10 font-semibold text-foreground" : "text-muted-foreground"}`}
+                      >
+                        <span className="inline-flex h-5 w-5 flex-shrink-0 items-center justify-center rounded-full bg-white text-[11px] font-bold text-foreground ring-1 ring-border">
+                          {i + 1}
+                        </span>
+                        <span className="truncate">{r.name || "Unknown"}</span>
+                        {r.isUs && <span className="ml-auto rounded bg-brand-dark px-1.5 py-0.5 text-[10px] font-medium text-white">You</span>}
+                      </li>
+                    ))}
+                  </ol>
+                ) : (
+                  <p className="text-xs text-muted-foreground">No competitor list recorded for this point. Re-run the scan to capture it.</p>
+                )}
+              </div>
+            )}
           </div>
 
           {/* Competitors — who out-ranks us, for reference */}

--- a/apps/backoffice/src/app/(admin)/reviews/geogrid/page.tsx
+++ b/apps/backoffice/src/app/(admin)/reviews/geogrid/page.tsx
@@ -74,6 +74,38 @@ function evalKpi(
   return { measurable: true, pct: Math.round((met / inRing.length) * 100), n: inRing.length };
 }
 
+// Who out-ranks us in the OUTER ring of the scan (the far points where proximity
+// favours rivals). "Far" = points at ≥50% of the scanned reach, so it adapts to
+// any scan size. A rival "beats us" at a point when it ranks above our position
+// there (or we're absent). Returns the worst offenders + the km threshold used.
+function outerRingRivals(
+  scan: Scan,
+): { thresholdKm: number; farPoints: number; rivals: { name: string; beats: number; bestRank: number }[] } {
+  const withData = scan.points.filter((p) => p.results && p.results.length);
+  const dists = withData.map((p) => distM(scan.centerLat, scan.centerLng, p.lat, p.lng));
+  const maxDist = dists.length ? Math.max(...dists) : 0;
+  const threshold = maxDist * 0.5;
+  const tally = new Map<string, { name: string; beats: number; bestRank: number }>();
+  let farPoints = 0;
+  withData.forEach((p, i) => {
+    if (dists[i] < threshold) return;
+    farPoints++;
+    (p.results ?? []).forEach((r, idx) => {
+      const theirRank = idx + 1;
+      if (r.isUs || !r.name) return;
+      const beatsUs = p.rank == null || theirRank < p.rank;
+      if (!beatsUs) return;
+      const key = r.placeId || r.name.toLowerCase();
+      const t = tally.get(key) ?? { name: r.name, beats: 0, bestRank: theirRank };
+      t.beats++;
+      t.bestRank = Math.min(t.bestRank, theirRank);
+      tally.set(key, t);
+    });
+  });
+  const rivals = [...tally.values()].sort((a, b) => b.beats - a.beats || a.bestRank - b.bestRank).slice(0, 5);
+  return { thresholdKm: threshold / 1000, farPoints, rivals };
+}
+
 function Stat({ label, value, sub }: { label: string; value: string; sub?: string }) {
   return (
     <div className="rounded-xl border border-border bg-white p-4">
@@ -324,6 +356,35 @@ export default function GeogridPage() {
               </div>
             )}
           </div>
+
+          {/* Outer-ring callout — who beats us at distance, where proximity favours rivals */}
+          {(() => {
+            const ring = outerRingRivals(active);
+            if (ring.farPoints === 0 || ring.rivals.length === 0) return null;
+            return (
+              <div className="mt-5 rounded-xl border border-amber-200 bg-amber-50 p-4">
+                <div className="text-sm font-medium text-amber-900">
+                  Who out-ranks you at distance (≥{ring.thresholdKm.toFixed(1)} km)
+                </div>
+                <p className="mt-0.5 text-[11px] text-amber-800">
+                  Across the {ring.farPoints} outer-ring point{ring.farPoints === 1 ? "" : "s"}, these rivals rank above you most often. Out here Google leans on proximity — you climb past them with prominence (more reviews, faster).
+                </p>
+                <ul className="mt-2 space-y-1">
+                  {ring.rivals.map((r, i) => (
+                    <li key={i} className="flex items-center gap-2 text-sm text-amber-900">
+                      <span className="inline-flex h-5 w-5 flex-shrink-0 items-center justify-center rounded-full bg-white text-[11px] font-bold text-amber-900 ring-1 ring-amber-200">
+                        {i + 1}
+                      </span>
+                      <span className="truncate">{r.name}</span>
+                      <span className="ml-auto whitespace-nowrap text-xs text-amber-800">
+                        beats you at {r.beats} pt{r.beats === 1 ? "" : "s"} · best #{r.bestRank}
+                      </span>
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            );
+          })()}
 
           {/* Competitors — who out-ranks us, for reference */}
           {active.competitors && active.competitors.length > 0 && (

--- a/apps/backoffice/src/lib/geogrid/places.ts
+++ b/apps/backoffice/src/lib/geogrid/places.ts
@@ -13,7 +13,19 @@
 
 const MILES_PER_DEG_LAT = 69.0;
 
-export type GridPoint = { row: number; col: number; lat: number; lng: number; rank: number | null };
+export type PointResult = { name: string; placeId: string; isUs: boolean };
+
+// `results` = the ranked businesses returned at this point (index 0 = local #1),
+// kept so the UI can show "who out-ranks us here" per grid cell. Optional for
+// back-compat with scans recorded before per-point results were stored.
+export type GridPoint = {
+  row: number;
+  col: number;
+  lat: number;
+  lng: number;
+  rank: number | null;
+  results?: PointResult[];
+};
 
 /** N×N points centred on (lat,lng), spaced `rangeMiles` apart. Row 0 = north. */
 export function buildGrid(centerLat: number, centerLng: number, gridSize: number, rangeMiles: number): GridPoint[] {
@@ -45,7 +57,6 @@ export function distanceMeters(lat1: number, lng1: number, lat2: number, lng2: n
   return 2 * R * Math.asin(Math.sqrt(a));
 }
 
-export type PointResult = { name: string; placeId: string; isUs: boolean };
 export type Competitor = { name: string; top3Points: number; avgRank: number };
 
 /** Our rank + the ranked businesses (for the competitor reference) at one point. */
@@ -124,6 +135,7 @@ export async function scanGrid(
         try {
           const { rank, results } = await rankAtPoint(apiKey, keyword, p.lat, p.lng, radiusM, targetPlaceId, targetTitle);
           p.rank = rank;
+          p.results = results;
           results.forEach((r, i2) => {
             if (r.isUs || !r.name) return;
             const key = r.placeId || r.name.toLowerCase();


### PR DESCRIPTION
## What

Makes the local-rank geogrid drill-downable so you can see **who ranks at each point**, not just your own rank.

### Per-point competitor breakdown (click any cell)
- Each grid point now persists the ranked businesses returned there (index 0 = local #1). These were already computed in `rankAtPoint` but discarded after the global tally — now stored on the `GridPoint` (no DB migration; `points` is already `jsonb`).
- Clicking a cell opens a panel with the distance from the storefront, your rank there, and the full ordered list with **you** highlighted.
- Old scans without per-point data stay non-clickable and show a "re-run to capture" note.

### Outer-ring rivals callout
- Surfaces who out-ranks you at the **far points** (≥50% of the scan's actual reach), where Google's proximity bias favours closer competitors.
- Tallies how many outer points each rival beats you at and their best rank there.
- Renders only when the scan has outer-ring data.

## Files
- `apps/backoffice/src/lib/geogrid/places.ts` — store `results` per `GridPoint`.
- `apps/backoffice/src/app/(admin)/reviews/geogrid/page.tsx` — clickable cells, per-point panel, outer-ring callout.

Typecheck + lint pass on both files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01XEP8S5VfwGKww4BGNB7Xk3)_