### PR TITLE
fix(procurement): keep Ops Pulse nudges out of the supplier inbox (the CATELUX dupes)

### DIFF
--- a/apps/backoffice/src/app/api/inventory/supplier-chats/route.ts
+++ b/apps/backoffice/src/app/api/inventory/supplier-chats/route.ts
@@ -72,9 +72,14 @@ export async function GET(req: NextRequest) {
   for (const m of rows) {
     const counter = m.direction === "inbound" ? m.fromNumber : m.toNumber;
     if (!counter) continue;
+    const raw = (m.raw ?? null) as Record<string, unknown> | null;
+    // Internal Ops Pulse nudges (clock-in digests etc.) are stamped raw.kind="ops_nudge".
+    // They go to STAFF, never suppliers — skip them so they can't surface as a supplier chat
+    // even when a junk supplier phone (e.g. "+") causes a mis-match. The staff-User filter
+    // below only catches numbers that DON'T match a supplier; this catches the mis-tagged ones.
+    if (raw?.kind === "ops_nudge") continue;
     let t = threads.get(counter);
     if (!t) {
-      const raw = (m.raw ?? null) as Record<string, unknown> | null;
       const v = raw?.verifier as { rating?: string } | undefined;
       t = {
         key: counter,


### PR DESCRIPTION
**The "why is CATELUX double" bug.** The supplier inbox was rendering internal **Ops Pulse clock-in digests** ("N staff haven't clocked in…") as if they were supplier chats — surfacing under **CATELUX ENTERPRISE**.

**Root cause — a phone-data mess, not a logic bug per se:**
- The nudge is sent to a manager's number `60163230590`.
- That same number is saved as **ELITE PAC**'s supplier phone (`+60163230590`), and **CATELUX**'s phone is literally `"+"`, **Shopee**'s is `163230590`.
- `matchSupplierIdByPhone` therefore mis-tags the internal nudge to a supplier (it lands on CATELUX), so it shows up in the supplier inbox.
- The staff-User filter from #593 only drops threads that match **no** supplier — so it missed these *mis-tagged-to-a-supplier* ones.

**Fix:** Ops Pulse nudges are stamped `raw.kind = "ops_nudge"`. The list route now **skips those rows entirely** when folding threads, so an ops nudge can never appear as a supplier chat no matter how broken the phone data is. Complements #593 (bare staff numbers) and #588-#590.

**Still to do (data, not code):** clean the junk supplier phones — `CATELUX = "+"`, `ELITE PAC = +60163230590` (a manager's number), `Shopee = 163230590`. Flagged to the owner; not touching supplier master data without the go-ahead.

Typecheck + lint clean.