### PR TITLE
geogrid: actionable "beat them" tips (metric×time, levers, win-likelihood)

### DIFF
--- a/apps/backoffice/src/app/(admin)/reviews/geogrid/page.tsx
+++ b/apps/backoffice/src/app/(admin)/reviews/geogrid/page.tsx
@@ -165,6 +165,32 @@ function winLikelihood(opts: {
   return { band: "Low", reason: "They’re much closer to this spot — proximity caps you here; reviews alone rarely flip a point this deep in their backyard." };
 }
 
+// Shared renderer for the prioritised actions + their how-to levers.
+function SuggestionList({ suggestions }: { suggestions: Suggestion[] }) {
+  return (
+    <ul className="space-y-1.5">
+      {suggestions.map((s, i) => (
+        <li key={i} className="flex gap-2 text-xs text-foreground">
+          <span className={`mt-1 h-1.5 w-1.5 flex-shrink-0 rounded-full ${PRIORITY_DOT[s.priority] ?? "bg-neutral-400"}`} />
+          <span>
+            <span className="font-medium">{s.tag}:</span> {s.text}
+            {s.levers && s.levers.length > 0 && (
+              <ul className="mt-1 space-y-0.5 border-l-2 border-border pl-2.5 text-[11px] text-muted-foreground">
+                {s.levers.map((l, j) => (
+                  <li key={j} className="flex gap-1.5">
+                    <span className="select-none">→</span>
+                    <span>{l}</span>
+                  </li>
+                ))}
+              </ul>
+            )}
+          </span>
+        </li>
+      ))}
+    </ul>
+  );
+}
+
 // A ranked business in the per-point list, with an on-demand "how to beat them"
 // drawer that diffs their Google profile against ours into concrete actions.
 function CompetitorRow({
@@ -273,26 +299,7 @@ function CompetitorRow({
                   {data.us ? `${data.us.reviews ?? "–"} reviews${data.us.rating != null ? ` · ${data.us.rating.toFixed(1)}★` : ""}` : "profile not linked"}
                 </span>
               </div>
-              <ul className="space-y-1.5">
-                {data.suggestions.map((s, i) => (
-                  <li key={i} className="flex gap-2 text-xs text-foreground">
-                    <span className={`mt-1 h-1.5 w-1.5 flex-shrink-0 rounded-full ${PRIORITY_DOT[s.priority] ?? "bg-neutral-400"}`} />
-                    <span>
-                      <span className="font-medium">{s.tag}:</span> {s.text}
-                      {s.levers && s.levers.length > 0 && (
-                        <ul className="mt-1 space-y-0.5 border-l-2 border-border pl-2.5 text-[11px] text-muted-foreground">
-                          {s.levers.map((l, j) => (
-                            <li key={j} className="flex gap-1.5">
-                              <span className="select-none">→</span>
-                              <span>{l}</span>
-                            </li>
-                          ))}
-                        </ul>
-                      )}
-                    </span>
-                  </li>
-                ))}
-              </ul>
+              <SuggestionList suggestions={data.suggestions} />
             </>
           ) : null}
         </div>
@@ -301,6 +308,134 @@ function CompetitorRow({
   );
 }
 
+type BeatTarget = { name: string; placeId: string; beats: number; points: number; typicalRank: number };
+
+// Rank the rivals you actually need to beat: aggregate the stored per-point
+// results into "how many grid points does each out-rank us at", worst first.
+function beatTargets(scan: Scan): BeatTarget[] {
+  const tally = new Map<string, { name: string; placeId: string; beats: number; points: number; rankSum: number }>();
+  for (const p of scan.points) {
+    if (!p.results || !p.results.length) continue;
+    p.results.forEach((r, idx) => {
+      if (r.isUs || !r.name) return;
+      const theirRank = idx + 1;
+      const beatsUs = p.rank == null || theirRank < p.rank;
+      const key = r.placeId || r.name.toLowerCase();
+      const t = tally.get(key) ?? { name: r.name, placeId: r.placeId, beats: 0, points: 0, rankSum: 0 };
+      t.points++;
+      t.rankSum += theirRank;
+      if (beatsUs) t.beats++;
+      tally.set(key, t);
+    });
+  }
+  return [...tally.values()]
+    .filter((t) => t.beats > 0)
+    .map((t) => ({ name: t.name, placeId: t.placeId, beats: t.beats, points: t.points, typicalRank: Math.round(t.rankSum / t.points) }))
+    .sort((a, b) => b.beats - a.beats || a.typicalRank - b.typicalRank)
+    .slice(0, 6);
+}
+
+// Grid-wide proximity read: what share of the grid you sit closer to than them.
+function aggregateWinBand(scan: Scan, theirLoc: { lat: number; lng: number } | null): { band: Band; reason: string } {
+  if (!theirLoc) {
+    return { band: "Moderate", reason: "Close the review/rating gap — their location wasn’t available to weigh proximity across the grid." };
+  }
+  let closer = 0;
+  for (const p of scan.points) {
+    const dUs = distM(scan.centerLat, scan.centerLng, p.lat, p.lng);
+    const dThem = distM(theirLoc.lat, theirLoc.lng, p.lat, p.lng);
+    if (dUs <= dThem) closer++;
+  }
+  const pct = Math.round((closer / scan.points.length) * 100);
+  if (pct >= 55) return { band: "High", reason: `You’re closer than them across ~${pct}% of the grid — match their prominence and you take most of it.` };
+  if (pct >= 30) return { band: "Moderate", reason: `You’re closer across ~${pct}% of the grid — prominence decides the contested middle, so closing the review gap swings it.` };
+  return { band: "Low", reason: `You’re closer at only ~${pct}% of the grid — they own the proximity; expect to win near your store, not their turf.` };
+}
+
+// A target in the "who to beat first" list: impact summary + on-demand actions.
+function BeatTargetRow({ rank, target, scan }: { rank: number; target: BeatTarget; scan: Scan }) {
+  const [open, setOpen] = useState(false);
+  const [loading, setLoading] = useState(false);
+  const [data, setData] = useState<Compare | null>(null);
+  const [err, setErr] = useState("");
+
+  const toggle = async () => {
+    if (open) {
+      setOpen(false);
+      return;
+    }
+    setOpen(true);
+    if (data || !target.placeId) return;
+    setLoading(true);
+    setErr("");
+    try {
+      const res = await fetch("/api/geogrid/compare", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ competitorPlaceId: target.placeId, ourPlaceId: scan.placeId ?? null }),
+      });
+      const d = await res.json();
+      if (res.ok) setData(d);
+      else setErr(d.error || "Lookup failed");
+    } catch {
+      setErr("Network error");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <li className="rounded-lg border border-border">
+      <button onClick={toggle} className="flex w-full items-center gap-2 px-3 py-2 text-left hover:bg-muted/40">
+        <span className="inline-flex h-6 w-6 flex-shrink-0 items-center justify-center rounded-full bg-red-100 text-xs font-bold text-red-700">{rank}</span>
+        <span className="min-w-0">
+          <span className="block truncate text-sm font-medium text-foreground">{target.name}</span>
+          <span className="text-[11px] text-muted-foreground">
+            Out-ranks you at {target.beats}/{target.points} points · typically #{target.typicalRank}
+          </span>
+        </span>
+        <span className="ml-auto flex items-center gap-1 whitespace-nowrap text-[11px] font-medium text-foreground">
+          <Sparkles className="h-3 w-3" /> How to beat them
+          <ChevronDown className={`h-3 w-3 transition ${open ? "rotate-180" : ""}`} />
+        </span>
+      </button>
+      {open && (
+        <div className="border-t border-border p-3">
+          {loading ? (
+            <p className="flex items-center gap-2 text-xs text-muted-foreground">
+              <Loader2 className="h-3.5 w-3.5 animate-spin" /> Comparing profiles…
+            </p>
+          ) : err ? (
+            <p className="text-xs text-red-600">{err}</p>
+          ) : data ? (
+            (() => {
+              const wl = aggregateWinBand(scan, data.them.location);
+              return (
+                <>
+                  <div className={`mb-2 rounded-lg border px-2.5 py-1.5 ${BAND_STYLE[wl.band]}`}>
+                    <div className="text-[10px] font-semibold uppercase tracking-wide">Win likelihood if you do all this: {wl.band}</div>
+                    <p className="mt-0.5 text-[11px] leading-snug">{wl.reason}</p>
+                  </div>
+                  <div className="mb-2 flex flex-wrap gap-x-4 gap-y-1 text-[11px] text-muted-foreground">
+                    <span>
+                      <span className="font-medium text-foreground">Them:</span> {data.them.reviews ?? "–"} reviews
+                      {data.them.rating != null ? ` · ${data.them.rating.toFixed(1)}★` : ""}
+                    </span>
+                    <span>
+                      <span className="font-medium text-foreground">You:</span>{" "}
+                      {data.us ? `${data.us.reviews ?? "–"} reviews${data.us.rating != null ? ` · ${data.us.rating.toFixed(1)}★` : ""}` : "profile not linked"}
+                    </span>
+                  </div>
+                  <SuggestionList suggestions={data.suggestions} />
+                </>
+              );
+            })()
+          ) : null}
+        </div>
+      )}
+    </li>
+  );
+}
 export default function GeogridPage() {
   const [outlets, setOutlets] = useState<Outlet[]>([]);
   const [outletId, setOutletId] = useState("");
@@ -652,6 +787,25 @@ export default function GeogridPage() {
                     </li>
                   ))}
                 </ul>
