### PR TITLE
feat(procurement): human "boleh" applies the agent's held proposal

### DIFF
--- a/apps/backoffice/src/app/api/inventory/supplier-chats/[key]/send/route.ts
+++ b/apps/backoffice/src/app/api/inventory/supplier-chats/[key]/send/route.ts
@@ -3,6 +3,7 @@ import { prisma } from "@/lib/prisma";
 import { getUserFromHeaders } from "@/lib/auth";
 import { sendWhatsAppText } from "@/lib/whatsapp";
 import { recordOutboundMessage } from "@/lib/whatsapp-store";
+import { tryApplyHumanApproval } from "@/lib/inventory/agents/human-approval";
 
 // Human-takeover send (#9). Staff reply to a supplier from the inbox. Free-text
 // is only allowed inside the 24h customer-service window (supplier messaged us in
@@ -57,5 +58,9 @@ export async function POST(req: NextRequest, { params }: { params: Promise<{ key
     status: "sent",
   });
 
-  return NextResponse.json({ ok: true, messageId: result.messageId });
+  // If this reply is an affirmative ("boleh") and the agent has a held proposal on the
+  // thread, apply it now — so approving in chat actually moves the PO (closes the loop).
+  const approval = await tryApplyHumanApproval(key, text, caller.id);
+
+  return NextResponse.json({ ok: true, messageId: result.messageId, approval });
 }

