### PR TITLE
feat(procurement): human takeover — agent stands down when a human replies

### DIFF
--- a/apps/backoffice/src/app/(admin)/inventory/supplier-chats/page.tsx
+++ b/apps/backoffice/src/app/(admin)/inventory/supplier-chats/page.tsx
@@ -17,6 +17,7 @@ import {
   Search,
   Plus,
   X,
+  Hand,
 } from "lucide-react";
 
 type AutomationMode = "OFF" | "ASSIST" | "AUTO";
@@ -66,6 +67,7 @@ type Detail = {
     recentPOs: { orderNumber: string; status: string }[];
   };
   windowOpen: boolean;
+  humanHandling: boolean;
   messages: Msg[];
   agentProposal?: {
     messageId: string;
@@ -425,6 +427,12 @@ export default function SupplierChatsPage() {
               <div ref={messagesEndRef} />
             </div>
             <div className="border-t border-border px-4 py-2.5">
+              {detail.humanHandling && (
+                <div className="mb-2 flex items-center gap-1.5 rounded-md bg-amber-500/10 px-2.5 py-1.5 text-[11px] text-amber-700 dark:text-amber-400">
+                  <Hand size={13} className="shrink-0" />
+                  You&apos;re handling this chat — AI paused here. It resumes once you go quiet.
+                </div>
+              )}
               <div className="flex items-center gap-2">
                 <input
                   value={draft}

--- a/apps/backoffice/src/app/api/inventory/supplier-chats/[key]/route.ts
+++ b/apps/backoffice/src/app/api/inventory/supplier-chats/[key]/route.ts
@@ -139,6 +139,14 @@ export async function GET(req: NextRequest, { params }: { params: Promise<{ key:
     select: { id: true, raw: true, timestamp: true },
   });
   const raw = (lastOutbound?.raw ?? null) as Record<string, unknown> | null;
+  // Human takeover: if the last outbound was typed by a human (no system marker) and is
+  // recent, the agent is standing down — you're handling this thread.
+  const HUMAN_TAKEOVER_MS = (Number(process.env.PROCUREMENT_HUMAN_TAKEOVER_HOURS) || 6) * 60 * 60 * 1000;
+  const lastOutByHuman =
+    !raw ||
+    (!raw.agent && !raw.invoiceRequestFor && !raw.receivingChaseFor && !raw.poSentFor && !raw.execBriefDate && !raw.soaHandoffFor && !raw.promiseChaseFor);
+  const humanHandling =
+    !!lastOutbound && lastOutByHuman && Date.now() - +new Date(lastOutbound.timestamp) < HUMAN_TAKEOVER_MS;
   // raw.proposalResolved is stamped when a human applies the proposal — once
   // resolved, stop surfacing the banner even though it's still the last message.
   if (raw && raw.escalated === true && raw.proposalResolved !== true && raw.proposal && typeof raw.proposal === "object") {
@@ -179,5 +187,5 @@ export async function GET(req: NextRequest, { params }: { params: Promise<{ key:
     };
   }
 
-  return NextResponse.json({ key, supplierId, supplier, context, windowOpen, messages, agentProposal, agentReSource });
+  return NextResponse.json({ key, supplierId, supplier, context, windowOpen, humanHandling, messages, agentProposal, agentReSource });
 }

--- a/apps/backoffice/src/lib/inventory/agents/supplier-chat-agent.ts
+++ b/apps/backoffice/src/lib/inventory/agents/supplier-chat-agent.ts
@@ -109,6 +109,18 @@ function todayMyt(): string {
   return new Date(Date.now() + 8 * 60 * 60 * 1000).toISOString().slice(0, 10);
 }
 
+// Human takeover: once a human replies from the inbox, the agent stands down on that
+// thread for this long so it doesn't talk over them. Auto-resumes after.
+const HUMAN_TAKEOVER_MS = (Number(process.env.PROCUREMENT_HUMAN_TAKEOVER_HOURS) || 6) * 60 * 60 * 1000;
+// A human-typed reply (inbox composer) carries no system marker; agent + cron senders
+// all stamp one — so "no known marker" ⇒ a human sent it.
+function isHumanOutbound(raw: Record<string, unknown> | null | undefined): boolean {
+  const r = raw ?? {};
+  return (
+    !r.agent && !r.invoiceRequestFor && !r.receivingChaseFor && !r.poSentFor && !r.execBriefDate && !r.soaHandoffFor && !r.promiseChaseFor
+  );
+}
+
 /**
  * Entry point. Safe to `await` from the webhook — never throws, no-ops fast for
  * non-suppliers / disabled flag.
@@ -143,6 +155,24 @@ export async function handleSupplierMessage(evt: SupplierMessageEvent): Promise<
         select: { id: true },
       });
       if (already) return;
+    }
+
+    // Human takeover: if the last thing WE sent this supplier was typed by a human
+    // (inbox composer) within the takeover window, stand down — they're handling this
+    // thread. Stops the agent talking over a human who's stepped in. Auto-resumes once
+    // the human goes quiet past the window (or set the supplier to OFF to pause for good).
+    const lastOut = await prisma.whatsAppMessage.findFirst({
+      where: { toNumber: fromDigits, direction: "outbound" },
+      orderBy: { timestamp: "desc" },
+      select: { raw: true, timestamp: true },
+    });
+    if (
+      lastOut &&
+      isHumanOutbound(lastOut.raw as Record<string, unknown> | null) &&
+      Date.now() - +new Date(lastOut.timestamp) < HUMAN_TAKEOVER_MS
+    ) {
+      console.log(`[supplier-agent] standing down — human is handling ${supplier.name}`);
+      return;
     }
 
     // Most recent open PO for this supplier + its line items + invoice presence.


### PR DESCRIPTION
**The problem (seen in your live thread):** you typed *"we want to proceed"* and the agent auto-replied *"we'd like to proceed"* at the same moment — talking over you. The composer works, but the agent didn't know to back off when a human stepped in.

**Fix:** before the agent auto-acts on a supplier message, it checks the last thing *we* sent — if that was typed by a **human** (the inbox composer, which carries no system marker) within the takeover window (**default 6h**, `PROCUREMENT_HUMAN_TAKEOVER_HOURS`), it **stands down** and returns. It resumes automatically once you go quiet past the window; setting the supplier to **OFF** pauses it for good.

The workspace shows a **"You're handling this — AI paused here"** banner above the composer when you've taken over, so it's obvious.

Independent of #549 (the "boleh" approval fix) — together they make human intervention work both ways: approve the AI's proposal, or take the wheel entirely.

Typecheck + lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)