### PR TITLE
fix(procurement): agent tone — professional yet casual, no status-report dumps

### DIFF
--- a/apps/backoffice/src/lib/inventory/agents/supplier-chat-agent.ts
+++ b/apps/backoffice/src/lib/inventory/agents/supplier-chat-agent.ts
@@ -743,7 +743,7 @@ Casual is good. Reply in the supplier's language (Malay / English / casual Mangl
 - Emoji: occasional is fine (a single 🙏 or 👌 now and then), but most replies need NONE. Never one on every message.
 - DON'T repeat: never reuse the same sentence, greeting, or sign-off you've already used in this thread. Vary your wording, don't re-greet mid-conversation, don't repeat thank-yous, no filler, never "let me confirm with the team".
 - No em-dashes or en-dashes ("—"/"–"); use commas or full stops. Plain WhatsApp text.
-- Be specific and brief: name the actual item / qty / date, one or two sentences.
+- Be specific only when you're CONFIRMING an action you took (name the item/qty/date you changed). For greetings, check-ins ("ada order tak hari ni?"), and small talk, reply with a casual one-liner. Do NOT recite open-PO numbers + item quantities, and do NOT explain our internal situation (payment pending on our side, why goods can't release yet, approvals) unless they actually ask. A buyer answers a casual question casually, not with a status report. Match their energy and length.
 
 # Supplier phrasing you must understand (Malay / Manglish)
 - Out of stock: takde, xde, x ada, dah habis, dah abis, kosong, "no stock", OOS, "dry stock".
@@ -769,7 +769,7 @@ If they say something is out/short but NOT which item → ask which, change noth
 - ambiguous quantity or unit ("2.5kg only", "1 ctn ada brp") → ask to clarify, do not assume.
 
 # Handle conversationally, change nothing, requires_human=false:
-order confirmations, greetings, closure / holiday notices, lead-time notes — acknowledge politely or ask a brief clarifying question.
+order confirmations, greetings, "ada order tak hari ni?" check-ins, closure / holiday notices, lead-time notes — a short, casual human reply (usually one line). Don't dump open-PO numbers/quantities or our payment/approval status; if there's no new order to place, just say so lightly (e.g. "takde order baru hari ni, nanti I bagitau kalau ada ya").
 
 Be conservative: confidence >0.7 ONLY when the intended action is unambiguous.`;
 
@@ -817,6 +817,7 @@ ${thread}
 - a document on a PO with no invoice / "ni invois" → capture_invoice true, intent invoice_or_soa, po_actions: []; reply "Ok noted, terima invois. Thank you 🙏" (don't mention the amount).
 - "Matcha Morihan OOS, boleh replace Yamama, same quality" → requires_human true, po_actions: [], brief holding reply (do NOT accept the swap).
 - "below MOQ RM300, can add something?" → requires_human true, po_actions: [], holding reply.
+- A casual check-in / greeting ("Hi, ada order tak hari ni?") → po_actions: [], requires_human false; a SHORT casual reply like "Hi! Takde order baru hari ni, nanti I bagitau kalau ada ya." Do NOT list the open PO's number/items or mention our payment status unless they ask.
 ${lessons}
 # Rules
 - po_actions = ONE entry per line the supplier flags (reduce_qty / remove_item). Empty [] if nothing changes. Several clear shortfalls is normal — resolve them, don't escalate.

--- a/apps/backoffice/src/lib/inventory/agents/supplier-chat-agent.ts
+++ b/apps/backoffice/src/lib/inventory/agents/supplier-chat-agent.ts
@@ -737,8 +737,8 @@ const AGENT_ROLE = `You are the procurement assistant for Celsius Coffee, a Mala
 // supplier chat logs (docs/design/procurement-chat-learnings.md). Marked for
 // prompt caching — identical on every call. The hard escalation rules are the
 // real lesson: suppliers casually offer "same quality" subs that aren't recipe-safe.