--- a/apps/backoffice/src/lib/inventory/agents/human-approval.ts
+++ b/apps/backoffice/src/lib/inventory/agents/human-approval.ts
@@ -1,0 +1,208 @@
+/**
+ * Human approval of a held proposal (closes the ASSIST loop).
+ *
+ * When the agent escalates it stores a structured proposal (raw.proposal) and posts a
+ * holding line. Until now the ONLY way to apply it was the inbox "Apply" button — and
+ * that covers only remove/reduce, so a substitution approved in chat ("boleh") went
+ * nowhere. This makes a plain affirmative reply from a human DO the thing:
+ *  - reduce_qty / remove_item → apply (re-source the removed line)
+ *  - substitute_item → swap to the supplier's offered replacement (resolved from their
+ *    price list); if it isn't priced there, remove + re-source so the need is still met
+ *  - cancel_order → not auto-applied (too consequential — left for the PO page)
+ *
+ * Triggered from the human-send route AFTER the message is recorded. Best-effort: only
+ * fires on a short affirmative AND a pending unresolved proposal, so normal chatter is
+ * untouched. Stamps raw.proposalResolved so it can't double-apply. Never throws.
+ */
+import { prisma } from "@/lib/prisma";
+import { createReSourcePO } from "@/lib/inventory/agents/resource-po";
+
+// Whole message is essentially just "yes" (EN/Malay) — strict, so questions like
+// "boleh tak hantar esok?" don't match.
+const APPROVE_RX =
+  /^\s*(boleh|ok(ay)?( la)?|ok boleh|yes( please)?|ya|yep|yup|proceed|teruskan|terus(kan)?|setuju|confirm(ed)?|go ?ahead|sila|baik|approved?|noted ok)\s*[.!,👍🙏🆗✅]*\s*$/i;
+
+const norm = (s: string) => s.toLowerCase().replace(/[^a-z0-9]/g, "");
+
+type ProposalAction = { type: string; poItemId: string | null; newQuantity: number | null; note: string | null };
+type Proposal = { orderId: string | null; poAction: ProposalAction | null };
+
+export interface ApprovalResult {
+  applied: string; // machine tag: reduce_qty | remove_item | substitute_item | cancel_pending | none
+  detail: string; // human-readable
+}
+
+export async function tryApplyHumanApproval(
+  key: string,
+  text: string,
+  callerId: string,
+): Promise<ApprovalResult | null> {
+  try {
+    if (!APPROVE_RX.test(text)) return null;
+
+    // Most recent UNRESOLVED, actionable proposal on this thread = the one the human
+    // is approving.
+    const recent = await prisma.whatsAppMessage.findMany({
+      where: { OR: [{ fromNumber: key }, { toNumber: key }], direction: "outbound" },
+      orderBy: { timestamp: "desc" },
+      take: 12,
+      select: { id: true, raw: true },
+    });
+    let msgId: string | null = null;
+    let proposal: Proposal | null = null;
+    for (const m of recent) {
+      const raw = (m.raw ?? {}) as Record<string, unknown>;
+      if (raw.proposalResolved === true) continue;
+      const p = raw.proposal as Proposal | null;
+      if (p && typeof p === "object" && p.poAction && p.poAction.type && p.poAction.type !== "none") {
+        msgId = m.id;
+        proposal = p;
+        break;
+      }
+    }
+    if (!msgId || !proposal?.poAction || !proposal.orderId) return null;
+
+    const pa = proposal.poAction;
+    if (!pa.poItemId) return null;
+
+    const item = await prisma.orderItem.findFirst({
+      where: { id: pa.poItemId, orderId: proposal.orderId },
+      select: {
+        id: true,
+        quantity: true,
+        unitPrice: true,
+        productId: true,
+        productPackageId: true,
+        product: { select: { name: true } },
+        productPackage: { select: { conversionFactor: true } },
+        order: { select: { status: true, outletId: true, supplierId: true } },
+      },
+    });
+    if (!item) return null;
+    if (item.order.status === "COMPLETED" || item.order.status === "CANCELLED") return null;
+
+    const orderId = proposal.orderId;
+    const baseQty = Number(item.quantity) * (item.productPackage ? Number(item.productPackage.conversionFactor) || 1 : 1);
+    let result: ApprovalResult;
+
+    if (pa.type === "reduce_qty" && typeof pa.newQuantity === "number" && pa.newQuantity > 0) {
+      await prisma.orderItem.update({
+        where: { id: item.id },
+        data: { quantity: pa.newQuantity, totalPrice: Number(item.unitPrice) * pa.newQuantity },
+      });
+      result = { applied: "reduce_qty", detail: `${item.product?.name}: qty → ${pa.newQuantity}` };
+    } else if (pa.type === "remove_item") {
+      await prisma.orderItem.delete({ where: { id: item.id } });
+      const rs = await reSource(item.productId, item.product?.name ?? "item", baseQty, item.order, callerId);
+      result = { applied: "remove_item", detail: `removed ${item.product?.name}${rs ? ` · re-sourced (${rs})` : ""}` };
+    } else if (pa.type === "substitute_item") {
+      result = await applySubstitution(key, item, baseQty, orderId, callerId);
+    } else if (pa.type === "cancel_order") {
+      // Don't auto-cancel from a chat "boleh" — flag it, leave for the PO page.
+      return { applied: "cancel_pending", detail: "cancellation approved — confirm on the PO page" };
+    } else {
+      return null;
+    }
+
+    await recomputeTotal(orderId);
+    await prisma.whatsAppMessage.update({
+      where: { id: msgId },
+      data: {
+        raw: {
+          ...((recent.find((m) => m.id === msgId)?.raw as Record<string, unknown>) ?? {}),
+          proposalResolved: true,
+          resolvedById: callerId,
+          resolvedVia: "human-approval-chat",
+          resolvedAt: new Date().toISOString(),
+          appliedOnApproval: result.applied,
+        },
+      },
+    });
+    console.log(`[human-approval] ${key} applied=${result.applied} — ${result.detail}`);
+    return result;
+  } catch (e) {
+    console.warn("[human-approval] failed:", e instanceof Error ? e.message : e);
+    return null;
+  }
+}
+
+/** Swap the OOS line to the supplier's offered replacement, resolved from their price list. */
+async function applySubstitution(
+  key: string,
+  item: { id: string; quantity: unknown; productId: string; product: { name: string } | null; order: { outletId: string; supplierId: string | null } },
+  baseQty: number,
+  orderId: string,
+  callerId: string,
+): Promise<ApprovalResult> {
+  const offer = await prisma.whatsAppMessage.findFirst({
+    where: { fromNumber: key, direction: "inbound" },
+    orderBy: { timestamp: "desc" },
+    select: { body: true },
+  });
+  const offerText = (offer?.body ?? "").toLowerCase();
+  const offerNorm = norm(offerText);
+
+  const sps = item.order.supplierId
+    ? await prisma.supplierProduct.findMany({
+        where: { supplierId: item.order.supplierId, isActive: true, price: { gt: 0 }, product: { isActive: true } },
+        select: { price: true, productPackageId: true, product: { select: { id: true, name: true } } },
+      })
+    : [];
+  // The replacement = a supplier product (not the OOS one) whose name appears in the offer.
+  const repl =
+    sps.find((sp) => sp.product.id !== item.productId && offerText.includes(sp.product.name.toLowerCase())) ||
+    sps.find((sp) => sp.product.id !== item.productId && offerNorm.includes(norm(sp.product.name)));
+
+  await prisma.orderItem.delete({ where: { id: item.id } });
+  if (repl) {
+    const qty = Number(item.quantity);
+    await prisma.orderItem.create({
+      data: {
+        orderId,
+        productId: repl.product.id,
+        productPackageId: repl.productPackageId,
+        quantity: qty,
+        unitPrice: Number(repl.price),
+        totalPrice: Number(repl.price) * qty,
+      },
+    });
+    return { applied: "substitute_item", detail: `${item.product?.name} → ${repl.product.name} (${qty})` };
+  }
+  // Couldn't price the replacement on this supplier → cover the need elsewhere.
+  const rs = await reSource(item.productId, item.product?.name ?? "item", baseQty, item.order, callerId);
+  return {
+    applied: "substitute_item",
+    detail: `removed ${item.product?.name} (replacement not in price list — add manually)${rs ? ` · re-sourced (${rs})` : ""}`,
+  };
+}
+
+async function reSource(
+  productId: string,
+  productName: string,
+  baseQty: number,
+  order: { outletId: string; supplierId: string | null },
+  callerId: string,
+): Promise<string | null> {
+  if (!order.supplierId || baseQty <= 0) return null;
+  const sys = (await prisma.user.findFirst({ where: { role: "OWNER" }, select: { id: true } }))?.id ?? callerId;
+  const rs = await createReSourcePO({
+    productId,
+    productName,
+    baseQtyNeeded: baseQty,
+    fromSupplierId: order.supplierId,
+    fromSupplierName: "",
+    outletId: order.outletId,
+    systemUserId: sys,
+  });
+  return rs ? rs.orderNumber : null;
+}
+
+async function recomputeTotal(orderId: string): Promise<void> {
+  const [remaining, order] = await Promise.all([
+    prisma.orderItem.findMany({ where: { orderId }, select: { totalPrice: true } }),
+    prisma.order.findUnique({ where: { id: orderId }, select: { deliveryCharge: true } }),
+  ]);
+  const itemsTotal = remaining.reduce((s, i) => s + Number(i.totalPrice), 0);
+  const dc = order?.deliveryCharge ? Number(order.deliveryCharge) : 0;
+  await prisma.order.update({ where: { id: orderId }, data: { totalAmount: itemsTotal + dc } });
+}


### PR DESCRIPTION
Fixes the dead-end you hit: the supplier offered a substitution ("biscoff habis, ganti choc chip?"), the agent correctly escalated, you replied **"boleh"** — and nothing happened. The held proposal was never applied (the Apply button only covers remove/reduce, and a substitution had no path at all).

## Fix
After the human-send route records your reply, it runs `tryApplyHumanApproval`: on a **short affirmative** ("boleh / ok / ya / proceed / setuju…") **with a pending unresolved proposal** on the thread, it applies it:
- **reduce_qty / remove_item** → apply (+ re-source the removed line)
- **substitute_item** → swap to the supplier's offered replacement, resolved from their price list; if it isn't priced there, remove + re-source so the need is still covered
- **cancel_order** → not auto-applied (flagged for the PO page — too consequential)

Stamps `raw.proposalResolved` (no double-apply), recomputes the order total. The strict affirmative match + the pending-proposal gate keep normal chatter untouched. The rail refreshes on send, so the proposal banner clears and the PO updates.

New module (`human-approval.ts`) + a small hook in the send route — doesn't edit the chat agent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)