### PR TITLE
feat(procurement): complete the agent loop — invoice chase + delivery-date + invoice capture

### DIFF
--- a/apps/backoffice/src/app/api/cron/request-invoices/route.ts
+++ b/apps/backoffice/src/app/api/cron/request-invoices/route.ts
@@ -1,0 +1,31 @@
+import { NextRequest, NextResponse } from "next/server";
+import { checkCronAuth } from "@celsius/shared";
+import { getSession } from "@/lib/auth";
+import { runInvoiceRequests } from "@/lib/inventory/agents/invoice-requester";
+
+export const dynamic = "force-dynamic";
+export const maxDuration = 120;
+
+// GET /api/cron/request-invoices — the agent's proactive invoice chaser. Asks the
+// supplier for an invoice on every confirmed/in-delivery PO that has none yet
+// (gated + allow-listed; de-duped per PO). Scheduled in vercel.json.
+//
+// Auth: the Vercel cron secret (checkCronAuth). As a convenience for testing, an
+// authenticated OWNER/ADMIN may also trigger it by hitting the URL while logged
+// in (so you can run it on demand without the secret).
+export async function GET(req: NextRequest) {
+  const cronAuth = checkCronAuth(req.headers);
+  if (!cronAuth.ok) {
+    const user = await getSession();
+    if (!user || !["OWNER", "ADMIN"].includes(user.role)) {
+      return NextResponse.json({ error: cronAuth.error }, { status: cronAuth.status });
+    }
+  }
+  try {
+    const result = await runInvoiceRequests();
+    return NextResponse.json({ ok: true, ...result });
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : "request-invoices failed";
+    return NextResponse.json({ error: msg }, { status: 500 });
+  }
+}

