### PR TITLE
feat(procurement): natural finance holding reply + 'Mark handled' to resolve escalations

### DIFF
--- a/apps/backoffice/src/app/(admin)/inventory/supplier-chats/page.tsx
+++ b/apps/backoffice/src/app/(admin)/inventory/supplier-chats/page.tsx
@@ -572,6 +572,33 @@ export default function SupplierChatsPage() {
     }
   }
 
+  // Clear the "Agent suggests" banner once you've handled it your own way (paid the
+  // invoice, replied yourself, no PO change) — the resolution for escalations that have
+  // no auto-appliable PO action, so the banner isn't a dead-end redirect.
+  async function dismissProposal() {
+    const p = detail?.agentProposal;
+    if (!selected || applying || !p?.messageId) return;
+    setApplying(true);
+    setApplyError(null);
+    try {
+      const res = await fetch(`/api/inventory/supplier-chats/${selected}/apply-proposal`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ messageId: p.messageId, action: "dismiss" }),
+      });
+      const json = await res.json().catch(() => ({}));
+      if (!res.ok) {
+        setApplyError(json.error ?? "Failed");
+        return;
+      }
+      mutateDetail();
+    } catch {
+      setApplyError("Network error");
+    } finally {
+      setApplying(false);
+    }
+  }
+
   return (
     <div className="flex h-[calc(100vh-64px)] min-h-[560px] gap-3 p-3 text-foreground">
       {/* ── Thread list ─────────────────────────────── */}
@@ -1044,6 +1071,14 @@ export default function SupplierChatsPage() {
                                 Open PO <ExternalLink size={11} />
                               </a>
                             )}
+                            <button
+                              onClick={dismissProposal}
+                              disabled={applying}
+                              title="Clear this suggestion once you've handled it"
+                              className="inline-flex items-center gap-1 rounded px-2 py-1 text-[11px] font-medium text-muted-foreground hover:bg-muted disabled:opacity-50"
+                            >
+                              <Check size={11} /> Mark handled
+                            </button>
                           </div>
                         );
                       })()}

--- a/apps/backoffice/src/app/api/inventory/supplier-chats/[key]/apply-proposal/route.ts
+++ b/apps/backoffice/src/app/api/inventory/supplier-chats/[key]/apply-proposal/route.ts
@@ -28,14 +28,8 @@ export async function POST(req: NextRequest, { params }: { params: Promise<{ key
     newQuantity?: number;
   };
 
-  if (!messageId || !orderId || !poItemId) {
-    return NextResponse.json({ error: "messageId, orderId and poItemId are required" }, { status: 400 });
-  }
-  if (action !== "remove_item" && action !== "reduce_qty") {
-    return NextResponse.json(
-      { error: "Only remove_item and reduce_qty can be applied from chat. Open the PO for other changes." },
-      { status: 400 },
-    );
+  if (!messageId) {
+    return NextResponse.json({ error: "messageId is required" }, { status: 400 });
   }
 
   // The message must be this thread's escalation, not yet resolved — prevents
@@ -47,7 +41,29 @@ export async function POST(req: NextRequest, { params }: { params: Promise<{ key
   if (!message) return NextResponse.json({ error: "Proposal message not found" }, { status: 404 });
   const raw = (message.raw ?? {}) as Record<string, unknown>;
   if (raw.proposalResolved === true) {
-    return NextResponse.json({ error: "This proposal was already applied." }, { status: 409 });
+    return NextResponse.json({ error: "This proposal was already resolved." }, { status: 409 });
+  }
+
+  // Dismiss = the human handled it out-of-band (paid the invoice, replied themselves, no
+  // PO change needed). Just clear the banner. This is the resolution for escalations with
+  // no auto-appliable PO action — payment chase, SOA query, complaint, lead-time, etc.
+  if (action === "dismiss") {
+    await prisma.whatsAppMessage.update({
+      where: { id: message.id },
+      data: { raw: { ...raw, proposalResolved: true, dismissed: true, resolvedById: caller.id, resolvedAt: new Date().toISOString() } },
+    });
+    return NextResponse.json({ ok: true, dismissed: true });
+  }
+
+  // Apply path: needs the order + line, and only the two low-risk edits.
+  if (!orderId || !poItemId) {
+    return NextResponse.json({ error: "orderId and poItemId are required to apply" }, { status: 400 });
+  }
+  if (action !== "remove_item" && action !== "reduce_qty") {
+    return NextResponse.json(
+      { error: "Only remove_item and reduce_qty can be applied from chat. Open the PO for other changes." },
+      { status: 400 },
+    );
   }
 
   // The line must belong to THIS order, and the order must be open.

--- a/apps/backoffice/src/lib/inventory/agents/supplier-chat-agent.ts
+++ b/apps/backoffice/src/lib/inventory/agents/supplier-chat-agent.ts
@@ -96,6 +96,13 @@ const HOLDING_REPLY = {
   ms: "Ok noted, saya semak dulu dan revert sekejap.",
   en: "Ok noted, let me check on this and revert shortly.",
 };
+// Payment / finance is never the agent's call — the supplier just needs a short, honest
+// "hang on" rather than the agent explaining prepay/deposit mechanics. Used for the
+// payment_gating_or_chase intent so the held reply stays casual + non-committal.
+const FINANCE_HOLDING_REPLY = {
+  ms: "Kejap ya, saya tengah tunggu respon dari team finance.",
+  en: "Hang on ya, I'm waiting on a reply from our finance team.",
+};
 
 function flagEnabled(): boolean {
   return process.env.PROCUREMENT_AGENT_ENABLED === "true";
@@ -256,6 +263,9 @@ export async function handleSupplierMessage(evt: SupplierMessageEvent): Promise<
       // playbook makes it honest + non-committal). Fall back to the canned line only if
       // it came back empty, so we never confirm an action we're not taking.
       replyText = decision.reply_text?.trim() || HOLDING_REPLY[lang];
+      // ...except payment/finance: force a short "waiting on finance" line so the agent
+      // doesn't free-write a prepay explainer (reads stiff + risks over-promising).
+      if (decision.intent === "payment_gating_or_chase") replyText = FINANCE_HOLDING_REPLY[lang];
     } else {
       // Fetch the system user once if any line is being removed (for the re-source PO).
       const systemUser = actions.some((a) => a.type === "remove_item")


### PR DESCRIPTION
Two fixes from testing the payment-chase escalation:

**1. The held reply was too stiff.** On a payment chase the agent was free-writing a prepay explainer ("ni prepay PO so payment kena clear dulu…"). Payment is never the agent's call, so it shouldn't explain mechanics — it now sends a fixed short line: **"Kejap ya, saya tengah tunggu respon dari team finance."** (en: "Hang on ya, I'm waiting on a reply from our finance team."). Only for the `payment_gating_or_chase` intent; other intents keep the model's contextual line.

**2. "Open PO" was a dead end.** On a non-PO escalation (payment chase, SOA query, complaint) the only action was *Open PO*, which can't resolve a payment hold. Added **"Mark handled"** — `apply-proposal` now accepts `action:"dismiss"` which just stamps `proposalResolved` (no PO edit), so you can clear the banner once you've paid it / replied yourself. The actual payment now also lives in the **To pay** tab.

Typecheck + lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)