### PR TITLE
feat(procurement): wire PO auto-send (#2) + staff GRN chaser (#5)

### DIFF
--- a/apps/backoffice/src/app/api/cron/request-receivings/route.ts
+++ b/apps/backoffice/src/app/api/cron/request-receivings/route.ts
@@ -1,0 +1,30 @@
+import { NextRequest, NextResponse } from "next/server";
+import { checkCronAuth } from "@celsius/shared";
+import { getSession } from "@/lib/auth";
+import { runReceivingRequests } from "@/lib/inventory/agents/receiving-requester";
+
+export const dynamic = "force-dynamic";
+export const maxDuration = 120;
+
+// GET /api/cron/request-receivings — the GRN chaser. Reminds staff to receive POs
+// that should have arrived but have no Receiving yet (gated + allow-listed,
+// de-duped per PO). Scheduled in vercel.json.
+//
+// Auth: the Vercel cron secret (checkCronAuth), or an authenticated OWNER/ADMIN
+// (so it can be run on demand for testing without the secret).
+export async function GET(req: NextRequest) {
+  const cronAuth = checkCronAuth(req.headers);
+  if (!cronAuth.ok) {
+    const user = await getSession();
+    if (!user || !["OWNER", "ADMIN"].includes(user.role)) {
+      return NextResponse.json({ error: cronAuth.error }, { status: cronAuth.status });
+    }
+  }
+  try {
+    const result = await runReceivingRequests();
+    return NextResponse.json({ ok: true, ...result });
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : "request-receivings failed";
+    return NextResponse.json({ error: msg }, { status: 500 });
+  }
+}

--- a/apps/backoffice/src/app/api/inventory/orders/[id]/route.ts
+++ b/apps/backoffice/src/app/api/inventory/orders/[id]/route.ts
@@ -2,6 +2,7 @@ import { NextResponse, NextRequest } from "next/server";
 import { prisma } from "@/lib/prisma";
 import { getUserFromHeaders } from "@/lib/auth";
 import { computeDepositAmount } from "@/lib/inventory/deposit";
+import { sendPurchaseOrder } from "@/lib/inventory/procurement-po-send";
 
 export async function GET(_req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   try {
@@ -156,6 +157,13 @@ export async function PATCH(req: NextRequest, { params }: { params: Promise<{ id
         invoices: true,
       },
     });
+
+    // Auto-send the order block to the supplier on the SENT / AWAITING_DELIVERY
+    // transition (gated + allow-listed + de-duped per PO). Awaited so it runs to
+    // completion before the response; it's internally guarded and never throws.
+    if (status === "SENT" || status === "AWAITING_DELIVERY") {
+      await sendPurchaseOrder(order);
+    }
 
     // Cascade cancel: when a PO is cancelled, drop any GRNI placeholder
     // invoices auto-attached to it. Without this, the placeholder lingers

--- a/apps/backoffice/src/lib/inventory/agents/receiving-requester.ts
+++ b/apps/backoffice/src/lib/inventory/agents/receiving-requester.ts
@@ -1,0 +1,166 @@
+/**
+ * Staff GRN chaser — reminds staff to RECEIVE (GRN) a PO that should have arrived
+ * but has no receiving recorded. Finds PURCHASE ORDERs that are sent/awaiting,
+ * past their delivery date (or 2+ days after they were sent when no date is set),
+ * with NO Receiving, and messages the responsible staff to do the goods-receipt
+ * in the app — so a delivered order doesn't sit un-received and silently break
+ * stock + invoice matching.
+ *
+ * Cron /api/cron/request-receivings. Gated by PROCUREMENT_AGENT_ENABLED, scoped to
+ * allow-listed SUPPLIERS (PROCUREMENT_AGENT_ALLOWLIST) during rollout. Messages the
+ * PO creator; set PROCUREMENT_RECEIVING_CHASE_TO to route all chases to one number
+ * for testing. Free text inside the 24h window; outside it skipped + logged (a
+ * staff-reminder template is the production path). De-duped per PO via
+ * raw.receivingChaseFor. Never throws.
+ */
+import type { OrderStatus } from "@celsius/db";
+import { prisma } from "@/lib/prisma";
+import { sendWhatsAppText } from "@/lib/whatsapp";
+import { recordOutboundMessage } from "@/lib/whatsapp-store";
+
+export const RECEIVING_REQUESTER_VERSION = "receiving-requester-v1";
+
+const digits = (s: string | null | undefined) => (s ?? "").replace(/[^0-9]/g, "");
+
+// "Supplier has it / due" but not yet (fully) received. PARTIALLY_RECEIVED already
+// has a Receiving, so the `receivings none` filter excludes it anyway.
+const DUE_STATUSES: OrderStatus[] = ["SENT", "CONFIRMED", "AWAITING_DELIVERY"];
+
+function enabled(): boolean {
+  return process.env.PROCUREMENT_AGENT_ENABLED === "true";
+}
+
+function allowedSupplier(phone: string | null | undefined): boolean {
+  const raw = process.env.PROCUREMENT_AGENT_ALLOWLIST?.trim();
+  if (!raw) return true;
+  const tail = digits(phone).slice(-8);
+  if (!tail) return false;
+  return raw
+    .split(",")
+    .map((s) => digits(s).slice(-8))
+    .filter(Boolean)
+    .includes(tail);
+}
+
+const firstName = (name: string | null | undefined) => (name || "team").trim().split(/\s+/)[0];
+
+export interface ReceivingRequestSummary {
+  scanned: number;
+  requested: number;
+  skipped: number;
+}
+
+export async function runReceivingRequests(): Promise<ReceivingRequestSummary> {
+  if (!enabled()) return { scanned: 0, requested: 0, skipped: 0 };
+
+  const now = new Date();
+  const staleSentBefore = new Date(now.getTime() - 2 * 24 * 60 * 60 * 1000);
+
+  const orders = await prisma.order.findMany({
+    where: {
+      orderType: "PURCHASE_ORDER",
+      status: { in: DUE_STATUSES },
+      receivings: { none: {} },
+      supplier: { phone: { not: null }, status: "ACTIVE" },
+      OR: [
+        { deliveryDate: { lt: now } },
+        { deliveryDate: null, sentAt: { lt: staleSentBefore } },
+      ],
+    },
+    orderBy: { createdAt: "asc" },
+    take: 100,
+    select: {
+      id: true,
+      orderNumber: true,
+      deliveryDate: true,
+      supplier: { select: { name: true, phone: true } },
+      outlet: { select: { name: true } },
+      createdBy: { select: { name: true, phone: true } },
+    },
+  });
+
+  let requested = 0;
+  let skipped = 0;
+  for (const o of orders) {
+    if (!o.supplier?.phone || !allowedSupplier(o.supplier.phone)) {
+      skipped++;
+      continue;
+    }
+    const ok = await chaseOne(o);
+    if (ok) requested++;
+    else skipped++;
+  }
+  return { scanned: orders.length, requested, skipped };
+}
+
+type DueOrder = {
+  id: string;
+  orderNumber: string;
+  deliveryDate: Date | null;
+  supplier: { name: string; phone: string | null } | null;
+  outlet: { name: string } | null;
+  createdBy: { name: string | null; phone: string | null } | null;
+};
+
+async function chaseOne(o: DueOrder): Promise<boolean> {
+  try {
+    // Dedupe: already chased this PO?
+    const already = await prisma.whatsAppMessage.findFirst({
+      where: { direction: "outbound", raw: { path: ["receivingChaseFor"], equals: o.id } },
+      select: { id: true },
+    });
+    if (already) return false;
+
+    // Route to the PO creator, or the test override.
+    const override = process.env.PROCUREMENT_RECEIVING_CHASE_TO?.trim();
+    const dest = digits(override || o.createdBy?.phone);
+    if (dest.length < 8) return false; // no usable recipient
+
+    // 24h window with this recipient?
+    const lastInbound = await prisma.whatsAppMessage.findFirst({
+      where: { fromNumber: dest, direction: "inbound" },
+      orderBy: { timestamp: "desc" },
+      select: { timestamp: true },
+    });
+    const windowOpen =
+      !!lastInbound && Date.now() - +new Date(lastInbound.timestamp) < 24 * 60 * 60 * 1000;
+
+    const name = firstName(o.createdBy?.name);
+    const supplierName = o.supplier?.name ?? "supplier";
+    const dateStr = o.deliveryDate ? new Date(o.deliveryDate).toISOString().slice(0, 10) : null;
+    const text =
+      `Hi ${name} 🙏 PO ${o.orderNumber} dari ${supplierName}` +
+      `${dateStr ? ` (delivery ${dateStr})` : ""} sepatutnya dah sampai. ` +
+      `Dah terima barang? Tolong update receiving/GRN dalam app ya. Terima kasih!`;
+
+    if (!windowOpen) {
+      console.log(
+        `[receiving-requester] po=${o.orderNumber} skipped — 24h window closed for staff (needs a reminder template)`,
+      );
+      return false;
+    }
+
+    const res = await sendWhatsAppText(dest, text);
+    await recordOutboundMessage({
+      waMessageId: res.messageId,
+      fromNumber: "",
+      toNumber: dest,
+      type: "text",
+      body: text,
+      supplierId: null,
+      status: res.ok ? "sent" : "failed",
+      raw: {
+        agent: RECEIVING_REQUESTER_VERSION,
+        receivingChaseFor: o.id,
+        poNumber: o.orderNumber,
+        ok: res.ok,
+        error: res.error ?? null,
+      },
+    });
+    console.log(`[receiving-requester] po=${o.orderNumber} staff=${name} sent=${res.ok}`);
+    return res.ok;
+  } catch (err) {
+    console.error("[receiving-requester] error:", err instanceof Error ? err.message : err);
+    return false;
+  }
+}

--- a/apps/backoffice/src/lib/inventory/procurement-po-send.ts
+++ b/apps/backoffice/src/lib/inventory/procurement-po-send.ts
@@ -1,0 +1,127 @@
+/**
+ * Auto-send the PO order block to the supplier when a PO transitions to SENT /
+ * AWAITING_DELIVERY. Reuses the EXISTING `formatWhatsAppOrder` 📋 block — the
+ * same message staff send by hand via wa.me today — so suppliers see the format
+ * they already know.
+ *
+ * Gated by PROCUREMENT_AGENT_ENABLED + PROCUREMENT_AGENT_ALLOWLIST (scoped to the
+ * test supplier for the first live run). De-duped per PO via the outbound row's
+ * raw.poSentFor. Free text inside the 24h customer-service window; OUTSIDE it the
+ * send is skipped + logged — a business-initiated `purchase_order` template is the
+ * production path for cold sends and isn't wired here yet. Never throws.
+ */
+import { prisma } from "@/lib/prisma";
+import { sendWhatsAppText } from "@/lib/whatsapp";
+import { recordOutboundMessage } from "@/lib/whatsapp-store";
+import { formatWhatsAppOrder } from "@celsius/shared";
+
+export const PO_SEND_VERSION = "po-send-v1";
+
+const digits = (s: string | null | undefined) => (s ?? "").replace(/[^0-9]/g, "");
+
+function enabled(): boolean {
+  return process.env.PROCUREMENT_AGENT_ENABLED === "true";
+}
+
+function allowed(phone: string | null | undefined): boolean {
+  const raw = process.env.PROCUREMENT_AGENT_ALLOWLIST?.trim();
+  if (!raw) return true;
+  const tail = digits(phone).slice(-8);
+  if (!tail) return false;
+  return raw
+    .split(",")
+    .map((s) => digits(s).slice(-8))
+    .filter(Boolean)
+    .includes(tail);
+}
+
+// What we read off the order the PATCH route already loaded (outlet + supplier +
+// items.product included). Loose shapes so the caller can pass its richer object.
+export interface PoForSend {
+  id: string;
+  orderNumber: string;
+  deliveryDate: Date | null;
+  outlet: { name: string; address: string | null };
+  supplier: { id: string; name: string; phone: string | null } | null;
+  items: Array<{ quantity: unknown; product: { name: string; baseUom: string } | null }>;
+}
+
+export async function sendPurchaseOrder(order: PoForSend): Promise<void> {
+  try {
+    if (!enabled()) return;
+    const supplier = order.supplier;
+    if (!supplier?.phone || !allowed(supplier.phone)) return;
+    const dest = digits(supplier.phone);
+
+    // Dedupe: already sent this PO once?
+    const already = await prisma.whatsAppMessage.findFirst({
+      where: { direction: "outbound", raw: { path: ["poSentFor"], equals: order.id } },
+      select: { id: true },
+    });
+    if (already) return;
+
+    // 24h window? (supplier messaged us within the last 24h)
+    const lastInbound = await prisma.whatsAppMessage.findFirst({
+      where: { supplierId: supplier.id, direction: "inbound" },
+      orderBy: { timestamp: "desc" },
+      select: { timestamp: true },
+    });
+    const windowOpen =
+      !!lastInbound && Date.now() - +new Date(lastInbound.timestamp) < 24 * 60 * 60 * 1000;
+    if (!windowOpen) {
+      console.log(
+        `[po-send] po=${order.orderNumber} skipped — 24h window closed (cold send needs the purchase_order template)`,
+      );
+      return;
+    }
+
+    const message = formatWhatsAppOrder({
+      outletName: order.outlet.name,
+      orderNumber: order.orderNumber,
+      date: new Date().toISOString().slice(0, 10),
+      items: order.items
+        .filter((it) => it.product)
+        .map((it) => ({
+          name: it.product!.name,
+          quantity: Number(it.quantity),
+          uom: it.product!.baseUom,
+        })),
+      deliveryDate: order.deliveryDate
+        ? new Date(order.deliveryDate).toISOString().slice(0, 10)
+        : undefined,
+      address: order.outlet.address ?? undefined,
+    });
+
+    const res = await sendWhatsAppText(dest, message);
+
+    // Resolve our own business number from a recent message so the row threads right.
+    const ref = await prisma.whatsAppMessage.findFirst({
+      where: { supplierId: supplier.id },
+      orderBy: { timestamp: "desc" },
+      select: { direction: true, fromNumber: true, toNumber: true },
+    });
+    const ourNumber = ref ? (ref.direction === "inbound" ? ref.toNumber : ref.fromNumber) : "";
+
+    await recordOutboundMessage({
+      waMessageId: res.messageId,
+      fromNumber: ourNumber,
+      toNumber: dest,
+      type: "text",
+      body: message,
+      supplierId: supplier.id,
+      status: res.ok ? "sent" : "failed",
+      raw: {
+        agent: PO_SEND_VERSION,
+        poSentFor: order.id,
+        poNumber: order.orderNumber,
+        via: "freetext",
+        ok: res.ok,
+        error: res.error ?? null,
+      },
+    });
+
+    console.log(`[po-send] po=${order.orderNumber} supplier=${supplier.name} sent=${res.ok}`);
+  } catch (err) {
+    console.error("[po-send] error:", err instanceof Error ? err.message : err);
+  }
+}

--- a/apps/backoffice/vercel.json
+++ b/apps/backoffice/vercel.json
@@ -123,6 +123,10 @@
     {
       "path": "/api/cron/consumption-post",
       "schedule": "25 19 * * *"
+    },
+    {
+      "path": "/api/cron/request-receivings",
+      "schedule": "0 */6 * * *"
     }
   ]
 }


### PR DESCRIPTION
Closes the two remaining gaps in the procurement e2e loop (the runbook's "not wired" items).

## #2 — PO auto-send to supplier
On the **SENT / AWAITING_DELIVERY** transition, the orders PATCH route now sends the supplier the **existing** `formatWhatsAppOrder` 📋 order block (the same one staff send by hand via wa.me today — not a new format).
- `lib/inventory/procurement-po-send.ts` — gated by `PROCUREMENT_AGENT_ENABLED` + `PROCUREMENT_AGENT_ALLOWLIST`, **de-duped per PO** (`raw.poSentFor`).
- Free text inside the 24h window; **cold sends log-skip** pending the business-initiated `purchase_order` template (the documented production path).

## #5 — staff GRN / receiving chaser
Cron `/api/cron/request-receivings` (every 6h) finds POs that are sent/awaiting, **past their delivery date** (or 2d+ after sent) with **no Receiving**, and messages the **PO creator** to do the goods-receipt in the app.
- `lib/inventory/agents/receiving-requester.ts` — gated + supplier-allow-listed, de-duped (`raw.receivingChaseFor`).
- `PROCUREMENT_RECEIVING_CHASE_TO` env routes all chases to one number for testing.
- Cron-secret auth **+ OWNER/ADMIN manual trigger**.

## Shared posture
Both reuse the agent's flag + allow-list, never throw, and degrade gracefully out-of-window. The 24h-window/template constraint is the one production follow-up for cold (un-prompted) sends.

🤖 Generated with [Claude Code](https://claude.com/claude-code)