### PR TITLE
feat(procurement): store WhatsApp media (open attachments + invoice photos) + reply-to

### DIFF
--- a/apps/backoffice/src/app/(admin)/inventory/supplier-chats/page.tsx
+++ b/apps/backoffice/src/app/(admin)/inventory/supplier-chats/page.tsx
@@ -21,6 +21,7 @@ import {
   X,
   Hand,
   ShoppingCart,
+  Reply,
 } from "lucide-react";
 
 type AutomationMode = "OFF" | "ASSIST" | "AUTO";
@@ -53,6 +54,7 @@ type NeedGroup = { supplierId: string; supplierName: string; outletId: string; o
 
 type Msg = {
   id: string;
+  waMessageId: string | null;
   direction: "inbound" | "outbound";
   type: string;
   body: string | null;
@@ -112,6 +114,14 @@ function initials(name: string): string {
   return name.replace(/[^A-Za-z0-9]/g, "").slice(0, 2).toUpperCase() || "?";
 }
 
+// Short one-line preview of a message for the "Replying to" bar.
+function msgPreview(m: Msg): string {
+  if (m.body && m.body.trim()) return m.body.trim().slice(0, 80);
+  if (m.type === "image") return "📷 Photo";
+  if (m.type === "document") return "📄 Document";
+  return m.type;
+}
+
 export default function SupplierChatsPage() {
   const searchParams = useSearchParams();
   // Deep-link support: /inventory/supplier-chats?key=<number> opens that thread
@@ -142,6 +152,8 @@ export default function SupplierChatsPage() {
   const [draft, setDraft] = useState("");
   const [sending, setSending] = useState(false);
   const [sendError, setSendError] = useState<string | null>(null);
+  // Quoted reply: the message the composer is replying to (clears on send/cancel).
+  const [replyingTo, setReplyingTo] = useState<Msg | null>(null);
   const [applying, setApplying] = useState(false);
   const [applyError, setApplyError] = useState<string | null>(null);
 
@@ -473,17 +485,21 @@ export default function SupplierChatsPage() {
     setDraft("");
     setSendError(null);
     setApplyError(null);
+    setReplyingTo(null);
   }, [selected]);
 
   async function send() {
     if (!selected || !draft.trim() || sending) return;
     setSending(true);
     setSendError(null);
+    // Prefer the Meta message id (so WhatsApp threads the quote); fall back to
+    // our DB row id, which the send route resolves to the Meta id server-side.
+    const replyTo = replyingTo ? replyingTo.waMessageId ?? replyingTo.id : undefined;
     try {
       const res = await fetch(`/api/inventory/supplier-chats/${selected}/send`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ text: draft.trim() }),
+        body: JSON.stringify({ text: draft.trim(), ...(replyTo ? { replyTo } : {}) }),
       });
       const json = await res.json().catch(() => ({}));
       if (!res.ok) {
@@ -491,6 +507,7 @@ export default function SupplierChatsPage() {
         return;
       }
       setDraft("");
+      setReplyingTo(null);
       mutateDetail();
     } catch {
       setSendError("Network error");
@@ -646,22 +663,57 @@ export default function SupplierChatsPage() {
               {detail.messages.map((m) => (
                 <div
                   key={m.id}
-                  className={`max-w-[80%] rounded-lg px-3 py-2 text-[13px] leading-snug ${
-                    m.direction === "outbound"
-                      ? "self-end bg-primary text-primary-foreground"
-                      : "self-start bg-muted text-foreground"
-                  }`}
+                  className={`group flex items-center gap-1.5 ${
+                    m.direction === "outbound" ? "flex-row-reverse self-end" : "self-start"
+                  } max-w-[80%]`}
                 >
-                  {m.body ?? (
-                    <span className="inline-flex items-center gap-1">
-                      <FileText size={13} /> {m.type}
-                    </span>
-                  )}
                   <div
-                    className={`mt-1 text-[10px] ${m.direction === "outbound" ? "text-primary-foreground/70" : "text-muted-foreground"}`}
+                    className={`min-w-0 rounded-lg px-3 py-2 text-[13px] leading-snug ${
+                      m.direction === "outbound"
+                        ? "bg-primary text-primary-foreground"
+                        : "bg-muted text-foreground"
+                    }`}
                   >
-                    {clock(m.timestamp)}
+                    {m.type === "image" && m.mediaUrl ? (
+                      <a href={m.mediaUrl} target="_blank" rel="noopener noreferrer" className="block">
+                        {/* eslint-disable-next-line @next/next/no-img-element */}
+                        <img
+                          src={m.mediaUrl}
+                          alt={m.body ?? "Photo"}
+                          className="max-h-[180px] max-w-full rounded-md object-cover"
+                        />
+                        {m.body && <div className="mt-1">{m.body}</div>}
+                      </a>
+                    ) : m.type === "document" && m.mediaUrl ? (
+                      <a
+                        href={m.mediaUrl}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="inline-flex items-center gap-1 underline-offset-2 hover:underline"
+                      >
+                        <FileText size={13} /> {m.body || "Document"}
+                      </a>
+                    ) : (
+                      m.body ?? (
+                        <span className="inline-flex items-center gap-1">
+                          <FileText size={13} /> {m.type}
+                        </span>
+                      )
+                    )}
+                    <div
+                      className={`mt-1 text-[10px] ${m.direction === "outbound" ? "text-primary-foreground/70" : "text-muted-foreground"}`}
+                    >
+                      {clock(m.timestamp)}
+                    </div>
                   </div>
+                  <button
+                    onClick={() => setReplyingTo(m)}
+                    aria-label="Reply"
+                    title="Reply"
+                    className="shrink-0 rounded-full p-1 text-muted-foreground opacity-0 transition-opacity hover:bg-muted hover:text-foreground group-hover:opacity-100"
+                  >
+                    <Reply size={13} />
+                  </button>
                 </div>
               ))}
               <div ref={messagesEndRef} />
@@ -671,6 +723,21 @@ export default function SupplierChatsPage() {
                 <div className="mb-2 flex items-center gap-1.5 rounded-md bg-amber-500/10 px-2.5 py-1.5 text-[11px] text-amber-700 dark:text-amber-400">
                   <Hand size={13} className="shrink-0" />
                   You&apos;re handling this chat — AI paused here. It resumes once you go quiet.
+                </div>
+              )}
+              {replyingTo && (
+                <div className="mb-2 flex items-center gap-2 rounded-md border-l-2 border-primary bg-muted px-2.5 py-1.5 text-[11px]">
+                  <Reply size={12} className="shrink-0 text-muted-foreground" />
+                  <span className="min-w-0 flex-1 truncate text-muted-foreground">
+                    Replying to: {msgPreview(replyingTo)}
+                  </span>
+                  <button
+                    onClick={() => setReplyingTo(null)}
+                    aria-label="Cancel reply"
+                    className="shrink-0 text-muted-foreground hover:text-foreground"
+                  >
+                    <X size={13} />
+                  </button>
                 </div>
               )}
               <div className="flex items-center gap-2">

--- a/apps/backoffice/src/app/api/inventory/supplier-chats/[key]/route.ts
+++ b/apps/backoffice/src/app/api/inventory/supplier-chats/[key]/route.ts
@@ -21,6 +21,7 @@ export async function GET(req: NextRequest, { params }: { params: Promise<{ key:
     take: 500,
     select: {
       id: true,
+      waMessageId: true,
       direction: true,
       type: true,
       body: true,

--- a/apps/backoffice/src/app/api/inventory/supplier-chats/[key]/send/route.ts
+++ b/apps/backoffice/src/app/api/inventory/supplier-chats/[key]/send/route.ts
@@ -18,6 +18,22 @@ export async function POST(req: NextRequest, { params }: { params: Promise<{ key
   const body = await req.json().catch(() => ({}));
   const text = typeof body.text === "string" ? body.text.trim() : "";
   if (!text) return NextResponse.json({ error: "Message is empty" }, { status: 400 });
+  // Optional quoted-reply: the Meta message id of the inbound message being
+  // replied to. The UI passes the WhatsApp `waMessageId` directly; if a caller
+  // only has our DB row id, resolve it to the Meta id server-side.
+  const replyToRaw = typeof body.replyTo === "string" ? body.replyTo.trim() : "";
+  let replyTo = "";
+  if (replyToRaw) {
+    if (replyToRaw.startsWith("wamid.")) {
+      replyTo = replyToRaw;
+    } else {
+      const ref = await prisma.whatsAppMessage.findUnique({
+        where: { id: replyToRaw },
+        select: { waMessageId: true },
+      });
+      replyTo = ref?.waMessageId ?? "";
+    }
+  }
 
   // 24h window: did this counterparty message us within the last 24h?
   const lastInbound = await prisma.whatsAppMessage.findFirst({
@@ -34,7 +50,7 @@ export async function POST(req: NextRequest, { params }: { params: Promise<{ key
     );
   }
 
-  const result = await sendWhatsAppText(key, text);
+  const result = await sendWhatsAppText(key, text, replyTo || undefined);
   if (!result.ok) {
     return NextResponse.json({ error: result.error ?? "Send failed" }, { status: 502 });
   }

--- a/apps/backoffice/src/app/api/whatsapp/webhook/route.ts
+++ b/apps/backoffice/src/app/api/whatsapp/webhook/route.ts
@@ -17,6 +17,7 @@
  */
 import { NextRequest, NextResponse } from "next/server";
 import { verifyWhatsAppSignature } from "@/lib/whatsapp";
+import { storeWhatsAppMedia } from "@/lib/whatsapp-media";
 import { recordInboundMessage } from "@/lib/whatsapp-store";
 import { handleInboundAck } from "@/lib/ops-pulse/inbound";
 import { handleSupplierMessage } from "@/lib/inventory/agents/supplier-chat-agent";
@@ -72,15 +73,25 @@ export async function POST(request: NextRequest) {
         console.log(
           `[whatsapp:webhook] inbound from=${msg.from} type=${msg.type} text=${JSON.stringify(body ?? `<${msg.type}>`)}`,
         );
+        // For image/document messages, fetch the media bytes once and persist them
+        // to Supabase Storage so the inbox can open the attachment (the Cloud API
+        // media id alone is useless — the download URL is short-lived + token-gated).
+        // storeWhatsAppMedia never throws and returns null on any failure, so this
+        // can't block the 200 to Meta.
+        const mediaUrl =
+          msg.type === "image" || msg.type === "document"
+            ? await storeWhatsAppMedia(msg.image?.id ?? msg.document?.id ?? null)
+            : null;
         // 1) Persist for the supplier-chat monitor/inbox (Option 1). Best-effort —
         // recordInboundMessage never throws, so it never blocks the 200 to Meta.
-        // supplierId is matched by phone inside; media URL resolution is a follow-up.
+        // supplierId is matched by phone inside.
         await recordInboundMessage({
           waMessageId: msg.id,
           fromNumber: msg.from,
           toNumber: businessNumber,
           type: msg.type,
           body,
+          mediaUrl,
           timestamp: msg.timestamp ? new Date(Number(msg.timestamp) * 1000) : undefined,
           raw: msg,
         });

--- a/apps/backoffice/src/lib/inventory/agents/supplier-chat-agent.ts
+++ b/apps/backoffice/src/lib/inventory/agents/supplier-chat-agent.ts
@@ -28,6 +28,7 @@ import Anthropic from "@anthropic-ai/sdk";
 import type { OrderStatus, Prisma } from "@celsius/db";
 import { prisma } from "@/lib/prisma";
 import { sendWhatsAppText, fetchWhatsAppMedia } from "@/lib/whatsapp";
+import { storeWhatsAppMedia } from "@/lib/whatsapp-media";
 import { recordOutboundMessage } from "@/lib/whatsapp-store";
 import { parseSupplierDoc } from "@/lib/finance/parsers/supplier-doc";
 import { detectCreationFlags } from "@/lib/inventory/flag-detector";
@@ -543,6 +544,11 @@ async function captureInvoice(
   const invoiceNumber = extractedNumber || `AI-${order.orderNumber}`;
   const provisional = extractedTotal == null;
 
+  // Persist the supplier-sent document to storage so the captured invoice keeps
+  // the photo (the inbox webhook already stored it under the same deterministic
+  // path — this upsert is idempotent). Best-effort: never throws, returns null.
+  const photoUrl = await storeWhatsAppMedia(mediaId);
+
   try {
     const flags = await detectCreationFlags({
       orderId: order.id,
@@ -559,6 +565,7 @@ async function captureInvoice(
         amount: amount as never, // Decimal passthrough
         status: "DRAFT",
         paymentType: "SUPPLIER",
+        photos: photoUrl ? [photoUrl] : [],
         ...(billDate ? { issueDate: billDate } : {}),
         ...(dueDate ? { dueDate } : {}),
         ...(prefilled.length > 0

--- a/apps/backoffice/src/lib/whatsapp-media.ts
+++ b/apps/backoffice/src/lib/whatsapp-media.ts
@@ -1,0 +1,64 @@
+/**
+ * Persist inbound WhatsApp media (supplier images / invoice PDFs) to Supabase
+ * Storage so the chat inbox can open the attachment and captured invoices keep
+ * the photo.
+ *
+ * The Cloud API only hands us a media id + a short-lived, token-gated download
+ * URL — useless once the webhook returns. We fetch the bytes once and upload
+ * them to the `invoices` bucket at a DETERMINISTIC path keyed on the media id,
+ * so re-running (webhook redelivery, or captureInvoice re-fetching the same
+ * media) upserts the same object rather than duplicating it.
+ *
+ * Best-effort: returns null and never throws so a storage hiccup can't block
+ * the webhook's 200 to Meta.
+ */
+import { createClient } from "@supabase/supabase-js";
+import { fetchWhatsAppMedia } from "@/lib/whatsapp";
+
+const supabaseUrl = process.env.NEXT_PUBLIC_LOYALTY_SUPABASE_URL || "";
+const supabaseKey = process.env.LOYALTY_SUPABASE_SERVICE_ROLE_KEY || "";
+
+const BUCKET = "invoices";
+
+/** Map a MIME type to a file extension for the stored object path. */
+function extFromMime(mimeType: string): string {
+  const m = mimeType.toLowerCase();
+  if (m === "image/jpeg" || m === "image/jpg") return "jpg";
+  if (m === "image/png") return "png";
+  if (m === "image/webp") return "webp";
+  if (m === "application/pdf") return "pdf";
+  return "bin";
+}
+
+/**
+ * Fetch a WhatsApp media object by id and upload it to Supabase Storage.
+ * Returns the public URL, or null when there's no media id, Supabase isn't
+ * configured, or anything fails. Idempotent: same media id → same object path.
+ */
+export async function storeWhatsAppMedia(
+  mediaId: string | null | undefined,
+): Promise<string | null> {
+  if (!mediaId) return null;
+  if (!supabaseUrl || !supabaseKey) return null;
+  try {
+    const media = await fetchWhatsAppMedia(mediaId);
+    if (!media) return null;
+    const ext = extFromMime(media.mimeType);
+    const path = `whatsapp/${mediaId}.${ext}`;
+    const supabase = createClient(supabaseUrl, supabaseKey);
+    const { error } = await supabase.storage
+      .from(BUCKET)
+      .upload(path, media.bytes, { contentType: media.mimeType, upsert: true });
+    if (error) {
+      console.warn(`[whatsapp:media] upload failed for ${mediaId}: ${error.message}`);
+      return null;
+    }
+    const { data } = supabase.storage.from(BUCKET).getPublicUrl(path);
+    return data.publicUrl;
+  } catch (e) {
+    console.warn(
+      `[whatsapp:media] store failed for ${mediaId}: ${e instanceof Error ? e.message : e}`,
+    );
+    return null;
+  }
+}

--- a/apps/backoffice/src/lib/whatsapp.ts
+++ b/apps/backoffice/src/lib/whatsapp.ts
@@ -117,12 +117,20 @@ async function postMessage(body: Record<string, unknown>): Promise<WhatsAppSendR
  * service window (the recipient messaged us within the last 24h). For
  * business-initiated messages outside that window, use sendWhatsAppTemplate.
  * `to` may be passed in any human format ("+60 12-345 6789") — it's normalised.
+ *
+ * Pass `replyToWaId` (the Meta message id of an inbound message) to send this as
+ * a quoted reply — WhatsApp threads it under that message in the supplier's app.
  */
-export function sendWhatsAppText(to: string, body: string): Promise<WhatsAppSendResult> {
+export function sendWhatsAppText(
+  to: string,
+  body: string,
+  replyToWaId?: string,
+): Promise<WhatsAppSendResult> {
   return postMessage({
     recipient_type: "individual",
     to: normalizeMsisdn(to),
     type: "text",
+    ...(replyToWaId ? { context: { message_id: replyToWaId } } : {}),
     text: { preview_url: false, body },
   });
 }


### PR DESCRIPTION
Fixes "can't open attachments" + "invoices have no photo" + adds reply-to-a-specific-message.

**Root cause:** inbound media was never stored — the webhook saved only the `mediaId`, the image was fetched transiently for AI vision then discarded, so `mediaUrl` stayed null. So chat images couldn't open and captured invoices had no photo.

### Media pipeline
- `lib/whatsapp-media.ts` → `storeWhatsAppMedia(mediaId)`: fetch + upload to Supabase Storage (`invoices` bucket, deterministic `whatsapp/<mediaId>.<ext>`, idempotent upsert) → public URL.
- **Webhook** stores inbound image/document → `mediaUrl` on the message.
- **captureInvoice** attaches the stored URL to `Invoice.photos` (so the Invoices "Photo" column shows it).
- **Chat** renders a clickable thumbnail for images (opens full) and a link for documents.

### Reply-to a specific message
- `sendWhatsAppText` gains `replyToWaId` → Cloud API `context.message_id`.
- Human-send route accepts `replyTo` (resolves a DB id → `waMessageId`).
- Chat gets a per-message **↩ reply** affordance + a "Replying to …" bar above the composer.

### Caveats
- Additive; webhook/agent behaviour otherwise unchanged. Typecheck + lint clean.
- Stores **new** inbound media. The **existing** image rows (already saved with `mediaUrl` null) and the already-captured invoices won't show retroactively without a one-off backfill (re-fetch from the `mediaId` still in each message's `raw`, within WhatsApp's ~30-day retention). Easy to add.

🤖 Generated with [Claude Code](https://claude.com/claude-code)