### PR TITLE
Global cross-loop weekly send cap (anti-spam)

### DIFF
--- a/apps/backoffice/src/lib/loyalty/loop-engine.ts
+++ b/apps/backoffice/src/lib/loyalty/loop-engine.ts
@@ -567,12 +567,33 @@ export async function sendRound(roundId: string) {
     .map((r) => r.member_id).filter((x): x is string => !!x);
   const tokensByMember = await pushTokensByMember(treatmentMemberIds);
 
+  // GLOBAL frequency cap across ALL loops: skip any member who already hit the
+  // weekly cap (any loop) so winback + round-gap + reward-expiring etc. can't
+  // stack into spam in one week. Per-loop cooldowns don't see each other; this
+  // does. Tunable: app_settings.marketing_weekly_cap (default 2 per 7 days).
+  const cappedPhones = new Set<string>();
+  {
+    let cap = 2;
+    try {
+      const { data: s } = await supabaseAdmin.from("app_settings").select("value").eq("key", "marketing_weekly_cap").maybeSingle();
+      const n = parseInt(String(s?.value ?? "").replace(/[^0-9]/g, ""), 10);
+      if (Number.isFinite(n) && n > 0) cap = n;
+    } catch { /* default 2 */ }
+    const { data: cp } = await supabaseAdmin.rpc("loyalty_capped_phones", { p_cap: cap, p_days: 7 });
+    for (const r of (cp ?? []) as Array<{ phone: string }>) if (r.phone) cappedPhones.add(r.phone.trim());
+  }
+
   let sentPush = 0;
   let sentSms = 0;
   let failed = 0;
+  let capped = 0;
   let firstError: string | undefined;
   for (const r of (rows ?? []) as Array<{ id: string; phone: string; arm: string; sms_status: string | null; member_id: string | null; issued_reward_id: string | null }>) {
     if (r.sms_status === "sent") continue; // idempotent (covers push + SMS)
+    if (cappedPhones.has(r.phone)) { // global weekly cap hit on another loop
+      await supabaseAdmin.from("loop_assignments").update({ sms_status: "capped", sms_message_id: "weekly_cap" }).eq("id", r.id);
+      capped++; continue;
+    }
     let message = armMsg[r.arm] ?? "";
     if (!message) { failed++; continue; }
     if (needsName) {
@@ -615,7 +636,7 @@ export async function sendRound(roundId: string) {
     .update({ status: "sent", sent_at: sentAt.toISOString(), send_window: round.send_window ?? deriveWindow(sentAt) })
     .eq("id", roundId);
 
-  return { round_id: roundId, sent: sentPush + sentSms, sent_push: sentPush, sent_sms: sentSms, failed, error: firstError };
+  return { round_id: roundId, sent: sentPush + sentSms, sent_push: sentPush, sent_sms: sentSms, capped, failed, error: firstError };
 }
 
 // ── MEASURE ───────────────────────────────────────────────────────────────────

--- a/supabase/migrations/059_loyalty_global_weekly_cap.sql
+++ b/supabase/migrations/059_loyalty_global_weekly_cap.sql
@@ -1,0 +1,21 @@
+-- Global cross-loop frequency cap. Per-loop cooldowns don't see each other, so a
+-- member could get winback + round-gap + reward-expiring + ... in one week.
+-- sendRound calls loyalty_capped_phones() and skips anyone already at the cap.
+-- Tunable via app_settings.marketing_weekly_cap (default 2 per 7 days).
+CREATE OR REPLACE FUNCTION loyalty_capped_phones(p_cap int DEFAULT 2, p_days int DEFAULT 7)
+RETURNS TABLE(phone text) LANGUAGE sql STABLE AS $$
+  SELECT la.phone
+  FROM loop_assignments la
+  JOIN loop_rounds lr ON lr.id = la.round_id
+  WHERE la.sms_status = 'sent'
+    AND la.phone IS NOT NULL
+    AND lr.sent_at >= now() - (p_days || ' days')::interval
+  GROUP BY la.phone
+  HAVING count(*) >= p_cap;
+$$;
+
+-- default cap setting (idempotent)
+UPDATE app_settings SET value='2'::jsonb WHERE key='marketing_weekly_cap';
+INSERT INTO app_settings(key, value)
+  SELECT 'marketing_weekly_cap','2'::jsonb
+  WHERE NOT EXISTS (SELECT 1 FROM app_settings WHERE key='marketing_weekly_cap');


### PR DESCRIPTION
Follow-up to the cooldown fix (#533): per-loop cooldowns don't see each other, so a member could still get **winback + round-gap + reward-expiring + birthday** in one week.

**Adds a global cap** enforced at the single send chokepoint (`sendRound`): skip any member who already received **≥ cap marketing sends (any loop)** in the trailing 7 days. Covers every loop including round-gap (it also sends via `sendRound`). Capped assignments are recorded `sms_status='capped'`.

- **`loyalty_capped_phones()` RPC** counts cross-loop sends server-side (no 1000-row cap).
- **Tunable:** `app_settings.marketing_weekly_cap` (default **2** per 7 days).
- **Ordering:** loops run lifecycle-first (winback/welcome/birthday/reward-expiring) then the round-gap drip, so the high-value nudges win the weekly quota.

Typecheck clean. Migration 059 (RPC + setting already applied live).

🤖 Generated with [Claude Code](https://claude.com/claude-code)