### PR TITLE
fix(procurement): don't auto-send a PO for OFF (manual / group) suppliers

### DIFF
--- a/apps/backoffice/src/lib/inventory/procurement-po-send.ts
+++ b/apps/backoffice/src/lib/inventory/procurement-po-send.ts
@@ -49,7 +49,7 @@ export interface PoForSend {
   orderNumber: string;
   deliveryDate: Date | null;
   outlet: { name: string; address: string | null };
-  supplier: { id: string; name: string; phone: string | null } | null;
+  supplier: { id: string; name: string; phone: string | null; automationMode?: string | null } | null;
   items: Array<{
     quantity: unknown;
     product: { name: string; baseUom: string } | null;
@@ -62,6 +62,13 @@ export async function sendPurchaseOrder(order: PoForSend): Promise<void> {
     if (!enabled()) return;
     const supplier = order.supplier;
     if (!supplier?.phone || !allowed(supplier.phone)) return;
+    // OFF = the manual lane: these suppliers are ordered from by hand on the Smart Order
+    // page (incl. WhatsApp GROUPS via the wa.me picker, which the Cloud API can't reach).
+    // Don't also fire a Cloud-API send for them, or they'd get a duplicate 1:1 message.
+    if (supplier.automationMode === "OFF") {
+      console.log(`[po-send] po=${order.orderNumber} skipped — supplier is OFF (manual / group send)`);
+      return;
+    }
     const dest = digits(supplier.phone);
 
     // Dedupe: already sent this PO once?


### PR DESCRIPTION
Keeps the two PO lanes clean now that we have both: the automated **workspace** (Cloud API, 1:1 chat suppliers) and the manual **Smart Order** page (incl. WhatsApp **groups** via the `wa.me` picker — the Cloud API can't message a group at all).

**The latent bug:** the Smart Order page creates a PO and PATCHes it to `AWAITING_DELIVERY`, which also fires `sendPurchaseOrder` (the Cloud-API auto-send). Today the test allowlist hides it, but once you broaden past the test supplier, a supplier you sent **manually to a group** would *also* get a duplicate 1:1 Cloud-API message.

**Fix:** `sendPurchaseOrder` now skips suppliers whose `automationMode` is **OFF** — that's the manual/group lane. ASSIST/AUTO (chat) suppliers auto-send exactly as before. The PATCH route already includes the full supplier, so no caller change. Typecheck + lint clean.

So: keep this page (it's the only way to reach groups + it creates a properly tracked PO that still flows into PO Lists / invoice tracking); group suppliers just live at `automationMode = OFF`.