### PR TITLE
feat(procurement): cold-send PO via a reply-prompt template (gated)

### DIFF
--- a/apps/backoffice/src/lib/inventory/procurement-po-send.ts
+++ b/apps/backoffice/src/lib/inventory/procurement-po-send.ts
@@ -6,16 +6,23 @@
  *
  * Gated by PROCUREMENT_AGENT_ENABLED + PROCUREMENT_AGENT_ALLOWLIST (scoped to the
  * test supplier for the first live run). De-duped per PO via the outbound row's
- * raw.poSentFor. Free text inside the 24h customer-service window; OUTSIDE it the
- * send is skipped + logged — a business-initiated `purchase_order` template is the
- * production path for cold sends and isn't wired here yet. Never throws.
+ * raw.poSentFor. Free text inside the 24h customer-service window; OUTSIDE it, when
+ * PROCUREMENT_PO_PROMPT_TEMPLATE is set we ping the supplier with that approved UTILITY
+ * template to invite a reply (which opens the window so the PO block can follow); else the
+ * cold send is skipped + logged. Never throws.
  */
 import { prisma } from "@/lib/prisma";
-import { sendWhatsAppText } from "@/lib/whatsapp";
+import { sendWhatsAppText, sendWhatsAppTemplate } from "@/lib/whatsapp";
 import { recordOutboundMessage } from "@/lib/whatsapp-store";
 import { formatWhatsAppOrder } from "@celsius/shared";
 
 export const PO_SEND_VERSION = "po-send-v1";
+
+// Cold-send (no 24h window) prompt: a UTILITY template that pings the supplier to reply,
+// which opens the window so the full PO block can follow in-window (free). Set this to the
+// APPROVED template's name to enable; unset → cold sends skip (as before). The template body
+// must be: {{1}} = supplier name, {{2}} = PO number.
+const PO_PROMPT_TEMPLATE = process.env.PROCUREMENT_PO_PROMPT_TEMPLATE?.trim();
 
 const digits = (s: string | null | undefined) => (s ?? "").replace(/[^0-9]/g, "");
 
@@ -73,9 +80,51 @@ export async function sendPurchaseOrder(order: PoForSend): Promise<void> {
     const windowOpen =
       !!lastInbound && Date.now() - +new Date(lastInbound.timestamp) < 24 * 60 * 60 * 1000;
     if (!windowOpen) {
-      console.log(
-        `[po-send] po=${order.orderNumber} skipped — 24h window closed (cold send needs the purchase_order template)`,
-      );
+      // Cold: WhatsApp blocks free text. Ping with the approved prompt template (if
+      // configured) so the supplier replies and opens the window; the full PO block then
+      // follows in-window. Deduped via poPromptFor. No template set → skip + log as before.
+      if (!PO_PROMPT_TEMPLATE) {
+        console.log(`[po-send] po=${order.orderNumber} skipped — 24h window closed, no PROCUREMENT_PO_PROMPT_TEMPLATE`);
+        return;
+      }
+      const alreadyPrompted = await prisma.whatsAppMessage.findFirst({
+        where: { direction: "outbound", raw: { path: ["poPromptFor"], equals: order.id } },
+        select: { id: true },
+      });
+      if (alreadyPrompted) return;
+      const ref = await prisma.whatsAppMessage.findFirst({
+        where: { supplierId: supplier.id },
+        orderBy: { timestamp: "desc" },
+        select: { direction: true, fromNumber: true, toNumber: true },
+      });
+      const ourNumber = ref ? (ref.direction === "inbound" ? ref.toNumber : ref.fromNumber) : "";
+      const t = await sendWhatsAppTemplate(dest, PO_PROMPT_TEMPLATE, "en", [
+        {
+          type: "body",
+          parameters: [
+            { type: "text", text: supplier.name },
+            { type: "text", text: order.orderNumber },
+          ],
+        },
+      ]);
+      await recordOutboundMessage({
+        waMessageId: t.messageId,
+        fromNumber: ourNumber,
+        toNumber: dest,
+        type: "text",
+        body: `New order ${order.orderNumber} — sent a new-order prompt (cold; supplier to reply for the details).`,
+        supplierId: supplier.id,
+        status: t.ok ? "sent" : "failed",
+        raw: {
+          agent: PO_SEND_VERSION,
+          poPromptFor: order.id,
+          poNumber: order.orderNumber,
+          via: "template-prompt",
+          ok: t.ok,
+          error: t.error ?? null,
+        },
+      });
+      console.log(`[po-send] po=${order.orderNumber} cold → new-order prompt sent (${PO_PROMPT_TEMPLATE}) ok=${t.ok}`);
       return;
     }
 


### PR DESCRIPTION
Closes the cold-send dead-end (a PO to a supplier who hasn't messaged in 24h used to silently skip — marked SENT, supplier got nothing).

**How:** when `PROCUREMENT_PO_PROMPT_TEMPLATE` is set to the approved UTILITY template's name, a cold send pings the supplier with it to invite a reply; replying opens the 24h window, and the full PO block then goes out in-window as free text (no per-message cost). Deduped via `raw.poPromptFor`. Unset env → cold sends skip + log exactly as before, so this is **inert until the template is live** (safe rollout).

The template the code expects (you submit this to Meta → WhatsApp Manager, **UTILITY**, English):
- Name: anything (set `PROCUREMENT_PO_PROMPT_TEMPLATE` to it).
- Body: `Hi {{1}}, this is Celsius Coffee. We have a new purchase order ({{2}}) for you. Please reply to this message and we'll send you the full details. Thank you!`
- Variables: `{{1}}` = supplier name, `{{2}}` = PO number.

Typecheck + lint clean. (For full AUTO later, the in-window block can auto-send the moment the supplier replies; for ASSIST the human sends it once the window's open.)
🤖 Generated with [Claude Code](https://claude.com/claude-code)