### PR TITLE
feat(procurement): cap reorder qty (overstock/shelf-life) + alternative suppliers

### DIFF
--- a/apps/backoffice/src/app/(admin)/inventory/ai-decisions/page.tsx
+++ b/apps/backoffice/src/app/(admin)/inventory/ai-decisions/page.tsx
@@ -17,6 +17,8 @@ type ReorderItem = {
   orderQty: number;
   unitPrice: number;
   priceChangePercent?: number | null;
+  capNote?: string | null;
+  alternatives?: { supplierName: string; price: number; moq: number }[];
   totalPrice: number;
   productPackageId: string | null;
   packageName: string | null;
@@ -360,6 +362,14 @@ export default function AIDecisionsPage() {
                             <td className="py-1.5 px-3 text-zinc-300">
                               {item.productName}
                               {item.packageName && <span className="text-zinc-500 ml-1">({item.packageName})</span>}
+                              {item.capNote && (
+                                <div className="text-[10px] text-amber-400/90">⚠ {item.capNote}</div>
+                              )}
+                              {item.alternatives && item.alternatives.length > 0 && (
+                                <div className="text-[10px] text-zinc-500">
+                                  alt: {item.alternatives.map((a) => `${a.supplierName} RM${a.price.toFixed(2)}`).join(" · ")}
+                                </div>
+                              )}
                             </td>
                             <td className={`py-1.5 px-3 text-right font-medium ${item.currentQty <= 0 ? "text-red-400" : item.currentQty <= item.reorderPoint ? "text-orange-400" : "text-zinc-300"}`}>
                               {item.currentQty}

--- a/apps/backoffice/src/app/api/inventory/ai-decisions/route.ts
+++ b/apps/backoffice/src/app/api/inventory/ai-decisions/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { getSession } from "@/lib/auth";
 import { prisma } from "@/lib/prisma";
-import { validateSupplierOrder, type OrderWarning } from "@/lib/inventory/order-validation";
+import { validateSupplierOrder, boundedReorderQty, type OrderWarning } from "@/lib/inventory/order-validation";
 
 // ─── GET /api/inventory/ai-decisions ────────────────────────────────────
 // Returns executable decisions: draft POs to create, transfers to make,
@@ -223,6 +223,8 @@ export async function GET(request: NextRequest) {
       productPackageId: string | null;
       packageName: string | null;
       daysUntilStockout: number;
+      capNote: string | null; // why orderQty was capped (overstock / shelf-life), if any
+      alternatives: { supplierName: string; price: number; moq: number }[]; // next-cheapest sources
     };
 
     // ── Pre-compute surplus stock at each outlet per product ──
@@ -342,12 +344,41 @@ export async function GET(request: NextRequest) {
         const supplier = cheapestSupplier[product.id];
         if (!supplier) continue; // no supplier = can't order
 
-        // Calculate order quantity: only remaining deficit after transfers, in package units
-        const packageQty = Math.ceil(baseUnitsNeeded / supplier.conversionFactor);
-        // Respect MOQ
-        const orderQty = Math.max(packageQty, supplier.moq);
+        // Order quantity: enough to reach par (after transfers), floored by MOQ,
+        // but capped so we don't overstock past maxLevel or order more than can be
+        // used before it spoils (perishables). MOQ stays a hard floor.
+        const maxLevel = par.maxLevel != null ? Number(par.maxLevel) : null;
+        const headroomBase = maxLevel != null ? Math.max(0, maxLevel - currentQty - onOrderQty) : null;
+        const shelfLifeDays = product.shelfLifeDays != null ? Number(product.shelfLifeDays) : null;
+        const shelfUsableBase = shelfLifeDays && shelfLifeDays > 0 && avgDaily > 0 ? shelfLifeDays * avgDaily : null;
+        const bounded = boundedReorderQty({
+          neededBase: baseUnitsNeeded,
+          conversionFactor: supplier.conversionFactor,
+          moq: supplier.moq,
+          headroomBase,
+          shelfUsableBase,
+        });
+        const orderQty = bounded.orderQty;
         const totalPrice = orderQty * supplier.price;
         const daysLeft = avgDaily > 0 ? Math.round(currentQty / avgDaily) : 0;
+
+        let capNote: string | null = null;
+        if (bounded.moqForced) {
+          capNote = bounded.cap === "shelf_life"
+            ? "MOQ exceeds shelf-life usage — spoilage risk"
+            : "MOQ pushes above max level — overstock";
+        } else if (bounded.cap === "shelf_life") {
+          capNote = "Capped to shelf-life usage";
+        } else if (bounded.cap === "max_level") {
+          capNote = "Capped at max level";
+        }
+
+        // Alternative suppliers (next-cheapest) so an OOS/unavailable line can be
+        // re-sourced without leaving the need unfilled.
+        const alternatives = (supplierOptionsMap[product.id] ?? [])
+          .filter((o) => o.supplierId !== supplier.supplierId)
+          .slice(0, 3)
+          .map((o) => ({ supplierName: o.supplierName, price: o.price, moq: o.moq }));
 
         const conv = supplier.conversionFactor;
         const item: ReorderItem = {
@@ -367,6 +398,8 @@ export async function GET(request: NextRequest) {
           productPackageId: supplier.productPackageId,
           packageName: supplier.packageName,
           daysUntilStockout: daysLeft,
+          capNote,
+          alternatives,
         };
 
         if (!reorderGroups[outlet.id]) reorderGroups[outlet.id] = {};

--- a/apps/backoffice/src/lib/inventory/order-validation.test.ts
+++ b/apps/backoffice/src/lib/inventory/order-validation.test.ts
@@ -1,5 +1,33 @@
 import { describe, it, expect } from "vitest";
-import { parseMoqRm, nextDeliveryDate, validateSupplierOrder } from "./order-validation";
+import { parseMoqRm, nextDeliveryDate, validateSupplierOrder, boundedReorderQty } from "./order-validation";
+
+describe("boundedReorderQty", () => {
+  it("orders to need, floored by MOQ, rounded to pack size", () => {
+    expect(boundedReorderQty({ neededBase: 50, conversionFactor: 1, moq: 1 })).toMatchObject({ orderQty: 50, cap: null, moqForced: false });
+    expect(boundedReorderQty({ neededBase: 2, conversionFactor: 1, moq: 10 }).orderQty).toBe(10); // MOQ floor
+    expect(boundedReorderQty({ neededBase: 45, conversionFactor: 10, moq: 1 }).orderQty).toBe(5); // ceil(45/10)
+  });
+
+  it("caps at maxLevel headroom (overstock guard)", () => {
+    const r = boundedReorderQty({ neededBase: 80, conversionFactor: 1, moq: 1, headroomBase: 50 });
+    expect(r).toMatchObject({ orderQty: 50, cap: "max_level", moqForced: false });
+  });
+
+  it("caps at shelf-life usable qty (spoilage guard)", () => {
+    const r = boundedReorderQty({ neededBase: 100, conversionFactor: 1, moq: 1, shelfUsableBase: 30 });
+    expect(r).toMatchObject({ orderQty: 30, cap: "shelf_life" });
+  });
+
+  it("takes the tighter of the two ceilings", () => {
+    const r = boundedReorderQty({ neededBase: 100, conversionFactor: 1, moq: 1, headroomBase: 40, shelfUsableBase: 25 });
+    expect(r).toMatchObject({ orderQty: 25, cap: "shelf_life" });
+  });
+
+  it("never goes below MOQ — flags moqForced when MOQ overshoots a ceiling", () => {
+    const r = boundedReorderQty({ neededBase: 5, conversionFactor: 1, moq: 20, headroomBase: 10 });
+    expect(r).toMatchObject({ orderQty: 20, cap: "max_level", moqForced: true });
+  });
+});
 
 // A UTC-midnight Date for a given YYYY-MM-DD (what callers pass as "today"/planned).
 const d = (s: string) => new Date(`${s}T00:00:00Z`);

--- a/apps/backoffice/src/lib/inventory/order-validation.ts
+++ b/apps/backoffice/src/lib/inventory/order-validation.ts
@@ -13,6 +13,62 @@
 // cron, PO draft API, supplier-chat agent context). Dates are compared in UTC —
 // callers pass a UTC-midnight Date representing the intended local (MYT) day.
 
+// ─── Reorder quantity bounding ──────────────────────────────
+// The reorder engine orders "enough to reach par", floored by the per-line MOQ.
+// But MOQ + pack-size rounding can overshoot two real ceilings:
+//   - maxLevel: ordering above it overstocks (cash tied up, storage).
+//   - shelf life: ordering more than can be used before expiry → spoilage.
+// boundedReorderQty caps the order at the tighter of those, but never below MOQ
+// (a hard supplier floor) — when MOQ forces an overshoot it reports why so the
+// buyer sees it. Pure + unit-tested.
+
+export type ReorderCap = "max_level" | "shelf_life" | null;
+
+export type ReorderQty = {
+  orderQty: number; // package units to order
+  cap: ReorderCap; // which ceiling bound the qty (null = pure need/MOQ)
+  moqForced: boolean; // true when MOQ pushed the qty above a ceiling
+};
+
+export function boundedReorderQty(input: {
+  neededBase: number; // base units short of par (after transfers + on-order)
+  conversionFactor: number; // base units per package unit
+  moq: number; // per-line package MOQ (hard floor)
+  /** maxLevel − currentBase − onOrderBase: base units we can add before exceeding max. null = no max. */
+  headroomBase?: number | null;
+  /** shelfLifeDays × avgDailyUsage: base units usable before spoilage. null = non-perishable. */
+  shelfUsableBase?: number | null;
+}): ReorderQty {
+  const conv = input.conversionFactor > 0 ? input.conversionFactor : 1;
+  const moq = Math.max(0, Math.floor(input.moq) || 0);
+
+  const needPkg = Math.max(0, Math.ceil(input.neededBase / conv));
+  let orderQty = Math.max(needPkg, moq);
+
+  // Ceilings in package units (floor — never round a cap up past itself).
+  const maxPkg = input.headroomBase != null ? Math.max(0, Math.floor(input.headroomBase / conv)) : Infinity;
+  const shelfPkg =
+    input.shelfUsableBase != null && input.shelfUsableBase > 0
+      ? Math.max(0, Math.floor(input.shelfUsableBase / conv))
+      : Infinity;
+
+  const cap = Math.min(maxPkg, shelfPkg);
+  let which: ReorderCap = null;
+  let moqForced = false;
+
+  if (orderQty > cap) {
+    which = maxPkg <= shelfPkg ? "max_level" : "shelf_life";
+    if (cap >= moq) {
+      orderQty = cap; // cap is the binding ceiling, still ≥ MOQ
+    } else {
+      orderQty = moq; // MOQ is a hard floor — overshoot the ceiling, flag it
+      moqForced = true;
+    }
+  }
+
+  return { orderQty: Math.max(orderQty, moq > 0 ? moq : 1), cap: which, moqForced };
+}
+
 export type OrderWarningCode = "BELOW_MOQ" | "DELIVERY_DAY";
 
 export type OrderWarning = {


### PR DESCRIPTION
Fills three actionable gaps from the reorder-decision operational-risk review:

- **Overstock cap (#5):** `orderQty` capped at `maxLevel` headroom (`current + on-order + order ≤ maxLevel`) so MOQ/pack-rounding can't overshoot into overstock.
- **Spoilage cap (#6):** for perishables (`shelfLifeDays`), capped at `shelfLifeDays × avgDailyUsage`.
- **MOQ stays a hard floor:** when it forces an overshoot, the line shows why ("MOQ pushes above max level" / "exceeds shelf-life usage").
- **Re-sourcing (#3, data half):** each recommended line carries the **next-cheapest alternative suppliers** (name/price/MOQ), so an OOS/unavailable line can be re-sourced instead of leaving the need unfilled.

New pure, **unit-tested** `boundedReorderQty()` in `order-validation.ts`; the AI Decisions page shows the cap note + alternatives per line.

Still open (separate increments): agent **auto-proposing** a re-source PO on supplier OOS (vs surfacing alternatives), short-delivery shortfall re-order, and the structural stock-accuracy work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HSjTZCnJGpx7yp6hJrkYqg)_