### PR TITLE
feat(procurement): Purchase Order workspace — all suppliers, filters, inline create+send PO

### DIFF
--- a/apps/backoffice/src/app/(admin)/inventory/supplier-chats/page.tsx
+++ b/apps/backoffice/src/app/(admin)/inventory/supplier-chats/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect, useRef } from "react";
+import { useState, useEffect, useRef, type ReactNode } from "react";
 import { useSearchParams } from "next/navigation";
 import { useFetch } from "@/lib/use-fetch";
 import { formatRM } from "@celsius/shared";
@@ -14,18 +14,27 @@ import {
   Phone,
   Check,
   ExternalLink,
+  Search,
+  Plus,
+  X,
 } from "lucide-react";
 
+type AutomationMode = "OFF" | "ASSIST" | "AUTO";
 type Thread = {
   key: string;
   supplierId: string | null;
   name: string;
   phone: string;
   preview: string;
-  lastAt: string;
+  lastAt: string | null;
   count: number;
   needsAttention: boolean;
+  registered: boolean;
+  automationMode: AutomationMode | null;
+  hasMessages: boolean;
 };
+type Counts = { all: number; suppliers: number; needsAttention: number; other: number; auto: number; assist: number; off: number };
+type PoProduct = { supplierProductId: string; productId: string; name: string; packageLabel: string; productPackageId: string | null; price: number; moq: number };
 
 type Msg = {
   id: string;
@@ -91,11 +100,12 @@ export default function SupplierChatsPage() {
   // Deep-link support: /inventory/supplier-chats?key=<number> opens that thread
   // (e.g. from Agent QA). Lazy init so it wins over the auto-select-first effect.
   const [selected, setSelected] = useState<string | null>(() => searchParams.get("key"));
-  const [filter, setFilter] = useState<"all" | "attention">("all");
+  const [filter, setFilter] = useState<"all" | "attention" | "auto" | "assist" | "off" | "other">("all");
+  const [query, setQuery] = useState("");
 
   // Poll so inbound supplier messages + the agent's auto-replies appear without
   // a manual refresh. The open thread polls faster than the list.
-  const { data: threadsData, isLoading } = useFetch<{ threads: Thread[]; needsAttention: number }>(
+  const { data: threadsData, isLoading } = useFetch<{ threads: Thread[]; counts: Counts; needsAttention: number }>(
     "/api/inventory/supplier-chats",
     { refreshInterval: 10000, revalidateOnFocus: true },
   );
@@ -118,8 +128,96 @@ export default function SupplierChatsPage() {
   const [applying, setApplying] = useState(false);
   const [applyError, setApplyError] = useState<string | null>(null);
 
+  // ── New PO panel ──────────────────────────────────────────────
+  const [poOpen, setPoOpen] = useState(false);
+  const [outlets, setOutlets] = useState<{ id: string; name: string }[]>([]);
+  const [poOutlet, setPoOutlet] = useState("");
+  const [poProducts, setPoProducts] = useState<PoProduct[]>([]);
+  const [poQty, setPoQty] = useState<Record<string, number>>({});
+  const [poBusy, setPoBusy] = useState(false);
+  const [poError, setPoError] = useState<string | null>(null);
+
+  async function openPO() {
+    if (!detail?.supplierId) return;
+    setPoOpen(true);
+    setPoError(null);
+    setPoQty({});
+    try {
+      const [oRaw, pRaw] = await Promise.all([
+        fetch("/api/settings/outlets?status=ACTIVE").then((r) => r.json()),
+        fetch(`/api/inventory/suppliers/${detail.supplierId}/products`).then((r) => r.json()),
+      ]);
+      const oList: { id: string; name: string }[] = Array.isArray(oRaw) ? oRaw : (oRaw.outlets ?? []);
+      setOutlets(oList.map((o) => ({ id: o.id, name: o.name })));
+      setPoOutlet((prev) => prev || oList[0]?.id || "");
+      setPoProducts(Array.isArray(pRaw) ? pRaw : []);
+    } catch {
+      setPoError("Couldn't load outlets / products.");
+    }
+  }
+
+  async function createPO(send: boolean) {
+    if (!detail?.supplierId || !poOutlet) {
+      setPoError("Pick an outlet first.");
+      return;
+    }
+    const items = poProducts
+      .filter((p) => (poQty[p.productId] ?? 0) > 0)
+      .map((p) => ({ productId: p.productId, productPackageId: p.productPackageId, quantity: poQty[p.productId], unitPrice: p.price }));
+    if (items.length === 0) {
+      setPoError("Set a quantity on at least one item.");
+      return;
+    }
+    setPoBusy(true);
+    setPoError(null);
+    try {
+      const cRes = await fetch("/api/inventory/orders", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ outletId: poOutlet, supplierId: detail.supplierId, items, clientRequestId: crypto.randomUUID() }),
+      });
+      if (!cRes.ok) throw new Error((await cRes.json().catch(() => ({}))).error || "Create failed");
+      const order = await cRes.json();
+      if (send && order.id) {
+        const sRes = await fetch(`/api/inventory/orders/${order.id}`, {
+          method: "PATCH",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ status: "SENT" }),
+        });
+        if (!sRes.ok) throw new Error((await sRes.json().catch(() => ({}))).error || "Created, but send failed");
+      }
+      setPoOpen(false);
+      mutateDetail();
+    } catch (e) {
+      setPoError(e instanceof Error ? e.message : "Failed");
+    } finally {
+      setPoBusy(false);
+    }
+  }
+  const poTotal = poProducts.reduce((s, p) => s + (poQty[p.productId] ?? 0) * p.price, 0);
+
   const threads = threadsData?.threads ?? [];
