### PR TITLE
feat(procurement): "Need ordering" — suggested draft POs in the workspace

### DIFF
--- a/apps/backoffice/src/app/(admin)/inventory/supplier-chats/page.tsx
+++ b/apps/backoffice/src/app/(admin)/inventory/supplier-chats/page.tsx
@@ -18,6 +18,7 @@ import {
   Plus,
   X,
   Hand,
+  ShoppingCart,
 } from "lucide-react";
 
 type AutomationMode = "OFF" | "ASSIST" | "AUTO";
@@ -45,6 +46,8 @@ type PoView = {
   outlet?: { name: string } | null;
   items: { id: string; quantity: number | string; unitPrice: number | string; product?: { name: string } | null }[];
 };
+type NeedItem = { productId: string; productPackageId: string | null; name: string; qty: number; unitPrice: number; packageLabel: string; onHand: number; reorderPoint: number };
+type NeedGroup = { supplierId: string; supplierName: string; outletId: string; outletName: string; items: NeedItem[]; total: number; itemCount: number };
 
 type Msg = {
   id: string;
@@ -272,6 +275,49 @@ export default function SupplierChatsPage() {
     }
   }
 
+  // ── Need ordering (suggested draft POs) ───────────────────────
+  const [needOrderOpen, setNeedOrderOpen] = useState(false);
+  const [needGroups, setNeedGroups] = useState<NeedGroup[] | null>(null);
+  const [needCreated, setNeedCreated] = useState<Set<string>>(new Set());
+  const [needCreatingKey, setNeedCreatingKey] = useState<string | null>(null);
+
+  async function openNeedOrder() {
+    setNeedOrderOpen(true);
+    setNeedGroups(null);
+    setNeedCreated(new Set());
+    try {
+      const r = await fetch("/api/inventory/reorder-suggestions");
+      const data = r.ok ? await r.json() : { groups: [] };
+      setNeedGroups(data.groups ?? []);
+    } catch {
+      setNeedGroups([]);
+    }
+  }
+  async function createDraftFromGroup(g: NeedGroup) {
+    const key = `${g.supplierId}_${g.outletId}`;
+    setNeedCreatingKey(key);
+    try {
+      const r = await fetch("/api/inventory/orders", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          outletId: g.outletId,
+          supplierId: g.supplierId,
+          notes: "Suggested reorder (below par)",
+          items: g.items.map((i) => ({ productId: i.productId, productPackageId: i.productPackageId, quantity: i.qty, unitPrice: i.unitPrice })),
+          clientRequestId: crypto.randomUUID(),
+        }),
+      });
+      if (r.ok) {
+        setNeedCreated((prev) => new Set(prev).add(key));
+        mutateDetail();
+        mutateThreads();
+      }
+    } finally {
+      setNeedCreatingKey(null);
+    }
+  }
+
   const threads = threadsData?.threads ?? [];
   const counts = threadsData?.counts;
   const q = query.trim().toLowerCase();
@@ -365,8 +411,16 @@ export default function SupplierChatsPage() {
       {/* ── Thread list ─────────────────────────────── */}
       <div className="flex w-72 shrink-0 flex-col overflow-hidden rounded-xl border border-border bg-background shadow-sm">
         <div className="border-b border-border p-3">
-          <div className="flex items-center gap-2 text-sm font-medium">
-            <MessageCircle size={16} /> Suppliers
+          <div className="flex items-center justify-between gap-2 text-sm font-medium">
+            <span className="flex items-center gap-2">
+              <MessageCircle size={16} /> Suppliers
+            </span>
+            <button
+              onClick={openNeedOrder}
+              className="inline-flex items-center gap-1 rounded-md border border-amber-300 bg-amber-50 px-2 py-1 text-[11px] font-medium text-amber-700 hover:bg-amber-100 dark:border-amber-800 dark:bg-amber-950/40 dark:text-amber-300"
+            >
+              <ShoppingCart size={12} /> Need ordering
+            </button>
           </div>
           <div className="relative mt-2">
             <Search size={13} className="absolute left-2 top-1/2 -translate-y-1/2 text-muted-foreground" />
@@ -919,6 +973,78 @@ export default function SupplierChatsPage() {
                 </div>
               </>
             )}
