### PR TITLE
feat(procurement): full-auto supplier-chat AI agent

### DIFF
--- a/apps/backoffice/src/app/(admin)/inventory/supplier-chats/page.tsx
+++ b/apps/backoffice/src/app/(admin)/inventory/supplier-chats/page.tsx
@@ -67,6 +67,10 @@ function clock(iso: string): string {
   return new Date(iso).toLocaleTimeString("en-GB", { hour: "2-digit", minute: "2-digit" });
 }
 
+function initials(name: string): string {
+  return name.replace(/[^A-Za-z0-9]/g, "").slice(0, 2).toUpperCase() || "?";
+}
+
 export default function SupplierChatsPage() {
   const [selected, setSelected] = useState<string | null>(null);
   const [filter, setFilter] = useState<"all" | "attention">("all");
@@ -119,23 +123,23 @@ export default function SupplierChatsPage() {
   }
 
   return (
-    <div className="flex h-[calc(100vh-120px)] min-h-[560px] overflow-hidden rounded-lg border border-gray-800 bg-gray-950 text-gray-100">
+    <div className="flex h-[calc(100vh-120px)] min-h-[560px] overflow-hidden rounded-lg border border-border bg-background text-foreground">
       {/* ── Thread list ─────────────────────────────── */}
-      <div className="flex w-64 shrink-0 flex-col border-r border-gray-800">
-        <div className="border-b border-gray-800 p-3">
+      <div className="flex w-64 shrink-0 flex-col border-r border-border">
+        <div className="border-b border-border p-3">
           <div className="flex items-center gap-2 text-sm font-medium">
             <MessageCircle size={16} /> Supplier chats
           </div>
           <div className="mt-2 flex gap-1">
             <button
               onClick={() => setFilter("all")}
-              className={`rounded-full px-2.5 py-0.5 text-xs ${filter === "all" ? "bg-gray-700 text-white" : "text-gray-400 hover:bg-gray-800"}`}
+              className={`rounded-full px-2.5 py-0.5 text-xs ${filter === "all" ? "bg-muted text-foreground" : "text-muted-foreground hover:bg-muted"}`}
             >
               All
             </button>
             <button
               onClick={() => setFilter("attention")}
-              className={`rounded-full px-2.5 py-0.5 text-xs ${filter === "attention" ? "bg-red-900/60 text-red-200" : "text-gray-400 hover:bg-gray-800"}`}
+              className={`rounded-full px-2.5 py-0.5 text-xs ${filter === "attention" ? "bg-destructive/10 text-destructive" : "text-muted-foreground hover:bg-muted"}`}
             >
               Needs attention {threadsData?.needsAttention ?? 0}
             </button>
@@ -143,12 +147,12 @@ export default function SupplierChatsPage() {
         </div>
         <div className="flex-1 overflow-y-auto">
           {isLoading && (
-            <div className="flex items-center justify-center p-6 text-gray-500">
+            <div className="flex items-center justify-center p-6 text-muted-foreground">
               <Loader2 size={18} className="animate-spin" />
             </div>
           )}
           {!isLoading && shown.length === 0 && (
-            <p className="p-4 text-xs text-gray-500">
+            <p className="p-4 text-xs text-muted-foreground">
               No supplier messages yet. They appear here once the WhatsApp number is live and receiving.
             </p>
           )}
@@ -156,18 +160,18 @@ export default function SupplierChatsPage() {
             <button
               key={t.key}
               onClick={() => setSelected(t.key)}
-              className={`flex w-full gap-2.5 border-b border-gray-800/70 p-2.5 text-left ${selected === t.key ? "bg-gray-800" : "hover:bg-gray-900"}`}
+              className={`flex w-full gap-2.5 border-b border-border p-2.5 text-left ${selected === t.key ? "bg-muted" : "hover:bg-muted/50"}`}
             >
-              <div className="flex h-7 w-7 shrink-0 items-center justify-center rounded-full bg-gray-700 text-[11px] font-medium">
-                {t.name.replace(/[^A-Za-z0-9]/g, "").slice(0, 2).toUpperCase() || "?"}
+              <div className="flex h-7 w-7 shrink-0 items-center justify-center rounded-full bg-primary/10 text-[11px] font-medium text-primary">
+                {initials(t.name)}
               </div>
               <div className="min-w-0 flex-1">
                 <div className="flex justify-between">
                   <span className="truncate text-[13px] font-medium">{t.name}</span>
-                  <span className="shrink-0 pl-1 text-[11px] text-gray-500">{rel(t.lastAt)}</span>
+                  <span className="shrink-0 pl-1 text-[11px] text-muted-foreground">{rel(t.lastAt)}</span>
                 </div>
-                <div className="flex items-center gap-1 text-[11px] text-gray-400">
-                  {t.needsAttention && <AlertCircle size={11} className="shrink-0 text-red-400" />}
+                <div className="flex items-center gap-1 text-[11px] text-muted-foreground">
+                  {t.needsAttention && <AlertCircle size={11} className="shrink-0 text-destructive" />}
                   <span className="truncate">{t.preview}</span>
                 </div>
               </div>
@@ -177,41 +181,49 @@ export default function SupplierChatsPage() {
       </div>
 
       {/* ── Conversation ────────────────────────────── */}
-      <div className="flex min-w-0 flex-1 flex-col border-r border-gray-800">
+      <div className="flex min-w-0 flex-1 flex-col border-r border-border">
         {!detail ? (
-          <div className="flex flex-1 items-center justify-center text-sm text-gray-500">
+          <div className="flex flex-1 items-center justify-center text-sm text-muted-foreground">
             Select a chat
           </div>
         ) : (
           <>
-            <div className="flex items-center justify-between border-b border-gray-800 px-4 py-2.5">
+            <div className="flex items-center justify-between border-b border-border px-4 py-2.5">
               <div>
                 <div className="text-sm font-medium">{detail.supplier?.name ?? `+${detail.key}`}</div>
-                <div className="text-xs text-gray-500">+{detail.key}</div>
+                <div className="text-xs text-muted-foreground">+{detail.key}</div>
               </div>
-              <span className="rounded-full bg-emerald-900/50 px-2 py-0.5 text-[11px] text-emerald-300">
+              <span className="rounded-full bg-green-500/10 px-2 py-0.5 text-[11px] text-green-600 dark:text-green-400">
                 WhatsApp
               </span>
             </div>
             <div className="flex flex-1 flex-col gap-2 overflow-y-auto p-4">
               {detail.messages.length === 0 && (
-                <p className="m-auto text-xs text-gray-500">No messages in this thread yet.</p>
+                <p className="m-auto text-xs text-muted-foreground">No messages in this thread yet.</p>
               )}
               {detail.messages.map((m) => (
                 <div
                   key={m.id}
                   className={`max-w-[80%] rounded-lg px-3 py-2 text-[13px] leading-snug ${
                     m.direction === "outbound"
-                      ? "self-end bg-emerald-900/40 text-emerald-50"
-                      : "self-start bg-gray-800 text-gray-100"
+                      ? "self-end bg-primary text-primary-foreground"
+                      : "self-start bg-muted text-foreground"
                   }`}
                 >
-                  {m.body ?? <span className="inline-flex items-center gap-1 text-gray-300"><FileText size={13} /> {m.type}</span>}
-                  <div className="mt-1 text-[10px] text-gray-500">{clock(m.timestamp)}</div>
+                  {m.body ?? (
+                    <span className="inline-flex items-center gap-1">
+                      <FileText size={13} /> {m.type}
+                    </span>
+                  )}
+                  <div
+                    className={`mt-1 text-[10px] ${m.direction === "outbound" ? "text-primary-foreground/70" : "text-muted-foreground"}`}
+                  >
+                    {clock(m.timestamp)}
+                  </div>
                 </div>
               ))}
             </div>
-            <div className="border-t border-gray-800 px-4 py-2.5">
+            <div className="border-t border-border px-4 py-2.5">
               <div className="flex items-center gap-2">
                 <input
                   value={draft}
@@ -223,23 +235,26 @@ export default function SupplierChatsPage() {
                   placeholder={
                     detail.windowOpen ? "Type a reply…" : "Window closed — free text not allowed (template only)"
                   }
-                  className="h-9 flex-1 rounded-md border border-gray-700 bg-gray-900 px-3 text-[13px] text-gray-100 placeholder:text-gray-600 disabled:opacity-50"
+                  className="h-9 flex-1 rounded-md border border-border bg-background px-3 text-[13px] text-foreground placeholder:text-muted-foreground disabled:opacity-50"
                 />
                 <button
                   onClick={send}
                   disabled={!detail.windowOpen || sending || !draft.trim()}
                   aria-label="Send"
-                  className="flex h-9 w-9 items-center justify-center rounded-md border border-gray-700 text-gray-200 hover:bg-gray-800 disabled:opacity-40"
+                  className="flex h-9 w-9 items-center justify-center rounded-md border border-border text-foreground hover:bg-muted disabled:opacity-40"
                 >
                   {sending ? <Loader2 size={15} className="animate-spin" /> : <Send size={15} />}
                 </button>
               </div>
               <div className="mt-1.5 flex items-center gap-1.5 text-[11px]">
-                <Clock size={12} className={detail.windowOpen ? "text-emerald-400" : "text-amber-400"} />
-                <span className="text-gray-500">
+                <Clock
+                  size={12}
+                  className={detail.windowOpen ? "text-green-600 dark:text-green-400" : "text-amber-600 dark:text-amber-400"}
+                />
+                <span className="text-muted-foreground">
                   {detail.windowOpen ? "24h window open — free reply" : "24h window closed — template only"}
                 </span>
-                {sendError && <span className="ml-auto text-red-400">{sendError}</span>}
+                {sendError && <span className="ml-auto text-destructive">{sendError}</span>}
               </div>
             </div>
           </>
@@ -250,56 +265,56 @@ export default function SupplierChatsPage() {
       <div className="w-60 shrink-0 overflow-y-auto p-3">
         {!detail ? null : (
           <>
-            <div className="flex flex-col items-center gap-1.5 border-b border-gray-800 pb-3 text-center">
-              <div className="flex h-10 w-10 items-center justify-center rounded-full bg-gray-700 text-sm font-medium">
-                {(detail.supplier?.name ?? detail.key).replace(/[^A-Za-z0-9]/g, "").slice(0, 2).toUpperCase()}
+            <div className="flex flex-col items-center gap-1.5 border-b border-border pb-3 text-center">
+              <div className="flex h-10 w-10 items-center justify-center rounded-full bg-primary/10 text-sm font-medium text-primary">
+                {initials(detail.supplier?.name ?? detail.key)}
               </div>
               <div className="text-[13px] font-medium">{detail.supplier?.name ?? `+${detail.key}`}</div>
-              <div className="flex items-center gap-1 text-[11px] text-gray-500">
+              <div className="flex items-center gap-1 text-[11px] text-muted-foreground">
                 <Phone size={11} /> +{detail.key}
               </div>
             </div>
 
             {detail.supplierId ? (
               <>
-                <div className="flex flex-col gap-1.5 border-b border-gray-800 py-3">
-                  <div className="rounded-md bg-gray-900 px-2.5 py-1.5">
-                    <div className="text-[11px] text-gray-500">Open POs</div>
+                <div className="flex flex-col gap-1.5 border-b border-border py-3">
+                  <div className="rounded-md bg-muted px-2.5 py-1.5">
+                    <div className="text-[11px] text-muted-foreground">Open POs</div>
                     <div className="text-[15px] font-medium">{detail.context.openPOs}</div>
                   </div>
-                  <div className="rounded-md bg-gray-900 px-2.5 py-1.5">
-                    <div className="text-[11px] text-gray-500">Unpaid</div>
+                  <div className="rounded-md bg-muted px-2.5 py-1.5">
+                    <div className="text-[11px] text-muted-foreground">Unpaid</div>
                     <div className="text-[15px] font-medium">{formatRM(detail.context.unpaidTotal)}</div>
                   </div>
                   {detail.context.overdueTotal > 0 && (
-                    <div className="rounded-md bg-red-950/60 px-2.5 py-1.5">
-                      <div className="text-[11px] text-red-300">Overdue</div>
-                      <div className="text-[15px] font-medium text-red-300">
+                    <div className="rounded-md bg-destructive/10 px-2.5 py-1.5">
+                      <div className="text-[11px] text-destructive">Overdue</div>
+                      <div className="text-[15px] font-medium text-destructive">
                         {formatRM(detail.context.overdueTotal)}
                       </div>
                     </div>
                   )}
                 </div>
-                <div className="flex flex-col gap-1 border-b border-gray-800 py-3 text-[12px]">
+                <div className="flex flex-col gap-1 border-b border-border py-3 text-[12px]">
                   <Row label="Delivery" value={detail.supplier?.deliveryDays?.join(", ") || "—"} />
                   <Row label="Lead time" value={`${detail.supplier?.leadTimeDays ?? 0}d`} />
                   <Row label="Terms" value={detail.supplier?.paymentTerms || "—"} />
                 </div>
                 <div className="pt-3">
-                  <div className="mb-1.5 text-[11px] text-gray-500">Open purchase orders</div>
+                  <div className="mb-1.5 text-[11px] text-muted-foreground">Open purchase orders</div>
                   {detail.context.recentPOs.length === 0 && (
-                    <p className="text-[11px] text-gray-600">None open.</p>
+                    <p className="text-[11px] text-muted-foreground">None open.</p>
                   )}
                   {detail.context.recentPOs.map((po) => (
                     <div key={po.orderNumber} className="flex justify-between py-0.5 text-[11px]">
                       <span>{po.orderNumber}</span>
-                      <span className="text-gray-500">{po.status.replace(/_/g, " ").toLowerCase()}</span>
+                      <span className="text-muted-foreground">{po.status.replace(/_/g, " ").toLowerCase()}</span>
                     </div>
                   ))}
                 </div>
               </>
             ) : (
-              <p className="py-4 text-[11px] text-gray-500">
+              <p className="py-4 text-[11px] text-muted-foreground">
                 Not linked to a supplier yet — no procurement context. Match this number on the supplier record to see open POs and balances.
               </p>
             )}
@@ -313,7 +328,7 @@ export default function SupplierChatsPage() {
 function Row({ label, value }: { label: string; value: string }) {
   return (
     <div className="flex justify-between">
-      <span className="text-gray-500">{label}</span>
+      <span className="text-muted-foreground">{label}</span>
       <span className="text-right">{value}</span>
     </div>
   );

--- a/apps/backoffice/src/app/api/whatsapp/webhook/route.ts
+++ b/apps/backoffice/src/app/api/whatsapp/webhook/route.ts
@@ -19,6 +19,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { verifyWhatsAppSignature } from "@/lib/whatsapp";
 import { recordInboundMessage } from "@/lib/whatsapp-store";
 import { handleInboundAck } from "@/lib/ops-pulse/inbound";
+import { handleSupplierMessage } from "@/lib/inventory/agents/supplier-chat-agent";
 
 // GET — webhook verification handshake.
 export async function GET(request: NextRequest) {
@@ -94,7 +95,21 @@ export async function POST(request: NextRequest) {
         } catch (err) {
           console.error("[ops-pulse] inbound ack failed:", err);
         }
-        // TODO (next): Telegram monitor mirror + route non-ack inbound (AI-propose PO edit).
+        // 3) Supplier-chat AI agent (full-auto, flag-gated + allow-listed). Reads
+        // the message in PO context, auto-replies in the supplier's language, and
+        // edits the PO for clear low-risk cases; substitutions / cancellations /
+        // low-confidence escalate to a human. It's internally guarded and never
+        // throws, so we AWAIT it (serverless can freeze after the response, so a
+        // fire-and-forget promise might not run) — it still returns fast for
+        // non-suppliers and when the flag is off. TODO: Telegram monitor mirror.
+        if (msg.type === "text" && body) {
+          await handleSupplierMessage({
+            fromNumber: msg.from,
+            toNumber: businessNumber,
+            text: body,
+            waMessageId: msg.id,
+          });
+        }
       }
       for (const status of value.statuses ?? []) {
         console.log(

--- a/apps/backoffice/src/lib/inventory/agents/supplier-chat-agent.ts
+++ b/apps/backoffice/src/lib/inventory/agents/supplier-chat-agent.ts
@@ -1,0 +1,362 @@
+/**
+ * Supplier-chat AI agent — full-auto procurement conversation handler.
+ *
+ * On an inbound WhatsApp message from a matched supplier that has an open PO,
+ * this reads the message in context (recent thread + the PO's line items),
+ * works out what the supplier means (out of stock, reduce qty, price change,
+ * delivery update, …) and:
+ *   - auto-replies to the supplier in THEIR language (Malay / English / mix), and
+ *   - for clear, low-risk cases, edits the open PO itself (remove / reduce a line).
+ *
+ * Guardrails are enforced in CODE, not left to the model:
+ *   - Off unless PROCUREMENT_AGENT_ENABLED=true.
+ *   - Only acts for suppliers on PROCUREMENT_AGENT_ALLOWLIST (comma-separated,
+ *     matched on the last 8 phone digits) when that var is set — so the first
+ *     live run is scoped to the Test supplier, not all suppliers. Unset = all.
+ *   - substitutions, full cancellations, and ANY low-confidence call ESCALATE:
+ *     we send a safe holding reply and leave the PO untouched for a human.
+ *   - every decision is stamped onto the outbound message's `raw` for audit, and
+ *     used to de-dupe Meta webhook redeliveries.
+ *
+ * Sends use sendWhatsAppText, which uses the app's own permanent token server
+ * side — no token is needed from a caller. Never throws (callers can await it
+ * without risking the webhook's 200).
+ *
+ * Model: claude-sonnet-4-6 — this edits real POs and writes to real suppliers,
+ * so it gets a reasoning-grade model rather than Haiku.
+ */
+import Anthropic from "@anthropic-ai/sdk";
+import type { OrderStatus } from "@celsius/db";
+import { prisma } from "@/lib/prisma";
+import { sendWhatsAppText } from "@/lib/whatsapp";
+import { recordOutboundMessage } from "@/lib/whatsapp-store";
+
+const anthropic = new Anthropic({ apiKey: process.env.ANTHROPIC_API_KEY });
+
+export const SUPPLIER_AGENT_VERSION = "supplier-chat-agent-v1";
+
+const digits = (s: string | null | undefined) => (s ?? "").replace(/[^0-9]/g, "");
+
+// "Open" = a PO still in flight (everything except the terminal states).
+const OPEN_ORDER_STATUSES: OrderStatus[] = [
+  "DRAFT",
+  "PENDING_APPROVAL",
+  "APPROVED",
+  "SENT",
+  "CONFIRMED",
+  "AWAITING_DELIVERY",
+  "PARTIALLY_RECEIVED",
+];
+
+type PoActionType = "none" | "remove_item" | "reduce_qty" | "substitute_item" | "cancel_order";
+
+type AgentDecision = {
+  intent: string;
+  language: "ms" | "en" | "mixed";
+  po_action: {
+    type: PoActionType;
+    po_item_id: string | null;
+    new_quantity: number | null;
+    note: string | null;
+  };
+  reply_text: string;
+  confidence: number;
+  requires_human: boolean;
+  escalation_reason: string | null;
+};
+
+export interface SupplierMessageEvent {
+  fromNumber: string; // supplier's number (digits or +form)
+  toNumber: string; // our business number
+  text: string;
+  waMessageId?: string;
+}
+
+const HOLDING_REPLY = {
+  ms: "Baik, terima kasih. Saya semak dengan team dulu dan akan maklum balas sebentar lagi. 🙏",
+  en: "Noted, thank you — let me confirm with the team and get right back to you. 🙏",
+};
+
+function flagEnabled(): boolean {
+  return process.env.PROCUREMENT_AGENT_ENABLED === "true";
+}
+
+// Allow-list of supplier numbers (last-8 digits) the agent may act on. Unset or
+// empty => all suppliers. Set to the Test number for the first live run.
+function allowed(supplierPhone: string | null | undefined): boolean {
+  const raw = process.env.PROCUREMENT_AGENT_ALLOWLIST?.trim();
+  if (!raw) return true;
+  const tail = digits(supplierPhone).slice(-8);
+  if (!tail) return false;
+  return raw
+    .split(",")
+    .map((s) => digits(s).slice(-8))
+    .filter(Boolean)
+    .includes(tail);
+}
+
+/**
+ * Entry point. Safe to `await` from the webhook — it never throws and no-ops
+ * fast for non-suppliers / disabled flag.
+ */
+export async function handleSupplierMessage(evt: SupplierMessageEvent): Promise<void> {
+  try {
+    if (!flagEnabled() || !process.env.ANTHROPIC_API_KEY) return;
+
+    const fromDigits = digits(evt.fromNumber);
+    const tail = fromDigits.slice(-8);
+    if (tail.length < 8 || !evt.text.trim()) return;
+
+    // Match the supplier by last-8 digits (same rule as whatsapp-store).
+    const suppliers = await prisma.supplier.findMany({
+      where: { phone: { not: null }, status: "ACTIVE" },
+      select: { id: true, name: true, phone: true, paymentTerms: true },
+    });
+    const supplier = suppliers.find((s) => {
+      const sd = digits(s.phone);
+      return sd === fromDigits || (sd.length >= 8 && sd.slice(-8) === tail);
+    });
+    if (!supplier || !allowed(supplier.phone)) return; // unknown / not allow-listed → leave to humans
+
+    // Redelivery dedupe: if we've already auto-answered this exact inbound, stop.
+    if (evt.waMessageId) {
+      const already = await prisma.whatsAppMessage.findFirst({
+        where: { direction: "outbound", raw: { path: ["inReplyTo"], equals: evt.waMessageId } },
+        select: { id: true },
+      });
+      if (already) return;
+    }
+
+    // Most recent open PO for this supplier + its line items.
+    const order = await prisma.order.findFirst({
+      where: {
+        supplierId: supplier.id,
+        orderType: "PURCHASE_ORDER",
+        status: { in: OPEN_ORDER_STATUSES },
+      },
+      orderBy: { createdAt: "desc" },
+      select: {
+        id: true,
+        orderNumber: true,
+        status: true,
+        items: {
+          select: {
+            id: true,
+            quantity: true,
+            unitPrice: true,
+            product: { select: { name: true, baseUom: true } },
+          },
+        },
+      },
+    });
+    if (!order || order.items.length === 0) return; // nothing actionable
+
+    // Recent thread for context (chronological, last 8).
+    const history = await prisma.whatsAppMessage.findMany({
+      where: { supplierId: supplier.id },
+      orderBy: { timestamp: "desc" },
+      take: 8,
+      select: { direction: true, body: true },
+    });
+    history.reverse();
+
+    const decision = await classify(evt.text, supplier, order, history);
+    if (!decision) return;
+
+    // ── Guardrails (code, not model): auto-act vs escalate ──
+    const risky =
+      decision.po_action.type === "substitute_item" || decision.po_action.type === "cancel_order";
+    const escalate = decision.requires_human || risky || decision.confidence < 0.7;
+
+    const lang: "ms" | "en" = decision.language === "ms" ? "ms" : "en";
+    let replyText = decision.reply_text?.trim();
+    let appliedAction: PoActionType = "none";
+
+    if (escalate) {
+      // Never confirm an action we're not taking — send a safe holding line.
+      replyText = HOLDING_REPLY[lang];
+    } else if (
+      decision.po_action.type === "remove_item" ||
+      decision.po_action.type === "reduce_qty"
+    ) {
+      appliedAction = await applyPoAction(order.id, decision.po_action);
+    }
+    if (!replyText) replyText = HOLDING_REPLY[lang];
+
+    // Auto-reply (24h window is open — the supplier just messaged us).
+    const sent = await sendWhatsAppText(supplier.phone ?? fromDigits, replyText);
+
+    await recordOutboundMessage({
+      waMessageId: sent.messageId,
+      fromNumber: digits(evt.toNumber),
+      toNumber: fromDigits,
+      type: "text",
+      body: replyText,
+      supplierId: supplier.id,
+      status: sent.ok ? "sent" : "failed",
+      raw: {
+        agent: SUPPLIER_AGENT_VERSION,
+        inReplyTo: evt.waMessageId ?? null,
+        intent: decision.intent,
+        confidence: decision.confidence,
+        appliedAction,
+        escalated: escalate,
+        escalationReason: escalate ? (decision.escalation_reason ?? "guardrail") : null,
+        poNumber: order.orderNumber,
+      },
+    });
+
+    console.log(
+      `[supplier-agent] supplier=${supplier.name} po=${order.orderNumber} intent=${decision.intent} ` +
+        `conf=${decision.confidence.toFixed(2)} action=${appliedAction} escalate=${escalate} sent=${sent.ok}`,
+    );
+  } catch (err) {
+    // Never let the agent break the webhook's 200.
+    console.error("[supplier-agent] error:", err instanceof Error ? err.message : err);
+  }
+}
+
+/** Apply a vetted, low-risk edit to the PO and recompute its total. */
+async function applyPoAction(
+  orderId: string,
+  action: AgentDecision["po_action"],
+): Promise<PoActionType> {
+  if (!action.po_item_id) return "none";
+  const item = await prisma.orderItem.findFirst({
+    where: { id: action.po_item_id, orderId }, // ensure the line belongs to THIS order
+    select: { id: true, unitPrice: true },
+  });
+  if (!item) return "none";
+
+  if (action.type === "remove_item") {
+    await prisma.orderItem.delete({ where: { id: item.id } });
+  } else if (action.type === "reduce_qty" && action.new_quantity && action.new_quantity > 0) {
+    const q = action.new_quantity;
+    await prisma.orderItem.update({
+      where: { id: item.id },
+      data: { quantity: q, totalPrice: Number(item.unitPrice) * q },
+    });
+  } else {
+    return "none";
+  }
+
+  // Recompute the order total from the remaining lines.
+  const remaining = await prisma.orderItem.findMany({
+    where: { orderId },
+    select: { totalPrice: true },
+  });
+  const total = remaining.reduce((s, i) => s + Number(i.totalPrice), 0);
+  await prisma.order.update({ where: { id: orderId }, data: { totalAmount: total } });
+  return action.type;
+}
+
+type SupplierCtx = { name: string; paymentTerms: string | null };
+type OrderCtx = {
+  orderNumber: string;
+  status: OrderStatus;
+  items: Array<{
+    id: string;
+    quantity: Prisma_Decimalish;
+    unitPrice: Prisma_Decimalish;
+    product: { name: string; baseUom: string };
+  }>;
+};
+// Prisma Decimal serialises via Number(); we only ever read it numerically here.
+type Prisma_Decimalish = { toString(): string };
+
+const SYSTEM = `You are the procurement assistant for Celsius Coffee, a Malaysian F&B chain. You chat with SUPPLIERS on WhatsApp to manage purchase orders. Suppliers write in Malay, English, or a mix ("Manglish") and often use voice-note-style short text. Reply in the SAME language they use — short, warm, and professional, like a Malaysian operations person. Output ONLY a JSON object, no prose.`;
+
+async function classify(
+  text: string,
+  supplier: SupplierCtx,
+  order: OrderCtx,
+  history: Array<{ direction: string; body: string | null }>,
+): Promise<AgentDecision | null> {
+  const items = order.items
+    .map(
+      (it) =>
+        `- po_item_id=${it.id} | ${it.product.name} | qty ${Number(it.quantity)} ${it.product.baseUom} | RM ${Number(it.unitPrice).toFixed(2)} each`,
+    )
+    .join("\n");
+  const thread =
+    history
+      .filter((m) => m.body)
+      .map((m) => `${m.direction === "inbound" ? "Supplier" : "Us"}: ${m.body}`)
+      .join("\n") || "(no earlier messages)";
+
+  const prompt = `A supplier just messaged us about an open purchase order.
+
+# Supplier
+${supplier.name} (payment terms: ${supplier.paymentTerms ?? "—"})
+
+# Open PO ${order.orderNumber} (status ${order.status}) — line items
+${items}
+
+# Recent conversation
+${thread}
+
+# New message from the supplier
+"${text}"
+
+# Decide
+Work out what the supplier means and how to respond. Choose a po_action ONLY when it is unambiguous which line item and what change. If the supplier says something is unavailable/short but does NOT say which item, ask which item — do NOT guess.
+
+Rules:
+- Out of stock / "takde" / "habis" / "tak dapat" → if the exact item is clear, po_action remove_item with its po_item_id; if it's unclear which, po_action none and ASK which item.
+- Less quantity available / "ada sikit je" / "boleh bagi X je" → reduce_qty with new_quantity.
+- Offers a different brand / substitute → po_action substitute_item AND requires_human=true (recipe risk; a human must approve).
+- Price change, cancelling the whole order, asking for payment/invoice, or anything you are unsure about → requires_human=true, po_action none.
+- reply_text: the WhatsApp message to send back, in the supplier's language. If requires_human, keep it to a brief, honest holding acknowledgement — do not promise a specific change.
+- Be conservative with confidence: only >0.7 when both the item and the action are unambiguous.
+
+# Output — JSON only:
+{
+  "intent": "out_of_stock|reduce_qty|substitution_offer|price_change|delivery_update|confirmation|greeting|invoice_request|other|unclear",
+  "language": "ms|en|mixed",
+  "po_action": {"type":"none|remove_item|reduce_qty|substitute_item|cancel_order","po_item_id": null,"new_quantity": null,"note": null},
+  "reply_text": "…",
+  "confidence": 0.0,
+  "requires_human": false,
+  "escalation_reason": null
+}`;
+
+  const response = await anthropic.messages.create({
+    model: "claude-sonnet-4-6",
+    max_tokens: 700,
+    system: SYSTEM,
+    messages: [{ role: "user", content: prompt }],
+  });
+
+  const out = response.content
+    .filter((b): b is Anthropic.TextBlock => b.type === "text")
+    .map((b) => b.text)
+    .join("");
+  const m = out.match(/\{[\s\S]*\}/);
+  if (!m) return null;
+
+  try {
+    const p = JSON.parse(m[0]) as Record<string, unknown>;
+    const pa = (p.po_action ?? {}) as Record<string, unknown>;
+    const type = String(pa.type ?? "none") as PoActionType;
+    return {
+      intent: String(p.intent ?? "unclear"),
+      language: p.language === "ms" || p.language === "mixed" ? (p.language as "ms" | "mixed") : "en",
+      po_action: {
+        type: (
+          ["none", "remove_item", "reduce_qty", "substitute_item", "cancel_order"] as PoActionType[]
+        ).includes(type)
+          ? type
+          : "none",
+        po_item_id: typeof pa.po_item_id === "string" ? pa.po_item_id : null,
+        new_quantity: typeof pa.new_quantity === "number" ? pa.new_quantity : null,
+        note: typeof pa.note === "string" ? pa.note : null,
+      },
+      reply_text: String(p.reply_text ?? ""),
+      confidence: Math.max(0, Math.min(1, Number(p.confidence) || 0)),
+      requires_human: Boolean(p.requires_human),
+      escalation_reason: typeof p.escalation_reason === "string" ? p.escalation_reason : null,
+    };
+  } catch {
+    return null;
+  }
+}

--- a/apps/backoffice/src/lib/inventory/agents/supplier-chat-agent.ts
+++ b/apps/backoffice/src/lib/inventory/agents/supplier-chat-agent.ts
@@ -264,7 +264,41 @@ type OrderCtx = {
 // Prisma Decimal serialises via Number(); we only ever read it numerically here.
 type Prisma_Decimalish = { toString(): string };
 
-const SYSTEM = `You are the procurement assistant for Celsius Coffee, a Malaysian F&B chain. You chat with SUPPLIERS on WhatsApp to manage purchase orders. Suppliers write in Malay, English, or a mix ("Manglish") and often use voice-note-style short text. Reply in the SAME language they use — short, warm, and professional, like a Malaysian operations person. Output ONLY a JSON object, no prose.`;
+const AGENT_ROLE = `You are the procurement assistant for Celsius Coffee, a Malaysian specialty-coffee chain. You handle WhatsApp chats with SUPPLIERS for the buying team: read each message in the context of the supplier's open purchase order, reply the way a Celsius ops person would, and — only for clearly safe cases — adjust the PO. Output ONLY a JSON object, no prose.`;
+
+// Static voice + glossary + decision policy, distilled from 17 real Celsius
+// supplier chat logs (docs/design/procurement-chat-learnings.md). Marked for
+// prompt caching — identical on every call, so we pay input tokens once per
+// 5-min window. The hard escalation rules below are the real lesson from those
+// chats: suppliers casually offer "same quality" subs that are not recipe-safe.
+const PLAYBOOK = `# Voice (match it)
+Warm, brief, never pushy. Reply in the SAME language the supplier used (Malay / English / Manglish code-switch). Address them "bos"/"boss" or by name; greet "Hi"/"Salam". Light emoji only (🙏 👌). Keep confirmations short: "noted bos", "ok", "baik, thank you".
+
+# Supplier phrasing you must understand (Malay / Manglish)
+- Out of stock: takde, xde, x ada, dah habis, dah abis, kosong, "no stock", OOS, "dry stock" (their own supplier is out).
+- Short quantity: "ada sikit je", "boleh bagi X je", "tinggal X".
+- Delivery/ETA: "boleh hantar bila", "bila sampai", harini=today, esok=tomorrow, otw, "dah hantar/sampai". Days: Isnin Mon, Selasa Tue, Rabu Wed, Khamis Thu, Jumaat Fri, Sabtu Sat.
+- Price: berapa, "1 ctn ada brp", "RM9 per pc". Invoice: "keluarkan invois", SOA (statement of account), "resend invoice".
+- Payment: "attached PoP", "dah initiate", "clear payment first" (pay before they release), "received with thanks".
+- MOQ: "below MOQ", "add something more", "trip min RMxxx". Closure: cuti, tutup, "off day", Raya/CNY/PH last-order/resume notices.
+- Units: ctn carton, pkt packet, pcs, btl bottle, kg, kotak box, tin. boleh=ok/can, faham=understood.
+
+# You may act AUTONOMOUSLY only here (set po_action + a confirming reply):
+- remove_item — only when it is unambiguous WHICH line is out of stock.
+- reduce_qty — only when they state a smaller available quantity for a specific line.
+If they say something is out/short but NOT which item → ask which, po_action none. Never guess.
+
+# You MUST escalate (requires_human=true, po_action none, send a short honest holding reply — never confirm the action):
+- ANY substitution offer, even "same quality / identical" — Celsius recipes are fat-%/grade/brand-sensitive (e.g. cream 35.7% vs 35.1%, matcha grade, syrup line). Relay it; never accept it.
+- price increases or committing to a quote; MOQ top-up decisions (buying filler is a judgement call).
+- payment, proof-of-payment, payment-gating, and ANY reconciliation query (you cannot see invoice / PoP contents).
+- complaints / damaged / wrong goods; e-invoice / PO-number / TIN / compliance; credit-term questions.
+- ambiguous quantity or unit ("2.5kg only", "1 ctn ada brp") → ask to clarify, do not assume.
+
+# Handle conversationally, NO PO change, requires_human=false:
+order confirmations, delivery / ETA, invoice / SOA receipt, closure / holiday notices, greetings, lead-time notes — acknowledge politely or ask a brief clarifying question.
+
+Be conservative: confidence >0.7 ONLY when both the item AND the action are unambiguous.`;
 
 async function classify(
   text: string,
@@ -284,12 +318,7 @@ async function classify(
       .map((m) => `${m.direction === "inbound" ? "Supplier" : "Us"}: ${m.body}`)
       .join("\n") || "(no earlier messages)";
 
-  const prompt = `A supplier just messaged us about an open purchase order.
-
-# Supplier
-${supplier.name} (payment terms: ${supplier.paymentTerms ?? "—"})
-
-# Open PO ${order.orderNumber} (status ${order.status}) — line items
+  const prompt = `# Open PO ${order.orderNumber} (status ${order.status}) — ${supplier.name}, terms ${supplier.paymentTerms ?? "—"}
 ${items}
 
 # Recent conversation
@@ -298,22 +327,20 @@ ${thread}
 # New message from the supplier
 "${text}"
 
-# Decide
-Work out what the supplier means and how to respond. Choose a po_action ONLY when it is unambiguous which line item and what change. If the supplier says something is unavailable/short but does NOT say which item, ask which item — do NOT guess.
-
-Rules:
-- Out of stock / "takde" / "habis" / "tak dapat" → if the exact item is clear, po_action remove_item with its po_item_id; if it's unclear which, po_action none and ASK which item.
-- Less quantity available / "ada sikit je" / "boleh bagi X je" → reduce_qty with new_quantity.
-- Offers a different brand / substitute → po_action substitute_item AND requires_human=true (recipe risk; a human must approve).
-- Price change, cancelling the whole order, asking for payment/invoice, or anything you are unsure about → requires_human=true, po_action none.
-- reply_text: the WhatsApp message to send back, in the supplier's language. If requires_human, keep it to a brief, honest holding acknowledgement — do not promise a specific change.
-- Be conservative with confidence: only >0.7 when both the item and the action are unambiguous.
+# Judgement examples (follow this behaviour)
+- "caramel syrup takde" AND Caramel is a line item → remove_item that line; reply e.g. "Noted bos 🙏 kita remove caramel dulu, proceed yang lain ya".
+- "ada barang yang takde" (does NOT say which) → po_action none; ask "Hi bos, boleh confirm item mana yang takde? 🙏".
+- "boleh bagi 3 ctn je" for a line of 5 → reduce_qty new_quantity 3; confirm briefly.
+- "Matcha Morihan OOS, boleh replace Yamama, same quality" → substitution → requires_human true, po_action none, brief holding reply only (do NOT accept the swap).
+- "dah hantar ya, otw" → delivery_eta; reply "noted, thank you bos 🙏"; no PO change.
+- "below MOQ RM300, can add something?" → moq_topup → requires_human true, po_action none, holding reply.
+- "attached invoice" / "this PoP for inv -0142 or -0143?" → invoice_or_soa / reconciliation_query → requires_human true; you can't read the document.
 
 # Output — JSON only:
 {
-  "intent": "out_of_stock|reduce_qty|substitution_offer|price_change|delivery_update|confirmation|greeting|invoice_request|other|unclear",
+  "intent": "out_of_stock|reduce_qty|substitution_offer|price_quote_or_increase|delivery_eta|order_confirmation|invoice_or_soa|payment_gating_or_chase|moq_topup|closure_or_holiday|new_product_offer|reconciliation_query|complaint_or_quality|lead_time_advisory|compliance_or_einvoice|staff_handover|greeting|other|unclear",
   "language": "ms|en|mixed",
-  "po_action": {"type":"none|remove_item|reduce_qty|substitute_item|cancel_order","po_item_id": null,"new_quantity": null,"note": null},
+  "po_action": {"type":"none|remove_item|reduce_qty|substitute_item|cancel_order","po_item_id":null,"new_quantity":null,"note":null},
   "reply_text": "…",
   "confidence": 0.0,
   "requires_human": false,
@@ -323,7 +350,11 @@ Rules:
   const response = await anthropic.messages.create({
     model: "claude-sonnet-4-6",
     max_tokens: 700,
-    system: SYSTEM,
+    system: [
+      { type: "text", text: AGENT_ROLE },
+      // The playbook is identical every call — cache it.
+      { type: "text", text: PLAYBOOK, cache_control: { type: "ephemeral" } },
+    ],
     messages: [{ role: "user", content: prompt }],
   });
 

--- a/apps/backoffice/src/lib/whatsapp-store.ts
+++ b/apps/backoffice/src/lib/whatsapp-store.ts
@@ -75,6 +75,10 @@ export interface OutboundRecord {
   mediaUrl?: string | null;
   supplierId?: string | null;
   status?: string | null;
+  // Free-form audit payload stored on the row. The supplier-chat agent stamps
+  // its decision + the inbound waMessageId it answers ({ agent, inReplyTo, … })
+  // here, so the inbox can show "AI replied" and redeliveries are de-duped.
+  raw?: unknown;
 }
 
 export async function recordOutboundMessage(rec: OutboundRecord): Promise<void> {
@@ -90,6 +94,7 @@ export async function recordOutboundMessage(rec: OutboundRecord): Promise<void> 
         body: rec.body ?? null,
         mediaUrl: rec.mediaUrl ?? null,
         status: rec.status ?? "sent",
+        raw: (rec.raw ?? undefined) as Prisma.InputJsonValue | undefined,
       },
     });
   } catch (e) {

--- a/docs/design/procurement-chat-learnings.md
+++ b/docs/design/procurement-chat-learnings.md
@@ -94,3 +94,11 @@ helps; matching/short/partial/double detection is still manual.
 - **Bake/make-to-order** (Cake Discovery, JS Breadserie, Jiju's, Blancoz, Xora cups): "OOS" =
   lead-time wait; vendor-push prompts common.
 - **External-channel** (Dankoff email, HNJ app, BBM portal): mirror/track only.
+
+## Agent v1 — what got baked into the prompt (2026-06-26)
+`apps/backoffice/src/lib/inventory/agents/supplier-chat-agent.ts` turns these learnings into behaviour. A cached `PLAYBOOK` system block carries the Malay/Manglish glossary (takde/kosong/otw/cuti/ctn…), the Celsius voice (warm, terse, "bos", 🙏), and the auto-vs-escalate matrix:
+
+- **Auto (full-auto, no human):** unambiguous OOS → `remove_item`; clear smaller qty → `reduce_qty`; plain delivery/ETA, order confirmation, greeting, closure notice → short conversational reply, no PO change.
+- **Always escalate** (holding reply, PO untouched, human decides): ANY substitution offer ("same quality" is the trap — cream 35.7 vs 35.1); price increase / quote commitment; MOQ top-up; payment / PoP / payment-gating / reconciliation (agent can't read invoice/PoP images); complaints / damaged / wrong goods; e-invoice / PO-number / TIN / credit terms; ambiguous qty or unit → clarify.
+
+Rollout is gated: `PROCUREMENT_AGENT_ENABLED` (off by default) + `PROCUREMENT_AGENT_ALLOWLIST` (last-8 phone digits; scope the first live run to the Test supplier). Shipped in PR #526. Substitution auto-accept and the reconciliation ledger remain the open high-ROI follow-ups.


### PR DESCRIPTION
## What
A full-auto AI agent that handles supplier WhatsApp conversations for procurement. When a supplier messages us about an open PO, it reads the message **in PO context**, **auto-replies** in their language, and **edits the PO** for clear low-risk cases — replacing the human in the loop for routine supplier chat (e.g. "item out of stock").

Hooks into the inbound webhook at the spot that already had a `TODO: route non-ack inbound (AI-propose PO edit)`.

## How it decides
`supplier-chat-agent.ts` → Claude `sonnet-4-6` → structured JSON `{intent, po_action, reply_text, confidence, requires_human}`.

**Guardrails enforced in code (not left to the model):**
- 🔒 Off unless `PROCUREMENT_AGENT_ENABLED=true`.
- 🎯 Scoped by `PROCUREMENT_AGENT_ALLOWLIST` (comma-sep, matched on last-8 phone digits) — so the first live run hits **only the Test supplier**, not all 53 real suppliers. Unset = all.
- ✋ **Substitutions, cancellations, and any `confidence < 0.7` escalate** → safe holding reply, PO untouched, for a human. Recipe risk is never auto-actioned.
- 🔁 Redelivery dedupe via `raw.inReplyTo`; never throws (safe to `await` before the webhook 200).
- 🧾 Every decision stamped on the outbound message `raw` for audit.

PO edits supported auto: `remove_item`, `reduce_qty` (recompute order total). Substitute/cancel are human-gated.

## Files
- `lib/inventory/agents/supplier-chat-agent.ts` (new)
- `app/api/whatsapp/webhook/route.ts` — await the agent at the inbound hook
- `lib/whatsapp-store.ts` — outbound rows can carry a `raw` audit payload

## Go-live (after merge)
Set on Vercel `celsius-backoffice` (Production):
- `PROCUREMENT_AGENT_ENABLED=true`
- `PROCUREMENT_AGENT_ALLOWLIST=60109335369`  ← Test supplier only, for the first run
- `ANTHROPIC_API_KEY` (already present for the other agents)

Then a WhatsApp message from the Test supplier naming an item ("mozzarella takde") → agent replies + removes that line from PO-TEST-0001. Vague messages ("ada barang takde") → it asks which item, no edit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)