### PR TITLE
fix(procurement): PO WhatsApp message shows the package unit, not the base unit

### DIFF
--- a/apps/backoffice/src/lib/inventory/procurement-po-send.ts
+++ b/apps/backoffice/src/lib/inventory/procurement-po-send.ts
@@ -43,7 +43,11 @@ export interface PoForSend {
   deliveryDate: Date | null;
   outlet: { name: string; address: string | null };
   supplier: { id: string; name: string; phone: string | null } | null;
-  items: Array<{ quantity: unknown; product: { name: string; baseUom: string } | null }>;
+  items: Array<{
+    quantity: unknown;
+    product: { name: string; baseUom: string } | null;
+    productPackage: { packageLabel: string } | null;
+  }>;
 }
 
 export async function sendPurchaseOrder(order: PoForSend): Promise<void> {
@@ -84,7 +88,9 @@ export async function sendPurchaseOrder(order: PoForSend): Promise<void> {
         .map((it) => ({
           name: it.product!.name,
           quantity: Number(it.quantity),
-          uom: it.product!.baseUom,
+          // The supplier orders in PACKAGE units (cartons/boxes), so label the line with the
+          // package, not the base unit — "3 Box (10× 10pcs Loaf)", not "3 loaf".
+          uom: it.productPackage?.packageLabel ?? it.product!.baseUom,
         })),
       deliveryDate: order.deliveryDate
         ? new Date(order.deliveryDate).toISOString().slice(0, 10)


### PR DESCRIPTION
The auto-sent PO block labelled each line with the product's **base unit** ("loaf"), but PO lines are ordered + priced in **package units** (cartons/boxes). So a supplier read "**3 loaf**" when we meant "**3 Box (10× 10pcs Loaf)**" — a real quantity + unit miscommunication, exactly the kind the 17-chat learnings flagged.

Now the PO message uses the line's `productPackage.packageLabel` (falls back to `baseUom` if a line has no package). The orders PATCH route already includes `productPackage`, so no caller change. Typecheck + lint clean.

(Half of the "make it live-ready" pair — the **cold-send template** is the other half; see the note in chat, it needs the approved `purchase_order` template's structure from Meta.)
🤖 Generated with [Claude Code](https://claude.com/claude-code)