+          </div>
+        </div>
+      )}
+
+      {needOrderOpen && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4" onClick={() => setNeedOrderOpen(false)}>
+          <div
+            onClick={(e) => e.stopPropagation()}
+            className="flex max-h-[85vh] w-full max-w-lg flex-col overflow-hidden rounded-xl border border-border bg-background shadow-lg"
+          >
+            <div className="flex items-center justify-between border-b border-border px-4 py-3">
+              <div className="flex items-center gap-2 text-sm font-medium">
+                <ShoppingCart size={15} /> Need ordering
+              </div>
+              <button onClick={() => setNeedOrderOpen(false)} aria-label="Close" className="text-muted-foreground hover:text-foreground">
+                <X size={16} />
+              </button>
+            </div>
+            <div className="flex-1 overflow-y-auto p-3">
+              {!needGroups ? (
+                <div className="flex items-center justify-center p-8">
+                  <Loader2 size={18} className="animate-spin text-muted-foreground" />
+                </div>
+              ) : needGroups.length === 0 ? (
+                <p className="p-6 text-center text-xs text-muted-foreground">Nothing below reorder point right now.</p>
+              ) : (
+                <div className="flex flex-col gap-3">
+                  {needGroups.map((g) => {
+                    const key = `${g.supplierId}_${g.outletId}`;
+                    const done = needCreated.has(key);
+                    return (
+                      <div key={key} className="rounded-lg border border-border p-3">
+                        <div className="mb-2 flex items-center justify-between gap-2">
+                          <div className="min-w-0">
+                            <div className="truncate text-[13px] font-medium">{g.supplierName}</div>
+                            <div className="text-[11px] text-muted-foreground">
+                              {g.outletName} · {g.itemCount} item{g.itemCount > 1 ? "s" : ""} · {formatRM(g.total)}
+                            </div>
+                          </div>
+                          {done ? (
+                            <span className="inline-flex shrink-0 items-center gap-1 text-[11px] font-medium text-green-600 dark:text-green-400">
+                              <Check size={13} /> Draft created
+                            </span>
+                          ) : (
+                            <button
+                              onClick={() => createDraftFromGroup(g)}
+                              disabled={needCreatingKey === key}
+                              className="inline-flex shrink-0 items-center gap-1 rounded-md bg-primary px-2.5 py-1.5 text-[11px] font-medium text-primary-foreground hover:bg-primary/90 disabled:opacity-50"
+                            >
+                              {needCreatingKey === key ? <Loader2 size={12} className="animate-spin" /> : <Plus size={12} />} Create draft PO
+                            </button>
+                          )}
+                        </div>
+                        <div className="flex flex-col gap-0.5">
+                          {g.items.map((it) => (
+                            <div key={it.productId} className="flex items-center justify-between gap-2 text-[11px]">
+                              <span className="truncate">{it.name}</span>
+                              <span className="shrink-0 text-muted-foreground">
+                                {Math.round(it.onHand)} on hand ≤ {Math.round(it.reorderPoint)} → order {it.qty} {it.packageLabel}
+                              </span>
+                            </div>
+                          ))}
+                        </div>
+                      </div>
+                    );
+                  })}
+                </div>
+              )}
+            </div>
+            <div className="border-t border-border px-4 py-2.5 text-[11px] text-muted-foreground">
+              Below-par items with no open PO, grouped to the cheapest supplier. Create a draft, then review + send it from the PO list.
+            </div>
           </div>
         </div>
       )}

