### PR TITLE
feat(procurement): add Supplier Chats to the nav

### DIFF
--- a/apps/backoffice/src/app/(admin)/layout.tsx
+++ b/apps/backoffice/src/app/(admin)/layout.tsx
@@ -222,6 +222,7 @@ const NAV_SECTIONS: NavSection[] = [
         label: "Ordering",
         items: [
           { label: "Purchase Orders", href: "/inventory/orders", icon: <FileText className={ICON_SIZE} />, moduleKey: "inventory:orders" },
+          { label: "Supplier Chats", href: "/inventory/supplier-chats", icon: <MessageCircle className={ICON_SIZE} />, moduleKey: "inventory:orders" },
           { label: "Transfers", href: "/inventory/transfers", icon: <ArrowLeftRight className={ICON_SIZE} />, moduleKey: "inventory:transfers" },
           { label: "Receivings", href: "/inventory/receivings", icon: <Receipt className={ICON_SIZE} />, moduleKey: "inventory:receivings" },
           { label: "Invoices", href: "/inventory/invoices", icon: <ClipboardList className={ICON_SIZE} />, moduleKey: "inventory:invoices" },


### PR DESCRIPTION
The Supplier Chats inbox shipped but wasn't in the sidebar — only reachable by direct URL. Adds it under **Procurement → Ordering** (gated on `inventory:orders`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)