--- a/apps/backoffice/src/app/api/whatsapp/webhook/route.ts
+++ b/apps/backoffice/src/app/api/whatsapp/webhook/route.ts
@@ -102,12 +102,14 @@ export async function POST(request: NextRequest) {
         // throws, so we AWAIT it (serverless can freeze after the response, so a
         // fire-and-forget promise might not run) — it still returns fast for
         // non-suppliers and when the flag is off. TODO: Telegram monitor mirror.
-        if (msg.type === "text" && body) {
+        if (msg.type === "text" || msg.type === "document" || msg.type === "image") {
           await handleSupplierMessage({
             fromNumber: msg.from,
             toNumber: businessNumber,
-            text: body,
+            text: body ?? "",
             waMessageId: msg.id,
+            type: msg.type,
+            mediaId: msg.document?.id ?? msg.image?.id ?? null,
           });
         }
       }

--- a/apps/backoffice/src/lib/inventory/agents/invoice-requester.ts
+++ b/apps/backoffice/src/lib/inventory/agents/invoice-requester.ts
@@ -1,0 +1,171 @@
+/**
+ * Proactive invoice requester — the agent CHASES the invoice instead of waiting.
+ *
+ * For each PURCHASE ORDER that the supplier has confirmed (or that's already in
+ * delivery) but has NO invoice attached yet, and that we haven't already asked
+ * about, this messages the supplier asking them to issue the invoice — the way a
+ * Celsius ops person would ("Hi bos, boleh keluarkan invois untuk order X?").
+ *
+ * Driven by the /api/cron/request-invoices cron. Same gates as the chat agent:
+ * PROCUREMENT_AGENT_ENABLED + PROCUREMENT_AGENT_ALLOWLIST (so the first live run
+ * is scoped to the Test supplier). Inside an open 24h window it sends free text;
+ * otherwise it uses the approved `invoice_request` template (business-initiated).
+ * De-duped via the outbound row's raw.invoiceRequestFor so a PO is asked at most
+ * once. Never throws.
+ */
+import type { OrderStatus } from "@celsius/db";
+import { prisma } from "@/lib/prisma";
+import { sendWhatsAppText, sendWhatsAppTemplate } from "@/lib/whatsapp";
+import { recordOutboundMessage } from "@/lib/whatsapp-store";
+
+export const INVOICE_REQUESTER_VERSION = "invoice-requester-v1";
+const TEMPLATE_NAME = "invoice_request";
+
+const digits = (s: string | null | undefined) => (s ?? "").replace(/[^0-9]/g, "");
+
+// Confirmed onward — the supplier has acknowledged the order, so it's fair to ask
+// for the invoice. Excludes DRAFT / PENDING_APPROVAL / SENT (too early) and the
+// terminal CANCELLED.
+const INVOICE_DUE_STATUSES: OrderStatus[] = [
+  "CONFIRMED",
+  "AWAITING_DELIVERY",
+  "PARTIALLY_RECEIVED",
+  "COMPLETED",
+];
+
+function enabled(): boolean {
+  return process.env.PROCUREMENT_AGENT_ENABLED === "true";
+}
+
+function allowed(phone: string | null | undefined): boolean {
+  const raw = process.env.PROCUREMENT_AGENT_ALLOWLIST?.trim();
+  if (!raw) return true;
+  const tail = digits(phone).slice(-8);
+  if (!tail) return false;
+  return raw
+    .split(",")
+    .map((s) => digits(s).slice(-8))
+    .filter(Boolean)
+    .includes(tail);
+}
+
+const firstName = (name: string) => (name || "bos").trim().split(/\s+/)[0];
+
+export interface InvoiceRequestSummary {
+  scanned: number;
+  requested: number;
+  skipped: number;
+}
+
+export async function runInvoiceRequests(): Promise<InvoiceRequestSummary> {
+  if (!enabled()) return { scanned: 0, requested: 0, skipped: 0 };
+
+  // POs confirmed/in-delivery with NO invoice attached yet.
+  const orders = await prisma.order.findMany({
+    where: {
+      orderType: "PURCHASE_ORDER",
+      status: { in: INVOICE_DUE_STATUSES },
+      invoices: { none: {} },
+      supplier: { phone: { not: null }, status: "ACTIVE" },
+    },
+    orderBy: { createdAt: "asc" },
+    take: 100,
+    select: {
+      id: true,
+      orderNumber: true,
+      supplier: { select: { id: true, name: true, phone: true } },
+    },
+  });
+
+  let requested = 0;
+  let skipped = 0;
+  for (const o of orders) {
+    const sup = o.supplier;
+    if (!sup?.phone || !allowed(sup.phone)) {
+      skipped++;
+      continue;
+    }
+    const ok = await requestOne(o.id, o.orderNumber, sup.id, sup.name, sup.phone);
+    if (ok) requested++;
+    else skipped++;
+  }
+  return { scanned: orders.length, requested, skipped };
+}
+
+async function requestOne(
+  orderId: string,
+  orderNumber: string,
+  supplierId: string,
+  supplierName: string,
+  phone: string,
+): Promise<boolean> {
+  try {
+    // Dedupe: have we already asked for this PO's invoice?
+    const already = await prisma.whatsAppMessage.findFirst({
+      where: { direction: "outbound", raw: { path: ["invoiceRequestFor"], equals: orderId } },
+      select: { id: true },
+    });
+    if (already) return false;
+
+    const dest = digits(phone);
+
+    // 24h customer-service window open? (supplier messaged us in the last 24h)
+    const lastInbound = await prisma.whatsAppMessage.findFirst({
+      where: { supplierId, direction: "inbound" },
+      orderBy: { timestamp: "desc" },
+      select: { timestamp: true },
+    });
+    const windowOpen =
+      !!lastInbound && Date.now() - +new Date(lastInbound.timestamp) < 24 * 60 * 60 * 1000;
+
+    const text = `Hi ${firstName(supplierName)} 🙏 boleh keluarkan invois untuk order ${orderNumber}? Terima kasih`;
+
+    // Inside the window → free text. Outside → approved business-initiated template
+    // (fails gracefully until `invoice_request` is approved in WhatsApp Manager).
+    const res = windowOpen
+      ? await sendWhatsAppText(dest, text)
+      : await sendWhatsAppTemplate(dest, TEMPLATE_NAME, "ms", [
+          {
+            type: "body",
+            parameters: [
+              { type: "text", text: firstName(supplierName) },
+              { type: "text", text: orderNumber },
+            ],
+          },
+        ]);
+
+    // Resolve our own business number from a recent message so the row threads right.
+    const ref = await prisma.whatsAppMessage.findFirst({
+      where: { supplierId },
+      orderBy: { timestamp: "desc" },
+      select: { direction: true, fromNumber: true, toNumber: true },
+    });
+    const ourNumber = ref ? (ref.direction === "inbound" ? ref.toNumber : ref.fromNumber) : "";
+
+    await recordOutboundMessage({
+      waMessageId: res.messageId,
+      fromNumber: ourNumber,
+      toNumber: dest,
+      type: "text",
+      body: text,
+      supplierId,
+      status: res.ok ? "sent" : "failed",
+      raw: {
+        agent: INVOICE_REQUESTER_VERSION,
+        invoiceRequestFor: orderId,
+        poNumber: orderNumber,
+        via: windowOpen ? "freetext" : "template",
+        ok: res.ok,
+        error: res.error ?? null,
+      },
+    });
+
+    console.log(
+      `[invoice-requester] po=${orderNumber} supplier=${supplierName} via=${windowOpen ? "freetext" : "template"} sent=${res.ok}`,
+    );
+    return res.ok;
+  } catch (err) {
+    console.error("[invoice-requester] error:", err instanceof Error ? err.message : err);
+    return false;
+  }
+}

--- a/apps/backoffice/src/lib/inventory/agents/supplier-chat-agent.ts
+++ b/apps/backoffice/src/lib/inventory/agents/supplier-chat-agent.ts
@@ -3,27 +3,26 @@
  *
  * On an inbound WhatsApp message from a matched supplier that has an open PO,
  * this reads the message in context (recent thread + the PO's line items),
- * works out what the supplier means (out of stock, reduce qty, price change,
- * delivery update, …) and:
- *   - auto-replies to the supplier in THEIR language (Malay / English / mix), and
- *   - for clear, low-risk cases, edits the open PO itself (remove / reduce a line).
+ * works out what the supplier means and acts:
+ *   - auto-replies to the supplier in THEIR language (Malay / English / mix),
+ *   - edits the open PO for clear OOS / quantity cases (remove / reduce a line),
+ *   - updates the PO delivery date when the supplier states when they'll deliver,
+ *   - captures an invoice/SOA the supplier sends as a DRAFT invoice on the PO
+ *     (amount left provisional for a human to verify — it can't read the PDF).
  *
  * Guardrails are enforced in CODE, not left to the model:
  *   - Off unless PROCUREMENT_AGENT_ENABLED=true.
- *   - Only acts for suppliers on PROCUREMENT_AGENT_ALLOWLIST (comma-separated,
- *     matched on the last 8 phone digits) when that var is set — so the first
- *     live run is scoped to the Test supplier, not all suppliers. Unset = all.
- *   - substitutions, full cancellations, and ANY low-confidence call ESCALATE:
- *     we send a safe holding reply and leave the PO untouched for a human.
- *   - every decision is stamped onto the outbound message's `raw` for audit, and
+ *   - Only acts for suppliers on PROCUREMENT_AGENT_ALLOWLIST (last-8 phone digits)
+ *     when set — so the first live run is scoped to the Test supplier.
+ *   - substitutions, full cancellations, payment/PoP/reconciliation, complaints,
+ *     and ANY low-confidence call ESCALATE: a safe holding reply, no PO change.
+ *   - every decision is stamped on the outbound message's `raw` for audit, and
  *     used to de-dupe Meta webhook redeliveries.
  *
- * Sends use sendWhatsAppText, which uses the app's own permanent token server
- * side — no token is needed from a caller. Never throws (callers can await it
- * without risking the webhook's 200).
+ * Sends use sendWhatsAppText (the app's own permanent token, server-side). Never
+ * throws — callers can await it without risking the webhook's 200.
  *
- * Model: claude-sonnet-4-6 — this edits real POs and writes to real suppliers,
- * so it gets a reasoning-grade model rather than Haiku.
+ * Model: claude-sonnet-4-6 — it edits real POs and writes to real suppliers.
  */
 import Anthropic from "@anthropic-ai/sdk";
 import type { OrderStatus } from "@celsius/db";
@@ -33,7 +32,7 @@ import { recordOutboundMessage } from "@/lib/whatsapp-store";
 
 const anthropic = new Anthropic({ apiKey: process.env.ANTHROPIC_API_KEY });
 
-export const SUPPLIER_AGENT_VERSION = "supplier-chat-agent-v1";
+export const SUPPLIER_AGENT_VERSION = "supplier-chat-agent-v2";
 
 const digits = (s: string | null | undefined) => (s ?? "").replace(/[^0-9]/g, "");
 
@@ -59,6 +58,8 @@ type AgentDecision = {
     new_quantity: number | null;
     note: string | null;
   };
+  delivery_date: string | null; // YYYY-MM-DD when the supplier states a future delivery day
+  capture_invoice: boolean; // true when this message is the supplier sending their invoice/SOA
   reply_text: string;
   confidence: number;
   requires_human: boolean;
@@ -70,6 +71,8 @@ export interface SupplierMessageEvent {
   toNumber: string; // our business number
   text: string;
   waMessageId?: string;
+  type?: string; // WhatsApp message type: text | document | image | …
+  mediaId?: string | null; // media id for document/image (the invoice PDF, etc.)
 }
 
 const HOLDING_REPLY = {
@@ -95,17 +98,27 @@ function allowed(supplierPhone: string | null | undefined): boolean {
     .includes(tail);
 }
 
+const isValidIsoDate = (d: string | null): d is string =>
+  !!d && /^\d{4}-\d{2}-\d{2}$/.test(d) && !Number.isNaN(Date.parse(d));
+
+/** Today's date in Malaysia (UTC+8), YYYY-MM-DD — so the model can resolve "esok"/"Rabu". */
+function todayMyt(): string {
+  return new Date(Date.now() + 8 * 60 * 60 * 1000).toISOString().slice(0, 10);
+}
+
 /**
- * Entry point. Safe to `await` from the webhook — it never throws and no-ops
- * fast for non-suppliers / disabled flag.
+ * Entry point. Safe to `await` from the webhook — never throws, no-ops fast for
+ * non-suppliers / disabled flag.
  */
 export async function handleSupplierMessage(evt: SupplierMessageEvent): Promise<void> {
   try {
     if (!flagEnabled() || !process.env.ANTHROPIC_API_KEY) return;
 
+    const hasDoc = evt.type === "document" || evt.type === "image";
     const fromDigits = digits(evt.fromNumber);
     const tail = fromDigits.slice(-8);
-    if (tail.length < 8 || !evt.text.trim()) return;
+    if (tail.length < 8) return;
+    if (!evt.text.trim() && !hasDoc) return; // nothing to act on
 
     // Match the supplier by last-8 digits (same rule as whatsapp-store).
     const suppliers = await prisma.supplier.findMany({
@@ -127,7 +140,7 @@ export async function handleSupplierMessage(evt: SupplierMessageEvent): Promise<
       if (already) return;
     }
 
-    // Most recent open PO for this supplier + its line items.
+    // Most recent open PO for this supplier + its line items + invoice presence.
     const order = await prisma.order.findFirst({
       where: {
         supplierId: supplier.id,
@@ -139,6 +152,8 @@ export async function handleSupplierMessage(evt: SupplierMessageEvent): Promise<
         id: true,
         orderNumber: true,
         status: true,
+        outletId: true,
+        totalAmount: true,
         items: {
           select: {
             id: true,
@@ -147,9 +162,10 @@ export async function handleSupplierMessage(evt: SupplierMessageEvent): Promise<
             product: { select: { name: true, baseUom: true } },
           },
         },
+        invoices: { select: { id: true }, take: 1 },
       },
     });
-    if (!order || order.items.length === 0) return; // nothing actionable
+    if (!order) return; // no open PO — nothing to act on
 
     // Recent thread for context (chronological, last 8).
     const history = await prisma.whatsAppMessage.findMany({
@@ -160,7 +176,7 @@ export async function handleSupplierMessage(evt: SupplierMessageEvent): Promise<
     });
     history.reverse();
 
-    const decision = await classify(evt.text, supplier, order, history);
+    const decision = await classify(evt.text, supplier, order, history, todayMyt(), hasDoc);
     if (!decision) return;
 
     // ── Guardrails (code, not model): auto-act vs escalate ──
@@ -171,15 +187,30 @@ export async function handleSupplierMessage(evt: SupplierMessageEvent): Promise<
     const lang: "ms" | "en" = decision.language === "ms" ? "ms" : "en";
     let replyText = decision.reply_text?.trim();
     let appliedAction: PoActionType = "none";
+    let deliveryUpdated: string | null = null;
+    let invoiceCaptured = false;
 
     if (escalate) {
       // Never confirm an action we're not taking — send a safe holding line.
       replyText = HOLDING_REPLY[lang];
-    } else if (
-      decision.po_action.type === "remove_item" ||
-      decision.po_action.type === "reduce_qty"
-    ) {
-      appliedAction = await applyPoAction(order.id, decision.po_action);
+    } else {
+      if (
+        decision.po_action.type === "remove_item" ||
+        decision.po_action.type === "reduce_qty"
+      ) {
+        appliedAction = await applyPoAction(order.id, decision.po_action);
+      }
+      if (isValidIsoDate(decision.delivery_date)) {
+        await applyDeliveryDate(order.id, decision.delivery_date);
+        deliveryUpdated = decision.delivery_date;
+      }
+      if (decision.capture_invoice && order.invoices.length === 0) {
+        invoiceCaptured = await captureInvoice(
+          { id: order.id, orderNumber: order.orderNumber, outletId: order.outletId, totalAmount: order.totalAmount },
+          supplier.id,
+          evt.mediaId ?? null,
+        );
+      }
     }
     if (!replyText) replyText = HOLDING_REPLY[lang];
 
@@ -200,6 +231,8 @@ export async function handleSupplierMessage(evt: SupplierMessageEvent): Promise<
         intent: decision.intent,
         confidence: decision.confidence,
         appliedAction,
+        deliveryUpdated,
+        invoiceCaptured,
         escalated: escalate,
         escalationReason: escalate ? (decision.escalation_reason ?? "guardrail") : null,
         poNumber: order.orderNumber,
@@ -208,7 +241,8 @@ export async function handleSupplierMessage(evt: SupplierMessageEvent): Promise<
 
     console.log(
       `[supplier-agent] supplier=${supplier.name} po=${order.orderNumber} intent=${decision.intent} ` +
-        `conf=${decision.confidence.toFixed(2)} action=${appliedAction} escalate=${escalate} sent=${sent.ok}`,
+        `conf=${decision.confidence.toFixed(2)} action=${appliedAction} delivery=${deliveryUpdated ?? "-"} ` +
+        `invoice=${invoiceCaptured} escalate=${escalate} sent=${sent.ok}`,
     );
   } catch (err) {
     // Never let the agent break the webhook's 200.
@@ -250,6 +284,47 @@ async function applyPoAction(
   return action.type;
 }
 
+/** Update the PO's delivery date (informational — safe to auto-apply). */
+async function applyDeliveryDate(orderId: string, isoDate: string): Promise<void> {
+  await prisma.order.update({ where: { id: orderId }, data: { deliveryDate: new Date(isoDate) } });
+}
+
+/**
+ * Capture a supplier-sent invoice as a DRAFT invoice on the PO. The amount is
+ * provisional (the PO total) — the agent can't read the PDF, so a human verifies
+ * it in the Invoices screen. Safe to auto: a DRAFT never triggers payment.
+ */
+async function captureInvoice(
+  order: { id: string; orderNumber: string; outletId: string; totalAmount: unknown },
+  supplierId: string,
+  mediaId: string | null,
+): Promise<boolean> {
+  try {
+    await prisma.invoice.create({
+      data: {
+        invoiceNumber: `AI-${order.orderNumber}`,
+        orderId: order.id,
+        outletId: order.outletId,
+        supplierId,
+        amount: order.totalAmount as never, // Decimal passthrough
+        status: "DRAFT",
+        paymentType: "SUPPLIER",
+        notes:
+          "Captured from WhatsApp by the supplier-chat agent — amount is provisional (PO total); " +
+          `verify against the document before paying.${mediaId ? ` [wa-media:${mediaId}]` : ""}`,
+      },
+    });
+    return true;
+  } catch (e) {
+    // Unique invoiceNumber collision (already captured) or any write error.
+    console.warn(
+      "[supplier-agent] invoice capture skipped:",
+      e instanceof Error ? e.message : e,
+    );
+    return false;
+  }
+}
+
 type SupplierCtx = { name: string; paymentTerms: string | null };
 type OrderCtx = {
   orderNumber: string;
@@ -268,43 +343,46 @@ const AGENT_ROLE = `You are the procurement assistant for Celsius Coffee, a Mala
 
 // Static voice + glossary + decision policy, distilled from 17 real Celsius
 // supplier chat logs (docs/design/procurement-chat-learnings.md). Marked for
-// prompt caching — identical on every call, so we pay input tokens once per
-// 5-min window. The hard escalation rules below are the real lesson from those
-// chats: suppliers casually offer "same quality" subs that are not recipe-safe.
+// prompt caching — identical on every call. The hard escalation rules are the
+// real lesson: suppliers casually offer "same quality" subs that aren't recipe-safe.
 const PLAYBOOK = `# Voice (match it)
 Warm, brief, never pushy. Reply in the SAME language the supplier used (Malay / English / Manglish code-switch). Address them "bos"/"boss" or by name; greet "Hi"/"Salam". Light emoji only (🙏 👌). Keep confirmations short: "noted bos", "ok", "baik, thank you".
 
 # Supplier phrasing you must understand (Malay / Manglish)
-- Out of stock: takde, xde, x ada, dah habis, dah abis, kosong, "no stock", OOS, "dry stock" (their own supplier is out).
+- Out of stock: takde, xde, x ada, dah habis, dah abis, kosong, "no stock", OOS, "dry stock".
 - Short quantity: "ada sikit je", "boleh bagi X je", "tinggal X".
 - Delivery/ETA: "boleh hantar bila", "bila sampai", harini=today, esok=tomorrow, otw, "dah hantar/sampai". Days: Isnin Mon, Selasa Tue, Rabu Wed, Khamis Thu, Jumaat Fri, Sabtu Sat.
 - Price: berapa, "1 ctn ada brp", "RM9 per pc". Invoice: "keluarkan invois", SOA (statement of account), "resend invoice".
 - Payment: "attached PoP", "dah initiate", "clear payment first" (pay before they release), "received with thanks".
-- MOQ: "below MOQ", "add something more", "trip min RMxxx". Closure: cuti, tutup, "off day", Raya/CNY/PH last-order/resume notices.
+- MOQ: "below MOQ", "add something more", "trip min RMxxx". Closure: cuti, tutup, "off day", Raya/CNY/PH notices.
 - Units: ctn carton, pkt packet, pcs, btl bottle, kg, kotak box, tin. boleh=ok/can, faham=understood.
 
-# You may act AUTONOMOUSLY only here (set po_action + a confirming reply):
+# You may act AUTONOMOUSLY (set the field + a confirming reply):
 - remove_item — only when it is unambiguous WHICH line is out of stock.
 - reduce_qty — only when they state a smaller available quantity for a specific line.
-If they say something is out/short but NOT which item → ask which, po_action none. Never guess.
+- delivery_date — when they state WHEN they'll deliver ("hantar Rabu", "esok", a date). Resolve it to an absolute YYYY-MM-DD relative to today. "dah hantar"/"otw"/"sampai" (already sent / on the way) is NOT a future date → delivery_date null.
+- capture_invoice — when this message is them SENDING their invoice/SOA (especially a document on a PO with no invoice yet). We save it as a DRAFT for a human to verify the amount, so just acknowledge ("terima invois, thank you") — do NOT discuss or confirm the amount.
+If they say something is out/short but NOT which item → ask which, change nothing. Never guess.
 
-# You MUST escalate (requires_human=true, po_action none, send a short honest holding reply — never confirm the action):
-- ANY substitution offer, even "same quality / identical" — Celsius recipes are fat-%/grade/brand-sensitive (e.g. cream 35.7% vs 35.1%, matcha grade, syrup line). Relay it; never accept it.
-- price increases or committing to a quote; MOQ top-up decisions (buying filler is a judgement call).
-- payment, proof-of-payment, payment-gating, and ANY reconciliation query (you cannot see invoice / PoP contents).
+# You MUST escalate (requires_human=true, change nothing, send a short honest holding reply — never confirm the action):
+- ANY substitution offer, even "same quality / identical" — Celsius recipes are fat-%/grade/brand-sensitive (e.g. cream 35.7% vs 35.1%). Relay it; never accept it.
+- price increase / committing to a quote; MOQ top-up decisions.
+- payment, proof-of-payment, payment-gating, and reconciliation queries ("is this PoP for inv -0142 or -0143?").
 - complaints / damaged / wrong goods; e-invoice / PO-number / TIN / compliance; credit-term questions.
 - ambiguous quantity or unit ("2.5kg only", "1 ctn ada brp") → ask to clarify, do not assume.
 
-# Handle conversationally, NO PO change, requires_human=false:
-order confirmations, delivery / ETA, invoice / SOA receipt, closure / holiday notices, greetings, lead-time notes — acknowledge politely or ask a brief clarifying question.
+# Handle conversationally, change nothing, requires_human=false:
+order confirmations, greetings, closure / holiday notices, lead-time notes — acknowledge politely or ask a brief clarifying question.
 
-Be conservative: confidence >0.7 ONLY when both the item AND the action are unambiguous.`;
+Be conservative: confidence >0.7 ONLY when the intended action is unambiguous.`;
 
 async function classify(
   text: string,
   supplier: SupplierCtx,
   order: OrderCtx,
   history: Array<{ direction: string; body: string | null }>,
+  today: string,
+  hasDoc: boolean,
 ): Promise<AgentDecision | null> {
   const items = order.items
     .map(
@@ -317,30 +395,35 @@ async function classify(
       .filter((m) => m.body)
       .map((m) => `${m.direction === "inbound" ? "Supplier" : "Us"}: ${m.body}`)
       .join("\n") || "(no earlier messages)";
+  const newMsg = text.trim() || (hasDoc ? "[sent a document, no caption]" : "");
 
-  const prompt = `# Open PO ${order.orderNumber} (status ${order.status}) — ${supplier.name}, terms ${supplier.paymentTerms ?? "—"}
+  const prompt = `Today is ${today} (Asia/Kuala_Lumpur). A document was attached: ${hasDoc ? "YES — most likely their invoice/PoP/photo" : "no"}.
+
+# Open PO ${order.orderNumber} (status ${order.status}) — ${supplier.name}, terms ${supplier.paymentTerms ?? "—"}
 ${items}
 
 # Recent conversation
 ${thread}
 
 # New message from the supplier
-"${text}"
+"${newMsg}"
 
 # Judgement examples (follow this behaviour)
 - "caramel syrup takde" AND Caramel is a line item → remove_item that line; reply e.g. "Noted bos 🙏 kita remove caramel dulu, proceed yang lain ya".
-- "ada barang yang takde" (does NOT say which) → po_action none; ask "Hi bos, boleh confirm item mana yang takde? 🙏".
+- "ada barang yang takde" (does NOT say which) → change nothing; ask "Hi bos, boleh confirm item mana yang takde? 🙏".
 - "boleh bagi 3 ctn je" for a line of 5 → reduce_qty new_quantity 3; confirm briefly.
-- "Matcha Morihan OOS, boleh replace Yamama, same quality" → substitution → requires_human true, po_action none, brief holding reply only (do NOT accept the swap).
-- "dah hantar ya, otw" → delivery_eta; reply "noted, thank you bos 🙏"; no PO change.
-- "below MOQ RM300, can add something?" → moq_topup → requires_human true, po_action none, holding reply.
-- "attached invoice" / "this PoP for inv -0142 or -0143?" → invoice_or_soa / reconciliation_query → requires_human true; you can't read the document.
+- "hantar Rabu ya" → delivery_date = the next Wednesday's date; reply "noted bos, Rabu ya 🙏".
+- a document on a PO with no invoice / "ni invois" → capture_invoice true, intent invoice_or_soa; reply "Noted bos, terima invois 🙏 thank you" (don't mention the amount).
+- "Matcha Morihan OOS, boleh replace Yamama, same quality" → requires_human true, change nothing, brief holding reply (do NOT accept the swap).
+- "below MOQ RM300, can add something?" → requires_human true, change nothing, holding reply.
 
 # Output — JSON only:
 {
   "intent": "out_of_stock|reduce_qty|substitution_offer|price_quote_or_increase|delivery_eta|order_confirmation|invoice_or_soa|payment_gating_or_chase|moq_topup|closure_or_holiday|new_product_offer|reconciliation_query|complaint_or_quality|lead_time_advisory|compliance_or_einvoice|staff_handover|greeting|other|unclear",
   "language": "ms|en|mixed",
   "po_action": {"type":"none|remove_item|reduce_qty|substitute_item|cancel_order","po_item_id":null,"new_quantity":null,"note":null},
+  "delivery_date": null,
+  "capture_invoice": false,
   "reply_text": "…",
   "confidence": 0.0,
   "requires_human": false,
@@ -382,6 +465,8 @@ ${thread}
         new_quantity: typeof pa.new_quantity === "number" ? pa.new_quantity : null,
         note: typeof pa.note === "string" ? pa.note : null,
       },
+      delivery_date: typeof p.delivery_date === "string" ? p.delivery_date : null,
+      capture_invoice: Boolean(p.capture_invoice),
       reply_text: String(p.reply_text ?? ""),
       confidence: Math.max(0, Math.min(1, Number(p.confidence) || 0)),
       requires_human: Boolean(p.requires_human),

--- a/apps/backoffice/vercel.json
+++ b/apps/backoffice/vercel.json
@@ -115,6 +115,10 @@
     {
       "path": "/api/cron/reviews-daily-snapshot",
       "schedule": "0 6 * * *"
+    },
+    {
+      "path": "/api/cron/request-invoices",
+      "schedule": "0 */4 * * *"
     }
   ]
 }


### PR DESCRIPTION
## What
Completes the supplier-chat agent's procurement loop. After the base agent (OOS → PO edit, #526), this adds the rest of the inbound lifecycle + a proactive chaser:

1. **Proactive invoice request** (cron `/api/cron/request-invoices`, every 4h) — asks suppliers for the invoice on confirmed / in-delivery POs that have none yet. De-duped per PO; OWNER/ADMIN manual-trigger for testing.
2. **Delivery-date update** — supplier states when they'll deliver ("hantar Rabu", "esok") → resolved vs today (Asia/KL) → updates `Order.deliveryDate`.
3. **Invoice capture** — supplier sends their invoice/SOA (esp. a document) → creates a DRAFT `Invoice` on the PO (amount provisional = PO total, flagged for human verify since it can't read the PDF) → acks. The webhook now runs the agent for document/image messages too.

All gated by `PROCUREMENT_AGENT_ENABLED` + `PROCUREMENT_AGENT_ALLOWLIST`. Escalation matrix unchanged (substitutions / price / MOQ / payment / PoP / reconciliation / complaints → human).

## Loop status
| Step | Where |
|---|---|
| Edit PO (OOS → remove/reduce) | agent — merged #526 |
| Proactive invoice request | **this PR** |
| Capture invoice on reply | **this PR** |
| Update delivery date | **this PR** |
| Send POP (mark invoice PAID) | existing flow |
| Send PO to supplier on approval | not yet (#3) |

## Dependency
An `invoice_request` Utility template for the out-of-window chase: `Hi {{1}} 🙏 boleh keluarkan invois untuk order {{2}}? Terima kasih`. Inside the 24h window it's free text and needs nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)