### PR TITLE
feat(procurement): workflow-stage filtering — Need-ordering default + action tabs + Mode dropdown

### DIFF
--- a/apps/backoffice/src/app/(admin)/inventory/supplier-chats/page.tsx
+++ b/apps/backoffice/src/app/(admin)/inventory/supplier-chats/page.tsx
@@ -34,11 +34,25 @@ type Thread = {
   lastAt: string | null;
   count: number;
   needsAttention: boolean;
+  awaitingReply: boolean;
+  toPay: boolean;
+  awaitingDelivery: boolean;
   registered: boolean;
   automationMode: AutomationMode | null;
   hasMessages: boolean;
 };
-type Counts = { all: number; suppliers: number; needsAttention: number; other: number; auto: number; assist: number; off: number };
+type Counts = {
+  all: number;
+  suppliers: number;
+  needsAttention: number;
+  needsReply: number;
+  toPay: number;
+  awaitingDelivery: number;
+  other: number;
+  auto: number;
+  assist: number;
+  off: number;
+};
 type PoProduct = { supplierProductId: string; productId: string; name: string; packageLabel: string; productPackageId: string | null; price: number; moq: number };
 type PoView = {
   id: string;
@@ -127,7 +141,9 @@ export default function SupplierChatsPage() {
   // Deep-link support: /inventory/supplier-chats?key=<number> opens that thread
   // (e.g. from Agent QA). Lazy init so it wins over the auto-select-first effect.
   const [selected, setSelected] = useState<string | null>(() => searchParams.get("key"));
-  const [filter, setFilter] = useState<"all" | "attention" | "auto" | "assist" | "off" | "other" | "need">("need");
+  const [filter, setFilter] = useState<
+    "all" | "reply" | "topay" | "awaiting" | "auto" | "assist" | "off" | "other" | "need"
+  >("need");
   const [query, setQuery] = useState("");
 
   // Poll so inbound supplier messages + the agent's auto-replies appear without
@@ -465,8 +481,12 @@ export default function SupplierChatsPage() {
       return false;
     }
     switch (filter) {
-      case "attention":
-        return t.needsAttention;
+      case "reply":
+        return t.awaitingReply;
+      case "topay":
+        return t.toPay;
+      case "awaiting":
+        return t.awaitingDelivery;
       case "auto":
         return t.automationMode === "AUTO";
       case "assist":
@@ -571,8 +591,11 @@ export default function SupplierChatsPage() {
               className="h-8 w-full rounded-md border border-border bg-background pl-7 pr-2 text-xs text-foreground placeholder:text-muted-foreground"
             />
           </div>
-          <div className="mt-2 flex flex-wrap gap-1">
-            {needSupplierIds.size > 0 && (
+          {/* Action tabs in workflow order (order → reply → pay → receive). Each shows
+              only when it has items (or is the active filter). Automation config lives in
+              the Mode dropdown so it doesn't clutter the daily view. */}
+          <div className="mt-2 flex flex-wrap items-center gap-1">
+            {(needSupplierIds.size > 0 || filter === "need") && (
               <button
                 onClick={() => setFilter("need")}
                 className={`inline-flex items-center gap-1 rounded-full px-2.5 py-0.5 text-[11px] font-medium ${filter === "need" ? "bg-amber-500/20 text-amber-800 dark:text-amber-300" : "bg-amber-50 text-amber-700 hover:bg-amber-100 dark:bg-amber-950/40 dark:text-amber-400"}`}
@@ -580,16 +603,32 @@ export default function SupplierChatsPage() {
                 <ShoppingCart size={11} /> Need ordering {needSupplierIds.size}
               </button>
             )}
-            <Chip on={filter === "all"} onClick={() => setFilter("all")}>All {counts?.suppliers ?? 0}</Chip>
-            <Chip on={filter === "attention"} tone="danger" onClick={() => setFilter("attention")}>
-              Attention {counts?.needsAttention ?? 0}
-            </Chip>
-            <Chip on={filter === "auto"} tone="auto" onClick={() => setFilter("auto")}>Auto {counts?.auto ?? 0}</Chip>
-            <Chip on={filter === "assist"} tone="assist" onClick={() => setFilter("assist")}>Assist {counts?.assist ?? 0}</Chip>
-            <Chip on={filter === "off"} onClick={() => setFilter("off")}>Off {counts?.off ?? 0}</Chip>
-            {(counts?.other ?? 0) > 0 && (
-              <Chip on={filter === "other"} onClick={() => setFilter("other")}>Other {counts?.other ?? 0}</Chip>
+            {(filter === "reply" || (counts?.needsReply ?? 0) > 0) && (
+              <Chip on={filter === "reply"} tone="danger" onClick={() => setFilter("reply")}>
+                Needs reply {counts?.needsReply ?? 0}
+              </Chip>
             )}
+            {(filter === "topay" || (counts?.toPay ?? 0) > 0) && (
+              <Chip on={filter === "topay"} onClick={() => setFilter("topay")}>To pay {counts?.toPay ?? 0}</Chip>
+            )}
+            {(filter === "awaiting" || (counts?.awaitingDelivery ?? 0) > 0) && (
+              <Chip on={filter === "awaiting"} onClick={() => setFilter("awaiting")}>
+                Awaiting delivery {counts?.awaitingDelivery ?? 0}
+              </Chip>
+            )}
+            <Chip on={filter === "all"} onClick={() => setFilter("all")}>All {counts?.suppliers ?? 0}</Chip>
+            <select
+              value={(["auto", "assist", "off", "other"] as string[]).includes(filter) ? filter : ""}
+              onChange={(e) => e.target.value && setFilter(e.target.value as "auto" | "assist" | "off" | "other")}
+              title="Filter by automation mode"
+              className={`rounded-full border px-2 py-[3px] text-[11px] ${(["auto", "assist", "off", "other"] as string[]).includes(filter) ? "border-primary/40 bg-primary/10 text-foreground" : "border-border bg-background text-muted-foreground"}`}
+            >
+              <option value="">Mode</option>
+              <option value="auto">Auto {counts?.auto ?? 0}</option>
+              <option value="assist">Assist {counts?.assist ?? 0}</option>
+              <option value="off">Off {counts?.off ?? 0}</option>
+              {(counts?.other ?? 0) > 0 && <option value="other">Other {counts?.other ?? 0}</option>}
+            </select>
           </div>
         </div>
         <div className="flex-1 overflow-y-auto">

--- a/apps/backoffice/src/app/(admin)/inventory/supplier-chats/page.tsx
+++ b/apps/backoffice/src/app/(admin)/inventory/supplier-chats/page.tsx
@@ -127,7 +127,7 @@ export default function SupplierChatsPage() {
   // Deep-link support: /inventory/supplier-chats?key=<number> opens that thread
   // (e.g. from Agent QA). Lazy init so it wins over the auto-select-first effect.
   const [selected, setSelected] = useState<string | null>(() => searchParams.get("key"));
-  const [filter, setFilter] = useState<"all" | "attention" | "auto" | "assist" | "off" | "other" | "need">("all");
+  const [filter, setFilter] = useState<"all" | "attention" | "auto" | "assist" | "off" | "other" | "need">("need");
   const [query, setQuery] = useState("");
 
   // Poll so inbound supplier messages + the agent's auto-replies appear without
@@ -421,6 +421,15 @@ export default function SupplierChatsPage() {
   );
   const needGroups: NeedGroup[] | null = needData?.groups ?? null;
   const needSupplierIds = new Set((needGroups ?? []).map((g) => g.supplierId));
+  // Land on "Need ordering" by default (what to order today). Once the reorder data
+  // loads, if nothing is below reorder point, fall back to All so we never sit on an
+  // empty view. One-shot — never overrides a manual filter pick afterwards.
+  const didDefaultFilter = useRef(false);
+  useEffect(() => {
+    if (didDefaultFilter.current || !needData) return;
+    didDefaultFilter.current = true;
+    if (needSupplierIds.size === 0) setFilter("all");
+  }, [needData, needSupplierIds.size]);
 
   async function createDraftFromGroup(g: NeedGroup) {
     const key = `${g.supplierId}_${g.outletId}`;

--- a/apps/backoffice/src/app/api/inventory/supplier-chats/route.ts
+++ b/apps/backoffice/src/app/api/inventory/supplier-chats/route.ts
@@ -1,6 +1,10 @@
 import { NextResponse, NextRequest } from "next/server";
+import type { OrderStatus } from "@celsius/db";
 import { prisma } from "@/lib/prisma";
 import { getUserFromHeaders } from "@/lib/auth";
+
+// A PO that's out the door and we're still expecting goods against.
+const DELIVERY_STATUSES: OrderStatus[] = ["SENT", "CONFIRMED", "AWAITING_DELIVERY", "PARTIALLY_RECEIVED"];
 
 // Threads for the Supplier Chats workspace. Folds WhatsAppMessage rows into one
 // thread per counterparty, then MERGES in every active supplier — so suppliers with
@@ -52,6 +56,7 @@ export async function GET(req: NextRequest) {
     lastAt: Date;
     count: number;
     lastInbound: string | null;
+    lastDirection: string;
     verifierFailed: boolean;
   };
   const threads = new Map<string, T>();
@@ -69,6 +74,8 @@ export async function GET(req: NextRequest) {
         lastAt: m.timestamp,
         count: 0,
         lastInbound: null,
+        // rows are desc, so the first one we see for a thread is the most recent.
+        lastDirection: m.direction,
         verifierFailed: m.direction === "outbound" && !!raw?.agent && v?.rating === "fail",
       };
       threads.set(counter, t);
@@ -99,6 +106,25 @@ export async function GET(req: NextRequest) {
     : [];
   const overdue = new Set(overdueRows.map((o) => o.supplierId));
 
+  // Workflow-stage signals across ALL active suppliers (cheap distinct lookups):
+  // who has an unpaid invoice (To pay) and who has a PO out awaiting goods (Awaiting
+  // delivery). Used to drive the action-oriented filter tabs.
+  const allSupplierIds = suppliers.map((s) => s.id);
+  const [unpaidRows, deliveryRows] = await Promise.all([
+    prisma.invoice.findMany({
+      where: { supplierId: { in: allSupplierIds }, status: { not: "PAID" } },
+      select: { supplierId: true },
+      distinct: ["supplierId"],
+    }),
+    prisma.order.findMany({
+      where: { supplierId: { in: allSupplierIds }, status: { in: DELIVERY_STATUSES } },
+      select: { supplierId: true },
+      distinct: ["supplierId"],
+    }),
+  ]);
+  const unpaidSet = new Set(unpaidRows.map((o) => o.supplierId).filter((x): x is string => !!x));
+  const deliverySet = new Set(deliveryRows.map((o) => o.supplierId).filter((x): x is string => !!x));
+
   type Out = {
     key: string;
     supplierId: string | null;
@@ -108,6 +134,9 @@ export async function GET(req: NextRequest) {
     lastAt: Date | null;
     count: number;
     needsAttention: boolean;
+    awaitingReply: boolean;
+    toPay: boolean;
+    awaitingDelivery: boolean;
     registered: boolean;
     automationMode: "OFF" | "ASSIST" | "AUTO" | null;
     hasMessages: boolean;
@@ -129,6 +158,9 @@ export async function GET(req: NextRequest) {
       lastAt: t.lastAt,
       count: t.count,
       needsAttention,
+      awaitingReply: t.lastDirection === "inbound",
+      toPay: !!t.supplierId && unpaidSet.has(t.supplierId),
+      awaitingDelivery: !!t.supplierId && deliverySet.has(t.supplierId),
       registered: !!s,
       automationMode: s?.automationMode ?? null,
       hasMessages: true,
@@ -146,6 +178,9 @@ export async function GET(req: NextRequest) {
       lastAt: null,
       count: 0,
       needsAttention: overdue.has(s.id),
+      awaitingReply: false,
+      toPay: unpaidSet.has(s.id),
+      awaitingDelivery: deliverySet.has(s.id),
       registered: true,
       automationMode: s.automationMode,
       hasMessages: false,
@@ -163,6 +198,9 @@ export async function GET(req: NextRequest) {
     all: out.length,
     suppliers: reg.length,
     needsAttention: out.filter((t) => t.needsAttention).length,
+    needsReply: out.filter((t) => t.awaitingReply).length,
+    toPay: out.filter((t) => t.toPay).length,
+    awaitingDelivery: out.filter((t) => t.awaitingDelivery).length,
     other: out.length - reg.length,
     auto: reg.filter((t) => t.automationMode === "AUTO").length,
     assist: reg.filter((t) => t.automationMode === "ASSIST").length,


### PR DESCRIPTION
Reworks the supplier-list filtering around **what needs doing**, not automation config.

- **Default** = **Need ordering** (what to order today); one-shot fallback to All when nothing's below reorder point.
- **Action tabs in workflow order:** Need ordering → **Needs reply** (supplier messaged, unanswered) → **To pay** (unpaid invoice) → **Awaiting delivery** (PO out, goods pending) → All. Each appears only when it has items (or is active), so the row stays clean.
- **Mode dropdown** holds Auto / Assist / Off / Other — there when you're tuning automation, out of the way otherwise (53/54 are Off, so it was just noise as tabs).
- Dropped the standalone **Attention** tab — its signals now live in *Needs reply* (OOS / last-inbound) and *To pay* (overdue); the red row dot still uses needsAttention.

Backend: the list route computes `awaitingReply`/`toPay`/`awaitingDelivery` per supplier via cheap distinct invoice/order lookups, plus counts. Typecheck + lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)