### PR TITLE
feat(ops): "Send test pulse" button — sample digest to your own WhatsApp

### DIFF
--- a/apps/backoffice/src/app/(admin)/ops/chat-inbox/_PulsePanel.tsx
+++ b/apps/backoffice/src/app/(admin)/ops/chat-inbox/_PulsePanel.tsx
@@ -4,7 +4,7 @@ import { useState } from "react";
 import { Card } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
-import { Loader2, ShieldAlert, Check, Eye, RefreshCw } from "lucide-react";
+import { Loader2, ShieldAlert, Check, Eye, RefreshCw, Send } from "lucide-react";
 import { useFetch } from "@/lib/use-fetch";
 
 type Alert = {
@@ -40,6 +40,26 @@ export default function PulsePanel({ onChange }: { onChange: () => void }) {
   const { data, isLoading, mutate } = useFetch<{ alerts: Alert[] }>("/api/ops/workspace/pulse");
   const alerts = data?.alerts ?? [];
   const [busy, setBusy] = useState<string | null>(null);
+  const [testing, setTesting] = useState(false);
+  const [testMsg, setTestMsg] = useState<{ ok: boolean; text: string } | null>(null);
+
+  const sendTest = async () => {
+    setTesting(true);
+    setTestMsg(null);
+    try {
+      const res = await fetch("/api/ops/workspace/test-pulse", { method: "POST" });
+      const j = await res.json().catch(() => ({}));
+      setTestMsg(
+        res.ok
+          ? { ok: true, text: `Test pulse sent to ${j.to ?? "your number"} — check WhatsApp.` }
+          : { ok: false, text: j.message || j.error || "Failed to send test pulse." },
+      );
+    } catch {
+      setTestMsg({ ok: false, text: "Network error sending test pulse." });
+    } finally {
+      setTesting(false);
+    }
+  };
 
   const act = async (id: string, action: "resolve" | "ack") => {
     setBusy(id);
@@ -61,10 +81,31 @@ export default function PulsePanel({ onChange }: { onChange: () => void }) {
       <div className="mb-3 flex items-center gap-2">
         <ShieldAlert className="h-4 w-4 text-terracotta" />
         <span className="text-sm font-medium">Open pulse alerts</span>
-        <button onClick={() => mutate()} className="ml-auto flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground">
+        <Button
+          size="sm"
+          variant="outline"
+          onClick={sendTest}
+          disabled={testing}
+          className="ml-auto h-7 gap-1 px-2 text-xs"
+          title="Send a sample pulse digest to your own WhatsApp"
+        >
+          {testing ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <Send className="h-3.5 w-3.5" />}
+          Send test pulse
+        </Button>
+        <button onClick={() => mutate()} className="flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground">
           <RefreshCw className="h-3.5 w-3.5" /> Refresh
         </button>
       </div>
+      {testMsg && (
+        <div
+          className={
+            "mb-3 rounded-md px-3 py-2 text-xs " +
+            (testMsg.ok ? "bg-green-50 text-green-700" : "bg-amber-50 text-amber-800")
+          }
+        >
+          {testMsg.text}
+        </div>
+      )}
 
       {isLoading ? (
         <div className="p-6 text-center text-muted-foreground">

--- a/apps/backoffice/src/app/api/ops/workspace/test-pulse/route.ts
+++ b/apps/backoffice/src/app/api/ops/workspace/test-pulse/route.ts
@@ -1,0 +1,57 @@
+import { NextResponse } from "next/server";
+import { getSession } from "@/lib/auth";
+import { prisma } from "@/lib/prisma";
+import { sendDailyDigest } from "@/lib/ops-pulse/sender";
+
+export const dynamic = "force-dynamic";
+
+const ALLOWED = ["OWNER", "ADMIN", "MANAGER"];
+
+// POST — send a SAMPLE ops-pulse daily digest to the caller's own WhatsApp,
+// through the real sender (approved template if one is configured, else
+// free-form which only delivers inside the caller's open 24h window). Lets an
+// owner verify pulse delivery + formatting before arming the cron. Sample data
+// only — never touches the OpsAlert ledger or any real detector.
+export async function POST() {
+  const session = await getSession();
+  if (!session) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  if (!ALLOWED.includes(session.role)) return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+
+  const me = await prisma.user.findUnique({ where: { id: session.id }, select: { phone: true } });
+  if (!me?.phone) {
+    return NextResponse.json(
+      { error: "no_phone", message: "Your staff profile has no phone number on file — add one to receive a test pulse." },
+      { status: 400 },
+    );
+  }
+
+  // Representative sample spanning the real detector categories: routine
+  // (recurring discipline) vs adhoc (event-driven). Mirrors what a live daily
+  // digest looks like so the format + delivery are validated end to end.
+  const routine = [
+    "🧪 TEST PULSE — sample data, not real alerts",
+    "Stock count overdue (2 days) · Bangsar",
+    "Weekly barista audit due · Bangsar",
+    "Opening checklist incomplete · Bangsar",
+  ];
+  const adhoc = [
+    "⭐ New 2★ review — “Long wait, latte was cold” · Bangsar",
+    "Menu item snoozed 3h — Iced Latte · Bangsar",
+    "Receiving short 2 units — PO #1042",
+  ];
+
+  const result = await sendDailyDigest(me.phone, routine, adhoc);
+
+  if (!result.ok) {
+    return NextResponse.json(
+      {
+        ok: false,
+        error: result.error || "send_failed",
+        message:
+          "Send failed — most likely outside your 24h WhatsApp window and no approved pulse template is configured yet. Send any WhatsApp to the business number from your phone, then try again.",
+      },
+      { status: 502 },
+    );
+  }
+  return NextResponse.json({ ok: true, messageId: result.messageId, to: me.phone });
+}


### PR DESCRIPTION
Adds an owner-triggered **"Send test pulse"** button to the Ops Workspace **Pulse** tab.

### What it does
- `POST /api/ops/workspace/test-pulse` sends a **sample daily ops-pulse digest** to the **caller's own WhatsApp**, through the *real* sender (`sendDailyDigest` → approved template if configured, else free-form inside the 24h window).
- The sample spans the real detector categories so you can see a realistic pulse: **review/feedback, menu-snoozed, stock-count, audit, opening-checklist, receiving**.
- Sample data only — **never touches the `OpsAlert` ledger** or any detector.

### Why
Ops-pulse runs in **shadow** by default, so nothing sends. This lets an owner verify WhatsApp delivery + digest formatting to their own number **before** arming the cron.

### Notes
- Gated to OWNER/ADMIN/MANAGER; only ever sends to the logged-in user's own registered phone.
- If the caller's 24h window is closed and no template is approved yet, the send returns a clear "message the bot first" hint (surfaced in the button's result line).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014QegYiiJdvMZXYwrmgtCCx

---
_Generated by [Claude Code](https://claude.ai/code/session_014QegYiiJdvMZXYwrmgtCCx)_