### PR TITLE
fix(procurement): New PO composer showed the previous supplier's items on thread switch

### DIFF
--- a/apps/backoffice/src/app/(admin)/inventory/supplier-chats/page.tsx
+++ b/apps/backoffice/src/app/(admin)/inventory/supplier-chats/page.tsx
@@ -511,6 +511,12 @@ export default function SupplierChatsPage() {
     setSendError(null);
     setApplyError(null);
     setReplyingTo(null);
+    // Close the New PO composer on thread switch — its products/qty/outlet belong to the
+    // supplier it was opened for; leaving it open showed the previous supplier's items.
+    setPoOpen(false);
+    setPoProducts([]);
+    setPoQty({});
+    setPoError(null);
   }, [selected]);
 
   async function send() {


### PR DESCRIPTION
Bug: with the inline **New PO** composer open, switching to another supplier kept the old supplier's `poProducts`/qty/outlet — so e.g. Feast Market's panel showed Chocolate Powder / Mint Chocolate from a different supplier.

Fix: reset the composer (close + clear products/qty/error) in the existing per-thread reset effect (keyed on `selected`), alongside the draft/reply resets. Switching suppliers now closes the composer; reopening it loads the correct supplier's price list.

Typecheck + lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)