### PR TITLE
feat(ops): arm the ops loops — full auto

### DIFF
--- a/apps/backoffice/src/lib/ops-nudges/index.ts
+++ b/apps/backoffice/src/lib/ops-nudges/index.ts
@@ -22,9 +22,11 @@ import { sendClockInNudge, sendStockCountNudge, sendOpsDigest, sendAuditNudge } 
 import type { Assignee, Breach, RouteKey } from "@/lib/ops-pulse/types";
 
 export type NudgesMode = "off" | "shadow" | "armed";
+// Default ARMED (owner go-live 2026-06-28, "full auto"). Kill switch / staging
+// via OPS_NUDGES_MODE=off|shadow in Vercel — no code change needed to pause.
 export function nudgesMode(): NudgesMode {
-  const m = (process.env.OPS_NUDGES_MODE || "shadow").trim().toLowerCase();
-  return m === "off" || m === "armed" ? m : "shadow";
+  const m = (process.env.OPS_NUDGES_MODE || "armed").trim().toLowerCase();
+  return m === "off" || m === "shadow" ? m : "armed";
 }
 
 // Owner choice 2026-06-28: nudge if no stock count in the last 3 days.

--- a/apps/backoffice/src/lib/ops-pulse/index.ts
+++ b/apps/backoffice/src/lib/ops-pulse/index.ts
@@ -202,7 +202,15 @@ export async function runDailyPulse(now = new Date()): Promise<PulseRunResult> {
   // event signals (reviews, 86'd items, receiving disputes) are trigger-based:
   // they fire on the real-time pulse the moment they happen, so re-listing them
   // a day later would just double-page. Excluded here by category.
-  const breaches = (await detectAll(now)).filter((b) => categoryFor(b.signal) === "routine");
+  //
+  // Clock-in, stock count, and audit are now owned by the dedicated ops-nudges
+  // loops (which DM staff + the lead). Excluded here so the daily digest doesn't
+  // double-ping the leads. The daily pulse keeps its unique routine signals
+  // (checklist, POS-open, phone capture, restock).
+  const NUDGE_OWNED = new Set(["NO_CLOCK_IN", "STOCK_COUNT", "AUDIT"]);
+  const breaches = (await detectAll(now)).filter(
+    (b) => categoryFor(b.signal) === "routine" && !NUDGE_OWNED.has(b.signal),
+  );
   const routed = await routeAll(breaches, now);
 
   // Group routine items by recipient, splitting AUDIT (its own template for the

--- a/apps/backoffice/src/lib/ops-scoreboard/index.ts
+++ b/apps/backoffice/src/lib/ops-scoreboard/index.ts
@@ -20,9 +20,10 @@ import { sendScoreboard } from "@/lib/ops-pulse/sender";
 
 export type ScoreboardMode = "off" | "shadow" | "armed";
 
+// Default ARMED (owner go-live 2026-06-28). Pause via OPS_SCOREBOARD_MODE=off|shadow.
 export function scoreboardMode(): ScoreboardMode {
-  const m = (process.env.OPS_SCOREBOARD_MODE || "shadow").trim().toLowerCase();
-  return m === "off" || m === "armed" ? m : "shadow";
+  const m = (process.env.OPS_SCOREBOARD_MODE || "armed").trim().toLowerCase();
+  return m === "off" || m === "shadow" ? m : "armed";
 }
 
 function mask(phone: string | null): string | null {


### PR DESCRIPTION
Flips OPS_NUDGES_MODE + OPS_SCOREBOARD_MODE defaults to armed (env still overrides for a kill switch) so the ops loops run autonomously: clock-in (30m), stock (daily), audit (weekly), scoreboard (weekly). De-dups the daily pulse (drops clock-in/stock/audit, now owned by the nudges) so leads aren't double-pinged; daily pulse keeps checklist/POS-open/phone/restock. Real-time pulse stays shadow. Templates all approved; shadow runs verified the recipients + content.