### PR TITLE
feat(procurement): act on supplier-chat agent decisions (re-source OOS + apply/open-PO from the inbox)

### DIFF
--- a/apps/backoffice/src/app/(admin)/inventory/supplier-chats/page.tsx
+++ b/apps/backoffice/src/app/(admin)/inventory/supplier-chats/page.tsx
@@ -11,6 +11,8 @@ import {
   Send,
   Loader2,
   Phone,
+  Check,
+  ExternalLink,
 } from "lucide-react";
 
 type Thread = {
@@ -55,14 +57,16 @@ type Detail = {
   windowOpen: boolean;
   messages: Msg[];
   agentProposal?: {
+    messageId: string;
+    orderId: string | null;
     intent: string;
     escalationReason: string;
     paymentModel?: string;
     popDeliveryCritical?: boolean;
-    poAction: { type: string; itemName: string | null; newQuantity: number | null; note: string | null } | null;
+    poAction: { type: string; poItemId: string | null; itemName: string | null; newQuantity: number | null; note: string | null } | null;
     at: string;
   } | null;
-  agentReSource?: { supplierName: string; orderNumber: string; qty: number; unit: string; existing: boolean } | null;
+  agentReSource?: { orderId: string | null; supplierName: string; orderNumber: string; qty: number; unit: string; existing: boolean } | null;
 };
 
 function rel(iso: string): string {
@@ -107,6 +111,8 @@ export default function SupplierChatsPage() {
   const [draft, setDraft] = useState("");
   const [sending, setSending] = useState(false);
   const [sendError, setSendError] = useState<string | null>(null);
+  const [applying, setApplying] = useState(false);
+  const [applyError, setApplyError] = useState<string | null>(null);
 
   const threads = threadsData?.threads ?? [];
   const shown = filter === "attention" ? threads.filter((t) => t.needsAttention) : threads;
@@ -118,6 +124,7 @@ export default function SupplierChatsPage() {
   useEffect(() => {
     setDraft("");
     setSendError(null);
+    setApplyError(null);
   }, [selected]);
 
   async function send() {
@@ -141,6 +148,37 @@ export default function SupplierChatsPage() {
       setSendError("Network error");
     } finally {
       setSending(false);
+    }
+  }
+
+  // Apply the agent's held proposal to the PO (remove_item / reduce_qty only).
+  async function applyProposal() {
+    const p = detail?.agentProposal;
+    if (!selected || applying || !p?.poAction?.poItemId || !p.orderId) return;
+    setApplying(true);
+    setApplyError(null);
+    try {
+      const res = await fetch(`/api/inventory/supplier-chats/${selected}/apply-proposal`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          messageId: p.messageId,
+          orderId: p.orderId,
+          poItemId: p.poAction.poItemId,
+          action: p.poAction.type,
+          newQuantity: p.poAction.newQuantity,
+        }),
+      });
+      const json = await res.json().catch(() => ({}));
+      if (!res.ok) {
+        setApplyError(json.error ?? "Apply failed");
+        return;
+      }
+      mutateDetail();
+    } catch {
+      setApplyError("Network error");
+    } finally {
+      setApplying(false);
     }
   }
 
@@ -340,6 +378,38 @@ export default function SupplierChatsPage() {
                       <div className="mt-1 text-[10.5px] text-muted-foreground">
                         Held for review: {detail.agentProposal.escalationReason}. The agent did not change the PO.
                       </div>
+                      {(() => {
+                        const pa = detail.agentProposal.poAction;
+                        const canApply =
+                          !!pa?.poItemId &&
+                          !!detail.agentProposal.orderId &&
+                          (pa.type === "remove_item" || pa.type === "reduce_qty");
+                        return (
+                          <div className="mt-2 flex items-center gap-2">
+                            {canApply && (
+                              <button
+                                onClick={applyProposal}
+                                disabled={applying}
+                                className="inline-flex items-center gap-1 rounded bg-amber-600 px-2 py-1 text-[11px] font-medium text-white hover:bg-amber-700 disabled:opacity-50"
+                              >
+                                {applying ? <Loader2 size={11} className="animate-spin" /> : <Check size={11} />}
+                                {pa?.type === "remove_item" ? "Apply: remove line" : "Apply: reduce qty"}
+                              </button>
+                            )}
+                            {detail.agentProposal.orderId && (
+                              <a
+                                href={`/inventory/orders/${detail.agentProposal.orderId}`}
+                                className="inline-flex items-center gap-1 rounded border border-amber-300 px-2 py-1 text-[11px] font-medium text-amber-700 hover:bg-amber-100 dark:border-amber-700 dark:text-amber-300 dark:hover:bg-amber-900/40"
+                              >
+                                Open PO <ExternalLink size={11} />
+                              </a>
+                            )}
+                          </div>
+                        );
+                      })()}
+                      {applyError && (
+                        <div className="mt-1 text-[10.5px] text-destructive">{applyError}</div>
+                      )}
                     </div>
                   </div>
                 )}
