### PR TITLE
feat(procurement): clickable Unpaid + unpaid-invoice list in the workspace rail

### DIFF
--- a/apps/backoffice/src/app/(admin)/inventory/invoices/page.tsx
+++ b/apps/backoffice/src/app/(admin)/inventory/invoices/page.tsx
@@ -148,6 +148,24 @@ export default function InvoicesPage() {
   const [cardFilter, setCardFilter] = useState<"all" | "pending" | "overdue" | "initiated" | "paid" | "due_today" | "payable" | "pending_invoice" | null>(null);
   const [batchInitiating, setBatchInitiating] = useState(false);
 
+  // Deep-link from the Purchase Orders workspace: ?supplier=<id>&cardFilter=payable&search=<inv>
+  // pre-applies the supplier + unpaid filters, so the rail's Unpaid card / invoice rows land on
+  // exactly this supplier's unpaid invoices. window.location (not useSearchParams) avoids the
+  // Suspense-boundary requirement on this route.
+  useEffect(() => {
+    const params = new URLSearchParams(window.location.search);
+    const sup = params.get("supplier");
+    const card = params.get("cardFilter");
+    const q = params.get("search");
+    if (sup) setSupplierFilter([sup]);
+    if (q) {
+      setSearch(q);
+      setDebouncedSearch(q);
+    }
+    const validCards = ["all", "pending", "overdue", "initiated", "paid", "due_today", "payable", "pending_invoice"];
+    if (card && validCards.includes(card)) setCardFilter(card as typeof cardFilter);
+  }, []); // once on mount
+
   // Payment dialog
   const [payingInvoice, setPayingInvoice] = useState<Invoice | null>(null);
   const [payingTargetStatus, setPayingTargetStatus] = useState<string>("");

--- a/apps/backoffice/src/app/(admin)/inventory/supplier-chats/page.tsx
+++ b/apps/backoffice/src/app/(admin)/inventory/supplier-chats/page.tsx
@@ -89,6 +89,7 @@ type Detail = {
     unpaidTotal: number;
     overdueTotal: number;
     recentPOs: { id: string; orderNumber: string; status: string }[];
+    unpaidInvoices: { id: string; invoiceNumber: string; balance: number; status: string; dueDate: string | null; overdue: boolean }[];
   };
   windowOpen: boolean;
   humanHandling: boolean;
@@ -1210,10 +1211,16 @@ export default function SupplierChatsPage() {
                     <div className="text-[11px] text-muted-foreground">Open POs</div>
                     <div className="text-[15px] font-medium">{detail.context.openPOs}</div>
                   </div>
-                  <div className="rounded-md bg-muted px-2.5 py-1.5">
-                    <div className="text-[11px] text-muted-foreground">Unpaid</div>
+                  <a
+                    href={`/inventory/invoices?supplier=${detail.supplierId ?? ""}&cardFilter=payable`}
+                    className="block rounded-md bg-muted px-2.5 py-1.5 transition hover:bg-muted/70"
+                  >
+                    <div className="flex items-center justify-between text-[11px] text-muted-foreground">
+                      <span>Unpaid</span>
+                      <ExternalLink size={11} className="opacity-50" />
+                    </div>
                     <div className="text-[15px] font-medium">{formatRM(detail.context.unpaidTotal)}</div>
-                  </div>
+                  </a>
                   {detail.context.overdueTotal > 0 && (
                     <div className="rounded-md bg-destructive/10 px-2.5 py-1.5">
                       <div className="text-[11px] text-destructive">Overdue</div>
@@ -1223,6 +1230,26 @@ export default function SupplierChatsPage() {
                     </div>
                   )}
                 </div>
+                {detail.context.unpaidInvoices.length > 0 && (
+                  <div className="border-b border-border py-3">
+                    <div className="mb-1.5 text-[11px] text-muted-foreground">Unpaid invoices</div>
+                    {detail.context.unpaidInvoices.map((inv) => (
+                      <a
+                        key={inv.id}
+                        href={`/inventory/invoices?supplier=${detail.supplierId ?? ""}&cardFilter=payable&search=${encodeURIComponent(inv.invoiceNumber)}`}
+                        className="flex items-center justify-between gap-2 rounded px-1 py-1 text-[11px] hover:bg-muted"
+                      >
+                        <span className="truncate font-medium text-primary">{inv.invoiceNumber}</span>
+                        <span className="flex shrink-0 items-center gap-1.5">
+                          {inv.overdue && (
+                            <span className="rounded bg-destructive/10 px-1 text-[9.5px] font-medium text-destructive">overdue</span>
+                          )}
+                          <span className="text-muted-foreground">{formatRM(inv.balance)}</span>
+                        </span>
+                      </a>
+                    ))}
+                  </div>
+                )}
                 {(() => {
                   const myNeed = (needGroups ?? []).filter((g) => g.supplierId === detail.supplierId);
                   if (myNeed.length === 0) return null;

--- a/apps/backoffice/src/app/api/inventory/supplier-chats/[key]/route.ts
+++ b/apps/backoffice/src/app/api/inventory/supplier-chats/[key]/route.ts
@@ -69,12 +69,20 @@ export async function GET(req: NextRequest, { params }: { params: Promise<{ key:
     unpaidTotal: 0,
     overdueTotal: 0,
     recentPOs: [] as { id: string; orderNumber: string; status: string }[],
+    unpaidInvoices: [] as {
+      id: string;
+      invoiceNumber: string;
+      balance: number;
+      status: string;
+      dueDate: string | null;
+      overdue: boolean;
+    }[],
   };
 
   if (supplierId) {
     const closedStatuses: OrderStatus[] = ["COMPLETED", "CANCELLED"];
     const openFilter = { supplierId, status: { notIn: closedStatuses } };
-    const [s, openPOs, recentPOs, unpaid, overdue] = await Promise.all([
+    const [s, openPOs, recentPOs, unpaid, overdue, unpaidList] = await Promise.all([
       prisma.supplier.findUnique({
         where: { id: supplierId },
         select: { id: true, name: true, phone: true, deliveryDays: true, paymentTerms: true, leadTimeDays: true, depositPercent: true, automationMode: true },
@@ -94,17 +102,32 @@ export async function GET(req: NextRequest, { params }: { params: Promise<{ key:
         where: { supplierId, status: { not: "PAID" }, dueDate: { lt: new Date() } },
         _sum: { amount: true, amountPaid: true },
       }),
+      prisma.invoice.findMany({
+        where: { supplierId, status: { not: "PAID" } },
+        orderBy: [{ dueDate: "asc" }, { createdAt: "asc" }],
+        take: 12,
+        select: { id: true, invoiceNumber: true, amount: true, amountPaid: true, status: true, dueDate: true },
+      }),
     ]);
     supplier = s
       ? { ...s, paymentModel: paymentModel({ paymentTerms: s.paymentTerms, depositPercent: s.depositPercent }) }
       : null;
     const bal = (a: { _sum: { amount: unknown; amountPaid: unknown } }) =>
       Math.max(0, Number(a._sum.amount ?? 0) - Number(a._sum.amountPaid ?? 0));
+    const nowMs = Date.now();
     context = {
       openPOs,
       unpaidTotal: bal(unpaid),
       overdueTotal: bal(overdue),
       recentPOs: recentPOs.map((o) => ({ id: o.id, orderNumber: o.orderNumber, status: o.status })),
+      unpaidInvoices: unpaidList.map((i) => ({
+        id: i.id,
+        invoiceNumber: i.invoiceNumber,
+        balance: Math.max(0, Number(i.amount) - Number(i.amountPaid ?? 0)),
+        status: i.status,
+        dueDate: i.dueDate ? i.dueDate.toISOString().slice(0, 10) : null,
+        overdue: !!i.dueDate && i.dueDate.getTime() < nowMs,
+      })),
     };
   }
 


### PR DESCRIPTION
The supplier-context rail in the Purchase Orders workspace showed only the **unpaid total** (e.g. "Unpaid RM 0.00") — not *which* invoices, and it wasn't clickable.

**Now:**
- **The "Unpaid" card is clickable** → opens the Invoices page **deep-linked to this supplier's unpaid invoices** (`?supplier=<id>&cardFilter=payable`).
- **New "Unpaid invoices" list** in the rail — each open invoice with its number, outstanding balance, and an `overdue` badge; each row deep-links to that specific invoice (`&search=<invoiceNumber>`).
- **Detail API** returns the unpaid-invoice list (`id, invoiceNumber, balance, status, dueDate, overdue`) next to the existing totals.
- **Invoices page** reads `?supplier` / `?cardFilter` / `?search` from the URL on mount and pre-applies the filters (via `window.location` to avoid a `useSearchParams` Suspense boundary on that route).

Typecheck + lint clean. (Can't runtime-test the authenticated app in the worktree — please confirm on a supplier with open invoices after deploy.)