### PR TITLE
fix(procurement): workspace fits the mobile viewport (100vh → 100dvh)

### DIFF
--- a/apps/backoffice/src/app/(admin)/inventory/supplier-chats/page.tsx
+++ b/apps/backoffice/src/app/(admin)/inventory/supplier-chats/page.tsx
@@ -637,7 +637,7 @@ export default function SupplierChatsPage() {
   }
 
   return (
-    <div className="flex h-[calc(100vh-64px)] min-h-[560px] gap-3 p-3 text-foreground">
+    <div className="flex h-[calc(100dvh-64px)] gap-3 p-3 text-foreground lg:min-h-[560px]">
       {/* ── Thread list ─────────────────────────────── */}
       <div className={`${selected ? "hidden lg:flex" : "flex"} w-full lg:w-72 shrink-0 flex-col overflow-hidden rounded-xl border border-border bg-background shadow-sm`}>
         <div className="border-b border-border p-3">


### PR DESCRIPTION
**Bug:** the supplier-chat workspace looked broken on mobile — the container was `h-[calc(100vh-64px)]`, and on mobile browsers `100vh` includes the address-bar area, so the now-full-screen pane overflowed the visible viewport and the **reply composer at the bottom got pushed off-screen**.

**Fix:** `100vh` → `100dvh` (dynamic viewport height — accounts for mobile browser chrome; identical to `100vh` on desktop), and `min-h-[560px]` → `lg:min-h-[560px]` so a short/landscape phone isn't forced taller than its screen. Desktop layout unchanged.

(Couldn't run the authenticated app locally in the worktree — verified via typecheck/lint; please confirm on a phone.)