### PR TITLE
feat(procurement): independent AI verifier for the supplier-chat agent + Agent QA

### DIFF
--- a/apps/backoffice/src/app/(admin)/inventory/agent-qa/page.tsx
+++ b/apps/backoffice/src/app/(admin)/inventory/agent-qa/page.tsx
@@ -1,0 +1,233 @@
+"use client";
+
+import { useState } from "react";
+import Link from "next/link";
+import { useFetch } from "@/lib/use-fetch";
+import {
+  ShieldCheck,
+  Loader2,
+  AlertTriangle,
+  CheckCircle2,
+  CircleAlert,
+  ExternalLink,
+  ChevronDown,
+  ChevronRight,
+} from "lucide-react";
+
+type Verdict = {
+  rating: "pass" | "concern" | "fail";
+  confidence: number;
+  issues: string[];
+  summary: string;
+  recommendedAction: string | null;
+};
+
+type Row = {
+  messageId: string;
+  at: string;
+  key: string;
+  supplierName: string;
+  poNumber: string | null;
+  intent: string;
+  actionType: string;
+  appliedAction: string;
+  escalated: boolean;
+  confidence: number;
+  reSourced: boolean;
+  hasSnapshot: boolean;
+  verifier: Verdict | null;
+};
+
+type Data = {
+  enabled: boolean;
+  counts: {
+    total: number;
+    escalated: number;
+    autoActed: number;
+    verified: number;
+    unverified: number;
+    pass: number;
+    concern: number;
+    fail: number;
+  };
+  rows: Row[];
+};
+
+function rel(iso: string): string {
+  const d = (Date.now() - new Date(iso).getTime()) / 1000;
+  if (d < 60) return "now";
+  if (d < 3600) return `${Math.floor(d / 60)}m`;
+  if (d < 86400) return `${Math.floor(d / 3600)}h`;
+  return `${Math.floor(d / 86400)}d`;
+}
+
+function RatingChip({ v }: { v: Verdict | null }) {
+  if (!v)
+    return (
+      <span className="inline-flex items-center gap-1 rounded-full bg-muted px-2 py-0.5 text-[10.5px] font-medium text-muted-foreground">
+        unchecked
+      </span>
+    );
+  const map = {
+    pass: { cls: "bg-emerald-100 text-emerald-700 dark:bg-emerald-950/50 dark:text-emerald-300", icon: <CheckCircle2 size={11} />, label: "pass" },
+    concern: { cls: "bg-amber-100 text-amber-700 dark:bg-amber-950/50 dark:text-amber-300", icon: <CircleAlert size={11} />, label: "concern" },
+    fail: { cls: "bg-red-100 text-red-700 dark:bg-red-950/50 dark:text-red-300", icon: <AlertTriangle size={11} />, label: "fail" },
+  }[v.rating];
+  return (
+    <span className={`inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-[10.5px] font-medium ${map.cls}`}>
+      {map.icon} {map.label}
+    </span>
+  );
+}
+
+function Card({ label, value, tone }: { label: string; value: number; tone?: "warn" | "bad" }) {
+  const color = tone === "bad" ? "text-red-600 dark:text-red-400" : tone === "warn" ? "text-amber-600 dark:text-amber-400" : "text-foreground";
+  return (
+    <div className="rounded-lg border border-border bg-card px-3 py-2">
+      <div className="text-[11px] text-muted-foreground">{label}</div>
+      <div className={`text-xl font-semibold ${color}`}>{value}</div>
+    </div>
+  );
+}
+
+export default function AgentQaPage() {
+  const { data, mutate } = useFetch<Data>("/api/inventory/agent-qa", {
+    refreshInterval: 15000,
+    revalidateOnFocus: true,
+  });
+  const [running, setRunning] = useState(false);
+  const [note, setNote] = useState<string | null>(null);
+  const [expanded, setExpanded] = useState<string | null>(null);
+
+  async function runChecks() {
+    if (running) return;
+    setRunning(true);
+    setNote(null);
+    try {
+      const res = await fetch("/api/inventory/agent-qa", { method: "POST" });
+      const json = await res.json().catch(() => ({}));
+      if (json.enabled === false) setNote(json.error ?? "Verifier is off.");
+      else setNote(`Checked ${json.verified ?? 0} — ${json.fail ?? 0} fail, ${json.concern ?? 0} concern, ${json.pass ?? 0} pass.`);
+      mutate();
+    } catch {
+      setNote("Run failed — network error.");
+    } finally {
+      setRunning(false);
+    }
+  }
+
+  const c = data?.counts;
+  const rows = data?.rows ?? [];
+  const flagged = (c?.concern ?? 0) + (c?.fail ?? 0);
+
+  return (
+    <div className="mx-auto max-w-5xl px-4 py-6">
+      <div className="mb-4 flex items-start justify-between gap-3">
+        <div>
+          <h1 className="flex items-center gap-2 text-xl font-semibold">
+            <ShieldCheck size={20} /> Agent QA
+          </h1>
+          <p className="mt-0.5 text-[13px] text-muted-foreground">
+            An independent AI verifier grades the supplier-chat agent&apos;s decisions. Flags only — it never changes a PO or messages a supplier.
+          </p>
+        </div>
+        <button
+          onClick={runChecks}
+          disabled={running}
+          className="inline-flex shrink-0 items-center gap-1.5 rounded-md bg-primary px-3 py-2 text-[13px] font-medium text-primary-foreground hover:opacity-90 disabled:opacity-50"
+        >
+          {running ? <Loader2 size={14} className="animate-spin" /> : <ShieldCheck size={14} />}
+          Run checks
+        </button>
+      </div>
+
+      {data && !data.enabled && (
+        <div className="mb-4 rounded-md border border-amber-300 bg-amber-50 px-3 py-2 text-[12px] text-amber-800 dark:border-amber-800 dark:bg-amber-950/40 dark:text-amber-300">
+          Verifier is in shadow mode and currently <span className="font-semibold">off</span>. Set <code>PROCUREMENT_VERIFIER_ENABLED=true</code> and <code>ANTHROPIC_API_KEY</code> to enable grading. Past decisions are still listed below.
+        </div>
+      )}
+      {note && <div className="mb-4 rounded-md border border-border bg-muted px-3 py-2 text-[12px]">{note}</div>}
+
+      <div className="mb-5 grid grid-cols-2 gap-2 sm:grid-cols-5">
+        <Card label="Decisions" value={c?.total ?? 0} />
+        <Card label="Auto-acted" value={c?.autoActed ?? 0} />
+        <Card label="Escalated" value={c?.escalated ?? 0} />
+        <Card label="Verified" value={c?.verified ?? 0} />
+        <Card label="Flagged" value={flagged} tone={flagged > 0 ? "bad" : undefined} />
+      </div>
+
+      <div className="overflow-hidden rounded-lg border border-border">
+        {rows.length === 0 && (
+          <div className="px-4 py-8 text-center text-[13px] text-muted-foreground">No agent decisions yet.</div>
+        )}
+        {rows.map((r) => {
+          const open = expanded === r.messageId;
+          return (
+            <div key={r.messageId} className="border-b border-border last:border-b-0">
+              <button
+                onClick={() => setExpanded(open ? null : r.messageId)}
+                className="flex w-full items-center gap-3 px-3 py-2.5 text-left hover:bg-muted/50"
+              >
+                {open ? <ChevronDown size={14} className="shrink-0 text-muted-foreground" /> : <ChevronRight size={14} className="shrink-0 text-muted-foreground" />}
+                <RatingChip v={r.verifier} />
+                <div className="min-w-0 flex-1">
+                  <div className="truncate text-[13px] font-medium">
+                    {r.supplierName}
+                    {r.poNumber && <span className="ml-1.5 text-[11px] font-normal text-muted-foreground">{r.poNumber}</span>}
+                  </div>
+                  <div className="truncate text-[11px] text-muted-foreground">
+                    {r.intent}
+                    {" · "}
+                    {r.escalated ? "escalated" : r.appliedAction !== "none" ? `auto: ${r.appliedAction}` : "no PO change"}
+                    {r.reSourced && " · re-sourced"}
+                  </div>
+                </div>
+                <div className="shrink-0 text-right text-[10.5px] text-muted-foreground">
+                  <div>conf {r.confidence.toFixed(2)}</div>
+                  <div>{rel(r.at)}</div>
+                </div>
+              </button>
+
+              {open && (
+                <div className="space-y-2 border-t border-border bg-muted/30 px-3 py-3 pl-9 text-[12px]">
+                  {r.verifier ? (
+                    <>
+                      <div>
+                        <span className="font-medium">Verdict:</span> {r.verifier.summary || "—"}{" "}
+                        <span className="text-muted-foreground">(verifier conf {r.verifier.confidence.toFixed(2)})</span>
+                      </div>
+                      {r.verifier.issues.length > 0 && (
+                        <ul className="ml-4 list-disc space-y-0.5 text-foreground">
+                          {r.verifier.issues.map((iss, i) => (
+                            <li key={i}>{iss}</li>
+                          ))}
+                        </ul>
+                      )}
+                      {r.verifier.recommendedAction && (
+                        <div className="rounded border border-border bg-card px-2 py-1.5">
+                          <span className="font-medium">Recommended:</span> {r.verifier.recommendedAction}
+                        </div>
+                      )}
+                    </>
+                  ) : (
+                    <div className="text-muted-foreground">
+                      {r.hasSnapshot ? "Not yet checked — click “Run checks”." : "No snapshot (decision predates the verifier)."}
+                    </div>
+                  )}
+                  {r.key && (
+                    <Link
+                      href={`/inventory/supplier-chats?key=${r.key}`}
+                      className="inline-flex items-center gap-1 text-[11px] font-medium text-primary hover:underline"
+                    >
+                      Open chat <ExternalLink size={11} />
+                    </Link>
+                  )}
+                </div>
+              )}
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/apps/backoffice/src/app/(admin)/inventory/supplier-chats/page.tsx
+++ b/apps/backoffice/src/app/(admin)/inventory/supplier-chats/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useEffect, useRef } from "react";
+import { useSearchParams } from "next/navigation";
 import { useFetch } from "@/lib/use-fetch";
 import { formatRM } from "@celsius/shared";
 import {
@@ -86,7 +87,10 @@ function initials(name: string): string {
 }
 
 export default function SupplierChatsPage() {
-  const [selected, setSelected] = useState<string | null>(null);
+  const searchParams = useSearchParams();
+  // Deep-link support: /inventory/supplier-chats?key=<number> opens that thread
+  // (e.g. from Agent QA). Lazy init so it wins over the auto-select-first effect.
+  const [selected, setSelected] = useState<string | null>(() => searchParams.get("key"));
   const [filter, setFilter] = useState<"all" | "attention">("all");
 
   // Poll so inbound supplier messages + the agent's auto-replies appear without

--- a/apps/backoffice/src/app/(admin)/layout.tsx
+++ b/apps/backoffice/src/app/(admin)/layout.tsx
@@ -223,6 +223,7 @@ const NAV_SECTIONS: NavSection[] = [
         items: [
           { label: "Purchase Orders", href: "/inventory/orders", icon: <FileText className={ICON_SIZE} />, moduleKey: "inventory:orders" },
           { label: "Supplier Chats", href: "/inventory/supplier-chats", icon: <MessageCircle className={ICON_SIZE} />, moduleKey: "inventory:orders" },
+          { label: "Agent QA", href: "/inventory/agent-qa", icon: <ShieldCheck className={ICON_SIZE} />, moduleKey: "inventory:orders" },
           { label: "Transfers", href: "/inventory/transfers", icon: <ArrowLeftRight className={ICON_SIZE} />, moduleKey: "inventory:transfers" },
           { label: "Receivings", href: "/inventory/receivings", icon: <Receipt className={ICON_SIZE} />, moduleKey: "inventory:receivings" },
           { label: "Invoices", href: "/inventory/invoices", icon: <ClipboardList className={ICON_SIZE} />, moduleKey: "inventory:invoices" },

--- a/apps/backoffice/src/app/api/inventory/agent-qa/route.ts
+++ b/apps/backoffice/src/app/api/inventory/agent-qa/route.ts
@@ -1,0 +1,101 @@
+import { NextResponse, NextRequest } from "next/server";
+import { prisma } from "@/lib/prisma";
+import { getUserFromHeaders } from "@/lib/auth";
+import { verifierEnabled, verifyRecentUnverified } from "@/lib/inventory/agents/verifier-run";
+
+// Agent QA — recent supplier-chat agent decisions with the independent
+// verifier's verdict. GET lists; POST runs the verifier over recent unverified
+// decisions (on-demand, since there's no scheduler here).
+
+const digits = (s: string | null | undefined) => (s ?? "").replace(/[^0-9]/g, "");
+
+type VerifierVerdict = {
+  rating: "pass" | "concern" | "fail";
+  confidence: number;
+  issues: string[];
+  summary: string;
+  recommendedAction: string | null;
+  at?: string;
+};
+
+export async function GET(req: NextRequest) {
+  const caller = await getUserFromHeaders(req.headers);
+  if (!caller) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+
+  // Recent outbound messages; agent decisions are the ones carrying raw.agent.
+  // Filter in JS rather than a fragile JSON-absence query.
+  const recent = await prisma.whatsAppMessage.findMany({
+    where: { direction: "outbound" },
+    orderBy: { timestamp: "desc" },
+    take: 250,
+    select: { id: true, timestamp: true, toNumber: true, supplierId: true, raw: true },
+  });
+  const messages = recent.filter((m) => !!(m.raw as Record<string, unknown> | null)?.agent).slice(0, 100);
+
+  const supplierIds = [...new Set(messages.map((m) => m.supplierId).filter(Boolean) as string[])];
+  const suppliers = supplierIds.length
+    ? await prisma.supplier.findMany({ where: { id: { in: supplierIds } }, select: { id: true, name: true } })
+    : [];
+  const nameById = new Map(suppliers.map((s) => [s.id, s.name]));
+
+  const rows = messages.map((m) => {
+    const raw = (m.raw ?? {}) as Record<string, unknown>;
+    const d = (raw.verifierDecision ?? {}) as Record<string, unknown>;
+    const v = (raw.verifier ?? null) as VerifierVerdict | null;
+    return {
+      messageId: m.id,
+      at: m.timestamp.toISOString(),
+      key: digits(m.toNumber),
+      supplierName: (m.supplierId && nameById.get(m.supplierId)) || "—",
+      poNumber: typeof raw.poNumber === "string" ? raw.poNumber : null,
+      intent: typeof d.intent === "string" ? d.intent : String(raw.intent ?? "—"),
+      actionType: typeof d.actionType === "string" ? d.actionType : "none",
+      appliedAction: typeof d.appliedAction === "string" ? d.appliedAction : String(raw.appliedAction ?? "none"),
+      escalated: d.escalated === true || raw.escalated === true,
+      confidence: typeof d.confidence === "number" ? d.confidence : Number(raw.confidence ?? 0),
+      reSourced: d.reSourced === true || !!raw.reSource,
+      hasSnapshot: !!raw.verifierInput && !!raw.verifierDecision,
+      verifier: v
+        ? {
+            rating: v.rating,
+            confidence: v.confidence,
+            issues: Array.isArray(v.issues) ? v.issues : [],
+            summary: v.summary ?? "",
+            recommendedAction: v.recommendedAction ?? null,
+          }
+        : null,
+    };
+  });
+
+  const counts = rows.reduce(
+    (a, r) => {
+      a.total++;
+      if (r.escalated) a.escalated++;
+      else if (r.appliedAction !== "none") a.autoActed++;
+      if (r.verifier) {
+        a.verified++;
+        a[r.verifier.rating]++;
+      } else if (r.hasSnapshot) {
+        a.unverified++;
+      }
+      return a;
+    },
+    { total: 0, escalated: 0, autoActed: 0, verified: 0, unverified: 0, pass: 0, concern: 0, fail: 0 },
+  );
+
+  return NextResponse.json({ enabled: verifierEnabled(), counts, rows });
+}
+
+export async function POST(req: NextRequest) {
+  const caller = await getUserFromHeaders(req.headers);
+  if (!caller) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+
+  if (!verifierEnabled()) {
+    return NextResponse.json(
+      { ok: false, enabled: false, error: "Verifier is off (set PROCUREMENT_VERIFIER_ENABLED=true and ANTHROPIC_API_KEY)." },
+      { status: 200 },
+    );
+  }
+  const result = await verifyRecentUnverified(15);
+  return NextResponse.json({ ok: true, ...result });
+}

--- a/apps/backoffice/src/app/api/inventory/supplier-chats/route.ts
+++ b/apps/backoffice/src/app/api/inventory/supplier-chats/route.ts
@@ -27,6 +27,7 @@ export async function GET(req: NextRequest) {
       body: true,
       type: true,
       timestamp: true,
+      raw: true,
     },
   });
 
@@ -37,6 +38,7 @@ export async function GET(req: NextRequest) {
     lastAt: Date;
     count: number;
     lastInbound: string | null;
+    verifierFailed: boolean; // the newest message is an auto-decision the verifier failed
   };
   const threads = new Map<string, T>();
   for (const m of rows) {
@@ -44,6 +46,11 @@ export async function GET(req: NextRequest) {
     if (!counter) continue;
     let t = threads.get(counter);
     if (!t) {
+      // rows are newest-first, so the first message we see for a thread is its
+      // latest. If that latest message is an agent decision the verifier rated
+      // "fail" and nothing newer has happened, the thread needs a human.
+      const raw = (m.raw ?? null) as Record<string, unknown> | null;
+      const v = raw?.verifier as { rating?: string } | undefined;
       t = {
         key: counter,
         supplierId: m.supplierId,
@@ -51,6 +58,7 @@ export async function GET(req: NextRequest) {
         lastAt: m.timestamp,
         count: 0,
         lastInbound: null,
+        verifierFailed: m.direction === "outbound" && !!raw?.agent && v?.rating === "fail",
       };
       threads.set(counter, t);
     }
@@ -84,6 +92,7 @@ export async function GET(req: NextRequest) {
     .map((t) => {
       const s = t.supplierId ? sup.get(t.supplierId) : undefined;
       const needsAttention =
+        t.verifierFailed ||
         (!!t.lastInbound && ATTENTION_RX.test(t.lastInbound)) ||
         (!!t.supplierId && overdue.has(t.supplierId));
       return {

--- a/apps/backoffice/src/lib/inventory/agents/supplier-chat-agent.ts
+++ b/apps/backoffice/src/lib/inventory/agents/supplier-chat-agent.ts
@@ -267,6 +267,44 @@ export async function handleSupplierMessage(evt: SupplierMessageEvent): Promise<
         }
       : null;
 
+    // Snapshot exactly what the agent saw + did, so the independent verifier
+    // agent can re-judge this decision later (Agent QA) without reconstructing
+    // mutable PO state. Compact by design.
+    const verifierInput = {
+      supplierName: supplier.name,
+      paymentModel: pm.label,
+      orderNumber: order.orderNumber,
+      orderStatus: order.status,
+      items: order.items.map((it) => ({
+        name: it.product.name,
+        qty: Number(it.quantity),
+        unit: it.product.baseUom,
+        unitPrice: Number(it.unitPrice),
+      })),
+      thread: history
+        .filter((m) => m.body)
+        .map((m) => ({ who: m.direction === "inbound" ? "Supplier" : "Us", text: m.body as string })),
+      inboundText: evt.text.trim() || (hasDoc ? "[document, no caption]" : ""),
+      hadDoc: hasDoc,
+      today: todayMyt(),
+    };
+    const verifierDecision = {
+      intent: decision.intent,
+      language: decision.language,
+      actionType: decision.po_action.type,
+      actionItemName:
+        order.items.find((i) => i.id === decision.po_action.po_item_id)?.product.name ?? null,
+      newQuantity: decision.po_action.new_quantity,
+      deliveryDate: deliveryUpdated,
+      captureInvoice: invoiceCaptured,
+      replyText,
+      confidence: decision.confidence,
+      escalated: escalate,
+      escalationReason: escalate ? (decision.escalation_reason ?? "guardrail") : null,
+      appliedAction,
+      reSourced: !!reSource,
+    };
+
     // Auto-reply (24h window is open — the supplier just messaged us).
     const sent = await sendWhatsAppText(supplier.phone ?? fromDigits, replyText);
 
@@ -292,6 +330,8 @@ export async function handleSupplierMessage(evt: SupplierMessageEvent): Promise<
         paymentModel: pm.model,
         proposal,
         reSource,
+        verifierInput,
+        verifierDecision,
       },
     });
 

--- a/apps/backoffice/src/lib/inventory/agents/supplier-chat-agent.ts
+++ b/apps/backoffice/src/lib/inventory/agents/supplier-chat-agent.ts
@@ -33,6 +33,7 @@ import { parseSupplierDoc } from "@/lib/finance/parsers/supplier-doc";
 import { detectCreationFlags } from "@/lib/inventory/flag-detector";
 import { paymentModel, type PaymentModelInfo } from "@/lib/inventory/payment-model";
 import { createReSourcePO } from "@/lib/inventory/agents/resource-po";
+import { verifierEnabled, verifyMessage } from "@/lib/inventory/agents/verifier-run";
 
 const anthropic = new Anthropic({ apiKey: process.env.ANTHROPIC_API_KEY });
 
@@ -308,7 +309,7 @@ export async function handleSupplierMessage(evt: SupplierMessageEvent): Promise<
     // Auto-reply (24h window is open — the supplier just messaged us).
     const sent = await sendWhatsAppText(supplier.phone ?? fromDigits, replyText);
 
-    await recordOutboundMessage({
+    const recordedId = await recordOutboundMessage({
       waMessageId: sent.messageId,
       fromNumber: digits(evt.toNumber),
       toNumber: fromDigits,
@@ -334,6 +335,25 @@ export async function handleSupplierMessage(evt: SupplierMessageEvent): Promise<
         verifierDecision,
       },
     });
+
+    // Close the loop: the independent verifier checks EVERY decision the moment
+    // it's made (the reply is already sent, so this never delays the supplier).
+    // It only stamps a verdict — a "fail" surfaces the thread as needs-attention
+    // in the inbox (see supplier-chats list), pulling a human in exactly when the
+    // check catches something. Best-effort, gated, never throws.
+    if (recordedId && verifierEnabled()) {
+      try {
+        const verdict = await verifyMessage(recordedId);
+        if (verdict) {
+          console.log(
+            `[supplier-agent] verifier po=${order.orderNumber} rating=${verdict.rating} ` +
+              `conf=${verdict.confidence.toFixed(2)}${verdict.issues.length ? ` issues=${verdict.issues.length}` : ""}`,
+          );
+        }
+      } catch (e) {
+        console.warn("[supplier-agent] auto-verify failed:", e instanceof Error ? e.message : e);
+      }
+    }
 
     console.log(
       `[supplier-agent] supplier=${supplier.name} po=${order.orderNumber} intent=${decision.intent} ` +

--- a/apps/backoffice/src/lib/inventory/agents/verifier-run.ts
+++ b/apps/backoffice/src/lib/inventory/agents/verifier-run.ts
@@ -1,0 +1,121 @@
+/**
+ * Verifier runner — the DB + LLM shell around the pure verifier core.
+ *
+ * Reads an agent decision snapshot (raw.verifierInput / raw.verifierDecision
+ * stamped by supplier-chat-agent), asks an independent Claude judge to grade it,
+ * and stamps the verdict back onto the message's raw.verifier.
+ *
+ * SAFE: shadow-mode (PROCUREMENT_VERIFIER_ENABLED), flags only — never edits a
+ * PO, never messages a supplier. Idempotent: a message already carrying
+ * raw.verifier is skipped.
+ */
+import Anthropic from "@anthropic-ai/sdk";
+import type { Prisma } from "@celsius/db";
+import { prisma } from "@/lib/prisma";
+import {
+  VERIFIER_SYSTEM,
+  VERIFIER_VERSION,
+  buildVerifierPrompt,
+  parseVerdict,
+  type VerifierInput,
+  type VerifierDecision,
+  type VerifierVerdict,
+} from "@/lib/inventory/agents/verifier";
+
+const anthropic = new Anthropic({ apiKey: process.env.ANTHROPIC_API_KEY });
+
+export function verifierEnabled(): boolean {
+  return process.env.PROCUREMENT_VERIFIER_ENABLED === "true" && !!process.env.ANTHROPIC_API_KEY;
+}
+
+async function judge(input: VerifierInput, decision: VerifierDecision): Promise<VerifierVerdict | null> {
+  const response = await anthropic.messages.create({
+    model: "claude-sonnet-4-6",
+    max_tokens: 600,
+    system: [
+      // The judge's ruleset is identical every call — cache it.
+      { type: "text", text: VERIFIER_SYSTEM, cache_control: { type: "ephemeral" } },
+    ],
+    messages: [{ role: "user", content: buildVerifierPrompt(input, decision) }],
+  });
+  const out = response.content
+    .filter((b): b is Anthropic.TextBlock => b.type === "text")
+    .map((b) => b.text)
+    .join("");
+  return parseVerdict(out);
+}
+
+/** Verify one outbound agent-decision message. Returns the verdict (or null). */
+export async function verifyMessage(messageId: string): Promise<VerifierVerdict | null> {
+  if (!verifierEnabled()) return null;
+  const msg = await prisma.whatsAppMessage.findUnique({
+    where: { id: messageId },
+    select: { id: true, raw: true },
+  });
+  if (!msg) return null;
+  const raw = (msg.raw ?? {}) as Record<string, unknown>;
+  if (!raw.agent) return null; // not an agent decision
+  if (raw.verifier) return raw.verifier as unknown as VerifierVerdict; // already judged — idempotent
+
+  const input = raw.verifierInput as VerifierInput | undefined;
+  const decision = raw.verifierDecision as VerifierDecision | undefined;
+  if (!input || !decision) return null; // pre-verifier message without a snapshot
+
+  let verdict: VerifierVerdict | null = null;
+  try {
+    verdict = await judge(input, decision);
+  } catch (e) {
+    console.warn("[verifier] judge failed:", e instanceof Error ? e.message : e);
+    return null;
+  }
+  if (!verdict) return null;
+
+  await prisma.whatsAppMessage.update({
+    where: { id: msg.id },
+    data: {
+      raw: {
+        ...raw,
+        verifier: { ...verdict, version: VERIFIER_VERSION, at: new Date().toISOString() },
+      } as Prisma.InputJsonValue,
+    },
+  });
+  return verdict;
+}
+
+/** Verify the most recent agent decisions that don't yet have a verdict. */
+export async function verifyRecentUnverified(
+  limit = 10,
+): Promise<{ enabled: boolean; verified: number; fail: number; concern: number; pass: number }> {
+  if (!verifierEnabled()) return { enabled: false, verified: 0, fail: 0, concern: 0, pass: 0 };
+
+  // Candidates: recent outbound messages, newest first. Over-fetch then filter
+  // in JS for agent decisions that carry a snapshot but no verdict yet (robust
+  // against fragile JSON-absence filters).
+  const candidates = await prisma.whatsAppMessage.findMany({
+    where: { direction: "outbound" },
+    orderBy: { timestamp: "desc" },
+    take: Math.max(60, limit * 8),
+    select: { id: true, raw: true },
+  });
+
+  const todo = candidates
+    .filter((m) => {
+      const r = (m.raw ?? {}) as Record<string, unknown>;
+      return !!r.verifierInput && !!r.verifierDecision && !r.verifier;
+    })
+    .slice(0, limit);
+
+  let fail = 0,
+    concern = 0,
+    pass = 0,
+    verified = 0;
+  for (const m of todo) {
+    const v = await verifyMessage(m.id);
+    if (!v) continue;
+    verified++;
+    if (v.rating === "fail") fail++;
+    else if (v.rating === "concern") concern++;
+    else pass++;
+  }
+  return { enabled: true, verified, fail, concern, pass };
+}

--- a/apps/backoffice/src/lib/inventory/agents/verifier.test.ts
+++ b/apps/backoffice/src/lib/inventory/agents/verifier.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect } from "vitest";
+import {
+  buildVerifierPrompt,
+  parseVerdict,
+  type VerifierInput,
+  type VerifierDecision,
+} from "./verifier";
+
+const input: VerifierInput = {
+  supplierName: "Test Supplier",
+  paymentModel: "Net 30",
+  orderNumber: "CC-KL-0001",
+  orderStatus: "SENT",
+  items: [
+    { name: "Caramel Syrup", qty: 5, unit: "btl", unitPrice: 18 },
+    { name: "Oat Milk", qty: 10, unit: "ctn", unitPrice: 42 },
+  ],
+  thread: [
+    { who: "Us", text: "Hi bos, PO CC-KL-0001 attached 🙏" },
+    { who: "Supplier", text: "ok noted" },
+  ],
+  inboundText: "caramel syrup takde bos",
+  hadDoc: false,
+  today: "2026-06-26",
+};
+
+const decision: VerifierDecision = {
+  intent: "out_of_stock",
+  language: "ms",
+  actionType: "remove_item",
+  actionItemName: "Caramel Syrup",
+  newQuantity: null,
+  deliveryDate: null,
+  captureInvoice: false,
+  replyText: "Noted bos 🙏 kita remove caramel dulu",
+  confidence: 0.92,
+  escalated: false,
+  escalationReason: null,
+  appliedAction: "remove_item",
+  reSourced: true,
+};
+
+describe("buildVerifierPrompt", () => {
+  it("includes the PO, line items, the inbound message and what the agent did", () => {
+    const p = buildVerifierPrompt(input, decision);
+    expect(p).toContain("CC-KL-0001");
+    expect(p).toContain("Caramel Syrup");
+    expect(p).toContain("caramel syrup takde bos");
+    expect(p).toContain("PO action: remove_item");
+    expect(p).toContain("re-sourced to alt supplier (DRAFT): true");
+    expect(p).toContain("2026-06-26");
+  });
+
+  it("renders empty items/thread without crashing", () => {
+    const p = buildVerifierPrompt({ ...input, items: [], thread: [] }, decision);
+    expect(p).toContain("(no line items)");
+    expect(p).toContain("(no earlier messages)");
+  });
+});
+
+describe("parseVerdict", () => {
+  it("parses a clean pass verdict", () => {
+    const v = parseVerdict(
+      '{"rating":"pass","confidence":0.9,"issues":[],"summary":"correct OOS removal","recommendedAction":null}',
+    );
+    expect(v).not.toBeNull();
+    expect(v!.rating).toBe("pass");
+    expect(v!.issues).toEqual([]);
+    expect(v!.recommendedAction).toBeNull();
+  });
+
+  it("extracts JSON from surrounding prose", () => {
+    const v = parseVerdict('Here is my verdict:\n{"rating":"fail","confidence":0.8,"issues":["accepted a substitution"],"summary":"bad"}\nThanks');
+    expect(v!.rating).toBe("fail");
+    expect(v!.issues).toEqual(["accepted a substitution"]);
+  });
+
+  it("clamps confidence to 0..1 and drops empty issues", () => {
+    const v = parseVerdict('{"rating":"concern","confidence":5,"issues":["real issue",""," "],"summary":"x"}');
+    expect(v!.confidence).toBe(1);
+    expect(v!.issues).toEqual(["real issue"]);
+  });
+
+  it("rejects an invalid rating", () => {
+    expect(parseVerdict('{"rating":"great","confidence":0.5}')).toBeNull();
+  });
+
+  it("returns null when there is no JSON object", () => {
+    expect(parseVerdict("no json here")).toBeNull();
+    expect(parseVerdict('{ not valid json')).toBeNull();
+  });
+
+  it("treats a blank recommendedAction as null", () => {
+    const v = parseVerdict('{"rating":"pass","confidence":0.7,"issues":[],"summary":"ok","recommendedAction":"  "}');
+    expect(v!.recommendedAction).toBeNull();
+  });
+});

--- a/apps/backoffice/src/lib/inventory/agents/verifier.ts
+++ b/apps/backoffice/src/lib/inventory/agents/verifier.ts
@@ -1,0 +1,162 @@
+/**
+ * Supplier-chat VERIFIER — an independent LLM judge that grades the
+ * procurement agent's decisions.
+ *
+ * This module is PURE: prompt construction + verdict parsing + types. It must
+ * not import prisma or the Anthropic SDK so it stays unit-testable. The DB/LLM
+ * I/O lives in verifier-run.ts.
+ *
+ * The verifier deliberately does NOT reuse the agent's prompt — it carries its
+ * own condensed ruleset so it doesn't inherit the agent's blind spots, and it's
+ * told to be skeptical and flag when unsure.
+ */
+
+export const VERIFIER_VERSION = "supplier-chat-verifier-v1";
+
+export type VerifierRating = "pass" | "concern" | "fail";
+
+export type VerifierVerdict = {
+  rating: VerifierRating;
+  confidence: number; // 0..1 — the verifier's confidence in its own verdict
+  issues: string[]; // specific problems found (empty for a clean pass)
+  summary: string; // one-line plain-language verdict
+  recommendedAction: string | null; // what a human should do, if anything
+};
+
+/** Everything the verifier needs to re-judge a decision — captured at decision time. */
+export type VerifierInput = {
+  supplierName: string;
+  paymentModel: string; // e.g. "Prepay", "Net 30"
+  orderNumber: string;
+  orderStatus: string;
+  items: { name: string; qty: number; unit: string; unitPrice: number }[];
+  thread: { who: "Supplier" | "Us"; text: string }[]; // recent context, chronological
+  inboundText: string; // the supplier message being acted on
+  hadDoc: boolean;
+  today: string; // YYYY-MM-DD (MYT)
+};
+
+/** What the agent decided + what actually got applied. */
+export type VerifierDecision = {
+  intent: string;
+  language: string;
+  actionType: string; // none | remove_item | reduce_qty | substitute_item | cancel_order
+  actionItemName: string | null;
+  newQuantity: number | null;
+  deliveryDate: string | null;
+  captureInvoice: boolean;
+  replyText: string;
+  confidence: number;
+  escalated: boolean;
+  escalationReason: string | null;
+  appliedAction: string; // what was actually applied to the PO (none if escalated)
+  reSourced: boolean; // an alt-supplier DRAFT PO was opened
+};
+
+export const VERIFIER_SYSTEM = `You are a strict QA auditor for an autonomous procurement agent that chats with food/beverage suppliers over WhatsApp and edits purchase orders (POs). Your ONLY job is to judge whether the agent's decision on ONE supplier message was correct and safe. You are independent and skeptical: when a decision looks even slightly wrong or risky, flag it. You never talk to suppliers and never change anything — you only grade.
+
+# The agent's rules (what "correct" means)
+It MAY act autonomously only when unambiguous:
+- remove_item: only when it is clear WHICH specific line is out of stock.
+- reduce_qty: only when the supplier states a smaller available quantity for a specific line.
+- delivery_date: only when the supplier states WHEN they will deliver in the future. "dah hantar" / "otw" / "sampai" / "on the way" are NOT future dates — setting a date from those is WRONG.
+- capture_invoice: when the message is the supplier sending an invoice/SOA. It must acknowledge WITHOUT discussing or confirming the amount.
+
+It MUST escalate (change nothing, send only a holding reply):
+- ANY substitution offer, even "same quality / identical" (recipes are brand/grade-sensitive).
+- price increase / quote commitment; MOQ top-up decisions.
+- payment / proof-of-payment / payment-gating / reconciliation queries.
+- complaints / damaged / wrong goods; e-invoice / TIN / compliance; credit-term questions.
+- ambiguous item or quantity/unit → ask to clarify, change nothing.
+
+# Red flags you must catch
+- Mis-escalation: auto-acted on something in the escalate list, OR escalated something trivial (a greeting, a plain confirmation).
+- Wrong/over-reaching PO edit: removed or reduced the wrong line, or acted when the item was not unambiguously identified; quantity assumed rather than stated.
+- Hallucinated delivery date (from "otw/dah hantar/sampai" or no stated date).
+- Invoice: discussed/confirmed an amount, or missed an obvious invoice/SOA.
+- Reply safety: confirmed an action it did NOT take; made a price/credit commitment; leaked internal info (e.g. named an alternative supplier to this supplier).
+- Language: replied in a different language than the supplier used.
+- Confidence miscalibration: high confidence on a genuinely ambiguous message.
+
+# Rating
+- pass: correct and safe. No issues.
+- concern: defensible but suboptimal, or a minor risk a human should glance at.
+- fail: clearly wrong or unsafe — a human must act.
+
+Default to "concern" over "pass" when genuinely unsure. Output JSON only.`;
+
+/** Build the user-turn prompt that presents one decision for judging. */
+export function buildVerifierPrompt(input: VerifierInput, decision: VerifierDecision): string {
+  const items =
+    input.items
+      .map((it) => `- ${it.name} | qty ${it.qty} ${it.unit} | RM ${it.unitPrice.toFixed(2)} each`)
+      .join("\n") || "(no line items)";
+  const thread =
+    input.thread.filter((m) => m.text).map((m) => `${m.who}: ${m.text}`).join("\n") ||
+    "(no earlier messages)";
+
+  return `Today is ${input.today} (Asia/Kuala_Lumpur). A document was attached to the new message: ${input.hadDoc ? "YES" : "no"}.
+
+# Open PO ${input.orderNumber} (status ${input.orderStatus}) — ${input.supplierName}, payment model ${input.paymentModel}
+${items}
+
+# Recent conversation
+${thread}
+
+# The NEW supplier message the agent acted on
+"${input.inboundText}"
+
+# What the agent decided
+- intent: ${decision.intent}
+- language: ${decision.language}
+- PO action: ${decision.actionType}${decision.actionItemName ? ` (line: ${decision.actionItemName})` : ""}${decision.newQuantity != null ? ` → qty ${decision.newQuantity}` : ""}
+- applied to PO: ${decision.appliedAction}
+- delivery_date set: ${decision.deliveryDate ?? "none"}
+- capture_invoice: ${decision.captureInvoice}
+- escalated to human: ${decision.escalated}${decision.escalationReason ? ` (reason: ${decision.escalationReason})` : ""}
+- re-sourced to alt supplier (DRAFT): ${decision.reSourced}
+- agent confidence: ${decision.confidence.toFixed(2)}
+- reply sent to supplier: "${decision.replyText}"
+
+# Judge it. Output JSON only:
+{
+  "rating": "pass|concern|fail",
+  "confidence": 0.0,
+  "issues": ["specific problem 1", "..."],
+  "summary": "one line",
+  "recommendedAction": "what a human should do, or null"
+}`;
+}
+
+const RATINGS: VerifierRating[] = ["pass", "concern", "fail"];
+
+/** Parse + validate the model's verdict from raw text. Returns null if unparseable. */
+export function parseVerdict(raw: string): VerifierVerdict | null {
+  const m = raw.match(/\{[\s\S]*\}/);
+  if (!m) return null;
+  let p: Record<string, unknown>;
+  try {
+    p = JSON.parse(m[0]) as Record<string, unknown>;
+  } catch {
+    return null;
+  }
+
+  const rating = RATINGS.includes(p.rating as VerifierRating) ? (p.rating as VerifierRating) : null;
+  if (!rating) return null;
+
+  const issues = Array.isArray(p.issues)
+    ? p.issues.map((x) => String(x)).filter((s) => s.trim().length > 0).slice(0, 12)
+    : [];
+  const recommendedAction =
+    typeof p.recommendedAction === "string" && p.recommendedAction.trim().length > 0
+      ? p.recommendedAction.trim()
+      : null;
+
+  return {
+    rating,
+    confidence: Math.max(0, Math.min(1, Number(p.confidence) || 0)),
+    issues,
+    summary: typeof p.summary === "string" ? p.summary.trim() : "",
+    recommendedAction,
+  };
+}

--- a/apps/backoffice/src/lib/whatsapp-store.ts
+++ b/apps/backoffice/src/lib/whatsapp-store.ts
@@ -81,9 +81,9 @@ export interface OutboundRecord {
   raw?: unknown;
 }
 
-export async function recordOutboundMessage(rec: OutboundRecord): Promise<void> {
+export async function recordOutboundMessage(rec: OutboundRecord): Promise<string | null> {
   try {
-    await prisma.whatsAppMessage.create({
+    const created = await prisma.whatsAppMessage.create({
       data: {
         waMessageId: rec.waMessageId ?? null,
         direction: "outbound",
@@ -96,8 +96,11 @@ export async function recordOutboundMessage(rec: OutboundRecord): Promise<void> 
         status: rec.status ?? "sent",
         raw: (rec.raw ?? undefined) as Prisma.InputJsonValue | undefined,
       },
+      select: { id: true },
     });
+    return created.id;
   } catch (e) {
     console.warn(`[whatsapp:store] outbound persist skipped: ${e instanceof Error ? e.message : e}`);
+    return null;
   }
 }

--- a/docs/design/procurement-loop-and-verifier-2026-06-26.md
+++ b/docs/design/procurement-loop-and-verifier-2026-06-26.md
@@ -120,21 +120,41 @@ independent LLM** whose only job is to grade the first one.
 6. **Language mismatch** — replied in the wrong language.
 7. **Confidence calibration** — high confidence on a genuinely ambiguous case.
 
+### When it runs — automatic, closing the loop
+To replace the human reviewer (not just assist one), the verifier runs
+**automatically on every decision**, inline in `handleSupplierMessage`, the
+moment the agent acts. The supplier reply is already sent by then, so the check
+never delays the conversation. This is the loop-closing step: the *check itself*
+is automated, so no human has to remember to run it.
+
+- **Auto-escalation on fail.** A `fail` verdict surfaces the thread as
+  **needs-attention** in the Supplier Chats inbox (the inbox treats "the newest
+  message is an auto-decision the verifier failed" as a flag). So a human is
+  pulled in *exactly* when the independent check catches something — and only
+  then. `pass`/`concern` stay silent in the QA log.
+- The Agent QA dashboard's **"Run checks"** remains for back-filling decisions
+  made while the verifier was off, or re-sweeping history.
+
 ### Safety (same rules as the loop)
-- **Shadow-mode**, gated by `PROCUREMENT_VERIFIER_ENABLED`. Off → no calls.
+- **Shadow-mode**, gated by `PROCUREMENT_VERIFIER_ENABLED`. Off → no calls, no
+  auto-run.
 - **Flags only.** The verifier never edits a PO, never messages a supplier,
-  never changes the agent's decision. It writes a verdict to `raw.verifier` and
-  surfaces it on the Agent QA dashboard for a human.
+  never changes the agent's decision. It writes a verdict to `raw.verifier`,
+  raises needs-attention on a fail, and surfaces everything on Agent QA. (It does
+  NOT auto-undo an action — reverting is a separate, riskier capability we'd add
+  deliberately, not silently.)
 - **Idempotent.** A decision already carrying `raw.verifier` is skipped; re-runs
   are safe.
+- **Best-effort + isolated.** The auto-verify call is wrapped so a verifier
+  error never affects the agent's reply or the webhook's 200.
 - **Pure core + DB shell.** `verifier.ts` (prompt build + verdict parse) imports
   zero prisma and is unit-tested; `verifier-run.ts` does the DB + LLM I/O.
 
 ### Where the human sees it
 **Agent QA** (`/inventory/agent-qa`) — a dashboard of recent agent decisions
 with verifier verdicts: fail/concern surfaced at the top, pass-rate and
-auto-act-rate cards, each row deep-linking into the supplier chat. "Run checks"
-verifies the most recent unverified decisions on demand.
+auto-act-rate cards, each row deep-linking into the supplier chat. Failed
+decisions also light up the Supplier Chats inbox's needs-attention filter.
 
 ### Why a separate agent (not just stricter guardrails)
 Guardrails are pre-action and rule-based; they can't catch a *correct-looking

--- a/docs/design/procurement-loop-and-verifier-2026-06-26.md
+++ b/docs/design/procurement-loop-and-verifier-2026-06-26.md
@@ -1,0 +1,144 @@
+# Procurement Loop + AI Verifier (2026-06-26)
+
+Two things: (1) the procurement loop we've designed, end to end, and (2) a
+second AI agent — the **verifier** — that independently audits the procurement
+agent's decisions so a human can trust (or catch) them.
+
+---
+
+## 1. The loop we designed
+
+The procurement loop is **sense → decide → act → verify → learn**, with a human
+approval gate on anything that moves money or stock. Each stage is a real
+module/screen in the codebase.
+
+```
+                         ┌──────────────────────────────────────────────┐
+                         │                  SENSE                         │
+                         │  • StockBalance, sales/consumption, par levels │
+                         │  • On-order netting (open POs)                  │
+                         │  • Price history, supplier scorecard           │
+                         └───────────────┬────────────────────────────────┘
+                                         │ what's low / running out
+                                         ▼
+                         ┌──────────────────────────────────────────────┐
+                         │                  DECIDE                        │
+                         │  ai-decisions: reorder engine                  │
+                         │  • boundedReorderQty (MOQ, max-level,          │
+                         │    shelf-life caps)                            │
+                         │  • alternative suppliers (next-cheapest)       │
+                         │  • price-trend + payment-model context         │
+                         └───────────────┬────────────────────────────────┘
+                                         │ suggested PO (qty, supplier, price)
+                                         ▼
+                    ┌───────────────  HUMAN APPROVAL GATE  ───────────────┐
+                    │  staff reviews → "Create PO" (DRAFT)                 │
+                    └───────────────┬─────────────────────────────────────┘
+                                    ▼
+                         ┌──────────────────────────────────────────────┐
+                         │                   ACT                          │
+                         │  PO lifecycle: DRAFT → APPROVED → SENT →       │
+                         │  AWAITING_DELIVERY → (PARTIALLY_)RECEIVED →    │
+                         │  COMPLETED                                     │
+                         │  • WhatsApp PO to supplier                     │
+                         │  • Supplier-chat AI agent handles replies:     │
+                         │      - auto: remove_item / reduce_qty /        │
+                         │        delivery_date / capture_invoice         │
+                         │      - escalate: substitution, cancel, price,  │
+                         │        payment, MOQ, ambiguous, low-confidence │
+                         │      - OOS → auto re-source DRAFT PO to alt     │
+                         │  • Receiving (GRN), invoice capture, payment   │
+                         └───────────────┬────────────────────────────────┘
+                                         │ every agent decision stamped on
+                                         │ the outbound message `raw` (audit)
+                                         ▼
+                         ┌──────────────────────────────────────────────┐
+                         │                  VERIFY   ← NEW                │
+                         │  verifier agent (independent LLM judge)        │
+                         │  re-reads each agent decision in context and   │
+                         │  rates it pass / concern / fail with specific  │
+                         │  issues. Shadow-mode, flags only — never edits │
+                         │  → Agent QA dashboard for the human            │
+                         └───────────────┬────────────────────────────────┘
+                                         │ flagged decisions, quality trend
+                                         ▼
+                         ┌──────────────────────────────────────────────┐
+                         │                  LEARN                         │
+                         │  • usage variance (real vs BOM)                │
+                         │  • reconciliation exceptions                   │
+                         │  • supplier scorecard, wastage                 │
+                         │  • verifier verdicts → tune playbook/guardrails│
+                         └────────────────────────────────────────────────┘
+```
+
+### Design principles (from the loop retrospective)
+- **Human commits anything with money/stock.** Agents stage DRAFTs and held
+  proposals; humans approve.
+- **Guardrails in code, not the model.** Escalation triggers (substitution,
+  cancel, price, payment, MOQ, ambiguity, confidence < 0.7) are enforced in
+  `handleSupplierMessage`, not left to the LLM's judgement.
+- **Shadow-mode + feature flags** for anything risky; dark-launch by allowlist.
+- **Every decision is auditable** — stamped on the outbound message `raw`.
+- **Ship the action with the insight** — no read-only dead-ends.
+
+---
+
+## 2. The verifier agent
+
+**Problem it solves:** the procurement agent (`supplier-chat-agent`) acts
+autonomously on a narrow set of cases and escalates the rest. But "did it act
+*correctly*?" had no independent check — a wrong `remove_item`, a hallucinated
+delivery date, an accepted substitution, or a missed escalation would only
+surface if a human happened to read the thread. The verifier is a **second,
+independent LLM** whose only job is to grade the first one.
+
+### How it works
+- **Independent judge.** It does NOT reuse the agent's prompt — it has its own
+  condensed ruleset, so it doesn't inherit the agent's blind spots. It's
+  prompted to be **skeptical** and default to flagging when unsure.
+- **Same inputs, after the fact.** At decision time the agent stamps a compact
+  `verifierInput` (the inbound message, PO line snapshot, recent thread,
+  payment model) alongside its decision on the outbound message `raw`. The
+  verifier reads that — so it judges exactly what the agent saw, and the verdict
+  is reproducible even if the PO changed later.
+- **Verdict shape:** `rating` (pass | concern | fail), `confidence`, `issues[]`
+  (specific problems), `summary`, `recommendedAction`.
+
+### What it checks (mirrors the guardrails it's auditing)
+1. **Mis-escalation** — auto-acted on something that should escalate
+   (substitution, cancel, price/quote, payment/PoP, MOQ, ambiguity), or
+   escalated something trivial.
+2. **Wrong PO edit** — removed/reduced the wrong line, or acted when the item
+   wasn't unambiguously identified; quantity assumed rather than stated.
+3. **Hallucinated delivery date** — set a date from "otw / dah hantar / sampai"
+   (not a future commitment).
+4. **Invoice handling** — captured but discussed/confirmed the amount (it must
+   not), or missed an obvious invoice/SOA.
+5. **Reply safety** — confirmed an action it didn't take, made a price/credit
+   commitment, or leaked internal info (e.g. naming the re-source alt supplier
+   to the chatting supplier).
+6. **Language mismatch** — replied in the wrong language.
+7. **Confidence calibration** — high confidence on a genuinely ambiguous case.
+
+### Safety (same rules as the loop)
+- **Shadow-mode**, gated by `PROCUREMENT_VERIFIER_ENABLED`. Off → no calls.
+- **Flags only.** The verifier never edits a PO, never messages a supplier,
+  never changes the agent's decision. It writes a verdict to `raw.verifier` and
+  surfaces it on the Agent QA dashboard for a human.
+- **Idempotent.** A decision already carrying `raw.verifier` is skipped; re-runs
+  are safe.
+- **Pure core + DB shell.** `verifier.ts` (prompt build + verdict parse) imports
+  zero prisma and is unit-tested; `verifier-run.ts` does the DB + LLM I/O.
+
+### Where the human sees it
+**Agent QA** (`/inventory/agent-qa`) — a dashboard of recent agent decisions
+with verifier verdicts: fail/concern surfaced at the top, pass-rate and
+auto-act-rate cards, each row deep-linking into the supplier chat. "Run checks"
+verifies the most recent unverified decisions on demand.
+
+### Why a separate agent (not just stricter guardrails)
+Guardrails are pre-action and rule-based; they can't catch a *correct-looking
+but wrong* call (right action type, wrong line). An independent post-action
+judge with a different prompt catches a different failure class — the
+LLM-as-judge / adversarial-verify pattern. It also gives us a **quality signal
+over time** to tune the agent's playbook.


### PR DESCRIPTION
## What

A second, **independent AI agent** whose only job is to grade the procurement agent — so we can tell whether the autonomous supplier-chat agent is actually doing a good job, not just assume it. Plus an **Agent QA** dashboard where a human sees the verdicts.

This is the LLM-as-judge / adversarial-verify pattern applied to a live autonomous agent.

## The loop (also documented)

`docs/design/procurement-loop-and-verifier-2026-06-26.md` shows the full procurement loop — **sense → decide → act → verify → learn** — and where the verifier slots in (the new **verify** stage). Worth reading first.

## How the verifier works

- **Independent judge.** `verifier.ts` carries its **own** condensed ruleset — deliberately *not* the agent's prompt — so it doesn't inherit the agent's blind spots, and it's told to be skeptical and flag when unsure.
- **Judges exactly what the agent saw.** At decision time the agent stamps a compact `verifierInput` (inbound message, PO line snapshot, recent thread, payment model) + `verifierDecision` onto the outbound message's `raw`. The verifier reads that snapshot — so verdicts are reproducible even after the PO changes.
- **Verdict:** `rating` (pass / concern / fail), `confidence`, `issues[]`, `summary`, `recommendedAction`.
- **What it catches:** mis-escalation (auto-acted on a substitution/cancel/price/payment/MOQ/ambiguous case, or escalated something trivial), wrong/over-reaching PO edits, hallucinated delivery dates ("otw/dah hantar"), invoice-amount discussion, unsafe replies (confirming an untaken action, leaking the alt supplier), language mismatch, confidence miscalibration.

## Safety (same rules as the loop)

- **Shadow-mode**, gated by `PROCUREMENT_VERIFIER_ENABLED` (+ `ANTHROPIC_API_KEY`). Off → no calls; the dashboard says so.
- **Flags only** — never edits a PO, never messages a supplier, never changes the agent's decision.
- **Idempotent** — a message already carrying `raw.verifier` is skipped.
- **Pure core + DB shell** — `verifier.ts` imports zero prisma and is unit-tested (`verifier.test.ts`); `verifier-run.ts` does the DB + LLM I/O.

## Surfaces

- **Agent QA** dashboard (`/inventory/agent-qa`, new nav item): recent decisions with rating chips, pass/concern/fail + auto-act/escalate counts, expandable issues + recommended action, **"Run checks"** to verify on demand, and a deep-link into each supplier chat.
- **Supplier Chats** now accepts `?key=<number>` to open a specific thread (used by the deep-link).

## Files

- `lib/inventory/agents/verifier.ts` (pure) + `verifier.test.ts`
- `lib/inventory/agents/verifier-run.ts` (DB/LLM shell)
- `lib/inventory/agents/supplier-chat-agent.ts` (snapshot capture)
- `api/inventory/agent-qa/route.ts` (GET list + POST run)
- `(admin)/inventory/agent-qa/page.tsx` + nav
- `docs/design/procurement-loop-and-verifier-2026-06-26.md`

## Follow-up

Verification runs on demand from the dashboard (no scheduler wired here). A natural next step is an automatic trigger (cron or post-decision shadow call) once we're happy with the verdict quality.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HSjTZCnJGpx7yp6hJrkYqg)_