### PR TITLE
feat(procurement): supplier reconciliation ledger — statement of account + mismatch exceptions

### DIFF
--- a/apps/backoffice/src/app/(admin)/inventory/ai-decisions/page.tsx
+++ b/apps/backoffice/src/app/(admin)/inventory/ai-decisions/page.tsx
@@ -16,6 +16,7 @@ type ReorderItem = {
   avgDailyUsage: number;
   orderQty: number;
   unitPrice: number;
+  priceChangePercent?: number | null;
   totalPrice: number;
   productPackageId: string | null;
   packageName: string | null;
@@ -371,7 +372,14 @@ export default function AIDecisionsPage() {
                               {item.daysUntilStockout}d
                             </td>
                             <td className="py-1.5 px-3 text-right text-white font-medium">{item.orderQty}</td>
-                            <td className="py-1.5 px-3 text-right text-zinc-400">RM {item.unitPrice.toFixed(2)}</td>
+                            <td className="py-1.5 px-3 text-right text-zinc-400">
+                              RM {item.unitPrice.toFixed(2)}
+                              {typeof item.priceChangePercent === "number" && Math.abs(item.priceChangePercent) >= 1 && (
+                                <span className={`ml-1 text-[10px] ${item.priceChangePercent > 0 ? "text-red-400" : "text-emerald-400"}`}>
+                                  {item.priceChangePercent > 0 ? "↑" : "↓"}{Math.abs(item.priceChangePercent)}%
+                                </span>
+                              )}
+                            </td>
                             <td className="py-1.5 px-3 text-right text-zinc-300">RM {item.totalPrice.toFixed(2)}</td>
                           </tr>
                         ))}

