### PR TITLE
feat(procurement): AI POP-match verifier + self-improving loop (stop double-payments)

### DIFF
--- a/apps/backoffice/src/app/api/inventory/telegram/webhook/route.ts
+++ b/apps/backoffice/src/app/api/inventory/telegram/webhook/route.ts
@@ -8,6 +8,7 @@ import { createShortLink } from "@/lib/shortlink";
 import { detectPaymentFlags, appendInvoiceFlags } from "@/lib/inventory/flag-detector";
 import { computeDepositAmount } from "@/lib/inventory/deposit";
 import { sendProofOfPayment } from "@/lib/inventory/procurement-whatsapp";
+import { rescueNoMatch, judgeDuplicate } from "@/lib/inventory/agents/pop-verifier-run";
 import {
   sendMessage,
   sendPhoto,
@@ -713,9 +714,33 @@ async function resolvePop(
   chatId: number, msgId: number, photoUrl: string, pop: PopData, amount: number,
   candidates: Awaited<ReturnType<typeof prisma.invoice.findMany>>,
 ) {
+  // Snapshot the POP fields the AI POP-match verifier needs (same shape for both dead-ends).
+  const popForVerify = {
+    amount,
+    referenceNumber: pop.referenceNumber,
+    recipientName: pop.recipientName,
+    recipientAccount: pop.recipientAccount,
+    recipientBank: pop.recipientBank,
+    invoiceReference: pop.invoiceReference,
+    date: pop.date,
+  };
+
   if (candidates.length === 0) {
-    await sendMessage(chatId, `💳 POP received — RM ${amount.toFixed(2)}\nRef: ${pop.referenceNumber ?? "–"}\nRecipient: ${pop.recipientName ?? "–"}\nAccount: ${pop.recipientAccount ?? "–"}\n\n❌ No matching unpaid invoice found.`, msgId);
-    return;
+    // Dead-end #1 — the deterministic matcher found nothing. Before giving up (which leaves
+    // a real payment unpaid → double-pay risk), let the AI verifier scan open invoices.
+    const rescue = await rescueNoMatch(popForVerify, amount);
+    if (rescue.action === "notify") {
+      await sendMessage(chatId, rescue.message, msgId);
+      return;
+    }
+    if (rescue.action === "pay") {
+      // Verifier rescued a real payment the matcher missed (armed + confident + corroborated)
+      // — pay it through the normal single-candidate path below.
+      candidates = [rescue.invoice];
+    } else {
+      await sendMessage(chatId, `💳 POP received — RM ${amount.toFixed(2)}\nRef: ${pop.referenceNumber ?? "–"}\nRecipient: ${pop.recipientName ?? "–"}\nAccount: ${pop.recipientAccount ?? "–"}\n\n❌ No matching unpaid invoice found.`, msgId);
+      return;
+    }
   }
 
   if (candidates.length > 1) {
@@ -803,15 +828,43 @@ async function resolvePop(
         status: { in: ["PAID", "DEPOSIT_PAID"] },
         NOT: { id: invoice.id },
       },
-      select: { invoiceNumber: true, paidAt: true },
+      select: { invoiceNumber: true, paidAt: true, amount: true, paymentRef: true },
     });
     if (existingRef) {
-      await sendMessage(
-        chatId,
-        `⛔ <b>Duplicate POP blocked</b>\nRef <code>${pop.referenceNumber}</code> is already attached to <b>${existingRef.invoiceNumber}</b>${existingRef.paidAt ? ` (paid ${existingRef.paidAt.toISOString().slice(0, 10)})` : ""}.\n\nSame bank ref can't be on two invoices. Verify before retrying.`,
-        msgId,
-      );
-      return;
+      // Deterministic stop-bleed: a repeated bank reference only signals a genuine re-send when
+      // the AMOUNT also matches. A DIFFERENT amount means a distinct payment that merely reuses a
+      // ref (e.g. a shared corporate account) — the old code hard-blocked these, leaving a real
+      // payment unpaid → double-pay. We now proceed to pay (the normal flag-detector still records
+      // the reused ref as DUPLICATE_PAYMENT_REF for review). Only the same-amount case is ambiguous.
+      const sameAmount = Math.abs(Number(existingRef.amount) - amount) <= 0.5;
+      if (sameAmount) {
+        // Same ref + same amount could be a real re-send OR a coincidental shared ref. The AI
+        // verifier decides: "pay" (proceed), "notify" (proposed to a human), or "none" (block).
+        const dup = await judgeDuplicate({
+          pop: popForVerify,
+          popAmount: amount,
+          invoice,
+          existingPaid: {
+            invoiceNumber: existingRef.invoiceNumber,
+            amount: Number(existingRef.amount),
+            paidAt: existingRef.paidAt ? existingRef.paidAt.toISOString().slice(0, 10) : null,
+            paymentRef: existingRef.paymentRef ?? pop.referenceNumber,
+          },
+        });
+        if (dup.action === "notify") {
+          await sendMessage(chatId, dup.message, msgId);
+          return;
+        }
+        if (dup.action === "none") {
+          await sendMessage(
+            chatId,
+            `⛔ <b>Duplicate POP blocked</b>\nRef <code>${pop.referenceNumber}</code> is already attached to <b>${existingRef.invoiceNumber}</b>${existingRef.paidAt ? ` (paid ${existingRef.paidAt.toISOString().slice(0, 10)})` : ""}.\n\nSame bank ref + same amount — likely the same payment re-sent. Verify before retrying.`,
+            msgId,
+          );
+          return;
+        }
+        // dup.action === "pay" → verifier judged a distinct payment; fall through to pay.
+      }
     }
   }
 