@@ -356,6 +426,16 @@ export default function SupplierChatsPage() {
                       <div className="mt-0.5 text-[10.5px] text-muted-foreground">
                         {detail.agentReSource.existing ? "Already pending — review & send." : "Review & send in Purchase Orders. Not visible to this supplier."}
                       </div>
+                      {detail.agentReSource.orderId && (
+                        <div className="mt-2">
+                          <a
+                            href={`/inventory/orders/${detail.agentReSource.orderId}`}
+                            className="inline-flex items-center gap-1 rounded bg-sky-600 px-2 py-1 text-[11px] font-medium text-white hover:bg-sky-700"
+                          >
+                            Open draft PO <ExternalLink size={11} />
+                          </a>
+                        </div>
+                      )}
                     </div>
                   </div>
                 )}

--- a/apps/backoffice/src/app/(admin)/inventory/supplier-chats/page.tsx
+++ b/apps/backoffice/src/app/(admin)/inventory/supplier-chats/page.tsx
@@ -62,6 +62,7 @@ type Detail = {
     poAction: { type: string; itemName: string | null; newQuantity: number | null; note: string | null } | null;
     at: string;
   } | null;
+  agentReSource?: { supplierName: string; orderNumber: string; qty: number; unit: string; existing: boolean } | null;
 };
 
 function rel(iso: string): string {
@@ -338,6 +339,22 @@ export default function SupplierChatsPage() {
                       </div>
                       <div className="mt-1 text-[10.5px] text-muted-foreground">
                         Held for review: {detail.agentProposal.escalationReason}. The agent did not change the PO.
+                      </div>
+                    </div>
+                  </div>
+                )}
+                {detail.agentReSource && (
+                  <div className="border-b border-border py-3">
+                    <div className="rounded-md border border-sky-300 bg-sky-50 p-2.5 dark:border-sky-800 dark:bg-sky-950/40">
+                      <div className="mb-1 text-[11px] font-semibold text-sky-700 dark:text-sky-300">
+                        Re-sourced (OOS)
+                      </div>
+                      <div className="text-[12px] text-foreground">
+                        Draft PO <span className="font-medium">{detail.agentReSource.orderNumber}</span> to{" "}
+                        <span className="font-medium">{detail.agentReSource.supplierName}</span> · {detail.agentReSource.qty} {detail.agentReSource.unit}
+                      </div>
+                      <div className="mt-0.5 text-[10.5px] text-muted-foreground">
+                        {detail.agentReSource.existing ? "Already pending — review & send." : "Review & send in Purchase Orders. Not visible to this supplier."}
                       </div>
                     </div>
                   </div>

--- a/apps/backoffice/src/app/api/inventory/supplier-chats/[key]/apply-proposal/route.ts
+++ b/apps/backoffice/src/app/api/inventory/supplier-chats/[key]/apply-proposal/route.ts
@@ -1,0 +1,91 @@
+import { NextResponse, NextRequest } from "next/server";
+import { prisma } from "@/lib/prisma";
+import { getUserFromHeaders } from "@/lib/auth";
+
+// Human applies the supplier-chat agent's held proposal to the PO — the
+// "AI proposes / human approves" handoff, now one click from the chat instead
+// of a hunt through Purchase Orders.
+//
+// SAFE by construction:
+//  - Only the two low-risk, internal edits are appliable here: remove_item and
+//    reduce_qty. Substitution / cancellation stay on the PO page (they carry
+//    pricing or external-effect decisions a human should see in full).
+//  - Never touches a COMPLETED / CANCELLED PO.
+//  - Stamps the originating message raw.proposalResolved so the banner clears
+//    and the same proposal can't be applied twice.
+
+export async function POST(req: NextRequest, { params }: { params: Promise<{ key: string }> }) {
+  const caller = await getUserFromHeaders(req.headers);
+  if (!caller) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+
+  const { key } = await params;
+  const body = await req.json().catch(() => ({}));
+  const { messageId, orderId, poItemId, action, newQuantity } = body as {
+    messageId?: string;
+    orderId?: string;
+    poItemId?: string;
+    action?: string;
+    newQuantity?: number;
+  };
+
+  if (!messageId || !orderId || !poItemId) {
+    return NextResponse.json({ error: "messageId, orderId and poItemId are required" }, { status: 400 });
+  }
+  if (action !== "remove_item" && action !== "reduce_qty") {
+    return NextResponse.json(
+      { error: "Only remove_item and reduce_qty can be applied from chat. Open the PO for other changes." },
+      { status: 400 },
+    );
+  }
+
+  // The message must be this thread's escalation, not yet resolved — prevents
+  // double-apply and cross-thread tampering with a stale messageId.
+  const message = await prisma.whatsAppMessage.findFirst({
+    where: { id: messageId, OR: [{ fromNumber: key }, { toNumber: key }], direction: "outbound" },
+    select: { id: true, raw: true },
+  });
+  if (!message) return NextResponse.json({ error: "Proposal message not found" }, { status: 404 });
+  const raw = (message.raw ?? {}) as Record<string, unknown>;
+  if (raw.proposalResolved === true) {
+    return NextResponse.json({ error: "This proposal was already applied." }, { status: 409 });
+  }
+
+  // The line must belong to THIS order, and the order must be open.
+  const item = await prisma.orderItem.findFirst({
+    where: { id: poItemId, orderId },
+    select: { id: true, unitPrice: true, order: { select: { status: true, orderNumber: true } } },
+  });
+  if (!item) return NextResponse.json({ error: "PO line not found on this order" }, { status: 404 });
+  if (item.order.status === "COMPLETED" || item.order.status === "CANCELLED") {
+    return NextResponse.json({ error: `PO ${item.order.orderNumber} is ${item.order.status.toLowerCase()} — can't edit.` }, { status: 400 });
+  }
+
+  if (action === "reduce_qty") {
+    if (typeof newQuantity !== "number" || newQuantity <= 0) {
+      return NextResponse.json({ error: "reduce_qty needs a positive newQuantity" }, { status: 400 });
+    }
+    await prisma.orderItem.update({
+      where: { id: item.id },
+      data: { quantity: newQuantity, totalPrice: Number(item.unitPrice) * newQuantity },
+    });
+  } else {
+    await prisma.orderItem.delete({ where: { id: item.id } });
+  }
+
+  // Recompute the order total from the remaining lines (+ keep delivery charge).
+  const [remaining, order] = await Promise.all([
+    prisma.orderItem.findMany({ where: { orderId }, select: { totalPrice: true } }),
+    prisma.order.findUnique({ where: { id: orderId }, select: { deliveryCharge: true } }),
+  ]);
+  const itemsTotal = remaining.reduce((s, i) => s + Number(i.totalPrice), 0);
+  const dc = order?.deliveryCharge ? Number(order.deliveryCharge) : 0;
+  await prisma.order.update({ where: { id: orderId }, data: { totalAmount: itemsTotal + dc } });
+
+  // Stamp the proposal resolved so the banner clears and it can't re-apply.
+  await prisma.whatsAppMessage.update({
+    where: { id: message.id },
+    data: { raw: { ...raw, proposalResolved: true, resolvedById: caller.id, resolvedAt: new Date().toISOString() } },
+  });
+
+  return NextResponse.json({ ok: true, action, orderId });
+}

--- a/apps/backoffice/src/app/api/inventory/supplier-chats/[key]/route.ts
+++ b/apps/backoffice/src/app/api/inventory/supplier-chats/[key]/route.ts
@@ -104,12 +104,15 @@ export async function GET(req: NextRequest, { params }: { params: Promise<{ key:
   // That's the "AI proposes / human approves" handoff — the human sees the
   // concrete suggested PO edit and acts on it (the agent never applies it).
   let agentProposal: {
+    messageId: string;
+    orderId: string | null;
     intent: string;
     escalationReason: string;
     paymentModel?: string;
     popDeliveryCritical?: boolean;
     poAction: {
       type: string;
+      poItemId: string | null;
       itemName: string | null;
       newQuantity: number | null;
       note: string | null;
@@ -119,13 +122,17 @@ export async function GET(req: NextRequest, { params }: { params: Promise<{ key:
   const lastOutbound = await prisma.whatsAppMessage.findFirst({
     where: { ...counter, direction: "outbound" },
     orderBy: { timestamp: "desc" },
-    select: { raw: true, timestamp: true },
+    select: { id: true, raw: true, timestamp: true },
   });
   const raw = (lastOutbound?.raw ?? null) as Record<string, unknown> | null;
-  if (raw && raw.escalated === true && raw.proposal && typeof raw.proposal === "object") {
+  // raw.proposalResolved is stamped when a human applies the proposal — once
+  // resolved, stop surfacing the banner even though it's still the last message.
+  if (raw && raw.escalated === true && raw.proposalResolved !== true && raw.proposal && typeof raw.proposal === "object") {
     const p = raw.proposal as Record<string, unknown>;
     const pa = (p.poAction ?? null) as Record<string, unknown> | null;
     agentProposal = {
+      messageId: lastOutbound!.id,
+      orderId: typeof p.orderId === "string" ? p.orderId : null,
       intent: String(p.intent ?? "unclear"),
       escalationReason: String(p.escalationReason ?? "guardrail"),
       paymentModel: typeof p.paymentModel === "string" ? p.paymentModel : undefined,
@@ -133,6 +140,7 @@ export async function GET(req: NextRequest, { params }: { params: Promise<{ key:
       poAction: pa
         ? {
             type: String(pa.type ?? ""),
+            poItemId: typeof pa.poItemId === "string" ? pa.poItemId : null,
             itemName: typeof pa.itemName === "string" ? pa.itemName : null,
             newQuantity: typeof pa.newQuantity === "number" ? pa.newQuantity : null,
             note: typeof pa.note === "string" ? pa.note : null,
@@ -144,10 +152,11 @@ export async function GET(req: NextRequest, { params }: { params: Promise<{ key:
 
   // A DRAFT re-source PO the agent opened to an alternative supplier after this
   // supplier said an item was OOS (internal — never mentioned to the supplier).
-  let agentReSource: { supplierName: string; orderNumber: string; qty: number; unit: string; existing: boolean } | null = null;
+  let agentReSource: { orderId: string | null; supplierName: string; orderNumber: string; qty: number; unit: string; existing: boolean } | null = null;
   if (raw && raw.reSource && typeof raw.reSource === "object") {
     const r = raw.reSource as Record<string, unknown>;
     agentReSource = {
+      orderId: typeof r.orderId === "string" ? r.orderId : null,
       supplierName: String(r.supplierName ?? ""),
       orderNumber: String(r.orderNumber ?? ""),
       qty: typeof r.qty === "number" ? r.qty : 0,

--- a/apps/backoffice/src/app/api/inventory/supplier-chats/[key]/route.ts
+++ b/apps/backoffice/src/app/api/inventory/supplier-chats/[key]/route.ts
@@ -142,5 +142,19 @@ export async function GET(req: NextRequest, { params }: { params: Promise<{ key:
     };
   }
 
-  return NextResponse.json({ key, supplierId, supplier, context, windowOpen, messages, agentProposal });
+  // A DRAFT re-source PO the agent opened to an alternative supplier after this
+  // supplier said an item was OOS (internal — never mentioned to the supplier).
+  let agentReSource: { supplierName: string; orderNumber: string; qty: number; unit: string; existing: boolean } | null = null;
+  if (raw && raw.reSource && typeof raw.reSource === "object") {
+    const r = raw.reSource as Record<string, unknown>;
+    agentReSource = {
+      supplierName: String(r.supplierName ?? ""),
+      orderNumber: String(r.orderNumber ?? ""),
+      qty: typeof r.qty === "number" ? r.qty : 0,
+      unit: typeof r.unit === "string" ? r.unit : "",
+      existing: r.existing === true,
+    };
+  }
+
+  return NextResponse.json({ key, supplierId, supplier, context, windowOpen, messages, agentProposal, agentReSource });
 }

--- a/apps/backoffice/src/lib/inventory/agents/resource-po.ts
+++ b/apps/backoffice/src/lib/inventory/agents/resource-po.ts
@@ -11,6 +11,7 @@ import { boundedReorderQty } from "@/lib/inventory/order-validation";
 // Idempotent: won't duplicate a pending re-source for the same product+supplier.
 
 export type ReSourceResult = {
+  orderId: string; // the draft PO's id (for deep-linking from the chat)
   supplierName: string;
   orderNumber: string;
   qty: number; // alternative-supplier package units
@@ -79,10 +80,10 @@ export async function createReSourcePO(opts: {
       notes: { startsWith: RESOURCE_NOTE_PREFIX },
       items: { some: { productId: opts.productId } },
     },
-    select: { orderNumber: true },
+    select: { id: true, orderNumber: true },
   });
   if (existing) {
-    return { supplierName: best.a.supplier.name, orderNumber: existing.orderNumber, qty: orderQty, unit, existing: true };
+    return { orderId: existing.id, supplierName: best.a.supplier.name, orderNumber: existing.orderNumber, qty: orderQty, unit, existing: true };
   }
 
   try {
@@ -111,9 +112,9 @@ export async function createReSourcePO(opts: {
           ],
         },
       },
-      select: { orderNumber: true },
+      select: { id: true, orderNumber: true },
     });
-    return { supplierName: best.a.supplier.name, orderNumber: order.orderNumber, qty: orderQty, unit, existing: false };
+    return { orderId: order.id, supplierName: best.a.supplier.name, orderNumber: order.orderNumber, qty: orderQty, unit, existing: false };
   } catch (e) {
     console.warn("[resource-po] create failed:", e instanceof Error ? e.message : e);
     return null;

--- a/apps/backoffice/src/lib/inventory/agents/resource-po.ts
+++ b/apps/backoffice/src/lib/inventory/agents/resource-po.ts
@@ -1,0 +1,121 @@
+import { prisma } from "@/lib/prisma";
+import { boundedReorderQty } from "@/lib/inventory/order-validation";
+
+// When the supplier-chat agent removes a line because the supplier is out of
+// stock, the need would otherwise vanish (stockout risk). createReSourcePO opens
+// a DRAFT purchase order to the next-cheapest alternative supplier for that
+// product, so procurement just reviews + sends it.
+//
+// SAFE: DRAFT only — never sent, no payment, no stock move. Internal: the
+// alternative supplier is NEVER surfaced to the supplier we're chatting with.
+// Idempotent: won't duplicate a pending re-source for the same product+supplier.
+
+export type ReSourceResult = {
+  supplierName: string;
+  orderNumber: string;
+  qty: number; // alternative-supplier package units
+  unit: string;
+  existing: boolean; // true if an existing draft re-source already covered it
+};
+
+const RESOURCE_NOTE_PREFIX = "Auto re-source by supplier-chat agent";
+
+export async function createReSourcePO(opts: {
+  productId: string;
+  productName: string;
+  baseQtyNeeded: number; // base units to re-source (the removed line's qty)
+  fromSupplierId: string; // the OOS supplier — excluded + never named to them
+  fromSupplierName: string;
+  outletId: string;
+  systemUserId: string;
+}): Promise<ReSourceResult | null> {
+  if (opts.baseQtyNeeded <= 0) return null;
+
+  // Alternative active suppliers carrying this product (exclude the OOS one).
+  const alts = await prisma.supplierProduct.findMany({
+    where: {
+      productId: opts.productId,
+      isActive: true,
+      price: { gt: 0 },
+      supplierId: { not: opts.fromSupplierId },
+      supplier: { status: "ACTIVE" },
+    },
+    select: {
+      price: true,
+      moq: true,
+      productPackageId: true,
+      supplier: { select: { id: true, name: true } },
+      productPackage: { select: { conversionFactor: true, packageLabel: true } },
+    },
+  });
+  if (alts.length === 0) return null;
+
+  // Cheapest per base unit.
+  const ranked = alts
+    .map((a) => {
+      const conv = a.productPackage ? Number(a.productPackage.conversionFactor) : 1;
+      return { a, conv: conv > 0 ? conv : 1, unitCost: Number(a.price) / (conv > 0 ? conv : 1) };
+    })
+    .sort((x, y) => x.unitCost - y.unitCost);
+  const best = ranked[0];
+  const altSupplierId = best.a.supplier.id;
+
+  const { orderQty } = boundedReorderQty({
+    neededBase: opts.baseQtyNeeded,
+    conversionFactor: best.conv,
+    moq: Number(best.a.moq) || 0,
+  });
+  const unitPrice = Number(best.a.price);
+  const unit = best.a.productPackage?.packageLabel ?? "unit";
+
+  // Idempotency: a pending (DRAFT) re-source for this supplier+outlet that
+  // already includes this product → don't open a second.
+  const existing = await prisma.order.findFirst({
+    where: {
+      supplierId: altSupplierId,
+      outletId: opts.outletId,
+      orderType: "PURCHASE_ORDER",
+      status: "DRAFT",
+      notes: { startsWith: RESOURCE_NOTE_PREFIX },
+      items: { some: { productId: opts.productId } },
+    },
+    select: { orderNumber: true },
+  });
+  if (existing) {
+    return { supplierName: best.a.supplier.name, orderNumber: existing.orderNumber, qty: orderQty, unit, existing: true };
+  }
+
+  try {
+    const outlet = await prisma.outlet.findUniqueOrThrow({ where: { id: opts.outletId }, select: { code: true } });
+    const count = await prisma.order.count({ where: { outletId: opts.outletId } });
+    const orderNumber = `CC-${outlet.code}-${String(count + 1).padStart(4, "0")}`;
+    const order = await prisma.order.create({
+      data: {
+        orderNumber,
+        orderType: "PURCHASE_ORDER",
+        outletId: opts.outletId,
+        supplierId: altSupplierId,
+        status: "DRAFT",
+        totalAmount: Math.round(orderQty * unitPrice * 100) / 100,
+        notes: `${RESOURCE_NOTE_PREFIX}: ${opts.productName} OOS at ${opts.fromSupplierName}. Review + send.`,
+        createdById: opts.systemUserId,
+        items: {
+          create: [
+            {
+              productId: opts.productId,
+              productPackageId: best.a.productPackageId || null,
+              quantity: orderQty,
+              unitPrice,
+              totalPrice: Math.round(orderQty * unitPrice * 100) / 100,
+            },
+          ],
+        },
+      },
+      select: { orderNumber: true },
+    });
+    return { supplierName: best.a.supplier.name, orderNumber: order.orderNumber, qty: orderQty, unit, existing: false };
+  } catch (e) {
+    console.warn("[resource-po] create failed:", e instanceof Error ? e.message : e);
+    return null;
+  }
+}

--- a/apps/backoffice/src/lib/inventory/agents/supplier-chat-agent.ts
+++ b/apps/backoffice/src/lib/inventory/agents/supplier-chat-agent.ts
@@ -194,7 +194,7 @@ export async function handleSupplierMessage(evt: SupplierMessageEvent): Promise<
     let appliedAction: PoActionType = "none";
     let deliveryUpdated: string | null = null;
     let invoiceCaptured = false;
-    let reSource: { supplierName: string; orderNumber: string; qty: number; unit: string; existing: boolean } | null = null;
+    let reSource: { orderId: string; supplierName: string; orderNumber: string; qty: number; unit: string; existing: boolean } | null = null;
 
     if (escalate) {
       // Never confirm an action we're not taking — send a safe holding line.
@@ -253,6 +253,7 @@ export async function handleSupplierMessage(evt: SupplierMessageEvent): Promise<
           escalationReason: decision.escalation_reason ?? "guardrail",
           paymentModel: pm.model,
           popDeliveryCritical: pm.popDeliveryCritical,
+          orderId: order.id,
           poAction:
             decision.po_action.type !== "none"
               ? {

--- a/apps/backoffice/src/lib/inventory/agents/supplier-chat-agent.ts
+++ b/apps/backoffice/src/lib/inventory/agents/supplier-chat-agent.ts
@@ -32,6 +32,7 @@ import { recordOutboundMessage } from "@/lib/whatsapp-store";
 import { parseSupplierDoc } from "@/lib/finance/parsers/supplier-doc";
 import { detectCreationFlags } from "@/lib/inventory/flag-detector";
 import { paymentModel, type PaymentModelInfo } from "@/lib/inventory/payment-model";
+import { createReSourcePO } from "@/lib/inventory/agents/resource-po";
 
 const anthropic = new Anthropic({ apiKey: process.env.ANTHROPIC_API_KEY });
 
@@ -193,6 +194,7 @@ export async function handleSupplierMessage(evt: SupplierMessageEvent): Promise<
     let appliedAction: PoActionType = "none";
     let deliveryUpdated: string | null = null;
     let invoiceCaptured = false;
+    let reSource: { supplierName: string; orderNumber: string; qty: number; unit: string; existing: boolean } | null = null;
 
     if (escalate) {
       // Never confirm an action we're not taking — send a safe holding line.
@@ -202,7 +204,26 @@ export async function handleSupplierMessage(evt: SupplierMessageEvent): Promise<
         decision.po_action.type === "remove_item" ||
         decision.po_action.type === "reduce_qty"
       ) {
-        appliedAction = await applyPoAction(order.id, decision.po_action);
+        const actionResult = await applyPoAction(order.id, decision.po_action);
+        appliedAction = actionResult.type;
+
+        // OOS removal → open a DRAFT re-source PO to the next-cheapest supplier
+        // so the need isn't dropped. Internal only — we never tell THIS supplier
+        // we're sourcing elsewhere; the supplier reply is unchanged.
+        if (actionResult.type === "remove_item" && actionResult.removed) {
+          const systemUser = await prisma.user.findFirst({ where: { role: "OWNER" }, select: { id: true } });
+          if (systemUser) {
+            reSource = await createReSourcePO({
+              productId: actionResult.removed.productId,
+              productName: actionResult.removed.productName,
+              baseQtyNeeded: actionResult.removed.baseQty,
+              fromSupplierId: supplier.id,
+              fromSupplierName: supplier.name,
+              outletId: order.outletId,
+              systemUserId: systemUser.id,
+            });
+          }
+        }
       }
       if (isValidIsoDate(decision.delivery_date)) {
         await applyDeliveryDate(order.id, decision.delivery_date);
@@ -269,13 +290,15 @@ export async function handleSupplierMessage(evt: SupplierMessageEvent): Promise<
         poNumber: order.orderNumber,
         paymentModel: pm.model,
         proposal,
+        reSource,
       },
     });
 
     console.log(
       `[supplier-agent] supplier=${supplier.name} po=${order.orderNumber} intent=${decision.intent} ` +
         `conf=${decision.confidence.toFixed(2)} action=${appliedAction} delivery=${deliveryUpdated ?? "-"} ` +
-        `invoice=${invoiceCaptured} escalate=${escalate} sent=${sent.ok}`,
+        `invoice=${invoiceCaptured} escalate=${escalate} sent=${sent.ok}` +
+        (reSource ? ` reSource=${reSource.orderNumber}->${reSource.supplierName}(${reSource.qty}${reSource.existing ? ",existing" : ""})` : ""),
     );
   } catch (err) {
     // Never let the agent break the webhook's 200.
@@ -283,19 +306,39 @@ export async function handleSupplierMessage(evt: SupplierMessageEvent): Promise<
   }
 }
 
-/** Apply a vetted, low-risk edit to the PO and recompute its total. */
+type RemovedLine = { productId: string; productName: string; baseQty: number };
+
+/**
+ * Apply a vetted, low-risk edit to the PO and recompute its total. For an OOS
+ * removal it also returns the removed line (base units) so the caller can
+ * re-source it from another supplier.
+ */
 async function applyPoAction(
   orderId: string,
   action: AgentDecision["po_action"],
-): Promise<PoActionType> {
-  if (!action.po_item_id) return "none";
+): Promise<{ type: PoActionType; removed?: RemovedLine }> {
+  if (!action.po_item_id) return { type: "none" };
   const item = await prisma.orderItem.findFirst({
     where: { id: action.po_item_id, orderId }, // ensure the line belongs to THIS order
-    select: { id: true, unitPrice: true },
+    select: {
+      id: true,
+      unitPrice: true,
+      quantity: true,
+      productId: true,
+      product: { select: { name: true } },
+      productPackage: { select: { conversionFactor: true } },
+    },
   });
-  if (!item) return "none";
+  if (!item) return { type: "none" };
 
+  let removed: RemovedLine | undefined;
   if (action.type === "remove_item") {
+    const conv = item.productPackage ? Number(item.productPackage.conversionFactor) : 1;
+    removed = {
+      productId: item.productId,
+      productName: item.product?.name ?? "item",
+      baseQty: Number(item.quantity) * (conv > 0 ? conv : 1),
+    };
     await prisma.orderItem.delete({ where: { id: item.id } });
   } else if (action.type === "reduce_qty" && action.new_quantity && action.new_quantity > 0) {
     const q = action.new_quantity;
@@ -304,7 +347,7 @@ async function applyPoAction(
       data: { quantity: q, totalPrice: Number(item.unitPrice) * q },
     });
   } else {
-    return "none";
+    return { type: "none" };
   }
 
   // Recompute the order total from the remaining lines.
@@ -314,7 +357,7 @@ async function applyPoAction(
   });
   const total = remaining.reduce((s, i) => s + Number(i.totalPrice), 0);
   await prisma.order.update({ where: { id: orderId }, data: { totalAmount: total } });
-  return action.type;
+  return { type: action.type, removed };
 }
 
 /** Update the PO's delivery date (informational — safe to auto-apply). */

--- a/docs/design/procurement-loop-retrospective-2026-06-26.md
+++ b/docs/design/procurement-loop-retrospective-2026-06-26.md
@@ -1,0 +1,137 @@
+# Procurement Loop — Retrospective & Learnings (2026-06-26)
+
+A reflective pass over the procurement build loop (PRs #500–#540) to capture
+what worked, what didn't, and the rules we carry into the next iterations. The
+goal isn't to re-list features — it's to learn from our own process so the next
+loop is faster and lower-defect.
+
+## The loop so far (what shipped)
+
+| PR | Theme | Loop role |
+|----|-------|-----------|
+| #500 | WhatsApp POP auto-send + supplier-chat capture | foundation |
+| #521 | Inbox reply/send (24h-window aware human takeover) | human-in-loop |
+| #523–#524 | Supplier Chats nav + theme | surface |
+| #526 | Full-auto supplier-chat AI agent | automation |
+| #529 | Agent loop: invoice chase + delivery-date + invoice capture | automation |
+| #532 | Reconciliation ledger, usage-variance, consumption data, QA fixes | decision data |
+| #537 | Live-refresh Supplier Chats inbox (poll + auto-scroll) | realtime |
+| #538 | Cap reorder qty (overstock/shelf-life) + alternative suppliers | decision quality |
+| #540 | Auto re-source OOS lines to alternative supplier | decision continuity |
+
+The arc: **capture → human reply → automate the reply → give the automation
+good data → make the data actionable.** That arc is sound. The friction was in
+*how* each step landed.
+
+---
+
+## What worked (keep doing)
+
+1. **Approval-gating every automated mutation.** The agent proposes; a human
+   approves. Re-source POs, substitution proposals, and qty edits all land as
+   DRAFT or as a held proposal — never an irreversible action. This is why we
+   could ship aggressive automation without fear. **Rule: an agent may compute
+   and stage, but a human commits anything with money or stock attached.**
+
+2. **Shadow-mode by default for risky engines.** The consumption engine shipped
+   computing-but-not-writing, gated behind `CONSUMPTION_ENGINE_ENABLED`. We got
+   the code reviewed and the math validated in production data *before* it could
+   move a number. **Rule: new engines ship in shadow; flip live only after the
+   shadow output is trusted.**
+
+3. **Pure core + DB shell split, with the pure half unit-tested.**
+   `boundedReorderQty`, `consumption.ts`, `usage-variance` core, `payment-model`,
+   `flag-detector` are all pure functions with vitest coverage; the DB-touching
+   wrappers (`consumption-post.ts`) are thin. This caught real logic bugs cheaply
+   and kept tests runnable.
+
+4. **Idempotency designed in, not bolted on.** The re-source PO checks for an
+   existing pending draft before opening another; invoice capture de-dupes.
+   Webhook-driven agents *will* fire twice — designing for it up front avoided a
+   class of duplicate-PO bugs.
+
+5. **Feature-flag + allowlist gating for the live agent.** `PROCUREMENT_AGENT_ENABLED`,
+   an allowlist on the last-8 phone digits, and a separate WhatsApp-send flag let
+   us dark-launch to one test supplier. **Rule: every external-effect path gets an
+   independent kill switch.**
+
+---
+
+## What hurt (stop doing / guard against)
+
+1. **Prisma `is`/`isNot` on *required* relations — hit TWICE** (usage-variance
+   route, then resource-po.ts). `is`/`isNot` are only for *nullable* to-one
+   relations; on a required relation Prisma errors at runtime, not compile time,
+   so CI's typecheck doesn't catch it. **Rule: filter required to-one relations
+   directly (`supplier: { status: "ACTIVE" }`), never `supplier: { is: {...} }`.
+   Reserve `is`/`isNot` for nullable relations only.** This is now the single most
+   repeated defect — worth a lint rule or a grep in pre-commit.
+
+2. **vitest can't resolve the `@/lib/*` alias.** The consumption test failed CI
+   with "Cannot find package '@/lib/prisma'" because a pure module imported prisma
+   transitively. Cost a red CI + a split. **Rule: anything that will be unit-tested
+   must not import prisma (even transitively). Keep the pure core import-clean.**
+
+3. **Branching off pre-squash history → guaranteed merge conflict.** PR #536 was
+   cut from a commit that the squash-merge had already collapsed on main,
+   conflicting with itself. Had to recreate the doc on fresh main as #539 and close
+   #536. **Rule: always `git fetch origin main && branch from origin/main` at the
+   start of each loop iteration. Never branch from a feature branch that's been
+   squash-merged.**
+
+4. **We built the data before we built the action — repeatedly.** Reconciliation
+   exceptions, agent proposals, re-sourced POs, report variances all shipped as
+   *read-only surfaces*. The staffer sees the computed answer, then has to leave
+   the screen and redo it by hand (open PO, edit line, save). We generated insight
+   and stranded it one click away from being useful. **This is the biggest systemic
+   miss.** **Rule: every computed recommendation ships with the button that acts on
+   it, in the same view. "Surfaced" is not "done."**
+
+5. **Realtime was an afterthought, fixed reactively.** The user had to report
+   "not realtime, need to refresh" before we added polling — and only to Supplier
+   Chats. The PO list, receivings, and invoices still go stale. **Rule: any list
+   that reflects a mutable workflow state polls or revalidates by default; don't
+   wait for the staleness complaint.**
+
+6. **Structural blockers were deferred silently, not tracked loudly.** Unit
+   normalization (StockBalance fragmented across packages with mixed base/pack
+   units) and recipe/BOM import are the two things gating consumption going live —
+   yet they live in scattered notes, not a visible blocker list. **Rule: keep the
+   "what's stopping us going live" list explicit and at the top of the loop, so we
+   don't keep building around the blocker.**
+
+---
+
+## The throughline: insight without action
+
+Four of the six "what hurt" items are really one root cause — **we optimized for
+producing correct information and under-invested in letting the staffer act on
+it.** The agent got smart (good data, caps, alternatives, re-sourcing) but the
+human's hands stayed slow (leave the page, find the record, redo by hand,
+refresh to confirm). The next phase of the loop should bias hard toward
+**closing the action gap**: apply/send buttons where the proposal lives, inline
+edits where the suggestion lives, live state without reloads.
+
+## Carry-forward rules (the checklist for the next iteration)
+
+- [ ] Branch from a freshly fetched `origin/main`.
+- [ ] Filter required relations directly; `is/isNot` only on nullable relations.
+- [ ] Pure/tested modules import zero prisma.
+- [ ] Every mutation an agent makes is DRAFT/held until a human commits it.
+- [ ] New engines ship in shadow behind a flag.
+- [ ] Webhook-driven writes are idempotent by construction.
+- [ ] **Ship the action with the insight — no read-only dead-ends.**
+- [ ] Mutable-state lists are realtime by default.
+- [ ] Keep the go-live blocker list (unit normalization, recipe import) explicit.
+
+## Known go-live blockers (explicit, so we stop building around them)
+
+1. **Unit normalization.** StockBalance is fragmented by `productPackageId` with
+   mixed package/base units and no normalization layer. Reorder math, consumption,
+   and variance all paper over this with per-call `conversionFactor` reads. Until
+   there's a single base-unit truth, every new calc re-derives it and risks drift.
+2. **Recipe/BOM import.** Consumption (expected usage) can't go live without
+   complete BOMs; menu items without recipes silently drop from variance.
+3. **Double-receiving idempotency at the GRN layer.** Receiving doesn't yet guard
+   a PO line from being received twice, and short deliveries drop the shortfall
+   need (no re-order) — the physical-world twin of the OOS re-source we just built.


### PR DESCRIPTION
## What

Two linked moves that make the supplier-chat agent's output **actionable in place**, plus a retrospective that motivated the second.

### 1. Auto re-source OOS lines (original scope)
When the agent removes a PO line because the supplier is out of stock, the need would otherwise silently vanish. `createReSourcePO` opens a **DRAFT** PO to the next-cheapest alternative supplier (ranked per-base-unit, `boundedReorderQty` for MOQ/caps, idempotent, internal-only — never named to the chatting supplier).

### 2. Act on the agent from the chat inbox (new)
The retrospective below flagged our recurring miss: we ship *read-only insight* and make staff leave the screen to act. The agent-proposal banner and the re-source banner were exactly that. Now:

- **Agent proposal → one-click "Apply"** for the two low-risk internal edits (`remove_item` / `reduce_qty`). New `apply-proposal` route validates the line belongs to the order, rejects closed POs, applies the edit, recomputes the total, and stamps `raw.proposalResolved` so the banner clears and it can't double-apply. Substitution / cancellation deliberately stay on the PO page (pricing / external-effect decisions a human should see in full).
- **"Open PO" deep links** on both banners. The external-effect *send* still happens on the PO page behind its existing guarded flow — **no second uncontrolled send path** (a rule from the retrospective).
- Plumbed `orderId` (proposal + re-source) and `poItemId` through the detail route.

### 3. Loop retrospective
`docs/design/procurement-loop-retrospective-2026-06-26.md` — what worked (approval-gating, shadow-mode, pure+tested cores, designed-in idempotency) and what hurt (Prisma `is`/`isNot` on required relations hit twice, vitest `@/lib` alias, branching off squash-merged history, and the systemic insight-without-action miss) across PRs #500→#540, with a carry-forward checklist and explicit go-live blockers.

## Safety
- Apply is limited to internal PO edits; no message is sent to any supplier.
- DRAFT re-source PO requires human review + send before anything happens.
- All paths fall through gracefully (null / 4xx) and never break the webhook 200.

🤖 Generated with [Claude Code](https://claude.com/claude-code)