### PR TITLE
fix(procurement): pre-send QA gate judges ALL lines of a multi-item message (AUTO-blocker 1)

### DIFF
--- a/apps/backoffice/src/lib/inventory/agents/supplier-chat-agent.ts
+++ b/apps/backoffice/src/lib/inventory/agents/supplier-chat-agent.ts
@@ -241,6 +241,13 @@ export async function handleSupplierMessage(evt: SupplierMessageEvent): Promise<
     // ASSIST. No confidence-threshold gate — that was escalating clean multi-item
     // shortfalls; the independent verifier backstops every auto-act instead.
     const actions = decision.po_actions.filter((a) => a.type !== "none");
+    // Every planned line, name-resolved, for the verifier — so the pre-send gate + post-hoc
+    // check judge ALL lines of a multi-item message, not just the primary one.
+    const verifierActions = actions.map((a) => ({
+      type: a.type,
+      itemName: order.items.find((i) => i.id === a.po_item_id)?.product.name ?? null,
+      newQuantity: a.new_quantity,
+    }));
     const hasRisky = actions.some((a) => a.type === "substitute_item" || a.type === "cancel_order");
     // A "reduce" that doesn't actually LOWER the line (new_qty missing/<=0/>= current) is a
     // model misread — e.g. "ada 50 je" on a line of 5, or echoing a price as a qty. Auto-
@@ -317,6 +324,7 @@ export async function handleSupplierMessage(evt: SupplierMessageEvent): Promise<
         actionItemName:
           order.items.find((i) => i.id === decision.po_action.po_item_id)?.product.name ?? null,
         newQuantity: decision.po_action.new_quantity,
+        actions: verifierActions,
         deliveryDate: isValidIsoDate(decision.delivery_date) ? decision.delivery_date : null,
         captureInvoice: invoiceCaptured,
         replyText: decision.reply_text?.trim() || "",
@@ -421,6 +429,7 @@ export async function handleSupplierMessage(evt: SupplierMessageEvent): Promise<
       actionItemName:
         order.items.find((i) => i.id === decision.po_action.po_item_id)?.product.name ?? null,
       newQuantity: decision.po_action.new_quantity,
+      actions: verifierActions,
       deliveryDate: deliveryUpdated,
       captureInvoice: invoiceCaptured,
       replyText,

--- a/apps/backoffice/src/lib/inventory/agents/verifier.ts
+++ b/apps/backoffice/src/lib/inventory/agents/verifier.ts
@@ -43,6 +43,9 @@ export type VerifierDecision = {
   actionType: string; // none | remove_item | reduce_qty | substitute_item | cancel_order
   actionItemName: string | null;
   newQuantity: number | null;
+  // ALL planned line actions for a multi-item message. When present + >1 the verifier MUST
+  // check EVERY line, not just the primary actionType. Optional (older snapshots lack it).
+  actions?: Array<{ type: string; itemName: string | null; newQuantity: number | null }>;
   deliveryDate: string | null;
   captureInvoice: boolean;
   replyText: string;
@@ -95,6 +98,19 @@ export function buildVerifierPrompt(input: VerifierInput, decision: VerifierDeci
     input.thread.filter((m) => m.text).map((m) => `${m.who}: ${m.text}`).join("\n") ||
     "(no earlier messages)";
 
+  // Render EVERY planned line action (multi-item), not just the primary one, so the judge
+  // can catch a bad line 2..N (lines apply non-atomically; any bad line fails the message).
+  const acts = decision.actions && decision.actions.length > 0 ? decision.actions : null;
+  const actionDesc = acts
+    ? (acts.length > 1 ? `MULTI (${acts.length} lines — check EVERY one): ` : "") +
+      acts
+        .map(
+          (a) =>
+            `${a.type}${a.itemName ? ` (${a.itemName})` : ""}${a.newQuantity != null ? ` → qty ${a.newQuantity}` : ""}`,
+        )
+        .join("; ")
+    : `${decision.actionType}${decision.actionItemName ? ` (line: ${decision.actionItemName})` : ""}${decision.newQuantity != null ? ` → qty ${decision.newQuantity}` : ""}`;
+
   return `Today is ${input.today} (Asia/Kuala_Lumpur). A document was attached to the new message: ${input.hadDoc ? "YES" : "no"}.
 
 # Open PO ${input.orderNumber} (status ${input.orderStatus}) — ${input.supplierName}, payment model ${input.paymentModel}
@@ -109,7 +125,7 @@ ${thread}
 # What the agent decided
 - intent: ${decision.intent}
 - language: ${decision.language}
-- PO action: ${decision.actionType}${decision.actionItemName ? ` (line: ${decision.actionItemName})` : ""}${decision.newQuantity != null ? ` → qty ${decision.newQuantity}` : ""}
+- PO action(s): ${actionDesc}
 - applied to PO: ${decision.appliedAction}
 - delivery_date set: ${decision.deliveryDate ?? "none"}
 - capture_invoice: ${decision.captureInvoice}


### PR DESCRIPTION
**AUTO-blocker #1 of 3.** The pre-send QA gate (#567) built its `VerifierDecision` from `po_action[0]` only — so on a multi-item message ("Earl Grey 5, Peppermint 3, Orange habis", the headline feature) it verified **line 1** while lines 2..N applied **unverified**. The least-guarded AUTO path.

**Fix:** the agent now passes **every** planned line (name-resolved) to the verifier; `buildVerifierPrompt` renders them all with a `MULTI (N lines — check EVERY one)` cue. A `fail` on any line already flips the whole message to escalate (the apply branch is skipped wholesale), so it's **block-all** — exactly right since lines apply non-atomically. The full list is also stamped on the recorded decision, so the post-hoc Agent-QA check sees every line too. `actions[]` is optional, so older snapshots are unaffected.

Typecheck + lint clean. Next: AUTO-blocker #2 (send-failure rollback / dedup) and #3 (auto-send-on-reply).