--- a/apps/backoffice/src/lib/inventory/agents/pop-lessons.ts
+++ b/apps/backoffice/src/lib/inventory/agents/pop-lessons.ts
@@ -1,0 +1,95 @@
+/**
+ * POP-match correction memory — the self-improving half of the POP QA loop.
+ *
+ * The pop-verifier judges a POP at a matcher dead-end and stamps its verdict on the
+ * target invoice's `flags` (code POP_VERIFIER). This module reads recent verdicts back,
+ * compares them to what ACTUALLY happened to the invoice (did it end up PAID?), and
+ * distils a short "what you've gotten wrong before" block that's prepended to the next
+ * judge prompt — so the same supplier's quirk (delivery-charge gap, a shared corporate
+ * account that reuses bank refs, an always-deposit supplier) stops re-breaking.
+ *
+ * SAFE by construction (mirrors agent-lessons.ts):
+ *  - Gated (PROCUREMENT_POP_VERIFIER_LESSONS) for staged rollout.
+ *  - Uses ONLY our own structured fields (payee name + enums + the resulting status) —
+ *    never the raw POP text — so a crafted receipt can't smuggle instructions forward.
+ *  - Bounded + deduped, most-recent first. Framed as reference, not orders.
+ */
+import { prisma } from "@/lib/prisma";
+
+export function popLessonsEnabled(): boolean {
+  return process.env.PROCUREMENT_POP_VERIFIER_LESSONS === "true";
+}
+
+type PopVerifierFlag = {
+  code?: string;
+  meta?: {
+    scenario?: string; // "no_match" | "duplicate_blocked"
+    decision?: string; // "pay" | "propose" | "no_action"
+    payee?: string;
+    isGenuineDuplicate?: boolean;
+  };
+};
+
+const PAID = new Set(["PAID", "DEPOSIT_PAID", "PARTIALLY_PAID"]);
+
+/**
+ * A compact "lessons from past POP matches" block. Two signals:
+ *  (a) the judge said propose/no_action but the invoice is now PAID → it was too cautious;
+ *      learn to recognise that payee's real payment next time.
+ *  (b) a duplicate-blocked POP judged a DISTINCT payment that then paid → that payee/account
+ *      reuses bank references; don't treat a repeated ref as a re-send.
+ * Returns "" when disabled / nothing to learn.
+ */
+export async function recentPopLessons(limit = 6): Promise<string> {
+  if (!popLessonsEnabled()) return "";
+
+  // Recent invoices, newest first; filter in JS for a POP_VERIFIER flag (robust against
+  // nested-JSON query filters). POPs are almost always for recent invoices.
+  const rows = await prisma.invoice.findMany({
+    orderBy: { createdAt: "desc" },
+    take: 200,
+    select: { status: true, flags: true, supplier: { select: { name: true } }, vendorName: true },
+  });
+
+  const seenMiss = new Set<string>();
+  const misses: string[] = [];
+  const seenDup = new Set<string>();
+  const dups: string[] = [];
+
+  for (const r of rows) {
+    const flags = Array.isArray(r.flags) ? (r.flags as unknown as PopVerifierFlag[]) : [];
+    const vf = flags.find((f) => f && f.code === "POP_VERIFIER")?.meta;
+    if (!vf) continue;
+    const payee = vf.payee || r.supplier?.name || r.vendorName || "a supplier";
+    const paid = PAID.has(r.status);
+
+    // (a) judge under-called but the payment was real
+    if (paid && (vf.decision === "propose" || vf.decision === "no_action") && misses.length < limit) {
+      const key = `${payee}::${vf.scenario}`;
+      if (!seenMiss.has(key)) {
+        seenMiss.add(key);
+        misses.push(`- ${payee}: a POP the matcher dropped (${vf.scenario}) turned out to be a real payment — recognise this one.`);
+      }
+    }
+
+    // (b) a repeated bank ref that was actually a distinct payment
+    if (paid && vf.scenario === "duplicate_blocked" && vf.isGenuineDuplicate === false && dups.length < limit) {
+      const key = `${payee}::dup`;
+      if (!seenDup.has(key)) {
+        seenDup.add(key);
+        dups.push(`- ${payee}: a reused bank reference was a DISTINCT payment, not a re-send — don't block on the ref alone.`);
+      }
+    }
+  }
+
+  if (misses.length === 0 && dups.length === 0) return "";
+
+  let block = "";
+  if (misses.length) {
+    block += `\n# Real payments the matcher has dropped before (reference only — still verify amount + payee)\n${misses.join("\n")}\n`;
+  }
+  if (dups.length) {
+    block += `\n# Bank references that have repeated across DISTINCT payments (don't read a repeat as a re-send)\n${dups.join("\n")}\n`;
+  }
+  return block;
+}

