### PR TITLE
feat(ops-pulse): go live — arm the daily pulse by default

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -54,9 +54,10 @@ WHATSAPP_VERIFY_TOKEN=""           # random string you choose; echoed back durin
 # applied, and (2) the templates below are APPROVED in WhatsApp Manager.
 OPS_PULSE_MODE="shadow"
 # Daily pulse (once-a-day digest per lead — the habit-builder, shipped first).
-# Independent of OPS_PULSE_MODE: set this to "armed" to start the daily digest
-# while the real-time path stays in shadow. off | shadow | armed; unset => shadow.
-OPS_PULSE_DAILY_MODE="shadow"
+# Independent of OPS_PULSE_MODE. off | shadow | armed. GONE LIVE 2026-06-25:
+# defaults to "armed" in production (no ledger — re-evaluates fresh daily, so a
+# missed send just retries tomorrow). Set "shadow" to log-only, "off" to disable.
+OPS_PULSE_DAILY_MODE="armed"
 # Signals the fast real-time pulse alerts on (every ~5 min); the rest only appear
 # in the daily digest. Comma-separated. Default: Google reviews + menu snoozed.
 OPS_PULSE_REALTIME_SIGNALS="REVIEW,MENU_SNOOZED,NO_CLOCK_IN,POS_NOT_OPEN,CHECKLIST,RECEIVING"

--- a/apps/backoffice/src/lib/ops-pulse/config.ts
+++ b/apps/backoffice/src/lib/ops-pulse/config.ts
@@ -17,10 +17,16 @@ export function pulseMode(): PulseMode {
 
 // Controls the DAILY pulse — a once-a-day digest per recipient, the habit-builder
 // shipped first. Independent of OPS_PULSE_MODE so the daily digest can go live
-// while the real-time path stays in shadow. off | shadow | armed; unset ⇒ shadow.
+// while the real-time path stays in shadow. off | shadow | armed.
+//
+// GO-LIVE 2026-06-25 (owner authorized): defaults to "armed" so the daily digest
+// sends in production without further config. Safe to arm first because — unlike
+// the real-time tier — it has NO ledger: it re-evaluates the full current state
+// each day, so a missed/failed send is simply retried tomorrow (nothing is
+// "burned"). Override anytime: OPS_PULSE_DAILY_MODE=shadow (log-only) or off.
 export function dailyMode(): PulseMode {
-  const m = (process.env.OPS_PULSE_DAILY_MODE || "shadow").trim().toLowerCase();
-  return m === "off" || m === "armed" ? m : "shadow";
+  const m = (process.env.OPS_PULSE_DAILY_MODE || "armed").trim().toLowerCase();
+  return m === "off" || m === "shadow" ? m : "armed";
 }
 
 // Signals that fire on the FAST real-time pulse (every ~5 min). Everything else

--- a/docs/design/ops-kpi-pulse-loop.md
+++ b/docs/design/ops-kpi-pulse-loop.md
@@ -425,3 +425,13 @@ WhatsApp templates for approval**, and **confirm the manager's + owner's WhatsAp
   DB; (2) get `ops_breach_digest` + `ops_escalation` templates APPROVED and set
   `OPS_PULSE_TPL_*`; (3) confirm manager + owner `User.phone`; (4) bump the cron from hourly to
   15-min in `vercel.json`; (5) set `OPS_PULSE_MODE=armed`. Until then it stays in shadow.
+- **2026-06-25 — DAILY pulse GONE LIVE.** Owner authorized firing it. Flipped `dailyMode()` default
+  `shadow → armed` (the go-live commit; `OPS_PULSE_DAILY_MODE` still overrides). Armed the daily
+  tier first because it has no ledger — it re-sends the full current state each day, so a failed
+  send just retries tomorrow (nothing burned). **Real-time tier deliberately held in shadow**
+  (`pulseMode()` default unchanged): armed real-time `markSent`s each breach once, so arming it
+  before WhatsApp delivery is proven would silently consume the first real breaches. Delivery is
+  still gated on WhatsApp's rule — the daily digest sends free-form (no `OPS_PULSE_TPL_DAILY` set),
+  which Meta only delivers inside each recipient's open 24h window, so the leads must message the
+  bot once (or the templates must be approved) for it to actually land. Flip real-time to armed
+  once a window/template is confirmed.


### PR DESCRIPTION
## What
Owner authorized **firing the ops pulse**. This flips the **daily** pulse on in production by defaulting `dailyMode()` to `armed` (was `shadow`). `OPS_PULSE_DAILY_MODE` still overrides, so `shadow`/`off` remain available.

## Why daily first, real-time held
- **Daily is armed.** It has **no ledger** — `runDailyPulse` re-evaluates the full current state each day and only messages recipients who have open items. A failed/missed send just retries tomorrow; nothing is "burned."
- **Real-time stays in shadow** (`pulseMode()` default unchanged). The real-time tier `markSent`s each breach exactly once, so arming it before WhatsApp delivery is proven would silently consume the first real breaches. It gets flipped (`OPS_PULSE_MODE=armed`) once a delivery window/template is confirmed.

## Delivery note (still on the WhatsApp side)
The daily digest sends **free-form** (no `OPS_PULSE_TPL_DAILY` set), which Meta only delivers inside each recipient's **open 24h window**. So for tonight's 09:00 MYT digest to land, the leads (Ariff, Adam, Syafiq, Chef Bo) each need to message the bot once — or the Utility templates need to be approved. If neither is true yet, the send fails harmlessly (logged) and retries the next day.

## Files
- `apps/backoffice/src/lib/ops-pulse/config.ts` — `dailyMode()` default `shadow → armed`.
- `.env.example` — document the new default.
- `docs/design/ops-kpi-pulse-loop.md` — go-live build-log entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_014QegYiiJdvMZXYwrmgtCCx)_