+              </div>
+            );
+          })()}
+
+          {/* Who to beat first — ranked hit-list with actions per target */}
+          {(() => {
+            const targets = beatTargets(active);
+            if (!targets.length) return null;
+            return (
+              <div className="mt-5 rounded-xl border border-border bg-white p-4">
+                <div className="text-sm font-medium text-foreground">Who to beat first</div>
+                <p className="mb-3 mt-0.5 text-[11px] text-muted-foreground">
+                  Ranked by how much of your grid each rival out-ranks you across. Beat the top ones to reclaim the most map — expand for the actions.
+                </p>
+                <ol className="space-y-2">
+                  {targets.map((t, i) => (
+                    <BeatTargetRow key={t.placeId || t.name} rank={i + 1} target={t} scan={active} />
+                  ))}
+                </ol>
               </div>
             );
           })()}

--- a/apps/backoffice/src/app/(admin)/reviews/geogrid/page.tsx
+++ b/apps/backoffice/src/app/(admin)/reviews/geogrid/page.tsx
@@ -16,7 +16,7 @@ type PlaceProfile = {
   photos: number;
   hasDescription: boolean;
 };
-type Suggestion = { tag: string; priority: "high" | "med" | "low"; text: string };
+type Suggestion = { tag: string; priority: "high" | "med" | "low"; text: string; levers: string[] };
 type Compare = { us: PlaceProfile | null; them: PlaceProfile; suggestions: Suggestion[] };
 type Scan = {
   id: string;
@@ -214,6 +214,16 @@ function CompetitorRow({ rank, r, ourPlaceId }: { rank: number; r: PointResult; 
                     <span className={`mt-1 h-1.5 w-1.5 flex-shrink-0 rounded-full ${PRIORITY_DOT[s.priority] ?? "bg-neutral-400"}`} />
                     <span>
                       <span className="font-medium">{s.tag}:</span> {s.text}
+                      {s.levers && s.levers.length > 0 && (
+                        <ul className="mt-1 space-y-0.5 border-l-2 border-border pl-2.5 text-[11px] text-muted-foreground">
+                          {s.levers.map((l, j) => (
+                            <li key={j} className="flex gap-1.5">
+                              <span className="select-none">→</span>
+                              <span>{l}</span>
+                            </li>
+                          ))}
+                        </ul>
+                      )}
                     </span>
                   </li>
                 ))}

