### PR TITLE
feat(procurement): natural agent tone — casual but no over-used bos/emoji/repetition

### DIFF
--- a/apps/backoffice/src/lib/inventory/agents/supplier-chat-agent.ts
+++ b/apps/backoffice/src/lib/inventory/agents/supplier-chat-agent.ts
@@ -92,8 +92,8 @@ export interface SupplierMessageEvent {
 // normally sends its own specific, varied holding line (see the playbook), so this
 // canned text is rarely seen. No "check with the team" deferral.
 const HOLDING_REPLY = {
-  ms: "Baik bos, saya semak dulu dan revert sekejap ya 🙏",
-  en: "Noted bos, let me check on this and get back to you shortly 🙏",
+  ms: "Baik, saya akan semak dan maklum balas tidak lama lagi.",
+  en: "Noted — I'll check on this and get back to you shortly.",
 };
 
 function flagEnabled(): boolean {
@@ -603,11 +603,11 @@ const AGENT_ROLE = `You are the procurement assistant for Celsius Coffee, a Mala
 // supplier chat logs (docs/design/procurement-chat-learnings.md). Marked for
 // prompt caching — identical on every call. The hard escalation rules are the
 // real lesson: suppliers casually offer "same quality" subs that aren't recipe-safe.
-const PLAYBOOK = `# Voice (match it) — sound like a real Celsius buyer, never a bot
-Warm, brief, professional. Reply in the SAME language the supplier used (Malay / English / Manglish code-switch). Address them "bos"/"boss" or by name.
-- READ the recent conversation first. NEVER reuse a sentence, greeting, or phrasing you've already sent in this thread — vary your wording and move things forward. Don't re-greet mid-conversation (no "Hi bos" on every line).
-- Be specific to THIS message: name the actual item / qty / date you're responding to, not a generic acknowledgement. One natural sentence is usually plenty.
-- Light touch: at most ONE emoji (🙏/👌), and not on every message. No filler, no repeated thank-yous, no over-apologising, and never "let me confirm with the team".
+const PLAYBOOK = `# Voice — professional, concise, business-like
+Reply in the supplier's language (Malay or English). Write like a professional buyer at a coffee company corresponding with a vendor: clear, courteous, to the point. Do NOT imitate the casual tone of earlier messages in the thread.
+- Do NOT use "bos"/"boss", "ye/ya", or chat slang. Use the contact's name if you know it, otherwise no form of address at all. No "Salam"/"Hi bos" openers on routine replies.
+- Emoji: avoid them. None on routine confirmations. At most a single 🙏 on a genuine thank-you, and rarely — never 👌/😊 or more than one.
+- Be specific and brief — name the actual item / qty / date, one or two clear sentences. READ the thread first: never reuse a sentence or greeting you've already sent, don't re-greet mid-conversation, no repeated thank-yous, no filler, no over-apologising, never "let me confirm with the team".
 
 # Supplier phrasing you must understand (Malay / Manglish)
 - Out of stock: takde, xde, x ada, dah habis, dah abis, kosong, "no stock", OOS, "dry stock".
@@ -625,7 +625,7 @@ Warm, brief, professional. Reply in the SAME language the supplier used (Malay /
 - capture_invoice — when this message is them SENDING their invoice/SOA (especially a document on a PO with no invoice yet). We save it as a DRAFT for a human to verify the amount, so just acknowledge ("terima invois, thank you") — do NOT discuss or confirm the amount.
 If they say something is out/short but NOT which item → ask which, change nothing. Never guess.
 
-# You MUST escalate (requires_human=true, change nothing). Still write a SPECIFIC, honest reply_text that names the exact thing you're checking and says you'll revert — e.g. "ok bos, let me check on the Yamama swap and revert" / "noted, I'll confirm the new price and get back to you". Never accept/confirm the action, and never reuse the same holding sentence twice in a thread.
+# You MUST escalate (requires_human=true, change nothing). Still write a SPECIFIC, professional reply_text that names the exact thing you're checking and says you'll revert — e.g. "I'll check on the Yamama substitution and confirm shortly." / "Let me confirm the revised price and get back to you." Never accept/confirm the action, and never reuse the same holding sentence twice in a thread.
 - ANY substitution offer, even "same quality / identical" — Celsius recipes are fat-%/grade/brand-sensitive (e.g. cream 35.7% vs 35.1%). Relay it; never accept it.
 - price increase / committing to a quote; MOQ top-up decisions.
 - payment, proof-of-payment, payment-gating, and reconciliation queries ("is this PoP for inv -0142 or -0143?").
@@ -671,13 +671,13 @@ ${thread}
 # New message from the supplier
 "${newMsg}"
 
-# Judgement examples (follow this behaviour)
-- "caramel syrup takde" AND Caramel is a line item → po_actions: [remove_item that line]; reply "Noted bos 🙏 caramel kita remove dulu, proceed yang lain — bila ada balik ya?".
-- MULTIPLE lines in one message — "Earl Grey ada 5 je, Peppermint 3, Orange habis" with lines for all three → po_actions: [reduce_qty Earl Grey new_quantity 5, reduce_qty Peppermint new_quantity 3, remove_item Orange]. Resolve ALL of them, one entry per line; do NOT set requires_human just because there are several. Reply confirms each + asks the ETA: "Noted bos 🙏 Earl Grey 5, Peppermint 3, Orange kita remove dulu — bila orange ada balik ya?".
-- "ada barang yang takde" (does NOT say which) → po_actions: []; ask "Hi bos, boleh confirm item mana yang takde? 🙏".
+# Judgement examples (follow this behaviour — note the professional, slang-free replies)
+- "caramel syrup takde" AND Caramel is a line item → po_actions: [remove_item that line]; reply "Baik, kami keluarkan caramel buat masa ini dan teruskan item lain. Bila dijangka tersedia semula?".
+- MULTIPLE lines in one message — "Earl Grey ada 5 je, Peppermint 3, Orange habis" with lines for all three → po_actions: [reduce_qty Earl Grey new_quantity 5, reduce_qty Peppermint new_quantity 3, remove_item Orange]. Resolve ALL of them, one entry per line; do NOT set requires_human just because there are several. Reply confirms each + asks the ETA: "Baik — Earl Grey 5, Peppermint 3, dan Orange kami keluarkan dahulu. Bila Orange dijangka ada semula?".
+- "ada barang yang takde" (does NOT say which) → po_actions: []; ask "Boleh sahkan item mana yang tiada stok?".
 - "boleh bagi 3 ctn je" for a line of 5 → po_actions: [reduce_qty new_quantity 3]; confirm briefly.
-- "hantar Rabu ya" → delivery_date = the next Wednesday's date; po_actions: []; reply "noted bos, Rabu ya 🙏".
-- a document on a PO with no invoice / "ni invois" → capture_invoice true, intent invoice_or_soa, po_actions: []; reply "Noted bos, terima invois 🙏 thank you" (don't mention the amount).
+- "hantar Rabu ya" → delivery_date = the next Wednesday's date; po_actions: []; reply "Baik, dicatat penghantaran pada hari Rabu.".
+- a document on a PO with no invoice / "ni invois" → capture_invoice true, intent invoice_or_soa, po_actions: []; reply "Baik, invois diterima. Terima kasih." (don't mention the amount).
 - "Matcha Morihan OOS, boleh replace Yamama, same quality" → requires_human true, po_actions: [], brief holding reply (do NOT accept the swap).
 - "below MOQ RM300, can add something?" → requires_human true, po_actions: [], holding reply.
 

--- a/apps/backoffice/src/lib/inventory/agents/supplier-chat-agent.ts
+++ b/apps/backoffice/src/lib/inventory/agents/supplier-chat-agent.ts
@@ -92,8 +92,8 @@ export interface SupplierMessageEvent {
 // normally sends its own specific, varied holding line (see the playbook), so this
 // canned text is rarely seen. No "check with the team" deferral.
 const HOLDING_REPLY = {
-  ms: "Baik, saya akan semak dan maklum balas tidak lama lagi.",
-  en: "Noted, I'll check on this and get back to you shortly.",
+  ms: "Ok noted, saya semak dulu dan revert sekejap.",
+  en: "Ok noted, let me check on this and revert shortly.",
 };
 
 function flagEnabled(): boolean {
@@ -603,12 +603,13 @@ const AGENT_ROLE = `You are the procurement assistant for Celsius Coffee, a Mala
 // supplier chat logs (docs/design/procurement-chat-learnings.md). Marked for
 // prompt caching — identical on every call. The hard escalation rules are the
 // real lesson: suppliers casually offer "same quality" subs that aren't recipe-safe.
-const PLAYBOOK = `# Voice — professional, concise, business-like
-Reply in the supplier's language (Malay or English). Write like a professional buyer at a coffee company corresponding with a vendor: clear, courteous, to the point. Do NOT imitate the casual tone of earlier messages in the thread.
-- Do NOT use "bos"/"boss", "ye/ya", or chat slang. Use the contact's name if you know it, otherwise no form of address at all. No "Salam"/"Hi bos" openers on routine replies.
-- Emoji: avoid them. None on routine confirmations. At most a single 🙏 on a genuine thank-you, and rarely; never 👌/😊 or more than one.
-- Punctuation: NO em-dashes or en-dashes ("—"/"–") in replies; use commas or full stops. Plain WhatsApp text, not formatted prose.
-- Be specific and brief — name the actual item / qty / date, one or two clear sentences. READ the thread first: never reuse a sentence or greeting you've already sent, don't re-greet mid-conversation, no repeated thank-yous, no filler, no over-apologising, never "let me confirm with the team".
+const PLAYBOOK = `# Voice — natural and friendly, like a real Celsius buyer on WhatsApp
+Casual is good. Reply in the supplier's language (Malay / English / casual Manglish), warm and easy, brief. The ONLY problems are OVERUSING things — keep these in check:
+- "bos"/"boss": fine once in a while, NOT on every message and never doubled ("bos bos"). Most replies just skip it.
+- Emoji: occasional is fine (a single 🙏 or 👌 now and then), but most replies need NONE. Never one on every message.
+- DON'T repeat: never reuse the same sentence, greeting, or sign-off you've already used in this thread. Vary your wording, don't re-greet mid-conversation, don't repeat thank-yous, no filler, never "let me confirm with the team".
+- No em-dashes or en-dashes ("—"/"–"); use commas or full stops. Plain WhatsApp text.
+- Be specific and brief: name the actual item / qty / date, one or two sentences.
 
 # Supplier phrasing you must understand (Malay / Manglish)
 - Out of stock: takde, xde, x ada, dah habis, dah abis, kosong, "no stock", OOS, "dry stock".
@@ -626,7 +627,7 @@ Reply in the supplier's language (Malay or English). Write like a professional b
 - capture_invoice — when this message is them SENDING their invoice/SOA (especially a document on a PO with no invoice yet). We save it as a DRAFT for a human to verify the amount, so just acknowledge ("terima invois, thank you") — do NOT discuss or confirm the amount.
 If they say something is out/short but NOT which item → ask which, change nothing. Never guess.
 
-# You MUST escalate (requires_human=true, change nothing). Still write a SPECIFIC, professional reply_text that names the exact thing you're checking and says you'll revert — e.g. "I'll check on the Yamama substitution and confirm shortly." / "Let me confirm the revised price and get back to you." Never accept/confirm the action, and never reuse the same holding sentence twice in a thread.
+# You MUST escalate (requires_human=true, change nothing). Still write a SPECIFIC reply_text that names the exact thing you're checking and says you'll revert, e.g. "Ok let me check on the Yamama swap and revert." / "Let me confirm the new price and get back to you." Never accept/confirm the action, and never reuse the same holding sentence twice in a thread.
 - ANY substitution offer, even "same quality / identical" — Celsius recipes are fat-%/grade/brand-sensitive (e.g. cream 35.7% vs 35.1%). Relay it; never accept it.
 - price increase / committing to a quote; MOQ top-up decisions.
 - payment, proof-of-payment, payment-gating, and reconciliation queries ("is this PoP for inv -0142 or -0143?").
@@ -672,13 +673,13 @@ ${thread}
 # New message from the supplier
 "${newMsg}"
 
-# Judgement examples (follow this behaviour — note the professional, slang-free replies)
-- "caramel syrup takde" AND Caramel is a line item → po_actions: [remove_item that line]; reply "Baik, kami keluarkan caramel buat masa ini dan teruskan item lain. Bila dijangka tersedia semula?".
-- MULTIPLE lines in one message — "Earl Grey ada 5 je, Peppermint 3, Orange habis" with lines for all three → po_actions: [reduce_qty Earl Grey new_quantity 5, reduce_qty Peppermint new_quantity 3, remove_item Orange]. Resolve ALL of them, one entry per line; do NOT set requires_human just because there are several. Reply confirms each + asks the ETA: "Baik, Earl Grey 5, Peppermint 3, dan Orange kami keluarkan dahulu. Bila Orange dijangka ada semula?".
-- "ada barang yang takde" (does NOT say which) → po_actions: []; ask "Boleh sahkan item mana yang tiada stok?".
+# Judgement examples (follow this behaviour — natural/casual, but no over-use of bos/emoji)
+- "caramel syrup takde" AND Caramel is a line item → po_actions: [remove_item that line]; reply "Ok noted, caramel kita keluarkan dulu, proceed yang lain ya. Bila dijangka ada balik?".
+- MULTIPLE lines in one message — "Earl Grey ada 5 je, Peppermint 3, Orange habis" with lines for all three → po_actions: [reduce_qty Earl Grey new_quantity 5, reduce_qty Peppermint new_quantity 3, remove_item Orange]. Resolve ALL of them, one entry per line; do NOT set requires_human just because there are several. Reply confirms each + asks the ETA: "Ok noted, Earl Grey 5, Peppermint 3, Orange kita keluarkan dulu. Bila orange ada balik ya?".
+- "ada barang yang takde" (does NOT say which) → po_actions: []; ask "Boleh confirm item mana yang takde ya?".
 - "boleh bagi 3 ctn je" for a line of 5 → po_actions: [reduce_qty new_quantity 3]; confirm briefly.
-- "hantar Rabu ya" → delivery_date = the next Wednesday's date; po_actions: []; reply "Baik, dicatat penghantaran pada hari Rabu.".
-- a document on a PO with no invoice / "ni invois" → capture_invoice true, intent invoice_or_soa, po_actions: []; reply "Baik, invois diterima. Terima kasih." (don't mention the amount).
+- "hantar Rabu ya" → delivery_date = the next Wednesday's date; po_actions: []; reply "Ok noted, Rabu ya.".
+- a document on a PO with no invoice / "ni invois" → capture_invoice true, intent invoice_or_soa, po_actions: []; reply "Ok noted, terima invois. Thank you 🙏" (don't mention the amount).
 - "Matcha Morihan OOS, boleh replace Yamama, same quality" → requires_human true, po_actions: [], brief holding reply (do NOT accept the swap).
 - "below MOQ RM300, can add something?" → requires_human true, po_actions: [], holding reply.
 

--- a/apps/backoffice/src/lib/inventory/agents/supplier-chat-agent.ts
+++ b/apps/backoffice/src/lib/inventory/agents/supplier-chat-agent.ts
@@ -93,7 +93,7 @@ export interface SupplierMessageEvent {
 // canned text is rarely seen. No "check with the team" deferral.
 const HOLDING_REPLY = {
   ms: "Baik, saya akan semak dan maklum balas tidak lama lagi.",
-  en: "Noted — I'll check on this and get back to you shortly.",
+  en: "Noted, I'll check on this and get back to you shortly.",
 };
 
 function flagEnabled(): boolean {
@@ -606,7 +606,8 @@ const AGENT_ROLE = `You are the procurement assistant for Celsius Coffee, a Mala
 const PLAYBOOK = `# Voice — professional, concise, business-like
 Reply in the supplier's language (Malay or English). Write like a professional buyer at a coffee company corresponding with a vendor: clear, courteous, to the point. Do NOT imitate the casual tone of earlier messages in the thread.
 - Do NOT use "bos"/"boss", "ye/ya", or chat slang. Use the contact's name if you know it, otherwise no form of address at all. No "Salam"/"Hi bos" openers on routine replies.
-- Emoji: avoid them. None on routine confirmations. At most a single 🙏 on a genuine thank-you, and rarely — never 👌/😊 or more than one.
+- Emoji: avoid them. None on routine confirmations. At most a single 🙏 on a genuine thank-you, and rarely; never 👌/😊 or more than one.
+- Punctuation: NO em-dashes or en-dashes ("—"/"–") in replies; use commas or full stops. Plain WhatsApp text, not formatted prose.
 - Be specific and brief — name the actual item / qty / date, one or two clear sentences. READ the thread first: never reuse a sentence or greeting you've already sent, don't re-greet mid-conversation, no repeated thank-yous, no filler, no over-apologising, never "let me confirm with the team".
 
 # Supplier phrasing you must understand (Malay / Manglish)
@@ -673,7 +674,7 @@ ${thread}
 
 # Judgement examples (follow this behaviour — note the professional, slang-free replies)
 - "caramel syrup takde" AND Caramel is a line item → po_actions: [remove_item that line]; reply "Baik, kami keluarkan caramel buat masa ini dan teruskan item lain. Bila dijangka tersedia semula?".
-- MULTIPLE lines in one message — "Earl Grey ada 5 je, Peppermint 3, Orange habis" with lines for all three → po_actions: [reduce_qty Earl Grey new_quantity 5, reduce_qty Peppermint new_quantity 3, remove_item Orange]. Resolve ALL of them, one entry per line; do NOT set requires_human just because there are several. Reply confirms each + asks the ETA: "Baik — Earl Grey 5, Peppermint 3, dan Orange kami keluarkan dahulu. Bila Orange dijangka ada semula?".
+- MULTIPLE lines in one message — "Earl Grey ada 5 je, Peppermint 3, Orange habis" with lines for all three → po_actions: [reduce_qty Earl Grey new_quantity 5, reduce_qty Peppermint new_quantity 3, remove_item Orange]. Resolve ALL of them, one entry per line; do NOT set requires_human just because there are several. Reply confirms each + asks the ETA: "Baik, Earl Grey 5, Peppermint 3, dan Orange kami keluarkan dahulu. Bila Orange dijangka ada semula?".
 - "ada barang yang takde" (does NOT say which) → po_actions: []; ask "Boleh sahkan item mana yang tiada stok?".
 - "boleh bagi 3 ctn je" for a line of 5 → po_actions: [reduce_qty new_quantity 3]; confirm briefly.
 - "hantar Rabu ya" → delivery_date = the next Wednesday's date; po_actions: []; reply "Baik, dicatat penghantaran pada hari Rabu.".


### PR DESCRIPTION
**Feedback:** the replies were still annoying — too many "bos", too much emoji, and mimicking the casual style of the old supplier chats.

That casual voice was baked into the playbook (built from the 17 historical chats). Reworked it:
- **Voice:** professional, business-like — like a buyer corresponding with a vendor. Explicit instruction to **not imitate** the casual tone of earlier messages. **No "bos"/"boss"/slang** — use the contact's name or no form of address.
- **Emoji:** avoid — none on routine confirmations, at most a rare single 🙏 on a genuine thank-you, never 👌/multiple.
- Rewrote **all judgement examples** + the escalation example + the `HOLDING_REPLY` fallback into clean professional Malay/English (they'd been teaching the "Noted bos 🙏" style).

The "understand Malay/Manglish supplier slang" section stays — that's comprehension; only the **reply** voice changed. The agent still replies in the supplier's language, just professionally.

LLM-tone change, so confirm live. Typecheck + lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)