### PR TITLE
fix(procurement): land on Need-ordering + exclude staff/ops threads from the inbox

### DIFF
--- a/apps/backoffice/src/app/(admin)/inventory/supplier-chats/page.tsx
+++ b/apps/backoffice/src/app/(admin)/inventory/supplier-chats/page.tsx
@@ -531,9 +531,9 @@ export default function SupplierChatsPage() {
     return ap - bp;
   });
 
-  useEffect(() => {
-    if (!selected && threads.length) setSelected(threads[0].key);
-  }, [threads, selected]);
+  // Default landing = the Need-ordering list ("what to order today"), NOT an auto-opened
+  // thread. Only a ?key= deep-link selects a thread on load; otherwise the conversation pane
+  // stays on "Select a chat" until you pick one.
 
   useEffect(() => {
     setDraft("");

--- a/apps/backoffice/src/app/api/inventory/supplier-chats/route.ts
+++ b/apps/backoffice/src/app/api/inventory/supplier-chats/route.ts
@@ -21,7 +21,7 @@ export async function GET(req: NextRequest) {
   const caller = await getUserFromHeaders(req.headers);
   if (!caller) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
 
-  const [rows, suppliers] = await Promise.all([
+  const [rows, suppliers, staff] = await Promise.all([
     prisma.whatsAppMessage.findMany({
       orderBy: { timestamp: "desc" },
       take: 1000,
@@ -40,6 +40,9 @@ export async function GET(req: NextRequest) {
       where: { status: "ACTIVE" },
       select: { id: true, name: true, phone: true, automationMode: true },
     }),
+    // Staff phones — used to drop internal Ops Pulse / clock-in threads from the supplier
+    // inbox (a number that's a staff member but no supplier isn't a supplier conversation).
+    prisma.user.findMany({ where: { phone: { not: null } }, select: { phone: true } }),
   ]);
 
   const byId = new Map(suppliers.map((s) => [s.id, s]));
@@ -47,6 +50,11 @@ export async function GET(req: NextRequest) {
   for (const s of suppliers) {
     const k = last8(s.phone);
     if (k.length >= 8) byPhone.set(k, s);
+  }
+  const staffPhones = new Set<string>();
+  for (const u of staff) {
+    const k = last8(u.phone);
+    if (k.length >= 8) staffPhones.add(k);
   }
 
   type T = {
@@ -147,6 +155,10 @@ export async function GET(req: NextRequest) {
   const out: Out[] = [];
   for (const t of threads.values()) {
     const s = t.supplierId ? byId.get(t.supplierId) : undefined;
+    // Skip internal staff / ops threads (e.g. Ops Pulse clock-in "done" replies): a number
+    // that matches a staff member but no supplier isn't a supplier conversation. Keeps them
+    // out of the list, the counts, and "Needs reply".
+    if (!s && staffPhones.has(last8(t.key))) continue;
     const needsAttention =
       t.verifierFailed ||
       t.sendFailed ||


### PR DESCRIPTION
Two fixes from the workspace screenshot:

**1. Default to the Need-ordering list, not an auto-opened thread.** The page auto-selected the most-recent thread on load, so you landed *inside a conversation* (often an internal staff "DONE" reply) instead of the "what to order today" list. Dropped the auto-select-first effect — the page now lands on the Need-ordering list; a `?key=` deep-link still opens a specific thread.

**2. Exclude staff / ops threads from the supplier inbox.** Internal Ops Pulse clock-in threads (the "X staff haven't clocked in" sends + staff "done" replies) were being folded into the supplier list as bare +60 numbers, and even counted in **Needs reply**. The list route now matches each thread's number against **staff User phones** and drops any that match a staff member but no supplier — so the list, the counts, and Needs reply are supplier-only.

Typecheck + lint clean. (This is the fix I'd spun off as a task earlier — handled inline instead.)