### PR TITLE
feat(inventory): delete button for DRAFT/PENDING invoices

### DIFF
--- a/apps/backoffice/src/app/(admin)/inventory/invoices/page.tsx
+++ b/apps/backoffice/src/app/(admin)/inventory/invoices/page.tsx
@@ -271,6 +271,7 @@ export default function InvoicesPage() {
   });
   const [editPhotos, setEditPhotos] = useState<string[]>([]);
   const [editSaving, setEditSaving] = useState(false);
+  const [editDeleting, setEditDeleting] = useState(false);
   const [editUploading, setEditUploading] = useState(false);
 
   // Attach Invoice dialog (GRNI placeholder → real supplier invoice)
@@ -658,6 +659,25 @@ export default function InvoicesPage() {
       loadInvoices(undefined, { revalidate: true });
     } finally {
       setEditSaving(false);
+    }
+  };
+
+  // Hard-delete a DRAFT/PENDING invoice (the API rejects anything further along —
+  // initiated/paid stay put). Used to clear junk placeholders / mis-captured drafts.
+  const deleteInvoice = async () => {
+    if (!editingInvoice) return;
+    if (!confirm(`Delete invoice ${editingInvoice.invoiceNumber}? This can't be undone.`)) return;
+    setEditDeleting(true);
+    try {
+      const res = await fetch(`/api/inventory/invoices/${editingInvoice.id}`, { method: "DELETE" });
+      if (!res.ok) {
+        alert((await res.json().catch(() => ({}))).error || "Delete failed");
+        return;
+      }
+      setEditingInvoice(null);
+      loadInvoices(undefined, { revalidate: true });
+    } finally {
+      setEditDeleting(false);
     }
   };
 
@@ -1877,6 +1897,16 @@ export default function InvoicesPage() {
             </div>
 
             <div className="mt-4 flex gap-2">
+              {["DRAFT", "PENDING"].includes(editingInvoice.status) && (
+                <button
+                  onClick={deleteInvoice}
+                  disabled={editDeleting || editSaving}
+                  title="Delete this draft/pending invoice"
+                  className="rounded-md border border-red-200 px-3 py-2 text-sm font-medium text-red-600 hover:bg-red-50 disabled:opacity-50"
+                >
+                  {editDeleting ? <Loader2 className="mx-auto h-4 w-4 animate-spin" /> : "Delete"}
+                </button>
+              )}
               <button onClick={() => setEditingInvoice(null)} className="flex-1 rounded-md border border-gray-200 px-3 py-2 text-sm text-gray-600 hover:bg-gray-50">Cancel</button>
               <button
                 onClick={saveEdit}

--- a/apps/backoffice/src/app/(admin)/inventory/invoices/page.tsx
+++ b/apps/backoffice/src/app/(admin)/inventory/invoices/page.tsx
@@ -666,7 +666,15 @@ export default function InvoicesPage() {
   // initiated/paid stay put). Used to clear junk placeholders / mis-captured drafts.
   const deleteInvoice = async () => {
     if (!editingInvoice) return;
-    if (!confirm(`Delete invoice ${editingInvoice.invoiceNumber}? This can't be undone.`)) return;
+    if (
+      !(await confirm({
+        title: `Delete invoice ${editingInvoice.invoiceNumber}?`,
+        description: "This can't be undone.",
+        confirmLabel: "Delete",
+        destructive: true,
+      }))
+    )
+      return;
     setEditDeleting(true);
     try {
       const res = await fetch(`/api/inventory/invoices/${editingInvoice.id}`, { method: "DELETE" });


### PR DESCRIPTION
Adds a **Delete** button to the edit-invoice modal (Invoices screen), shown only for **DRAFT/PENDING** invoices, with a confirm. Wires the existing `DELETE /api/inventory/invoices/[id]` endpoint (which already guards to DRAFT/PENDING — initiated/paid are rejected).

Lets staff clear junk placeholders / mis-captured drafts from the UI — no DB query needed. Immediate use: clearing the 5 Test Supplier test invoices for a clean re-test.

Typecheck + lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)