--- a/apps/backoffice/src/lib/inventory/agents/pop-verifier-run.ts
+++ b/apps/backoffice/src/lib/inventory/agents/pop-verifier-run.ts
@@ -1,0 +1,294 @@
+/**
+ * POP-match verifier runner — the DB + LLM shell around the pure pop-verifier core.
+ *
+ * Called from the Telegram POP matcher at its two dead-ends:
+ *   - rescueNoMatch():  the deterministic matcher found NO invoice. We ask the judge to
+ *                       scan the open invoices for the one this POP really pays.
+ *   - judgeDuplicate(): the matcher would block this POP because its bank ref already sits
+ *                       on a paid invoice. We ask the judge: same payment re-sent, or a
+ *                       distinct payment sharing a ref?
+ *
+ * MONEY SAFETY — auto-pay is gated in CODE, never on the model's word:
+ *   - PROCUREMENT_POP_VERIFIER_ENABLED gates the judge running at all (shadow: it proposes
+ *     + flags, but never pays).
+ *   - PROCUREMENT_POP_VERIFIER_AUTOPAY additionally allows an actual PAID write, and ONLY
+ *     when: verdict="pay" AND confidence ≥ 0.9 AND the amount re-matches in code (±RM1) AND
+ *     the payee corroborates (recipient account / name / invoice-ref) AND it's not a genuine
+ *     re-send. Otherwise it falls back to "propose" (Telegram message + an invoice flag for
+ *     finance to confirm) — so a real payment is never silently dropped, but the AI never
+ *     moves money on a hunch.
+ *
+ * Never throws — any failure returns a "no-op" outcome so the caller falls back to its
+ * original deterministic behaviour.
+ */
+import Anthropic from "@anthropic-ai/sdk";
+import { prisma } from "@/lib/prisma";
+import { appendInvoiceFlags, type InvoiceFlag } from "@/lib/inventory/flag-detector";
+import { recentPopLessons } from "@/lib/inventory/agents/pop-lessons";
+import {
+  POP_VERIFIER_SYSTEM,
+  POP_VERIFIER_VERSION,
+  buildPopVerifierPrompt,
+  parsePopVerdict,
+  type PopVerifierInput,
+  type PopVerifierVerdict,
+  type PopForVerify,
+  type CandidateInvoice,
+} from "@/lib/inventory/agents/pop-verifier";
+
+const anthropic = new Anthropic({ apiKey: process.env.ANTHROPIC_API_KEY });
+
+const AUTOPAY_CONFIDENCE = 0.9;
+const AUTOPAY_AMOUNT_TOL = 1.0; // RM — code re-check; bigger gaps fall to "propose", not auto-pay
+
+export function popVerifierEnabled(): boolean {
+  return process.env.PROCUREMENT_POP_VERIFIER_ENABLED === "true" && !!process.env.ANTHROPIC_API_KEY;
+}
+export function popVerifierAutoPay(): boolean {
+  return process.env.PROCUREMENT_POP_VERIFIER_AUTOPAY === "true" && popVerifierEnabled();
+}
+
+// Same include the webhook uses, so a rescued invoice can be paid by the normal path unchanged.
+const POP_INCLUDE = {
+  supplier: { select: { id: true, name: true, telegramChatId: true, bankAccountNumber: true, bankName: true, depositTermsDays: true } },
+  outlet: { select: { name: true, code: true } },
+  order: { select: { orderNumber: true, claimedBy: { select: { id: true, name: true, bankAccountNumber: true, bankName: true } } } },
+} as const;
+
+/* eslint-disable @typescript-eslint/no-explicit-any -- loaded invoice rows are untyped here, like the webhook */
+export type NoMatchOutcome =
+  | { action: "pay"; invoice: any } // caller: candidates = [invoice]; fall through to the pay path
+  | { action: "notify"; message: string } // caller: send this Telegram message; do not pay
+  | { action: "none" }; // caller: keep its original "no matching invoice" message
+
+export type DuplicateOutcome =
+  | { action: "pay" } // caller: proceed PAST the duplicate block and pay the candidate
+  | { action: "notify"; message: string }
+  | { action: "none" }; // caller: keep its original "duplicate blocked" message
+
+const digits = (s: string | null | undefined) => (s ?? "").replace(/\D/g, "");
+const norm = (s: string | null | undefined) => (s ?? "").replace(/[^a-z0-9]/gi, "").toLowerCase();
+const tokens = (s: string | null | undefined) =>
+  (s ?? "").toLowerCase().split(/[^a-z0-9]+/).filter((t) => t.length >= 3);
+const escapeHtml = (s: string) => s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+
+function todayMyt(): string {
+  return new Date(Date.now() + 8 * 60 * 60 * 1000).toISOString().slice(0, 10);
+}
+
+function payeeName(inv: any): string {
+  return inv.supplier?.name ?? inv.order?.claimedBy?.name ?? inv.vendorName ?? "?";
+}
+function payeeAccount(inv: any): string {
+  return digits(inv.supplier?.bankAccountNumber ?? inv.order?.claimedBy?.bankAccountNumber);
+}
+
+function toCandidate(inv: any): CandidateInvoice {
+  return {
+    invoiceNumber: inv.invoiceNumber,
+    payeeName: payeeName(inv),
+    payeeAccount: payeeAccount(inv) || null,
+    amount: Number(inv.amount),
+    depositAmount: inv.depositAmount != null ? Number(inv.depositAmount) : null,
+    outlet: inv.outlet?.name ?? inv.outlet?.code ?? null,
+    status: inv.status,
+    dueDate: inv.dueDate ? new Date(inv.dueDate).toISOString().slice(0, 10) : null,
+  };
+}
+
+// Independent code re-check that the POP amount really matches this invoice (the LLM's
+// "pay" is NOT enough to move money). Returns whether it matches + deposit-vs-full.
+function amountMatch(inv: any, popAmount: number): { ok: boolean; isDepositMatch: boolean } {
+  const full = Number(inv.amount);
+  const dep = inv.depositAmount != null ? Number(inv.depositAmount) : null;
+  const matchesFull = Math.abs(full - popAmount) <= AUTOPAY_AMOUNT_TOL;
+  const matchesDep = dep != null && Math.abs(dep - popAmount) <= AUTOPAY_AMOUNT_TOL;
+  return { ok: matchesFull || matchesDep, isDepositMatch: !matchesFull && matchesDep };
+}
+
+// Independent code re-check that the payee corroborates (account / name / invoice ref) — so
+// an auto-pay can't fire on amount coincidence alone.
+function corroborates(inv: any, pop: PopForVerify): boolean {
+  const popAcct = digits(pop.recipientAccount);
+  const acct = payeeAccount(inv);
+  const acctOk = popAcct.length >= 6 && acct.length >= 6 && (acct.includes(popAcct) || popAcct.includes(acct));
+
+  const pn = norm(pop.recipientName);
+  const cn = norm(payeeName(inv));
+  let nameOk = false;
+  if (pn.length >= 4 && cn.length >= 4) {
+    nameOk = pn.includes(cn) || cn.includes(pn);
+    if (!nameOk) {
+      const tb = new Set(tokens(payeeName(inv)));
+      nameOk = tokens(pop.recipientName).some((t) => t.length >= 4 && tb.has(t));
+    }
+  }
+
+  const r = norm(pop.invoiceReference);
+  const i = norm(inv.invoiceNumber);
+  const refOk = r.length >= 4 && (i === r || i.endsWith(r) || r.endsWith(i));
+
+  return acctOk || nameOk || refOk;
+}
+
+async function judge(input: PopVerifierInput): Promise<PopVerifierVerdict | null> {
+  const lessons = await recentPopLessons().catch(() => "");
+  const response = await anthropic.messages.create({
+    model: "claude-sonnet-4-6",
+    max_tokens: 700,
+    system: [{ type: "text", text: POP_VERIFIER_SYSTEM, cache_control: { type: "ephemeral" } }],
+    messages: [{ role: "user", content: buildPopVerifierPrompt(input, lessons) }],
+  });
+  const out = response.content
+    .filter((b): b is Anthropic.TextBlock => b.type === "text")
+    .map((b) => b.text)
+    .join("");
+  return parsePopVerdict(out);
+}
+
+async function recordAudit(
+  invoiceId: string,
+  m: {
+    scenario: "no_match" | "duplicate_blocked";
+    verdict: PopVerifierVerdict;
+    payee: string;
+    autoPaid: boolean;
+    popAmount: number;
+  },
+): Promise<void> {
+  try {
+    const flag: InvoiceFlag = {
+      code: "POP_VERIFIER",
+      message: `${m.autoPaid ? "AI auto-marked paid" : "AI: possible missed payment"} — POP RM ${m.popAmount.toFixed(
+        2,
+      )} (${m.scenario}, ${(m.verdict.confidence * 100).toFixed(0)}% conf). ${escapeHtml(m.verdict.reasoning)}`.slice(0, 300),
+      detectedAt: new Date().toISOString(),
+      // Auto-paid → nothing for finance to do, pre-dismiss so it doesn't nag. A proposal stays
+      // ACTIVE so it surfaces in the reconciliation board for a human to confirm.
+      ...(m.autoPaid ? { dismissed: true, dismissedAt: new Date().toISOString() } : {}),
+      meta: {
+        scenario: m.scenario,
+        decision: m.verdict.decision,
+        confidence: m.verdict.confidence,
+        payee: m.payee,
+        isGenuineDuplicate: m.verdict.isGenuineDuplicate,
+        autoPaid: m.autoPaid,
+        version: POP_VERIFIER_VERSION,
+      },
+    };
+    await appendInvoiceFlags(invoiceId, [flag]);
+  } catch (e) {
+    console.warn("[pop-verifier] audit flag failed:", e instanceof Error ? e.message : e);
+  }
+}
+
+function proposeMessage(inv: any, popAmount: number, v: PopVerifierVerdict, isDepositMatch: boolean): string {
+  return `⚠️ <b>Possible missed payment</b>\nPOP RM ${popAmount.toFixed(2)} looks like it pays <b>${
+    inv.invoiceNumber
+  }</b> (${escapeHtml(payeeName(inv))}, RM ${Number(inv.amount).toFixed(2)}${
+    isDepositMatch ? " — deposit" : ""
+  }).\n<i>${escapeHtml(v.reasoning)}</i>\n\nThe matcher missed it — verify &amp; mark paid in the invoices tab (flagged there). [${(
+    v.confidence * 100
+  ).toFixed(0)}% conf]`;
+}
+
+function distinctMessage(inv: any, popAmount: number, v: PopVerifierVerdict): string {
+  return `⚠️ <b>Likely NOT a duplicate</b>\nThis POP (RM ${popAmount.toFixed(2)}) looks like a DISTINCT payment for <b>${
+    inv.invoiceNumber
+  }</b> — the bank ref just repeats, it isn't a re-send.\n<i>${escapeHtml(
+    v.reasoning,
+  )}</i>\n\nVerify &amp; mark paid in the invoices tab. [${(v.confidence * 100).toFixed(0)}% conf]`;
+}
+
+/**
+ * Dead-end #1: the deterministic matcher found ZERO candidates. Scan open invoices for the
+ * one this POP genuinely pays. Returns a "pay" outcome (caller pays it via the normal path)
+ * only when armed + confident + code-corroborated; otherwise proposes or no-ops.
+ */
+export async function rescueNoMatch(pop: PopForVerify, popAmount: number): Promise<NoMatchOutcome> {
+  if (!popVerifierEnabled()) return { action: "none" };
+  try {
+    const open = await prisma.invoice.findMany({
+      where: { status: { in: ["PENDING", "INITIATED", "OVERDUE"] } },
+      orderBy: { createdAt: "desc" },
+      take: 40,
+      include: POP_INCLUDE,
+    });
+    if (open.length === 0) return { action: "none" };
+
+    const candidates = open.map((inv) => toCandidate(inv as any));
+    const verdict = await judge({ pop, today: todayMyt(), scenario: { kind: "no_match", openInvoices: candidates } });
+    if (!verdict) return { action: "none" };
+
+    const chosen =
+      verdict.targetRef != null && verdict.targetRef <= open.length ? (open[verdict.targetRef - 1] as any) : null;
+    if (!chosen || verdict.decision === "no_action") return { action: "none" };
+
+    const amt = amountMatch(chosen, popAmount);
+    const corro = corroborates(chosen, pop);
+    const canAuto =
+      popVerifierAutoPay() && verdict.decision === "pay" && verdict.confidence >= AUTOPAY_CONFIDENCE && amt.ok && corro;
+
+    await recordAudit(chosen.id, { scenario: "no_match", verdict, payee: payeeName(chosen), autoPaid: canAuto, popAmount });
+
+    if (canAuto) return { action: "pay", invoice: chosen };
+    return { action: "notify", message: proposeMessage(chosen, popAmount, verdict, amt.isDepositMatch) };
+  } catch (e) {
+    console.warn("[pop-verifier] rescueNoMatch failed:", e instanceof Error ? e.message : e);
+    return { action: "none" };
+  }
+}
+
+/**
+ * Dead-end #2: the matcher would block this POP as a duplicate (its ref is on a paid invoice).
+ * Judge same-payment-re-send vs distinct-payment-sharing-a-ref. Returns "pay" (proceed past
+ * the block) only when armed + confident + corroborated AND not a genuine duplicate.
+ */
+export async function judgeDuplicate(args: {
+  pop: PopForVerify;
+  popAmount: number;
+  invoice: any;
+  existingPaid: { invoiceNumber: string; amount: number; paidAt: string | null; paymentRef: string | null };
+}): Promise<DuplicateOutcome> {
+  if (!popVerifierEnabled()) return { action: "none" };
+  try {
+    const candidate = toCandidate(args.invoice);
+    const verdict = await judge({
+      pop: args.pop,
+      today: todayMyt(),
+      scenario: { kind: "duplicate_blocked", candidate, existingPaid: args.existingPaid },
+    });
+    if (!verdict) return { action: "none" };
+
+    if (verdict.isGenuineDuplicate || verdict.decision === "no_action") {
+      await recordAudit(args.invoice.id, {
+        scenario: "duplicate_blocked",
+        verdict,
+        payee: payeeName(args.invoice),
+        autoPaid: false,
+        popAmount: args.popAmount,
+      });
+      return { action: "none" }; // genuinely the same payment — keep the block
+    }
+
+    const amt = amountMatch(args.invoice, args.popAmount);
+    const corro = corroborates(args.invoice, args.pop);
+    const canAuto =
+      popVerifierAutoPay() && verdict.decision === "pay" && verdict.confidence >= AUTOPAY_CONFIDENCE && amt.ok && corro;
+
+    await recordAudit(args.invoice.id, {
+      scenario: "duplicate_blocked",
+      verdict,
+      payee: payeeName(args.invoice),
+      autoPaid: canAuto,
+      popAmount: args.popAmount,
+    });
+
+    if (canAuto) return { action: "pay" };
+    return { action: "notify", message: distinctMessage(args.invoice, args.popAmount, verdict) };
+  } catch (e) {
+    console.warn("[pop-verifier] judgeDuplicate failed:", e instanceof Error ? e.message : e);
+    return { action: "none" };
+  }
+}
+/* eslint-enable @typescript-eslint/no-explicit-any */

