### PR TITLE
feat(ops): clock-in nudge triggers per-shift lateness (every 15 min)

### DIFF
--- a/apps/backoffice/src/app/api/cron/ops-nudge-clockin/route.ts
+++ b/apps/backoffice/src/app/api/cron/ops-nudge-clockin/route.ts
@@ -10,10 +10,12 @@ export const maxDuration = 60;
  *
  * For each staff with a published shift today whose start + grace has passed and
  * no clock-in: DMs the staff member ("please clock in") and adds them to a digest
- * for the manager (ops leads). Runs ONCE daily (~8:30am MYT) — catches the main
- * morning shift while it's still actionable, and keeps cost low (one run, not 48).
- * The ledger still dedupes per (staff, day). OPS_NUDGES_MODE (off|shadow|armed),
- * default armed. Design: docs/design/ops-performance-loop.md.
+ * for the manager (ops leads). Runs every 15 min so each shift trips at its OWN
+ * start time (morning, midday, afternoon, evening), not just the morning. Cost is
+ * unchanged: the ledger dedupes per (staff, day), so each no-show is DM'd once no
+ * matter how often the cron runs — frequency only sets how promptly lateness is
+ * caught. OPS_NUDGES_MODE (off|shadow|armed), default armed.
+ * Design: docs/design/ops-performance-loop.md.
  */
 export async function GET(req: NextRequest) {
   const cronAuth = checkCronAuth(req.headers);

--- a/apps/backoffice/vercel.json
+++ b/apps/backoffice/vercel.json
@@ -114,7 +114,7 @@
     },
     {
       "path": "/api/cron/ops-nudge-clockin",
-      "schedule": "30 0 * * *"
+      "schedule": "*/15 * * * *"
     },
     {
       "path": "/api/cron/ops-nudge-stockcount",


### PR DESCRIPTION
The clock-in nudge ran once at 08:30 MYT, so only shifts starting before ~08:15 were caught — mid-morning/afternoon/evening no-shows were never nudged. The detector already evaluates lateness per shift (`now > start + 15m grace`); this just runs the check every 15 min so each shift trips at its own start time.

Cost is unchanged: the ledger dedupes per (staff, day), so each no-show is DM'd once no matter how often the cron runs — frequency only sets how promptly lateness is caught. Managers get a digest as each new wave of no-shows appears.