### PR TITLE
feat(ops): stock-count nudge -> supervisors + managers (not floor team)

### DIFF
--- a/apps/backoffice/src/lib/ops-nudges/index.ts
+++ b/apps/backoffice/src/lib/ops-nudges/index.ts
@@ -17,7 +17,7 @@
 import { prisma } from "@/lib/prisma";
 import { findNoClockInBreaches, detectOutletAudit, detectSkillTraining, detectReviews } from "@/lib/ops-pulse/detectors";
 import { recordBreach } from "@/lib/ops-pulse/ledger";
-import { resolveRecipients, resolveOutletTeam } from "@/lib/ops-pulse/router";
+import { resolveRecipients, resolveOutletTeam, resolveOutletSupervisors } from "@/lib/ops-pulse/router";
 import { sendClockInNudge, sendStockCountNudge, sendOpsDigest, sendAuditNudge, sendReviewNudge } from "@/lib/ops-pulse/sender";
 import type { Assignee, Breach, RouteKey } from "@/lib/ops-pulse/types";
 
@@ -179,27 +179,29 @@ export async function runStockCountNudges(now = new Date()): Promise<NudgeRunRes
   const breaches = await findScheduledStockBreaches(now);
   if (breaches.length === 0) return { mode, ranAt, items: 0, staffSent: 0, managerSent: 0 };
 
+  // Owner 2026-06-28: stock count goes to SUPERVISORS + managers, not the whole
+  // floor team. Per outlet → that outlet's supervisor(s); managers get the digest.
   const managerLines: string[] = [];
-  let staffSent = 0;
+  let staffSent = 0; // supervisor DMs (kept under the existing result field)
   for (const b of breaches) {
-    const team = await resolveOutletTeam(b.outletId, now); // on-shift staff w/ phone
+    const supervisors = await resolveOutletSupervisors(b.outletId); // outlet's supervisor(s), not the floor team
     const full = Boolean((b.detail as { full?: boolean }).full);
 
     if (mode === "shadow") {
-      console.log("[ops-nudge:stock:shadow]", JSON.stringify({ outlet: b.outletName, team: team.map((t) => t.name), full }));
+      console.log("[ops-nudge:stock:shadow]", JSON.stringify({ outlet: b.outletName, supervisors: supervisors.map((t) => t.name), full }));
       managerLines.push(b.summary);
       continue;
     }
 
-    const { isNew } = await recordBreach(b, team[0] ?? null);
+    const { isNew } = await recordBreach(b, supervisors[0] ?? null);
     if (!isNew) continue;
-    for (const t of team) {
+    for (const t of supervisors) {
       if (!t.phone) continue;
       const r = await sendStockCountNudge(t.phone, b.outletName, full);
       if (r.ok) staffSent += 1;
-      else console.error(`[ops-nudge:stock] staff nudge to ${t.name} failed:`, r.error);
+      else console.error(`[ops-nudge:stock] supervisor nudge to ${t.name} failed:`, r.error);
     }
-    if (team.length === 0) console.warn(`[ops-nudge:stock] no on-shift team for ${b.outletName} — only manager notified`);
+    if (supervisors.length === 0) console.warn(`[ops-nudge:stock] no supervisor for ${b.outletName} — only managers notified`);
     managerLines.push(b.summary);
   }
 

--- a/apps/backoffice/src/lib/ops-pulse/router.ts
+++ b/apps/backoffice/src/lib/ops-pulse/router.ts
@@ -89,3 +89,21 @@ export async function resolveOutletTeam(outletId: string, now: Date): Promise<As
   });
   return users.map((u) => ({ userId: u.id, name: u.name, phone: u.phone, role: u.role, fallback: false }));
 }
+
+// The OUTLET's SUPERVISORS — active staff whose HR position is "Supervisor" at
+// this outlet, with a phone. Used for work the shift supervisor owns (e.g. stock
+// counts) so the message goes to the supervisor, not the whole floor team. Empty
+// when the outlet has no supervisor assigned (the manager digest is the backstop).
+export async function resolveOutletSupervisors(outletId: string): Promise<Assignee[]> {
+  if (!outletId) return [];
+  const users = await prisma.$queryRaw<Array<{ id: string; name: string; phone: string | null; role: string }>>`
+    SELECT u.id, u.name, u.phone, u.role
+    FROM "User" u
+    JOIN hr_employee_profiles p ON p.user_id = u.id
+    WHERE u."outletId" = ${outletId}
+      AND u.status = 'ACTIVE'
+      AND u.phone IS NOT NULL
+      AND p.position = 'Supervisor'
+  `;
+  return users.map((u) => ({ userId: u.id, name: u.name, phone: u.phone, role: u.role, fallback: false }));
+}


### PR DESCRIPTION
Owner request: the stock-count WhatsApp should go to **supervisors and managers**, not the whole on-shift floor team.

- Supervisor = HR position `Supervisor` (role STAFF), scoped to the outlet. Currently: Yusri (Putrajaya), Aina (Tamarind).
- New `resolveOutletSupervisors(outletId)`; `runStockCountNudges` now DMs the outlet's supervisor(s) instead of the full roster (`resolveOutletTeam`).
- Managers still receive the digest (operations leads). Outlets with no supervisor (Shah Alam, Nilai) fall back to the manager digest only.

Typecheck clean. (Only the unrelated stale procurement test `verifier.test.ts` fails CI → UNSTABLE, non-required.)