--- a/apps/backoffice/src/lib/inventory/agents/pop-verifier.ts
+++ b/apps/backoffice/src/lib/inventory/agents/pop-verifier.ts
@@ -1,0 +1,203 @@
+/**
+ * POP-match VERIFIER — an independent LLM judge that re-checks the deterministic
+ * proof-of-payment matcher, to PREVENT double-payments.
+ *
+ * The deterministic matcher (telegram/webhook resolvePop) is stateless: when it
+ * can't land a clean match it hits a dead-end — "❌ no matching invoice" or
+ * "⛔ duplicate POP blocked" — and leaves the invoice UNPAID. A real payment then
+ * looks unpaid → finance pays again. This judge runs at exactly those two dead-ends
+ * and decides whether a genuine payment is being dropped.
+ *
+ * This module is PURE: prompt construction + verdict parsing + types. No prisma, no
+ * Anthropic SDK — the DB/LLM I/O lives in pop-verifier-run.ts, and the money-write
+ * guardrails (confidence bar + amount/payee corroboration) are enforced THERE, in
+ * code, never left to the model.
+ *
+ * The judge carries its own ruleset (not the matcher's) so it doesn't inherit the
+ * matcher's blind spots, and it is told to be skeptical and to refuse to "pay" on
+ * amount alone.
+ */
+
+export const POP_VERIFIER_VERSION = "pop-match-verifier-v1";
+
+export type PopVerifierDecision = "pay" | "propose" | "no_action";
+
+export type PopVerifierVerdict = {
+  // pay      = this is unambiguously a real payment for exactly one invoice (the runner
+  //            still re-checks amount + payee in code before any auto-pay).
+  // propose  = a plausible match a human should confirm — surface it, don't auto-pay.
+  // no_action= no genuine match / a true re-send duplicate — leave the matcher's outcome.
+  decision: PopVerifierDecision;
+  targetRef: number | null; // 1-based index into the open-invoice list (no_match scenario)
+  isDepositMatch: boolean; // paying the deposit portion rather than the full amount
+  isGenuineDuplicate: boolean; // duplicate scenario: true ⇒ same payment already recorded
+  confidence: number; // 0..1 — the judge's confidence in its own verdict
+  reasoning: string; // one-line plain-language rationale
+  issues: string[]; // specific risks a human should know
+};
+
+export type PopForVerify = {
+  amount: number;
+  referenceNumber: string | null;
+  recipientName: string | null;
+  recipientAccount: string | null;
+  recipientBank: string | null;
+  invoiceReference: string | null;
+  date: string | null;
+};
+
+/** One open invoice the POP could belong to (no_match scenario). */
+export type CandidateInvoice = {
+  invoiceNumber: string;
+  payeeName: string; // supplier / staff claimant / one-off vendor
+  payeeAccount: string | null; // their bank account on file (digits)
+  amount: number;
+  depositAmount: number | null;
+  outlet: string | null;
+  status: string;
+  dueDate: string | null;
+};
+
+/** The already-PAID invoice that shares this POP's bank reference (duplicate scenario). */
+export type ExistingPaidInvoice = {
+  invoiceNumber: string;
+  amount: number;
+  paidAt: string | null;
+  paymentRef: string | null;
+};
+
+export type PopVerifyScenario =
+  | { kind: "no_match"; openInvoices: CandidateInvoice[] }
+  | { kind: "duplicate_blocked"; candidate: CandidateInvoice; existingPaid: ExistingPaidInvoice };
+
+export type PopVerifierInput = {
+  pop: PopForVerify;
+  today: string; // YYYY-MM-DD (MYT)
+  scenario: PopVerifyScenario;
+};
+
+export const POP_VERIFIER_SYSTEM = `You are a strict QA auditor for an autonomous proof-of-payment (POP) matcher used by a Malaysian F&B company. A POP is a bank-transfer receipt (Maybank etc.) that finance uploads; the matcher tries to attach it to the right unpaid invoice and mark that invoice PAID. Your ONE job is to stop money mistakes — chiefly DOUBLE-PAYMENTS, which happen when a real payment fails to match so the invoice stays unpaid and finance pays it a second time.
+
+You are independent, skeptical, and conservative. You judge ONE POP at one of two dead-ends the deterministic matcher hit, and you output JSON only.
+
+# What "pay" requires (be strict)
+Only choose "pay" when the POP unambiguously corresponds to EXACTLY ONE invoice:
+- the POP amount equals the invoice's full amount OR its deposit amount, within about RM1 (small rounding / SST), AND
+- the payee corroborates: the POP recipient name or recipient account matches that invoice's supplier / staff claimant / vendor, OR the POP's invoice-reference text clearly names that invoice number.
+If amount matches but the payee does NOT corroborate → "propose", never "pay".
+NEVER infer "pay" from the amount alone. NEVER "pay" when two or more invoices are equally plausible — choose "propose".
+
+# "propose" vs "no_action"
+- propose: a plausible single match a human should confirm (amount close but payee weakly corroborated, reference garbled, deposit-vs-full unclear, or your confidence is moderate).
+- no_action: nothing here genuinely matches an open invoice — it is safe to leave unmatched for a human to investigate.
+
+# Deposit vs full
+Set isDepositMatch=true ONLY when the POP amount matches the invoice's depositAmount and clearly NOT the full amount. Prefer a full-amount match when both could apply.
+
+# Duplicate-blocked scenario
+The matcher refused to attach this POP because its bank reference already sits on a PAID invoice. Decide which is true:
+- GENUINE re-send (the SAME payment uploaded twice): same amount AND same reference AND same payee as the already-paid invoice → isGenuineDuplicate=true, decision="no_action". Do NOT pay again.
+- DISTINCT real payment that merely shares a bank reference or a shared corporate account (different amount, different payee, or a clearly separate invoice) → isGenuineDuplicate=false, and "pay" (if it cleanly matches the candidate) or "propose" (if unsure). This is the false-block that causes the double-pay.
+
+# Confidence
+Report your TRUE confidence 0..1. A money write only happens downstream when confidence is very high AND code re-confirms amount + payee, so do not inflate it. When genuinely unsure, prefer "propose" with moderate confidence over "pay".
+
+Output JSON only.`;
+
+/** Build the user-turn prompt presenting one POP + its dead-end scenario for judging. */
+export function buildPopVerifierPrompt(input: PopVerifierInput, lessons = ""): string {
+  const p = input.pop;
+  const popBlock = [
+    `- amount paid: RM ${p.amount.toFixed(2)}`,
+    `- bank reference: ${p.referenceNumber ?? "—"}`,
+    `- recipient name: ${p.recipientName ?? "—"}`,
+    `- recipient account: ${p.recipientAccount ?? "—"}`,
+    `- recipient bank: ${p.recipientBank ?? "—"}`,
+    `- invoice reference text on the POP: ${p.invoiceReference ?? "—"}`,
+    `- payment date: ${p.date ?? "—"}`,
+  ].join("\n");
+
+  let scenarioBlock: string;
+  if (input.scenario.kind === "no_match") {
+    const list =
+      input.scenario.openInvoices
+        .map((inv, i) => {
+          const dep = inv.depositAmount != null ? ` | deposit RM ${inv.depositAmount.toFixed(2)}` : "";
+          return `[${i + 1}] ${inv.invoiceNumber} | payee ${inv.payeeName}${
+            inv.payeeAccount ? ` (acct ${inv.payeeAccount})` : ""
+          } | RM ${inv.amount.toFixed(2)}${dep} | ${inv.outlet ?? "?"} | ${inv.status}${
+            inv.dueDate ? ` | due ${inv.dueDate}` : ""
+          }`;
+        })
+        .join("\n") || "(no open invoices)";
+    scenarioBlock = `# Scenario: the matcher found NO invoice and was about to give up.
+# Open (unpaid) invoices it could belong to — pick the one (if any) this POP genuinely pays.
+# Return its number in "targetRef" (the [n] index). targetRef=null if none truly matches.
+${list}`;
+  } else {
+    const c = input.scenario.candidate;
+    const e = input.scenario.existingPaid;
+    scenarioBlock = `# Scenario: DUPLICATE-blocked. The matcher would pay this candidate, but the POP's bank
+# reference already sits on a PAID invoice, so it refused. Decide: same payment re-sent, or a
+# distinct real payment sharing a reference?
+# Candidate invoice to (maybe) pay:
+[1] ${c.invoiceNumber} | payee ${c.payeeName}${c.payeeAccount ? ` (acct ${c.payeeAccount})` : ""} | RM ${c.amount.toFixed(
+      2,
+    )}${c.depositAmount != null ? ` | deposit RM ${c.depositAmount.toFixed(2)}` : ""} | ${c.outlet ?? "?"}
+# Already-PAID invoice that shares the reference:
+${e.invoiceNumber} | RM ${e.amount.toFixed(2)} | ref ${e.paymentRef ?? "—"}${e.paidAt ? ` | paid ${e.paidAt}` : ""}`;
+  }
+
+  return `Today is ${input.today} (Asia/Kuala_Lumpur).
+${lessons ? `${lessons}\n` : ""}
+# The POP (bank receipt) under review
+${popBlock}
+
+${scenarioBlock}
+
+# Judge it. Output JSON only:
+{
+  "decision": "pay|propose|no_action",
+  "targetRef": <the [n] index of the matching open invoice, or null>,
+  "isDepositMatch": <true if the POP pays the deposit portion, else false>,
+  "isGenuineDuplicate": <true only in the duplicate scenario when it's the same payment re-sent>,
+  "confidence": 0.0,
+  "reasoning": "one line",
+  "issues": ["specific risk a human should know", "..."]
+}`;
+}
+
+/** Parse + validate the model's verdict from raw text. Returns null if unparseable. */
+export function parsePopVerdict(raw: string): PopVerifierVerdict | null {
+  const m = raw.match(/\{[\s\S]*\}/);
+  if (!m) return null;
+  let p: Record<string, unknown>;
+  try {
+    p = JSON.parse(m[0]) as Record<string, unknown>;
+  } catch {
+    return null;
+  }
+
+  const decisions: PopVerifierDecision[] = ["pay", "propose", "no_action"];
+  const decision = decisions.includes(p.decision as PopVerifierDecision)
+    ? (p.decision as PopVerifierDecision)
+    : null;
+  if (!decision) return null;
+
+  const targetRefNum = Number(p.targetRef);
+  const targetRef = Number.isInteger(targetRefNum) && targetRefNum > 0 ? targetRefNum : null;
+
+  const issues = Array.isArray(p.issues)
+    ? p.issues.map((x) => String(x)).filter((s) => s.trim().length > 0).slice(0, 12)
+    : [];
+
+  return {
+    decision,
+    targetRef,
+    isDepositMatch: p.isDepositMatch === true,
+    isGenuineDuplicate: p.isGenuineDuplicate === true,
+    confidence: Math.max(0, Math.min(1, Number(p.confidence) || 0)),
+    reasoning: typeof p.reasoning === "string" ? p.reasoning.trim().slice(0, 300) : "",
+    issues,
+  };
+}