--- a/apps/backoffice/src/app/(admin)/inventory/ai-decisions/page.tsx
+++ b/apps/backoffice/src/app/(admin)/inventory/ai-decisions/page.tsx
@@ -10,6 +10,7 @@ type ReorderItem = {
   sku: string;
   baseUom: string;
   currentQty: number;
+  onOrderQty?: number;
   parLevel: number;
   reorderPoint: number;
   avgDailyUsage: number;
@@ -344,6 +345,7 @@ export default function AIDecisionsPage() {
                         <tr className="text-zinc-500 bg-zinc-950/50">
                           <th className="text-left py-1.5 px-3 font-medium">Product</th>
                           <th className="text-right py-1.5 px-3 font-medium">Stock</th>
+                          <th className="text-right py-1.5 px-3 font-medium">On Order</th>
                           <th className="text-right py-1.5 px-3 font-medium">Par</th>
                           <th className="text-right py-1.5 px-3 font-medium">Days Left</th>
                           <th className="text-right py-1.5 px-3 font-medium">Order Qty</th>
@@ -360,6 +362,9 @@ export default function AIDecisionsPage() {
                             </td>
                             <td className={`py-1.5 px-3 text-right font-medium ${item.currentQty <= 0 ? "text-red-400" : item.currentQty <= item.reorderPoint ? "text-orange-400" : "text-zinc-300"}`}>
                               {item.currentQty}
+                            </td>
+                            <td className="py-1.5 px-3 text-right text-zinc-400">
+                              {item.onOrderQty && item.onOrderQty > 0 ? <span className="text-sky-400">+{item.onOrderQty}</span> : <span className="text-zinc-600">—</span>}
                             </td>
                             <td className="py-1.5 px-3 text-right text-zinc-400">{item.parLevel}</td>
                             <td className={`py-1.5 px-3 text-right ${item.daysUntilStockout <= 1 ? "text-red-400 font-medium" : item.daysUntilStockout <= 3 ? "text-orange-400" : "text-zinc-400"}`}>

--- a/apps/backoffice/src/app/(admin)/inventory/ai-decisions/page.tsx
+++ b/apps/backoffice/src/app/(admin)/inventory/ai-decisions/page.tsx
@@ -32,6 +32,7 @@ type PORecommendation = {
   items: ReorderItem[];
   totalAmount: number;
   urgency: "critical" | "low" | "restock";
+  warnings?: { code: string; severity: "warn" | "info"; message: string }[];
 };
 
 type TransferRecommendation = {
@@ -323,6 +324,18 @@ export default function AIDecisionsPage() {
                       )}
                     </div>
                   </div>
+
+                  {/* Order-level warnings (below trip MOQ, off-calendar delivery) */}
+                  {po.warnings && po.warnings.length > 0 && (
+                    <div className="border-t border-amber-500/20 bg-amber-500/5 px-3 py-2 space-y-1">
+                      {po.warnings.map((w, i) => (
+                        <div key={i} className="flex items-start gap-1.5 text-[11px] text-amber-300/90">
+                          <span aria-hidden>⚠</span>
+                          <span>{w.message}</span>
+                        </div>
+                      ))}
+                    </div>
+                  )}
 
                   {/* Items table */}
                   <div className="border-t border-zinc-800 overflow-x-auto">

--- a/apps/backoffice/src/app/(admin)/inventory/reconciliation/page.tsx
+++ b/apps/backoffice/src/app/(admin)/inventory/reconciliation/page.tsx
@@ -17,7 +17,7 @@ import {
   CheckCircle2,
 } from "lucide-react";
 
-type ExceptionKind = "FLAGGED" | "SHORT_PAID" | "CARRY_FORWARD" | "UNVERIFIED" | "OVERDUE";
+type ExceptionKind = "FLAGGED" | "SHORT_PAID" | "CARRY_FORWARD" | "UNVERIFIED" | "OVERDUE" | "BILLED_OVER_PO";
 
 type Exception = {
   invoiceId: string;
@@ -61,6 +61,7 @@ const KIND_META: Record<ExceptionKind, { label: string; cls: string }> = {
   FLAGGED: { label: "Mismatch", cls: "bg-red-100 text-red-700 dark:bg-red-950 dark:text-red-300" },
   SHORT_PAID: { label: "Short-paid", cls: "bg-amber-100 text-amber-700 dark:bg-amber-950 dark:text-amber-300" },
   OVERDUE: { label: "Overdue", cls: "bg-orange-100 text-orange-700 dark:bg-orange-950 dark:text-orange-300" },
+  BILLED_OVER_PO: { label: "Over PO", cls: "bg-rose-100 text-rose-700 dark:bg-rose-950 dark:text-rose-300" },
   CARRY_FORWARD: { label: "Balance due", cls: "bg-blue-100 text-blue-700 dark:bg-blue-950 dark:text-blue-300" },
   UNVERIFIED: { label: "Verify", cls: "bg-purple-100 text-purple-700 dark:bg-purple-950 dark:text-purple-300" },
 };

--- a/apps/backoffice/src/app/(admin)/inventory/reconciliation/page.tsx
+++ b/apps/backoffice/src/app/(admin)/inventory/reconciliation/page.tsx
@@ -1,0 +1,283 @@
+"use client";
+
+import { useState, type ReactNode } from "react";
+import Link from "next/link";
+import { useFetch } from "@/lib/use-fetch";
+import { formatRM } from "@celsius/shared";
+import {
+  Scale,
+  AlertTriangle,
+  Clock,
+  ChevronDown,
+  ChevronRight,
+  Flag,
+  Wallet,
+  ExternalLink,
+  Loader2,
+  CheckCircle2,
+} from "lucide-react";
+
+type ExceptionKind = "FLAGGED" | "SHORT_PAID" | "CARRY_FORWARD" | "UNVERIFIED" | "OVERDUE";
+
+type Exception = {
+  invoiceId: string;
+  invoiceNumber: string;
+  poNumber: string | null;
+  status: string;
+  amount: number;
+  amountPaid: number;
+  balance: number;
+  issueDate: string;
+  dueDate: string | null;
+  ageDays: number;
+  kinds: ExceptionKind[];
+  reason: string;
+  flags: { code: string; label: string; message: string }[];
+};
+
+type SupplierRow = {
+  supplierId: string;
+  supplierName: string;
+  paymentTerms: string | null;
+  outstanding: number;
+  openCount: number;
+  overdueAmount: number;
+  overdueCount: number;
+  oldestOpenDays: number;
+  exceptions: Exception[];
+};
+
+type Totals = {
+  outstanding: number;
+  openCount: number;
+  overdueAmount: number;
+  overdueCount: number;
+  exceptionCount: number;
+  flaggedCount: number;
+  supplierCount: number;
+};
+
+const KIND_META: Record<ExceptionKind, { label: string; cls: string }> = {
+  FLAGGED: { label: "Mismatch", cls: "bg-red-100 text-red-700 dark:bg-red-950 dark:text-red-300" },
+  SHORT_PAID: { label: "Short-paid", cls: "bg-amber-100 text-amber-700 dark:bg-amber-950 dark:text-amber-300" },
+  OVERDUE: { label: "Overdue", cls: "bg-orange-100 text-orange-700 dark:bg-orange-950 dark:text-orange-300" },
+  CARRY_FORWARD: { label: "Balance due", cls: "bg-blue-100 text-blue-700 dark:bg-blue-950 dark:text-blue-300" },
+  UNVERIFIED: { label: "Verify", cls: "bg-purple-100 text-purple-700 dark:bg-purple-950 dark:text-purple-300" },
+};
+
+function KindBadge({ kind }: { kind: ExceptionKind }) {
+  const m = KIND_META[kind];
+  return <span className={`inline-flex items-center rounded px-1.5 py-0.5 text-[11px] font-medium ${m.cls}`}>{m.label}</span>;
+}
+
+function SummaryCard({
+  icon,
+  label,
+  value,
+  sub,
+  tone,
+}: {
+  icon: ReactNode;
+  label: string;
+  value: string;
+  sub?: string;
+  tone?: "danger" | "warn";
+}) {
+  const ring =
+    tone === "danger" ? "border-red-200 dark:border-red-900" : tone === "warn" ? "border-amber-200 dark:border-amber-900" : "border-border";
+  return (
+    <div className={`rounded-lg border ${ring} bg-card p-4`}>
+      <div className="flex items-center gap-2 text-xs font-medium text-muted-foreground">
+        {icon}
+        {label}
+      </div>
+      <div className="mt-1.5 text-2xl font-semibold text-foreground">{value}</div>
+      {sub && <div className="mt-0.5 text-xs text-muted-foreground">{sub}</div>}
+    </div>
+  );
+}
+
+export default function ReconciliationPage() {
+  const { data, isLoading } = useFetch<{ suppliers: SupplierRow[]; totals: Totals }>(
+    "/api/inventory/invoices/reconciliation",
+  );
+  const [expanded, setExpanded] = useState<Set<string>>(new Set());
+
+  const suppliers = data?.suppliers ?? [];
+  const totals = data?.totals;
+
+  function toggle(id: string) {
+    setExpanded((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  }
+
+  return (
+    <div className="space-y-5">
+      <div>
+        <h1 className="flex items-center gap-2 text-xl font-semibold text-foreground">
+          <Scale className="h-5 w-5" />
+          Supplier Reconciliation
+        </h1>
+        <p className="mt-1 text-sm text-muted-foreground">
+          Statement of account per supplier — outstanding balances, aging, and the payment ↔ invoice ↔ PoP mismatches
+          that need a human to match or chase.
+        </p>
+      </div>
+
+      {/* Summary cards */}
+      <div className="grid grid-cols-2 gap-3 lg:grid-cols-4">
+        <SummaryCard
+          icon={<Wallet className="h-3.5 w-3.5" />}
+          label="Total outstanding"
+          value={formatRM(totals?.outstanding ?? 0)}
+          sub={`${totals?.openCount ?? 0} open across ${totals?.supplierCount ?? 0} suppliers`}
+        />
+        <SummaryCard
+          icon={<Clock className="h-3.5 w-3.5" />}
+          label="Overdue"
+          value={formatRM(totals?.overdueAmount ?? 0)}
+          sub={`${totals?.overdueCount ?? 0} invoice(s) past due`}
+          tone={totals && totals.overdueAmount > 0 ? "warn" : undefined}
+        />
+        <SummaryCard
+          icon={<AlertTriangle className="h-3.5 w-3.5" />}
+          label="Reconciliation exceptions"
+          value={String(totals?.exceptionCount ?? 0)}
+          sub="rows needing attention"
+          tone={totals && totals.exceptionCount > 0 ? "warn" : undefined}
+        />
+        <SummaryCard
+          icon={<Flag className="h-3.5 w-3.5" />}
+          label="Payment mismatches"
+          value={String(totals?.flaggedCount ?? 0)}
+          sub="duplicate / double / wrong-account"
+          tone={totals && totals.flaggedCount > 0 ? "danger" : undefined}
+        />
+      </div>
+
+      {/* Per-supplier statement */}
+      {isLoading ? (
+        <div className="flex items-center justify-center gap-2 py-16 text-sm text-muted-foreground">
+          <Loader2 className="h-4 w-4 animate-spin" />
+          Loading statements…
+        </div>
+      ) : suppliers.length === 0 ? (
+        <div className="flex flex-col items-center justify-center gap-2 rounded-lg border border-border bg-card py-16 text-center">
+          <CheckCircle2 className="h-8 w-8 text-green-500" />
+          <div className="text-sm font-medium text-foreground">Nothing to reconcile</div>
+          <div className="text-xs text-muted-foreground">Every supplier is settled with no open balances or mismatches.</div>
+        </div>
+      ) : (
+        <div className="overflow-hidden rounded-lg border border-border bg-card">
+          {suppliers.map((s) => {
+            const isOpen = expanded.has(s.supplierId);
+            return (
+              <div key={s.supplierId} className="border-b border-border last:border-b-0">
+                <button
+                  type="button"
+                  onClick={() => toggle(s.supplierId)}
+                  className="flex w-full items-center gap-3 px-4 py-3 text-left hover:bg-muted/40"
+                >
+                  {isOpen ? (
+                    <ChevronDown className="h-4 w-4 shrink-0 text-muted-foreground" />
+                  ) : (
+                    <ChevronRight className="h-4 w-4 shrink-0 text-muted-foreground" />
+                  )}
+                  <div className="min-w-0 flex-1">
+                    <div className="flex items-center gap-2">
+                      <span className="truncate font-medium text-foreground">{s.supplierName}</span>
+                      {s.paymentTerms && (
+                        <span className="rounded bg-muted px-1.5 py-0.5 text-[11px] text-muted-foreground">{s.paymentTerms}</span>
+                      )}
+                    </div>
+                    <div className="mt-0.5 flex flex-wrap items-center gap-x-3 gap-y-0.5 text-xs text-muted-foreground">
+                      <span>{s.openCount} open</span>
+                      {s.overdueCount > 0 && (
+                        <span className="text-amber-600 dark:text-amber-400">{s.overdueCount} overdue</span>
+                      )}
+                      {s.oldestOpenDays > 0 && <span>oldest {s.oldestOpenDays}d</span>}
+                    </div>
+                  </div>
+                  {/* Exception badge */}
+                  {s.exceptions.length > 0 && (
+                    <span className="inline-flex items-center gap-1 rounded-full bg-amber-100 px-2 py-0.5 text-[11px] font-medium text-amber-700 dark:bg-amber-950 dark:text-amber-300">
+                      <AlertTriangle className="h-3 w-3" />
+                      {s.exceptions.length}
+                    </span>
+                  )}
+                  <div className="text-right">
+                    <div className="font-semibold text-foreground">{formatRM(s.outstanding)}</div>
+                    <div className="text-[11px] text-muted-foreground">outstanding</div>
+                  </div>
+                </button>
+
+                {isOpen && (
+                  <div className="border-t border-border bg-muted/20 px-4 py-3">
+                    {s.exceptions.length === 0 ? (
+                      <div className="py-2 text-xs text-muted-foreground">
+                        No mismatches — {formatRM(s.outstanding)} outstanding across {s.openCount} open invoice(s).
+                      </div>
+                    ) : (
+                      <div className="space-y-2">
+                        {s.exceptions.map((e) => (
+                          <div
+                            key={e.invoiceId}
+                            className="rounded-md border border-border bg-card p-3 text-sm"
+                          >
+                            <div className="flex flex-wrap items-start justify-between gap-2">
+                              <div className="min-w-0">
+                                <div className="flex flex-wrap items-center gap-1.5">
+                                  <span className="font-medium text-foreground">{e.invoiceNumber}</span>
+                                  {e.poNumber && (
+                                    <span className="text-xs text-muted-foreground">· {e.poNumber}</span>
+                                  )}
+                                  {e.kinds.map((k) => (
+                                    <KindBadge key={k} kind={k} />
+                                  ))}
+                                </div>
+                                <div className="mt-1 text-xs text-muted-foreground">{e.reason}</div>
+                                {e.flags.length > 0 && (
+                                  <ul className="mt-1.5 space-y-1">
+                                    {e.flags.map((f) => (
+                                      <li key={f.code} className="flex items-start gap-1.5 text-xs text-red-600 dark:text-red-400">
+                                        <Flag className="mt-0.5 h-3 w-3 shrink-0" />
+                                        <span>{f.message}</span>
+                                      </li>
+                                    ))}
+                                  </ul>
+                                )}
+                              </div>
+                              <div className="flex shrink-0 flex-col items-end gap-1">
+                                <div className="text-right">
+                                  <div className="font-medium text-foreground">{formatRM(e.balance)}</div>
+                                  <div className="text-[11px] text-muted-foreground">
+                                    {formatRM(e.amountPaid)} of {formatRM(e.amount)}
+                                  </div>
+                                </div>
+                                <Link
+                                  href={`/inventory/invoices?search=${encodeURIComponent(e.invoiceNumber)}`}
+                                  className="inline-flex items-center gap-1 text-xs font-medium text-blue-600 hover:text-blue-700 dark:text-blue-400"
+                                >
+                                  Open invoice
+                                  <ExternalLink className="h-3 w-3" />
+                                </Link>
+                              </div>
+                            </div>
+                          </div>
+                        ))}
+                      </div>
+                    )}
+                  </div>
+                )}
+              </div>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/backoffice/src/app/(admin)/inventory/reports/ingredient-variance/page.tsx
+++ b/apps/backoffice/src/app/(admin)/inventory/reports/ingredient-variance/page.tsx
@@ -1,0 +1,224 @@
+"use client";
+
+import { useState } from "react";
+import { useFetch } from "@/lib/use-fetch";
+import { Badge } from "@/components/ui/badge";
+import Link from "next/link";
+import { ArrowLeft, Loader2, Scale, AlertTriangle, TrendingUp, TrendingDown, Info } from "lucide-react";
+
+type Outlet = { id: string; name: string };
+
+type VarianceItem = {
+  productId: string;
+  productName: string;
+  sku: string | null;
+  category: string | null;
+  baseUom: string;
+  actualQty: number;
+  expectedQty: number;
+  varianceQty: number;
+  costPerBase: number;
+  expectedCost: number;
+  varianceCost: number;
+  variancePercent: number | null;
+  flags: string[];
+  movements: Record<string, number>;
+};
+
+type Summary = {
+  outletId: string;
+  outletName: string;
+  openingCountDate: string | null;
+  closingCountDate: string | null;
+  totalExpectedCost: number | null;
+  totalVarianceCost: number | null;
+  totalVariancePercent: number | null;
+  itemsAnalyzed: number;
+  itemsOverUsed?: number;
+  highVarianceCount?: number;
+  dataQuality: "complete" | "incomplete" | "insufficient";
+  reason?: string;
+};
+
+type Data = {
+  summary: Summary | null;
+  outlets: Outlet[];
+  items: VarianceItem[];
+  requireOutlet?: boolean;
+  warnings: {
+    menuItemsWithoutBom: string[];
+    productsWithoutCost: string[];
+    uomMismatches: { productId: string; menuUom: string; baseUom: string }[];
+    noSales: boolean;
+  };
+};
+
+const fmt = (n: number) => n.toLocaleString("en-MY", { minimumFractionDigits: 2, maximumFractionDigits: 2 });
+const day = (iso: string | null) => (iso ? iso.slice(0, 10) : "—");
+
+export default function IngredientVariancePage() {
+  const [outletId, setOutletId] = useState("");
+  const [from, setFrom] = useState("");
+  const [to, setTo] = useState("");
+
+  const params = new URLSearchParams();
+  if (outletId) params.set("outletId", outletId);
+  if (from) params.set("from", from);
+  if (to) params.set("to", to);
+  const { data, isLoading } = useFetch<Data>(`/api/inventory/reports/ingredient-variance?${params.toString()}`);
+
+  const s = data?.summary;
+  const insufficient = s?.dataQuality === "insufficient";
+
+  return (
+    <div className="p-3 sm:p-6">
+      {/* Header */}
+      <div className="flex items-center gap-3">
+        <Link href="/inventory/reports" className="rounded-lg p-1.5 text-gray-400 hover:bg-gray-100 hover:text-gray-600">
+          <ArrowLeft className="h-5 w-5" />
+        </Link>
+        <div>
+          <h2 className="text-xl font-semibold text-gray-900">Usage Variance</h2>
+          <p className="text-sm text-gray-500">Actual usage (stock movements) vs expected (recipe BOM × sales)</p>
+        </div>
+      </div>
+
+      {/* Filters */}
+      <div className="mt-4 flex flex-wrap items-center gap-3">
+        <select className="rounded-lg border border-gray-200 px-3 py-2 text-sm" value={outletId} onChange={(e) => setOutletId(e.target.value)}>
+          <option value="">Select outlet…</option>
+          {(data?.outlets ?? []).map((o) => (
+            <option key={o.id} value={o.id}>{o.name}</option>
+          ))}
+        </select>
+        <label className="flex items-center gap-1.5 text-sm text-gray-500">From
+          <input type="date" value={from} onChange={(e) => setFrom(e.target.value)} className="rounded-lg border border-gray-200 px-2 py-1.5 text-sm" />
+        </label>
+        <label className="flex items-center gap-1.5 text-sm text-gray-500">To
+          <input type="date" value={to} onChange={(e) => setTo(e.target.value)} className="rounded-lg border border-gray-200 px-2 py-1.5 text-sm" />
+        </label>
+      </div>
+
+      {/* Choose-outlet prompt */}
+      {data?.requireOutlet && (
+        <div className="mt-6 flex items-center gap-3 rounded-xl border border-blue-200 bg-blue-50 px-4 py-3">
+          <Info className="h-5 w-5 shrink-0 text-blue-500" />
+          <p className="text-sm text-blue-800">Select an outlet to compute usage variance — it&apos;s measured between that outlet&apos;s stock counts.</p>
+        </div>
+      )}
+
+      {/* Insufficient-data banner */}
+      {insufficient && (
+        <div className="mt-6 flex items-center gap-3 rounded-xl border border-amber-200 bg-amber-50 px-4 py-3">
+          <AlertTriangle className="h-5 w-5 shrink-0 text-amber-500" />
+          <div>
+            <p className="text-sm font-medium text-amber-800">Not enough stock counts to measure usage</p>
+            <p className="text-xs text-amber-600">{s?.reason}</p>
+          </div>
+        </div>
+      )}
+
+      {/* Summary cards */}
+      {s && !insufficient && (
+        <>
+          <p className="mt-5 text-xs text-gray-500">
+            Measured between counts <span className="font-medium text-gray-700">{day(s.openingCountDate)}</span> and <span className="font-medium text-gray-700">{day(s.closingCountDate)}</span> · {s.outletName}
+          </p>
+          <div className="mt-2 grid grid-cols-2 gap-3 lg:grid-cols-4">
+            <Card label="Expected cost" value={`RM ${fmt(s.totalExpectedCost ?? 0)}`} sub="recipe × sales" />
+            <Card
+              label="Usage variance"
+              value={`${(s.totalVarianceCost ?? 0) >= 0 ? "+" : "-"}RM ${fmt(Math.abs(s.totalVarianceCost ?? 0))}`}
+              sub={s.totalVariancePercent !== null ? `${s.totalVariancePercent}% of expected` : undefined}
+              tone={(s.totalVarianceCost ?? 0) > 0 ? "bad" : "good"}
+            />
+            <Card label="Items analysed" value={String(s.itemsAnalyzed)} sub={`${s.itemsOverUsed ?? 0} over-used`} />
+            <Card label="High variance" value={String(s.highVarianceCount ?? 0)} sub="≥5% or RM20" tone={(s.highVarianceCount ?? 0) > 0 ? "warn" : undefined} />
+          </div>
+        </>
+      )}
+
+      {/* Data-quality warnings */}
+      {data && !insufficient && data.warnings && (data.warnings.menuItemsWithoutBom.length > 0 || data.warnings.productsWithoutCost.length > 0 || data.warnings.uomMismatches.length > 0 || data.warnings.noSales) && (
+        <div className="mt-4 space-y-1.5 rounded-xl border border-gray-200 bg-gray-50 px-4 py-3 text-xs text-gray-600">
+          <p className="font-medium text-gray-700">Data quality — variance may be incomplete:</p>
+          {data.warnings.noSales && <p>• No sales in this window — actual usage shown without an expected baseline.</p>}
+          {data.warnings.menuItemsWithoutBom.length > 0 && <p>• {data.warnings.menuItemsWithoutBom.length} sold menu item(s) have no recipe (BOM): {data.warnings.menuItemsWithoutBom.slice(0, 5).join(", ")}{data.warnings.menuItemsWithoutBom.length > 5 ? "…" : ""}</p>}
+          {data.warnings.productsWithoutCost.length > 0 && <p>• {data.warnings.productsWithoutCost.length} product(s) have no supplier cost — variance qty only, no RM.</p>}
+          {data.warnings.uomMismatches.length > 0 && <p>• {data.warnings.uomMismatches.length} recipe line(s) use a unit different from the product base UOM — check the recipe.</p>}
+        </div>
+      )}
+
+      {isLoading && (
+        <div className="flex items-center justify-center p-12"><Loader2 className="h-6 w-6 animate-spin text-terracotta" /></div>
+      )}
+
+      {/* Table */}
+      {s && !insufficient && (
+        <div className="mt-4 rounded-xl border border-gray-200 bg-white overflow-x-auto">
+          <table className="w-full text-sm min-w-[820px]">
+            <thead>
+              <tr className="border-b border-gray-100 bg-gray-50/50">
+                <th className="px-4 py-3 text-left font-medium text-gray-500">Ingredient</th>
+                <th className="px-4 py-3 text-right font-medium text-gray-500">Expected</th>
+                <th className="px-4 py-3 text-right font-medium text-gray-500">Actual</th>
+                <th className="px-4 py-3 text-right font-medium text-gray-500">Variance</th>
+                <th className="px-4 py-3 text-right font-medium text-gray-500">Cost/Unit</th>
+                <th className="px-4 py-3 text-right font-medium text-gray-500">Variance RM</th>
+                <th className="px-4 py-3 text-right font-medium text-gray-500">%</th>
+              </tr>
+            </thead>
+            <tbody>
+              {(data?.items ?? []).length === 0 && (
+                <tr><td colSpan={7} className="px-4 py-8 text-center text-sm text-gray-400">No ingredient activity in this window.</td></tr>
+              )}
+              {(data?.items ?? []).map((it, idx) => (
+                <tr key={it.productId} className={`border-b border-gray-50 ${idx % 2 ? "bg-gray-50/30" : ""}`}>
+                  <td className="px-4 py-2.5">
+                    <div className="flex items-center gap-1.5">
+                      <span className="font-medium text-gray-900">{it.productName}</span>
+                      {it.flags.includes("HIGH_VARIANCE") && <AlertTriangle className="h-3.5 w-3.5 text-amber-500" />}
+                      {it.flags.includes("NO_COST") && <Badge variant="outline" className="text-[10px] text-gray-400">no cost</Badge>}
+                    </div>
+                    {it.category && <span className="text-xs text-gray-400">{it.category}</span>}
+                  </td>
+                  <td className="px-4 py-2.5 text-right font-mono text-gray-700">{fmt(it.expectedQty)} <span className="text-xs text-gray-400">{it.baseUom}</span></td>
+                  <td className="px-4 py-2.5 text-right font-mono text-gray-700">{fmt(it.actualQty)} <span className="text-xs text-gray-400">{it.baseUom}</span></td>
+                  <td className="px-4 py-2.5 text-right font-mono">
+                    <span className={it.varianceQty > 0 ? "text-red-600" : it.varianceQty < 0 ? "text-blue-600" : "text-gray-400"}>
+                      {it.varianceQty > 0 ? "+" : ""}{fmt(it.varianceQty)}
+                    </span>
+                  </td>
+                  <td className="px-4 py-2.5 text-right font-mono text-gray-500">{it.costPerBase > 0 ? `RM ${fmt(it.costPerBase)}` : "—"}</td>
+                  <td className="px-4 py-2.5 text-right font-mono">
+                    {it.costPerBase > 0 ? (
+                      <span className={`font-medium ${it.varianceCost > 0 ? "text-red-600" : it.varianceCost < 0 ? "text-green-600" : "text-gray-400"}`}>
+                        {it.varianceCost > 0 ? <TrendingUp className="mr-0.5 inline h-3 w-3" /> : it.varianceCost < 0 ? <TrendingDown className="mr-0.5 inline h-3 w-3" /> : null}
+                        {it.varianceCost > 0 ? "+" : ""}RM {fmt(Math.abs(it.varianceCost))}
+                      </span>
+                    ) : <span className="text-gray-300">—</span>}
+                  </td>
+                  <td className="px-4 py-2.5 text-right font-mono text-gray-500">{it.variancePercent !== null ? `${it.variancePercent}%` : "—"}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function Card({ label, value, sub, tone }: { label: string; value: string; sub?: string; tone?: "good" | "bad" | "warn" }) {
+  const valueColor = tone === "bad" ? "text-red-600" : tone === "good" ? "text-green-600" : tone === "warn" ? "text-amber-600" : "text-gray-900";
+  return (
+    <div className="rounded-xl border border-gray-200 bg-white p-4">
+      <div className="flex items-center gap-2">
+        <div className="rounded-lg bg-amber-50 p-2"><Scale className="h-4 w-4 text-amber-600" /></div>
+        <span className="text-sm text-gray-500">{label}</span>
+      </div>
+      <p className={`mt-2 text-2xl font-bold ${valueColor}`}>{value}</p>
+      {sub && <p className="mt-0.5 text-xs text-gray-500">{sub}</p>}
+    </div>
+  );
+}

--- a/apps/backoffice/src/app/(admin)/inventory/reports/page.tsx
+++ b/apps/backoffice/src/app/(admin)/inventory/reports/page.tsx
@@ -1,10 +1,11 @@
 "use client";
 
 import Link from "next/link";
-import { DollarSign, Package, ShoppingCart, Trash2, Truck, ArrowRight } from "lucide-react";
+import { DollarSign, Package, ShoppingCart, Trash2, Truck, Scale, ArrowRight } from "lucide-react";
 
 const REPORTS = [
   { name: "Stock Valuation", description: "System qty vs last count with RM values — expected vs real inventory", icon: Package, color: "bg-blue-50 text-blue-600", href: "/inventory/reports/stock-valuation" },
+  { name: "Usage Variance", description: "Actual usage (stock movements) vs expected (recipe BOM × sales) — over-portioning, theft, spoilage", icon: Scale, color: "bg-amber-50 text-amber-600", href: "/inventory/reports/ingredient-variance" },
   { name: "COGS Report", description: "Actual vs expected ingredient usage and cost variance per outlet per period", icon: DollarSign, color: "bg-red-50 text-red-600", href: "/inventory/reports/cogs" },
   { name: "Purchase Summary", description: "Total spending by supplier, product, and period with trend comparison", icon: ShoppingCart, color: "bg-green-50 text-green-600", href: "/inventory/reports/purchase-summary" },
   { name: "Wastage Report", description: "Cost of waste by reason (expired, spillage, breakage), outlet, and period", icon: Trash2, color: "bg-terracotta/10 text-terracotta", href: "/inventory/reports/wastage" },

--- a/apps/backoffice/src/app/(admin)/inventory/supplier-chats/page.tsx
+++ b/apps/backoffice/src/app/(admin)/inventory/supplier-chats/page.tsx
@@ -44,6 +44,7 @@ type Detail = {
     deliveryDays: string[];
     paymentTerms: string | null;
     leadTimeDays: number;
+    paymentModel?: { model: string; label: string; note: string; popDeliveryCritical: boolean };
   };
   context: {
     openPOs: number;
@@ -53,6 +54,14 @@ type Detail = {
   };
   windowOpen: boolean;
   messages: Msg[];
+  agentProposal?: {
+    intent: string;
+    escalationReason: string;
+    paymentModel?: string;
+    popDeliveryCritical?: boolean;
+    poAction: { type: string; itemName: string | null; newQuantity: number | null; note: string | null } | null;
+    at: string;
+  } | null;
 };
 
 function rel(iso: string): string {
@@ -295,10 +304,44 @@ export default function SupplierChatsPage() {
                     </div>
                   )}
                 </div>
+                {detail.agentProposal && (
+                  <div className="border-b border-border py-3">
+                    <div className="rounded-md border border-amber-300 bg-amber-50 p-2.5 dark:border-amber-800 dark:bg-amber-950/40">
+                      <div className="mb-1 flex items-center gap-1.5 text-[11px] font-semibold text-amber-700 dark:text-amber-300">
+                        <AlertCircle size={12} /> Agent suggests — your call
+                      </div>
+                      <div className="text-[12px] text-foreground">
+                        {detail.agentProposal.poAction
+                          ? <>
+                              {detail.agentProposal.poAction.type === "substitute_item" && "Substitution offered"}
+                              {detail.agentProposal.poAction.type === "cancel_order" && "Cancel requested"}
+                              {detail.agentProposal.poAction.type === "remove_item" && "Remove line"}
+                              {detail.agentProposal.poAction.type === "reduce_qty" && "Reduce qty"}
+                              {detail.agentProposal.poAction.itemName && <> · <span className="font-medium">{detail.agentProposal.poAction.itemName}</span></>}
+                              {detail.agentProposal.poAction.newQuantity != null && <> → {detail.agentProposal.poAction.newQuantity}</>}
+                              {detail.agentProposal.poAction.note && <div className="mt-0.5 text-[11px] text-muted-foreground">“{detail.agentProposal.poAction.note}”</div>}
+                            </>
+                          : <span className="capitalize">{detail.agentProposal.intent.replace(/_/g, " ")}</span>}
+                      </div>
+                      <div className="mt-1 text-[10.5px] text-muted-foreground">
+                        Held for review: {detail.agentProposal.escalationReason}. The agent did not change the PO.
+                      </div>
+                    </div>
+                  </div>
+                )}
                 <div className="flex flex-col gap-1 border-b border-border py-3 text-[12px]">
                   <Row label="Delivery" value={detail.supplier?.deliveryDays?.join(", ") || "—"} />
                   <Row label="Lead time" value={`${detail.supplier?.leadTimeDays ?? 0}d`} />
                   <Row label="Terms" value={detail.supplier?.paymentTerms || "—"} />
+                  {detail.supplier?.paymentModel && (
+                    <Row
+                      label="Payment"
+                      value={
+                        detail.supplier.paymentModel.label +
+                        (detail.supplier.paymentModel.popDeliveryCritical ? " ⚡" : "")
+                      }
+                    />
+                  )}
                 </div>
                 <div className="pt-3">
                   <div className="mb-1.5 text-[11px] text-muted-foreground">Open purchase orders</div>

--- a/apps/backoffice/src/app/(admin)/layout.tsx
+++ b/apps/backoffice/src/app/(admin)/layout.tsx
@@ -226,6 +226,7 @@ const NAV_SECTIONS: NavSection[] = [
           { label: "Transfers", href: "/inventory/transfers", icon: <ArrowLeftRight className={ICON_SIZE} />, moduleKey: "inventory:transfers" },
           { label: "Receivings", href: "/inventory/receivings", icon: <Receipt className={ICON_SIZE} />, moduleKey: "inventory:receivings" },
           { label: "Invoices", href: "/inventory/invoices", icon: <ClipboardList className={ICON_SIZE} />, moduleKey: "inventory:invoices" },
+          { label: "Reconciliation", href: "/inventory/reconciliation", icon: <Scale className={ICON_SIZE} />, moduleKey: "inventory:invoices" },
           { label: "Payment Requests", href: "/inventory/pay-and-claim", icon: <HandCoins className={ICON_SIZE} />, moduleKey: "inventory:pay-and-claim" },
         ],
       },

--- a/apps/backoffice/src/app/api/cron/consumption-post/route.ts
+++ b/apps/backoffice/src/app/api/cron/consumption-post/route.ts
@@ -2,7 +2,8 @@ import { NextRequest, NextResponse } from "next/server";
 import { checkCronAuth } from "@celsius/shared";
 import { prisma } from "@/lib/prisma";
 import { getSession } from "@/lib/auth";
-import { postOutletConsumption, mytDayWindow, type ConsumptionResult } from "@/lib/inventory/consumption";
+import { mytDayWindow, type ConsumptionResult } from "@/lib/inventory/consumption";
+import { postOutletConsumption } from "@/lib/inventory/consumption-post";
 
 export const dynamic = "force-dynamic";
 export const maxDuration = 120;

--- a/apps/backoffice/src/app/api/cron/consumption-post/route.ts
+++ b/apps/backoffice/src/app/api/cron/consumption-post/route.ts
@@ -1,0 +1,82 @@
+import { NextRequest, NextResponse } from "next/server";
+import { checkCronAuth } from "@celsius/shared";
+import { prisma } from "@/lib/prisma";
+import { getSession } from "@/lib/auth";
+import { postOutletConsumption, mytDayWindow, type ConsumptionResult } from "@/lib/inventory/consumption";
+
+export const dynamic = "force-dynamic";
+export const maxDuration = 120;
+
+// GET /api/cron/consumption-post — the consumption engine.
+//
+// For each active outlet, turns yesterday's menu sales into theoretical
+// ingredient depletion (sales × recipe BOM) so stock reflects what was used, not
+// just what was received. SHADOW BY DEFAULT: it computes + reports the numbers
+// and writes nothing. It only posts negative stock adjustments when
+// CONSUMPTION_ENGINE_ENABLED=true AND a system user exists — and that should stay
+// off until stock quantities are normalised to base UOM (StockBalance is
+// currently fragmented by package; see docs/design/procurement-qa-2026-06-26.md).
+//
+// Auth: Vercel cron secret, or an OWNER/ADMIN may trigger on demand (and pass
+// ?date=YYYY-MM-DD to backfill a specific MYT day).
+export async function GET(req: NextRequest) {
+  const cronAuth = checkCronAuth(req.headers);
+  if (!cronAuth.ok) {
+    const user = await getSession();
+    if (!user || !["OWNER", "ADMIN"].includes(user.role)) {
+      return NextResponse.json({ error: cronAuth.error }, { status: cronAuth.status });
+    }
+  }
+
+  try {
+    const dateParam = req.nextUrl.searchParams.get("date");
+    // Default to yesterday in MYT (sales for a full closed day).
+    const mytNow = new Date(Date.now() + 8 * 60 * 60 * 1000);
+    const mytYesterday = new Date(mytNow.getTime() - 86_400_000);
+    const date = dateParam && /^\d{4}-\d{2}-\d{2}$/.test(dateParam) ? dateParam : mytYesterday.toISOString().slice(0, 10);
+    const { startUtc, endUtc } = mytDayWindow(date);
+
+    const flagLive = process.env.CONSUMPTION_ENGINE_ENABLED === "true";
+    // Live posting needs a real user for StockAdjustment.adjustedById.
+    const systemUser = flagLive
+      ? await prisma.user.findFirst({ where: { role: "OWNER" }, select: { id: true } })
+      : null;
+    const live = flagLive && !!systemUser;
+
+    const outlets = await prisma.outlet.findMany({ where: { status: "ACTIVE" }, select: { id: true, name: true } });
+
+    const results: ConsumptionResult[] = [];
+    for (const o of outlets) {
+      try {
+        results.push(
+          await postOutletConsumption({
+            outletId: o.id,
+            outletName: o.name,
+            date,
+            dayStartUtc: startUtc,
+            dayEndUtc: endUtc,
+            live,
+            systemUserId: systemUser?.id ?? null,
+          }),
+        );
+      } catch (e) {
+        console.error(`[consumption-post] outlet=${o.name} failed:`, e instanceof Error ? e.message : e);
+      }
+    }
+
+    const summary = {
+      date,
+      mode: live ? "live" : "shadow",
+      outlets: results.length,
+      posted: results.filter((r) => r.posted).length,
+      alreadyPosted: results.filter((r) => r.alreadyPosted).length,
+      totalProductsConsumed: results.reduce((s, r) => s + r.productsConsumed, 0),
+      menusWithoutRecipe: results.reduce((s, r) => s + r.menusWithoutRecipe, 0),
+    };
+    console.log(`[consumption-post] ${JSON.stringify(summary)}`);
+    return NextResponse.json({ ok: true, summary, results });
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : "consumption-post failed";
+    return NextResponse.json({ error: msg }, { status: 500 });
+  }
+}

--- a/apps/backoffice/src/app/api/inventory/ai-decisions/route.ts
+++ b/apps/backoffice/src/app/api/inventory/ai-decisions/route.ts
@@ -25,7 +25,7 @@ export async function GET(request: NextRequest) {
     const outletWhere = outletId ? { id: outletId, status: "ACTIVE" as const } : { status: "ACTIVE" as const };
 
     // ─── Parallel data fetches ──────────────────────────────────────
-    const [outlets, stockBalances, parLevels, supplierProducts, products, productPackages, existingDraftOrders, wastage30] = await Promise.all([
+    const [outlets, stockBalances, parLevels, supplierProducts, products, productPackages, existingDraftOrders, openPurchaseOrders, wastage30] = await Promise.all([
       prisma.outlet.findMany({
         where: outletWhere,
         select: { id: true, name: true, code: true },
@@ -66,13 +66,29 @@ export async function GET(request: NextRequest) {
         select: { id: true, productId: true, packageName: true, packageLabel: true, conversionFactor: true, isDefault: true },
         orderBy: { isDefault: "desc" }, // default packages first
       }),
-      // Existing DRAFT orders to avoid duplicates
+      // Existing DRAFT orders to avoid duplicate drafts
       prisma.order.findMany({
         where: { status: "DRAFT", orderType: "PURCHASE_ORDER" },
         select: {
           outletId: true,
           supplierId: true,
           items: { select: { productId: true } },
+        },
+      }),
+      // Open POs already placed but not yet received — this is incoming stock.
+      // Netting it off the reorder decision is what stops us re-ordering goods
+      // that are already on the way (the #1 overpurchase cause). PARTIALLY_RECEIVED
+      // is excluded on purpose: the receivings reconcile overwrites OrderItem.quantity
+      // with the received total, so its lines no longer represent what's still owed.
+      prisma.order.findMany({
+        where: {
+          orderType: "PURCHASE_ORDER",
+          status: { in: ["APPROVED", "SENT", "CONFIRMED", "AWAITING_DELIVERY"] },
+          ...(outletId ? { outletId } : {}),
+        },
+        select: {
+          outletId: true,
+          items: { select: { productId: true, productPackageId: true, quantity: true } },
         },
       }),
       // Wastage last 30 days
@@ -111,6 +127,20 @@ export async function GET(request: NextRequest) {
     for (const draftOrder of existingDraftOrders) {
       for (const item of draftOrder.items) {
         draftProductSet.add(`${item.productId}_${draftOrder.outletId}`);
+      }
+    }
+
+    // Incoming (on-order) quantity per product+outlet, converted to BASE units so
+    // it nets directly against the base-unit par level / current stock below.
+    // OrderItem.quantity is in package units; ×conversionFactor → base.
+    const pkgConvById = new Map(productPackages.map((p) => [p.id, Number(p.conversionFactor)]));
+    const onOrderMap = new Map<string, number>(); // key: productId_outletId → base units inbound
+    for (const po of openPurchaseOrders) {
+      for (const item of po.items) {
+        const conv = item.productPackageId ? pkgConvById.get(item.productPackageId) ?? 1 : 1;
+        const base = Number(item.quantity) * (conv > 0 ? conv : 1);
+        const key = `${item.productId}_${po.outletId}`;
+        onOrderMap.set(key, (onOrderMap.get(key) ?? 0) + base);
       }
     }
 
@@ -165,6 +195,7 @@ export async function GET(request: NextRequest) {
       sku: string;
       baseUom: string;
       currentQty: number;
+      onOrderQty: number; // package units already inbound from open POs
       parLevel: number;
       reorderPoint: number;
       avgDailyUsage: number;
@@ -208,18 +239,22 @@ export async function GET(request: NextRequest) {
         if (!par) continue; // no par level = skip
 
         const currentQty = stockMap.get(key) ?? 0;
+        const onOrderQty = onOrderMap.get(key) ?? 0; // base units already inbound
         const reorderPoint = Number(par.reorderPoint);
         const parLevel = Number(par.parLevel);
         const avgDaily = Number(par.avgDailyUsage);
 
-        // Only reorder if at or below reorder point
-        if (currentQty > reorderPoint) continue;
+        // Only reorder if stock-on-hand PLUS what's already on the way is at or
+        // below the reorder point. Counting inbound stock stops us re-ordering
+        // goods that are already coming.
+        if (currentQty + onOrderQty > reorderPoint) continue;
 
         // Skip if already in a DRAFT order
         if (draftProductSet.has(key)) continue;
 
         // ── Check if other outlets have surplus we can transfer ──
-        let baseUnitsNeeded = Math.max(parLevel - currentQty, 0);
+        // Need = par minus what we have minus what's inbound.
+        let baseUnitsNeeded = Math.max(parLevel - currentQty - onOrderQty, 0);
         if (baseUnitsNeeded <= 0) continue;
 
         // Look for surplus at other outlets (stock above par level)
@@ -303,6 +338,7 @@ export async function GET(request: NextRequest) {
           sku: product.sku || "",
           baseUom: product.baseUom,
           currentQty: conv > 1 ? Math.round((currentQty / conv) * 100) / 100 : currentQty,
+          onOrderQty: conv > 1 ? Math.round((onOrderQty / conv) * 100) / 100 : onOrderQty,
           parLevel: conv > 1 ? Math.round((parLevel / conv) * 100) / 100 : parLevel,
           reorderPoint: conv > 1 ? Math.round((reorderPoint / conv) * 100) / 100 : reorderPoint,
           avgDailyUsage: Math.round(avgDaily * 100) / 100,

--- a/apps/backoffice/src/app/api/inventory/ai-decisions/route.ts
+++ b/apps/backoffice/src/app/api/inventory/ai-decisions/route.ts
@@ -25,7 +25,10 @@ export async function GET(request: NextRequest) {
     const outletWhere = outletId ? { id: outletId, status: "ACTIVE" as const } : { status: "ACTIVE" as const };
 
     // ─── Parallel data fetches ──────────────────────────────────────
-    const [outlets, stockBalances, parLevels, supplierProducts, products, productPackages, existingDraftOrders, openPurchaseOrders, wastage30] = await Promise.all([
+    const d90 = new Date(mytNow);
+    d90.setDate(d90.getDate() - 90);
+
+    const [outlets, stockBalances, parLevels, supplierProducts, products, productPackages, existingDraftOrders, openPurchaseOrders, recentPriceChanges, wastage30] = await Promise.all([
       prisma.outlet.findMany({
         where: outletWhere,
         select: { id: true, name: true, code: true },
@@ -91,6 +94,13 @@ export async function GET(request: NextRequest) {
           items: { select: { productId: true, productPackageId: true, quantity: true } },
         },
       }),
+      // Recent supplier price changes (90d) so the decision can flag a line whose
+      // price just moved — newest first, we keep the latest per supplier+product.
+      prisma.priceHistory.findMany({
+        where: { changedAt: { gte: d90 } },
+        orderBy: { changedAt: "desc" },
+        select: { supplierId: true, productId: true, changePercent: true, changedAt: true },
+      }),
       // Wastage last 30 days
       prisma.stockAdjustment.findMany({
         where: {
@@ -133,6 +143,13 @@ export async function GET(request: NextRequest) {
     // Incoming (on-order) quantity per product+outlet, converted to BASE units so
     // it nets directly against the base-unit par level / current stock below.
     // OrderItem.quantity is in package units; ×conversionFactor → base.
+    // Latest price change per supplier+product (newest first, so first wins).
+    const priceChangeMap = new Map<string, number>();
+    for (const pc of recentPriceChanges) {
+      const key = `${pc.supplierId}_${pc.productId}`;
+      if (!priceChangeMap.has(key)) priceChangeMap.set(key, Number(pc.changePercent));
+    }
+
     const pkgConvById = new Map(productPackages.map((p) => [p.id, Number(p.conversionFactor)]));
     const onOrderMap = new Map<string, number>(); // key: productId_outletId → base units inbound
     for (const po of openPurchaseOrders) {
@@ -201,6 +218,7 @@ export async function GET(request: NextRequest) {
       avgDailyUsage: number;
       orderQty: number; // in package units
       unitPrice: number; // per package
+      priceChangePercent: number | null; // latest 90d change from this supplier, if any
       totalPrice: number;
       productPackageId: string | null;
       packageName: string | null;
@@ -344,6 +362,7 @@ export async function GET(request: NextRequest) {
           avgDailyUsage: Math.round(avgDaily * 100) / 100,
           orderQty,
           unitPrice: supplier.price,
+          priceChangePercent: priceChangeMap.get(`${supplier.supplierId}_${product.id}`) ?? null,
           totalPrice: Math.round(totalPrice * 100) / 100,
           productPackageId: supplier.productPackageId,
           packageName: supplier.packageName,

--- a/apps/backoffice/src/app/api/inventory/ai-decisions/route.ts
+++ b/apps/backoffice/src/app/api/inventory/ai-decisions/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { getSession } from "@/lib/auth";
 import { prisma } from "@/lib/prisma";
+import { validateSupplierOrder, type OrderWarning } from "@/lib/inventory/order-validation";
 
 // ─── GET /api/inventory/ai-decisions ────────────────────────────────────
 // Returns executable decisions: draft POs to create, transfers to make,
@@ -332,6 +333,9 @@ export async function GET(request: NextRequest) {
       items: ReorderItem[];
       totalAmount: number;
       urgency: "critical" | "low" | "restock";
+      // Order-level (per-trip) checks: below trip MOQ, off-calendar delivery.
+      // Surfaced so the buyer can top up to MOQ before the supplier asks.
+      warnings: OrderWarning[];
     };
 
     const poRecommendations: PORecommendation[] = [];
@@ -357,6 +361,30 @@ export async function GET(request: NextRequest) {
           items,
           totalAmount: Math.round(total * 100) / 100,
           urgency: hasCritical ? "critical" : hasLow ? "low" : "restock",
+          warnings: [],
+        });
+      }
+    }
+
+    // ── Attach trip-MOQ warnings ──
+    // The per-line MOQ is already enforced in the order quantities above; this
+    // checks the whole PO against the supplier's per-trip ringgit minimum so the
+    // buyer can top up before the supplier sends an "add more" message. (No
+    // planned delivery date on a draft, so the delivery-day check stays dormant
+    // until a date is set on the PO.)
+    if (poRecommendations.length > 0) {
+      const supplierIds = [...new Set(poRecommendations.map((p) => p.supplierId))];
+      const supplierMeta = await prisma.supplier.findMany({
+        where: { id: { in: supplierIds } },
+        select: { id: true, moq: true, deliveryDays: true },
+      });
+      const metaById = new Map(supplierMeta.map((s) => [s.id, s]));
+      for (const po of poRecommendations) {
+        const meta = metaById.get(po.supplierId);
+        po.warnings = validateSupplierOrder({
+          orderTotal: po.totalAmount,
+          moq: meta?.moq ?? null,
+          deliveryDays: meta?.deliveryDays ?? [],
         });
       }
     }

--- a/apps/backoffice/src/app/api/inventory/invoices/[id]/route.ts
+++ b/apps/backoffice/src/app/api/inventory/invoices/[id]/route.ts
@@ -74,6 +74,30 @@ export async function PATCH(req: NextRequest, { params }: { params: Promise<{ id
       data.aiPrefilledFields = null;
     }
 
+    // Amount edited on an already-PAID invoice (e.g. the supplier's real total
+    // came in higher than what we settled) without an explicit status or
+    // payment in this request → the invoice is no longer fully paid. Flip it
+    // back to PARTIALLY_PAID so the stranded balance is visible, instead of
+    // leaving it PAID with money still owed. Scoped to PAID only — deposit
+    // flows manage their own balance leg.
+    if (
+      amount !== undefined &&
+      status === undefined &&
+      !(typeof paymentAmountInput === "number" && paymentAmountInput > 0)
+    ) {
+      const current = await prisma.invoice.findUnique({
+        where: { id },
+        select: { status: true, amountPaid: true },
+      });
+      if (current?.status === "PAID") {
+        const paid = Number(current.amountPaid ?? 0);
+        if (Number(amount) - paid > 0.01) {
+          data.status = paid > 0 ? "PARTIALLY_PAID" : "PENDING";
+          data.paidAt = null;
+        }
+      }
+    }
+
     // Deposit overrides — caller can set/clear deposit on this invoice.
     // We always recompute depositAmount when percent or amount changes so
     // they can never drift apart silently.

--- a/apps/backoffice/src/app/api/inventory/invoices/reconciliation/route.ts
+++ b/apps/backoffice/src/app/api/inventory/invoices/reconciliation/route.ts
@@ -180,7 +180,9 @@ export async function GET(req: NextRequest) {
     // delivery/handling charge (or a price change) the order didn't account
     // for. Only surface on real, verified invoices (not provisional drafts).
     const poTotal = inv.order?.totalAmount != null ? Number(inv.order.totalAmount) : 0;
-    if (!isDraft && poTotal > 0) {
+    // amount > 0 guards against credit notes / zero invoices producing a
+    // spurious "billed over PO" reading.
+    if (!isDraft && poTotal > 0 && amount > 0) {
       const over = Math.round((amount - poTotal) * 100) / 100;
       if (over >= BILLED_OVER_PO_MIN_RM && over >= poTotal * BILLED_OVER_PO_MIN_PCT) {
         kinds.push("BILLED_OVER_PO");

--- a/apps/backoffice/src/app/api/inventory/invoices/reconciliation/route.ts
+++ b/apps/backoffice/src/app/api/inventory/invoices/reconciliation/route.ts
@@ -24,7 +24,14 @@ import { activeFlags, flagLabel, type InvoiceFlag } from "@/lib/inventory/flag-d
 const OPEN_STATUSES = ["PENDING", "INITIATED", "PARTIALLY_PAID", "DEPOSIT_PAID", "OVERDUE"] as const;
 const TOLERANCE = 0.01;
 
-type ExceptionKind = "FLAGGED" | "SHORT_PAID" | "CARRY_FORWARD" | "UNVERIFIED" | "OVERDUE";
+type ExceptionKind = "FLAGGED" | "SHORT_PAID" | "CARRY_FORWARD" | "UNVERIFIED" | "OVERDUE" | "BILLED_OVER_PO";
+
+// A supplier invoice legitimately adds SST + delivery/handling on top of the
+// PO's goods total, but an UNEXPECTED extra is the "missing delivery charge"
+// reconciliation pain: we pay the goods, the supplier chases the delivery fee.
+// Surface it only when the gap is material so SST-sized rounding isn't noise.
+const BILLED_OVER_PO_MIN_RM = 10;
+const BILLED_OVER_PO_MIN_PCT = 0.05;
 
 type Exception = {
   invoiceId: string;
@@ -82,7 +89,7 @@ export async function GET(req: NextRequest) {
       flags: true,
       supplierId: true,
       supplier: { select: { id: true, name: true, paymentTerms: true } },
-      order: { select: { orderNumber: true } },
+      order: { select: { orderNumber: true, totalAmount: true } },
     },
     orderBy: { issueDate: "asc" },
   });
@@ -169,6 +176,17 @@ export async function GET(req: NextRequest) {
       kinds.push("OVERDUE");
       reasons.push(`Overdue ${inv.dueDate ? daysBetween(inv.dueDate, now) : 0}d — RM ${balance.toFixed(2)} owed`);
     }
+    // Billed materially over the PO goods total — the supplier likely added a
+    // delivery/handling charge (or a price change) the order didn't account
+    // for. Only surface on real, verified invoices (not provisional drafts).
+    const poTotal = inv.order?.totalAmount != null ? Number(inv.order.totalAmount) : 0;
+    if (!isDraft && poTotal > 0) {
+      const over = Math.round((amount - poTotal) * 100) / 100;
+      if (over >= BILLED_OVER_PO_MIN_RM && over >= poTotal * BILLED_OVER_PO_MIN_PCT) {
+        kinds.push("BILLED_OVER_PO");
+        reasons.push(`Billed RM ${over.toFixed(2)} over PO total (RM ${poTotal.toFixed(2)}) — verify delivery/handling/SST and that payment covers it`);
+      }
+    }
 
     if (kinds.length > 0) {
       row.exceptions.push({
@@ -196,7 +214,7 @@ export async function GET(req: NextRequest) {
   // Sort exceptions within each supplier: flagged money-matching issues first
   // (highest risk), then by age. Sort suppliers by exception count then
   // outstanding so the rows that need a human bubble up.
-  const kindRank: Record<ExceptionKind, number> = { FLAGGED: 0, SHORT_PAID: 1, OVERDUE: 2, CARRY_FORWARD: 3, UNVERIFIED: 4 };
+  const kindRank: Record<ExceptionKind, number> = { FLAGGED: 0, BILLED_OVER_PO: 1, SHORT_PAID: 2, OVERDUE: 3, CARRY_FORWARD: 4, UNVERIFIED: 5 };
   const suppliers = [...bySupplier.values()]
     .map((s) => {
       s.outstanding = Math.round(s.outstanding * 100) / 100;

--- a/apps/backoffice/src/app/api/inventory/invoices/reconciliation/route.ts
+++ b/apps/backoffice/src/app/api/inventory/invoices/reconciliation/route.ts
@@ -1,0 +1,231 @@
+import { NextResponse, NextRequest } from "next/server";
+import { prisma } from "@/lib/prisma";
+import { getUserFromHeaders } from "@/lib/auth";
+import { activeFlags, flagLabel, type InvoiceFlag } from "@/lib/inventory/flag-detector";
+
+// GET /api/inventory/invoices/reconciliation
+//
+// The procurement "statement of account" view. The flat invoices list answers
+// "what do we owe right now"; this answers the money-matching questions that
+// 17 real supplier chats showed were the #1 recurring pain: "which invoice is
+// this PoP for", short/partial/double payments, missing delivery charges, and
+// carry-forward balances. We group supplier invoices into a per-supplier
+// statement (outstanding + aging) and surface the reconciliation EXCEPTIONS —
+// the rows a human needs to match or chase.
+//
+// Overpayment never lands as amountPaid > amount (the payment route clamps
+// amountPaid to the invoice total). Double/over/wrong-account payments are
+// caught by the per-invoice flags written by flag-detector at payment time, so
+// the ledger surfaces those flags rather than recomputing them.
+
+// Open = a real, verified liability still owed. DRAFT is excluded from the
+// outstanding total (provisional / AI-captured, amount not yet confirmed) but
+// still surfaced as a "verify" exception below.
+const OPEN_STATUSES = ["PENDING", "INITIATED", "PARTIALLY_PAID", "DEPOSIT_PAID", "OVERDUE"] as const;
+const TOLERANCE = 0.01;
+
+type ExceptionKind = "FLAGGED" | "SHORT_PAID" | "CARRY_FORWARD" | "UNVERIFIED" | "OVERDUE";
+
+type Exception = {
+  invoiceId: string;
+  invoiceNumber: string;
+  poNumber: string | null;
+  status: string;
+  amount: number;
+  amountPaid: number;
+  balance: number;
+  issueDate: string;
+  dueDate: string | null;
+  ageDays: number;
+  kinds: ExceptionKind[];
+  // Short human summary of why this row needs reconciliation attention.
+  reason: string;
+  flags: { code: string; label: string; message: string }[];
+};
+
+function daysBetween(from: Date, to: Date): number {
+  return Math.max(0, Math.floor((to.getTime() - from.getTime()) / 86_400_000));
+}
+
+export async function GET(req: NextRequest) {
+  const caller = await getUserFromHeaders(req.headers);
+  if (!caller) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+
+  const now = new Date();
+  const todayStart = new Date(now.getFullYear(), now.getMonth(), now.getDate());
+
+  // Optional supplier filter — same repeated-param shape as the invoices list.
+  const supplierIds = req.nextUrl.searchParams.getAll("supplier").filter(Boolean);
+
+  // Only real supplier (AP) invoices reconcile against a statement. Staff
+  // claims, internal transfers and one-off payment requests have null
+  // supplierId and no supplier statement, so they're excluded naturally by
+  // requiring a supplierId.
+  const invoices = await prisma.invoice.findMany({
+    where: {
+      paymentType: "SUPPLIER",
+      supplierId: supplierIds.length ? { in: supplierIds } : { not: null },
+      // Exclude finance one-off vendor payment requests (also paymentType
+      // SUPPLIER) but keep ad-hoc supplier invoices with no PO attached.
+      NOT: { order: { is: { orderType: "PAYMENT_REQUEST" } } },
+    },
+    select: {
+      id: true,
+      invoiceNumber: true,
+      amount: true,
+      amountPaid: true,
+      status: true,
+      issueDate: true,
+      dueDate: true,
+      paidAt: true,
+      aiPrefilledAt: true,
+      flags: true,
+      supplierId: true,
+      supplier: { select: { id: true, name: true, paymentTerms: true } },
+      order: { select: { orderNumber: true } },
+    },
+    orderBy: { issueDate: "asc" },
+  });
+
+  type SupplierRow = {
+    supplierId: string;
+    supplierName: string;
+    paymentTerms: string | null;
+    outstanding: number;
+    openCount: number;
+    overdueAmount: number;
+    overdueCount: number;
+    oldestOpenDays: number;
+    exceptions: Exception[];
+  };
+
+  const bySupplier = new Map<string, SupplierRow>();
+
+  for (const inv of invoices) {
+    const supplierId = inv.supplierId;
+    if (!supplierId) continue;
+    let row = bySupplier.get(supplierId);
+    if (!row) {
+      row = {
+        supplierId,
+        supplierName: inv.supplier?.name ?? "Unknown supplier",
+        paymentTerms: inv.supplier?.paymentTerms ?? null,
+        outstanding: 0,
+        openCount: 0,
+        overdueAmount: 0,
+        overdueCount: 0,
+        oldestOpenDays: 0,
+        exceptions: [],
+      };
+      bySupplier.set(supplierId, row);
+    }
+
+    const amount = Number(inv.amount);
+    const amountPaid = Number(inv.amountPaid ?? 0);
+    const balance = Math.round((amount - amountPaid) * 100) / 100;
+    const isOpen = (OPEN_STATUSES as readonly string[]).includes(inv.status);
+    const isDraft = inv.status === "DRAFT";
+    const ageDays = daysBetween(inv.issueDate, now);
+    const isOverdue = inv.dueDate != null && inv.dueDate < todayStart && balance > TOLERANCE && (isOpen || isDraft);
+
+    if (isOpen && balance > TOLERANCE) {
+      row.outstanding += balance;
+      row.openCount += 1;
+      row.oldestOpenDays = Math.max(row.oldestOpenDays, ageDays);
+    }
+    if (isOverdue) {
+      row.overdueAmount += balance;
+      row.overdueCount += 1;
+    }
+
+    // ─── Reconciliation exceptions ───────────────────────────
+    const flags = activeFlags(inv.flags);
+    const kinds: ExceptionKind[] = [];
+    const reasons: string[] = [];
+
+    if (flags.length > 0) {
+      kinds.push("FLAGGED");
+      reasons.push(flags.map((f) => flagLabel(f.code as InvoiceFlag["code"]) ?? f.code).join(", "));
+    }
+    // PAID but we applied less than billed — supplier "short paid 80 cents"
+    // / a post-payment amount edit. amountPaid is clamped to amount on the
+    // way up, so this only happens when the billed amount exceeds what was
+    // settled: a genuine residual the supplier will still chase.
+    if (inv.status === "PAID" && balance > TOLERANCE) {
+      kinds.push("SHORT_PAID");
+      reasons.push(`Marked paid but RM ${balance.toFixed(2)} short of billed`);
+    }
+    // Deposit/partial with a remaining balance carried forward.
+    if ((inv.status === "PARTIALLY_PAID" || inv.status === "DEPOSIT_PAID") && balance > TOLERANCE) {
+      kinds.push("CARRY_FORWARD");
+      reasons.push(`RM ${balance.toFixed(2)} balance outstanding after part payment`);
+    }
+    // AI-captured / draft invoice whose amount is still provisional.
+    if (isDraft || inv.aiPrefilledAt != null) {
+      kinds.push("UNVERIFIED");
+      reasons.push(inv.aiPrefilledAt ? "AI-captured — amount not yet verified" : "Draft — not yet verified");
+    }
+    if (isOverdue) {
+      kinds.push("OVERDUE");
+      reasons.push(`Overdue ${inv.dueDate ? daysBetween(inv.dueDate, now) : 0}d — RM ${balance.toFixed(2)} owed`);
+    }
+
+    if (kinds.length > 0) {
+      row.exceptions.push({
+        invoiceId: inv.id,
+        invoiceNumber: inv.invoiceNumber,
+        poNumber: inv.order?.orderNumber ?? null,
+        status: inv.status,
+        amount: Math.round(amount * 100) / 100,
+        amountPaid: Math.round(amountPaid * 100) / 100,
+        balance,
+        issueDate: inv.issueDate.toISOString().split("T")[0],
+        dueDate: inv.dueDate?.toISOString().split("T")[0] ?? null,
+        ageDays,
+        kinds,
+        reason: reasons.join(" · "),
+        flags: flags.map((f) => ({
+          code: f.code,
+          label: flagLabel(f.code as InvoiceFlag["code"]) ?? f.code,
+          message: f.message,
+        })),
+      });
+    }
+  }
+
+  // Sort exceptions within each supplier: flagged money-matching issues first
+  // (highest risk), then by age. Sort suppliers by exception count then
+  // outstanding so the rows that need a human bubble up.
+  const kindRank: Record<ExceptionKind, number> = { FLAGGED: 0, SHORT_PAID: 1, OVERDUE: 2, CARRY_FORWARD: 3, UNVERIFIED: 4 };
+  const suppliers = [...bySupplier.values()]
+    .map((s) => {
+      s.outstanding = Math.round(s.outstanding * 100) / 100;
+      s.overdueAmount = Math.round(s.overdueAmount * 100) / 100;
+      s.exceptions.sort((a, b) => {
+        const ra = Math.min(...a.kinds.map((k) => kindRank[k]));
+        const rb = Math.min(...b.kinds.map((k) => kindRank[k]));
+        return ra - rb || b.ageDays - a.ageDays;
+      });
+      return s;
+    })
+    // Hide fully-settled suppliers with nothing to reconcile.
+    .filter((s) => s.outstanding > TOLERANCE || s.exceptions.length > 0)
+    .sort((a, b) => b.exceptions.length - a.exceptions.length || b.outstanding - a.outstanding);
+
+  const totals = suppliers.reduce(
+    (acc, s) => {
+      acc.outstanding += s.outstanding;
+      acc.openCount += s.openCount;
+      acc.overdueAmount += s.overdueAmount;
+      acc.overdueCount += s.overdueCount;
+      acc.exceptionCount += s.exceptions.length;
+      acc.flaggedCount += s.exceptions.filter((e) => e.kinds.includes("FLAGGED")).length;
+      return acc;
+    },
+    { outstanding: 0, openCount: 0, overdueAmount: 0, overdueCount: 0, exceptionCount: 0, flaggedCount: 0, supplierCount: suppliers.length },
+  );
+  totals.outstanding = Math.round(totals.outstanding * 100) / 100;
+  totals.overdueAmount = Math.round(totals.overdueAmount * 100) / 100;
+
+  return NextResponse.json({ suppliers, totals });
+}

--- a/apps/backoffice/src/app/api/inventory/products/[id]/route.ts
+++ b/apps/backoffice/src/app/api/inventory/products/[id]/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse, NextRequest } from "next/server";
 import { prisma } from "@/lib/prisma";
 import { getUserFromHeaders } from "@/lib/auth";
+import { recordPriceChange } from "@/lib/inventory/price-history";
 
 export async function PATCH(req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   const caller = await getUserFromHeaders(req.headers);
@@ -168,6 +169,13 @@ export async function PATCH(req: NextRequest, { params }: { params: Promise<{ id
             where: { supplierId, productId: id, productPackageId: packageId },
           });
           if (existingLink) {
+            await recordPriceChange({
+              supplierId,
+              productId: id,
+              productPackageId: packageId,
+              oldPrice: Number(existingLink.price),
+              newPrice: Number(entry.price),
+            });
             await prisma.supplierProduct.update({
               where: { id: existingLink.id },
               data: { price: entry.price },

--- a/apps/backoffice/src/app/api/inventory/receivings/route.ts
+++ b/apps/backoffice/src/app/api/inventory/receivings/route.ts
@@ -115,12 +115,32 @@ export async function POST(req: NextRequest) {
 
   const isTransfer = !!transferId;
 
+  // Auto-derive orderedQty from the PO server-side so short-delivery tracking
+  // doesn't depend on the client sending it. This is the ONLY surviving record
+  // of what was ordered, because the PO-line reconcile below overwrites
+  // OrderItem.quantity with the received total. Keyed by product+package.
+  const orderedQtyMap = new Map<string, number>();
+  if (orderId) {
+    const poItems = await prisma.orderItem.findMany({
+      where: { orderId },
+      select: { productId: true, productPackageId: true, quantity: true },
+    });
+    for (const oi of poItems) {
+      orderedQtyMap.set(`${oi.productId}::${oi.productPackageId ?? ""}`, Number(oi.quantity));
+    }
+  }
+  const resolveOrderedQty = (i: { productId: string; productPackageId?: string; orderedQty?: number }): number | null => {
+    if (i.orderedQty !== undefined && i.orderedQty !== null) return i.orderedQty;
+    if (!orderId) return null;
+    return orderedQtyMap.get(`${i.productId}::${i.productPackageId ?? ""}`) ?? null;
+  };
+
   let receivingStatus = status || "COMPLETE";
   if (orderId) {
-    const hasShort = items.some(
-      (i: { orderedQty?: number; receivedQty: number }) =>
-        i.orderedQty !== undefined && i.receivedQty < i.orderedQty,
-    );
+    const hasShort = items.some((i: { productId: string; productPackageId?: string; orderedQty?: number; receivedQty: number }) => {
+      const ordered = resolveOrderedQty(i);
+      return ordered !== null && i.receivedQty < ordered;
+    });
     if (hasShort) receivingStatus = "PARTIAL";
   }
 
@@ -138,7 +158,7 @@ export async function POST(req: NextRequest) {
         create: items.map((i: { productId: string; productPackageId?: string; orderedQty?: number; receivedQty: number; expiryDate?: string; discrepancyReason?: string }) => ({
           productId: i.productId,
           productPackageId: i.productPackageId || null,
-          orderedQty: i.orderedQty ?? null,
+          orderedQty: resolveOrderedQty(i),
           receivedQty: i.receivedQty,
           expiryDate: i.expiryDate ? new Date(i.expiryDate) : null,
           discrepancyReason: i.discrepancyReason || null,

--- a/apps/backoffice/src/app/api/inventory/reports/ingredient-variance/route.ts
+++ b/apps/backoffice/src/app/api/inventory/reports/ingredient-variance/route.ts
@@ -1,0 +1,256 @@
+import { NextResponse, NextRequest } from "next/server";
+import { prisma } from "@/lib/prisma";
+import { requireAuth } from "@/lib/auth";
+import { toBaseQty, buildVarianceRow, round2, type VarianceRow } from "@/lib/inventory/usage-variance";
+
+// GET /api/inventory/reports/ingredient-variance?outletId=&from=&to=
+//
+// Compares ACTUAL ingredient usage (reconstructed from physical stock movements
+// between two stock counts) against EXPECTED usage (menu sales × recipe BOM).
+// The gap is unexplained loss — over-portioning, theft, unrecorded spoilage —
+// and tells us whether stock data is trustworthy enough to auto-reorder on.
+//
+// Count-bracketed: actual is only meaningful between two physical counts, so the
+// effective period is [openingCount.date .. closingCount.date], chosen to sit
+// inside the requested window. All movement quantities are normalised to base
+// UOM at read time (movements are stored in mixed package/base units).
+
+const WASTE_TYPES = ["WASTAGE", "BREAKAGE", "EXPIRED", "SPILLAGE", "THEFT", "USED_NOT_RECORDED"] as const;
+const USABLE_COUNT_STATUS = ["SUBMITTED", "REVIEWED"] as const;
+const ACTIVE_TRANSFER_STATUS = ["PENDING_APPROVAL", "PENDING", "APPROVED", "IN_TRANSIT", "RECEIVED", "COMPLETED"] as const;
+const DEFAULT_TAKEAWAY_RATIO = 0.5;
+
+const channelWeight = (mode: "ALL" | "DINE_IN" | "TAKEAWAY") =>
+  mode === "TAKEAWAY" ? DEFAULT_TAKEAWAY_RATIO : mode === "DINE_IN" ? 1 - DEFAULT_TAKEAWAY_RATIO : 1;
+
+export async function GET(req: NextRequest) {
+  const auth = await requireAuth(req);
+  if (auth.error) return auth.error;
+
+  const { searchParams } = new URL(req.url);
+  const outletId = searchParams.get("outletId");
+  const now = new Date();
+  const from = searchParams.get("from") ? new Date(searchParams.get("from")!) : new Date(now.getTime() - 30 * 86_400_000);
+  const to = searchParams.get("to") ? new Date(searchParams.get("to")!) : now;
+
+  const outlets = await prisma.outlet.findMany({ select: { id: true, name: true }, orderBy: { name: "asc" } });
+  if (!outletId) {
+    // Variance is count-bracketed per outlet, so an outlet must be chosen.
+    return NextResponse.json({ summary: null, outlets, items: [], warnings: emptyWarnings(), requireOutlet: true });
+  }
+  const outletName = outlets.find((o) => o.id === outletId)?.name ?? "Unknown";
+
+  // ── 1. Bracket the period with two usable stock counts ──
+  const counts = await prisma.stockCount.findMany({
+    where: { outletId, status: { in: USABLE_COUNT_STATUS as unknown as ("SUBMITTED" | "REVIEWED")[] } },
+    orderBy: { countDate: "asc" },
+    select: { id: true, countDate: true, items: { select: { productId: true, productPackageId: true, countedQty: true } } },
+  });
+
+  // opening = latest count at/before `from`; if none, the earliest count we have.
+  // closing = latest count at/before `to` strictly after opening.
+  let opening = [...counts].filter((c) => c.countDate <= from).pop() ?? null;
+  if (!opening && counts.length) opening = counts[0];
+  const closing = opening
+    ? [...counts].filter((c) => c.countDate <= to && c.countDate > opening!.countDate).pop() ?? null
+    : null;
+
+  if (!opening || !closing) {
+    return NextResponse.json({
+      summary: {
+        outletId, outletName,
+        requestedFrom: from.toISOString(), requestedTo: to.toISOString(),
+        openingCountDate: opening?.countDate.toISOString() ?? null,
+        closingCountDate: null,
+        dataQuality: "insufficient" as const,
+        reason: counts.length < 2
+          ? "Need at least two stock counts to measure usage between them."
+          : "No pair of stock counts brackets this period — widen the date range.",
+        totalExpectedCost: null, totalVarianceCost: null, itemsAnalyzed: 0,
+      },
+      outlets, items: [], warnings: emptyWarnings(),
+    });
+  }
+
+  const start = opening.countDate;
+  const end = closing.countDate;
+  const windowFilter = { gt: start, lte: end };
+
+  // ── 2. Reference maps: package conversion + cheapest cost per base unit ──
+  const [packages, supplierProducts] = await Promise.all([
+    prisma.productPackage.findMany({ select: { id: true, conversionFactor: true } }),
+    prisma.supplierProduct.findMany({
+      where: { isActive: true, price: { gt: 0 } },
+      select: { productId: true, price: true, productPackage: { select: { conversionFactor: true } } },
+    }),
+  ]);
+  const convByPackage = new Map(packages.map((p) => [p.id, Number(p.conversionFactor)]));
+  const costMap = new Map<string, number>();
+  for (const sp of supplierProducts) {
+    const conv = sp.productPackage ? Number(sp.productPackage.conversionFactor) : 0;
+    if (conv <= 0) continue;
+    const costPerBase = Number(sp.price) / conv;
+    const existing = costMap.get(sp.productId);
+    if (!existing || costPerBase < existing) costMap.set(sp.productId, costPerBase);
+  }
+
+  // ── 3. Stock-movement terms (all normalised to base UOM) ──
+  const addBase = (m: Map<string, number>, productId: string, qty: number) =>
+    m.set(productId, (m.get(productId) ?? 0) + qty);
+
+  const openingQty = new Map<string, number>();
+  for (const it of opening.items) addBase(openingQty, it.productId, toBaseQty(Number(it.countedQty ?? 0), it.productPackageId, convByPackage));
+  const closingQty = new Map<string, number>();
+  for (const it of closing.items) addBase(closingQty, it.productId, toBaseQty(Number(it.countedQty ?? 0), it.productPackageId, convByPackage));
+
+  const [receivings, transfers, wastage, sales] = await Promise.all([
+    prisma.receivingItem.findMany({
+      where: { receiving: { outletId, receivedAt: windowFilter } },
+      select: { productId: true, productPackageId: true, receivedQty: true },
+    }),
+    prisma.stockTransferItem.findMany({
+      where: {
+        transfer: {
+          status: { in: ACTIVE_TRANSFER_STATUS as unknown as ("RECEIVED" | "COMPLETED")[] },
+          OR: [
+            { toOutletId: outletId, receivedAt: windowFilter },
+            { fromOutletId: outletId, createdAt: windowFilter },
+          ],
+        },
+      },
+      select: {
+        productId: true, productPackageId: true, quantity: true,
+        transfer: { select: { fromOutletId: true, toOutletId: true } },
+      },
+    }),
+    prisma.stockAdjustment.findMany({
+      where: { outletId, adjustmentType: { in: WASTE_TYPES as unknown as ("WASTAGE")[] }, createdAt: windowFilter },
+      select: { productId: true, quantity: true },
+    }),
+    prisma.salesTransaction.findMany({
+      where: { outletId, menuId: { not: null }, transactedAt: windowFilter },
+      select: { menuId: true, quantity: true },
+    }),
+  ]);
+
+  const receiptsQty = new Map<string, number>();
+  for (const ri of receivings) addBase(receiptsQty, ri.productId, toBaseQty(Number(ri.receivedQty), ri.productPackageId, convByPackage));
+
+  const transfersInQty = new Map<string, number>();
+  const transfersOutQty = new Map<string, number>();
+  for (const ti of transfers) {
+    const base = toBaseQty(Number(ti.quantity), ti.productPackageId, convByPackage);
+    if (ti.transfer.toOutletId === outletId) addBase(transfersInQty, ti.productId, base);
+    if (ti.transfer.fromOutletId === outletId) addBase(transfersOutQty, ti.productId, base);
+  }
+
+  const wastageQty = new Map<string, number>();
+  for (const w of wastage) addBase(wastageQty, w.productId, Number(w.quantity)); // already base
+
+  // ── 4. Expected usage = Σ(sales × BOM qty), reusing the COGS recipe approach ──
+  const salesByMenu = new Map<string, number>();
+  for (const s of sales) if (s.menuId) salesByMenu.set(s.menuId, (salesByMenu.get(s.menuId) ?? 0) + s.quantity);
+
+  const recipes = await prisma.menuIngredient.findMany({
+    where: salesByMenu.size ? { menuId: { in: [...salesByMenu.keys()] } } : { menuId: "__none__" },
+    select: {
+      menuId: true, productId: true, quantityUsed: true, uom: true, serviceMode: true,
+      menu: { select: { name: true } },
+      product: { select: { baseUom: true } },
+    },
+  });
+  const expectedQty = new Map<string, number>();
+  const menusWithBom = new Set<string>();
+  const uomMismatches: { productId: string; menuUom: string; baseUom: string }[] = [];
+  for (const r of recipes) {
+    menusWithBom.add(r.menuId);
+    const sold = salesByMenu.get(r.menuId) ?? 0;
+    if (sold === 0) continue;
+    addBase(expectedQty, r.productId, sold * Number(r.quantityUsed) * channelWeight(r.serviceMode));
+    if (r.product.baseUom && r.uom && r.uom.trim().toLowerCase() !== r.product.baseUom.trim().toLowerCase()) {
+      uomMismatches.push({ productId: r.productId, menuUom: r.uom, baseUom: r.product.baseUom });
+    }
+  }
+  // Menus that sold but have no recipe → their ingredient usage is invisible.
+  const menusWithoutBom: string[] = [];
+  if (salesByMenu.size) {
+    const soldMenus = await prisma.menu.findMany({
+      where: { id: { in: [...salesByMenu.keys()] } },
+      select: { id: true, name: true },
+    });
+    for (const m of soldMenus) if (!menusWithBom.has(m.id)) menusWithoutBom.push(m.name);
+  }
+
+  // ── 5. Build per-product variance rows over the product universe ──
+  const universe = new Set<string>([
+    ...openingQty.keys(), ...closingQty.keys(), ...receiptsQty.keys(),
+    ...transfersInQty.keys(), ...transfersOutQty.keys(), ...wastageQty.keys(), ...expectedQty.keys(),
+  ]);
+  const products = await prisma.product.findMany({
+    where: { id: { in: [...universe] } },
+    select: { id: true, name: true, sku: true, baseUom: true, group: { select: { name: true } } },
+  });
+  const productMeta = new Map(products.map((p) => [p.id, p]));
+
+  const items: (VarianceRow & { sku: string | null; category: string | null; movements: Record<string, number> })[] = [];
+  const productsWithoutCost: string[] = [];
+  for (const productId of universe) {
+    const meta = productMeta.get(productId);
+    if (!meta) continue;
+    const o = openingQty.get(productId) ?? 0;
+    const c = closingQty.get(productId) ?? 0;
+    const rec = receiptsQty.get(productId) ?? 0;
+    const tin = transfersInQty.get(productId) ?? 0;
+    const tout = transfersOutQty.get(productId) ?? 0;
+    const waste = wastageQty.get(productId) ?? 0;
+    const actual = o + rec + tin - tout - waste - c;
+    const expected = expectedQty.get(productId) ?? 0;
+    // Skip products with no activity at all on either side.
+    if (Math.abs(actual) < 0.0001 && expected < 0.0001) continue;
+    const cost = costMap.get(productId) ?? 0;
+    if (cost <= 0) productsWithoutCost.push(meta.name);
+    const row = buildVarianceRow({
+      productId, productName: meta.name, baseUom: meta.baseUom,
+      actualQty: actual, expectedQty: expected, costPerBase: cost,
+    });
+    items.push({
+      ...row, sku: meta.sku, category: meta.group?.name ?? null,
+      movements: {
+        openingCountQty: round2(o), receiptsQty: round2(rec), transfersInQty: round2(tin),
+        transfersOutQty: round2(tout), recordedWastageQty: round2(waste), closingCountQty: round2(c),
+      },
+    });
+  }
+  // Biggest cost variance first — that's where the money leaks.
+  items.sort((a, b) => Math.abs(b.varianceCost) - Math.abs(a.varianceCost));
+
+  const totalExpectedCost = round2(items.reduce((s, i) => s + i.expectedCost, 0));
+  const totalVarianceCost = round2(items.reduce((s, i) => s + i.varianceCost, 0));
+  const dataQuality = menusWithoutBom.length === 0 && productsWithoutCost.length === 0 ? "complete" : "incomplete";
+
+  return NextResponse.json({
+    summary: {
+      outletId, outletName,
+      requestedFrom: from.toISOString(), requestedTo: to.toISOString(),
+      openingCountDate: start.toISOString(), closingCountDate: end.toISOString(),
+      totalExpectedCost, totalVarianceCost,
+      totalVariancePercent: totalExpectedCost > 0 ? round2((totalVarianceCost / totalExpectedCost) * 100) : null,
+      itemsAnalyzed: items.length,
+      itemsOverUsed: items.filter((i) => i.varianceQty > 0).length,
+      highVarianceCount: items.filter((i) => i.flags.includes("HIGH_VARIANCE")).length,
+      dataQuality,
+    },
+    outlets,
+    warnings: {
+      menuItemsWithoutBom: menusWithoutBom,
+      productsWithoutCost,
+      uomMismatches,
+      noSales: sales.length === 0,
+    },
+    items,
+  });
+}
+
+function emptyWarnings() {
+  return { menuItemsWithoutBom: [] as string[], productsWithoutCost: [] as string[], uomMismatches: [] as unknown[], noSales: false };
+}

--- a/apps/backoffice/src/app/api/inventory/supplier-chats/[key]/route.ts
+++ b/apps/backoffice/src/app/api/inventory/supplier-chats/[key]/route.ts
@@ -2,6 +2,7 @@ import { NextResponse, NextRequest } from "next/server";
 import type { OrderStatus } from "@celsius/db";
 import { prisma } from "@/lib/prisma";
 import { getUserFromHeaders } from "@/lib/auth";
+import { paymentModel } from "@/lib/inventory/payment-model";
 
 // One supplier thread: the full message history for a counterparty number,
 // the matched supplier, the right-panel procurement context (open POs, unpaid +
@@ -46,6 +47,7 @@ export async function GET(req: NextRequest, { params }: { params: Promise<{ key:
         deliveryDays: string[];
         paymentTerms: string | null;
         leadTimeDays: number;
+        paymentModel?: { model: string; label: string; note: string; popDeliveryCritical: boolean };
       } = null;
   let context = {
     openPOs: 0,
@@ -60,7 +62,7 @@ export async function GET(req: NextRequest, { params }: { params: Promise<{ key:
     const [s, openPOs, recentPOs, unpaid, overdue] = await Promise.all([
       prisma.supplier.findUnique({
         where: { id: supplierId },
-        select: { id: true, name: true, phone: true, deliveryDays: true, paymentTerms: true, leadTimeDays: true },
+        select: { id: true, name: true, phone: true, deliveryDays: true, paymentTerms: true, leadTimeDays: true, depositPercent: true },
       }),
       prisma.order.count({ where: openFilter }),
       prisma.order.findMany({
@@ -78,7 +80,9 @@ export async function GET(req: NextRequest, { params }: { params: Promise<{ key:
         _sum: { amount: true, amountPaid: true },
       }),
     ]);
-    supplier = s;
+    supplier = s
+      ? { ...s, paymentModel: paymentModel({ paymentTerms: s.paymentTerms, depositPercent: s.depositPercent }) }
+      : null;
     const bal = (a: { _sum: { amount: unknown; amountPaid: unknown } }) =>
       Math.max(0, Number(a._sum.amount ?? 0) - Number(a._sum.amountPaid ?? 0));
     context = {
@@ -94,5 +98,49 @@ export async function GET(req: NextRequest, { params }: { params: Promise<{ key:
   const windowOpen =
     !!lastInbound && Date.now() - +new Date(lastInbound.timestamp) < 24 * 60 * 60 * 1000;
 
-  return NextResponse.json({ key, supplierId, supplier, context, windowOpen, messages });
+  // Surface the supplier-chat agent's latest open proposal: only when the most
+  // recent message WE sent was an agent escalation (a holding reply with a
+  // structured proposal) and the supplier hasn't been answered by a human since.
+  // That's the "AI proposes / human approves" handoff — the human sees the
+  // concrete suggested PO edit and acts on it (the agent never applies it).
+  let agentProposal: {
+    intent: string;
+    escalationReason: string;
+    paymentModel?: string;
+    popDeliveryCritical?: boolean;
+    poAction: {
+      type: string;
+      itemName: string | null;
+      newQuantity: number | null;
+      note: string | null;
+    } | null;
+    at: string;
+  } | null = null;
+  const lastOutbound = await prisma.whatsAppMessage.findFirst({
+    where: { ...counter, direction: "outbound" },
+    orderBy: { timestamp: "desc" },
+    select: { raw: true, timestamp: true },
+  });
+  const raw = (lastOutbound?.raw ?? null) as Record<string, unknown> | null;
+  if (raw && raw.escalated === true && raw.proposal && typeof raw.proposal === "object") {
+    const p = raw.proposal as Record<string, unknown>;
+    const pa = (p.poAction ?? null) as Record<string, unknown> | null;
+    agentProposal = {
+      intent: String(p.intent ?? "unclear"),
+      escalationReason: String(p.escalationReason ?? "guardrail"),
+      paymentModel: typeof p.paymentModel === "string" ? p.paymentModel : undefined,
+      popDeliveryCritical: typeof p.popDeliveryCritical === "boolean" ? p.popDeliveryCritical : undefined,
+      poAction: pa
+        ? {
+            type: String(pa.type ?? ""),
+            itemName: typeof pa.itemName === "string" ? pa.itemName : null,
+            newQuantity: typeof pa.newQuantity === "number" ? pa.newQuantity : null,
+            note: typeof pa.note === "string" ? pa.note : null,
+          }
+        : null,
+      at: lastOutbound!.timestamp.toISOString(),
+    };
+  }
+
+  return NextResponse.json({ key, supplierId, supplier, context, windowOpen, messages, agentProposal });
 }

--- a/apps/backoffice/src/app/api/inventory/suppliers/[id]/products/route.ts
+++ b/apps/backoffice/src/app/api/inventory/suppliers/[id]/products/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse, NextRequest } from "next/server";
 import { prisma } from "@/lib/prisma";
 import { requireAuth } from "@/lib/auth";
+import { recordPriceChange } from "@/lib/inventory/price-history";
 
 /**
  * POST /api/suppliers/[id]/products
@@ -29,6 +30,16 @@ export async function POST(
       productPackageId: productPackageId || null,
     },
   });
+
+  if (existing) {
+    await recordPriceChange({
+      supplierId,
+      productId,
+      productPackageId: productPackageId || null,
+      oldPrice: Number(existing.price),
+      newPrice: Number(price),
+    });
+  }
 
   const sp = existing
     ? await prisma.supplierProduct.update({

--- a/apps/backoffice/src/lib/inventory/agents/supplier-chat-agent.ts
+++ b/apps/backoffice/src/lib/inventory/agents/supplier-chat-agent.ts
@@ -31,6 +31,7 @@ import { sendWhatsAppText, fetchWhatsAppMedia } from "@/lib/whatsapp";
 import { recordOutboundMessage } from "@/lib/whatsapp-store";
 import { parseSupplierDoc } from "@/lib/finance/parsers/supplier-doc";
 import { detectCreationFlags } from "@/lib/inventory/flag-detector";
+import { paymentModel, type PaymentModelInfo } from "@/lib/inventory/payment-model";
 
 const anthropic = new Anthropic({ apiKey: process.env.ANTHROPIC_API_KEY });
 
@@ -125,7 +126,7 @@ export async function handleSupplierMessage(evt: SupplierMessageEvent): Promise<
     // Match the supplier by last-8 digits (same rule as whatsapp-store).
     const suppliers = await prisma.supplier.findMany({
       where: { phone: { not: null }, status: "ACTIVE" },
-      select: { id: true, name: true, phone: true, paymentTerms: true },
+      select: { id: true, name: true, phone: true, paymentTerms: true, depositPercent: true },
     });
     const supplier = suppliers.find((s) => {
       const sd = digits(s.phone);
@@ -178,7 +179,8 @@ export async function handleSupplierMessage(evt: SupplierMessageEvent): Promise<
     });
     history.reverse();
 
-    const decision = await classify(evt.text, supplier, order, history, todayMyt(), hasDoc);
+    const pm = paymentModel(supplier);
+    const decision = await classify(evt.text, supplier, order, history, todayMyt(), hasDoc, pm);
     if (!decision) return;
 
     // ── Guardrails (code, not model): auto-act vs escalate ──
@@ -216,6 +218,33 @@ export async function handleSupplierMessage(evt: SupplierMessageEvent): Promise<
     }
     if (!replyText) replyText = HOLDING_REPLY[lang];
 
+    // When we escalate, capture a STRUCTURED PROPOSAL of the action we declined
+    // to auto-apply (e.g. the substitution swap, the qty change) so the inbox can
+    // show the human a concrete "AI suggests …" they can accept or reject —
+    // rather than just "needs attention". Read-only: the agent never applies it.
+    const proposedItem =
+      decision.po_action.po_item_id
+        ? order.items.find((i) => i.id === decision.po_action.po_item_id)
+        : undefined;
+    const proposal = escalate
+      ? {
+          intent: decision.intent,
+          escalationReason: decision.escalation_reason ?? "guardrail",
+          paymentModel: pm.model,
+          popDeliveryCritical: pm.popDeliveryCritical,
+          poAction:
+            decision.po_action.type !== "none"
+              ? {
+                  type: decision.po_action.type,
+                  poItemId: decision.po_action.po_item_id,
+                  itemName: proposedItem?.product.name ?? null,
+                  newQuantity: decision.po_action.new_quantity,
+                  note: decision.po_action.note,
+                }
+              : null,
+        }
+      : null;
+
     // Auto-reply (24h window is open — the supplier just messaged us).
     const sent = await sendWhatsAppText(supplier.phone ?? fromDigits, replyText);
 
@@ -238,6 +267,8 @@ export async function handleSupplierMessage(evt: SupplierMessageEvent): Promise<
         escalated: escalate,
         escalationReason: escalate ? (decision.escalation_reason ?? "guardrail") : null,
         poNumber: order.orderNumber,
+        paymentModel: pm.model,
+        proposal,
       },
     });
 
@@ -461,6 +492,7 @@ async function classify(
   history: Array<{ direction: string; body: string | null }>,
   today: string,
   hasDoc: boolean,
+  pm: PaymentModelInfo,
 ): Promise<AgentDecision | null> {
   const items = order.items
     .map(
@@ -478,6 +510,7 @@ async function classify(
   const prompt = `Today is ${today} (Asia/Kuala_Lumpur). A document was attached: ${hasDoc ? "YES — most likely their invoice/PoP/photo" : "no"}.
 
 # Open PO ${order.orderNumber} (status ${order.status}) — ${supplier.name}, terms ${supplier.paymentTerms ?? "—"}
+# Payment model: ${pm.label}${pm.popDeliveryCritical ? " — PREPAY/DEPOSIT: payment clears BEFORE goods are released, so any payment/PoP message here is delivery-critical; escalate promptly with an honest holding reply." : ""}
 ${items}
 
 # Recent conversation

--- a/apps/backoffice/src/lib/inventory/agents/supplier-chat-agent.ts
+++ b/apps/backoffice/src/lib/inventory/agents/supplier-chat-agent.ts
@@ -25,10 +25,12 @@
  * Model: claude-sonnet-4-6 — it edits real POs and writes to real suppliers.
  */
 import Anthropic from "@anthropic-ai/sdk";
-import type { OrderStatus } from "@celsius/db";
+import type { OrderStatus, Prisma } from "@celsius/db";
 import { prisma } from "@/lib/prisma";
-import { sendWhatsAppText } from "@/lib/whatsapp";
+import { sendWhatsAppText, fetchWhatsAppMedia } from "@/lib/whatsapp";
 import { recordOutboundMessage } from "@/lib/whatsapp-store";
+import { parseSupplierDoc } from "@/lib/finance/parsers/supplier-doc";
+import { detectCreationFlags } from "@/lib/inventory/flag-detector";
 
 const anthropic = new Anthropic({ apiKey: process.env.ANTHROPIC_API_KEY });
 
@@ -289,31 +291,107 @@ async function applyDeliveryDate(orderId: string, isoDate: string): Promise<void
   await prisma.order.update({ where: { id: orderId }, data: { deliveryDate: new Date(isoDate) } });
 }
 
+// WhatsApp inbound mime → the subset parseSupplierDoc (Claude vision) accepts.
+function visionMime(
+  mime: string | undefined,
+): "application/pdf" | "image/jpeg" | "image/png" | "image/webp" | null {
+  const m = (mime ?? "").toLowerCase();
+  if (m === "application/pdf") return "application/pdf";
+  if (m === "image/jpeg" || m === "image/jpg") return "image/jpeg";
+  if (m === "image/png") return "image/png";
+  if (m === "image/webp") return "image/webp";
+  return null;
+}
+
 /**
- * Capture a supplier-sent invoice as a DRAFT invoice on the PO. The amount is
- * provisional (the PO total) — the agent can't read the PDF, so a human verifies
- * it in the Invoices screen. Safe to auto: a DRAFT never triggers payment.
+ * Capture a supplier-sent invoice as a DRAFT invoice on the PO.
+ *
+ * The agent now READS the document: it downloads the media and runs the shared
+ * supplier-doc vision parser to extract the real billed total, the supplier's
+ * own invoice number, and the bill/due dates. Those land as AI-prefilled fields
+ * (aiPrefilledAt set) so the Invoices screen surfaces a "verify before paying"
+ * banner — a human still confirms the amount. Creation flags run so a duplicate
+ * PO / billed-over-PO mismatch is caught immediately. If the media can't be
+ * fetched or parsed (or the total is unreadable), we fall back to the old
+ * provisional capture (amount = PO total). Always DRAFT → never triggers payment.
  */
 async function captureInvoice(
   order: { id: string; orderNumber: string; outletId: string; totalAmount: unknown },
   supplierId: string,
   mediaId: string | null,
 ): Promise<boolean> {
+  // ── Try to read the document for a real amount/number/date ──
+  let extractedTotal: number | null = null;
+  let extractedNumber: string | null = null;
+  let billDate: Date | null = null;
+  let dueDate: Date | null = null;
+  const prefilled: string[] = [];
+  if (mediaId) {
+    try {
+      const media = await fetchWhatsAppMedia(mediaId);
+      const mime = visionMime(media?.mimeType);
+      if (media && mime) {
+        const parsed = await parseSupplierDoc({ fileBytes: media.bytes, mimeType: mime });
+        if (parsed.total != null && parsed.total > 0) {
+          extractedTotal = Math.round(parsed.total * 100) / 100;
+          prefilled.push("amount");
+        }
+        if (parsed.billNumber) {
+          extractedNumber = parsed.billNumber.slice(0, 64);
+          prefilled.push("invoiceNumber");
+        }
+        if (parsed.billDate && /^\d{4}-\d{2}-\d{2}$/.test(parsed.billDate)) {
+          billDate = new Date(parsed.billDate);
+          prefilled.push("issueDate");
+        }
+        if (parsed.dueDate && /^\d{4}-\d{2}-\d{2}$/.test(parsed.dueDate)) {
+          dueDate = new Date(parsed.dueDate);
+          prefilled.push("dueDate");
+        }
+      }
+    } catch (e) {
+      console.warn("[supplier-agent] doc extract failed:", e instanceof Error ? e.message : e);
+    }
+  }
+
+  const amount = extractedTotal ?? (Number(order.totalAmount) || 0);
+  const invoiceNumber = extractedNumber || `AI-${order.orderNumber}`;
+  const provisional = extractedTotal == null;
+
   try {
-    await prisma.invoice.create({
+    const flags = await detectCreationFlags({
+      orderId: order.id,
+      supplierId,
+      amount,
+      issueDate: billDate,
+    });
+    const created = await prisma.invoice.create({
       data: {
-        invoiceNumber: `AI-${order.orderNumber}`,
+        invoiceNumber,
         orderId: order.id,
         outletId: order.outletId,
         supplierId,
-        amount: order.totalAmount as never, // Decimal passthrough
+        amount: amount as never, // Decimal passthrough
         status: "DRAFT",
         paymentType: "SUPPLIER",
-        notes:
-          "Captured from WhatsApp by the supplier-chat agent — amount is provisional (PO total); " +
-          `verify against the document before paying.${mediaId ? ` [wa-media:${mediaId}]` : ""}`,
+        ...(billDate ? { issueDate: billDate } : {}),
+        ...(dueDate ? { dueDate } : {}),
+        ...(prefilled.length > 0
+          ? { aiPrefilledAt: new Date(), aiPrefilledFields: JSON.stringify(prefilled) }
+          : {}),
+        ...(flags.length > 0 ? { flags: flags as unknown as Prisma.InputJsonValue } : {}),
+        notes: provisional
+          ? "Captured from WhatsApp by the supplier-chat agent — document unreadable, amount is provisional (PO total); " +
+            `verify against the document before paying.${mediaId ? ` [wa-media:${mediaId}]` : ""}`
+          : "Captured + read from WhatsApp by the supplier-chat agent — amount/number extracted from the document; " +
+            `verify before paying.${mediaId ? ` [wa-media:${mediaId}]` : ""}`,
       },
+      select: { id: true },
     });
+    console.log(
+      `[supplier-agent] invoice captured id=${created.id} no=${invoiceNumber} ` +
+        `amount=${amount} extracted=${!provisional} prefilled=${prefilled.join("|") || "-"} flags=${flags.length}`,
+    );
     return true;
   } catch (e) {
     // Unique invoiceNumber collision (already captured) or any write error.

--- a/apps/backoffice/src/lib/inventory/consumption-post.ts
+++ b/apps/backoffice/src/lib/inventory/consumption-post.ts
@@ -1,0 +1,107 @@
+import { prisma } from "@/lib/prisma";
+import { adjustStockBalance } from "@/lib/stock";
+import { aggregateConsumption, reasonMarker, type ConsumptionResult, type RecipeLine } from "@/lib/inventory/consumption";
+
+// DB orchestration for the consumption engine (pure core in consumption.ts).
+//
+// SAFETY: shadow by default. Live posting writes negative StockAdjustments +
+// decrements StockBalance, but StockBalance is currently fragmented by package
+// (receivings write package-keyed rows, consumption would write the base/null-
+// package row), so the decrement is only correct once stock units are normalised
+// to base UOM. Keep CONSUMPTION_ENGINE_ENABLED off until then.
+
+/**
+ * Compute (and, when live, post) one outlet's consumption for a single MYT day.
+ * `[dayStartUtc, dayEndUtc)` must bound that MYT day. Never throws on a single
+ * outlet — caller aggregates results.
+ */
+export async function postOutletConsumption(opts: {
+  outletId: string;
+  outletName: string;
+  date: string;
+  dayStartUtc: Date;
+  dayEndUtc: Date;
+  live: boolean;
+  systemUserId?: string | null; // required to post live (StockAdjustment.adjustedById FK)
+  takeawayRatio?: number;
+}): Promise<ConsumptionResult> {
+  const { outletId, outletName, date, dayStartUtc, dayEndUtc } = opts;
+  // Live posting needs a real user for the adjustment's FK; without one we stay
+  // in shadow mode no matter the flag.
+  const live = opts.live && !!opts.systemUserId;
+
+  const sales = await prisma.salesTransaction.findMany({
+    where: { outletId, menuId: { not: null }, transactedAt: { gte: dayStartUtc, lt: dayEndUtc } },
+    select: { menuId: true, quantity: true },
+  });
+  const salesByMenu = new Map<string, number>();
+  for (const s of sales) if (s.menuId) salesByMenu.set(s.menuId, (salesByMenu.get(s.menuId) ?? 0) + s.quantity);
+
+  const recipes = salesByMenu.size
+    ? await prisma.menuIngredient.findMany({
+        where: { menuId: { in: [...salesByMenu.keys()] } },
+        select: { menuId: true, productId: true, quantityUsed: true, serviceMode: true },
+      })
+    : [];
+  const recipeMap = new Map<string, RecipeLine[]>();
+  for (const r of recipes) {
+    const arr = recipeMap.get(r.menuId) ?? [];
+    arr.push({ productId: r.productId, quantityUsed: Number(r.quantityUsed), serviceMode: r.serviceMode });
+    recipeMap.set(r.menuId, arr);
+  }
+  const menusWithoutRecipe = [...salesByMenu.keys()].filter((m) => !recipeMap.has(m)).length;
+
+  const consumed = aggregateConsumption(salesByMenu, recipeMap, opts.takeawayRatio);
+
+  // Idempotency: did we already post this outlet+date?
+  const already = await prisma.stockAdjustment.findFirst({
+    where: { outletId, reason: reasonMarker(date) },
+    select: { id: true },
+  });
+  const alreadyPosted = !!already;
+
+  const productMeta = consumed.size
+    ? await prisma.product.findMany({ where: { id: { in: [...consumed.keys()] } }, select: { id: true, name: true, baseUom: true } })
+    : [];
+  const metaById = new Map(productMeta.map((p) => [p.id, p]));
+
+  const lines = [...consumed.entries()]
+    .map(([productId, quantity]) => ({
+      productId,
+      productName: metaById.get(productId)?.name ?? "—",
+      baseUom: metaById.get(productId)?.baseUom ?? "",
+      quantity: Math.round(quantity * 10000) / 10000,
+    }))
+    .filter((l) => l.quantity > 0)
+    .sort((a, b) => b.quantity - a.quantity);
+
+  // Live posting (gated + idempotent). One StockAdjustment per product carrying
+  // the marker, plus a base-unit stock decrement.
+  if (live && !alreadyPosted && lines.length) {
+    for (const l of lines) {
+      await prisma.stockAdjustment.create({
+        data: {
+          outletId,
+          productId: l.productId,
+          adjustmentType: "USED_NOT_RECORDED",
+          quantity: l.quantity,
+          reason: reasonMarker(date),
+          adjustedById: opts.systemUserId!,
+        },
+      });
+      await adjustStockBalance(outletId, l.productId, -l.quantity, null);
+    }
+  }
+
+  return {
+    outletId,
+    outletName,
+    date,
+    posted: live && !alreadyPosted && lines.length > 0,
+    alreadyPosted,
+    menusSold: salesByMenu.size,
+    menusWithoutRecipe,
+    productsConsumed: lines.length,
+    lines,
+  };
+}

--- a/apps/backoffice/src/lib/inventory/consumption.test.ts
+++ b/apps/backoffice/src/lib/inventory/consumption.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from "vitest";
+import { aggregateConsumption, channelWeight } from "./consumption";
+
+describe("channelWeight", () => {
+  it("bills every ALL line, splits dine-in/takeaway by the ratio", () => {
+    expect(channelWeight("ALL")).toBe(1);
+    expect(channelWeight("TAKEAWAY", 0.6)).toBe(0.6);
+    expect(channelWeight("DINE_IN", 0.6)).toBeCloseTo(0.4);
+  });
+});
+
+describe("aggregateConsumption", () => {
+  const recipes = new Map([
+    ["latte", [
+      { productId: "beans", quantityUsed: 18, serviceMode: "ALL" as const },
+      { productId: "milk", quantityUsed: 200, serviceMode: "ALL" as const },
+      { productId: "cup", quantityUsed: 1, serviceMode: "TAKEAWAY" as const },
+    ]],
+    ["espresso", [
+      { productId: "beans", quantityUsed: 18, serviceMode: "ALL" as const },
+    ]],
+  ]);
+
+  it("multiplies sales by recipe qty and sums per ingredient", () => {
+    const sales = new Map([["latte", 10], ["espresso", 5]]);
+    const c = aggregateConsumption(sales, recipes, 0.5);
+    expect(c.get("beans")).toBe(18 * 10 + 18 * 5); // 270 g
+    expect(c.get("milk")).toBe(200 * 10); // 2000 ml
+    expect(c.get("cup")).toBe(1 * 10 * 0.5); // takeaway-weighted → 5
+  });
+
+  it("skips menus with no recipe and ignores zero/negative sales", () => {
+    const sales = new Map([["latte", 0], ["unknown-menu", 100]]);
+    const c = aggregateConsumption(sales, recipes);
+    expect(c.size).toBe(0);
+  });
+});

--- a/apps/backoffice/src/lib/inventory/consumption.ts
+++ b/apps/backoffice/src/lib/inventory/consumption.ts
@@ -1,21 +1,27 @@
-import { prisma } from "@/lib/prisma";
-import { adjustStockBalance } from "@/lib/stock";
-
-// Consumption engine — turns menu sales into theoretical ingredient depletion
-// (sales × recipe BOM). This is the missing half of stock accuracy: today stock
-// only ever goes UP from receipts and down from manual wastage/transfers, never
-// from sales, so par-level reorder runs off a quantity that drifts upward.
+// Consumption engine — PURE core. No DB imports so it unit-tests cleanly under
+// vitest (the resolver doesn't alias "@/lib/*"). DB orchestration lives in
+// consumption-post.ts.
 //
-// SAFETY: shadow-mode by default. Live posting writes negative StockAdjustments
-// + decrements StockBalance, but StockBalance is currently fragmented by package
-// (receivings write package-keyed rows, consumption would write the base/null-
-// package row), so the decrement is only correct once stock units are normalised
-// to base UOM. Keep CONSUMPTION_ENGINE_ENABLED off until that lands; shadow mode
-// computes + reports the numbers without touching stock.
+// Turns menu sales into theoretical ingredient depletion (sales × recipe BOM) —
+// the missing half of stock accuracy: today stock only ever goes UP from
+// receipts and down from manual wastage/transfers, never from sales, so
+// par-level reorder runs off a quantity that drifts upward.
 
 export const DEFAULT_TAKEAWAY_RATIO = 0.5;
 
-type RecipeLine = { productId: string; quantityUsed: number; serviceMode: "ALL" | "DINE_IN" | "TAKEAWAY" };
+export type RecipeLine = { productId: string; quantityUsed: number; serviceMode: "ALL" | "DINE_IN" | "TAKEAWAY" };
+
+export type ConsumptionResult = {
+  outletId: string;
+  outletName: string;
+  date: string; // YYYY-MM-DD (MYT)
+  posted: boolean; // false in shadow mode
+  alreadyPosted: boolean; // idempotency hit
+  menusSold: number;
+  menusWithoutRecipe: number;
+  productsConsumed: number;
+  lines: { productId: string; productName: string; baseUom: string; quantity: number }[];
+};
 
 export function channelWeight(mode: "ALL" | "DINE_IN" | "TAKEAWAY", takeawayRatio = DEFAULT_TAKEAWAY_RATIO): number {
   return mode === "TAKEAWAY" ? takeawayRatio : mode === "DINE_IN" ? 1 - takeawayRatio : 1;
@@ -44,117 +50,9 @@ export function aggregateConsumption(
   return consumed;
 }
 
-export type ConsumptionResult = {
-  outletId: string;
-  outletName: string;
-  date: string; // YYYY-MM-DD (MYT)
-  posted: boolean; // false in shadow mode
-  alreadyPosted: boolean; // idempotency hit
-  menusSold: number;
-  menusWithoutRecipe: number;
-  productsConsumed: number;
-  lines: { productId: string; productName: string; baseUom: string; quantity: number }[];
-};
-
 // Marker written into StockAdjustment.reason so a re-run is idempotent and the
 // posting is auditable / reversible.
-const reasonMarker = (date: string) => `auto-consumption:${date}`;
-
-/**
- * Compute (and, when live, post) one outlet's consumption for a single MYT day.
- * `[dayStartUtc, dayEndUtc)` must bound that MYT day. Never throws on a single
- * outlet — caller aggregates results.
- */
-export async function postOutletConsumption(opts: {
-  outletId: string;
-  outletName: string;
-  date: string;
-  dayStartUtc: Date;
-  dayEndUtc: Date;
-  live: boolean;
-  systemUserId?: string | null; // required to post live (StockAdjustment.adjustedById FK)
-  takeawayRatio?: number;
-}): Promise<ConsumptionResult> {
-  const { outletId, outletName, date, dayStartUtc, dayEndUtc } = opts;
-  // Live posting needs a real user for the adjustment's FK; without one we stay
-  // in shadow mode no matter the flag.
-  const live = opts.live && !!opts.systemUserId;
-
-  const sales = await prisma.salesTransaction.findMany({
-    where: { outletId, menuId: { not: null }, transactedAt: { gte: dayStartUtc, lt: dayEndUtc } },
-    select: { menuId: true, quantity: true },
-  });
-  const salesByMenu = new Map<string, number>();
-  for (const s of sales) if (s.menuId) salesByMenu.set(s.menuId, (salesByMenu.get(s.menuId) ?? 0) + s.quantity);
-
-  const recipes = salesByMenu.size
-    ? await prisma.menuIngredient.findMany({
-        where: { menuId: { in: [...salesByMenu.keys()] } },
-        select: { menuId: true, productId: true, quantityUsed: true, serviceMode: true },
-      })
-    : [];
-  const recipeMap = new Map<string, RecipeLine[]>();
-  for (const r of recipes) {
-    const arr = recipeMap.get(r.menuId) ?? [];
-    arr.push({ productId: r.productId, quantityUsed: Number(r.quantityUsed), serviceMode: r.serviceMode });
-    recipeMap.set(r.menuId, arr);
-  }
-  const menusWithoutRecipe = [...salesByMenu.keys()].filter((m) => !recipeMap.has(m)).length;
-
-  const consumed = aggregateConsumption(salesByMenu, recipeMap, opts.takeawayRatio);
-
-  // Idempotency: did we already post this outlet+date?
-  const already = await prisma.stockAdjustment.findFirst({
-    where: { outletId, reason: reasonMarker(date) },
-    select: { id: true },
-  });
-  const alreadyPosted = !!already;
-
-  const productMeta = consumed.size
-    ? await prisma.product.findMany({ where: { id: { in: [...consumed.keys()] } }, select: { id: true, name: true, baseUom: true } })
-    : [];
-  const metaById = new Map(productMeta.map((p) => [p.id, p]));
-
-  const lines = [...consumed.entries()]
-    .map(([productId, quantity]) => ({
-      productId,
-      productName: metaById.get(productId)?.name ?? "—",
-      baseUom: metaById.get(productId)?.baseUom ?? "",
-      quantity: Math.round(quantity * 10000) / 10000,
-    }))
-    .filter((l) => l.quantity > 0)
-    .sort((a, b) => b.quantity - a.quantity);
-
-  // Live posting (gated + idempotent). One StockAdjustment per product carrying
-  // the marker, plus a base-unit stock decrement.
-  if (live && !alreadyPosted && lines.length) {
-    for (const l of lines) {
-      await prisma.stockAdjustment.create({
-        data: {
-          outletId,
-          productId: l.productId,
-          adjustmentType: "USED_NOT_RECORDED",
-          quantity: l.quantity,
-          reason: reasonMarker(date),
-          adjustedById: opts.systemUserId!,
-        },
-      });
-      await adjustStockBalance(outletId, l.productId, -l.quantity, null);
-    }
-  }
-
-  return {
-    outletId,
-    outletName,
-    date,
-    posted: live && !alreadyPosted && lines.length > 0,
-    alreadyPosted,
-    menusSold: salesByMenu.size,
-    menusWithoutRecipe,
-    productsConsumed: lines.length,
-    lines,
-  };
-}
+export const reasonMarker = (date: string) => `auto-consumption:${date}`;
 
 /** MYT day window for a YYYY-MM-DD string → [startUtc, endUtc). MYT = UTC+8. */
 export function mytDayWindow(date: string): { startUtc: Date; endUtc: Date } {

--- a/apps/backoffice/src/lib/inventory/consumption.ts
+++ b/apps/backoffice/src/lib/inventory/consumption.ts
@@ -1,0 +1,164 @@
+import { prisma } from "@/lib/prisma";
+import { adjustStockBalance } from "@/lib/stock";
+
+// Consumption engine — turns menu sales into theoretical ingredient depletion
+// (sales × recipe BOM). This is the missing half of stock accuracy: today stock
+// only ever goes UP from receipts and down from manual wastage/transfers, never
+// from sales, so par-level reorder runs off a quantity that drifts upward.
+//
+// SAFETY: shadow-mode by default. Live posting writes negative StockAdjustments
+// + decrements StockBalance, but StockBalance is currently fragmented by package
+// (receivings write package-keyed rows, consumption would write the base/null-
+// package row), so the decrement is only correct once stock units are normalised
+// to base UOM. Keep CONSUMPTION_ENGINE_ENABLED off until that lands; shadow mode
+// computes + reports the numbers without touching stock.
+
+export const DEFAULT_TAKEAWAY_RATIO = 0.5;
+
+type RecipeLine = { productId: string; quantityUsed: number; serviceMode: "ALL" | "DINE_IN" | "TAKEAWAY" };
+
+export function channelWeight(mode: "ALL" | "DINE_IN" | "TAKEAWAY", takeawayRatio = DEFAULT_TAKEAWAY_RATIO): number {
+  return mode === "TAKEAWAY" ? takeawayRatio : mode === "DINE_IN" ? 1 - takeawayRatio : 1;
+}
+
+/**
+ * Pure: given units sold per menu and each menu's recipe, return the theoretical
+ * quantity consumed per ingredient product (in the recipe's UOM, assumed = base
+ * UOM). Channel-weighted because StoreHub sales carry no per-line dine-in/takeaway.
+ */
+export function aggregateConsumption(
+  salesByMenu: Map<string, number>,
+  recipeMap: Map<string, RecipeLine[]>,
+  takeawayRatio = DEFAULT_TAKEAWAY_RATIO,
+): Map<string, number> {
+  const consumed = new Map<string, number>();
+  for (const [menuId, qtySold] of salesByMenu) {
+    if (qtySold <= 0) continue;
+    const recipe = recipeMap.get(menuId);
+    if (!recipe) continue; // no BOM → can't attribute consumption
+    for (const line of recipe) {
+      const amount = qtySold * line.quantityUsed * channelWeight(line.serviceMode, takeawayRatio);
+      consumed.set(line.productId, (consumed.get(line.productId) ?? 0) + amount);
+    }
+  }
+  return consumed;
+}
+
+export type ConsumptionResult = {
+  outletId: string;
+  outletName: string;
+  date: string; // YYYY-MM-DD (MYT)
+  posted: boolean; // false in shadow mode
+  alreadyPosted: boolean; // idempotency hit
+  menusSold: number;
+  menusWithoutRecipe: number;
+  productsConsumed: number;
+  lines: { productId: string; productName: string; baseUom: string; quantity: number }[];
+};
+
+// Marker written into StockAdjustment.reason so a re-run is idempotent and the
+// posting is auditable / reversible.
+const reasonMarker = (date: string) => `auto-consumption:${date}`;
+
+/**
+ * Compute (and, when live, post) one outlet's consumption for a single MYT day.
+ * `[dayStartUtc, dayEndUtc)` must bound that MYT day. Never throws on a single
+ * outlet — caller aggregates results.
+ */
+export async function postOutletConsumption(opts: {
+  outletId: string;
+  outletName: string;
+  date: string;
+  dayStartUtc: Date;
+  dayEndUtc: Date;
+  live: boolean;
+  systemUserId?: string | null; // required to post live (StockAdjustment.adjustedById FK)
+  takeawayRatio?: number;
+}): Promise<ConsumptionResult> {
+  const { outletId, outletName, date, dayStartUtc, dayEndUtc } = opts;
+  // Live posting needs a real user for the adjustment's FK; without one we stay
+  // in shadow mode no matter the flag.
+  const live = opts.live && !!opts.systemUserId;
+
+  const sales = await prisma.salesTransaction.findMany({
+    where: { outletId, menuId: { not: null }, transactedAt: { gte: dayStartUtc, lt: dayEndUtc } },
+    select: { menuId: true, quantity: true },
+  });
+  const salesByMenu = new Map<string, number>();
+  for (const s of sales) if (s.menuId) salesByMenu.set(s.menuId, (salesByMenu.get(s.menuId) ?? 0) + s.quantity);
+
+  const recipes = salesByMenu.size
+    ? await prisma.menuIngredient.findMany({
+        where: { menuId: { in: [...salesByMenu.keys()] } },
+        select: { menuId: true, productId: true, quantityUsed: true, serviceMode: true },
+      })
+    : [];
+  const recipeMap = new Map<string, RecipeLine[]>();
+  for (const r of recipes) {
+    const arr = recipeMap.get(r.menuId) ?? [];
+    arr.push({ productId: r.productId, quantityUsed: Number(r.quantityUsed), serviceMode: r.serviceMode });
+    recipeMap.set(r.menuId, arr);
+  }
+  const menusWithoutRecipe = [...salesByMenu.keys()].filter((m) => !recipeMap.has(m)).length;
+
+  const consumed = aggregateConsumption(salesByMenu, recipeMap, opts.takeawayRatio);
+
+  // Idempotency: did we already post this outlet+date?
+  const already = await prisma.stockAdjustment.findFirst({
+    where: { outletId, reason: reasonMarker(date) },
+    select: { id: true },
+  });
+  const alreadyPosted = !!already;
+
+  const productMeta = consumed.size
+    ? await prisma.product.findMany({ where: { id: { in: [...consumed.keys()] } }, select: { id: true, name: true, baseUom: true } })
+    : [];
+  const metaById = new Map(productMeta.map((p) => [p.id, p]));
+
+  const lines = [...consumed.entries()]
+    .map(([productId, quantity]) => ({
+      productId,
+      productName: metaById.get(productId)?.name ?? "—",
+      baseUom: metaById.get(productId)?.baseUom ?? "",
+      quantity: Math.round(quantity * 10000) / 10000,
+    }))
+    .filter((l) => l.quantity > 0)
+    .sort((a, b) => b.quantity - a.quantity);
+
+  // Live posting (gated + idempotent). One StockAdjustment per product carrying
+  // the marker, plus a base-unit stock decrement.
+  if (live && !alreadyPosted && lines.length) {
+    for (const l of lines) {
+      await prisma.stockAdjustment.create({
+        data: {
+          outletId,
+          productId: l.productId,
+          adjustmentType: "USED_NOT_RECORDED",
+          quantity: l.quantity,
+          reason: reasonMarker(date),
+          adjustedById: opts.systemUserId!,
+        },
+      });
+      await adjustStockBalance(outletId, l.productId, -l.quantity, null);
+    }
+  }
+
+  return {
+    outletId,
+    outletName,
+    date,
+    posted: live && !alreadyPosted && lines.length > 0,
+    alreadyPosted,
+    menusSold: salesByMenu.size,
+    menusWithoutRecipe,
+    productsConsumed: lines.length,
+    lines,
+  };
+}
+
+/** MYT day window for a YYYY-MM-DD string → [startUtc, endUtc). MYT = UTC+8. */
+export function mytDayWindow(date: string): { startUtc: Date; endUtc: Date } {
+  const startUtc = new Date(`${date}T00:00:00+08:00`);
+  const endUtc = new Date(startUtc.getTime() + 86_400_000);
+  return { startUtc, endUtc };
+}

--- a/apps/backoffice/src/lib/inventory/flag-detector.ts
+++ b/apps/backoffice/src/lib/inventory/flag-detector.ts
@@ -111,17 +111,26 @@ export async function detectPaymentFlags(input: {
     }
   }
 
-  if (input.popInvoiceReference) {
-    // Supplier invoices often store with a "#" prefix (e.g. "#1-14306") while
-    // Maybank recipient references drop it ("1-14306"). Use contains to catch
-    // those variants without normalizing both sides.
-    const refMatch = await prisma.invoice.findFirst({
+    // Normalised reference: strip non-alphanumerics so "#1-14306" (supplier
+    // invoice) and "1-14306" (Maybank recipient ref) compare equal. Skip very
+    // short refs — a bare "30" would substring-match "INV-300" and fire a
+    // false double-payment flag (the bug this guard fixes).
+  const refNorm = (input.popInvoiceReference ?? "").replace(/[^a-z0-9]/gi, "").toLowerCase();
+  if (refNorm.length >= 4) {
+    // contains() narrows candidates in SQL; the normalised token comparison
+    // below is the real match so embedded-substring false positives are dropped.
+    const candidates = await prisma.invoice.findMany({
       where: {
-        invoiceNumber: { contains: input.popInvoiceReference, mode: "insensitive" },
+        invoiceNumber: { contains: input.popInvoiceReference!, mode: "insensitive" },
         status: "PAID",
         NOT: { id: input.invoiceId },
       },
       select: { id: true, invoiceNumber: true, paymentRef: true, paidAt: true },
+    });
+    const refMatch = candidates.find((c) => {
+      const inv = c.invoiceNumber.replace(/[^a-z0-9]/gi, "").toLowerCase();
+      // Equal, or one is a prefix-stripped form of the other (e.g. "#" dropped).
+      return inv === refNorm || inv.endsWith(refNorm) || refNorm.endsWith(inv);
     });
     if (refMatch) {
       flags.push({

--- a/apps/backoffice/src/lib/inventory/order-validation.test.ts
+++ b/apps/backoffice/src/lib/inventory/order-validation.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect } from "vitest";
+import { parseMoqRm, nextDeliveryDate, validateSupplierOrder } from "./order-validation";
+
+// A UTC-midnight Date for a given YYYY-MM-DD (what callers pass as "today"/planned).
+const d = (s: string) => new Date(`${s}T00:00:00Z`);
+
+describe("parseMoqRm", () => {
+  it("reads RM-prefixed amounts", () => {
+    expect(parseMoqRm("RM300")).toBe(300);
+    expect(parseMoqRm("rm 1,000")).toBe(1000);
+    expect(parseMoqRm("trip min RM500")).toBe(500);
+    expect(parseMoqRm("RM250.50")).toBe(250.5);
+  });
+
+  it("falls back to a bare number", () => {
+    expect(parseMoqRm("250")).toBe(250);
+    expect(parseMoqRm("min order 400")).toBe(400);
+  });
+
+  it("returns null when there is no number", () => {
+    expect(parseMoqRm("")).toBeNull();
+    expect(parseMoqRm(null)).toBeNull();
+    expect(parseMoqRm(undefined)).toBeNull();
+    expect(parseMoqRm("by arrangement")).toBeNull();
+  });
+});
+
+describe("nextDeliveryDate", () => {
+  it("finds the next configured delivery day after lead time", () => {
+    // 2026-06-26 is a Friday. Supplier delivers Tue/Thu, lead time 1 day.
+    // From Fri + 1 = Sat 27th → next Tue/Thu is Tue 30th.
+    const next = nextDeliveryDate(["Tuesday", "Thursday"], 1, d("2026-06-26"));
+    expect(next && next.toISOString().slice(0, 10)).toBe("2026-06-30");
+  });
+
+  it("accepts 3-letter prefixes and is case-insensitive", () => {
+    const next = nextDeliveryDate(["mon", "WED"], 0, d("2026-06-26")); // Fri → next Mon 29th
+    expect(next && next.toISOString().slice(0, 10)).toBe("2026-06-29");
+  });
+
+  it("returns null with no delivery days", () => {
+    expect(nextDeliveryDate([], 1, d("2026-06-26"))).toBeNull();
+  });
+});
+
+describe("validateSupplierOrder", () => {
+  it("warns when below trip MOQ with the exact shortfall", () => {
+    const w = validateSupplierOrder({ orderTotal: 180, moq: "RM300", deliveryDays: [] });
+    expect(w).toHaveLength(1);
+    expect(w[0].code).toBe("BELOW_MOQ");
+    expect(w[0].meta?.shortfall).toBe(120);
+  });
+
+  it("is silent at or above MOQ", () => {
+    const w = validateSupplierOrder({ orderTotal: 300, moq: "RM300", deliveryDays: [] });
+    expect(w).toHaveLength(0);
+  });
+
+  it("warns when the planned delivery date isn't a delivery day", () => {
+    // Planned Wed 2026-07-01, but supplier only delivers Tue/Thu.
+    const w = validateSupplierOrder({
+      orderTotal: 500,
+      moq: "RM300",
+      deliveryDays: ["Tuesday", "Thursday"],
+      deliveryDate: d("2026-07-01"),
+    });
+    expect(w).toHaveLength(1);
+    expect(w[0].code).toBe("DELIVERY_DAY");
+    expect(w[0].meta?.suggested).toBe("2026-07-02"); // next Thursday on/after the plan
+  });
+
+  it("does not warn when the planned date is a valid delivery day", () => {
+    const w = validateSupplierOrder({
+      orderTotal: 500,
+      moq: "RM300",
+      deliveryDays: ["Tuesday", "Thursday"],
+      deliveryDate: d("2026-07-02"), // Thursday
+    });
+    expect(w).toHaveLength(0);
+  });
+});

--- a/apps/backoffice/src/lib/inventory/order-validation.ts
+++ b/apps/backoffice/src/lib/inventory/order-validation.ts
@@ -1,0 +1,132 @@
+// Order-level (per-trip) validation for supplier purchase orders.
+//
+// The reorder engine already enforces per-LINE minimums (SupplierProduct.moq, a
+// quantity floor per product). This covers the per-ORDER constraints that 17
+// real supplier chats showed drive the "add more / which day / too late for
+// today's lorry" loops (docs/design/procurement-chat-learnings.md, P1):
+//   - trip MOQ: a ringgit minimum per delivery (Supplier.moq, free text like
+//     "RM300" / "trip min RM500"); below it, the supplier asks us to top up.
+//   - delivery calendar: fixed per-supplier delivery days + lead time, so a
+//     planned date that isn't a delivery day gets bumped.
+//
+// Pure + deterministic so it unit-tests cleanly and can run anywhere (reorder
+// cron, PO draft API, supplier-chat agent context). Dates are compared in UTC —
+// callers pass a UTC-midnight Date representing the intended local (MYT) day.
+
+export type OrderWarningCode = "BELOW_MOQ" | "DELIVERY_DAY";
+
+export type OrderWarning = {
+  code: OrderWarningCode;
+  severity: "warn" | "info";
+  message: string;
+  meta?: Record<string, unknown>;
+};
+
+export const WEEKDAYS = [
+  "Sunday",
+  "Monday",
+  "Tuesday",
+  "Wednesday",
+  "Thursday",
+  "Friday",
+  "Saturday",
+] as const;
+
+/**
+ * Pull a ringgit minimum out of a free-text MOQ field. Handles "RM300",
+ * "rm 1,000", "trip min RM500", "min order 250". Prefers an RM-prefixed number;
+ * falls back to the first bare number. Returns null when there's no number
+ * (e.g. "no MOQ", "", "by arrangement").
+ */
+export function parseMoqRm(moq: string | null | undefined): number | null {
+  if (!moq) return null;
+  const text = moq.trim();
+  if (!text) return null;
+  // Prefer a number that follows RM / MYR.
+  const rmMatch = text.match(/(?:rm|myr)\s*([\d,]+(?:\.\d+)?)/i);
+  const bareMatch = rmMatch ? null : text.match(/([\d,]+(?:\.\d+)?)/);
+  const raw = (rmMatch ?? bareMatch)?.[1];
+  if (!raw) return null;
+  const n = Number(raw.replace(/,/g, ""));
+  return Number.isFinite(n) && n > 0 ? n : null;
+}
+
+/** Normalise a delivery-day list to canonical weekday names we recognise. */
+function normaliseDays(deliveryDays: string[]): Set<number> {
+  const set = new Set<number>();
+  for (const d of deliveryDays) {
+    const key = d.trim().toLowerCase();
+    const idx = WEEKDAYS.findIndex((w) => w.toLowerCase() === key || w.toLowerCase().startsWith(key.slice(0, 3)));
+    if (idx >= 0) set.add(idx);
+  }
+  return set;
+}
+
+/**
+ * Earliest delivery date on/after `from + leadTimeDays` whose weekday is one of
+ * the supplier's delivery days. Returns null when no delivery days are
+ * configured (the supplier delivers on demand). Searches a two-week window.
+ */
+export function nextDeliveryDate(
+  deliveryDays: string[],
+  leadTimeDays: number,
+  from: Date,
+): Date | null {
+  const days = normaliseDays(deliveryDays);
+  if (days.size === 0) return null;
+  const start = new Date(from.getTime() + Math.max(0, leadTimeDays) * 86_400_000);
+  for (let i = 0; i < 14; i++) {
+    const d = new Date(start.getTime() + i * 86_400_000);
+    if (days.has(d.getUTCDay())) return d;
+  }
+  return null;
+}
+
+function ymd(d: Date): string {
+  return d.toISOString().slice(0, 10);
+}
+
+/**
+ * Validate a drafted supplier order against its trip MOQ and delivery calendar.
+ * Returns the warnings a human (or the approval message) should see — empty when
+ * everything lines up.
+ */
+export function validateSupplierOrder(input: {
+  orderTotal: number;
+  moq?: string | null;
+  deliveryDays: string[];
+  deliveryDate?: Date | null; // planned delivery date (UTC-midnight = the MYT day)
+}): OrderWarning[] {
+  const warnings: OrderWarning[] = [];
+
+  // ── Trip MOQ ──
+  const moqRm = parseMoqRm(input.moq);
+  if (moqRm != null && input.orderTotal > 0 && input.orderTotal < moqRm) {
+    const shortfall = Math.round((moqRm - input.orderTotal) * 100) / 100;
+    warnings.push({
+      code: "BELOW_MOQ",
+      severity: "warn",
+      message: `Order RM ${input.orderTotal.toFixed(2)} is below this supplier's MOQ RM ${moqRm.toFixed(2)} — add RM ${shortfall.toFixed(2)} to avoid a top-up request.`,
+      meta: { orderTotal: input.orderTotal, moq: moqRm, shortfall },
+    });
+  }
+
+  // ── Delivery calendar ──
+  // Only meaningful when the supplier has fixed delivery days AND a date is
+  // planned that falls outside them. The suggestion is the next valid delivery
+  // day ON OR AFTER the planned date (lead time 0 — this is a calendar fix, not
+  // a reorder-timing decision).
+  const days = normaliseDays(input.deliveryDays);
+  const planned = input.deliveryDate ?? null;
+  if (days.size > 0 && planned && !days.has(planned.getUTCDay())) {
+    const suggested = nextDeliveryDate(input.deliveryDays, 0, planned);
+    warnings.push({
+      code: "DELIVERY_DAY",
+      severity: "warn",
+      message: `Planned delivery ${WEEKDAYS[planned.getUTCDay()]} (${ymd(planned)}) isn't one of this supplier's delivery days (${input.deliveryDays.join(", ")})${suggested ? `; next is ${WEEKDAYS[suggested.getUTCDay()]} ${ymd(suggested)}` : ""}.`,
+      meta: { planned: ymd(planned), suggested: suggested ? ymd(suggested) : null, deliveryDays: input.deliveryDays },
+    });
+  }
+
+  return warnings;
+}

--- a/apps/backoffice/src/lib/inventory/payment-model.test.ts
+++ b/apps/backoffice/src/lib/inventory/payment-model.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from "vitest";
+import { paymentModel } from "./payment-model";
+
+describe("paymentModel", () => {
+  it("classifies a deposit policy as deposit + balance (two POPs, critical)", () => {
+    const m = paymentModel({ depositPercent: 50, paymentTerms: null });
+    expect(m.model).toBe("deposit_balance");
+    expect(m.popDeliveryCritical).toBe(true);
+    expect(m.label).toContain("50%");
+  });
+
+  it("treats a full 100% deposit as not a deposit-balance split", () => {
+    // 100 isn't a partial deposit; fall through to terms parsing.
+    expect(paymentModel({ depositPercent: 100, paymentTerms: "" }).model).toBe("standard");
+  });
+
+  it("detects prepay terms as delivery-critical", () => {
+    for (const t of ["Prepay before delivery", "clear payment first", "Cash before delivery", "COD", "pay in advance"]) {
+      const m = paymentModel({ paymentTerms: t });
+      expect(m.model, t).toBe("prepay");
+      expect(m.popDeliveryCritical, t).toBe(true);
+    }
+  });
+
+  it("detects credit / SOA terms as not delivery-critical", () => {
+    for (const t of ["Net 30", "14 days", "monthly credit", "settle by SOA", "30 day credit"]) {
+      const m = paymentModel({ paymentTerms: t });
+      expect(m.model, t).toBe("credit_soa");
+      expect(m.popDeliveryCritical, t).toBe(false);
+    }
+  });
+
+  it("defaults to standard when terms are unknown or empty", () => {
+    expect(paymentModel({ paymentTerms: null }).model).toBe("standard");
+    expect(paymentModel({ paymentTerms: "by arrangement" }).model).toBe("standard");
+  });
+
+  it("deposit policy wins over credit-looking terms", () => {
+    expect(paymentModel({ depositPercent: 30, paymentTerms: "Net 30" }).model).toBe("deposit_balance");
+  });
+});

--- a/apps/backoffice/src/lib/inventory/payment-model.test.ts
+++ b/apps/backoffice/src/lib/inventory/payment-model.test.ts
@@ -15,7 +15,7 @@ describe("paymentModel", () => {
   });
 
   it("detects prepay terms as delivery-critical", () => {
-    for (const t of ["Prepay before delivery", "clear payment first", "Cash before delivery", "COD", "pay in advance"]) {
+    for (const t of ["Prepay before delivery", "clear payment first", "Cash before delivery", "COD", "pay in advance", "100% upfront", "upfront"]) {
       const m = paymentModel({ paymentTerms: t });
       expect(m.model, t).toBe("prepay");
       expect(m.popDeliveryCritical, t).toBe(true);

--- a/apps/backoffice/src/lib/inventory/payment-model.ts
+++ b/apps/backoffice/src/lib/inventory/payment-model.ts
@@ -24,7 +24,7 @@ export type PaymentModelInfo = {
 };
 
 const PREPAY_RX =
-  /\b(pre-?pay|prepaid|pay\s*(?:first|before|upfront|in\s*advance)|clear\s*payment\s*first|before\s*delivery|cash\s*before|advance\s*payment|c\.?o\.?d\.?|cash\s*on\s*delivery)\b/i;
+  /\b(pre-?pay|prepaid|upfront|pay\s*(?:first|before|upfront|in\s*advance)|clear\s*payment\s*first|before\s*delivery|cash\s*before|advance\s*payment|c\.?o\.?d\.?|cash\s*on\s*delivery)\b/i;
 const CREDIT_RX =
   /\b(net\s*\d+|\d+\s*[- ]?days?|credit|monthly|month\s*end|soa|statement\s*of\s*account|invoice\s*\d+\s*days?)\b/i;
 

--- a/apps/backoffice/src/lib/inventory/payment-model.ts
+++ b/apps/backoffice/src/lib/inventory/payment-model.ts
@@ -1,0 +1,73 @@
+// Supplier payment-model classifier.
+//
+// The 17 supplier-chat analysis found automation must branch on three payment
+// models (docs/design/procurement-chat-learnings.md, pattern 3):
+//   - prepay-before-delivery (HNJ, RICH's, Xora, BeansCo, Farm Fresh) — the POP
+//     is delivery-critical: they load the lorry only after "clear payment first".
+//   - monthly credit + SOA batch settlement (GCR, BBM 14-day, Yow Seng).
+//   - deposit + balance (Collective 50/50) — two POPs per order.
+//
+// Derived deterministically from the fields we already store (depositPercent +
+// free-text paymentTerms) so the supplier-chat agent and the inbox can flag a
+// payment message as urgent for prepay suppliers, and so a deposit supplier is
+// understood to need two receipts. Pure + unit-tested.
+
+export type PaymentModel = "prepay" | "deposit_balance" | "credit_soa" | "standard";
+
+export type PaymentModelInfo = {
+  model: PaymentModel;
+  label: string;
+  note: string;
+  // True when a payment must clear BEFORE the supplier releases goods — the POP
+  // is on the critical path, so a payment query from this supplier is urgent.
+  popDeliveryCritical: boolean;
+};
+
+const PREPAY_RX =
+  /\b(pre-?pay|prepaid|pay\s*(?:first|before|upfront|in\s*advance)|clear\s*payment\s*first|before\s*delivery|cash\s*before|advance\s*payment|c\.?o\.?d\.?|cash\s*on\s*delivery)\b/i;
+const CREDIT_RX =
+  /\b(net\s*\d+|\d+\s*[- ]?days?|credit|monthly|month\s*end|soa|statement\s*of\s*account|invoice\s*\d+\s*days?)\b/i;
+
+/**
+ * Classify a supplier's payment model from its deposit policy + terms text.
+ * Deposit policy wins (it's structured); otherwise the free-text terms are
+ * matched, defaulting to "standard" (pay on/around delivery) when unknown.
+ */
+export function paymentModel(input: {
+  paymentTerms?: string | null;
+  depositPercent?: number | null;
+}): PaymentModelInfo {
+  const deposit = input.depositPercent ?? 0;
+  if (deposit > 0 && deposit < 100) {
+    return {
+      model: "deposit_balance",
+      label: `Deposit ${deposit}% + balance`,
+      note: "Deposit upfront, balance on/after delivery — expect two POPs per order.",
+      popDeliveryCritical: true,
+    };
+  }
+
+  const terms = (input.paymentTerms ?? "").trim();
+  if (terms && PREPAY_RX.test(terms)) {
+    return {
+      model: "prepay",
+      label: "Prepay before delivery",
+      note: "Pay before they release the goods — the POP is delivery-critical.",
+      popDeliveryCritical: true,
+    };
+  }
+  if (terms && CREDIT_RX.test(terms)) {
+    return {
+      model: "credit_soa",
+      label: "Credit / SOA settlement",
+      note: "On credit — settle by statement of account in a batch.",
+      popDeliveryCritical: false,
+    };
+  }
+  return {
+    model: "standard",
+    label: "Standard terms",
+    note: "Pay on delivery / standard terms.",
+    popDeliveryCritical: false,
+  };
+}

--- a/apps/backoffice/src/lib/inventory/price-history.ts
+++ b/apps/backoffice/src/lib/inventory/price-history.ts
@@ -1,0 +1,43 @@
+import { prisma } from "@/lib/prisma";
+
+// Records a supplier price change into PriceHistory.
+//
+// The PriceHistory table existed in the schema but was never written, so the
+// Supplier Scorecard's "price changes" metric was always empty and the
+// reconciliation/agent price-increase checks had no baseline. This is the
+// single write path: call it whenever a SupplierProduct.price is updated,
+// passing the price BEFORE the update. No-ops when the price is unchanged.
+export async function recordPriceChange(input: {
+  supplierId: string;
+  productId: string;
+  productPackageId?: string | null;
+  oldPrice: number;
+  newPrice: number;
+}): Promise<void> {
+  const { supplierId, productId } = input;
+  const oldPrice = Number(input.oldPrice);
+  const newPrice = Number(input.newPrice);
+  // Nothing to record on first-time pricing or an unchanged value.
+  if (!Number.isFinite(oldPrice) || !Number.isFinite(newPrice)) return;
+  if (Math.abs(newPrice - oldPrice) < 0.0001) return;
+
+  // % change vs the old price; guard divide-by-zero (old price of 0 → 100%).
+  const changePercent =
+    oldPrice === 0 ? 100 : Math.round(((newPrice - oldPrice) / oldPrice) * 100 * 100) / 100;
+
+  try {
+    await prisma.priceHistory.create({
+      data: {
+        supplierId,
+        productId,
+        productPackageId: input.productPackageId ?? null,
+        oldPrice,
+        newPrice,
+        changePercent,
+      },
+    });
+  } catch (e) {
+    // Price history is best-effort telemetry — never fail the price update over it.
+    console.warn("[price-history] record failed:", e instanceof Error ? e.message : e);
+  }
+}

--- a/apps/backoffice/src/lib/inventory/usage-variance.test.ts
+++ b/apps/backoffice/src/lib/inventory/usage-variance.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect } from "vitest";
+import { toBaseQty, buildVarianceRow, round2 } from "./usage-variance";
+
+describe("toBaseQty", () => {
+  const conv = new Map<string, number>([["pkg-1L", 1000]]);
+  it("multiplies package qty by conversion factor", () => {
+    expect(toBaseQty(2, "pkg-1L", conv)).toBe(2000); // 2 × 1L = 2000 ml
+  });
+  it("leaves base-unit (null package) qty untouched", () => {
+    expect(toBaseQty(500, null, conv)).toBe(500);
+    expect(toBaseQty(500, undefined, conv)).toBe(500);
+  });
+  it("falls back to 1× when conversion is missing or invalid", () => {
+    expect(toBaseQty(7, "pkg-unknown", conv)).toBe(7);
+    expect(toBaseQty(7, "pkg-zero", new Map([["pkg-zero", 0]]))).toBe(7);
+  });
+});
+
+describe("buildVarianceRow", () => {
+  it("computes a positive (over-used) variance and costs it", () => {
+    // expected 5000 g, actual 5400 g, cost RM0.035/g
+    const r = buildVarianceRow({
+      productId: "p1", productName: "Beans", baseUom: "g",
+      actualQty: 5400, expectedQty: 5000, costPerBase: 0.035,
+    });
+    expect(r.varianceQty).toBe(400);
+    expect(r.expectedCost).toBe(175); // 5000 × 0.035
+    expect(r.varianceCost).toBe(14); // 400 × 0.035
+    expect(r.variancePercent).toBe(8); // 14 / 175
+    expect(r.flags).toContain("OVER_USED");
+    expect(r.flags).toContain("HIGH_VARIANCE"); // 8% ≥ 5%
+  });
+
+  it("flags NO_COST when costPerBase is zero and leaves percent null on zero expected", () => {
+    const r = buildVarianceRow({
+      productId: "p2", productName: "Mystery", baseUom: "g",
+      actualQty: 100, expectedQty: 0, costPerBase: 0,
+    });
+    expect(r.flags).toContain("NO_COST");
+    expect(r.variancePercent).toBeNull(); // expectedCost 0 → undefined %
+    expect(r.varianceCost).toBe(0);
+  });
+
+  it("marks under-used and does not flag a small variance", () => {
+    const r = buildVarianceRow({
+      productId: "p3", productName: "Milk", baseUom: "ml",
+      actualQty: 9900, expectedQty: 10000, costPerBase: 0.002,
+    });
+    expect(r.varianceQty).toBe(-100);
+    expect(r.flags).toContain("UNDER_USED");
+    expect(r.flags).not.toContain("HIGH_VARIANCE"); // 1% and RM0.20
+  });
+});
+
+describe("round2", () => {
+  it("rounds to two decimals", () => {
+    expect(round2(1.005 * 100)).toBe(100.5);
+    expect(round2(0.1 + 0.2)).toBe(0.3);
+  });
+});

--- a/apps/backoffice/src/lib/inventory/usage-variance.ts
+++ b/apps/backoffice/src/lib/inventory/usage-variance.ts
@@ -1,0 +1,92 @@
+// Pure helpers for the ingredient usage-variance report.
+//
+// "Actual usage" is reconstructed from physical stock movements between two
+// stock counts (count-bracketed):
+//   actual = openingCount + receipts + transfersIn − transfersOut − wastage − closingCount
+// "Expected usage" is theoretical: Σ(menu sales × BOM qty per ingredient).
+// Variance = actual − expected → unexplained loss (over-portioning, theft,
+// unrecorded spoilage). A positive variance means more left inventory than the
+// recipes account for.
+//
+// CRITICAL: stock movements are recorded in MIXED units — receivings, transfers
+// and counts carry a productPackageId and are in PACKAGE units; wastage
+// (StockAdjustment) has no package and is already in BASE units. adjustStockBalance
+// does NO conversion, so every consumer must normalise to base UOM itself. That
+// is exactly what toBaseQty() does here, using ProductPackage.conversionFactor
+// (base units per package unit).
+
+export type VarianceFlag = "HIGH_VARIANCE" | "NO_COST" | "OVER_USED" | "UNDER_USED";
+
+export type VarianceRow = {
+  productId: string;
+  productName: string;
+  baseUom: string;
+  actualQty: number;
+  expectedQty: number;
+  varianceQty: number;
+  costPerBase: number;
+  expectedCost: number;
+  varianceCost: number;
+  variancePercent: number | null;
+  flags: VarianceFlag[];
+};
+
+// Convert a movement quantity to base UOM. A null packageId means the qty is
+// already in base units (wastage, base-keyed balances). conv missing/≤0 → treat
+// as already-base (1×) so we never multiply by garbage.
+export function toBaseQty(
+  qty: number,
+  productPackageId: string | null | undefined,
+  convByPackage: Map<string, number>,
+): number {
+  if (!productPackageId) return qty;
+  const conv = convByPackage.get(productPackageId);
+  return conv && conv > 0 ? qty * conv : qty;
+}
+
+export function round2(n: number): number {
+  return Math.round(n * 100) / 100;
+}
+
+// Flag thresholds: a variance worth a human's attention.
+const HIGH_VARIANCE_PCT = 5; // |variance| ≥ 5% of expected cost
+const HIGH_VARIANCE_RM = 20; // or ≥ RM 20 absolute
+
+export function buildVarianceRow(input: {
+  productId: string;
+  productName: string;
+  baseUom: string;
+  actualQty: number;
+  expectedQty: number;
+  costPerBase: number;
+}): VarianceRow {
+  const actualQty = round2(input.actualQty);
+  const expectedQty = round2(input.expectedQty);
+  const varianceQty = round2(actualQty - expectedQty);
+  const costPerBase = input.costPerBase;
+  const expectedCost = round2(expectedQty * costPerBase);
+  const varianceCost = round2(varianceQty * costPerBase);
+  const variancePercent = expectedCost > 0 ? round2((varianceCost / expectedCost) * 100) : null;
+
+  const flags: VarianceFlag[] = [];
+  if (costPerBase <= 0) flags.push("NO_COST");
+  if (Math.abs(varianceCost) >= HIGH_VARIANCE_RM || (variancePercent !== null && Math.abs(variancePercent) >= HIGH_VARIANCE_PCT)) {
+    flags.push("HIGH_VARIANCE");
+  }
+  if (varianceQty > 0) flags.push("OVER_USED");
+  else if (varianceQty < 0) flags.push("UNDER_USED");
+
+  return {
+    productId: input.productId,
+    productName: input.productName,
+    baseUom: input.baseUom,
+    actualQty,
+    expectedQty,
+    varianceQty,
+    costPerBase: round2(costPerBase),
+    expectedCost,
+    varianceCost,
+    variancePercent,
+    flags,
+  };
+}

--- a/apps/backoffice/src/lib/whatsapp.ts
+++ b/apps/backoffice/src/lib/whatsapp.ts
@@ -52,6 +52,41 @@ export interface WhatsAppSendResult {
   error?: string;
 }
 
+export interface WhatsAppMedia {
+  bytes: Buffer;
+  mimeType: string;
+}
+
+/**
+ * Download an inbound media object (invoice PDF, PoP image, …) by its media id.
+ * Two-step per the Cloud API: GET /{media-id} returns a short-lived URL, which
+ * must then be fetched with the same bearer token. Returns null on any failure
+ * so callers can degrade gracefully (the agent falls back to a provisional
+ * capture rather than throwing inside the webhook).
+ */
+export async function fetchWhatsAppMedia(mediaId: string): Promise<WhatsAppMedia | null> {
+  const token = process.env.WHATSAPP_ACCESS_TOKEN;
+  if (!token || !mediaId) return null;
+  try {
+    const metaRes = await fetch(`${GRAPH_BASE}/${mediaId}`, {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    if (!metaRes.ok) return null;
+    const meta = (await metaRes.json().catch(() => ({}))) as { url?: string; mime_type?: string };
+    if (!meta.url) return null;
+    // The media URL itself also requires the bearer token.
+    const binRes = await fetch(meta.url, { headers: { Authorization: `Bearer ${token}` } });
+    if (!binRes.ok) return null;
+    const arrayBuf = await binRes.arrayBuffer();
+    return {
+      bytes: Buffer.from(arrayBuf),
+      mimeType: meta.mime_type?.split(";")[0]?.trim() || "application/octet-stream",
+    };
+  } catch {
+    return null;
+  }
+}
+
 async function postMessage(body: Record<string, unknown>): Promise<WhatsAppSendResult> {
   const phoneNumberId = process.env.WHATSAPP_PHONE_NUMBER_ID;
   const token = process.env.WHATSAPP_ACCESS_TOKEN;

--- a/apps/backoffice/vercel.json
+++ b/apps/backoffice/vercel.json
@@ -119,6 +119,10 @@
     {
       "path": "/api/cron/request-invoices",
       "schedule": "0 */4 * * *"
+    },
+    {
+      "path": "/api/cron/consumption-post",
+      "schedule": "25 19 * * *"
     }
   ]
 }

--- a/apps/staff/src/app/api/receivings/route.ts
+++ b/apps/staff/src/app/api/receivings/route.ts
@@ -86,6 +86,14 @@ export async function POST(req: NextRequest) {
     return NextResponse.json({ error: "Cannot record receiving for another outlet" }, { status: 403 });
   }
 
+  // PO ordered quantities by product+package, used to backfill orderedQty.
+  const orderedQtyMap = new Map<string, number>();
+  const resolveOrderedQty = (i: { productId: string; productPackageId?: string; orderedQty?: number }): number | null => {
+    if (i.orderedQty !== undefined && i.orderedQty !== null) return i.orderedQty;
+    if (!orderId) return null;
+    return orderedQtyMap.get(`${i.productId}::${i.productPackageId ?? ""}`) ?? null;
+  };
+
   let receivingStatus = status || "COMPLETE";
   if (orderId) {
     // Receivable from SENT onwards — procurement must have transmitted the PO
@@ -105,10 +113,21 @@ export async function POST(req: NextRequest) {
       return NextResponse.json({ error: msg }, { status: 400 });
     }
 
-    const hasShort = items.some(
-      (i: { orderedQty?: number; receivedQty: number }) =>
-        i.orderedQty !== undefined && i.receivedQty < i.orderedQty,
-    );
+    // Auto-derive orderedQty from the PO server-side (the client may omit it),
+    // so short-delivery tracking survives even though the PO reconcile below
+    // overwrites OrderItem.quantity with the received total.
+    const poItems = await prisma.orderItem.findMany({
+      where: { orderId },
+      select: { productId: true, productPackageId: true, quantity: true },
+    });
+    for (const oi of poItems) {
+      orderedQtyMap.set(`${oi.productId}::${oi.productPackageId ?? ""}`, Number(oi.quantity));
+    }
+
+    const hasShort = items.some((i: { productId: string; productPackageId?: string; orderedQty?: number; receivedQty: number }) => {
+      const ordered = resolveOrderedQty(i);
+      return ordered !== null && i.receivedQty < ordered;
+    });
     if (hasShort) receivingStatus = "PARTIAL";
   }
 
@@ -125,7 +144,7 @@ export async function POST(req: NextRequest) {
         create: items.map((i: { productId: string; productPackageId?: string; orderedQty?: number; receivedQty: number; expiryDate?: string; discrepancyReason?: string }) => ({
           productId: i.productId,
           productPackageId: i.productPackageId || null,
-          orderedQty: i.orderedQty ?? null,
+          orderedQty: resolveOrderedQty(i),
           receivedQty: i.receivedQty,
           expiryDate: i.expiryDate ? new Date(i.expiryDate) : null,
           discrepancyReason: i.discrepancyReason || null,

--- a/docs/design/procurement-chat-learnings.md
+++ b/docs/design/procurement-chat-learnings.md
@@ -76,6 +76,13 @@ helps; matching/short/partial/double detection is still manual.
   template. Reconcile with `staff-native/lib/ops/invoices.ts`.
 - **P0 — Reconciliation ledger.** Match PoP ↔ invoice; flag short/partial/double/missing-charge;
   surface "which invoice unmatched." This is the real prize. Invoice model has the fields.
+  _Shipped (v1): `/inventory/reconciliation` + `GET /api/inventory/invoices/reconciliation` —
+  per-supplier statement of account (outstanding + aging) with a reconciliation-EXCEPTIONS list:
+  the existing per-invoice money flags (duplicate/double-pay/wrong-account/tolerance) grouped by
+  supplier, plus short-paid residuals, partial/deposit carry-forward, and AI-captured drafts to
+  verify. Overpayment surfaces via flags (amountPaid is clamped to amount on payment), so the
+  ledger aggregates flag-detector output rather than recomputing it. Open: automated PoP-amount ↔
+  invoice matching from inbound payment images, and missing-delivery-charge detection._
 - **P1 — Auto-send the order block on approval** (already generated) via the API, with MOQ +
   outlet + delivery-day/cut-off validation baked in (kills the "add more / which outlet /
   too late for today's lorry" loops).

--- a/docs/design/procurement-chat-learnings.md
+++ b/docs/design/procurement-chat-learnings.md
@@ -86,12 +86,27 @@ helps; matching/short/partial/double detection is still manual.
 - **P1 — Auto-send the order block on approval** (already generated) via the API, with MOQ +
   outlet + delivery-day/cut-off validation baked in (kills the "add more / which outlet /
   too late for today's lorry" loops).
+  _Shipped (validation): `lib/inventory/order-validation.ts` (validateSupplierOrder +
+  parseMoqRm + nextDeliveryDate, unit-tested) wired into ai-decisions — each drafted PO is
+  checked against the supplier's trip MOQ (ringgit) with the exact top-up shortfall, shown as
+  a warning on the PO card. Delivery-day check is built and fires once a date is set on the PO.
+  Open: per-outlet legal billing entity._
 - **P1 — Inbox/message-store (Option 1, in progress).** Capture all chats (done: Increment 1)
   → AI-parse inbound (Malay + media aware) → classify OOS / substitute / price-change /
   invoice / payment → propose action to a human.
+  _Shipped (propose-to-human): when the agent escalates it now stamps a STRUCTURED PROPOSAL
+  (intent + the declined PO edit + payment model) on the outbound message; the Supplier Chats
+  inbox surfaces it as an "Agent suggests — your call" card. The agent never applies it._
 - **P2 — OOS handling:** AI-propose / human-approve PO edit; recipe-critical always human.
+  _Shipped (proposal capture): substitution offers are escalated WITH the structured swap
+  detail (which line, the offered note) so the human sees a concrete proposal. WhatsApp-button
+  one-tap approval remains the external-gated follow-up (needs a Meta-approved template)._
 - **P2 — Per-payment-model + per-supplier rules:** prepay vs credit-SOA vs deposit; delivery
   calendar; legal billing entity per outlet.
+  _Shipped: `lib/inventory/payment-model.ts` (unit-tested) classifies prepay / deposit+balance
+  / credit-SOA / standard from depositPercent + terms. The agent treats prepay/deposit payment
+  messages as delivery-critical; the inbox shows the model (⚡ when POP-gated). Delivery
+  calendar lives in order-validation. Open: per-outlet legal billing entity._
 
 ## Reusable supplier archetypes (for the model)
 - **Single-SKU prepay** (RICH's foam, BeansCo choc powder, Farm Fresh milk, BBM lamb,

--- a/docs/design/procurement-qa-2026-06-26.md
+++ b/docs/design/procurement-qa-2026-06-26.md
@@ -46,8 +46,15 @@ These are larger than a safe in-PR fix; flagging for prioritisation.
    never called by any sales/POS flow, and `MenuIngredient` (BOM) is manual-only with
    no import. This is why COGS and the new variance report are empty until recipes +
    sales exist, and why par-level reorder can't be trusted (the docs' load-bearing
-   "stock accurate enough to auto-order" premise). Fix = a consumption engine
-   (sales × recipe → decrement) + a recipe import. Largest item; underpins the loop.
+   "stock accurate enough to auto-order" premise).
+   _Started (SHADOW): `lib/inventory/consumption.ts` + `/api/cron/consumption-post`
+   (daily) turn each outlet's menu sales into theoretical ingredient depletion
+   (sales × recipe BOM) and report it. Shadow by default — writes nothing.
+   `CONSUMPTION_ENGINE_ENABLED=true` (+ a system OWNER user) enables idempotent live
+   posting of negative StockAdjustments, but MUST stay off until stock units are
+   normalised to base UOM (#1) — otherwise the base-unit decrement misaligns with the
+   package-keyed StockBalance rows. Still open: a recipe (`MenuIngredient`) import, and
+   the unit normalisation that unblocks going live._
 
 4. **Lower-priority QA items:** orphaned `OrderStatus.CONFIRMED`; no PO status-transition
    allowlist; deposit rounding via `Number()` coercion; `Order.deliveryDate` optional

--- a/docs/design/procurement-qa-2026-06-26.md
+++ b/docs/design/procurement-qa-2026-06-26.md
@@ -1,0 +1,66 @@
+# Procurement flow — QA pass + gap fixes (2026-06-26)
+
+Static QA of the whole procurement/inventory loop (reorder → PO → receive →
+invoice → pay → reconcile → reports), plus the data-capture audit behind the
+five "empty" inventory reports. No running app was available, so this is
+static analysis + targeted code review (CI typecheck/lint/test validates).
+
+## Fixed in this PR
+
+- **Price history captured.** `PriceHistory` existed but had zero writers, so the
+  Supplier Scorecard "price changes" metric was always empty. New
+  `recordPriceChange()` logs old→new + % on every `SupplierProduct.price` update.
+- **`orderedQty` auto-derived on receiving.** It was client-only and is the ONLY
+  surviving record of ordered qty (the receivings reconcile overwrites
+  `OrderItem.quantity` with the received total). Now filled server-side from the PO
+  in both the backoffice and staff receiving routes — restores short-delivery tracking.
+- **Usage-variance report** (`/inventory/reports/ingredient-variance`): actual usage
+  from count-bracketed stock movements vs expected (recipe BOM × sales), with
+  read-time unit normalisation and graceful degradation.
+- **Code-review fixes** in the P0–P2 work: tightened the over-broad payment-reference
+  match (false double-payment flags), PAID→PARTIALLY_PAID on an amount-edit that
+  strands a balance, `BILLED_OVER_PO` guards `amount>0` (credit notes), payment-model
+  recognises "upfront".
+
+## Open — structural, need a decision (not done here)
+
+These are larger than a safe in-PR fix; flagging for prioritisation.
+
+1. **Stock is tracked in mixed units, fragmented by package.** `adjustStockBalance`
+   writes the raw delta with NO conversion, keyed by `(productId, productPackageId)`:
+   receivings write *package* units, wastage/transfers write *base* units, for the
+   same product. There is no canonical base-UOM quantity. Consequences:
+   - The **Stock Valuation report is unit-buggy** (compares mixed-unit balance rows to
+     counts with no conversion, and double-counts multi-package products).
+   - Reorder par-level checks compare against an unreliable quantity.
+   - Fix = normalise to base UOM at write time (touches `stock.ts` + counts) — a
+     systemic change. The new usage-variance report works around it by converting at
+     read time.
+
+2. **Double-receiving has no idempotency.** A double-submit double-counts stock and
+   the PO total (cumulative recompute + `adjustStockBalance`). PO *create* uses
+   `clientRequestId`; receiving does not. Fix = a `clientRequestId` column + unique
+   index (migration).
+
+3. **Stock is never decremented by sales; no recipe source.** `adjustStockBalance` is
+   never called by any sales/POS flow, and `MenuIngredient` (BOM) is manual-only with
+   no import. This is why COGS and the new variance report are empty until recipes +
+   sales exist, and why par-level reorder can't be trusted (the docs' load-bearing
+   "stock accurate enough to auto-order" premise). Fix = a consumption engine
+   (sales × recipe → decrement) + a recipe import. Largest item; underpins the loop.
+
+4. **Lower-priority QA items:** orphaned `OrderStatus.CONFIRMED`; no PO status-transition
+   allowlist; deposit rounding via `Number()` coercion; `Order.deliveryDate` optional
+   (on-time rate silently drops null-date orders — could impute from `leadTimeDays`);
+   backoffice wastage doesn't auto-fill cost (staff app does).
+
+## Report emptiness — root causes (data-capture vs wiring)
+
+- **Stock Valuation** — empty/untrustworthy: stock not decremented by sales (#3) + unit
+  bug (#1).
+- **COGS** — empty: no `MenuIngredient` recipes + StoreHub-only sales sync (#3).
+- **Purchase Summary** — understates: `Invoice.amount` placeholders default to PO total
+  or 0 and aren't synced to the supplier's real amount (P0.1 vision-capture helps).
+- **Wastage** — works when `StockAdjustment` rows exist; cost falls back to supplier price.
+- **Supplier Scorecard** — price-changes fixed here (#price history); short-delivery fixed
+  here (`orderedQty`); on-time depends on `Order.deliveryDate` being set (#4).


### PR DESCRIPTION
## Why

Continuing the procurement loop. The flat invoices list answers *"what do we owe right now"*, but it can't answer the money-matching questions that the analysis of **17 real supplier chats** (`docs/design/procurement-chat-learnings.md`) named the **#1 recurring procurement pain** — *"which invoice is this PoP for", short/partial/double payments, wrong-account transfers, and carry-forward balances.* That doc flags a **reconciliation ledger as the P0 "real prize."** This ships v1.

## What

A per-supplier **statement of account** that surfaces the rows a human needs to match or chase.

**`GET /api/inventory/invoices/reconciliation`**
- Groups supplier (AP) invoices by supplier into **outstanding + aging + overdue**, plus a reconciliation-**exceptions** list:
  - active per-invoice **money flags** (duplicate PO / duplicate ref / double-payment / bank mismatch / tolerance) surfaced together
  - **short-paid** residuals (marked paid but billed more)
  - **partial / deposit carry-forward** balances
  - **AI-captured drafts** awaiting verification
- Overpayment never lands as `amountPaid > amount` (the payment route clamps it), so the ledger **aggregates `flag-detector` output** rather than recomputing it — no new detection logic, single source of truth.
- Excludes finance one-off payment requests; keeps ad-hoc supplier invoices with no PO.

**`/inventory/reconciliation` page**
- Summary cards: Outstanding · Overdue · Reconciliation exceptions · Payment mismatches.
- Per-supplier accordion → expands to exception rows, each deep-linking to the invoice. Theme-aware (light/dark).

**Nav:** Procurement → Ordering → "Reconciliation" (after Invoices).

## Verification
- No `node_modules` in this web session, so no local `tsc`/`eslint` run — verified by inspection against existing patterns (`useFetch` shape, `flag-detector` exports, Prisma nullable-relation `NOT`/`is` filter, theme tokens). Worth a CI typecheck + a manual click-through.

## Open follow-ups
- Automated PoP-amount ↔ invoice matching from inbound payment images.
- Missing-delivery-charge detection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HSjTZCnJGpx7yp6hJrkYqg)_