### PR TITLE
fix(procurement): actually disable pull-to-refresh on the Purchase Orders workspace

### DIFF
--- a/apps/backoffice/src/app/(admin)/inventory/supplier-chats/page.tsx
+++ b/apps/backoffice/src/app/(admin)/inventory/supplier-chats/page.tsx
@@ -189,21 +189,6 @@ export default function SupplierChatsPage() {
     localStorage.setItem("sc-segments", JSON.stringify(segments));
   }, [segments]);
 
-  // Mobile: suppress the browser's native pull-to-refresh while this full-screen workspace is
-  // open — an overscroll at the top of the list/chat was reloading the page mid-navigation.
-  // Scoped to this page (restored on unmount) so the rest of the app keeps pull-to-refresh.
-  useEffect(() => {
-    const html = document.documentElement;
-    const prevHtml = html.style.overscrollBehaviorY;
-    const prevBody = document.body.style.overscrollBehaviorY;
-    html.style.overscrollBehaviorY = "none";
-    document.body.style.overscrollBehaviorY = "none";
-    return () => {
-      html.style.overscrollBehaviorY = prevHtml;
-      document.body.style.overscrollBehaviorY = prevBody;
-    };
-  }, []);
-
   function togglePin(key: string) {
     setPinnedKeys((prev) => {
       const next = new Set(prev);

--- a/apps/backoffice/src/app/(admin)/layout.tsx
+++ b/apps/backoffice/src/app/(admin)/layout.tsx
@@ -1081,6 +1081,7 @@ export default function AdminLayout({ children }: { children: React.ReactNode })
         <PullToRefresh
           onRefresh={async () => { window.location.reload(); }}
           className="flex-1 overflow-y-auto overflow-x-hidden print:overflow-visible print:h-auto"
+          disabled={pathname?.startsWith("/inventory/supplier-chats") ?? false}
         >
           {children}
         </PullToRefresh>

--- a/apps/backoffice/src/components/pull-to-refresh.tsx
+++ b/apps/backoffice/src/components/pull-to-refresh.tsx
@@ -7,11 +7,15 @@ interface PullToRefreshProps {
   onRefresh: () => Promise<void>;
   children: React.ReactNode;
   className?: string;
+  // When true the pull gesture is inert (no listeners attached) — e.g. on full-screen,
+  // internally-scrolled pages like the Purchase Orders workspace, where an accidental pull
+  // reloading the page makes it hard to navigate.
+  disabled?: boolean;
 }
 
 const THRESHOLD = 80;
 
-export function PullToRefresh({ onRefresh, children, className }: PullToRefreshProps) {
+export function PullToRefresh({ onRefresh, children, className, disabled = false }: PullToRefreshProps) {
   const [pulling, setPulling] = useState(false);
   const [refreshing, setRefreshing] = useState(false);
   const [pullDistance, setPullDistance] = useState(0);
@@ -45,7 +49,7 @@ export function PullToRefresh({ onRefresh, children, className }: PullToRefreshP
 
   useEffect(() => {
     const el = containerRef.current;
-    if (!el) return;
+    if (!el || disabled) return;
     el.addEventListener("touchstart", handleTouchStart, { passive: true });
     el.addEventListener("touchmove", handleTouchMove, { passive: true });
     el.addEventListener("touchend", handleTouchEnd);
@@ -54,7 +58,7 @@ export function PullToRefresh({ onRefresh, children, className }: PullToRefreshP
       el.removeEventListener("touchmove", handleTouchMove);
       el.removeEventListener("touchend", handleTouchEnd);
     };
-  }, [handleTouchStart, handleTouchMove, handleTouchEnd]);
+  }, [handleTouchStart, handleTouchMove, handleTouchEnd, disabled]);
 
   const progress = Math.min(pullDistance / THRESHOLD, 1);
 


### PR DESCRIPTION
**#599 fixed the wrong thing.** It wasn't the browser's native pull-to-refresh — the admin layout wraps every page in a **custom `<PullToRefresh>` component** ([layout.tsx](apps/backoffice/src/app/(admin)/layout.tsx)) that calls `window.location.reload()`. Pulling down at the top of the supplier list or a chat reloaded the page mid-navigation. My `overscroll-behavior` CSS did nothing because `body` isn't the scroll container (the layout's `overflow-y-auto` div is).

**This fix:**
- Added a `disabled` prop to `PullToRefresh` — when set, no touch listeners are attached, so the gesture is fully inert.
- The layout passes `disabled` for the `/inventory/supplier-chats` route only.
- Removed the dead overscroll effect #599 added.

Pull-to-refresh still works on every other page. Typecheck + lint clean — please confirm on your phone after deploy.