--- a/apps/backoffice/src/app/(admin)/reviews/geogrid/page.tsx
+++ b/apps/backoffice/src/app/(admin)/reviews/geogrid/page.tsx
@@ -15,6 +15,7 @@ type PlaceProfile = {
   hasHours: boolean;
   photos: number;
   hasDescription: boolean;
+  location: { lat: number; lng: number } | null;
 };
 type Suggestion = { tag: string; priority: "high" | "med" | "low"; text: string; levers: string[] };
 type Compare = { us: PlaceProfile | null; them: PlaceProfile; suggestions: Suggestion[] };
@@ -131,9 +132,60 @@ function Stat({ label, value, sub }: { label: string; value: string; sub?: strin
 
 const PRIORITY_DOT: Record<string, string> = { high: "bg-red-500", med: "bg-amber-500", low: "bg-emerald-500" };
 
+type Band = "Already ahead" | "High" | "Moderate" | "Low";
+const BAND_STYLE: Record<Band, string> = {
+  "Already ahead": "border-emerald-200 bg-emerald-50 text-emerald-700",
+  High: "border-emerald-200 bg-emerald-50 text-emerald-700",
+  Moderate: "border-amber-200 bg-amber-50 text-amber-700",
+  Low: "border-red-200 bg-red-50 text-red-700",
+};
+
+// Honest, directional read on whether doing the actions out-ranks this rival at
+// this point. Prominence (reviews/rating) is assumed closed by the actions, so
+// the swing factor is proximity: who is physically closer to the search point.
+function winLikelihood(opts: {
+  ourRank: number | null;
+  theirRank: number;
+  distUs: number;
+  distThem: number | null;
+}): { band: Band; reason: string } {
+  const { ourRank, theirRank, distUs, distThem } = opts;
+  if (ourRank != null && ourRank < theirRank) {
+    return { band: "Already ahead", reason: "You already out-rank them here — hold it with steady reviews." };
+  }
+  if (distThem == null) {
+    return { band: "Moderate", reason: "Closing the review/rating gap usually decides it; their exact location wasn’t available to weigh proximity here." };
+  }
+  if (distUs <= distThem) {
+    return { band: "High", reason: "You’re closer to this spot, so matching their prominence should put you ahead." };
+  }
+  if (distUs <= distThem * 1.4) {
+    return { band: "Moderate", reason: "They’re a bit closer to this spot — prominence is the swing factor, so closing the review gap can flip it." };
+  }
+  return { band: "Low", reason: "They’re much closer to this spot — proximity caps you here; reviews alone rarely flip a point this deep in their backyard." };
+}
+
 // A ranked business in the per-point list, with an on-demand "how to beat them"
 // drawer that diffs their Google profile against ours into concrete actions.
-function CompetitorRow({ rank, r, ourPlaceId }: { rank: number; r: PointResult; ourPlaceId: string | null }) {
+function CompetitorRow({
+  rank,
+  r,
+  ourPlaceId,
+  ourRank,
+  pLat,
+  pLng,
+  centerLat,
+  centerLng,
+}: {
+  rank: number;
+  r: PointResult;
+  ourPlaceId: string | null;
+  ourRank: number | null;
+  pLat: number;
+  pLng: number;
+  centerLat: number;
+  centerLng: number;
+}) {
   const [open, setOpen] = useState(false);
   const [loading, setLoading] = useState(false);
   const [data, setData] = useState<Compare | null>(null);
@@ -198,6 +250,19 @@ function CompetitorRow({ rank, r, ourPlaceId }: { rank: number; r: PointResult; 
             <p className="text-xs text-red-600">{err}</p>
           ) : data ? (
             <>
+              {(() => {
+                const distUs = distM(centerLat, centerLng, pLat, pLng);
+                const distThem = data.them.location ? distM(data.them.location.lat, data.them.location.lng, pLat, pLng) : null;
+                const wl = winLikelihood({ ourRank, theirRank: rank, distUs, distThem });
+                return (
+                  <div className={`mb-2 rounded-lg border px-2.5 py-1.5 ${BAND_STYLE[wl.band]}`}>
+                    <div className="text-[10px] font-semibold uppercase tracking-wide">
+                      Win likelihood if you do all this: {wl.band}
+                    </div>
+                    <p className="mt-0.5 text-[11px] leading-snug">{wl.reason}</p>
+                  </div>
+                );
+              })()}
               <div className="mb-2 flex flex-wrap gap-x-4 gap-y-1 text-[11px] text-muted-foreground">
                 <span>
                   <span className="font-medium text-foreground">Them:</span> {data.them.reviews ?? "–"} reviews
@@ -541,7 +606,17 @@ export default function GeogridPage() {
                     return (
                       <ol className="space-y-0.5">
                         {rows.map((r, i) => (
-                          <CompetitorRow key={r.placeId || `${r.name}-${i}`} rank={i + 1} r={r} ourPlaceId={active.placeId ?? null} />
+                          <CompetitorRow
+                            key={r.placeId || `${r.name}-${i}`}
+                            rank={i + 1}
+                            r={r}
+                            ourPlaceId={active.placeId ?? null}
+                            ourRank={selectedPoint.rank}
+                            pLat={selectedPoint.lat}
+                            pLng={selectedPoint.lng}
+                            centerLat={active.centerLat}
+                            centerLng={active.centerLng}
+                          />
                         ))}
                       </ol>
                     );

--- a/apps/backoffice/src/lib/geogrid/places.ts
+++ b/apps/backoffice/src/lib/geogrid/places.ts
@@ -118,6 +118,7 @@ export type PlaceProfile = {
   hasDescription: boolean;
   primaryType: string | null;
   businessStatus: string | null;
+  location: { lat: number; lng: number } | null;
 };
 
 /** Place Details (New) for one place — the fields that feed prominence. */
@@ -126,7 +127,7 @@ export async function placeDetails(apiKey: string, placeId: string): Promise<Pla
     headers: {
       "X-Goog-Api-Key": apiKey,
       "X-Goog-FieldMask":
-        "id,displayName,rating,userRatingCount,websiteUri,nationalPhoneNumber,regularOpeningHours,photos,editorialSummary,primaryTypeDisplayName,businessStatus",
+        "id,displayName,rating,userRatingCount,websiteUri,nationalPhoneNumber,regularOpeningHours,photos,editorialSummary,primaryTypeDisplayName,businessStatus,location",
     },
   });
   if (!res.ok) {
@@ -146,6 +147,10 @@ export async function placeDetails(apiKey: string, placeId: string): Promise<Pla
     hasDescription: !!p.editorialSummary?.text,
     primaryType: p.primaryTypeDisplayName?.text ?? null,
     businessStatus: p.businessStatus ?? null,
+    location:
+      typeof p.location?.latitude === "number" && typeof p.location?.longitude === "number"
+        ? { lat: p.location.latitude, lng: p.location.longitude }
+        : null,
   };
 }
 

--- a/apps/backoffice/src/lib/geogrid/places.ts
+++ b/apps/backoffice/src/lib/geogrid/places.ts
@@ -149,7 +149,7 @@ export async function placeDetails(apiKey: string, placeId: string): Promise<Pla
   };
 }
 
-export type Suggestion = { tag: string; priority: "high" | "med" | "low"; text: string };
+export type Suggestion = { tag: string; priority: "high" | "med" | "low"; text: string; levers: string[] };
 
 /** Concrete actions to close the gap on `them`, given our profile (or null). */
 export function buildSuggestions(us: PlaceProfile | null, them: PlaceProfile): Suggestion[] {
@@ -167,7 +167,13 @@ export function buildSuggestions(us: PlaceProfile | null, them: PlaceProfile): S
     out.push({
       tag: "Reviews",
       priority: target > 50 ? "high" : "med",
-      text: `Get +${target} reviews to pass their ${reviewsThem}. At ${PACE}/week (ask every customer + QR on receipts) → ~${weeks} week${weeks > 1 ? "s" : ""}.`,
+      text: `Get +${target} reviews to pass their ${reviewsThem}. At ${PACE}/week → ~${weeks} week${weeks > 1 ? "s" : ""}.`,
+      levers: [
+        "Staff asks for a review the moment a customer compliments the coffee — hand them a QR card.",
+        "Print a Google review QR on receipts and table tents.",
+        "Text/WhatsApp a one-tap review link to loyalty members after purchase.",
+        "Reply to every existing review — active profiles rank better.",
+      ],
     });
   }
 
@@ -179,27 +185,60 @@ export function buildSuggestions(us: PlaceProfile | null, them: PlaceProfile): S
       out.push({
         tag: "Rating",
         priority: "med",
-        text: `Lift your ${us.rating.toFixed(1)}★ past their ${them.rating.toFixed(1)}★: ~${need} new 5★ reviews. At ${PACE}/week → ~${weeks} week${weeks > 1 ? "s" : ""}; recover unhappy customers before they post.`,
+        text: `Lift your ${us.rating.toFixed(1)}★ past their ${them.rating.toFixed(1)}★: ~${need} new 5★ reviews. At ${PACE}/week → ~${weeks} week${weeks > 1 ? "s" : ""}.`,
+        levers: [
+          "Train staff to fix complaints on the spot, before the customer leaves.",
+          "Catch unhappy customers privately (receipt feedback link) and resolve before they post.",
+          "Only prompt for reviews after a clear win — fresh bake, fast service, a regular.",
+        ],
       });
     }
   }
 
   // Profile completeness — one-time fixes, each time-boxed.
   if (them.hasHours && us && !us.hasHours) {
-    out.push({ tag: "Hours", priority: "high", text: "Add opening hours — 5-min fix today. Missing hours get down-ranked." });
+    out.push({
+      tag: "Hours",
+      priority: "high",
+      text: "Add opening hours — 5-min fix today. Missing hours get down-ranked.",
+      levers: ["Google Business Profile → Edit profile → Hours → set regular + holiday hours."],
+    });
   }
   if (them.hasWebsite && us && !us.hasWebsite) {
-    out.push({ tag: "Website", priority: "med", text: "Add your website / menu link — 2-min fix today." });
+    out.push({
+      tag: "Website",
+      priority: "med",
+      text: "Add your website / menu link — 2-min fix today.",
+      levers: ["Edit profile → Contact → Website: link your site or online-order/menu page."],
+    });
   }
   if (them.hasPhone && us && !us.hasPhone) {
-    out.push({ tag: "Phone", priority: "low", text: "Add a phone number — 1-min fix today." });
+    out.push({
+      tag: "Phone",
+      priority: "low",
+      text: "Add a phone number — 1-min fix today.",
+      levers: ["Edit profile → Contact → Phone: add your primary number."],
+    });
   }
   if (us && them.photos > us.photos) {
     const add = Math.max(them.photos - us.photos, 5);
-    out.push({ tag: "Photos", priority: "low", text: `Add ${add} photos (storefront, interior, drinks) — ~15 min today, then 2/week to stay fresh.` });
+    out.push({
+      tag: "Photos",
+      priority: "low",
+      text: `Add ${add} photos — ~15 min today, then 2/week to stay fresh.`,
+      levers: [
+        "Maps app → your business → Add photos: storefront, interior, menu board, 3-5 hero drinks.",
+        "Set a weekly reminder to post 2 fresh photos.",
+      ],
+    });
   }
   if (them.hasDescription && us && !us.hasDescription) {
-    out.push({ tag: "Description", priority: "low", text: "Add a description with your key search terms — 10-min fix today." });
+    out.push({
+      tag: "Description",
+      priority: "low",
+      text: "Add a description with your key search terms — 10-min fix today.",
+      levers: ["Edit profile → Description: include 'specialty coffee', your area and signature items."],
+    });
   }
 
   if (out.length === 0) {
@@ -207,8 +246,11 @@ export function buildSuggestions(us: PlaceProfile | null, them: PlaceProfile): S
       tag: us ? "Even" : "Note",
       priority: "low",
       text: us
-        ? `Profile matches theirs — win on velocity: ${PACE} reviews/week + 1 Google post/week keeps you climbing.`
-        : `Link your profile to compare. Meanwhile: ${PACE} reviews/week and add hours, website + 5 photos today.`,
+        ? `Profile matches theirs — win on velocity to climb past them.`
+        : `Link your profile to compare. Meanwhile, work the basics.`,
+      levers: us
+        ? [`Keep ${PACE} reviews/week flowing.`, "Post 1 Google update/week (offer, new drink, event)."]
+        : [`Aim for ${PACE} reviews/week.`, "Add hours, website and 5 photos today."],
     });
   }
   return out;

