### PR TITLE
fix(procurement): send the supplier their POP when payment is matched via Telegram

### DIFF
--- a/apps/backoffice/src/app/api/inventory/telegram/webhook/route.ts
+++ b/apps/backoffice/src/app/api/inventory/telegram/webhook/route.ts
@@ -7,6 +7,7 @@ import { prisma } from "@/lib/prisma";
 import { createShortLink } from "@/lib/shortlink";
 import { detectPaymentFlags, appendInvoiceFlags } from "@/lib/inventory/flag-detector";
 import { computeDepositAmount } from "@/lib/inventory/deposit";
+import { sendProofOfPayment } from "@/lib/inventory/procurement-whatsapp";
 import {
   sendMessage,
   sendPhoto,
@@ -932,6 +933,24 @@ async function resolvePop(
     `✅ <b>${payType} matched</b>\n\nInvoice: ${invoice.invoiceNumber}${poRef}${outletRef}\n${payeeLabel}\n${isDepositMatch ? `Deposit` : `Amount`}: RM ${amount.toFixed(2)}${isDepositMatch ? ` / RM ${fullAmt.toFixed(2)} total` : ""}${balanceLine}\nRef: ${pop.referenceNumber ?? "–"}\n\nMarked as <b>${statusLabel}</b>.\n📎 Uploaded to PO + Invoice${receiptLink}`,
     msgId,
   );
+
+  // Send the supplier their Proof of Payment on WhatsApp — this was missing, so paying via
+  // Telegram marked the invoice paid but never told the supplier. Full payments only (a
+  // deposit POP is a different message, handled on the Invoices tab). sendProofOfPayment is
+  // gated (PROCUREMENT_WHATSAPP_ENABLED) + idempotent (popSentAt) + never throws; report
+  // the outcome back so the team knows whether the supplier actually received it.
+  if (!isDepositMatch && invoice.supplier) {
+    try {
+      const popSend = await sendProofOfPayment(invoice.id);
+      if (popSend.sent) {
+        await sendMessage(chatId, `📤 POP sent to ${invoice.supplier?.name ?? "supplier"} on WhatsApp.`, msgId);
+      } else if (popSend.reason && popSend.reason !== "already-sent") {
+        await sendMessage(chatId, `⚠️ Supplier POP not sent (${popSend.reason}). Send it from the Invoices tab.`, msgId);
+      }
+    } catch (e) {
+      console.error("[telegram] supplier POP send failed:", e);
+    }
+  }
 
   // Forward POP: supplier → their Telegram group; staff claim → owner chat
   // (staff don't have a Telegram group linked).


### PR DESCRIPTION
**Bug from testing:** uploading a POP into the Telegram channel matched it, marked the invoice PAID, attached it to PO + Invoice, generated the receipt link, and posted "Payment matched" — but **the supplier never got their POP**.

Root cause: `sendProofOfPayment` (the supplier-facing WhatsApp POP) was only wired into the inventory **Invoices-page** PATCH. The **Telegram** POP-match flow marked the invoice paid directly and skipped it.

Fix: the Telegram flow now calls `sendProofOfPayment` after the match (full payments only — a deposit POP is a separate message). It stays gated by `PROCUREMENT_WHATSAPP_ENABLED`, idempotent via `popSentAt`, and never throws. The outcome is reported back to the channel so it's not silent:
- `📤 POP sent to <supplier> on WhatsApp.`
- `⚠️ Supplier POP not sent (<reason>). Send it from the Invoices tab.` — e.g. `disabled`, `no-supplier-phone`, `no-pop-document`.

So if the POP still doesn't reach the supplier after this, the channel will say *why* (most likely `disabled` = `PROCUREMENT_WHATSAPP_ENABLED` is off). Typecheck + lint clean.
🤖 Generated with [Claude Code](https://claude.com/claude-code)