--- a/apps/backoffice/src/app/api/inventory/reorder-suggestions/route.ts
+++ b/apps/backoffice/src/app/api/inventory/reorder-suggestions/route.ts
@@ -1,0 +1,159 @@
+import { NextResponse, NextRequest } from "next/server";
+import type { OrderStatus } from "@celsius/db";
+import { prisma } from "@/lib/prisma";
+import { getUserFromHeaders } from "@/lib/auth";
+import { boundedReorderQty } from "@/lib/inventory/order-validation";
+
+// GET /api/inventory/reorder-suggestions
+// Items at/below their reorder point with NO open PO already covering them, grouped
+// into a suggested DRAFT PO per (cheapest active supplier × outlet). The "Need
+// ordering" workspace tab shows these for a human to review + create — the ASSIST
+// counterpart to the exec's auto-ordering (suggest, don't auto-fire).
+
+const OPEN_ORDER_STATUSES: OrderStatus[] = [
+  "DRAFT",
+  "PENDING_APPROVAL",
+  "APPROVED",
+  "SENT",
+  "CONFIRMED",
+  "AWAITING_DELIVERY",
+  "PARTIALLY_RECEIVED",
+];
+
+export async function GET(req: NextRequest) {
+  const caller = await getUserFromHeaders(req.headers);
+  if (!caller) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+
+  const [pars, stocks, openLines, sps, products, outlets] = await Promise.all([
+    prisma.parLevel.findMany({
+      select: { productId: true, outletId: true, parLevel: true, reorderPoint: true, maxLevel: true, avgDailyUsage: true },
+    }),
+    prisma.stockBalance.findMany({ select: { productId: true, outletId: true, quantity: true } }),
+    prisma.orderItem.findMany({
+      where: { order: { orderType: "PURCHASE_ORDER", status: { in: OPEN_ORDER_STATUSES } } },
+      select: { productId: true, order: { select: { outletId: true } } },
+    }),
+    prisma.supplierProduct.findMany({
+      where: { isActive: true, price: { gt: 0 }, supplier: { status: "ACTIVE" } },
+      select: {
+        supplierId: true,
+        productId: true,
+        price: true,
+        moq: true,
+        productPackageId: true,
+        supplier: { select: { name: true } },
+        productPackage: { select: { conversionFactor: true, packageLabel: true } },
+      },
+    }),
+    prisma.product.findMany({ where: { isActive: true }, select: { id: true, name: true, shelfLifeDays: true } }),
+    prisma.outlet.findMany({ select: { id: true, name: true } }),
+  ]);
+
+  // Cheapest active supplier per product (per base unit), with the full line info.
+  type Cheapest = {
+    supplierId: string;
+    supplierName: string;
+    price: number;
+    moq: number;
+    productPackageId: string | null;
+    conv: number;
+    packageLabel: string;
+    unitCost: number;
+  };
+  const cheapest = new Map<string, Cheapest>();
+  for (const sp of sps) {
+    const conv = sp.productPackage ? Number(sp.productPackage.conversionFactor) || 1 : 1;
+    const c = conv > 0 ? conv : 1;
+    const unitCost = Number(sp.price) / c;
+    const cur = cheapest.get(sp.productId);
+    if (!cur || unitCost < cur.unitCost) {
+      cheapest.set(sp.productId, {
+        supplierId: sp.supplierId,
+        supplierName: sp.supplier?.name ?? "?",
+        price: Number(sp.price),
+        moq: Number(sp.moq) || 0,
+        productPackageId: sp.productPackageId,
+        conv: c,
+        packageLabel: sp.productPackage?.packageLabel ?? "unit",
+        unitCost,
+      });
+    }
+  }
+
+  const stockMap = new Map<string, number>();
+  for (const s of stocks) {
+    const k = `${s.productId}_${s.outletId}`;
+    stockMap.set(k, (stockMap.get(k) ?? 0) + Number(s.quantity));
+  }
+  const covered = new Set<string>();
+  for (const l of openLines) if (l.order) covered.add(`${l.productId}_${l.order.outletId}`);
+  const prodMap = new Map(products.map((p) => [p.id, p]));
+  const outletMap = new Map(outlets.map((o) => [o.id, o.name]));
+
+  type Line = {
+    productId: string;
+    productPackageId: string | null;
+    name: string;
+    qty: number;
+    unitPrice: number;
+    packageLabel: string;
+    onHand: number;
+    reorderPoint: number;
+  };
+  const groups = new Map<string, { supplierId: string; supplierName: string; outletId: string; outletName: string; items: Line[] }>();
+
+  for (const par of pars) {
+    const p = prodMap.get(par.productId);
+    if (!p) continue;
+    const key = `${par.productId}_${par.outletId}`;
+    const stock = stockMap.get(key) ?? 0;
+    const reorder = Number(par.reorderPoint);
+    if (stock > reorder || covered.has(key)) continue;
+    const c = cheapest.get(par.productId);
+    if (!c) continue;
+    const parLvl = Number(par.parLevel);
+    const maxLvl = par.maxLevel != null ? Number(par.maxLevel) : null;
+    const avgDaily = par.avgDailyUsage != null ? Number(par.avgDailyUsage) : 0;
+    const needed = Math.max(parLvl - stock, 0);
+    if (needed <= 0) continue;
+    const { orderQty } = boundedReorderQty({
+      neededBase: needed,
+      conversionFactor: c.conv,
+      moq: c.moq,
+      headroomBase: maxLvl != null ? Math.max(maxLvl - stock, 0) : null,
+      shelfUsableBase: p.shelfLifeDays && avgDaily > 0 ? p.shelfLifeDays * avgDaily : null,
+    });
+    if (orderQty <= 0) continue;
+    const gkey = `${c.supplierId}_${par.outletId}`;
+    let g = groups.get(gkey);
+    if (!g) {
+      g = { supplierId: c.supplierId, supplierName: c.supplierName, outletId: par.outletId, outletName: outletMap.get(par.outletId) ?? "?", items: [] };
+      groups.set(gkey, g);
+    }
+    g.items.push({
+      productId: par.productId,
+      productPackageId: c.productPackageId,
+      name: p.name,
+      qty: orderQty,
+      unitPrice: c.price,
+      packageLabel: c.packageLabel,
+      onHand: stock,
+      reorderPoint: reorder,
+    });
+  }
+
+  const out = [...groups.values()]
+    .map((g) => ({
+      ...g,
+      items: g.items.sort((a, b) => a.name.localeCompare(b.name)),
+      total: Math.round(g.items.reduce((s, i) => s + i.qty * i.unitPrice, 0) * 100) / 100,
+      itemCount: g.items.length,
+    }))
+    .sort((a, b) => b.itemCount - a.itemCount);
+
+  return NextResponse.json({
+    groups: out,
+    supplierCount: out.length,
+    itemCount: out.reduce((s, g) => s + g.items.length, 0),
+  });
+}


### PR DESCRIPTION
The human-in-the-loop side of proactive ordering — exactly the review surface to build before transitioning suppliers to full-auto.

A **"Need ordering"** button in the workspace header opens a panel of everything **below reorder point**, grouped into a **suggested draft PO per (cheapest supplier × outlet)**:
- each line shows `on-hand ≤ reorder → order N [unit]`
- **"Create draft PO"** per group → creates a DRAFT (via orders POST) you then review + send from the PO list (the #552 PO panel)

**Suggest, don't auto-fire** — it never sends anything; it just turns "what needs ordering" into a one-click draft.

`GET /api/inventory/reorder-suggestions`: below-reorder items with no open covering PO → cheapest active supplier → suggested qty via `boundedReorderQty` (MOQ floor + max-level/shelf-life caps), grouped per supplier×outlet.

Typecheck + lint clean. (Modal UI not screenshot-able locally — dev server worktree issue + auth — so verified at compile level; the suggestion logic reuses the same engine as the exec's assessment.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)