### PR TITLE
feat(procurement): drop redundant 'Open full' from the workspace PO panel

### DIFF
--- a/apps/backoffice/src/app/(admin)/inventory/supplier-chats/page.tsx
+++ b/apps/backoffice/src/app/(admin)/inventory/supplier-chats/page.tsx
@@ -1210,12 +1210,6 @@ export default function SupplierChatsPage() {
                     >
                       {editLoading ? <Loader2 size={14} className="animate-spin" /> : <Pencil size={14} />} Edit
                     </button>
-                    <a
-                      href={`/inventory/orders/${poView.id}`}
-                      className="rounded-md border border-border px-3 py-2 text-[13px] font-medium hover:bg-muted"
-                    >
-                      Open full
-                    </a>
                   </div>
                 </div>
               </>


### PR DESCRIPTION
The inline **Edit** button (full editor — invoice upload + AI extract, deposit, editable qty/price, Save / Upload-&-Send) does strictly more than the basic `/inventory/orders/[id]` detail page that **Open full** linked to. So the button was redundant — removed it. The PO panel now has Approve / Send / Cancel + Edit.

The `/inventory/orders/[id]` route stays (still a deep-link target from the agent's 'Open PO' proposal links + re-source draft links) — the workspace just no longer sends you there. Typecheck + lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)