### PR TITLE
fix(procurement): capture supplier invoices even when the agent escalates

### DIFF
--- a/apps/backoffice/src/lib/inventory/agents/supplier-chat-agent.ts
+++ b/apps/backoffice/src/lib/inventory/agents/supplier-chat-agent.ts
@@ -238,6 +238,18 @@ export async function handleSupplierMessage(evt: SupplierMessageEvent): Promise<
     let reSource: ReSource | null = null;
     const reSources: ReSource[] = [];
 
+    // Capture a supplier-sent invoice as a DRAFT (amount left for a human to verify) —
+    // REGARDLESS of escalate/mode. Invoice messages routinely trip requires_human, so
+    // when this sat inside the non-escalate branch it was silently skipped while the
+    // agent still replied "saved". Safe: only creates a draft on a PO with no invoice yet.
+    if (decision.capture_invoice && order.invoices.length === 0) {
+      invoiceCaptured = await captureInvoice(
+        { id: order.id, orderNumber: order.orderNumber, outletId: order.outletId, totalAmount: order.totalAmount },
+        supplier.id,
+        evt.mediaId ?? null,
+      );
+    }
+
     if (escalate) {
       // Keep the model's OWN holding line — it's specific to this message + varied (the
       // playbook makes it honest + non-committal). Fall back to the canned line only if
@@ -272,13 +284,6 @@ export async function handleSupplierMessage(evt: SupplierMessageEvent): Promise<
       if (isValidIsoDate(decision.delivery_date)) {
         await applyDeliveryDate(order.id, decision.delivery_date);
         deliveryUpdated = decision.delivery_date;
-      }
-      if (decision.capture_invoice && order.invoices.length === 0) {
-        invoiceCaptured = await captureInvoice(
-          { id: order.id, orderNumber: order.orderNumber, outletId: order.outletId, totalAmount: order.totalAmount },
-          supplier.id,
-          evt.mediaId ?? null,
-        );
       }
     }
     if (!replyText) replyText = HOLDING_REPLY[lang];


### PR DESCRIPTION
**Bug you hit:** you sent the invoice image, the agent replied *"Terima invois bos, saved on our end 🙏"* — but `invoiceCaptured = false`. It claimed to save without saving.

**Root cause:** invoice/payment messages trip `requires_human` → the agent **escalates**, and the invoice-capture code lived *inside the non-escalate branch*, so it was silently skipped.

**Fix:** invoice capture now runs **before/outside** the escalate gate — whenever the supplier sends an invoice and the PO has no invoice yet, in any mode. It only ever creates a **DRAFT** (amount left for a human to verify on the Invoices screen), so it's safe to do even when escalating. PO line edits (reduce/remove) stay gated by mode/escalate as before.

**Note / follow-up:** if the PO *already* has an invoice, capture still skips (the dup guard) — that's the case for PO-TEST-0002 (it has INV-1159). That discrepancy should really **escalate for reconciliation** rather than skip silently; queued as a follow-up.

Typecheck + lint clean. Behaviour fix — confirm live by sending an invoice to a PO with no invoice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)