### PR TITLE
fix(procurement): disable pull-to-refresh on the Purchase Orders workspace

### DIFF
--- a/apps/backoffice/src/app/(admin)/inventory/supplier-chats/page.tsx
+++ b/apps/backoffice/src/app/(admin)/inventory/supplier-chats/page.tsx
@@ -175,6 +175,21 @@ export default function SupplierChatsPage() {
     localStorage.setItem("sc-segments", JSON.stringify(segments));
   }, [segments]);
 
+  // Mobile: suppress the browser's native pull-to-refresh while this full-screen workspace is
+  // open — an overscroll at the top of the list/chat was reloading the page mid-navigation.
+  // Scoped to this page (restored on unmount) so the rest of the app keeps pull-to-refresh.
+  useEffect(() => {
+    const html = document.documentElement;
+    const prevHtml = html.style.overscrollBehaviorY;
+    const prevBody = document.body.style.overscrollBehaviorY;
+    html.style.overscrollBehaviorY = "none";
+    document.body.style.overscrollBehaviorY = "none";
+    return () => {
+      html.style.overscrollBehaviorY = prevHtml;
+      document.body.style.overscrollBehaviorY = prevBody;
+    };
+  }, []);
+
   function togglePin(key: string) {
     setPinnedKeys((prev) => {
       const next = new Set(prev);


### PR DESCRIPTION
**Issue:** on mobile, pulling down at the top of the supplier list or a chat fired the browser's **native pull-to-refresh** and reloaded the page mid-navigation — making the workspace hard to navigate.

**Fix:** set `overscroll-behavior-y: none` on `html`+`body` while the workspace is mounted, restored on unmount — so the fix is **scoped to this page** and the rest of the app keeps pull-to-refresh. Normal scrolling inside the list/chat panes is unaffected (overscroll-behavior only governs the scroll boundary).

Typecheck + lint clean. (Can't runtime-test the authenticated app in the worktree — please confirm on your phone after deploy.)