--- a/apps/backoffice/src/lib/geogrid/places.ts
+++ b/apps/backoffice/src/lib/geogrid/places.ts
@@ -153,55 +153,62 @@ export type Suggestion = { tag: string; priority: "high" | "med" | "low"; text: 
 
 /** Concrete actions to close the gap on `them`, given our profile (or null). */
 export function buildSuggestions(us: PlaceProfile | null, them: PlaceProfile): Suggestion[] {
+  // Every tip is a concrete action with a number and a timeframe, aimed at the
+  // prominence signals that move local rank, so you can actually out-rank them.
   const out: Suggestion[] = [];
+  const PACE = 5; // realistic reviews/week from asking every happy customer
   const reviewsUs = us?.reviews ?? 0;
   const reviewsThem = them.reviews ?? 0;
+
+  // Reviews — overtake their review count (the strongest rank lever).
   if (reviewsThem > reviewsUs) {
-    const gap = reviewsThem - reviewsUs;
+    const target = reviewsThem - reviewsUs + 1; // pass them, not just match
+    const weeks = Math.ceil(target / PACE);
     out.push({
       tag: "Reviews",
-      priority: gap > 50 ? "high" : "med",
-      text: us
-        ? `They have ${reviewsThem} reviews vs your ${reviewsUs} — close the ${gap}-review gap. Review count + velocity is the strongest prominence lever: ask every happy customer and reply to each one.`
-        : `They have ${reviewsThem} reviews. Review count + velocity is the strongest prominence lever — ask every happy customer and reply to each.`,
+      priority: target > 50 ? "high" : "med",
+      text: `Get +${target} reviews to pass their ${reviewsThem}. At ${PACE}/week (ask every customer + QR on receipts) → ~${weeks} week${weeks > 1 ? "s" : ""}.`,
     });
   }
-  if (them.rating != null && (us?.rating == null || them.rating > us.rating + 0.1)) {
-    out.push({
-      tag: "Rating",
-      priority: "med",
-      text:
-        us?.rating != null
-          ? `Their rating is ${them.rating.toFixed(1)}★ vs your ${us.rating.toFixed(1)}★ — lift service quality and recover unhappy customers before they leave 1-stars.`
-          : `Their rating is ${them.rating.toFixed(1)}★ — protect yours by recovering unhappy customers fast.`,
-    });
+
+  // Rating — 5★ reviews needed to lift your average past theirs.
+  if (them.rating != null && them.rating < 5 && us?.rating != null && us.rating + 0.05 < them.rating) {
+    const need = Math.ceil((reviewsUs * (them.rating - us.rating)) / (5 - them.rating));
+    if (need > 0) {
+      const weeks = Math.ceil(need / PACE);
+      out.push({
+        tag: "Rating",
+        priority: "med",
+        text: `Lift your ${us.rating.toFixed(1)}★ past their ${them.rating.toFixed(1)}★: ~${need} new 5★ reviews. At ${PACE}/week → ~${weeks} week${weeks > 1 ? "s" : ""}; recover unhappy customers before they post.`,
+      });
+    }
   }
+
+  // Profile completeness — one-time fixes, each time-boxed.
   if (them.hasHours && us && !us.hasHours) {
-    out.push({ tag: "Hours", priority: "high", text: "Add your opening hours — they have them set, and a profile without hours gets down-ranked and loses walk-ins." });
+    out.push({ tag: "Hours", priority: "high", text: "Add opening hours — 5-min fix today. Missing hours get down-ranked." });
   }
   if (them.hasWebsite && us && !us.hasWebsite) {
-    out.push({ tag: "Website", priority: "med", text: "Add your website / menu link — they link one and you don't." });
+    out.push({ tag: "Website", priority: "med", text: "Add your website / menu link — 2-min fix today." });
   }
   if (them.hasPhone && us && !us.hasPhone) {
-    out.push({ tag: "Phone", priority: "low", text: "Add a phone number to your profile — they have one, you don't." });
+    out.push({ tag: "Phone", priority: "low", text: "Add a phone number — 1-min fix today." });
   }
-  if (them.photos > (us?.photos ?? 0)) {
-    out.push({
-      tag: "Photos",
-      priority: "low",
-      text: `They showcase more photos${us ? ` (${them.photos}+ vs your ${us.photos})` : ""} — add fresh storefront, interior and product photos; profiles with more photos get more clicks.`,
-    });
+  if (us && them.photos > us.photos) {
+    const add = Math.max(them.photos - us.photos, 5);
+    out.push({ tag: "Photos", priority: "low", text: `Add ${add} photos (storefront, interior, drinks) — ~15 min today, then 2/week to stay fresh.` });
   }
   if (them.hasDescription && us && !us.hasDescription) {
-    out.push({ tag: "Description", priority: "low", text: "Add a business description that includes your key search terms — they have one." });
+    out.push({ tag: "Description", priority: "low", text: "Add a description with your key search terms — 10-min fix today." });
   }
+
   if (out.length === 0) {
     out.push({
       tag: us ? "Even" : "Note",
       priority: "low",
       text: us
-        ? "Your profile matches theirs on the basics. The remaining edge is proximity + steady review velocity — keep reviews flowing and post weekly Google updates."
-        : "Couldn't load your profile to compare. Focus on review count, rating and a complete profile (hours, website, photos).",
+        ? `Profile matches theirs — win on velocity: ${PACE} reviews/week + 1 Google post/week keeps you climbing.`
+        : `Link your profile to compare. Meanwhile: ${PACE} reviews/week and add hours, website + 5 photos today.`,
     });
   }
   return out;


### PR DESCRIPTION
## What

Sharpens the geogrid "How to beat them" drawer (from #518) so it tells you, per competitor, what to do, how, and whether it'll work.

### 1. Tips are action + metric + timeframe
Each suggestion is now a concrete target with a number and ETA, aimed at out-ranking them:
- *"Get +41 reviews to pass their 240. At 5/week → ~9 weeks."*
- *"Lift your 4.3★ past their 4.6★: ~28 new 5★ reviews. At 5/week → ~6 weeks."* (real calc: `N·(T−A)/(5−T)` five-star reviews)
- Profile fixes are time-boxed (*"Add opening hours — 5-min fix today"*).

### 2. Actionable levers under each tip
Every suggestion carries a short list of concrete how-to steps (where to ask for reviews, which GBP field to edit), rendered as `→` sub-steps.

### 3. Per-point win-likelihood band
The drawer opens with a directional **Already ahead / High / Moderate / Low** read on whether doing the actions out-ranks that rival **at the clicked point**. Prominence is assumed closed by the actions, so the swing factor is proximity: it fetches the rival's location (Place Details) and compares each side's distance to the search point. The same competitor reads High near your store and Low next to theirs — the honest local-pack picture. Falls back to a prominence-only "Moderate" when the rival's location is unavailable.

## Files
- `apps/backoffice/src/lib/geogrid/places.ts` — `buildSuggestions()` reworked (metric+time+levers); `placeDetails()` now returns `location`.
- `apps/backoffice/src/app/(admin)/reviews/geogrid/page.tsx` — levers sub-steps + `winLikelihood()` band.

Typecheck + lint pass on both files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01XEP8S5VfwGKww4BGNB7Xk3)_