### PR TITLE
fix(procurement): restore the agent's reply-quote (lost after #561)

### DIFF
--- a/apps/backoffice/src/lib/inventory/agents/supplier-chat-agent.ts
+++ b/apps/backoffice/src/lib/inventory/agents/supplier-chat-agent.ts
@@ -432,7 +432,9 @@ export async function handleSupplierMessage(evt: SupplierMessageEvent): Promise<
     };
 
     // Auto-reply (24h window is open — the supplier just messaged us).
-    const sent = await sendWhatsAppText(supplier.phone ?? fromDigits, replyText);
+    // Quote the inbound message so the supplier sees which message we're answering (lost in
+    // a merge after #561; restored). evt.waMessageId is the supplier's Meta wamid.
+    const sent = await sendWhatsAppText(supplier.phone ?? fromDigits, replyText, evt.waMessageId);
 
     const recordedId = await recordOutboundMessage({
       waMessageId: sent.messageId,


### PR DESCRIPTION
The supplier-chat agent's auto-reply is supposed to quote the supplier's message (WhatsApp `context.message_id` = the inbound `evt.waMessageId`) so on a busy thread they see exactly which message it's answering — shipped in #561, but the 3rd arg got dropped from `sendWhatsAppText(...)` in a later merge (sibling to the double-click-to-reply that was also silently lost + re-added). Restored. Typecheck + lint clean.