### PR TITLE
feat(ops-pulse): go-live wiring — create templates via API, name defaults, free-form fallback

### DIFF
--- a/apps/backoffice/src/app/api/ops/workspace/templates/route.ts
+++ b/apps/backoffice/src/app/api/ops/workspace/templates/route.ts
@@ -10,6 +10,32 @@ const GRAPH = "https://graph.facebook.com/v23.0";
 // no secrets. Safe to remove once template setup is confirmed.
 const DIAG_KEY = "celsius-tpl-9Fb3xq";
 
+// The ops-pulse template set, created via ?action=create. Bodies are emoji-free
+// with a single {{1}} variable carrying the one-line "count · item · item"
+// summary built by the *Var helpers in sender.ts. Category UTILITY, language en.
+const TEMPLATE_DEFS = [
+  {
+    name: "ops_pulse_digest",
+    body: "Ops Pulse\n\n{{1}}\n\nReply DONE when handled.",
+    sample: "3 need you · Stock count overdue at Bangsar · 2-star review at KLCC",
+  },
+  {
+    name: "ops_pulse_daily",
+    body: "Daily Ops Pulse\n\n{{1}}\n\nClear them today. Reply DONE as you go.",
+    sample: "4 open today · Stock count overdue · Weekly audit due · Opening checklist incomplete",
+  },
+  {
+    name: "ops_pulse_escalation",
+    body: "Ops escalation\n\n{{1}}\n\nThese are past SLA — please follow up.",
+    sample: "2 unacked past SLA · Checklist incomplete at Bangsar — lead: Ariff",
+  },
+  {
+    name: "ops_pulse_audit",
+    body: "Audit\n\n{{1}}\n\nRun it and log the report. Reply DONE when done.",
+    sample: "1 audit due · Kitchen Quality Audit overdue at Bangsar (8 days)",
+  },
+] as const;
+
 // GET — list the WABA's WhatsApp message templates with their approval status,
 // so an owner can see what's approved before wiring a template into ops-pulse.
 export async function GET(req: NextRequest) {
@@ -25,6 +51,43 @@ export async function GET(req: NextRequest) {
       { error: "not_configured", waba_set: !!waba, token_set: !!token, tpl_daily_set: !!process.env.OPS_PULSE_TPL_DAILY },
       { status: 400 },
     );
+  }
+
+  // ?action=create — submit the ops-pulse template set to Meta for approval. A
+  // name that already exists comes back as an error we surface (so re-running is
+  // safe). Requires the token to carry whatsapp_business_management.
+  if (req.nextUrl.searchParams.get("action") === "create") {
+    const created: unknown[] = [];
+    for (const t of TEMPLATE_DEFS) {
+      try {
+        const res = await fetch(`${GRAPH}/${waba}/message_templates`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json", Authorization: `Bearer ${token}` },
+          body: JSON.stringify({
+            name: t.name,
+            language: "en",
+            category: "UTILITY",
+            components: [{ type: "BODY", text: t.body, example: { body_text: [[t.sample]] } }],
+          }),
+        });
+        const json = (await res.json().catch(() => ({}))) as {
+          id?: string;
+          status?: string;
+          error?: { message?: string; error_user_msg?: string };
+        };
+        created.push({
+          name: t.name,
+          ok: res.ok,
+          httpStatus: res.status,
+          id: json.id ?? null,
+          status: json.status ?? null,
+          error: json.error?.error_user_msg || json.error?.message || null,
+        });
+      } catch (e) {
+        created.push({ name: t.name, ok: false, error: String(e) });
+      }
+    }
+    return NextResponse.json({ created });
   }
 
   try {
@@ -52,6 +115,7 @@ export async function GET(req: NextRequest) {
         OPS_PULSE_TPL_DAILY: process.env.OPS_PULSE_TPL_DAILY || null,
         OPS_PULSE_TPL_DIGEST: process.env.OPS_PULSE_TPL_DIGEST || null,
         OPS_PULSE_TPL_ESCALATION: process.env.OPS_PULSE_TPL_ESCALATION || null,
+        OPS_PULSE_TPL_AUDIT: process.env.OPS_PULSE_TPL_AUDIT || null,
       },
     });
   } catch (e) {

--- a/apps/backoffice/src/lib/ops-pulse/config.ts
+++ b/apps/backoffice/src/lib/ops-pulse/config.ts
@@ -194,11 +194,15 @@ export const AUDIT = {
 // falls back to free-form text — which Meta only delivers inside the recipient's
 // open 24h window (fine for testing, NOT for production paging). Set these
 // before flipping OPS_PULSE_MODE=armed.
+// Template names default to the standard ops_pulse_* set (created in WhatsApp
+// Manager / via the templates create endpoint). Sending tries the template first
+// and FALLS BACK to free-form when it isn't APPROVED yet (see sendProactive), so
+// wiring the names here is safe even before approval — no env var needed once the
+// templates go live. Override only to point at differently-named templates.
 export const TEMPLATES = {
-  managerDigest: process.env.OPS_PULSE_TPL_DIGEST || "",
-  ownerEscalation: process.env.OPS_PULSE_TPL_ESCALATION || "",
-  dailyDigest: process.env.OPS_PULSE_TPL_DAILY || "",
-  // Audit goes to the discipline leads (barista/kitchen) on its own template.
-  audit: process.env.OPS_PULSE_TPL_AUDIT || "",
+  managerDigest: process.env.OPS_PULSE_TPL_DIGEST || "ops_pulse_digest",
+  ownerEscalation: process.env.OPS_PULSE_TPL_ESCALATION || "ops_pulse_escalation",
+  dailyDigest: process.env.OPS_PULSE_TPL_DAILY || "ops_pulse_daily",
+  audit: process.env.OPS_PULSE_TPL_AUDIT || "ops_pulse_audit",
   languageCode: process.env.OPS_PULSE_TPL_LANG || "en",
 } as const;

--- a/apps/backoffice/src/lib/ops-pulse/sender.ts
+++ b/apps/backoffice/src/lib/ops-pulse/sender.ts
@@ -93,27 +93,41 @@ async function sendProactive(
   freeForm: string,
   templateVar: string,
 ): Promise<WhatsAppSendResult> {
-  const usingTemplate = !!templateName;
   const param = sanitizeParam(templateVar);
-  const result = usingTemplate
-    ? await sendWhatsAppTemplate(to, templateName, TEMPLATES.languageCode, [
-        { type: "body", parameters: [{ type: "text", text: param }] },
-      ])
-    : await sendWhatsAppText(to, freeForm);
-  // Persist the outbound digest (success OR failure) into the shared WhatsApp
-  // store so it shows in the Ops chat inbox. We store what was actually sent —
-  // the {{1}} summary for a template, the full text for free-form.
-  // recordOutboundMessage swallows its own errors — the send result is what the
-  // caller acts on, never the record.
+
+  // Prefer the approved template — it delivers outside the recipient's 24h window.
+  if (templateName) {
+    const tpl = await sendWhatsAppTemplate(to, templateName, TEMPLATES.languageCode, [
+      { type: "body", parameters: [{ type: "text", text: param }] },
+    ]);
+    if (tpl.ok) {
+      await recordOutboundMessage({
+        waMessageId: tpl.messageId,
+        fromNumber: process.env.WHATSAPP_DISPLAY_NUMBER || "",
+        toNumber: to,
+        type: "template",
+        body: param,
+        status: "sent",
+      });
+      return tpl;
+    }
+    // Template path failed — most commonly the template isn't APPROVED yet. Fall
+    // back to free-form (delivered inside an open 24h window). Logged so a
+    // genuinely broken template never hides silently behind the fallback.
+    console.warn(`[ops-pulse] template "${templateName}" failed (${tpl.error}); falling back to free-form`);
+  }
+
+  // Free-form path (no template configured, or template send failed).
+  const ff = await sendWhatsAppText(to, freeForm);
   await recordOutboundMessage({
-    waMessageId: result.messageId,
+    waMessageId: ff.messageId,
     fromNumber: process.env.WHATSAPP_DISPLAY_NUMBER || "",
     toNumber: to,
-    type: usingTemplate ? "template" : "text",
-    body: usingTemplate ? param : freeForm,
-    status: result.ok ? "sent" : "failed",
+    type: "text",
+    body: freeForm,
+    status: ff.ok ? "sent" : "failed",
   });
-  return result;
+  return ff;
 }
 
 export function sendManagerDigest(phone: string, lines: string[]): Promise<WhatsAppSendResult> {


### PR DESCRIPTION
Wires ops-pulse for go-live with minimal manual steps.

### Changes
- **`GET /api/ops/workspace/templates?action=create`** — submits the `ops_pulse_*` template set (`digest` / `daily` / `escalation` / `audit`) to Meta for approval via the Graph API, using the server's WhatsApp creds. Emoji-free bodies, single `{{1}}` variable. (owner-gated; temp key for the one-off setup run.)
- **`TEMPLATES` name defaults** — default to `ops_pulse_*`, so **no env var is needed** once the templates are approved (override still possible).
- **`sendProactive` free-form fallback** — tries the template, and if it isn't approved yet, falls back to free-form (delivered inside the 24h window). So wiring the names early is safe: before approval sends still work in-window; after approval they deliver outside the window too.

### Result
After this + Meta approval, the **only remaining go-live action is arming** (`OPS_PULSE_MODE` / `OPS_PULSE_DAILY_MODE=armed`) — left as the deliberate human switch since it starts real staff paging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014QegYiiJdvMZXYwrmgtCCx

---
_Generated by [Claude Code](https://claude.ai/code/session_014QegYiiJdvMZXYwrmgtCCx)_