--- a/apps/backoffice/src/lib/inventory/flag-detector.ts
+++ b/apps/backoffice/src/lib/inventory/flag-detector.ts
@@ -9,7 +9,10 @@ export type InvoiceFlagCode =
   | "DUPLICATE_PAYMENT_REF"
   | "REF_MATCHES_PAID_INVOICE"
   | "AMOUNT_TOLERANCE_MATCH"
-  | "BANK_MISMATCH";
+  | "BANK_MISMATCH"
+  // The POP-match verifier (AI) thinks this unpaid invoice was actually paid by a POP the
+  // deterministic matcher dropped — surfaced for finance to confirm. meta holds the verdict.
+  | "POP_VERIFIER";
 
 export type InvoiceFlag = {
   code: InvoiceFlagCode;
@@ -27,6 +30,7 @@ const FLAG_LABEL: Record<InvoiceFlagCode, string> = {
   REF_MATCHES_PAID_INVOICE: "Reference points to a paid invoice",
   AMOUNT_TOLERANCE_MATCH: "Amount matched within tolerance only",
   BANK_MISMATCH: "POP bank differs from supplier bank",
+  POP_VERIFIER: "AI: a payment may have been missed — verify",
 };
 
 export function flagLabel(code: InvoiceFlagCode) {


### PR DESCRIPTION
## The problem
The POP matcher (`telegram/webhook` `resolvePop`) is stateless. When it can't match cleanly it hits a dead-end — **"❌ no matching invoice"** or **"⛔ duplicate POP blocked"** — and leaves the invoice **UNPAID**. A real payment then looks unpaid → finance pays it **again**. It never learned, so the same supplier's quirk re-broke every time ("there was no self-improving").

## What this adds (mirrors the supplier-chat verifier trio)
An independent AI judge at **both dead-ends**:

| File | Role |
|---|---|
| `agents/pop-verifier.ts` | pure judge — prompt + verdict types + parsing |
| `agents/pop-verifier-run.ts` | loads candidates, runs the judge, acts; **money guardrails in code** |
| `agents/pop-lessons.ts` | self-improving memory — past resolutions → next prompt |

### Auto-pay is gated in CODE, never on the model's word
You chose *"auto-mark paid when very confident"* — so it does, but a PAID write fires **only** when **all** hold:
- verdict = `pay` **and** confidence ≥ **0.9**
- the POP amount **re-matches in code** (±RM1) — not trusting the LLM's amount
- the **payee corroborates** (recipient account / name / invoice-ref) — no paying on amount coincidence
- it's **not** a genuine re-send
- `PROCUREMENT_POP_VERIFIER_AUTOPAY` is on

Otherwise it **proposes** — a Telegram message naming the likely invoice + a `POP_VERIFIER` flag in the reconciliation board for a human to confirm. **A real payment is never silently dropped; the AI never moves money on a hunch.**

### Deterministic stop-bleed (always on)
The duplicate-block now only fires on a **same-amount** ref collision. A **different amount** = a distinct payment that merely reuses a bank ref (shared corporate account) → it **proceeds to pay** (the existing flag-detector still records the reused ref as `DUPLICATE_PAYMENT_REF` for review) instead of blocking a real payment into a double-pay. This is the single always-on behaviour change.

### Self-improving
`pop-lessons` reads how past verdicts actually resolved — a POP the matcher dropped that later got paid, or a "duplicate" that was really distinct — and feeds the **per-payee pattern** back into the next judge prompt, so the recurring quirk stops recurring.

## Rollout — ships DARK behind flags
1. `PROCUREMENT_POP_VERIFIER_ENABLED=true` → **shadow**: the judge runs, proposes + flags, **never pays**. Watch the proposals/flags for accuracy.
2. `PROCUREMENT_POP_VERIFIER_AUTOPAY=true` → arm the very-confident auto-pay.
3. `PROCUREMENT_POP_VERIFIER_LESSONS=true` → turn on the learning loop.

Model `claude-sonnet-4-6`. Typecheck + lint clean. Can't runtime-test the authenticated app in the worktree — verified by typecheck/lint; the flags keep it inert in prod until you arm it.