### PR TITLE
feat(procurement): double-click to reply + agent quotes the message it answers

### DIFF
--- a/apps/backoffice/src/app/(admin)/inventory/supplier-chats/page.tsx
+++ b/apps/backoffice/src/app/(admin)/inventory/supplier-chats/page.tsx
@@ -668,7 +668,9 @@ export default function SupplierChatsPage() {
                   } max-w-[80%]`}
                 >
                   <div
-                    className={`min-w-0 rounded-lg px-3 py-2 text-[13px] leading-snug ${
+                    onDoubleClick={() => setReplyingTo(m)}
+                    title="Double-click to reply"
+                    className={`min-w-0 cursor-default select-none rounded-lg px-3 py-2 text-[13px] leading-snug ${
                       m.direction === "outbound"
                         ? "bg-primary text-primary-foreground"
                         : "bg-muted text-foreground"

--- a/apps/backoffice/src/lib/inventory/agents/supplier-chat-agent.ts
+++ b/apps/backoffice/src/lib/inventory/agents/supplier-chat-agent.ts
@@ -355,8 +355,10 @@ export async function handleSupplierMessage(evt: SupplierMessageEvent): Promise<
       reSourced: !!reSource,
     };
 
-    // Auto-reply (24h window is open — the supplier just messaged us).
-    const sent = await sendWhatsAppText(supplier.phone ?? fromDigits, replyText);
+    // Auto-reply (24h window is open — the supplier just messaged us). Quote THIS
+    // inbound message so the supplier sees exactly which message we're answering —
+    // avoids "which item / which order?" confusion on a busy thread.
+    const sent = await sendWhatsAppText(supplier.phone ?? fromDigits, replyText, evt.waMessageId);
 
     const recordedId = await recordOutboundMessage({
       waMessageId: sent.messageId,


### PR DESCRIPTION
Two reply-context improvements (both on the #558 plumbing):

- **Double-click to reply** — double-click any message (including the invoice image) to set it as the reply target, alongside the ↩ button.
- **Agent quotes the message it's answering** — the agent's auto-reply now goes out with WhatsApp's quote (`context.message_id` = the supplier's inbound message), so on a busy thread the supplier sees *exactly* which message it's responding to — no 'which item / which order?' misunderstanding.

Typecheck + lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)