### PR TITLE
feat(ops): live-refresh Supplier Chats inbox (poll + auto-scroll)

### DIFF
--- a/apps/backoffice/src/app/(admin)/inventory/supplier-chats/page.tsx
+++ b/apps/backoffice/src/app/(admin)/inventory/supplier-chats/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useState, useEffect, useRef } from "react";
 import { useFetch } from "@/lib/use-fetch";
 import { formatRM } from "@celsius/shared";
 import {
@@ -84,12 +84,24 @@ export default function SupplierChatsPage() {
   const [selected, setSelected] = useState<string | null>(null);
   const [filter, setFilter] = useState<"all" | "attention">("all");
 
+  // Poll so inbound supplier messages + the agent's auto-replies appear without
+  // a manual refresh. The open thread polls faster than the list.
   const { data: threadsData, isLoading } = useFetch<{ threads: Thread[]; needsAttention: number }>(
     "/api/inventory/supplier-chats",
+    { refreshInterval: 10000, revalidateOnFocus: true },
   );
   const { data: detail, mutate: mutateDetail } = useFetch<Detail>(
     selected ? `/api/inventory/supplier-chats/${selected}` : null,
+    { refreshInterval: 6000, revalidateOnFocus: true },
   );
+
+  // Auto-scroll to the newest message when the thread or its message count
+  // changes (so polled-in messages land in view, not below the fold).
+  const messagesEndRef = useRef<HTMLDivElement | null>(null);
+  const msgCount = detail?.messages.length ?? 0;
+  useEffect(() => {
+    messagesEndRef.current?.scrollIntoView({ block: "end" });
+  }, [selected, msgCount]);
 
   const [draft, setDraft] = useState("");
   const [sending, setSending] = useState(false);
@@ -231,6 +243,7 @@ export default function SupplierChatsPage() {
                   </div>
                 </div>
               ))}
+              <div ref={messagesEndRef} />
             </div>
             <div className="border-t border-border px-4 py-2.5">
               <div className="flex items-center gap-2">

--- a/apps/backoffice/src/lib/use-fetch.ts
+++ b/apps/backoffice/src/lib/use-fetch.ts
@@ -7,16 +7,33 @@ const fetcher = (url: string) => fetch(url).then((res) => {
   return res.json();
 });
 
+export type UseFetchOptions = {
+  /** Poll the URL on this interval (ms). Omit/0 = no polling. */
+  refreshInterval?: number;
+  /** Dedup window (ms). Defaults to 10s; lower it when polling fast. */
+  dedupingInterval?: number;
+  /** Revalidate when the tab regains focus (good for live inboxes). */
+  revalidateOnFocus?: boolean;
+};
+
 /**
  * Cached data fetcher using SWR.
  * - Returns cached data instantly on re-render / page navigation
  * - Revalidates in background (stale-while-revalidate)
  * - Deduplicates concurrent requests to the same URL
+ * - Optional polling (`refreshInterval`) for near-real-time views (chat inbox).
  */
-export function useFetch<T = unknown>(url: string | null) {
+export function useFetch<T = unknown>(url: string | null, opts: UseFetchOptions = {}) {
+  // When polling, the dedup window must not exceed the poll interval or
+  // scheduled refreshes get swallowed; default to just under the interval.
+  const dedupingInterval =
+    opts.dedupingInterval ??
+    (opts.refreshInterval ? Math.max(1000, Math.floor(opts.refreshInterval * 0.6)) : 10000);
+
   const { data, error, isLoading, mutate } = useSWR<T>(url, fetcher, {
-    revalidateOnFocus: false,
-    dedupingInterval: 10000, // don't re-fetch same URL within 10s
+    revalidateOnFocus: opts.revalidateOnFocus ?? false,
+    dedupingInterval,
+    refreshInterval: opts.refreshInterval ?? 0,
   });
 
   return { data: data as T | undefined, error, isLoading, mutate };


### PR DESCRIPTION
The Supplier Chats inbox only updated on a manual refresh — inbound supplier messages and the agent's auto-replies didn't appear live (reported during the procurement E2E test).

- `useFetch` now accepts polling options (`refreshInterval` / `dedupingInterval` / `revalidateOnFocus`); the dedup window auto-shrinks under the poll interval so scheduled refreshes aren't swallowed.
- Supplier Chats polls the thread list every 10s and the open thread every 6s, revalidates on focus, and auto-scrolls to the newest message.

No API/schema changes; backwards-compatible (`useFetch(url)` unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HSjTZCnJGpx7yp6hJrkYqg)_