### PR TITLE
feat(procurement): tidy workspace — Need-ordering as lead tab, drop redundant buttons

### DIFF
--- a/apps/backoffice/src/app/(admin)/inventory/supplier-chats/page.tsx
+++ b/apps/backoffice/src/app/(admin)/inventory/supplier-chats/page.tsx
@@ -411,7 +411,6 @@ export default function SupplierChatsPage() {
   }
 
   // ── Need ordering (suggested draft POs) ───────────────────────
-  const [needOrderOpen, setNeedOrderOpen] = useState(false);
   const [needCreated, setNeedCreated] = useState<Set<string>>(new Set());
   const [needCreatingKey, setNeedCreatingKey] = useState<string | null>(null);
   // Loaded on mount so the "Need ordering" filter chip + the per-supplier rail card
@@ -423,9 +422,6 @@ export default function SupplierChatsPage() {
   const needGroups: NeedGroup[] | null = needData?.groups ?? null;
   const needSupplierIds = new Set((needGroups ?? []).map((g) => g.supplierId));
 
-  function openNeedOrder() {
-    setNeedOrderOpen(true);
-  }
   async function createDraftFromGroup(g: NeedGroup) {
     const key = `${g.supplierId}_${g.outletId}`;
     setNeedCreatingKey(key);
@@ -556,12 +552,6 @@ export default function SupplierChatsPage() {
             <span className="flex items-center gap-2">
               <MessageCircle size={16} /> Suppliers
             </span>
-            <button
-              onClick={openNeedOrder}
-              className="inline-flex items-center gap-1 rounded-md border border-amber-300 bg-amber-50 px-2 py-1 text-[11px] font-medium text-amber-700 hover:bg-amber-100 dark:border-amber-800 dark:bg-amber-950/40 dark:text-amber-300"
-            >
-              <ShoppingCart size={12} /> Need ordering
-            </button>
           </div>
           <div className="relative mt-2">
             <Search size={13} className="absolute left-2 top-1/2 -translate-y-1/2 text-muted-foreground" />
@@ -573,6 +563,14 @@ export default function SupplierChatsPage() {
             />
           </div>
           <div className="mt-2 flex flex-wrap gap-1">
+            {needSupplierIds.size > 0 && (
+              <button
+                onClick={() => setFilter("need")}
+                className={`inline-flex items-center gap-1 rounded-full px-2.5 py-0.5 text-[11px] font-medium ${filter === "need" ? "bg-amber-500/20 text-amber-800 dark:text-amber-300" : "bg-amber-50 text-amber-700 hover:bg-amber-100 dark:bg-amber-950/40 dark:text-amber-400"}`}
+              >
+                <ShoppingCart size={11} /> Need ordering {needSupplierIds.size}
+              </button>
+            )}
             <Chip on={filter === "all"} onClick={() => setFilter("all")}>All {counts?.suppliers ?? 0}</Chip>
             <Chip on={filter === "attention"} tone="danger" onClick={() => setFilter("attention")}>
               Attention {counts?.needsAttention ?? 0}
@@ -580,14 +578,6 @@ export default function SupplierChatsPage() {
             <Chip on={filter === "auto"} tone="auto" onClick={() => setFilter("auto")}>Auto {counts?.auto ?? 0}</Chip>
             <Chip on={filter === "assist"} tone="assist" onClick={() => setFilter("assist")}>Assist {counts?.assist ?? 0}</Chip>
             <Chip on={filter === "off"} onClick={() => setFilter("off")}>Off {counts?.off ?? 0}</Chip>
-            {needSupplierIds.size > 0 && (
-              <button
-                onClick={() => setFilter("need")}
-                className={`inline-flex items-center gap-1 rounded-full px-2.5 py-0.5 text-[11px] ${filter === "need" ? "bg-amber-500/15 text-amber-700 dark:text-amber-400" : "text-muted-foreground hover:bg-muted"}`}
-              >
-                <ShoppingCart size={11} /> Need ordering {needSupplierIds.size}
-              </button>
-            )}
             {(counts?.other ?? 0) > 0 && (
               <Chip on={filter === "other"} onClick={() => setFilter("other")}>Other {counts?.other ?? 0}</Chip>
             )}
@@ -643,14 +633,6 @@ export default function SupplierChatsPage() {
                 <div className="text-xs text-muted-foreground">+{detail.key}</div>
               </div>
               <div className="flex items-center gap-2">
-                {detail.supplierId && (
-                  <button
-                    onClick={openPO}
-                    className="inline-flex items-center gap-1 rounded-md border border-border px-2 py-1 text-[11px] font-medium text-foreground hover:bg-muted"
-                  >
-                    <Plus size={12} /> New PO
-                  </button>
-                )}
                 <span className="rounded-full bg-green-500/10 px-2 py-0.5 text-[11px] text-green-600 dark:text-green-400">
                   WhatsApp
                 </span>
@@ -1214,78 +1196,6 @@ export default function SupplierChatsPage() {
                 </div>
               </>
             )}
-          </div>
-        </div>
-      )}
-
-      {needOrderOpen && (
-        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4" onClick={() => setNeedOrderOpen(false)}>
-          <div
-            onClick={(e) => e.stopPropagation()}
-            className="flex max-h-[85vh] w-full max-w-lg flex-col overflow-hidden rounded-xl border border-border bg-background shadow-lg"
-          >
-            <div className="flex items-center justify-between border-b border-border px-4 py-3">
-              <div className="flex items-center gap-2 text-sm font-medium">
-                <ShoppingCart size={15} /> Need ordering
-              </div>
-              <button onClick={() => setNeedOrderOpen(false)} aria-label="Close" className="text-muted-foreground hover:text-foreground">
-                <X size={16} />
-              </button>
-            </div>
-            <div className="flex-1 overflow-y-auto p-3">
-              {!needGroups ? (
-                <div className="flex items-center justify-center p-8">
-                  <Loader2 size={18} className="animate-spin text-muted-foreground" />
-                </div>
-              ) : needGroups.length === 0 ? (
-                <p className="p-6 text-center text-xs text-muted-foreground">Nothing below reorder point right now.</p>
-              ) : (
-                <div className="flex flex-col gap-3">
-                  {needGroups.map((g) => {
-                    const key = `${g.supplierId}_${g.outletId}`;
-                    const done = needCreated.has(key);
-                    return (
-                      <div key={key} className="rounded-lg border border-border p-3">
-                        <div className="mb-2 flex items-center justify-between gap-2">
-                          <div className="min-w-0">
-                            <div className="truncate text-[13px] font-medium">{g.supplierName}</div>
-                            <div className="text-[11px] text-muted-foreground">
-                              {g.outletName} · {g.itemCount} item{g.itemCount > 1 ? "s" : ""} · {formatRM(g.total)}
-                            </div>
-                          </div>
-                          {done ? (
-                            <span className="inline-flex shrink-0 items-center gap-1 text-[11px] font-medium text-green-600 dark:text-green-400">
-                              <Check size={13} /> Draft created
-                            </span>
-                          ) : (
-                            <button
-                              onClick={() => createDraftFromGroup(g)}
-                              disabled={needCreatingKey === key}
-                              className="inline-flex shrink-0 items-center gap-1 rounded-md bg-primary px-2.5 py-1.5 text-[11px] font-medium text-primary-foreground hover:bg-primary/90 disabled:opacity-50"
-                            >
-                              {needCreatingKey === key ? <Loader2 size={12} className="animate-spin" /> : <Plus size={12} />} Create draft PO
-                            </button>
-                          )}
-                        </div>
-                        <div className="flex flex-col gap-0.5">
-                          {g.items.map((it) => (
-                            <div key={it.productId} className="flex items-center justify-between gap-2 text-[11px]">
-                              <span className="truncate">{it.name}</span>
-                              <span className="shrink-0 text-muted-foreground">
-                                {Math.round(it.onHand)} on hand ≤ {Math.round(it.reorderPoint)} → order {it.qty} {it.packageLabel}
-                              </span>
-                            </div>
-                          ))}
-                        </div>
-                      </div>
-                    );
-                  })}
-                </div>
-              )}
-            </div>
-            <div className="border-t border-border px-4 py-2.5 text-[11px] text-muted-foreground">
-              Below-par items with no open PO, grouped to the cheapest supplier. Create a draft, then review + send it from the PO list.
-            </div>
           </div>
         </div>
       )}


### PR DESCRIPTION
Three cleanups from the screenshot:

1. **Removed the header 'Need ordering' button** (top-right of the Suppliers list) and its now-orphaned consolidated modal + state. The filter tab is the single entry point.
2. **Prioritised the Need-ordering tab** — moved to the **front** of the filter row with a prominent always-on amber style, so 'what to order today' leads.
3. **Removed the conversation-header '+ New PO'** — superseded by the rail's inline New PO composer (#562).

Typecheck + lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)