-  const shown = filter === "attention" ? threads.filter((t) => t.needsAttention) : threads;
+  const counts = threadsData?.counts;
+  const q = query.trim().toLowerCase();
+  const shown = threads.filter((t) => {
+    if (q && !(t.name.toLowerCase().includes(q) || t.phone.includes(q) || t.preview.toLowerCase().includes(q))) {
+      return false;
+    }
+    switch (filter) {
+      case "attention":
+        return t.needsAttention;
+      case "auto":
+        return t.automationMode === "AUTO";
+      case "assist":
+        return t.automationMode === "ASSIST";
+      case "off":
+        return t.registered && t.automationMode === "OFF";
+      case "other":
+        return !t.registered;
+      default:
+        return t.registered; // "all" = every supplier (non-suppliers live under "Other")
+    }
+  });
 
   useEffect(() => {
     if (!selected && threads.length) setSelected(threads[0].key);
@@ -192,21 +290,28 @@ export default function SupplierChatsPage() {
       <div className="flex w-72 shrink-0 flex-col overflow-hidden rounded-xl border border-border bg-background shadow-sm">
         <div className="border-b border-border p-3">
           <div className="flex items-center gap-2 text-sm font-medium">
-            <MessageCircle size={16} /> Supplier chats
+            <MessageCircle size={16} /> Suppliers
           </div>
-          <div className="mt-2 flex gap-1">
-            <button
-              onClick={() => setFilter("all")}
-              className={`rounded-full px-2.5 py-0.5 text-xs ${filter === "all" ? "bg-muted text-foreground" : "text-muted-foreground hover:bg-muted"}`}
-            >
-              All
-            </button>
-            <button
-              onClick={() => setFilter("attention")}
-              className={`rounded-full px-2.5 py-0.5 text-xs ${filter === "attention" ? "bg-destructive/10 text-destructive" : "text-muted-foreground hover:bg-muted"}`}
-            >
-              Needs attention {threadsData?.needsAttention ?? 0}
-            </button>
+          <div className="relative mt-2">
+            <Search size={13} className="absolute left-2 top-1/2 -translate-y-1/2 text-muted-foreground" />
+            <input
+              value={query}
+              onChange={(e) => setQuery(e.target.value)}
+              placeholder="Search name or number…"
+              className="h-8 w-full rounded-md border border-border bg-background pl-7 pr-2 text-xs text-foreground placeholder:text-muted-foreground"
+            />
+          </div>
+          <div className="mt-2 flex flex-wrap gap-1">
+            <Chip on={filter === "all"} onClick={() => setFilter("all")}>All {counts?.suppliers ?? 0}</Chip>
+            <Chip on={filter === "attention"} tone="danger" onClick={() => setFilter("attention")}>
+              Attention {counts?.needsAttention ?? 0}
+            </Chip>
+            <Chip on={filter === "auto"} tone="auto" onClick={() => setFilter("auto")}>Auto {counts?.auto ?? 0}</Chip>
+            <Chip on={filter === "assist"} tone="assist" onClick={() => setFilter("assist")}>Assist {counts?.assist ?? 0}</Chip>
+            <Chip on={filter === "off"} onClick={() => setFilter("off")}>Off {counts?.off ?? 0}</Chip>
+            {(counts?.other ?? 0) > 0 && (
+              <Chip on={filter === "other"} onClick={() => setFilter("other")}>Other {counts?.other ?? 0}</Chip>
+            )}
           </div>
         </div>
         <div className="flex-1 overflow-y-auto">
@@ -216,9 +321,7 @@ export default function SupplierChatsPage() {
             </div>
           )}
           {!isLoading && shown.length === 0 && (
-            <p className="p-4 text-xs text-muted-foreground">
-              No supplier messages yet. They appear here once the WhatsApp number is live and receiving.
-            </p>
+            <p className="p-4 text-xs text-muted-foreground">No suppliers match this filter.</p>
           )}
           {shown.map((t) => (
             <button
@@ -230,13 +333,16 @@ export default function SupplierChatsPage() {
                 {initials(t.name)}
               </div>
               <div className="min-w-0 flex-1">
-                <div className="flex justify-between">
-                  <span className="truncate text-[13px] font-medium">{t.name}</span>
-                  <span className="shrink-0 pl-1 text-[11px] text-muted-foreground">{rel(t.lastAt)}</span>
+                <div className="flex items-center justify-between gap-1">
+                  <span className="flex min-w-0 items-center gap-1.5 text-[13px] font-medium">
+                    {t.registered && t.automationMode && <ModeDot mode={t.automationMode} />}
+                    <span className="truncate">{t.name}</span>
+                  </span>
+                  <span className="shrink-0 text-[11px] text-muted-foreground">{t.lastAt ? rel(t.lastAt) : ""}</span>
                 </div>
                 <div className="flex items-center gap-1 text-[11px] text-muted-foreground">
                   {t.needsAttention && <AlertCircle size={11} className="shrink-0 text-destructive" />}
-                  <span className="truncate">{t.preview}</span>
+                  <span className="truncate">{t.hasMessages ? t.preview : "No messages yet"}</span>
                 </div>
               </div>
             </button>
@@ -257,9 +363,19 @@ export default function SupplierChatsPage() {
                 <div className="text-sm font-medium">{detail.supplier?.name ?? `+${detail.key}`}</div>
                 <div className="text-xs text-muted-foreground">+{detail.key}</div>
               </div>
-              <span className="rounded-full bg-green-500/10 px-2 py-0.5 text-[11px] text-green-600 dark:text-green-400">
-                WhatsApp
-              </span>
+              <div className="flex items-center gap-2">
+                {detail.supplierId && (
+                  <button
+                    onClick={openPO}
+                    className="inline-flex items-center gap-1 rounded-md border border-border px-2 py-1 text-[11px] font-medium text-foreground hover:bg-muted"
+                  >
+                    <Plus size={12} /> New PO
+                  </button>
+                )}
+                <span className="rounded-full bg-green-500/10 px-2 py-0.5 text-[11px] text-green-600 dark:text-green-400">
+                  WhatsApp
+                </span>
+              </div>
             </div>
             <div className="flex flex-1 flex-col gap-2 overflow-y-auto p-4">
               {detail.messages.length === 0 && (
@@ -478,6 +594,90 @@ export default function SupplierChatsPage() {
           </>
         )}
       </div>
+
+      {poOpen && detail && (
+        <div
+          className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4"
+          onClick={() => !poBusy && setPoOpen(false)}
+        >
+          <div
+            onClick={(e) => e.stopPropagation()}
+            className="flex max-h-[82vh] w-full max-w-md flex-col overflow-hidden rounded-xl border border-border bg-background shadow-lg"
+          >
+            <div className="flex items-center justify-between border-b border-border px-4 py-3">
+              <div className="text-sm font-medium">New PO — {detail.supplier?.name ?? `+${detail.key}`}</div>
+              <button onClick={() => !poBusy && setPoOpen(false)} aria-label="Close" className="text-muted-foreground hover:text-foreground">
+                <X size={16} />
+              </button>
+            </div>
+            <div className="flex items-center gap-2 border-b border-border px-4 py-2.5">
+              <span className="text-xs text-muted-foreground">Outlet</span>
+              <select
+                value={poOutlet}
+                onChange={(e) => setPoOutlet(e.target.value)}
+                className="h-8 flex-1 rounded-md border border-border bg-background px-2 text-xs text-foreground"
+              >
+                {outlets.map((o) => (
+                  <option key={o.id} value={o.id}>{o.name}</option>
+                ))}
+              </select>
+            </div>
+            <div className="flex-1 overflow-y-auto px-4 py-1">
+              {poProducts.length === 0 ? (
+                <p className="py-6 text-center text-xs text-muted-foreground">
+                  No price-list products for this supplier yet. Add them on the supplier record first.
+                </p>
+              ) : (
+                poProducts.map((p) => (
+                  <div key={p.productId} className="flex items-center gap-2 border-b border-border py-2">
+                    <div className="min-w-0 flex-1">
+                      <div className="truncate text-[13px]">{p.name}</div>
+                      <div className="text-[11px] text-muted-foreground">
+                        {formatRM(p.price)} / {p.packageLabel}
+                        {p.moq ? ` · MOQ ${p.moq}` : ""}
+                      </div>
+                    </div>
+                    <input
+                      type="number"
+                      min={0}
+                      value={poQty[p.productId] ?? ""}
+                      onChange={(e) =>
+                        setPoQty((q) => ({ ...q, [p.productId]: Math.max(0, Number(e.target.value) || 0) }))
+                      }
+                      placeholder="0"
+                      className="h-8 w-16 rounded-md border border-border bg-background px-2 text-right text-[13px] text-foreground"
+                    />
+                  </div>
+                ))
+              )}
+            </div>
+            <div className="border-t border-border px-4 py-3">
+              {poError && <div className="mb-2 text-[11px] text-destructive">{poError}</div>}
+              <div className="mb-2 flex justify-between text-[13px]">
+                <span className="text-muted-foreground">Total</span>
+                <span className="font-medium">{formatRM(poTotal)}</span>
+              </div>
+              <div className="flex gap-2">
+                <button
+                  onClick={() => createPO(false)}
+                  disabled={poBusy}
+                  className="flex-1 rounded-md border border-border px-3 py-2 text-[13px] font-medium hover:bg-muted disabled:opacity-50"
+                >
+                  Create draft
+                </button>
+                <button
+                  onClick={() => createPO(true)}
+                  disabled={poBusy || !detail.windowOpen}
+                  title={detail.windowOpen ? "" : "24h window closed — create a draft, then send via template"}
+                  className="flex flex-1 items-center justify-center gap-1 rounded-md bg-primary px-3 py-2 text-[13px] font-medium text-primary-foreground hover:bg-primary/90 disabled:opacity-50"
+                >
+                  {poBusy ? <Loader2 size={14} className="animate-spin" /> : <Send size={14} />} Create &amp; send
+                </button>
+              </div>
+            </div>
+          </div>
+        </div>
+      )}
     </div>
   );
 }
@@ -489,4 +689,38 @@ function Row({ label, value }: { label: string; value: string }) {
       <span className="text-right">{value}</span>
     </div>
   );
+}
+
+function Chip({
+  on,
+  tone,
+  onClick,
+  children,
+}: {
+  on: boolean;
+  tone?: "danger" | "auto" | "assist";
+  onClick: () => void;
+  children: ReactNode;
+}) {
+  const active =
+    tone === "danger"
+      ? "bg-destructive/10 text-destructive"
+      : tone === "auto"
+        ? "bg-green-500/15 text-green-700 dark:text-green-400"
+        : tone === "assist"
+          ? "bg-amber-500/15 text-amber-700 dark:text-amber-400"
+          : "bg-muted text-foreground";
+  return (
+    <button
+      onClick={onClick}
+      className={`rounded-full px-2.5 py-0.5 text-[11px] ${on ? active : "text-muted-foreground hover:bg-muted"}`}
+    >
+      {children}
+    </button>
+  );
+}
+
+function ModeDot({ mode }: { mode: AutomationMode }) {
+  const c = mode === "AUTO" ? "bg-green-500" : mode === "ASSIST" ? "bg-amber-500" : "bg-muted-foreground/40";
+  return <span title={`Automation: ${mode}`} className={`inline-block h-2 w-2 shrink-0 rounded-full ${c}`} />;
 }

--- a/apps/backoffice/src/app/(admin)/inventory/supplier-chats/page.tsx
+++ b/apps/backoffice/src/app/(admin)/inventory/supplier-chats/page.tsx
@@ -187,9 +187,9 @@ export default function SupplierChatsPage() {
   }
 
   return (
-    <div className="flex h-[calc(100vh-120px)] min-h-[560px] overflow-hidden rounded-lg border border-border bg-background text-foreground">
+    <div className="flex h-[calc(100vh-64px)] min-h-[560px] gap-3 p-3 text-foreground">
       {/* ── Thread list ─────────────────────────────── */}
-      <div className="flex w-64 shrink-0 flex-col border-r border-border">
+      <div className="flex w-72 shrink-0 flex-col overflow-hidden rounded-xl border border-border bg-background shadow-sm">
         <div className="border-b border-border p-3">
           <div className="flex items-center gap-2 text-sm font-medium">
             <MessageCircle size={16} /> Supplier chats
@@ -245,7 +245,7 @@ export default function SupplierChatsPage() {
       </div>
 
       {/* ── Conversation ────────────────────────────── */}
-      <div className="flex min-w-0 flex-1 flex-col border-r border-border">
+      <div className="flex min-w-0 flex-1 flex-col overflow-hidden rounded-xl border border-border bg-background shadow-sm">
         {!detail ? (
           <div className="flex flex-1 items-center justify-center text-sm text-muted-foreground">
             Select a chat
@@ -327,7 +327,7 @@ export default function SupplierChatsPage() {
       </div>
 
       {/* ── Supplier context ────────────────────────── */}
-      <div className="w-60 shrink-0 overflow-y-auto p-3">
+      <div className="flex w-64 shrink-0 flex-col overflow-y-auto rounded-xl border border-border bg-background p-3 shadow-sm">
         {!detail ? null : (
           <>
             <div className="flex flex-col items-center gap-1.5 border-b border-border pb-3 text-center">

--- a/apps/backoffice/src/app/api/inventory/supplier-chats/[key]/route.ts
+++ b/apps/backoffice/src/app/api/inventory/supplier-chats/[key]/route.ts
@@ -30,13 +30,26 @@ export async function GET(req: NextRequest, { params }: { params: Promise<{ key:
     },
   });
 
-  const supplierId =
+  let supplierId =
     (
       await prisma.whatsAppMessage.findFirst({
         where: { ...counter, supplierId: { not: null } },
         select: { supplierId: true },
       })
     )?.supplierId ?? null;
+
+  // No message carried a supplierId (e.g. a supplier with no chat yet, opened from
+  // the list) — resolve by phone (last-8 digits) so context + "New PO" still work.
+  if (!supplierId) {
+    const tail = key.replace(/[^0-9]/g, "").slice(-8);
+    if (tail.length >= 8) {
+      const actives = await prisma.supplier.findMany({
+        where: { status: "ACTIVE", phone: { not: null } },
+        select: { id: true, phone: true },
+      });
+      supplierId = actives.find((s) => (s.phone ?? "").replace(/[^0-9]/g, "").slice(-8) === tail)?.id ?? null;
+    }
+  }
 
   let supplier:
     | null

--- a/apps/backoffice/src/app/api/inventory/supplier-chats/route.ts
+++ b/apps/backoffice/src/app/api/inventory/supplier-chats/route.ts
@@ -2,34 +2,48 @@ import { NextResponse, NextRequest } from "next/server";
 import { prisma } from "@/lib/prisma";
 import { getUserFromHeaders } from "@/lib/auth";
 
-// Threads for the Supplier Chats inbox: folds WhatsAppMessage rows into one
-// thread per counterparty (the supplier's number) with a preview + a
-// "needs attention" flag (OOS/substitution language, or an overdue invoice).
+// Threads for the Supplier Chats workspace. Folds WhatsAppMessage rows into one
+// thread per counterparty, then MERGES in every active supplier — so suppliers with
+// no chat yet still appear (you can start one / raise a PO). A non-supplier number
+// that has messaged us shows as registered:false (filterable as "Other").
 
-// Inbound lines likely needing a human — EN + Malay. Tune as real data lands.
 const ATTENTION_RX =
   /out of stock|no stock|\boos\b|unavailable|sold out|tak ?ada|x ?ada|takde|habis|cancel|delay|short/i;
+
+const digits = (s: string | null | undefined) => (s ?? "").replace(/[^0-9]/g, "");
+const last8 = (s: string | null | undefined) => digits(s).slice(-8);
 
 export async function GET(req: NextRequest) {
   const caller = await getUserFromHeaders(req.headers);
   if (!caller) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
 
-  // v1: pull recent messages and fold into threads in JS (store is new + low
-  // volume). Switch to a SQL window query if it grows large.
-  const rows = await prisma.whatsAppMessage.findMany({
-    orderBy: { timestamp: "desc" },
-    take: 1000,
-    select: {
-      direction: true,
-      fromNumber: true,
-      toNumber: true,
-      supplierId: true,
-      body: true,
-      type: true,
-      timestamp: true,
-      raw: true,
-    },
-  });
+  const [rows, suppliers] = await Promise.all([
+    prisma.whatsAppMessage.findMany({
+      orderBy: { timestamp: "desc" },
+      take: 1000,
+      select: {
+        direction: true,
+        fromNumber: true,
+        toNumber: true,
+        supplierId: true,
+        body: true,
+        type: true,
+        timestamp: true,
+        raw: true,
+      },
+    }),
+    prisma.supplier.findMany({
+      where: { status: "ACTIVE" },
+      select: { id: true, name: true, phone: true, automationMode: true },
+    }),
+  ]);
+
+  const byId = new Map(suppliers.map((s) => [s.id, s]));
+  const byPhone = new Map<string, (typeof suppliers)[number]>();
+  for (const s of suppliers) {
+    const k = last8(s.phone);
+    if (k.length >= 8) byPhone.set(k, s);
+  }
 
   type T = {
     key: string;
@@ -38,7 +52,7 @@ export async function GET(req: NextRequest) {
     lastAt: Date;
     count: number;
     lastInbound: string | null;
-    verifierFailed: boolean; // the newest message is an auto-decision the verifier failed
+    verifierFailed: boolean;
   };
   const threads = new Map<string, T>();
   for (const m of rows) {
@@ -46,9 +60,6 @@ export async function GET(req: NextRequest) {
     if (!counter) continue;
     let t = threads.get(counter);
     if (!t) {
-      // rows are newest-first, so the first message we see for a thread is its
-      // latest. If that latest message is an agent decision the verifier rated
-      // "fail" and nothing newer has happened, the thread needs a human.
       const raw = (m.raw ?? null) as Record<string, unknown> | null;
       const v = raw?.verifier as { rating?: string } | undefined;
       t = {
@@ -67,46 +78,96 @@ export async function GET(req: NextRequest) {
     if (m.direction === "inbound" && t.lastInbound === null) t.lastInbound = m.body ?? `[${m.type}]`;
   }
 
-  const supplierIds = [
-    ...new Set([...threads.values()].map((t) => t.supplierId).filter((x): x is string => !!x)),
-  ];
-  const [suppliers, overdueRows] = await Promise.all([
-    supplierIds.length
-      ? prisma.supplier.findMany({
-          where: { id: { in: supplierIds } },
-          select: { id: true, name: true, phone: true },
-        })
-      : Promise.resolve([]),
-    supplierIds.length
-      ? prisma.invoice.findMany({
-          where: { supplierId: { in: supplierIds }, status: { not: "PAID" }, dueDate: { lt: new Date() } },
-          select: { supplierId: true },
-          distinct: ["supplierId"],
-        })
-      : Promise.resolve([]),
-  ]);
-  const sup = new Map(suppliers.map((s) => [s.id, s]));
+  // Resolve each thread to a supplier (by soft-matched id, else by phone), and note
+  // which suppliers already have a thread so we can append the ones that don't.
+  const supplierWithThread = new Set<string>();
+  for (const t of threads.values()) {
+    const s = (t.supplierId && byId.get(t.supplierId)) || byPhone.get(last8(t.key)) || null;
+    if (s) {
+      t.supplierId = s.id;
+      supplierWithThread.add(s.id);
+    }
+  }
+
+  const matchedIds = [...supplierWithThread];
+  const overdueRows = matchedIds.length
+    ? await prisma.invoice.findMany({
+        where: { supplierId: { in: matchedIds }, status: { not: "PAID" }, dueDate: { lt: new Date() } },
+        select: { supplierId: true },
+        distinct: ["supplierId"],
+      })
+    : [];
   const overdue = new Set(overdueRows.map((o) => o.supplierId));
 
-  const out = [...threads.values()]
-    .map((t) => {
-      const s = t.supplierId ? sup.get(t.supplierId) : undefined;
-      const needsAttention =
-        t.verifierFailed ||
-        (!!t.lastInbound && ATTENTION_RX.test(t.lastInbound)) ||
-        (!!t.supplierId && overdue.has(t.supplierId));
-      return {
-        key: t.key,
-        supplierId: t.supplierId,
-        name: s?.name ?? `+${t.key}`,
-        phone: s?.phone ?? t.key,
-        preview: t.preview.slice(0, 60),
-        lastAt: t.lastAt,
-        count: t.count,
-        needsAttention,
-      };
-    })
-    .sort((a, b) => +new Date(b.lastAt) - +new Date(a.lastAt));
+  type Out = {
+    key: string;
+    supplierId: string | null;
+    name: string;
+    phone: string;
+    preview: string;
+    lastAt: Date | null;
+    count: number;
+    needsAttention: boolean;
+    registered: boolean;
+    automationMode: "OFF" | "ASSIST" | "AUTO" | null;
+    hasMessages: boolean;
+  };
 
-  return NextResponse.json({ threads: out, needsAttention: out.filter((t) => t.needsAttention).length });
+  const out: Out[] = [];
+  for (const t of threads.values()) {
+    const s = t.supplierId ? byId.get(t.supplierId) : undefined;
+    const needsAttention =
+      t.verifierFailed ||
+      (!!t.lastInbound && ATTENTION_RX.test(t.lastInbound)) ||
+      (!!t.supplierId && overdue.has(t.supplierId));
+    out.push({
+      key: t.key,
+      supplierId: t.supplierId,
+      name: s?.name ?? `+${t.key}`,
+      phone: s?.phone ?? t.key,
+      preview: t.preview.slice(0, 60),
+      lastAt: t.lastAt,
+      count: t.count,
+      needsAttention,
+      registered: !!s,
+      automationMode: s?.automationMode ?? null,
+      hasMessages: true,
+    });
+  }
+  // Append every supplier that has no thread yet.
+  for (const s of suppliers) {
+    if (supplierWithThread.has(s.id)) continue;
+    out.push({
+      key: digits(s.phone) || s.id,
+      supplierId: s.id,
+      name: s.name,
+      phone: s.phone ?? "",
+      preview: "",
+      lastAt: null,
+      count: 0,
+      needsAttention: overdue.has(s.id),
+      registered: true,
+      automationMode: s.automationMode,
+      hasMessages: false,
+    });
+  }
+
+  out.sort((a, b) => {
+    if (a.hasMessages !== b.hasMessages) return a.hasMessages ? -1 : 1; // chats first
+    if (a.hasMessages) return +new Date(b.lastAt!) - +new Date(a.lastAt!);
+    return a.name.localeCompare(b.name); // then suppliers without chats, A→Z
+  });
+
+  const reg = out.filter((t) => t.registered);
+  const counts = {
+    all: out.length,
+    suppliers: reg.length,
+    needsAttention: out.filter((t) => t.needsAttention).length,
+    other: out.length - reg.length,
+    auto: reg.filter((t) => t.automationMode === "AUTO").length,
+    assist: reg.filter((t) => t.automationMode === "ASSIST").length,
+    off: reg.filter((t) => t.automationMode === "OFF").length,
+  };
+
+  return NextResponse.json({ threads: out, counts, needsAttention: counts.needsAttention });
 }

--- a/apps/backoffice/src/app/api/inventory/suppliers/[id]/products/route.ts
+++ b/apps/backoffice/src/app/api/inventory/suppliers/[id]/products/route.ts
@@ -4,6 +4,39 @@ import { requireAuth } from "@/lib/auth";
 import { recordPriceChange } from "@/lib/inventory/price-history";
 
 /**
+ * GET /api/inventory/suppliers/[id]/products
+ * The supplier's active price-list products — for building a PO from the workspace.
+ */
+export async function GET(req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  const auth = await requireAuth(req);
+  if (auth.error) return auth.error;
+  const { id: supplierId } = await params;
+  const rows = await prisma.supplierProduct.findMany({
+    where: { supplierId, isActive: true, price: { gt: 0 }, product: { isActive: true } },
+    select: {
+      id: true,
+      price: true,
+      moq: true,
+      productPackageId: true,
+      product: { select: { id: true, name: true } },
+      productPackage: { select: { packageLabel: true } },
+    },
+    orderBy: { product: { name: "asc" } },
+  });
+  return NextResponse.json(
+    rows.map((r) => ({
+      supplierProductId: r.id,
+      productId: r.product.id,
+      name: r.product.name,
+      packageLabel: r.productPackage?.packageLabel ?? "unit",
+      productPackageId: r.productPackageId,
+      price: Number(r.price),
+      moq: Number(r.moq) || 0,
+    })),
+  );
+}
+
+/**
  * POST /api/suppliers/[id]/products
  * Add a product to a supplier's price list.
  * Body: { productId, productPackageId?, price }


### PR DESCRIPTION
Turns the supplier-chats tab into the procurement command center (Phase 2 of the plan).

### Layout
Three separate bordered cards with gaps + fuller height (replacing the one dividers-only box).

### 1. Every supplier is listed
The threads API merges all active suppliers with their chats. Suppliers with no chat yet show "No messages yet" (still openable → raise a PO). Non-supplier numbers (e.g. the Ops Pulse system) move under an **Other** filter.

### 2. Filters
A search box (name / number) + chips — **All · Attention · Auto · Assist · Off · Other** with live counts. Each row shows an automation-mode dot (🟢 Auto / 🟡 Assist / ⚪ Off).

### 3. Create + send a PO inline
A **New PO** button opens a panel: outlet picker + the supplier's price-list products + qty + live total. **Create draft** saves it; **Create & send** marks it `SENT` so the existing PO-send fires the WhatsApp order block to the supplier (disabled when the 24h window is closed).

Supporting: `GET /api/inventory/suppliers/[id]/products`; the thread-detail route resolves a supplier by phone even with no messages.

_Verification: typecheck + lint clean across all touched files. Live screenshot not possible here (dev server Turbopack worktree issue + auth wall); the create→send path reuses the existing orders POST + PATCH(SENT) contracts. Worth a click-through on staging before relying on auto-send._

🤖 Generated with [Claude Code](https://claude.com/claude-code)