### PR TITLE
geogrid: clickable points on any scan, keyword filter, "how to beat them" actions

### DIFF
--- a/apps/backoffice/src/app/(admin)/reviews/geogrid/page.tsx
+++ b/apps/backoffice/src/app/(admin)/reviews/geogrid/page.tsx
@@ -13,6 +13,7 @@ type Scan = {
   rangeMiles: number;
   centerLat: number;
   centerLng: number;
+  placeId?: string | null;
   status: string;
   points: GridPoint[];
   avgRank: number | null;
@@ -123,11 +124,19 @@ export default function GeogridPage() {
   const [gridSize, setGridSize] = useState(9);
   const [radiusKm, setRadiusKm] = useState(2);
   const [scans, setScans] = useState<Scan[]>([]);
+  const [filterKeyword, setFilterKeyword] = useState(""); // "" = all keywords
   const [active, setActive] = useState<Scan | null>(null);
   const [selectedPoint, setSelectedPoint] = useState<GridPoint | null>(null);
+  const [liveResults, setLiveResults] = useState<Record<string, PointResult[]>>({});
+  const [pointLoading, setPointLoading] = useState(false);
+  const [pointError, setPointError] = useState("");
   const [running, setRunning] = useState(false);
   const [keyConfigured, setKeyConfigured] = useState(true);
   const [error, setError] = useState("");
+
+  // Scans for the chosen keyword (or all), and the distinct keywords for the filter.
+  const keywordOptions = [...new Set(scans.map((s) => s.keyword))];
+  const visibleScans = filterKeyword ? scans.filter((s) => s.keyword === filterKeyword) : scans;
 
   useEffect(() => {
     fetch("/api/settings/outlets")
@@ -156,7 +165,51 @@ export default function GeogridPage() {
   // Clear the per-point detail whenever the displayed scan changes.
   useEffect(() => {
     setSelectedPoint(null);
+    setLiveResults({});
+    setPointError("");
   }, [active?.id]);
+
+  // When the keyword filter changes, jump to the newest scan that matches it.
+  useEffect(() => {
+    const list = filterKeyword ? scans.filter((s) => s.keyword === filterKeyword) : scans;
+    setActive(list[0] ?? null);
+  }, [filterKeyword, scans]);
+
+  // Click a grid point → show who ranks there. Newer scans have the list stored;
+  // for older scans (and unranked points) we look it up live from the Places API.
+  const selectPoint = async (p: GridPoint) => {
+    if (!active) return;
+    if (selectedPoint?.row === p.row && selectedPoint?.col === p.col) {
+      setSelectedPoint(null);
+      return;
+    }
+    setSelectedPoint(p);
+    setPointError("");
+    const key = `${p.row}-${p.col}`;
+    if ((p.results && p.results.length) || liveResults[key]) return; // already have it
+    setPointLoading(true);
+    try {
+      const res = await fetch("/api/geogrid/point", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          outletId,
+          keyword: active.keyword,
+          lat: p.lat,
+          lng: p.lng,
+          rangeMiles: active.rangeMiles,
+          placeId: active.placeId ?? null,
+        }),
+      });
+      const d = await res.json();
+      if (res.ok) setLiveResults((prev) => ({ ...prev, [key]: d.results ?? [] }));
+      else setPointError(d.error || "Lookup failed");
+    } catch {
+      setPointError("Network error");
+    } finally {
+      setPointLoading(false);
+    }
+  };
 
   const run = async () => {
     setError("");
@@ -244,6 +297,25 @@ export default function GeogridPage() {
       </div>
       {error && <p className="mt-2 text-sm text-red-600">{error}</p>}
 
+      {/* Keyword filter — narrow the grid + trend to one tracked keyword */}
+      {keywordOptions.length > 1 && (
+        <div className="mt-4 flex items-center gap-2">
+          <label className="text-xs font-medium text-muted-foreground">Show keyword</label>
+          <select
+            value={filterKeyword}
+            onChange={(e) => setFilterKeyword(e.target.value)}
+            className="rounded-lg border border-border bg-white px-3 py-1.5 text-sm"
+          >
+            <option value="">All keywords ({scans.length})</option>
+            {keywordOptions.map((k) => (
+              <option key={k} value={k}>
+                {k} ({scans.filter((s) => s.keyword === k).length})
+              </option>
+            ))}
+          </select>
+        </div>
+      )}
+
       {active ? (
         <>
           {/* KPI vs target — #1@1km · Top-2@5km · Top-3@10km */}
@@ -298,17 +370,15 @@ export default function GeogridPage() {
             <div className="grid gap-1.5" style={{ gridTemplateColumns: `repeat(${active.gridSize}, minmax(0, 1fr))`, maxWidth: 520 }}>
               {grid.flat().map((p) => {
                 const c = rankColor(p.rank);
-                const hasDetail = !!(p.results && p.results.length);
                 const isSelected = selectedPoint?.row === p.row && selectedPoint?.col === p.col;
                 return (
                   <button
                     key={`${p.row}-${p.col}`}
                     type="button"
-                    onClick={() => setSelectedPoint(isSelected ? null : p)}
-                    disabled={!hasDetail}
-                    className={`flex aspect-square items-center justify-center rounded-full text-xs font-bold transition ${hasDetail ? "cursor-pointer hover:opacity-90" : "cursor-default"} ${isSelected ? "ring-2 ring-brand-dark ring-offset-2" : ""}`}
+                    onClick={() => selectPoint(p)}
+                    className={`flex aspect-square cursor-pointer items-center justify-center rounded-full text-xs font-bold transition hover:opacity-90 ${isSelected ? "ring-2 ring-brand-dark ring-offset-2" : ""}`}
                     style={{ backgroundColor: c.bg, color: c.fg }}
-                    title={hasDetail ? `rank ${p.rank ?? ">20"} — click for competitors here` : `rank ${p.rank ?? ">20"}`}
+                    title={`rank ${p.rank ?? ">20"} — click for competitors here`}
                   >
                     {c.label}
                   </button>
@@ -316,8 +386,7 @@ export default function GeogridPage() {
               })}
             </div>
             <p className="mt-2 text-[11px] text-muted-foreground">
-              Center = your storefront. Rank approximated from the Places API (proxy for the Maps local pack) — use it for trend, not exact position.
-              {grid.flat().some((p) => p.results?.length) && " Click any point to see who ranks there."}
+              Center = your storefront. Rank approximated from the Places API (proxy for the Maps local pack) — use it for trend, not exact position. Click any point to see who ranks there.
             </p>
 
             {/* Per-point detail — who ranks at the clicked grid cell */}
@@ -335,24 +404,40 @@ export default function GeogridPage() {
                     Close
                   </button>
                 </div>
-                {selectedPoint.results && selectedPoint.results.length > 0 ? (
-                  <ol className="space-y-1">
-                    {selectedPoint.results.map((r, i) => (
-                      <li
-                        key={r.placeId || `${r.name}-${i}`}
-                        className={`flex items-center gap-2 rounded-lg px-2 py-1.5 text-sm ${r.isUs ? "bg-brand-dark/10 font-semibold text-foreground" : "text-muted-foreground"}`}
-                      >
-                        <span className="inline-flex h-5 w-5 flex-shrink-0 items-center justify-center rounded-full bg-white text-[11px] font-bold text-foreground ring-1 ring-border">
-                          {i + 1}
-                        </span>
-                        <span className="truncate">{r.name || "Unknown"}</span>
-                        {r.isUs && <span className="ml-auto rounded bg-brand-dark px-1.5 py-0.5 text-[10px] font-medium text-white">You</span>}
-                      </li>
-                    ))}
-                  </ol>
-                ) : (
-                  <p className="text-xs text-muted-foreground">No competitor list recorded for this point. Re-run the scan to capture it.</p>
-                )}
+                {(() => {
+                  const stored = selectedPoint.results;
+                  const live = liveResults[`${selectedPoint.row}-${selectedPoint.col}`];
+                  const rows = stored && stored.length ? stored : live;
+                  if (pointLoading && !rows) {
+                    return (
+                      <p className="flex items-center gap-2 text-xs text-muted-foreground">
+                        <Loader2 className="h-3.5 w-3.5 animate-spin" /> Looking up who ranks here…
+                      </p>
+                    );
+                  }
+                  if (pointError) {
+                    return <p className="text-xs text-red-600">{pointError}</p>;
+                  }
+                  if (rows && rows.length > 0) {
+                    return (
+                      <ol className="space-y-1">
+                        {rows.map((r, i) => (
+                          <li
+                            key={r.placeId || `${r.name}-${i}`}
+                            className={`flex items-center gap-2 rounded-lg px-2 py-1.5 text-sm ${r.isUs ? "bg-brand-dark/10 font-semibold text-foreground" : "text-muted-foreground"}`}
+                          >
+                            <span className="inline-flex h-5 w-5 flex-shrink-0 items-center justify-center rounded-full bg-white text-[11px] font-bold text-foreground ring-1 ring-border">
+                              {i + 1}
+                            </span>
+                            <span className="truncate">{r.name || "Unknown"}</span>
+                            {r.isUs && <span className="ml-auto rounded bg-brand-dark px-1.5 py-0.5 text-[10px] font-medium text-white">You</span>}
+                          </li>
+                        ))}
+                      </ol>
+                    );
+                  }
+                  return <p className="text-xs text-muted-foreground">No businesses ranked here for this keyword.</p>;
+                })()}
               </div>
             )}
           </div>
@@ -413,10 +498,10 @@ export default function GeogridPage() {
           )}
 
           {/* History / trend — the loop */}
-          {scans.length > 1 && (
+          {visibleScans.length > 1 && (
             <div className="mt-5 rounded-xl border border-border bg-white p-4">
               <div className="mb-2 flex items-center gap-2 text-sm font-medium text-foreground">
-                <TrendingUp className="h-4 w-4" /> Trend (are the two goals moving?)
+                <TrendingUp className="h-4 w-4" /> Trend{filterKeyword ? ` · "${filterKeyword}"` : ""} (are the two goals moving?)
               </div>
               <table className="w-full text-sm">
                 <thead>
@@ -425,7 +510,7 @@ export default function GeogridPage() {
                   </tr>
                 </thead>
                 <tbody>
-                  {scans.map((s) => (
+                  {visibleScans.map((s) => (
                     <tr key={s.id} className={`border-t border-border ${active.id === s.id ? "bg-muted/40" : ""}`}>
                       <td className="py-1.5">
                         <button onClick={() => setActive(s)} className="text-foreground hover:underline">{new Date(s.createdAt).toLocaleDateString()}</button>

--- a/apps/backoffice/src/app/(admin)/reviews/geogrid/page.tsx
+++ b/apps/backoffice/src/app/(admin)/reviews/geogrid/page.tsx
@@ -2,10 +2,22 @@
 
 import { useEffect, useState, useCallback } from "react";
 import Link from "next/link";
-import { Loader2, MapPin, Play, ArrowLeft, TrendingUp } from "lucide-react";
+import { Loader2, MapPin, Play, ArrowLeft, TrendingUp, ChevronDown, Sparkles } from "lucide-react";
 
 type PointResult = { name: string; placeId: string; isUs: boolean };
 type GridPoint = { row: number; col: number; lat: number; lng: number; rank: number | null; results?: PointResult[] };
+type PlaceProfile = {
+  name: string;
+  rating: number | null;
+  reviews: number | null;
+  hasWebsite: boolean;
+  hasPhone: boolean;
+  hasHours: boolean;
+  photos: number;
+  hasDescription: boolean;
+};
+type Suggestion = { tag: string; priority: "high" | "med" | "low"; text: string };
+type Compare = { us: PlaceProfile | null; them: PlaceProfile; suggestions: Suggestion[] };
 type Scan = {
   id: string;
   keyword: string;
@@ -114,6 +126,103 @@ function Stat({ label, value, sub }: { label: string; value: string; sub?: strin
       <p className="mt-1 text-2xl font-bold text-foreground">{value}</p>
       {sub && <p className="text-[11px] text-muted-foreground">{sub}</p>}
     </div>
+  );
+}
+
+const PRIORITY_DOT: Record<string, string> = { high: "bg-red-500", med: "bg-amber-500", low: "bg-emerald-500" };
+
+// A ranked business in the per-point list, with an on-demand "how to beat them"
+// drawer that diffs their Google profile against ours into concrete actions.
+function CompetitorRow({ rank, r, ourPlaceId }: { rank: number; r: PointResult; ourPlaceId: string | null }) {
+  const [open, setOpen] = useState(false);
+  const [loading, setLoading] = useState(false);
+  const [data, setData] = useState<Compare | null>(null);
+  const [err, setErr] = useState("");
+
+  const canCompare = !r.isUs && !!r.placeId;
+
+  const toggle = async () => {
+    if (open) {
+      setOpen(false);
+      return;
+    }
+    setOpen(true);
+    if (data || !canCompare) return;
+    setLoading(true);
+    setErr("");
+    try {
+      const res = await fetch("/api/geogrid/compare", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ competitorPlaceId: r.placeId, ourPlaceId }),
+      });
+      const d = await res.json();
+      if (res.ok) setData(d);
+      else setErr(d.error || "Lookup failed");
+    } catch {
+      setErr("Network error");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <li className="rounded-lg">
+      <div
+        className={`flex items-center gap-2 rounded-lg px-2 py-1.5 text-sm ${r.isUs ? "bg-brand-dark/10 font-semibold text-foreground" : "text-muted-foreground"}`}
+      >
+        <span className="inline-flex h-5 w-5 flex-shrink-0 items-center justify-center rounded-full bg-white text-[11px] font-bold text-foreground ring-1 ring-border">
+          {rank}
+        </span>
+        <span className="truncate">{r.name || "Unknown"}</span>
+        {r.isUs ? (
+          <span className="ml-auto rounded bg-brand-dark px-1.5 py-0.5 text-[10px] font-medium text-white">You</span>
+        ) : canCompare ? (
+          <button
+            onClick={toggle}
+            className="ml-auto flex items-center gap-1 whitespace-nowrap rounded-md border border-border bg-white px-2 py-0.5 text-[11px] font-medium text-foreground hover:bg-muted/50"
+          >
+            <Sparkles className="h-3 w-3" /> How to beat them
+            <ChevronDown className={`h-3 w-3 transition ${open ? "rotate-180" : ""}`} />
+          </button>
+        ) : null}
+      </div>
+
+      {open && canCompare && (
+        <div className="ml-7 mr-2 mb-1.5 mt-1 rounded-lg border border-border bg-white p-3">
+          {loading ? (
+            <p className="flex items-center gap-2 text-xs text-muted-foreground">
+              <Loader2 className="h-3.5 w-3.5 animate-spin" /> Comparing profiles…
+            </p>
+          ) : err ? (
+            <p className="text-xs text-red-600">{err}</p>
+          ) : data ? (
+            <>
+              <div className="mb-2 flex flex-wrap gap-x-4 gap-y-1 text-[11px] text-muted-foreground">
+                <span>
+                  <span className="font-medium text-foreground">Them:</span> {data.them.reviews ?? "–"} reviews
+                  {data.them.rating != null ? ` · ${data.them.rating.toFixed(1)}★` : ""}
+                </span>
+                <span>
+                  <span className="font-medium text-foreground">You:</span>{" "}
+                  {data.us ? `${data.us.reviews ?? "–"} reviews${data.us.rating != null ? ` · ${data.us.rating.toFixed(1)}★` : ""}` : "profile not linked"}
+                </span>
+              </div>
+              <ul className="space-y-1.5">
+                {data.suggestions.map((s, i) => (
+                  <li key={i} className="flex gap-2 text-xs text-foreground">
+                    <span className={`mt-1 h-1.5 w-1.5 flex-shrink-0 rounded-full ${PRIORITY_DOT[s.priority] ?? "bg-neutral-400"}`} />
+                    <span>
+                      <span className="font-medium">{s.tag}:</span> {s.text}
+                    </span>
+                  </li>
+                ))}
+              </ul>
+            </>
+          ) : null}
+        </div>
+      )}
+    </li>
   );
 }
 
@@ -420,18 +529,9 @@ export default function GeogridPage() {
                   }
                   if (rows && rows.length > 0) {
                     return (
-                      <ol className="space-y-1">
+                      <ol className="space-y-0.5">
                         {rows.map((r, i) => (
-                          <li
-                            key={r.placeId || `${r.name}-${i}`}
-                            className={`flex items-center gap-2 rounded-lg px-2 py-1.5 text-sm ${r.isUs ? "bg-brand-dark/10 font-semibold text-foreground" : "text-muted-foreground"}`}
-                          >
-                            <span className="inline-flex h-5 w-5 flex-shrink-0 items-center justify-center rounded-full bg-white text-[11px] font-bold text-foreground ring-1 ring-border">
-                              {i + 1}
-                            </span>
-                            <span className="truncate">{r.name || "Unknown"}</span>
-                            {r.isUs && <span className="ml-auto rounded bg-brand-dark px-1.5 py-0.5 text-[10px] font-medium text-white">You</span>}
-                          </li>
+                          <CompetitorRow key={r.placeId || `${r.name}-${i}`} rank={i + 1} r={r} ourPlaceId={active.placeId ?? null} />
                         ))}
                       </ol>
                     );

--- a/apps/backoffice/src/app/api/geogrid/compare/route.ts
+++ b/apps/backoffice/src/app/api/geogrid/compare/route.ts
@@ -1,0 +1,42 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getUserFromHeaders } from "@/lib/auth";
+import { placeDetails, buildSuggestions } from "@/lib/geogrid/places";
+
+export const dynamic = "force-dynamic";
+export const maxDuration = 30;
+
+// POST /api/geogrid/compare — profile diff + concrete actions to out-rank a rival.
+// Body: { competitorPlaceId, ourPlaceId? }. ourPlaceId is the scan's target place
+// id; when absent we still return the rival's strengths + generic advice.
+export async function POST(request: NextRequest) {
+  const user = await getUserFromHeaders(request.headers);
+  if (!user) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+
+  const apiKey = process.env.GOOGLE_PLACES_API_KEY;
+  if (!apiKey) {
+    return NextResponse.json({ error: "GOOGLE_PLACES_API_KEY not configured" }, { status: 400 });
+  }
+
+  const body = await request.json().catch(() => ({}));
+  const competitorPlaceId: string = body.competitorPlaceId;
+  const ourPlaceId: string | null = body.ourPlaceId ?? null;
+  if (!competitorPlaceId) {
+    return NextResponse.json({ error: "No Google profile id for this competitor" }, { status: 400 });
+  }
+
+  try {
+    const them = await placeDetails(apiKey, competitorPlaceId);
+    let us = null;
+    if (ourPlaceId) {
+      try {
+        us = await placeDetails(apiKey, ourPlaceId);
+      } catch (err) {
+        console.error("[geogrid] own profile lookup failed:", (err as Error).message);
+      }
+    }
+    return NextResponse.json({ us, them, suggestions: buildSuggestions(us, them) });
+  } catch (err) {
+    console.error("[geogrid] compare failed:", (err as Error).message);
+    return NextResponse.json({ error: "Profile lookup failed" }, { status: 500 });
+  }
+}

--- a/apps/backoffice/src/app/api/geogrid/point/route.ts
+++ b/apps/backoffice/src/app/api/geogrid/point/route.ts
@@ -1,0 +1,46 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getUserFromHeaders } from "@/lib/auth";
+import { prisma } from "@/lib/prisma";
+import { rankAtPoint } from "@/lib/geogrid/places";
+
+export const dynamic = "force-dynamic";
+export const maxDuration = 30;
+
+const METERS_PER_MILE = 1609.34;
+
+// POST /api/geogrid/point — live "who ranks here" for a single grid point.
+// Lets the UI drill into older scans that predate stored per-point results, and
+// into the unranked (grey) points where we're outside the top 20 but rivals exist.
+// Body: { outletId, keyword, lat, lng, rangeMiles?, placeId? }
+export async function POST(request: NextRequest) {
+  const user = await getUserFromHeaders(request.headers);
+  if (!user) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+
+  const apiKey = process.env.GOOGLE_PLACES_API_KEY;
+  if (!apiKey) {
+    return NextResponse.json({ error: "GOOGLE_PLACES_API_KEY not configured" }, { status: 400 });
+  }
+
+  const body = await request.json().catch(() => ({}));
+  const outletId: string = body.outletId;
+  const keyword: string = (body.keyword || "").trim();
+  const lat = body.lat;
+  const lng = body.lng;
+  const placeId: string | null = body.placeId ?? null;
+  if (!outletId || !keyword || typeof lat !== "number" || typeof lng !== "number") {
+    return NextResponse.json({ error: "outletId, keyword, lat and lng required" }, { status: 400 });
+  }
+
+  const outlet = await prisma.outlet.findUnique({ where: { id: outletId } });
+  // Match the scan's radius clamp so the live lookup mirrors what produced the grid.
+  const rangeMiles = typeof body.rangeMiles === "number" && body.rangeMiles > 0 ? body.rangeMiles : 0.1;
+  const radiusM = Math.min(Math.max(rangeMiles * METERS_PER_MILE, 500), 5000);
+
+  try {
+    const { rank, results } = await rankAtPoint(apiKey, keyword, lat, lng, radiusM, placeId, outlet?.name ?? null);
+    return NextResponse.json({ rank, results });
+  } catch (err) {
+    console.error("[geogrid] point lookup failed:", (err as Error).message);
+    return NextResponse.json({ error: "Lookup failed" }, { status: 500 });
+  }
+}

--- a/apps/backoffice/src/lib/geogrid/places.ts
+++ b/apps/backoffice/src/lib/geogrid/places.ts
@@ -101,6 +101,112 @@ export async function rankAtPoint(
   return { rank: idx >= 0 ? idx + 1 : null, results };
 }
 
+// ── Profile comparison ───────────────────────────────────────────────────────
+// To advise how to out-rank a specific rival, we pull the prominence signals
+// Google's local ranking leans on (reviews, rating, profile completeness) for
+// both businesses and diff them into concrete to-dos.
+
+export type PlaceProfile = {
+  placeId: string;
+  name: string;
+  rating: number | null;
+  reviews: number | null;
+  hasWebsite: boolean;
+  hasPhone: boolean;
+  hasHours: boolean;
+  photos: number;
+  hasDescription: boolean;
+  primaryType: string | null;
+  businessStatus: string | null;
+};
+
+/** Place Details (New) for one place — the fields that feed prominence. */
+export async function placeDetails(apiKey: string, placeId: string): Promise<PlaceProfile> {
+  const res = await fetch(`https://places.googleapis.com/v1/places/${encodeURIComponent(placeId)}`, {
+    headers: {
+      "X-Goog-Api-Key": apiKey,
+      "X-Goog-FieldMask":
+        "id,displayName,rating,userRatingCount,websiteUri,nationalPhoneNumber,regularOpeningHours,photos,editorialSummary,primaryTypeDisplayName,businessStatus",
+    },
+  });
+  if (!res.ok) {
+    const body = await res.text();
+    throw new Error(`Places details error ${res.status}: ${body.slice(0, 200)}`);
+  }
+  const p = await res.json();
+  return {
+    placeId: p.id ?? placeId,
+    name: p.displayName?.text ?? "",
+    rating: typeof p.rating === "number" ? p.rating : null,
+    reviews: typeof p.userRatingCount === "number" ? p.userRatingCount : null,
+    hasWebsite: !!p.websiteUri,
+    hasPhone: !!p.nationalPhoneNumber,
+    hasHours: !!p.regularOpeningHours,
+    photos: Array.isArray(p.photos) ? p.photos.length : 0,
+    hasDescription: !!p.editorialSummary?.text,
+    primaryType: p.primaryTypeDisplayName?.text ?? null,
+    businessStatus: p.businessStatus ?? null,
+  };
+}
+
+export type Suggestion = { tag: string; priority: "high" | "med" | "low"; text: string };
+
+/** Concrete actions to close the gap on `them`, given our profile (or null). */
+export function buildSuggestions(us: PlaceProfile | null, them: PlaceProfile): Suggestion[] {
+  const out: Suggestion[] = [];
+  const reviewsUs = us?.reviews ?? 0;
+  const reviewsThem = them.reviews ?? 0;
+  if (reviewsThem > reviewsUs) {
+    const gap = reviewsThem - reviewsUs;
+    out.push({
+      tag: "Reviews",
+      priority: gap > 50 ? "high" : "med",
+      text: us
+        ? `They have ${reviewsThem} reviews vs your ${reviewsUs} — close the ${gap}-review gap. Review count + velocity is the strongest prominence lever: ask every happy customer and reply to each one.`
+        : `They have ${reviewsThem} reviews. Review count + velocity is the strongest prominence lever — ask every happy customer and reply to each.`,
+    });
+  }
+  if (them.rating != null && (us?.rating == null || them.rating > us.rating + 0.1)) {
+    out.push({
+      tag: "Rating",
+      priority: "med",
+      text:
+        us?.rating != null
+          ? `Their rating is ${them.rating.toFixed(1)}★ vs your ${us.rating.toFixed(1)}★ — lift service quality and recover unhappy customers before they leave 1-stars.`
+          : `Their rating is ${them.rating.toFixed(1)}★ — protect yours by recovering unhappy customers fast.`,
+    });
+  }
+  if (them.hasHours && us && !us.hasHours) {
+    out.push({ tag: "Hours", priority: "high", text: "Add your opening hours — they have them set, and a profile without hours gets down-ranked and loses walk-ins." });
+  }
+  if (them.hasWebsite && us && !us.hasWebsite) {
+    out.push({ tag: "Website", priority: "med", text: "Add your website / menu link — they link one and you don't." });
+  }
+  if (them.hasPhone && us && !us.hasPhone) {
+    out.push({ tag: "Phone", priority: "low", text: "Add a phone number to your profile — they have one, you don't." });
+  }
+  if (them.photos > (us?.photos ?? 0)) {
+    out.push({
+      tag: "Photos",
+      priority: "low",
+      text: `They showcase more photos${us ? ` (${them.photos}+ vs your ${us.photos})` : ""} — add fresh storefront, interior and product photos; profiles with more photos get more clicks.`,
+    });
+  }
+  if (them.hasDescription && us && !us.hasDescription) {
+    out.push({ tag: "Description", priority: "low", text: "Add a business description that includes your key search terms — they have one." });
+  }
+  if (out.length === 0) {
+    out.push({
+      tag: us ? "Even" : "Note",
+      priority: "low",
+      text: us
+        ? "Your profile matches theirs on the basics. The remaining edge is proximity + steady review velocity — keep reviews flowing and post weekly Google updates."
+        : "Couldn't load your profile to compare. Focus on review count, rating and a complete profile (hours, website, photos).",
+    });
+  }
+  return out;
+}
+
 export function computeMetrics(points: GridPoint[], centerLat: number, centerLng: number) {
   const ranked = points.filter((p) => p.rank != null) as (GridPoint & { rank: number })[];
   const top3 = ranked.filter((p) => p.rank <= 3);


### PR DESCRIPTION
## What

Builds on the per-point geogrid drill-down (#516) with three improvements.

### 1. Every grid point is clickable — on any scan
- Older scans (and the grey "not in top 20" points) had no stored per-point results and were disabled. Now clicking any point does a **live lookup** of "who ranks here" via a new `POST /api/geogrid/point` endpoint, with a loading state. Newer scans still use stored data instantly. Results cached per-point per session.

### 2. Keyword filter
- A **"Show keyword"** dropdown (shown when an outlet has scans for more than one keyword) narrows both the grid and the trend table to one tracked keyword, and auto-jumps to that keyword's newest scan. Defaults to "All keywords".

### 3. "How to beat them" actions per competitor
- Each rival in the per-point list gets a drawer that diffs their Google profile against yours (reviews, rating, hours, website, photos, description) into concrete, **prioritised** to-dos (high/med/low).
- New `POST /api/geogrid/compare` endpoint calls Place Details for both businesses; `buildSuggestions()` turns the gap into actions. Fetches on demand per competitor (no cost until expanded). Degrades gracefully when the store's profile isn't linked.

## Files
- `apps/backoffice/src/lib/geogrid/places.ts` — `placeDetails()` + `buildSuggestions()`.
- `apps/backoffice/src/app/api/geogrid/point/route.ts` — live per-point lookup (new).
- `apps/backoffice/src/app/api/geogrid/compare/route.ts` — profile diff + actions (new).
- `apps/backoffice/src/app/(admin)/reviews/geogrid/page.tsx` — clickable points, keyword filter, competitor drawer.

Typecheck + lint pass on all changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01XEP8S5VfwGKww4BGNB7Xk3)_