### PR TITLE
fix(procurement): atomic inbound dedup + surface send-failures (AUTO-blocker 2)

### DIFF
--- a/apps/backoffice/src/app/api/inventory/supplier-chats/route.ts
+++ b/apps/backoffice/src/app/api/inventory/supplier-chats/route.ts
@@ -58,6 +58,7 @@ export async function GET(req: NextRequest) {
     lastInbound: string | null;
     lastDirection: string;
     verifierFailed: boolean;
+    sendFailed: boolean;
   };
   const threads = new Map<string, T>();
   for (const m of rows) {
@@ -77,6 +78,7 @@ export async function GET(req: NextRequest) {
         // rows are desc, so the first one we see for a thread is the most recent.
         lastDirection: m.direction,
         verifierFailed: m.direction === "outbound" && !!raw?.agent && v?.rating === "fail",
+        sendFailed: m.direction === "outbound" && raw?.sendFailed === true,
       };
       threads.set(counter, t);
     }
@@ -147,6 +149,7 @@ export async function GET(req: NextRequest) {
     const s = t.supplierId ? byId.get(t.supplierId) : undefined;
     const needsAttention =
       t.verifierFailed ||
+      t.sendFailed ||
       (!!t.lastInbound && ATTENTION_RX.test(t.lastInbound)) ||
       (!!t.supplierId && overdue.has(t.supplierId));
     out.push({

--- a/apps/backoffice/src/app/api/whatsapp/webhook/route.ts
+++ b/apps/backoffice/src/app/api/whatsapp/webhook/route.ts
@@ -86,8 +86,9 @@ export async function POST(request: NextRequest) {
             : null;
         // 1) Persist for the supplier-chat monitor/inbox (Option 1). Best-effort —
         // recordInboundMessage never throws, so it never blocks the 200 to Meta.
-        // supplierId is matched by phone inside.
-        await recordInboundMessage({
+        // supplierId is matched by phone inside. Returns false on a Meta re-delivery
+        // (duplicate wamid) — atomic via the @unique — so we run the agent exactly once.
+        const isNewInbound = await recordInboundMessage({
           waMessageId: msg.id,
           fromNumber: msg.from,
           toNumber: businessNumber,
@@ -134,7 +135,10 @@ export async function POST(request: NextRequest) {
         // throws, so we AWAIT it (serverless can freeze after the response, so a
         // fire-and-forget promise might not run) — it still returns fast for
         // non-suppliers and when the flag is off. TODO: Telegram monitor mirror.
-        if (msg.type === "text" || msg.type === "document" || msg.type === "image") {
+        // Skip on a re-delivery (isNewInbound === false): otherwise two concurrent Meta
+        // re-deliveries could both pass the agent's own check and double-apply a PO edit +
+        // double-reply. The @unique wamid makes the first inbound store the atomic claim.
+        if (isNewInbound && (msg.type === "text" || msg.type === "document" || msg.type === "image")) {
           await handleSupplierMessage({
             fromNumber: msg.from,
             toNumber: businessNumber,

--- a/apps/backoffice/src/lib/inventory/agents/supplier-chat-agent.ts
+++ b/apps/backoffice/src/lib/inventory/agents/supplier-chat-agent.ts
@@ -445,6 +445,10 @@ export async function handleSupplierMessage(evt: SupplierMessageEvent): Promise<
       raw: {
         agent: SUPPLIER_AGENT_VERSION,
         inReplyTo: evt.waMessageId ?? null,
+        // The send failed — the supplier never got our reply. If a PO edit was applied, the
+        // PO is now changed but unconfirmed; the dedup correctly won't retry, so flag the
+        // thread for a human to resend (surfaced as needs-attention in the inbox list).
+        sendFailed: !sent.ok,
         intent: decision.intent,
         confidence: decision.confidence,
         appliedAction,

--- a/apps/backoffice/src/lib/whatsapp-store.ts
+++ b/apps/backoffice/src/lib/whatsapp-store.ts
@@ -43,7 +43,11 @@ export interface InboundRecord {
   raw?: unknown;
 }
 
-export async function recordInboundMessage(rec: InboundRecord): Promise<void> {
+// Returns true if the inbound was NEWLY stored, false if it was a duplicate (same wamid,
+// a Meta re-delivery). Because waMessageId is @unique, the create is an ATOMIC claim — two
+// concurrent re-deliveries can't both return true — so the webhook can run the agent exactly
+// once per inbound off this flag (prevents the double-act race).
+export async function recordInboundMessage(rec: InboundRecord): Promise<boolean> {
   try {
     const supplierId = await matchSupplierIdByPhone(rec.fromNumber);
     await prisma.whatsAppMessage.create({
@@ -60,9 +64,13 @@ export async function recordInboundMessage(rec: InboundRecord): Promise<void> {
         raw: (rec.raw ?? undefined) as Prisma.InputJsonValue | undefined,
       },
     });
+    return true; // newly stored
   } catch (e) {
-    // Duplicate wamid (re-delivery) or any write error — never throw.
-    console.warn(`[whatsapp:store] inbound persist skipped: ${e instanceof Error ? e.message : e}`);
+    // P2002 = duplicate wamid (re-delivery) → not new. Any OTHER write error → fail-open
+    // (treat as new so a transient DB error doesn't silently drop the message). Never throws.
+    const dup = (e as { code?: string }).code === "P2002";
+    if (!dup) console.warn(`[whatsapp:store] inbound persist skipped: ${e instanceof Error ? e.message : e}`);
+    return !dup;
   }
 }
 


### PR DESCRIPTION
**AUTO-blocker #2 of 3.** Two re-delivery safety fixes — **no migration needed**:

**1. Atomic dedup.** Meta re-delivers a webhook until it gets a 200, and we `await` the (slow, LLM) agent before that 200 — so two re-deliveries could interleave past the agent's non-atomic self-check and **double-apply a PO edit + double-reply**. Since `waMessageId` is already `@unique`, `recordInboundMessage` now reports whether the inbound was **newly stored** (false on a duplicate, atomic via P2002 — the DB constraint is the claim), and the webhook runs the agent **only for a new inbound** → exactly-once per message, even under concurrent re-deliveries.

**2. Send-failure surfaced.** With the dedup, a failed send is (correctly) not auto-retried — so if a PO edit applied but the confirmation send failed, the PO is changed while the supplier wasn't told. The agent now stamps `raw.sendFailed`, and the inbox list flags that thread as **needs-attention** so a human resends.

Typecheck + lint clean. (Spotted while here: the agent's send may have lost its `evt.waMessageId` reply-quote arg from #561 — verifying separately.) Next: AUTO-blocker #3 (auto-send-on-reply for cold POs).