### PR TITLE
feat(procurement): supplier-chat inbox reply/send (human takeover, 24h-window aware)

### DIFF
--- a/apps/backoffice/src/app/(admin)/inventory/supplier-chats/page.tsx
+++ b/apps/backoffice/src/app/(admin)/inventory/supplier-chats/page.tsx
@@ -74,9 +74,13 @@ export default function SupplierChatsPage() {
   const { data: threadsData, isLoading } = useFetch<{ threads: Thread[]; needsAttention: number }>(
     "/api/inventory/supplier-chats",
   );
-  const { data: detail } = useFetch<Detail>(
+  const { data: detail, mutate: mutateDetail } = useFetch<Detail>(
     selected ? `/api/inventory/supplier-chats/${selected}` : null,
   );
+
+  const [draft, setDraft] = useState("");
+  const [sending, setSending] = useState(false);
+  const [sendError, setSendError] = useState<string | null>(null);
 
   const threads = threadsData?.threads ?? [];
   const shown = filter === "attention" ? threads.filter((t) => t.needsAttention) : threads;
@@ -84,6 +88,35 @@ export default function SupplierChatsPage() {
   useEffect(() => {
     if (!selected && threads.length) setSelected(threads[0].key);
   }, [threads, selected]);
+
+  useEffect(() => {
+    setDraft("");
+    setSendError(null);
+  }, [selected]);
+
+  async function send() {
+    if (!selected || !draft.trim() || sending) return;
+    setSending(true);
+    setSendError(null);
+    try {
+      const res = await fetch(`/api/inventory/supplier-chats/${selected}/send`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ text: draft.trim() }),
+      });
+      const json = await res.json().catch(() => ({}));
+      if (!res.ok) {
+        setSendError(json.error ?? "Send failed");
+        return;
+      }
+      setDraft("");
+      mutateDetail();
+    } catch {
+      setSendError("Network error");
+    } finally {
+      setSending(false);
+    }
+  }
 
   return (
     <div className="flex h-[calc(100vh-120px)] min-h-[560px] overflow-hidden rounded-lg border border-gray-800 bg-gray-950 text-gray-100">
@@ -181,12 +214,24 @@ export default function SupplierChatsPage() {
             <div className="border-t border-gray-800 px-4 py-2.5">
               <div className="flex items-center gap-2">
                 <input
-                  disabled
-                  placeholder={detail.windowOpen ? "Type a reply…" : "Window closed — use a template"}
-                  className="h-9 flex-1 rounded-md border border-gray-700 bg-gray-900 px-3 text-[13px] text-gray-300 placeholder:text-gray-600"
+                  value={draft}
+                  onChange={(e) => setDraft(e.target.value)}
+                  onKeyDown={(e) => {
+                    if (e.key === "Enter") send();
+                  }}
+                  disabled={!detail.windowOpen || sending}
+                  placeholder={
+                    detail.windowOpen ? "Type a reply…" : "Window closed — free text not allowed (template only)"
+                  }
+                  className="h-9 flex-1 rounded-md border border-gray-700 bg-gray-900 px-3 text-[13px] text-gray-100 placeholder:text-gray-600 disabled:opacity-50"
                 />
-                <button disabled className="flex h-9 w-9 items-center justify-center rounded-md border border-gray-700 text-gray-500">
-                  <Send size={15} />
+                <button
+                  onClick={send}
+                  disabled={!detail.windowOpen || sending || !draft.trim()}
+                  aria-label="Send"
+                  className="flex h-9 w-9 items-center justify-center rounded-md border border-gray-700 text-gray-200 hover:bg-gray-800 disabled:opacity-40"
+                >
+                  {sending ? <Loader2 size={15} className="animate-spin" /> : <Send size={15} />}
                 </button>
               </div>
               <div className="mt-1.5 flex items-center gap-1.5 text-[11px]">
@@ -194,7 +239,7 @@ export default function SupplierChatsPage() {
                 <span className="text-gray-500">
                   {detail.windowOpen ? "24h window open — free reply" : "24h window closed — template only"}
                 </span>
-                <span className="ml-auto text-gray-600">Reply/send: coming in #9</span>
+                {sendError && <span className="ml-auto text-red-400">{sendError}</span>}
               </div>
             </div>
           </>

--- a/apps/backoffice/src/app/api/inventory/supplier-chats/[key]/send/route.ts
+++ b/apps/backoffice/src/app/api/inventory/supplier-chats/[key]/send/route.ts
@@ -1,0 +1,61 @@
+import { NextResponse, NextRequest } from "next/server";
+import { prisma } from "@/lib/prisma";
+import { getUserFromHeaders } from "@/lib/auth";
+import { sendWhatsAppText } from "@/lib/whatsapp";
+import { recordOutboundMessage } from "@/lib/whatsapp-store";
+
+// Human-takeover send (#9). Staff reply to a supplier from the inbox. Free-text
+// is only allowed inside the 24h customer-service window (supplier messaged us in
+// the last 24h); outside it Meta requires an approved template, so we refuse with
+// a clear 409 rather than silently failing.
+
+export async function POST(req: NextRequest, { params }: { params: Promise<{ key: string }> }) {
+  const caller = await getUserFromHeaders(req.headers);
+  if (!caller) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+
+  const { key } = await params; // supplier counterparty number (digits)
+  const body = await req.json().catch(() => ({}));
+  const text = typeof body.text === "string" ? body.text.trim() : "";
+  if (!text) return NextResponse.json({ error: "Message is empty" }, { status: 400 });
+
+  // 24h window: did this counterparty message us within the last 24h?
+  const lastInbound = await prisma.whatsAppMessage.findFirst({
+    where: { fromNumber: key, direction: "inbound" },
+    orderBy: { timestamp: "desc" },
+    select: { timestamp: true },
+  });
+  const windowOpen =
+    !!lastInbound && Date.now() - +new Date(lastInbound.timestamp) < 24 * 60 * 60 * 1000;
+  if (!windowOpen) {
+    return NextResponse.json(
+      { error: "The 24-hour reply window is closed. Free text can't be sent — use an approved template." },
+      { status: 409 },
+    );
+  }
+
+  const result = await sendWhatsAppText(key, text);
+  if (!result.ok) {
+    return NextResponse.json({ error: result.error ?? "Send failed" }, { status: 502 });
+  }
+
+  // Resolve our own business number + supplier link from a recent message so the
+  // outbound row threads correctly (inbound.toNumber / outbound.fromNumber = us).
+  const ref = await prisma.whatsAppMessage.findFirst({
+    where: { OR: [{ fromNumber: key }, { toNumber: key }] },
+    orderBy: { timestamp: "desc" },
+    select: { direction: true, fromNumber: true, toNumber: true, supplierId: true },
+  });
+  const ourNumber = ref ? (ref.direction === "inbound" ? ref.toNumber : ref.fromNumber) : "";
+
+  await recordOutboundMessage({
+    waMessageId: result.messageId,
+    fromNumber: ourNumber,
+    toNumber: key,
+    type: "text",
+    body: text,
+    supplierId: ref?.supplierId ?? null,
+    status: "sent",
+  });
+
+  return NextResponse.json({ ok: true, messageId: result.messageId });
+}


### PR DESCRIPTION
Adds the reply/send composer to the Supplier Chats inbox (#9) — staff can take over a supplier conversation. Free-text is gated on the 24h customer-service window (409 + clear message when closed; template-based out-of-window sends are a follow-up). Outbound is persisted via recordOutboundMessage so it threads. Builds on the capture + inbox shipped in #500.

🤖 Generated with [Claude Code](https://claude.com/claude-code)