### PR TITLE
feat(procurement): per-supplier automation dial — AUTO/ASSIST/OFF (Phase 1)

### DIFF
--- a/apps/backoffice/src/app/api/inventory/suppliers/[id]/route.ts
+++ b/apps/backoffice/src/app/api/inventory/suppliers/[id]/route.ts
@@ -14,7 +14,7 @@ export async function PATCH(req: NextRequest, { params }: { params: Promise<{ id
       name, phone, email, location, leadTimeDays, status, tags, moq,
       paymentTerms, deliveryDays, notes,
       bankName, bankAccountNumber, bankAccountName,
-      depositPercent, depositTermsDays,
+      depositPercent, depositTermsDays, automationMode,
     } = body;
     const data: Record<string, unknown> = {};
     if (name !== undefined) data.name = name;
@@ -37,6 +37,10 @@ export async function PATCH(req: NextRequest, { params }: { params: Promise<{ id
     }
     if (depositTermsDays !== undefined) {
       data.depositTermsDays = depositTermsDays === "" || depositTermsDays === null ? null : parseInt(depositTermsDays, 10);
+    }
+    // Per-supplier procurement automation dial (the hybrid model).
+    if (automationMode !== undefined && ["OFF", "ASSIST", "AUTO"].includes(automationMode)) {
+      data.automationMode = automationMode;
     }
 
     const supplier = await prisma.supplier.update({

--- a/apps/backoffice/src/lib/inventory/agents/supplier-chat-agent.ts
+++ b/apps/backoffice/src/lib/inventory/agents/supplier-chat-agent.ts
@@ -89,19 +89,9 @@ function flagEnabled(): boolean {
   return process.env.PROCUREMENT_AGENT_ENABLED === "true";
 }
 
-// Allow-list of supplier numbers (last-8 digits) the agent may act on. Unset or
-// empty => all suppliers. Set to the Test number for the first live run.
-function allowed(supplierPhone: string | null | undefined): boolean {
-  const raw = process.env.PROCUREMENT_AGENT_ALLOWLIST?.trim();
-  if (!raw) return true;
-  const tail = digits(supplierPhone).slice(-8);
-  if (!tail) return false;
-  return raw
-    .split(",")
-    .map((s) => digits(s).slice(-8))
-    .filter(Boolean)
-    .includes(tail);
-}
+// Which suppliers the agent may act on is now a per-supplier dial (Supplier.automationMode):
+// OFF = hands-off, ASSIST = draft + human-approve, AUTO = act + send. This replaces the
+// old global PROCUREMENT_AGENT_ALLOWLIST; PROCUREMENT_AGENT_ENABLED stays the master switch.
 
 const isValidIsoDate = (d: string | null): d is string =>
   !!d && /^\d{4}-\d{2}-\d{2}$/.test(d) && !Number.isNaN(Date.parse(d));
@@ -128,13 +118,15 @@ export async function handleSupplierMessage(evt: SupplierMessageEvent): Promise<
     // Match the supplier by last-8 digits (same rule as whatsapp-store).
     const suppliers = await prisma.supplier.findMany({
       where: { phone: { not: null }, status: "ACTIVE" },
-      select: { id: true, name: true, phone: true, paymentTerms: true, depositPercent: true },
+      select: { id: true, name: true, phone: true, paymentTerms: true, depositPercent: true, automationMode: true },
     });
     const supplier = suppliers.find((s) => {
       const sd = digits(s.phone);
       return sd === fromDigits || (sd.length >= 8 && sd.slice(-8) === tail);
     });
-    if (!supplier || !allowed(supplier.phone)) return; // unknown / not allow-listed → leave to humans
+    // Per-supplier dial: OFF → hands-off (leave to humans). ASSIST/AUTO continue;
+    // ASSIST forces escalate below (draft + human-approve, never auto-act).
+    if (!supplier || supplier.automationMode === "OFF") return;
 
     // Redelivery dedupe: if we've already auto-answered this exact inbound, stop.
     if (evt.waMessageId) {
@@ -186,9 +178,12 @@ export async function handleSupplierMessage(evt: SupplierMessageEvent): Promise<
     if (!decision) return;
 
     // ── Guardrails (code, not model): auto-act vs escalate ──
+    // ASSIST suppliers always escalate → the agent drafts a holding reply + a proposal
+    // for a human to approve, and never auto-edits the PO. AUTO suppliers auto-act below.
     const risky =
       decision.po_action.type === "substitute_item" || decision.po_action.type === "cancel_order";
-    const escalate = decision.requires_human || risky || decision.confidence < 0.7;
+    const escalate =
+      decision.requires_human || risky || decision.confidence < 0.7 || supplier.automationMode === "ASSIST";
 
     const lang: "ms" | "en" = decision.language === "ms" ? "ms" : "en";
     let replyText = decision.reply_text?.trim();

--- a/apps/backoffice/src/lib/inventory/exec/intent-responder.ts
+++ b/apps/backoffice/src/lib/inventory/exec/intent-responder.ts
@@ -12,10 +12,11 @@
  *  - delivery promise missed → a promised date passed with no GRN → chase for an ETA.
  *  - price-increase / invoice-revise → flag for review (surfaced in the brief).
  *
- * Supplier-facing sends are OFF unless PROCUREMENT_EXEC_AUTO_REPLY=true (else the draft
- * is surfaced in the brief for the inbox). The internal finance handoff sends whenever
- * PROCUREMENT_FINANCE_NOTIFY_TO is set + in-window. Gated by PROCUREMENT_AGENT_ENABLED;
- * de-duped via raw markers; never throws. See procurement-supplier-chat-intelligence.md.
+ * Supplier-facing sends go out only for AUTO suppliers (the per-supplier dial,
+ * Supplier.automationMode); ASSIST/OFF → the draft is surfaced in the brief for the
+ * inbox. The internal finance handoff sends whenever PROCUREMENT_FINANCE_NOTIFY_TO is
+ * set + in-window. Gated by PROCUREMENT_AGENT_ENABLED; de-duped via raw markers; never
+ * throws. See procurement-supplier-chat-intelligence.md.
  */
 import type { OrderStatus, Prisma } from "@celsius/db";
 import { prisma } from "@/lib/prisma";
@@ -50,7 +51,8 @@ const EMPTY: ResponderSummary = { soaHandoffs: 0, vendorPushDrafts: 0, promiseCh
 
 export async function runIntentResponder(): Promise<ResponderSummary> {
   if (process.env.PROCUREMENT_AGENT_ENABLED !== "true") return { ...EMPTY, skipped: "disabled" };
-  const autoReply = process.env.PROCUREMENT_EXEC_AUTO_REPLY === "true";
+  // Supplier-facing replies send only for AUTO suppliers (the per-supplier dial);
+  // ASSIST/OFF → drafted/surfaced. The internal finance handoff is unaffected.
   const financeDest = digits(process.env.PROCUREMENT_FINANCE_NOTIFY_TO);
   const today = todayMyt();
   const out: ResponderSummary = { ...EMPTY, actions: [] };
@@ -81,7 +83,7 @@ export async function runIntentResponder(): Promise<ResponderSummary> {
   }
 
   for (const job of jobs) {
-    const supplier = await prisma.supplier.findUnique({ where: { id: job.supplierId }, select: { name: true, phone: true } });
+    const supplier = await prisma.supplier.findUnique({ where: { id: job.supplierId }, select: { name: true, phone: true, automationMode: true } });
     if (!supplier) continue;
     const name = supplier.name;
     try {
@@ -95,7 +97,7 @@ export async function runIntentResponder(): Promise<ResponderSummary> {
         const draft = await draftWeeklyOrder(job.supplierId, name);
         if (draft) {
           out.vendorPushDrafts++;
-          const sent = autoReply && (await maybeSendToSupplier(job.phone, draft));
+          const sent = supplier.automationMode === "AUTO" && (await maybeSendToSupplier(job.phone, draft));
           out.actions.push(`🛒 ${name} asked for an order — ${sent ? "replied" : "draft ready"}: ${draft.slice(0, 60)}…`);
         }
       } else if (job.category === "price" || job.category === "invchange") {
@@ -108,8 +110,8 @@ export async function runIntentResponder(): Promise<ResponderSummary> {
     await markResponded(job.messageId);
   }
 
-  // Delivery promise missed → chase for a fresh ETA.
-  out.promiseChases = await chaseMissedPromises(autoReply);
+  // Delivery promise missed → chase for a fresh ETA (AUTO suppliers only).
+  out.promiseChases = await chaseMissedPromises();
 
   console.log(
     `[intent-responder] soa=${out.soaHandoffs} vendorPush=${out.vendorPushDrafts} chases=${out.promiseChases} flagged=${out.flagged}`,
@@ -229,7 +231,7 @@ async function maybeSendToSupplier(phone: string, text: string): Promise<boolean
 }
 
 /** POs whose promised delivery date has passed with no GRN → chase for a fresh ETA. */
-async function chaseMissedPromises(autoReply: boolean): Promise<number> {
+async function chaseMissedPromises(): Promise<number> {
   const now = new Date();
   const overdue = await prisma.order.findMany({
     where: {
@@ -239,7 +241,7 @@ async function chaseMissedPromises(autoReply: boolean): Promise<number> {
       receivings: { none: {} },
     },
     take: 30,
-    select: { id: true, orderNumber: true, deliveryDate: true, supplier: { select: { name: true, phone: true } } },
+    select: { id: true, orderNumber: true, deliveryDate: true, supplier: { select: { name: true, phone: true, automationMode: true } } },
   });
   let chased = 0;
   for (const o of overdue) {
@@ -251,7 +253,7 @@ async function chaseMissedPromises(autoReply: boolean): Promise<number> {
     if (dupe) continue;
     const dest = digits(o.supplier.phone);
     const text = `Hi ${o.supplier.name}, following up on ${o.orderNumber} — expected ${o.deliveryDate ? new Date(o.deliveryDate).toISOString().slice(0, 10) : "earlier"} but not received yet. New ETA? 🙏`;
-    if (autoReply && dest.length >= 8 && (await windowOpen(dest))) {
+    if (o.supplier.automationMode === "AUTO" && dest.length >= 8 && (await windowOpen(dest))) {
       const res = await sendWhatsAppText(dest, text);
       await recordOutboundMessage({
         waMessageId: res.messageId,

--- a/packages/db/prisma/migrations/20260627_supplier_automation_mode/migration.sql
+++ b/packages/db/prisma/migrations/20260627_supplier_automation_mode/migration.sql
@@ -1,0 +1,14 @@
+-- Per-supplier procurement automation dial (the hybrid model).
+-- OFF = manual only; ASSIST = agent/exec draft + a human approves; AUTO = act + send.
+
+-- CreateEnum
+CREATE TYPE "AutomationMode" AS ENUM ('OFF', 'ASSIST', 'AUTO');
+
+-- AlterTable
+ALTER TABLE "Supplier" ADD COLUMN "automationMode" "AutomationMode" NOT NULL DEFAULT 'OFF';
+
+-- Seed: put the test supplier (used to validate the loop) into ASSIST so the hybrid
+-- flow can be exercised safely (drafts + human-approve) before any supplier is AUTO.
+UPDATE "Supplier"
+SET "automationMode" = 'ASSIST'
+WHERE regexp_replace(COALESCE("phone", ''), '[^0-9]', '', 'g') LIKE '%0109335369';

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -309,6 +309,9 @@ model Supplier {
   phone        String?
   email        String?
   status       SupplierStatus @default(ACTIVE)
+  // Per-supplier procurement automation dial (the hybrid model). OFF = manual only;
+  // ASSIST = agent/exec draft + a human approves; AUTO = agent/exec act + send.
+  automationMode AutomationMode @default(OFF)
   tags         String[]       @default([])
   leadTimeDays Int            @default(1)
   deliveryDays String[]       @default([])  // e.g. ["Monday","Wednesday","Friday"]
@@ -334,6 +337,12 @@ model Supplier {
 enum SupplierStatus {
   ACTIVE
   INACTIVE
+}
+
+enum AutomationMode {
+  OFF
+  ASSIST
+  AUTO
 }
 
 // ─── SUPPLIER PRODUCTS (Price List) ─────────────────────────


### PR DESCRIPTION
**Phase 1 of the procurement-workspace plan** — the per-supplier automation dial that everything else renders. The chat agent + exec stop being all-or-nothing and become *hybrid*: some suppliers fully automate, some stay AI-assist, some manual.

## The dial — `Supplier.automationMode`
| Mode | Agent (mouth) | Exec (brain) |
|---|---|---|
| **OFF** | ignores the supplier | no supplier-facing sends |
| **ASSIST** | drafts a holding reply + a proposal to approve; **never auto-edits the PO** | drafts vendor-push orders / ETA chases (surfaced, not sent) |
| **AUTO** | auto-replies + auto-edits unambiguous OOS/qty | sends vendor-push orders + ETA chases |

Replaces the global `PROCUREMENT_AGENT_ALLOWLIST` + `PROCUREMENT_EXEC_AUTO_REPLY`; `PROCUREMENT_AGENT_ENABLED` stays the master kill-switch. Default **OFF** for all 54 suppliers; the migration puts the test supplier into **ASSIST** so the flow can be exercised safely.

## ⚠️ Merge order
The repo applies migrations via Supabase MCP (not CI), so the `automationMode` migration on **live kqdc must be applied first**, then merge — otherwise the deployed code queries a column that doesn't exist. (Migration applied separately with explicit approval.)

## Next (Phase 2, after this is validated)
Rename/replace the "Purchase Order" tab → the chat-first procurement workspace with the per-supplier mode toggle in the rail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)