### PR TITLE
Fix loop cooldown: paginate recentlyTargetedPhones (1000-cap → spam)

### DIFF
--- a/apps/backoffice/src/lib/loyalty/loop-engine.ts
+++ b/apps/backoffice/src/lib/loyalty/loop-engine.ts
@@ -1075,9 +1075,20 @@ async function recentlyTargetedPhones(loopKey: LoopKey, cooldownDays: number): P
     .from("loop_rounds").select("id").eq("loop_key", loopKey).gte("prepared_at", since);
   const roundIds = ((rounds ?? []) as Array<{ id: string }>).map((r) => r.id);
   if (roundIds.length === 0) return [];
-  const { data: rows } = await supabaseAdmin
-    .from("loop_assignments").select("phone").in("round_id", roundIds);
-  return Array.from(new Set(((rows ?? []) as Array<{ phone: string }>).map((r) => r.phone)));
+  // PAGINATE: Supabase caps a select at 1000 rows. A loop with daily rounds
+  // accumulates thousands of assignments in the cooldown window, so an unpaged
+  // query truncates the suppress list → already-messaged members slip through and
+  // get re-spammed. Page through all of them (ordered by id for stable ranges).
+  const phones = new Set<string>();
+  for (let from = 0; ; from += 1000) {
+    const { data: rows } = await supabaseAdmin
+      .from("loop_assignments").select("phone").in("round_id", roundIds)
+      .order("id", { ascending: true }).range(from, from + 999);
+    const batch = (rows ?? []) as Array<{ phone: string }>;
+    for (const r of batch) if (r.phone) phones.add(r.phone.trim());
+    if (batch.length < 1000) break;
+  }
+  return Array.from(phones);
 }
 
 // Has this loop already produced a round today (MYT)? Keeps the cadence at one


### PR DESCRIPTION
**Bug:** a member got **7 win-back SMS in 5 days** despite the 60-day cooldown.

**Root cause:** `recentlyTargetedPhones` (the per-loop anti-spam suppress list) read `loop_assignments` with no pagination → **Supabase's 1000-row cap truncated it**. Winback had **3,385 assignments / 1,394 distinct phones** in the 60-day window (10 force-run rounds while testing), so ~400 already-messaged members fell out of the suppress set and got re-messaged. The affected member sat **outside the first 1,000 rows** (`member_in_first_1000 = false`), so the cooldown never saw them.

**Fix:** paginate the assignment read (ordered by id for stable ranges) so the **full 1,394** recently-messaged phones are suppressed. Same 1000-row-cap class fixed in the segments earlier — this instance had broken the anti-spam guardrail itself.

Typecheck clean. Stops future repeats; the 7 already sent can't be unsent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)