### PR TITLE
fix(procurement): money-safety — block reduce-that-increases + paying an unverified invoice

### DIFF
--- a/apps/backoffice/src/app/api/inventory/invoices/[id]/route.ts
+++ b/apps/backoffice/src/app/api/inventory/invoices/[id]/route.ts
@@ -35,6 +35,32 @@ export async function PATCH(req: NextRequest, { params }: { params: Promise<{ id
     // below. Independent of (and pairs with) the existing status-based flow.
     const paymentAmountInput: number | null | undefined = body.paymentAmount;
 
+    // ── Payment guards (money-safety) ──────────────────────────────────────
+    // The PATCH route is the real boundary — the UI only hides buttons, so a direct
+    // call / stale client / double-submit could otherwise pay the wrong thing. Two rules:
+    //   1. Never re-stamp an already-PAID invoice (double-pay / paidAt reset).
+    //   2. Never record a payment on a DRAFT or unconfirmed AI-captured invoice — those
+    //      carry a PROVISIONAL amount (the PO total), not the supplier's real bill, so they
+    //      must be verified (confirm prefill or edit the amount) before any payment lands.
+    const PAYMENT_STATUSES = ["INITIATED", "PARTIALLY_PAID", "DEPOSIT_PAID", "PAID"];
+    if (typeof status === "string" && PAYMENT_STATUSES.includes(status)) {
+      const current = await prisma.invoice.findUnique({
+        where: { id },
+        select: { status: true, aiPrefilledAt: true },
+      });
+      if (!current) return NextResponse.json({ error: "Invoice not found" }, { status: 404 });
+      if (current.status === "PAID") {
+        return NextResponse.json({ error: "Invoice is already paid." }, { status: 409 });
+      }
+      const verifyingNow = body.confirmAiPrefill === true || body.amount !== undefined;
+      if ((current.status === "DRAFT" || current.aiPrefilledAt != null) && !verifyingNow) {
+        return NextResponse.json(
+          { error: "Verify the captured invoice amount before recording a payment." },
+          { status: 409 },
+        );
+      }
+    }
+
     const data: Record<string, unknown> = {};
     if (status !== undefined) data.status = status;
     if (invoiceNumber !== undefined) data.invoiceNumber = invoiceNumber;

--- a/apps/backoffice/src/lib/inventory/agents/supplier-chat-agent.ts
+++ b/apps/backoffice/src/lib/inventory/agents/supplier-chat-agent.ts
@@ -239,7 +239,16 @@ export async function handleSupplierMessage(evt: SupplierMessageEvent): Promise<
     // shortfalls; the independent verifier backstops every auto-act instead.
     const actions = decision.po_actions.filter((a) => a.type !== "none");
     const hasRisky = actions.some((a) => a.type === "substitute_item" || a.type === "cancel_order");
-    let escalate = decision.requires_human || hasRisky || supplier.automationMode === "ASSIST";
+    // A "reduce" that doesn't actually LOWER the line (new_qty missing/<=0/>= current) is a
+    // model misread — e.g. "ada 50 je" on a line of 5, or echoing a price as a qty. Auto-
+    // applying it would silently RAISE committed spend and confirm a cut that didn't happen.
+    // Force escalation so it holds with a neutral reply + a human-reviewed proposal instead.
+    const badReduce = actions.some((a) => {
+      if (a.type !== "reduce_qty") return false;
+      const line = order.items.find((i) => i.id === a.po_item_id);
+      return !a.new_quantity || a.new_quantity <= 0 || (!!line && a.new_quantity >= Number(line.quantity));
+    });
+    let escalate = decision.requires_human || hasRisky || badReduce || supplier.automationMode === "ASSIST";
     let qaBlocked = false;
     let gateVerdict: Awaited<ReturnType<typeof judgePlanned>> = null;
 
@@ -520,7 +529,14 @@ async function applyPoAction(
       baseQty: Number(item.quantity) * (conv > 0 ? conv : 1),
     };
     await prisma.orderItem.delete({ where: { id: item.id } });
-  } else if (action.type === "reduce_qty" && action.new_quantity && action.new_quantity > 0) {
+  } else if (
+    action.type === "reduce_qty" &&
+    action.new_quantity &&
+    action.new_quantity > 0 &&
+    // Defense-in-depth: a reduce must lower the line (the guardrail already escalates a bad
+    // reduce, but never let this path raise the order if reached another way).
+    action.new_quantity < Number(item.quantity)
+  ) {
     const q = action.new_quantity;
     await prisma.orderItem.update({
       where: { id: item.id },


### PR DESCRIPTION
First fixes out of the end-to-end QA pass — the two cleanest **money-safety** holes:

**1. `reduce_qty` could increase the order.** `applyPoAction` only checked `new_quantity > 0`, so a model misread ('ada 50 je' on a line of 5, or echoing a price as a qty) would silently *raise* committed spend — and the agent confirmed a reduction that never happened. Now any reduce that doesn't actually lower the line forces escalation (neutral hold + human-reviewed proposal), with a defense-in-depth bound in `applyPoAction`.

**2. Invoice PATCH was an unguarded setter.** The UI only hides buttons; a direct call / stale client / double-submit could pay a **DRAFT or unconfirmed AI-captured** invoice (provisional amount = the *PO total*, not the supplier's real bill) or **re-pay an already-PAID** one. Added a payment guard: reject a transition into a payment status when the invoice is already PAID (409) or is DRAFT/AI-prefilled and not being verified in the same request (409).

Both contained; typecheck + lint clean. More findings (gate covers only line 1 of multi-item, cold-send dead-end, send-failure rollback, UX dead-ends) reported separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)