### PR TITLE
feat(ops): land stranded ops-loop follow-ups (cadences, bad-review nudge, realtime reviews, inbox name+outlet)

### DIFF
--- a/apps/backoffice/src/app/(admin)/ops/chat-inbox/_InboxPanel.tsx
+++ b/apps/backoffice/src/app/(admin)/ops/chat-inbox/_InboxPanel.tsx
@@ -13,6 +13,8 @@ type Thread = {
   userId: string | null;
   name: string | null;
   role: string | null;
+  outletId: string | null;
+  outletName: string | null;
   lastBody: string;
   lastDirection: "IN" | "OUT";
   lastAt: string;
@@ -47,6 +49,7 @@ type ThreadDetail = {
   userId: string | null;
   name: string | null;
   role: string | null;
+  outletName: string | null;
   windowOpen: boolean;
   openAlerts: OpenAlert[];
   messages: Message[];
@@ -67,6 +70,18 @@ function fmtPhone(p: string): string {
 export default function InboxPanel() {
   const { data, isLoading, mutate: mutateList } = useFetch<{ threads: Thread[] }>("/api/ops/chat-inbox");
   const threads = data?.threads ?? [];
+
+  const [outletFilter, setOutletFilter] = useState<string>("all");
+  // Distinct outlets present in the threads, for the filter dropdown.
+  const outletOptions = Array.from(
+    new Map(threads.filter((t) => t.outletId).map((t) => [t.outletId as string, t.outletName || (t.outletId as string)])).entries(),
+  ).sort((a, b) => String(a[1]).localeCompare(String(b[1])));
+  const visibleThreads =
+    outletFilter === "all"
+      ? threads
+      : outletFilter === "none"
+        ? threads.filter((t) => !t.outletId)
+        : threads.filter((t) => t.outletId === outletFilter);
 
   const [selected, setSelected] = useState<string | null>(null);
   const { data: detail, isLoading: detailLoading, mutate: mutateThread } = useFetch<ThreadDetail>(
@@ -119,14 +134,28 @@ export default function InboxPanel() {
 
   return (
     <div>
-      <div className="mb-2 flex items-center">
+      <div className="mb-2 flex items-center gap-2">
         <span className="text-xs text-muted-foreground">WhatsApp — ops-pulse digests &amp; staff replies</span>
+        <select
+          value={outletFilter}
+          onChange={(e) => setOutletFilter(e.target.value)}
+          className="ml-auto h-7 rounded-md border bg-background px-2 text-xs text-foreground"
+          title="Filter by outlet"
+        >
+          <option value="all">All outlets</option>
+          {outletOptions.map(([id, name]) => (
+            <option key={id} value={id}>
+              {name}
+            </option>
+          ))}
+          <option value="none">No outlet</option>
+        </select>
         <button
           onClick={() => {
             mutateList();
             if (selected) mutateThread();
           }}
-          className="ml-auto flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground"
+          className="flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground"
         >
           <RefreshCw className="h-3.5 w-3.5" /> Refresh
         </button>
@@ -139,14 +168,15 @@ export default function InboxPanel() {
             <div className="p-6 text-center text-muted-foreground">
               <Loader2 className="mx-auto h-5 w-5 animate-spin" />
             </div>
-          ) : threads.length === 0 ? (
+          ) : visibleThreads.length === 0 ? (
             <div className="p-6 text-center text-sm text-muted-foreground">
-              No conversations yet. Messages appear here as staff reply to ops-pulse digests, or
-              message the WhatsApp number.
+              {outletFilter === "all"
+                ? "No conversations yet. Messages appear here as staff reply to ops-pulse digests, or message the WhatsApp number."
+                : "No conversations for this outlet."}
             </div>
           ) : (
             <ul className="divide-y">
-              {threads.map((t) => {
+              {visibleThreads.map((t) => {
                 const active = t.staffPhone === selected;
                 return (
                   <li key={t.staffPhone}>
@@ -165,6 +195,9 @@ export default function InboxPanel() {
                           <Badge variant="secondary" className="text-[10px]">
                             {t.role}
                           </Badge>
+                        )}
+                        {t.outletName && (
+                          <span className="truncate text-[10px] text-muted-foreground">· {t.outletName}</span>
                         )}
                         <span className="ml-auto shrink-0 text-[10px] text-muted-foreground">
                           {fmtTime(t.lastAt)}
@@ -222,6 +255,7 @@ export default function InboxPanel() {
                   <div className="text-[11px] text-muted-foreground">
                     {fmtPhone(detail.staffPhone)}
                     {detail.role ? ` · ${detail.role}` : ""}
+                    {detail.outletName ? ` · ${detail.outletName}` : ""}
                   </div>
                 </div>
                 {detail.openAlerts.length > 0 && (

--- a/apps/backoffice/src/app/api/cron/ops-nudge-audit/route.ts
+++ b/apps/backoffice/src/app/api/cron/ops-nudge-audit/route.ts
@@ -9,9 +9,9 @@ export const maxDuration = 60;
  * GET /api/cron/ops-nudge-audit — weekly audit nudge to the discipline leads.
  *
  * Outlet audits + staff skill training overdue this week, routed by discipline:
- * barista -> Syafiq, kitchen -> Chef Bo. Each lead gets one DM of their due
- * audits. Weekly (Mon); the ledger dedupes per 7-day cadence bucket.
- * OPS_NUDGES_MODE (off|shadow|armed, default shadow).
+ * barista -> Syafiq, kitchen -> Chef Bo. DAILY progress snapshot — each day the
+ * lead gets their CURRENT outstanding audits, so the list shrinks + skill counts
+ * climb as they work through them. OPS_NUDGES_MODE (off|shadow|armed, default armed).
  * Design: docs/design/ops-performance-loop.md.
  */
 export async function GET(req: NextRequest) {

--- a/apps/backoffice/src/app/api/cron/ops-nudge-clockin/route.ts
+++ b/apps/backoffice/src/app/api/cron/ops-nudge-clockin/route.ts
@@ -10,9 +10,10 @@ export const maxDuration = 60;
  *
  * For each staff with a published shift today whose start + grace has passed and
  * no clock-in: DMs the staff member ("please clock in") and adds them to a digest
- * for the manager (ops leads). Runs every ~30 min; the OpsAlert ledger dedupes so
- * each no-show is nudged at most once per day. OPS_NUDGES_MODE (off|shadow|armed),
- * default shadow. Design: docs/design/ops-performance-loop.md.
+ * for the manager (ops leads). Runs ONCE daily (~8:30am MYT) — catches the main
+ * morning shift while it's still actionable, and keeps cost low (one run, not 48).
+ * The ledger still dedupes per (staff, day). OPS_NUDGES_MODE (off|shadow|armed),
+ * default armed. Design: docs/design/ops-performance-loop.md.
  */
 export async function GET(req: NextRequest) {
   const cronAuth = checkCronAuth(req.headers);

--- a/apps/backoffice/src/app/api/cron/ops-nudge-review/route.ts
+++ b/apps/backoffice/src/app/api/cron/ops-nudge-review/route.ts
@@ -1,0 +1,29 @@
+import { NextRequest, NextResponse } from "next/server";
+import { checkCronAuth } from "@celsius/shared";
+import { runReviewNudges } from "@/lib/ops-nudges";
+
+export const dynamic = "force-dynamic";
+export const maxDuration = 60;
+
+/**
+ * GET /api/cron/ops-nudge-review — bad-review nudge.
+ *
+ * New negative reviews (internal QR <=2*, Google <=3*, last 72h) DM'd to the
+ * outlet's on-shift team for service recovery + a digest to the managers (ops
+ * leads). Hourly; the ledger dedupes per review so each is nudged once.
+ * OPS_NUDGES_MODE (off|shadow|armed, default armed).
+ * Design: docs/design/ops-performance-loop.md.
+ */
+export async function GET(req: NextRequest) {
+  const cronAuth = checkCronAuth(req.headers);
+  if (!cronAuth.ok) return NextResponse.json({ error: cronAuth.error }, { status: cronAuth.status });
+  try {
+    const result = await runReviewNudges();
+    console.log(`[cron/ops-nudge-review] mode=${result.mode} items=${result.items} staff=${result.staffSent} mgr=${result.managerSent}`);
+    return NextResponse.json({ ok: true, ...result });
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : "ops-nudge-review failed";
+    console.error("[cron/ops-nudge-review]", msg);
+    return NextResponse.json({ error: msg }, { status: 500 });
+  }
+}

--- a/apps/backoffice/src/app/api/cron/ops-nudge-review/route.ts
+++ b/apps/backoffice/src/app/api/cron/ops-nudge-review/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { checkCronAuth } from "@celsius/shared";
 import { runReviewNudges } from "@/lib/ops-nudges";
+import { syncNegativeReviewDrafts } from "@/lib/reviews/sync-negatives";
 
 export const dynamic = "force-dynamic";
 export const maxDuration = 60;
@@ -8,9 +9,11 @@ export const maxDuration = 60;
 /**
  * GET /api/cron/ops-nudge-review — bad-review nudge.
  *
- * New negative reviews (internal QR <=2*, Google <=3*, last 72h) DM'd to the
- * outlet's on-shift team for service recovery + a digest to the managers (ops
- * leads). Hourly; the ledger dedupes per review so each is nudged once.
+ * First INGESTS new negative Google reviews from GBP into ReviewReplyDraft (same
+ * path the reviews board uses — so negatives no longer wait for a human to open
+ * the board), then DMs the outlet's on-shift team for service recovery + a digest
+ * to the managers (ops leads). Covers internal QR <=2* + Google <=3* (last 72h).
+ * Hourly; the ledger dedupes per review so each is nudged once.
  * OPS_NUDGES_MODE (off|shadow|armed, default armed).
  * Design: docs/design/ops-performance-loop.md.
  */
@@ -18,9 +21,21 @@ export async function GET(req: NextRequest) {
   const cronAuth = checkCronAuth(req.headers);
   if (!cronAuth.ok) return NextResponse.json({ error: cronAuth.error }, { status: cronAuth.status });
   try {
+    // 1) Ingest new negative Google reviews into ReviewReplyDraft (same path the
+    // board uses) so there's something to nudge — they're no longer dependent on
+    // a human opening the reviews board. Best-effort; never blocks the nudge.
+    let ingest = { created: 0, resolved: 0 };
+    try {
+      ingest = await syncNegativeReviewDrafts();
+    } catch (e) {
+      console.error("[cron/ops-nudge-review] negative-review sync failed:", e);
+    }
+    // 2) Nudge on-shift teams + managers for the (now-ingested) new negatives.
     const result = await runReviewNudges();
-    console.log(`[cron/ops-nudge-review] mode=${result.mode} items=${result.items} staff=${result.staffSent} mgr=${result.managerSent}`);
-    return NextResponse.json({ ok: true, ...result });
+    console.log(
+      `[cron/ops-nudge-review] ingested=${ingest.created} resolved=${ingest.resolved} mode=${result.mode} items=${result.items} staff=${result.staffSent} mgr=${result.managerSent}`,
+    );
+    return NextResponse.json({ ok: true, ingest, ...result });
   } catch (err) {
     const msg = err instanceof Error ? err.message : "ops-nudge-review failed";
     console.error("[cron/ops-nudge-review]", msg);

--- a/apps/backoffice/src/app/api/cron/ops-nudge-review/route.ts
+++ b/apps/backoffice/src/app/api/cron/ops-nudge-review/route.ts
@@ -13,7 +13,9 @@ export const maxDuration = 60;
  * path the reviews board uses — so negatives no longer wait for a human to open
  * the board), then DMs the outlet's on-shift team for service recovery + a digest
  * to the managers (ops leads). Covers internal QR <=2* + Google <=3* (last 72h).
- * Hourly; the ledger dedupes per review so each is nudged once.
+ * Runs every 5 min (near-realtime — a bad review reaches the team within minutes);
+ * the ledger dedupes per review so each is nudged once. For TRUE instant delivery,
+ * GBP Pub/Sub notifications would push new reviews to a webhook (needs GCP setup).
  * OPS_NUDGES_MODE (off|shadow|armed, default armed).
  * Design: docs/design/ops-performance-loop.md.
  */

--- a/apps/backoffice/src/app/api/cron/ops-nudge-stockcount/route.ts
+++ b/apps/backoffice/src/app/api/cron/ops-nudge-stockcount/route.ts
@@ -8,10 +8,11 @@ export const maxDuration = 60;
 /**
  * GET /api/cron/ops-nudge-stockcount — no-stock-count nudge.
  *
- * For each active outlet with no SUBMITTED/REVIEWED count in the last 3 days
- * (OPS_NUDGE_STOCK_DAYS): DMs the on-shift team ("count + submit today") and adds
- * a line to the manager (ops leads) digest. Daily; the ledger dedupes per outlet
- * per day. OPS_NUDGES_MODE (off|shadow|armed), default shadow.
+ * Follows the owner's Stock Count schedule (Settings → Stock Count). On a
+ * scheduled count day (chosen weekday = regular count, month-end date = full
+ * count) it DMs each outlet's on-shift team + a manager digest, for outlets that
+ * haven't logged a count that day. Silent on non-count days. Runs daily (the
+ * schedule gates whether it sends). OPS_NUDGES_MODE (off|shadow|armed), default armed.
  * Design: docs/design/ops-performance-loop.md.
  */
 export async function GET(req: NextRequest) {

--- a/apps/backoffice/src/app/api/ops/workspace/test-nudge/route.ts
+++ b/apps/backoffice/src/app/api/ops/workspace/test-nudge/route.ts
@@ -2,7 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { getSession } from "@/lib/auth";
 import { prisma } from "@/lib/prisma";
 import { findNoClockInBreaches } from "@/lib/ops-pulse/detectors";
-import { findStaleStockBreaches } from "@/lib/ops-nudges";
+import { findScheduledStockBreaches } from "@/lib/ops-nudges";
 import { sendProactive } from "@/lib/ops-pulse/sender";
 import { TEMPLATES } from "@/lib/ops-pulse/config";
 
@@ -54,7 +54,7 @@ export async function POST(req: NextRequest) {
   const dateLabel = now.toLocaleDateString("en-MY", { timeZone: "Asia/Kuala_Lumpur", weekday: "short", day: "2-digit", month: "short" });
 
   // Real live data — same detectors the crons use.
-  const [clk, stock] = await Promise.all([findNoClockInBreaches(now), findStaleStockBreaches(now, 3)]);
+  const [clk, stock] = await Promise.all([findNoClockInBreaches(now), findScheduledStockBreaches(now)]);
 
   const ids = [...new Set(clk.map((b) => String(b.detail.userId ?? "")).filter(Boolean))];
   const users = ids.length
@@ -72,7 +72,7 @@ export async function POST(req: NextRequest) {
     const who = nameById.get(String(b.detail.userId ?? "")) ?? "Staff";
     return `${who} — ${b.outletName}, ${fmtTime(String(b.detail.scheduledStart ?? ""))}`;
   });
-  const stockLines = stock.map((b) => `${b.outletName} — ${String((b.detail as { when?: string }).when ?? "overdue")}`);
+  const stockLines = stock.map((b) => `${b.outletName} — ${(b.detail as { full?: boolean }).full ? "full count due" : "count due"}`);
 
   // Compose: professional but casual, no emoji.
   const parts = [`Morning ${greetName}. Quick ops check for ${dateLabel}:`];

--- a/apps/backoffice/src/app/api/reviews/negatives/route.ts
+++ b/apps/backoffice/src/app/api/reviews/negatives/route.ts
@@ -1,14 +1,10 @@
 import { NextRequest, NextResponse } from "next/server";
 import { getUserFromHeaders } from "@/lib/auth";
 import { prisma } from "@/lib/prisma";
-import { fetchGoogleReviews } from "@/lib/reviews/gbp";
-import { generateReply, POSITIVE_THRESHOLD } from "@/lib/reviews/auto-reply";
+import { syncNegativeReviewDrafts } from "@/lib/reviews/sync-negatives";
 
 export const dynamic = "force-dynamic";
 export const maxDuration = 120;
-
-// Cap LLM calls per sync so a large first-run backlog can't blow up.
-const MAX_NEW_DRAFTS_PER_SYNC = 30;
 
 // GET /api/reviews/negatives[?sync=1]
 // Returns the pending negative-review approval queue.
@@ -25,79 +21,10 @@ export async function GET(request: NextRequest) {
   let resolved = 0;
 
   if (sync) {
-    const outlets = await prisma.outlet.findMany({
-      where: { status: "ACTIVE" },
-      include: { reviewSettings: true },
-    });
-    const connected = outlets.filter(
-      (o) => o.reviewSettings?.gbpAccountId && o.reviewSettings?.gbpLocationName,
-    );
-
-    // Every review we've ever drafted (any status) — so we never double-draft.
-    const existing = await prisma.reviewReplyDraft.findMany({
-      select: { id: true, reviewId: true, status: true },
-    });
-    const seenReviewIds = new Set(existing.map((d) => d.reviewId));
-
-    for (const outlet of connected) {
-      const settings = outlet.reviewSettings!;
-      let reviews;
-      try {
-        const data = await fetchGoogleReviews(
-          settings.gbpAccountId!,
-          settings.gbpLocationName!,
-          50,
-        );
-        reviews = data.reviews;
-      } catch (err) {
-        console.error(`[reviews/negatives] sync fetch failed for ${outlet.name}:`, err);
-        continue;
-      }
-
-      // Resolve pending drafts whose review now carries a reply on Google.
-      const repliedIds = reviews.filter((r) => r.reply).map((r) => r.id);
-      const toResolve = existing.filter(
-        (d) => d.status === "pending" && repliedIds.includes(d.reviewId),
-      );
-      if (toResolve.length) {
-        await prisma.reviewReplyDraft.updateMany({
-          where: { id: { in: toResolve.map((d) => d.id) } },
-          data: { status: "resolved" },
-        });
-        resolved += toResolve.length;
-      }
-
-      // Draft replies for new unreplied negatives we haven't seen before.
-      const newNegatives = reviews.filter(
-        (r) => !r.reply && r.rating < POSITIVE_THRESHOLD && !seenReviewIds.has(r.id),
-      );
-      for (const review of newNegatives) {
-        if (created >= MAX_NEW_DRAFTS_PER_SYNC) break;
-        try {
-          const draft = await generateReply({
-            rating: review.rating,
-            reviewer: review.reviewer.name,
-            comment: review.comment,
-            outletName: outlet.name,
-          });
-          if (!draft) continue;
-          await prisma.reviewReplyDraft.create({
-            data: {
-              reviewId: review.id,
-              outletId: outlet.id,
-              reviewerName: review.reviewer.name,
-              rating: review.rating,
-              comment: review.comment ?? null,
-              draftReply: draft,
-            },
-          });
-          seenReviewIds.add(review.id);
-          created++;
-        } catch (err) {
-          console.error(`[reviews/negatives] draft create failed for ${review.id}:`, err);
-        }
-      }
-    }
+    // Same proven path the review-nudge cron uses (lib/reviews/sync-negatives).
+    const r = await syncNegativeReviewDrafts();
+    created = r.created;
+    resolved = r.resolved;
   }
 
   // scope=all → the full case board (every status). Default → pending only,

--- a/apps/backoffice/src/lib/ops-nudges/index.ts
+++ b/apps/backoffice/src/lib/ops-nudges/index.ts
@@ -193,10 +193,12 @@ export async function runStockCountNudges(now = new Date()): Promise<NudgeRunRes
   return { mode, ranAt, items: managerLines.length, staffSent, managerSent };
 }
 
-// ── 3. Audits due → discipline lead (barista -> Syafiq, kitchen -> Chef Bo) ──
-// Outlet audits + staff skill training overdue this week, routed by discipline.
-// staffSent = lead DMs sent. Weekly cadence (detector dedupeKey is per 7-day
-// bucket, so even a daily cron nudges each item at most once per week).
+// ── 3. Audit progress → discipline lead (barista -> Syafiq, kitchen -> Chef Bo) ──
+// DAILY progress snapshot (owner 2026-06-28): each day the lead gets their CURRENT
+// outstanding outlet audits + skill-training gaps, routed by discipline. No ledger
+// dedupe — it re-sends each daily run, so as they complete audits the list shrinks
+// and the skill counts climb (the message updates their progress). The daily cron
+// cadence is the once-per-day guard. staffSent = lead DMs sent.
 export async function runAuditNudges(now = new Date()): Promise<NudgeRunResult> {
   const mode = nudgesMode();
   const ranAt = now.toISOString();
@@ -221,20 +223,17 @@ export async function runAuditNudges(now = new Date()): Promise<NudgeRunResult> 
       continue;
     }
 
-    // armed — dedupe per audit (weekly), then DM the lead the new ones.
-    const newLines: string[] = [];
-    for (const b of byRoute[routeKey]) {
-      const { isNew } = await recordBreach(b, recips[0] ?? null);
-      if (isNew) newLines.push(b.summary);
-    }
-    if (newLines.length === 0) continue;
-    items += newLines.length;
+    // armed — daily progress snapshot: send the lead their CURRENT outstanding
+    // audits every run (no dedupe; the daily cron is the cadence). The list
+    // shrinks + skill counts climb as they complete, so it reads as progress.
+    const lines = byRoute[routeKey].map((b) => b.summary);
+    items += lines.length;
     for (const r of recips) {
       if (!r.phone) {
         console.warn(`[ops-nudge:audit] no phone for ${r.name} (${routeKey}) — not nudged`);
         continue;
       }
-      const res = await sendAuditNudge(r.phone, r.name, newLines);
+      const res = await sendAuditNudge(r.phone, r.name, lines);
       if (res.ok) staffSent += 1;
       else console.error(`[ops-nudge:audit] lead nudge to ${r.name} failed:`, res.error);
     }

--- a/apps/backoffice/src/lib/ops-nudges/index.ts
+++ b/apps/backoffice/src/lib/ops-nudges/index.ts
@@ -29,8 +29,20 @@ export function nudgesMode(): NudgesMode {
   return m === "off" || m === "shadow" ? m : "armed";
 }
 
-// Owner choice 2026-06-28: nudge if no stock count in the last 3 days.
-const STOCK_STALE_DAYS = Number(process.env.OPS_NUDGE_STOCK_DAYS || 3);
+// Stock counts follow the owner-set schedule (Settings → Stock Count): regular
+// counts on chosen weekdays + a full count on chosen month-end dates. Stored in
+// appConfig. Default mirrors the settings default (Sun/Tue/Thu + 28-31).
+const STOCK_SCHEDULE_KEY = "stock_count_schedule";
+const DEFAULT_STOCK_SCHEDULE = { weeklyDays: [0, 2, 4], endOfMonthDays: [28, 29, 30, 31] };
+
+async function getStockSchedule(): Promise<{ weeklyDays: number[]; endOfMonthDays: number[] }> {
+  const c = await prisma.appConfig.findUnique({ where: { key: STOCK_SCHEDULE_KEY } });
+  const v = (c?.value ?? null) as { weeklyDays?: number[]; endOfMonthDays?: number[] } | null;
+  return {
+    weeklyDays: v?.weeklyDays ?? DEFAULT_STOCK_SCHEDULE.weeklyDays,
+    endOfMonthDays: v?.endOfMonthDays ?? DEFAULT_STOCK_SCHEDULE.endOfMonthDays,
+  };
+}
 
 function mytYmd(now: Date): string {
   return new Date(now.getTime() + 8 * 3600_000).toISOString().slice(0, 10);
@@ -115,42 +127,45 @@ export async function runClockInNudges(now = new Date()): Promise<NudgeRunResult
   return { mode, ranAt, items: managerLines.length, staffSent, managerSent };
 }
 
-// ── 2. No stock count ───────────────────────────────────────────────────────
-export async function findStaleStockBreaches(now: Date, days: number): Promise<Breach[]> {
+// ── 2. Stock count — schedule-driven ────────────────────────────────────────
+// Follows the owner's Stock Count schedule (Settings → Stock Count): fires ONLY
+// on a configured count day — a chosen weekday (regular count) or a month-end
+// date (full count) — for outlets that haven't logged a SUBMITTED/REVIEWED count
+// THAT day. Returns [] on non-count days, so it never nudges off-schedule.
+export async function findScheduledStockBreaches(now: Date): Promise<Breach[]> {
+  const sched = await getStockSchedule();
+  const myt = new Date(now.getTime() + 8 * 3600_000);
+  const weekday = myt.getUTCDay(); // 0=Sun … 6=Sat (myt instant read as UTC)
+  const dom = myt.getUTCDate();
+  const isWeekly = sched.weeklyDays.includes(weekday);
+  const isMonthEnd = sched.endOfMonthDays.includes(dom);
+  if (!isWeekly && !isMonthEnd) return []; // not a scheduled count day → nothing due
+  const full = isMonthEnd; // month-end date = full count
+
   const ymd = mytYmd(now);
-  const cutoff = new Date(now.getTime() - days * 86_400_000);
-  const [outlets, recent, lastCounts] = await Promise.all([
+  const dayStart = new Date(`${ymd}T00:00:00+08:00`);
+  const [outlets, todayCounts] = await Promise.all([
     prisma.outlet.findMany({ where: { status: "ACTIVE", type: "OUTLET" }, select: { id: true, name: true } }),
     prisma.stockCount.findMany({
-      where: { status: { in: ["SUBMITTED", "REVIEWED"] }, countDate: { gte: cutoff } },
+      where: { status: { in: ["SUBMITTED", "REVIEWED"] }, countDate: { gte: dayStart } },
       select: { outletId: true },
     }),
-    prisma.stockCount.groupBy({
-      by: ["outletId"],
-      where: { status: { in: ["SUBMITTED", "REVIEWED"] } },
-      _max: { countDate: true },
-    }),
   ]);
-  const counted = new Set(recent.map((r) => r.outletId));
-  const lastBy = new Map(lastCounts.map((r) => [r.outletId, r._max.countDate ?? null]));
+  const countedToday = new Set(todayCounts.map((r) => r.outletId));
+  const label = full ? "Full stock count" : "Stock count";
 
   const breaches: Breach[] = [];
   for (const o of outlets) {
-    if (counted.has(o.id)) continue;
-    const last = lastBy.get(o.id) ?? null;
-    const daysSince = last ? Math.floor((now.getTime() - new Date(last).getTime()) / 86_400_000) : null;
-    const when = daysSince === null ? "no count on record" : `${daysSince}d ago`;
+    if (countedToday.has(o.id)) continue;
     breaches.push({
       signal: "STOCK_COUNT",
       outletId: o.id,
       outletName: o.name,
       severity: "MED",
       routeKey: "operations",
-      // Daily dedupe key (own namespace so it can't collide with the pulse's
-      // 7-day STOCK_COUNT bucket) → at most one nudge per outlet per day.
-      dedupeKey: `STOCK_NUDGE:${o.id}:${ymd}`,
-      summary: `Stock count overdue at ${o.name} — last ${when}. Please count + submit today.`,
-      detail: { daysSince, when, lastCount: last ? new Date(last).toISOString().slice(0, 10) : null },
+      dedupeKey: `STOCK_NUDGE:${o.id}:${ymd}`, // one nudge per outlet per day
+      summary: `${label} due today at ${o.name} — not logged yet.`,
+      detail: { full, when: "today" },
     });
   }
   return breaches;
@@ -161,17 +176,17 @@ export async function runStockCountNudges(now = new Date()): Promise<NudgeRunRes
   const ranAt = now.toISOString();
   if (mode === "off") return { mode, ranAt, items: 0, staffSent: 0, managerSent: 0 };
 
-  const breaches = await findStaleStockBreaches(now, STOCK_STALE_DAYS);
+  const breaches = await findScheduledStockBreaches(now);
   if (breaches.length === 0) return { mode, ranAt, items: 0, staffSent: 0, managerSent: 0 };
 
   const managerLines: string[] = [];
   let staffSent = 0;
   for (const b of breaches) {
     const team = await resolveOutletTeam(b.outletId, now); // on-shift staff w/ phone
-    const when = String((b.detail as { when?: string }).when ?? "");
+    const full = Boolean((b.detail as { full?: boolean }).full);
 
     if (mode === "shadow") {
-      console.log("[ops-nudge:stock:shadow]", JSON.stringify({ outlet: b.outletName, team: team.map((t) => t.name), when }));
+      console.log("[ops-nudge:stock:shadow]", JSON.stringify({ outlet: b.outletName, team: team.map((t) => t.name), full }));
       managerLines.push(b.summary);
       continue;
     }
@@ -180,7 +195,7 @@ export async function runStockCountNudges(now = new Date()): Promise<NudgeRunRes
     if (!isNew) continue;
     for (const t of team) {
       if (!t.phone) continue;
-      const r = await sendStockCountNudge(t.phone, b.outletName, when);
+      const r = await sendStockCountNudge(t.phone, b.outletName, full);
       if (r.ok) staffSent += 1;
       else console.error(`[ops-nudge:stock] staff nudge to ${t.name} failed:`, r.error);
     }

--- a/apps/backoffice/src/lib/ops-nudges/index.ts
+++ b/apps/backoffice/src/lib/ops-nudges/index.ts
@@ -15,10 +15,10 @@
 // WhatsApp's 24h rule until ops_nudge is approved.
 
 import { prisma } from "@/lib/prisma";
-import { findNoClockInBreaches, detectOutletAudit, detectSkillTraining } from "@/lib/ops-pulse/detectors";
+import { findNoClockInBreaches, detectOutletAudit, detectSkillTraining, detectReviews } from "@/lib/ops-pulse/detectors";
 import { recordBreach } from "@/lib/ops-pulse/ledger";
 import { resolveRecipients, resolveOutletTeam } from "@/lib/ops-pulse/router";
-import { sendClockInNudge, sendStockCountNudge, sendOpsDigest, sendAuditNudge } from "@/lib/ops-pulse/sender";
+import { sendClockInNudge, sendStockCountNudge, sendOpsDigest, sendAuditNudge, sendReviewNudge } from "@/lib/ops-pulse/sender";
 import type { Assignee, Breach, RouteKey } from "@/lib/ops-pulse/types";
 
 export type NudgesMode = "off" | "shadow" | "armed";
@@ -255,4 +255,58 @@ export async function runAuditNudges(now = new Date()): Promise<NudgeRunResult> 
   }
 
   return { mode, ranAt, items, staffSent, managerSent: 0 };
+}
+
+// ── 4. Bad reviews → on-shift team + managers ────────────────────────────────
+// New negative reviews (internal QR <=2*, Google <=3*) DM'd to the outlet's
+// on-shift team for service recovery + a digest to the managers (ops leads).
+// Ledger-deduped per review (each review nudged once, ever). Real-time-ish — the
+// cron runs hourly. Reuses detectReviews.
+export async function runReviewNudges(now = new Date()): Promise<NudgeRunResult> {
+  const mode = nudgesMode();
+  const ranAt = now.toISOString();
+  if (mode === "off") return { mode, ranAt, items: 0, staffSent: 0, managerSent: 0 };
+
+  const breaches = await detectReviews(now);
+  if (breaches.length === 0) return { mode, ranAt, items: 0, staffSent: 0, managerSent: 0 };
+
+  // Group by outlet so each outlet's team gets one message listing its reviews.
+  const byOutlet: Record<string, Breach[]> = {};
+  for (const b of breaches) (byOutlet[b.outletId] ??= []).push(b);
+
+  const managerLines: string[] = [];
+  let staffSent = 0;
+  for (const outletId of Object.keys(byOutlet)) {
+    const outletName = byOutlet[outletId][0].outletName;
+
+    // Dedupe per review (armed); shadow shows all.
+    let fresh = byOutlet[outletId];
+    if (mode === "armed") {
+      fresh = [];
+      for (const b of byOutlet[outletId]) {
+        const { isNew } = await recordBreach(b, null);
+        if (isNew) fresh.push(b);
+      }
+    }
+    if (fresh.length === 0) continue;
+    const lines = fresh.map((b) => b.summary);
+    managerLines.push(...lines);
+
+    const team = await resolveOutletTeam(outletId, now); // who's on shift now
+    if (mode === "shadow") {
+      console.log("[ops-nudge:review:shadow]", JSON.stringify({ outlet: outletName, team: team.map((t) => t.name), lines }));
+      continue;
+    }
+    for (const t of team) {
+      if (!t.phone) continue;
+      const r = await sendReviewNudge(t.phone, outletName, lines);
+      if (r.ok) staffSent += 1;
+      else console.error(`[ops-nudge:review] staff nudge to ${t.name} failed:`, r.error);
+    }
+    if (team.length === 0) console.warn(`[ops-nudge:review] no on-shift team for ${outletName} — only managers notified`);
+  }
+
+  const headline = `${managerLines.length} new guest review${managerLines.length === 1 ? "" : "s"} need a response`;
+  const managerSent = await sendManagerDigestToOps(headline, managerLines, mode);
+  return { mode, ranAt, items: managerLines.length, staffSent, managerSent };
 }

--- a/apps/backoffice/src/lib/ops-pulse/sender.ts
+++ b/apps/backoffice/src/lib/ops-pulse/sender.ts
@@ -251,19 +251,20 @@ export function sendClockInNudge(
   return sendProactive(phone, TEMPLATES.nudge, text, v);
 }
 
-export function composeStockCountNudge(outletName: string, when: string): string {
+export function composeStockCountNudge(outletName: string, full: boolean): string {
+  const label = full ? "Full stock count" : "Stock count";
   return [
-    `Stock count due at ${outletName} — last count ${when}.`,
+    `${label} due today at ${outletName}.`,
     "",
-    "Please do the stock take and submit it in the app today.",
+    `Please do the ${full ? "full count" : "count"} and submit it in the app before end of day.`,
   ].join("\n");
 }
 
-export function sendStockCountNudge(phone: string, outletName: string, when: string): Promise<WhatsAppSendResult> {
+export function sendStockCountNudge(phone: string, outletName: string, full: boolean): Promise<WhatsAppSendResult> {
   if (!isWhatsAppConfigured()) return Promise.resolve(NOT_CONFIGURED);
-  const text = composeStockCountNudge(outletName, when);
-  const v = `Stock count due at ${outletName} (last ${when}) — please count + submit today.`;
-  return sendProactive(phone, TEMPLATES.nudge, text, v);
+  const label = full ? "Full stock count" : "Stock count";
+  const v = `${label} due today at ${outletName} — please count + submit before end of day.`;
+  return sendProactive(phone, TEMPLATES.nudge, composeStockCountNudge(outletName, full), v);
 }
 
 // Manager-facing ops digest — professional but casual, no emoji. `headline` sets

--- a/apps/backoffice/src/lib/ops-pulse/sender.ts
+++ b/apps/backoffice/src/lib/ops-pulse/sender.ts
@@ -267,6 +267,25 @@ export function sendStockCountNudge(phone: string, outletName: string, full: boo
   return sendProactive(phone, TEMPLATES.nudge, composeStockCountNudge(outletName, full), v);
 }
 
+// Bad-review nudge to the on-shift team — awareness + service recovery, framed
+// constructively (not blame). `lines` are the new review summaries for the outlet.
+export function composeReviewNudge(outletName: string, lines: string[]): string {
+  return [
+    `Heads up — guest feedback just came in at ${outletName}:`,
+    "",
+    lines.map((l) => `- ${l}`).join("\n"),
+    "",
+    "Let's make the next visit right, and flag to your manager to recover this guest. Reply DONE once handled.",
+  ].join("\n");
+}
+
+export function sendReviewNudge(phone: string, outletName: string, lines: string[]): Promise<WhatsAppSendResult> {
+  if (!isWhatsAppConfigured()) return Promise.resolve(NOT_CONFIGURED);
+  const flat = sanitizeParam(`Guest feedback at ${outletName}: ${lines.join("; ")}`);
+  const v = flat.length <= 700 ? flat : flat.slice(0, 699).replace(/\s+\S*$/, "") + " …";
+  return sendProactive(phone, TEMPLATES.nudge, composeReviewNudge(outletName, lines), v);
+}
+
 // Manager-facing ops digest — professional but casual, no emoji. `headline` sets
 // the ask ("8 staff haven't clocked in yet"); `lines` are the specifics.
 export function composeOpsDigest(headline: string, lines: string[]): string {

--- a/apps/backoffice/src/lib/ops-pulse/sender.ts
+++ b/apps/backoffice/src/lib/ops-pulse/sender.ts
@@ -290,11 +290,11 @@ export function sendOpsDigest(phone: string, headline: string, lines: string[]):
 export function composeAuditNudge(name: string, lines: string[]): string {
   const first = name.split(" ")[0];
   return [
-    `Hi ${first}, audits due this week:`,
+    `Hi ${first}, audit progress this week — ${lines.length} still to do:`,
     "",
     lines.map((l) => `- ${l}`).join("\n"),
     "",
-    "Please run them and log each report in the app. Reply DONE as you go.",
+    "Knock these off and log each report in the app. I'll check in daily.",
   ].join("\n");
 }
 

--- a/apps/backoffice/src/lib/reviews/sync-negatives.ts
+++ b/apps/backoffice/src/lib/reviews/sync-negatives.ts
@@ -1,0 +1,82 @@
+// Ingest negative Google reviews into ReviewReplyDraft. Extracted verbatim from
+// /api/reviews/negatives (the board's sync=1 path) so the review-nudge cron and
+// the board use ONE proven code path — instead of negatives only being ingested
+// when a human opens the board.
+//
+// Per GBP-connected outlet: pull recent reviews, create a pending draft for each
+// NEW unreplied negative (rating < POSITIVE_THRESHOLD), and resolve any pending
+// draft whose review now carries a reply on Google. Best-effort per outlet
+// (a failed fetch skips that outlet, never throws). LLM drafting is capped.
+
+import { prisma } from "@/lib/prisma";
+import { fetchGoogleReviews } from "@/lib/reviews/gbp";
+import { generateReply, POSITIVE_THRESHOLD } from "@/lib/reviews/auto-reply";
+
+// Cap LLM calls per run so a large first-run backlog can't blow up.
+const MAX_NEW_DRAFTS_PER_SYNC = 30;
+
+export async function syncNegativeReviewDrafts(): Promise<{ created: number; resolved: number }> {
+  let created = 0;
+  let resolved = 0;
+
+  const outlets = await prisma.outlet.findMany({ where: { status: "ACTIVE" }, include: { reviewSettings: true } });
+  const connected = outlets.filter((o) => o.reviewSettings?.gbpAccountId && o.reviewSettings?.gbpLocationName);
+
+  // Every review we've ever drafted (any status) — so we never double-draft.
+  const existing = await prisma.reviewReplyDraft.findMany({ select: { id: true, reviewId: true, status: true } });
+  const seenReviewIds = new Set(existing.map((d) => d.reviewId));
+
+  for (const outlet of connected) {
+    const settings = outlet.reviewSettings!;
+    let reviews;
+    try {
+      const data = await fetchGoogleReviews(settings.gbpAccountId!, settings.gbpLocationName!, 50);
+      reviews = data.reviews;
+    } catch (err) {
+      console.error(`[reviews/sync-negatives] fetch failed for ${outlet.name}:`, err);
+      continue;
+    }
+
+    // Resolve pending drafts whose review now carries a reply on Google.
+    const repliedIds = reviews.filter((r) => r.reply).map((r) => r.id);
+    const toResolve = existing.filter((d) => d.status === "pending" && repliedIds.includes(d.reviewId));
+    if (toResolve.length) {
+      await prisma.reviewReplyDraft.updateMany({
+        where: { id: { in: toResolve.map((d) => d.id) } },
+        data: { status: "resolved" },
+      });
+      resolved += toResolve.length;
+    }
+
+    // Draft replies for new unreplied negatives we haven't seen before.
+    const newNegatives = reviews.filter((r) => !r.reply && r.rating < POSITIVE_THRESHOLD && !seenReviewIds.has(r.id));
+    for (const review of newNegatives) {
+      if (created >= MAX_NEW_DRAFTS_PER_SYNC) break;
+      try {
+        const draft = await generateReply({
+          rating: review.rating,
+          reviewer: review.reviewer.name,
+          comment: review.comment,
+          outletName: outlet.name,
+        });
+        if (!draft) continue;
+        await prisma.reviewReplyDraft.create({
+          data: {
+            reviewId: review.id,
+            outletId: outlet.id,
+            reviewerName: review.reviewer.name,
+            rating: review.rating,
+            comment: review.comment ?? null,
+            draftReply: draft,
+          },
+        });
+        seenReviewIds.add(review.id);
+        created++;
+      } catch (err) {
+        console.error(`[reviews/sync-negatives] draft create failed for ${review.id}:`, err);
+      }
+    }
+  }
+
+  return { created, resolved };
+}

--- a/apps/backoffice/src/lib/wa-messages.ts
+++ b/apps/backoffice/src/lib/wa-messages.ts
@@ -31,18 +31,19 @@ function staffSide(m: { direction: string; fromNumber: string; toNumber: string 
   return m.direction === "inbound" ? m.fromNumber : m.toNumber;
 }
 
-type StaffUser = { id: string; name: string; role: string };
+type StaffUser = { id: string; name: string; role: string; outletId: string | null };
 
 // Staff are a small set; load those with a phone and key them by canonical phone
 // so we can tell which threads belong to staff (vs suppliers / unknown numbers).
+// Prefer fullName so the inbox shows the real name, not a short handle.
 async function loadStaffByCanonical(): Promise<Map<string, StaffUser>> {
   const users = await prisma.user.findMany({
     where: { phone: { not: null } },
-    select: { id: true, name: true, role: true, phone: true },
+    select: { id: true, name: true, fullName: true, role: true, phone: true, outletId: true },
   });
   const map = new Map<string, StaffUser>();
   for (const u of users) {
-    if (u.phone) map.set(canonicalPhone(u.phone), { id: u.id, name: u.name, role: u.role });
+    if (u.phone) map.set(canonicalPhone(u.phone), { id: u.id, name: u.fullName || u.name, role: u.role, outletId: u.outletId });
   }
   return map;
 }
@@ -52,6 +53,8 @@ export interface ThreadSummary {
   userId: string | null;
   name: string | null;
   role: string | null;
+  outletId: string | null;
+  outletName: string | null;
   lastBody: string;
   lastDirection: string; // IN | OUT
   lastAt: string;
@@ -105,12 +108,17 @@ export async function listThreads(now: Date): Promise<ThreadSummary[]> {
   if (accs.length === 0) return [];
 
   const userIds = accs.map((a) => staffByCanon.get(a.staffPhone)!.id);
-  const alertRows = await prisma.opsAlert.groupBy({
-    by: ["assigneeUserId"],
-    where: { assigneeUserId: { in: userIds }, status: { in: ["OPEN", "ESCALATED"] } },
-    _count: { _all: true },
-  });
+  const outletIds = [...new Set(accs.map((a) => staffByCanon.get(a.staffPhone)!.outletId).filter(Boolean) as string[])];
+  const [alertRows, outlets] = await Promise.all([
+    prisma.opsAlert.groupBy({
+      by: ["assigneeUserId"],
+      where: { assigneeUserId: { in: userIds }, status: { in: ["OPEN", "ESCALATED"] } },
+      _count: { _all: true },
+    }),
+    outletIds.length ? prisma.outlet.findMany({ where: { id: { in: outletIds } }, select: { id: true, name: true } }) : Promise.resolve([] as { id: string; name: string }[]),
+  ]);
   const alertMap = new Map(alertRows.map((r) => [r.assigneeUserId, r._count._all]));
+  const outletNameById = new Map(outlets.map((o) => [o.id, o.name]));
 
   const threads = accs.map((a) => {
     const u = staffByCanon.get(a.staffPhone)!;
@@ -120,6 +128,8 @@ export async function listThreads(now: Date): Promise<ThreadSummary[]> {
       userId: u.id,
       name: u.name,
       role: u.role,
+      outletId: u.outletId,
+      outletName: u.outletId ? outletNameById.get(u.outletId) ?? null : null,
       lastBody: a.lastBody,
       lastDirection: a.lastDirection === "inbound" ? "IN" : "OUT",
       lastAt: a.lastAt.toISOString(),
@@ -138,6 +148,7 @@ export interface ThreadDetail {
   userId: string | null;
   name: string | null;
   role: string | null;
+  outletName: string | null;
   windowOpen: boolean;
   openAlerts: { id: string; signal: string; severity: string; summary: string; status: string; sentAt: string | null }[];
   messages: {
@@ -176,10 +187,14 @@ export async function getThread(staffPhoneRaw: string, now: Date): Promise<Threa
   const mine = rows.filter((m) => canonicalPhone(staffSide(m)) === canon);
   if (mine.length === 0) return null;
 
-  const user = await prisma.user.findFirst({
-    where: { phone: { endsWith: tail } },
-    select: { id: true, name: true, role: true },
-  });
+  // Match staff by CANONICAL phone, not raw endsWith — stored phones may be
+  // formatted ("011-28429710"), so a digits-only endsWith on the raw string
+  // misses them (the bug that showed the bare number instead of the name).
+  const staff = await loadStaffByCanonical();
+  const user = staff.get(canon) ?? null;
+  const outlet = user?.outletId
+    ? await prisma.outlet.findUnique({ where: { id: user.outletId }, select: { name: true } })
+    : null;
 
   const lastInbound = [...mine].reverse().find((m) => m.direction === "inbound");
   const windowOpen = !!lastInbound && now.getTime() - lastInbound.timestamp.getTime() < WINDOW_MS;
@@ -198,6 +213,7 @@ export async function getThread(staffPhoneRaw: string, now: Date): Promise<Threa
     userId: user?.id ?? null,
     name: user?.name ?? null,
     role: user?.role ?? null,
+    outletName: outlet?.name ?? null,
     windowOpen,
     openAlerts: alerts.map((a) => ({
       id: a.id,

--- a/apps/backoffice/vercel.json
+++ b/apps/backoffice/vercel.json
@@ -126,7 +126,7 @@
     },
     {
       "path": "/api/cron/ops-nudge-review",
-      "schedule": "0 * * * *"
+      "schedule": "*/5 * * * *"
     },
     {
       "path": "/api/cron/geogrid-keywords",

--- a/apps/backoffice/vercel.json
+++ b/apps/backoffice/vercel.json
@@ -125,6 +125,10 @@
       "schedule": "0 1 * * *"
     },
     {
+      "path": "/api/cron/ops-nudge-review",
+      "schedule": "0 * * * *"
+    },
+    {
       "path": "/api/cron/geogrid-keywords",
       "schedule": "0 6 1 * *"
     },

--- a/apps/backoffice/vercel.json
+++ b/apps/backoffice/vercel.json
@@ -114,7 +114,7 @@
     },
     {
       "path": "/api/cron/ops-nudge-clockin",
-      "schedule": "*/30 * * * *"
+      "schedule": "30 0 * * *"
     },
     {
       "path": "/api/cron/ops-nudge-stockcount",

--- a/apps/backoffice/vercel.json
+++ b/apps/backoffice/vercel.json
@@ -122,7 +122,7 @@
     },
     {
       "path": "/api/cron/ops-nudge-audit",
-      "schedule": "0 1 * * 1"
+      "schedule": "0 1 * * *"
     },
     {
       "path": "/api/cron/geogrid-keywords",

--- a/docs/design/ops-performance-loop.md
+++ b/docs/design/ops-performance-loop.md
@@ -284,7 +284,9 @@ that complements the passive weekly scoreboard.
     previously negatives only entered the DB when a human opened the reviews board, so nothing
     was ever sent), then nudges: new negatives (internal QR ≤2★, Google ≤3★, last 72h via
     `detectReviews`) → DM the outlet's on-shift team for recovery + a managers digest.
-    Ledger-deduped per review (once ever). Cron `/api/cron/ops-nudge-review` hourly.
+    Ledger-deduped per review (once ever). Cron `/api/cron/ops-nudge-review` **every 5 min**
+    (near-realtime; bounded by GBP API quota). True instant would need GBP Pub/Sub notifications
+    (GCP topic/subscription → webhook) — offered, not yet set up.
   - "Manager" = ops leads (Ariff/Adam) until an outlet→manager map exists. Templates: `ops_nudge`.
 - **Shadow run on live data (proof):** clock-in 8 real no-shows after fix (Badri, Ameir Haziq,
   Tengku Syahirah, Atthirah…), each DM'd + an 8-line digest to Ariff/Adam; stock 4 outlets

--- a/docs/design/ops-performance-loop.md
+++ b/docs/design/ops-performance-loop.md
@@ -275,8 +275,10 @@ that complements the passive weekly scoreboard.
     fires without flipping the pulse's NOCLOCKIN gate) → DM the no-show + digest to ops leads.
     Cron `/api/cron/ops-nudge-clockin` once daily (~8:30am MYT — catches the main
     morning shift, low cost; ledger still dedupes per staff/day).
-  - **Stock:** outlets with no SUBMITTED/REVIEWED count in 3 days → DM the on-shift team
-    (`resolveOutletTeam`) + digest to ops leads. Cron `/api/cron/ops-nudge-stockcount` daily.
+  - **Stock:** follows the owner's Stock Count schedule (`appConfig.stock_count_schedule`:
+    weekly count days + month-end full-count dates, Settings → Stock Count). On a scheduled
+    day, DM the on-shift team (`resolveOutletTeam`) + digest to ops leads for outlets that
+    haven't logged a count that day; silent off-schedule. Cron daily (schedule gates sending).
   - "Manager" = ops leads (Ariff/Adam) until an outlet→manager map exists. Templates: `ops_nudge`.
 - **Shadow run on live data (proof):** clock-in 8 real no-shows after fix (Badri, Ameir Haziq,
   Tengku Syahirah, Atthirah…), each DM'd + an 8-line digest to Ariff/Adam; stock 4 outlets

--- a/docs/design/ops-performance-loop.md
+++ b/docs/design/ops-performance-loop.md
@@ -279,6 +279,10 @@ that complements the passive weekly scoreboard.
     weekly count days + month-end full-count dates, Settings → Stock Count). On a scheduled
     day, DM the on-shift team (`resolveOutletTeam`) + digest to ops leads for outlets that
     haven't logged a count that day; silent off-schedule. Cron daily (schedule gates sending).
+  - **Reviews (2026-06-28):** new negative reviews (internal QR ≤2★, Google ≤3★, last 72h, reuses
+    `detectReviews`) → DM the outlet's on-shift team for service recovery + a managers digest.
+    Ledger-deduped per review (once ever). Cron `/api/cron/ops-nudge-review` hourly. This fills the
+    gap where reviews only lived in the shadow real-time pulse, so nobody was being told.
   - "Manager" = ops leads (Ariff/Adam) until an outlet→manager map exists. Templates: `ops_nudge`.
 - **Shadow run on live data (proof):** clock-in 8 real no-shows after fix (Badri, Ameir Haziq,
   Tengku Syahirah, Atthirah…), each DM'd + an 8-line digest to Ariff/Adam; stock 4 outlets

--- a/docs/design/ops-performance-loop.md
+++ b/docs/design/ops-performance-loop.md
@@ -279,10 +279,12 @@ that complements the passive weekly scoreboard.
     weekly count days + month-end full-count dates, Settings → Stock Count). On a scheduled
     day, DM the on-shift team (`resolveOutletTeam`) + digest to ops leads for outlets that
     haven't logged a count that day; silent off-schedule. Cron daily (schedule gates sending).
-  - **Reviews (2026-06-28):** new negative reviews (internal QR ≤2★, Google ≤3★, last 72h, reuses
-    `detectReviews`) → DM the outlet's on-shift team for service recovery + a managers digest.
-    Ledger-deduped per review (once ever). Cron `/api/cron/ops-nudge-review` hourly. This fills the
-    gap where reviews only lived in the shadow real-time pulse, so nobody was being told.
+  - **Reviews (2026-06-28):** the cron first INGESTS new negative Google reviews into
+    `ReviewReplyDraft` (`lib/reviews/sync-negatives`, extracted from the board's sync=1 path —
+    previously negatives only entered the DB when a human opened the reviews board, so nothing
+    was ever sent), then nudges: new negatives (internal QR ≤2★, Google ≤3★, last 72h via
+    `detectReviews`) → DM the outlet's on-shift team for recovery + a managers digest.
+    Ledger-deduped per review (once ever). Cron `/api/cron/ops-nudge-review` hourly.
   - "Manager" = ops leads (Ariff/Adam) until an outlet→manager map exists. Templates: `ops_nudge`.
 - **Shadow run on live data (proof):** clock-in 8 real no-shows after fix (Badri, Ameir Haziq,
   Tengku Syahirah, Atthirah…), each DM'd + an 8-line digest to Ariff/Adam; stock 4 outlets

--- a/docs/design/ops-performance-loop.md
+++ b/docs/design/ops-performance-loop.md
@@ -273,7 +273,8 @@ that complements the passive weekly scoreboard.
   manager. `OPS_NUDGES_MODE` (off|shadow|armed, default shadow).
   - **Clock-in:** `findNoClockInBreaches` (refactored ungated out of `detectNoClockIn`, so the nudge
     fires without flipping the pulse's NOCLOCKIN gate) → DM the no-show + digest to ops leads.
-    Cron `/api/cron/ops-nudge-clockin` every 30 min (ledger dedupes to once/day).
+    Cron `/api/cron/ops-nudge-clockin` once daily (~8:30am MYT — catches the main
+    morning shift, low cost; ledger still dedupes per staff/day).
   - **Stock:** outlets with no SUBMITTED/REVIEWED count in 3 days → DM the on-shift team
     (`resolveOutletTeam`) + digest to ops leads. Cron `/api/cron/ops-nudge-stockcount` daily.
   - "Manager" = ops leads (Ariff/Adam) until an outlet→manager map exists. Templates: `ops_nudge`.


### PR DESCRIPTION
#585 squash-merged an early state of `arm-ops-loops` (just the arming commit), so the follow-up work pushed afterward never reached main. This re-lands those 7 commits cleanly on current main:

- audit nudge -> daily progress snapshot
- clock-in nudge -> once daily (was every 30m — stops the 48 invocations/day + the afternoon-shift spam seen in prod)
- stock-count nudge -> follows the configured schedule (Sun/Tue/Thu + month-end full count)
- bad-review nudge -> on-shift team + managers (this feature was entirely missing on main — why bad reviews weren't being sent)
- auto-ingest negative Google reviews, then nudge (negatives no longer wait for a human to open the board)
- review nudge near-realtime (poll GBP every 5 min)
- inbox shows staff name (canonical phone match) + outlet, and an outlet filter (fixes the bare-number chat header)

Typecheck clean.