### PR TITLE
feat(procurement): make all rail stat cards clickable (Open POs, Overdue)

### DIFF
--- a/apps/backoffice/src/app/(admin)/inventory/orders/page.tsx
+++ b/apps/backoffice/src/app/(admin)/inventory/orders/page.tsx
@@ -123,6 +123,15 @@ export default function OrdersPage() {
     const t = setTimeout(() => setDebouncedSearch(search), 500);
     return () => clearTimeout(t);
   }, [search]);
+  // Deep-link from the Purchase Orders workspace: ?search=<supplier> pre-fills the search so the
+  // rail's "Open POs" card lands on this supplier's POs. window.location avoids a Suspense boundary.
+  useEffect(() => {
+    const q = new URLSearchParams(window.location.search).get("search");
+    if (q) {
+      setSearch(q);
+      setDebouncedSearch(q);
+    }
+  }, []);
   // Created-date range filter — mirrors the invoices page pattern.
   const [showFilters, setShowFilters] = useState(false);
   const [createdFrom, setCreatedFrom] = useState("");

--- a/apps/backoffice/src/app/(admin)/inventory/supplier-chats/page.tsx
+++ b/apps/backoffice/src/app/(admin)/inventory/supplier-chats/page.tsx
@@ -1235,10 +1235,16 @@ export default function SupplierChatsPage() {
                   </div>
                 </div>
                 <div className="flex flex-col gap-1.5 border-b border-border py-3">
-                  <div className="rounded-md bg-muted px-2.5 py-1.5">
-                    <div className="text-[11px] text-muted-foreground">Open POs</div>
+                  <a
+                    href={`/inventory/orders?search=${encodeURIComponent(detail.supplier?.name ?? "")}`}
+                    className="block rounded-md bg-muted px-2.5 py-1.5 transition hover:bg-muted/70"
+                  >
+                    <div className="flex items-center justify-between text-[11px] text-muted-foreground">
+                      <span>Open POs</span>
+                      <ExternalLink size={11} className="opacity-50" />
+                    </div>
                     <div className="text-[15px] font-medium">{detail.context.openPOs}</div>
-                  </div>
+                  </a>
                   <a
                     href={`/inventory/invoices?supplier=${detail.supplierId ?? ""}&cardFilter=payable`}
                     className="block rounded-md bg-muted px-2.5 py-1.5 transition hover:bg-muted/70"
@@ -1250,12 +1256,18 @@ export default function SupplierChatsPage() {
                     <div className="text-[15px] font-medium">{formatRM(detail.context.unpaidTotal)}</div>
                   </a>
                   {detail.context.overdueTotal > 0 && (
-                    <div className="rounded-md bg-destructive/10 px-2.5 py-1.5">
-                      <div className="text-[11px] text-destructive">Overdue</div>
+                    <a
+                      href={`/inventory/invoices?supplier=${detail.supplierId ?? ""}&cardFilter=overdue`}
+                      className="block rounded-md bg-destructive/10 px-2.5 py-1.5 transition hover:bg-destructive/15"
+                    >
+                      <div className="flex items-center justify-between text-[11px] text-destructive">
+                        <span>Overdue</span>
+                        <ExternalLink size={11} className="opacity-60" />
+                      </div>
                       <div className="text-[15px] font-medium text-destructive">
                         {formatRM(detail.context.overdueTotal)}
                       </div>
-                    </div>
+                    </a>
                   )}
                 </div>
                 {detail.context.unpaidInvoices.length > 0 && (


### PR DESCRIPTION
The supplier-context rail's stat cards are now all clickable (Unpaid already was from #600):

- **Open POs** → PO Lists deep-linked to this supplier (`?search=<name>`).
- **Overdue** → Invoices filtered to this supplier's **overdue** invoices (`?supplier=<id>&cardFilter=overdue` — the invoices page already reads `cardFilter`).

Added `?search` URL reading to the PO Lists page (mirrors the invoices-page deep-link) and an external-link cue on each card so they read as clickable. Typecheck + lint clean — please confirm on a supplier with open POs / overdue invoices after deploy.