### PR TITLE
feat(procurement): nav — workspace = 'Purchase Orders', table = 'PO Lists'

### DIFF
--- a/apps/backoffice/src/app/(admin)/inventory/orders/page.tsx
+++ b/apps/backoffice/src/app/(admin)/inventory/orders/page.tsx
@@ -217,7 +217,7 @@ export default function OrdersPage() {
       {/* Header */}
       <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
         <div>
-          <h2 className="text-lg sm:text-xl font-semibold text-gray-900">Purchase Orders</h2>
+          <h2 className="text-lg sm:text-xl font-semibold text-gray-900">PO Lists</h2>
           <p className="mt-0.5 text-xs sm:text-sm text-gray-500">
             {summary.total} {summary.total === 1 ? 'order' : 'orders'} &middot; {summary.active} active
           </p>

--- a/apps/backoffice/src/app/(admin)/layout.tsx
+++ b/apps/backoffice/src/app/(admin)/layout.tsx
@@ -221,8 +221,8 @@ const NAV_SECTIONS: NavSection[] = [
       {
         label: "Ordering",
         items: [
-          { label: "Purchase Orders", href: "/inventory/orders", icon: <FileText className={ICON_SIZE} />, moduleKey: "inventory:orders" },
-          { label: "Supplier Chats", href: "/inventory/supplier-chats", icon: <MessageCircle className={ICON_SIZE} />, moduleKey: "inventory:orders" },
+          { label: "Purchase Orders", href: "/inventory/supplier-chats", icon: <MessageCircle className={ICON_SIZE} />, moduleKey: "inventory:orders" },
+          { label: "PO Lists", href: "/inventory/orders", icon: <FileText className={ICON_SIZE} />, moduleKey: "inventory:orders" },
           { label: "Agent QA", href: "/inventory/agent-qa", icon: <ShieldCheck className={ICON_SIZE} />, moduleKey: "inventory:orders" },
           { label: "Transfers", href: "/inventory/transfers", icon: <ArrowLeftRight className={ICON_SIZE} />, moduleKey: "inventory:transfers" },
           { label: "Receivings", href: "/inventory/receivings", icon: <Receipt className={ICON_SIZE} />, moduleKey: "inventory:receivings" },


### PR DESCRIPTION
Renames the Ordering nav:
- **Supplier Chats** (the chat-first workspace) → **Purchase Orders**, now listed first as the primary procurement tab.
- old **Purchase Orders** (the orders table) → **PO Lists** (its page heading updated to match), kept as the secondary list view.

Hrefs/icons stay with their pages. Completes the Phase-2 nav rename. Typecheck + lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)