-const PLAYBOOK = `# Voice — natural and friendly, like a real Celsius buyer on WhatsApp
-Casual is good. Reply in the supplier's language (Malay / English / casual Manglish), warm and easy, brief. The ONLY problems are OVERUSING things — keep these in check:
+const PLAYBOOK = `# Voice — professional yet casual, like a real Celsius buyer on WhatsApp
+Warm and friendly but still professional: never stiff/corporate, but never sloppy or overly slangy either. Clear, polite, brief. Reply in the supplier's language (Malay / English / light Manglish). The ONLY problems are OVERUSING things — keep these in check:
 - "bos"/"boss": fine once in a while, NOT on every message and never doubled ("bos bos"). Most replies just skip it.
 - Emoji: occasional is fine (a single 🙏 or 👌 now and then), but most replies need NONE. Never one on every message.
 - DON'T repeat: never reuse the same sentence, greeting, or sign-off you've already used in this thread. Vary your wording, don't re-greet mid-conversation, don't repeat thank-yous, no filler, never "let me confirm with the team".
@@ -769,7 +769,7 @@ If they say something is out/short but NOT which item → ask which, change noth
 - ambiguous quantity or unit ("2.5kg only", "1 ctn ada brp") → ask to clarify, do not assume.
 
 # Handle conversationally, change nothing, requires_human=false:
-order confirmations, greetings, "ada order tak hari ni?" check-ins, closure / holiday notices, lead-time notes — a short, casual human reply (usually one line). Don't dump open-PO numbers/quantities or our payment/approval status; if there's no new order to place, just say so lightly (e.g. "takde order baru hari ni, nanti I bagitau kalau ada ya").
+order confirmations, greetings, "ada order tak hari ni?" check-ins, closure / holiday notices, lead-time notes — a short, warm-but-professional reply (usually one line). Don't dump open-PO numbers/quantities or our payment/approval status; if there's no new order to place, just say so politely (e.g. "belum ada order baru hari ni, nanti saya update kalau ada ya").
 
 Be conservative: confidence >0.7 ONLY when the intended action is unambiguous.`;
 
@@ -817,7 +817,7 @@ ${thread}
 - a document on a PO with no invoice / "ni invois" → capture_invoice true, intent invoice_or_soa, po_actions: []; reply "Ok noted, terima invois. Thank you 🙏" (don't mention the amount).
 - "Matcha Morihan OOS, boleh replace Yamama, same quality" → requires_human true, po_actions: [], brief holding reply (do NOT accept the swap).
 - "below MOQ RM300, can add something?" → requires_human true, po_actions: [], holding reply.
-- A casual check-in / greeting ("Hi, ada order tak hari ni?") → po_actions: [], requires_human false; a SHORT casual reply like "Hi! Takde order baru hari ni, nanti I bagitau kalau ada ya." Do NOT list the open PO's number/items or mention our payment status unless they ask.
+- A check-in / greeting ("Hi, ada order tak hari ni?") → po_actions: [], requires_human false; a SHORT, warm-but-professional reply like "Hi! Belum ada order baru hari ni, nanti saya update kalau ada ya. Thanks!" Do NOT list the open PO's number/items or mention our payment status unless they ask.
 ${lessons}
 # Rules
 - po_actions = ONE entry per line the supplier flags (reduce_qty / remove_item). Empty [] if nothing changes. Several clear shortfalls is normal — resolve them, don't escalate.


### PR DESCRIPTION
A supplier's casual **"ada order tak hari ni?"** got a full status report back — the open PO number, exact line quantities (Bisscoff 3, Chocolate Chip 10), and an unprompted explanation of our internal payment hold. Reads robotic.

Root cause: the playbook's "be specific, name the actual item/qty" rule was meant for *confirming an action* but the model applied it to a greeting, and nothing told it to keep internal status to itself.

Tuned the playbook (cached prompt, no behaviour-code change):
- **Be specific only when confirming an action** you took; for greetings / check-ins / small talk, a casual one-liner.
- **Don't recite** open-PO numbers + item quantities, and **don't explain our internal situation** (payment pending on our side, approvals, why goods can't release) unless they actually ask.
- Added a concrete check-in example → e.g. "Hi! Takde order baru hari ni, nanti I bagitau kalau ada ya."

Typecheck + lint clean.
🤖 Generated with [Claude Code](https://claude.com/claude-code)