### PR TITLE
feat(finance): live bank ledger from Bukku raw Maybank feed + daily cron

### DIFF
--- a/apps/backoffice/scripts/bukku-feed-sync.ts
+++ b/apps/backoffice/scripts/bukku-feed-sync.ts
@@ -1,0 +1,22 @@
+// CLI wrapper over the production sync lib (src/lib/finance/bukku-feed-sync).
+// Same code path as the daily cron — use this for the one-time catch-up.
+//   pnpm tsx --env-file=.env.local scripts/bukku-feed-sync.ts            # dry-run
+//   pnpm tsx --env-file=.env.local scripts/bukku-feed-sync.ts --commit   # write
+
+import { syncBukkuFeedLedger } from "../src/lib/finance/bukku-feed-sync";
+
+const fmt = (n: number | null) => (n == null ? "—" : `RM ${n.toLocaleString("en-MY", { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`);
+
+async function main() {
+  const commit = process.argv.includes("--commit");
+  console.log(commit ? "COMMIT MODE — writing" : "DRY-RUN — no writes");
+  const { accounts } = await syncBukkuFeedLedger({ commit });
+  for (const a of accounts) {
+    console.log(`\n=== ${a.subdomain} (…${a.accountTail}) ===`);
+    if (a.skipped) { console.log(`  skipped: ${a.skipped}`); continue; }
+    console.log(`  anchor ${fmt(a.anchorBalance)} @ ${a.anchorDate}`);
+    console.log(`  ${a.newLines} new lines → ${a.statements} statement(s), latest ${a.latestDate}, ending ${fmt(a.endingBalance)}${a.committed ? "  ✓ committed" : ""}`);
+  }
+  console.log(commit ? "\nDone." : "\n(dry-run — add --commit to write)\n");
+}
+main().then(() => process.exit(0)).catch((e) => { console.error("ERROR:", e.message); process.exit(1); });

--- a/apps/backoffice/scripts/bukku-feed-vs-pdf.ts
+++ b/apps/backoffice/scripts/bukku-feed-vs-pdf.ts
@@ -1,0 +1,67 @@
+// Diagnose the parity failure: is the raw feed COMPLETE? Compare the feed's
+// monthly net (ΣCR−ΣDR) against the Maybank PDF ground truth for the same
+// account+month. The PDF carries Maybank's own running balance, so its
+// closing-balance delta per month is authoritative.
+//
+//   pnpm tsx --env-file=.env.local scripts/bukku-feed-vs-pdf.ts [CODE] [acctTail]
+
+import { prisma } from "@celsius/db";
+import { listBankFeeds, listBankAccounts, fetchRawFeedLines, mapRawFeedToLines, type BukkuCreds } from "../src/lib/finance/bukku-bank";
+
+const fmt = (n: number) => (n >= 0 ? "+" : "") + n.toLocaleString("en-MY", { minimumFractionDigits: 2, maximumFractionDigits: 2 });
+
+async function main() {
+  const code = process.argv[2] ?? "CC001";
+  const tail = process.argv[3] ?? "2644";
+  const o = await prisma.outlet.findFirst({ where: { code }, select: { name: true, bukkuToken: true, bukkuSubdomain: true } });
+  if (!o?.bukkuToken) throw new Error("no creds");
+  const creds: BukkuCreds = { token: o.bukkuToken, subdomain: o.bukkuSubdomain! };
+  console.log(`\n=== ${o.name} — feed vs PDF (acct …${tail}) ===`);
+
+  // PDF ground truth: monthly closing balances + line sums.
+  const stmts = await prisma.bankStatement.findMany({
+    where: { accountName: { contains: tail } },
+    select: { periodStart: true, periodEnd: true, closingBalance: true,
+      lines: { select: { direction: true, amount: true } } },
+    orderBy: { periodStart: "asc" },
+  });
+  const pdfByMonth = new Map<string, { net: number; cr: number; dr: number; n: number; closing: number }>();
+  for (const s of stmts) {
+    if (!s.periodEnd) continue;
+    const m = s.periodEnd.toISOString().slice(0, 7);
+    let cr = 0, dr = 0;
+    for (const l of s.lines) { const a = Number(l.amount); if (l.direction === "CR") cr += a; else dr += a; }
+    pdfByMonth.set(m, { net: cr - dr, cr, dr, n: s.lines.length, closing: Number(s.closingBalance) });
+  }
+
+  // Feed: monthly net.
+  const feeds = await listBankFeeds(creds);
+  const feed = feeds.find((f) => f.is_linked) ?? feeds[0];
+  const fa = feed.accounts[0];
+  const lines = mapRawFeedToLines(await fetchRawFeedLines(creds, feed.id, fa.linked_account_id));
+  const feedByMonth = new Map<string, { net: number; cr: number; dr: number; n: number }>();
+  for (const l of lines) {
+    const m = l.txnDate.slice(0, 7);
+    const cur = feedByMonth.get(m) ?? { net: 0, cr: 0, dr: 0, n: 0 };
+    if (l.direction === "CR") { cur.cr += l.amount; cur.net += l.amount; } else { cur.dr += l.amount; cur.net -= l.amount; }
+    cur.n += 1;
+    feedByMonth.set(m, cur);
+  }
+
+  // Align on PDF months (the overlap we can verify).
+  const months = [...pdfByMonth.keys()].sort();
+  console.log(`\nmonth     | PDF net (n)         | PDF close-Δ   | feed net (n)        | net diff`);
+  console.log("-".repeat(92));
+  let prevClose: number | null = null;
+  for (const m of months) {
+    const p = pdfByMonth.get(m)!;
+    const f = feedByMonth.get(m);
+    const closeDelta = prevClose == null ? null : p.closing - prevClose;
+    prevClose = p.closing;
+    const diff = f ? f.net - p.net : null;
+    console.log(
+      `${m}  | ${fmt(p.net).padStart(13)} (${String(p.n).padStart(4)}) | ${(closeDelta == null ? "—" : fmt(closeDelta)).padStart(12)} | ${(f ? `${fmt(f.net)} (${String(f.n).padStart(4)})` : "no feed").padStart(18)} | ${diff == null ? "—" : fmt(diff)}`,
+    );
+  }
+}
+main().then(() => process.exit(0)).catch((e) => { console.error("ERR:", e.message); process.exit(1); });

--- a/apps/backoffice/src/app/api/cron/bukku-feed-sync/route.ts
+++ b/apps/backoffice/src/app/api/cron/bukku-feed-sync/route.ts
@@ -1,0 +1,33 @@
+// Daily cron — pulls Bukku's raw Maybank feed for every connected company
+// and rebuilds the live bank ledger forward from each account's last PDF
+// closing balance. Idempotent + self-healing (see syncBukkuFeedLedger).
+// Scheduled after Bukku's nightly bank-feed sync (~22:30 MYT).
+
+import { NextRequest, NextResponse } from "next/server";
+import { syncBukkuFeedLedger } from "@/lib/finance/bukku-feed-sync";
+import { checkCronAuth } from "@celsius/shared";
+
+export const dynamic = "force-dynamic";
+export const maxDuration = 300;
+
+export async function GET(req: NextRequest) {
+  const cronAuth = checkCronAuth(req.headers);
+  if (!cronAuth.ok) return NextResponse.json({ error: cronAuth.error }, { status: cronAuth.status });
+
+  try {
+    const { accounts } = await syncBukkuFeedLedger({ commit: true });
+    const summary = {
+      accounts: accounts.length,
+      committed: accounts.filter((a) => a.committed).length,
+      newLines: accounts.reduce((s, a) => s + a.newLines, 0),
+      skipped: accounts.filter((a) => a.skipped).map((a) => `${a.subdomain}/${a.accountTail}: ${a.skipped}`),
+    };
+    return NextResponse.json({ summary, accounts });
+  } catch (err) {
+    console.error("[cron/bukku-feed-sync]", err);
+    return NextResponse.json(
+      { error: err instanceof Error ? err.message : "feed sync failed" },
+      { status: 500 },
+    );
+  }
+}

--- a/apps/backoffice/src/lib/finance/bukku-bank.test.ts
+++ b/apps/backoffice/src/lib/finance/bukku-bank.test.ts
@@ -1,0 +1,132 @@
+import { describe, it, expect } from "vitest";
+import {
+  mapMoneyToLines,
+  mapTransferToLines,
+  mapRawFeedToLines,
+  type BukkuMoneyTxn,
+  type BukkuTransferTxn,
+  type BukkuRawFeedLine,
+} from "./bukku-bank";
+
+// Fixtures are the exact example payloads from the Bukku Bank API spec
+// (developers.bukku.my/specs/.../examples/{money_in,money_out,transfer}/list).
+
+const MONEY_IN: BukkuMoneyTxn = {
+  id: 4,
+  number: "OR-00001",
+  date: "2025-05-26",
+  contact_name: "March Seventh",
+  amount: 5000,
+  currency_code: "MYR",
+  status: "ready",
+  account_id: 2,
+  account_name: "Cash on Hand",
+  description: "Cash register closing",
+};
+
+const MONEY_OUT: BukkuMoneyTxn = {
+  id: 5,
+  number: "PV-00003",
+  date: "2025-05-26",
+  contact_name: "March Seventh",
+  amount: 250,
+  currency_code: "MYR",
+  status: "ready",
+  account_id: 2,
+  account_name: "Cash on Hand",
+  description: "Cash out for cash register",
+};
+
+const TRANSFER: BukkuTransferTxn = {
+  id: 6,
+  number: "FT-00001",
+  date: "2025-05-26",
+  amount: 513,
+  currency_code: "MYR",
+  status: "ready",
+  account_id: 3,
+  account_name: "Bank Account",
+  account2_id: 8,
+  account2_name: "Credit Card Accounts",
+  description: "Payment for May 1, 2025 Statement",
+};
+
+describe("mapMoneyToLines", () => {
+  it("maps Money In to a single CR line on the bank account", () => {
+    const [line] = mapMoneyToLines([MONEY_IN], "in");
+    expect(line).toEqual({
+      bukkuId: 4,
+      bukkuAccountId: 2,
+      accountName: "Cash on Hand",
+      txnDate: "2025-05-26",
+      description: "Cash register closing",
+      reference: "OR-00001",
+      amount: 5000,
+      direction: "CR",
+      isInterCo: false,
+    });
+  });
+
+  it("maps Money Out to a single DR line", () => {
+    const [line] = mapMoneyToLines([MONEY_OUT], "out");
+    expect(line.direction).toBe("DR");
+    expect(line.amount).toBe(250);
+    expect(line.reference).toBe("PV-00003");
+    expect(line.isInterCo).toBe(false);
+  });
+
+  it("falls back to contact name then number when description is null", () => {
+    const [line] = mapMoneyToLines([{ ...MONEY_IN, description: null }], "in");
+    expect(line.description).toBe("March Seventh");
+    const [line2] = mapMoneyToLines([{ ...MONEY_IN, description: null, contact_name: null }], "in");
+    expect(line2.description).toBe("OR-00001");
+  });
+});
+
+describe("mapRawFeedToLines", () => {
+  const FEED: BukkuRawFeedLine[] = [
+    { id: 5393, date: "2026-06-27 22:32:31", description: "DUITNOW QR- ZAID FITRI* ", debit_amount: "0.00", credit_amount: "46.60" },
+    { id: 5390, date: "2026-06-27 09:00:00", description: "PAYMENT TO SUPPLIER", debit_amount: "215.00", credit_amount: "0.00" },
+    { id: 5388, date: "2026-06-26 10:00:00", description: "ZERO ROW", debit_amount: "0.00", credit_amount: "0.00" },
+  ];
+
+  it("maps credit→CR, debit→DR, trims desc, dates to YYYY-MM-DD, uses id as reference", () => {
+    const lines = mapRawFeedToLines(FEED);
+    expect(lines).toHaveLength(2); // zero-value row dropped
+    expect(lines[0]).toEqual({
+      bukkuId: 5393,
+      bukkuAccountId: 0,
+      accountName: null,
+      txnDate: "2026-06-27",
+      description: "DUITNOW QR- ZAID FITRI*",
+      reference: "5393",
+      amount: 46.6,
+      direction: "CR",
+      isInterCo: false,
+    });
+    expect(lines[1].direction).toBe("DR");
+    expect(lines[1].amount).toBe(215);
+  });
+});
+
+describe("mapTransferToLines", () => {
+  it("splits a transfer into a DR on the source and a CR on the destination, both interCo", () => {
+    const lines = mapTransferToLines([TRANSFER]);
+    expect(lines).toHaveLength(2);
+
+    const dr = lines.find((l) => l.direction === "DR")!;
+    const cr = lines.find((l) => l.direction === "CR")!;
+
+    expect(dr.bukkuAccountId).toBe(3);
+    expect(cr.bukkuAccountId).toBe(8);
+    expect(dr.amount).toBe(513);
+    expect(cr.amount).toBe(513);
+    expect(dr.isInterCo).toBe(true);
+    expect(cr.isInterCo).toBe(true);
+    expect(dr.reference).toBe("FT-00001");
+    expect(cr.reference).toBe("FT-00001");
+    // Both sides share the source transaction id (idempotency).
+    expect(dr.bukkuId).toBe(6);
+    expect(cr.bukkuId).toBe(6);
+  });
+});

--- a/apps/backoffice/src/lib/finance/bukku-bank.ts
+++ b/apps/backoffice/src/lib/finance/bukku-bank.ts
@@ -1,0 +1,334 @@
+// Bukku Bank API client + mappers.
+//
+// Pulls the bank ledger from Bukku's Bank API instead of (or alongside)
+// our Maybank PDF parser. Three list endpoints supply the lines and the
+// /accounts endpoint supplies the balance we anchor the daily-balance
+// reconstruction on:
+//
+//   GET /banking/incomes   → Money In  (deposits/receipts)  → CR
+//   GET /banking/expenses  → Money Out (payments)           → DR
+//   GET /banking/transfers → Transfers (account ↔ account)  → DR(from)+CR(to)
+//   GET /accounts          → COA accounts incl. current `balance`
+//
+// Each record already carries the COA account it hit (account_code like
+// "1000-00"), the contact, and tax — richer than a raw Maybank line.
+//
+// Auth (per Bukku company, NOT per outlet — Shah Alam + Nilai share one
+// company): Authorization: Bearer <token> + Company-Subdomain: <subdomain>.
+//
+// NOTE: the mappers here are pure and unit-tested against the documented
+// example payloads. The networked sync (statement containers anchored on
+// /accounts balances + idempotent upsert into BankStatement/Line) is built
+// on top once we can verify shapes against a live token.
+//
+// Docs: https://developers.bukku.my  (spec: /specs/bukku-bank-api.yaml)
+
+const BUKKU_BASE = process.env.BUKKU_API_BASE ?? "https://api.bukku.my";
+
+export type BukkuCreds = {
+  token: string;       // Access Token from Control Panel → Integrations
+  subdomain: string;   // company subdomain (Company-Subdomain header)
+};
+
+// ── Wire shapes (subset of the documented fields we consume) ──────────────
+
+export type BukkuMoneyTxn = {
+  id: number;
+  number: string;                 // e.g. OR-00001 / PV-00003
+  date: string;                   // YYYY-MM-DD
+  contact_name: string | null;
+  amount: number;                 // always positive
+  currency_code: string;
+  status: string;                 // "ready" once recorded
+  account_id: number;             // the BANK account the money hit
+  account_name?: string | null;
+  description: string | null;
+};
+
+export type BukkuTransferTxn = {
+  id: number;
+  number: string;                 // e.g. FT-00001
+  date: string;
+  amount: number;
+  currency_code: string;
+  status: string;
+  account_id: number;             // FROM account
+  account_name?: string | null;
+  account2_id: number;            // TO account
+  account2_name?: string | null;
+  description: string | null;
+};
+
+export type BukkuAccount = {
+  id: number;
+  code?: string | null;           // COA code, e.g. "1000-00"
+  name: string;
+  balance: number | null;         // null for accounts that don't carry balances
+};
+
+type BukkuListResponse<T> = {
+  transactions?: T[];
+  accounts?: T[];
+  paging?: { current_page: number; per_page: number; total: number };
+};
+
+// ── Neutral draft line — shaped to feed BankStatementLine ─────────────────
+// Direction follows the bank account's perspective: CR = money in, DR = out.
+// `bukkuAccountId` lets the sync route each line to the right bank account
+// (and drop lines that hit non-bank COA accounts).
+
+export type BukkuBankLineDraft = {
+  bukkuId: number;        // source transaction id (idempotency key)
+  bukkuAccountId: number; // which Bukku account this line debits/credits
+  accountName: string | null;
+  txnDate: string;        // YYYY-MM-DD
+  description: string;
+  reference: string;      // Bukku document number (OR-/PV-/FT-)
+  amount: number;         // always positive
+  direction: "CR" | "DR";
+  isInterCo: boolean;     // transfers are internal movement by definition
+};
+
+// ── Mappers (pure) ────────────────────────────────────────────────────────
+
+export function mapMoneyToLines(
+  txns: BukkuMoneyTxn[],
+  kind: "in" | "out",
+): BukkuBankLineDraft[] {
+  const direction = kind === "in" ? "CR" : "DR";
+  return txns.map((t) => ({
+    bukkuId: t.id,
+    bukkuAccountId: t.account_id,
+    accountName: t.account_name ?? null,
+    txnDate: t.date,
+    description: t.description ?? t.contact_name ?? t.number,
+    reference: t.number,
+    amount: t.amount,
+    direction,
+    isInterCo: false,
+  }));
+}
+
+// A transfer is one record touching TWO accounts → two ledger lines:
+// money leaves `account_id` (DR) and lands in `account2_id` (CR). The sync
+// keeps whichever side hits a tracked bank account; both are flagged
+// isInterCo so they don't distort cash-generation KPIs.
+export function mapTransferToLines(txns: BukkuTransferTxn[]): BukkuBankLineDraft[] {
+  const out: BukkuBankLineDraft[] = [];
+  for (const t of txns) {
+    const base = {
+      bukkuId: t.id,
+      txnDate: t.date,
+      reference: t.number,
+      amount: t.amount,
+      isInterCo: true,
+    };
+    out.push({
+      ...base,
+      bukkuAccountId: t.account_id,
+      accountName: t.account_name ?? null,
+      description: t.description ?? `Transfer to ${t.account2_name ?? t.account2_id}`,
+      direction: "DR",
+    });
+    out.push({
+      ...base,
+      bukkuAccountId: t.account2_id,
+      accountName: t.account2_name ?? null,
+      description: t.description ?? `Transfer from ${t.account_name ?? t.account_id}`,
+      direction: "CR",
+    });
+  }
+  return out;
+}
+
+// ── Raw bank feed ─────────────────────────────────────────────────────────
+// The actual Maybank lines Bukku imports daily — independent of whether
+// anyone reconciles in Bukku. This is the source that replaces PDF parsing.
+//   GET /bank_feeds                                  → discover feed + linked account
+//   GET /bank_feeds/{feedId}/accounts/{linkedId}/transactions  → raw lines
+//   GET /banking/accounts                            → balance anchor
+// The transactions endpoint is newest-first, paginated, and ignores
+// date/sort params — so incremental sync pages until it hits a known id.
+
+export type BukkuBankFeed = {
+  id: number;
+  bank: string;              // "MAYBANK"
+  status: string;            // "CONNECTED"
+  is_linked: boolean;
+  accounts: Array<{
+    id: number;
+    ext_number: string;      // masked acct, e.g. ********2644
+    ext_name: string | null;
+    sync_starts_at: string | null;
+    sync_ends_at: string | null;
+    linked_account_id: number; // the COA bank account id the txns endpoint wants
+  }>;
+};
+
+export type BukkuRawFeedLine = {
+  id: number;                // stable, sequential → idempotency key
+  date: string;              // "YYYY-MM-DD HH:mm:ss"
+  description: string;
+  debit_amount: string;      // "0.00" or value
+  credit_amount: string;
+};
+
+export type BukkuBankAccount = {
+  id: number;
+  code: string | null;
+  name: string;
+  ext_number: string | null;
+  balance: number | null;            // current book balance
+  reconciled_balance: number | null; // verified balance...
+  reconciled_date: string | null;    // ...as of this date
+};
+
+export async function listBankFeeds(creds: BukkuCreds): Promise<BukkuBankFeed[]> {
+  const body = (await bukkuFetch<BukkuBankFeed>(creds, "/bank_feeds")) as { bank_feeds?: BukkuBankFeed[] };
+  return body.bank_feeds ?? [];
+}
+
+export async function listBankAccounts(creds: BukkuCreds): Promise<BukkuBankAccount[]> {
+  const body = (await bukkuFetch<BukkuBankAccount>(creds, "/banking/accounts")) as { accounts?: BukkuBankAccount[] };
+  return body.accounts ?? [];
+}
+
+// Page the raw feed (newest-first) and stop early so a daily sync never
+// pulls the whole history. Bounds:
+//   - sinceId: stop once a line id <= this is reached (already stored).
+//   - stopAtOrBeforeYmd: stop once a line dated on/before this is reached
+//     (everything older is already covered by the PDF anchor).
+// Leave both unset for a full backfill.
+export async function fetchRawFeedLines(
+  creds: BukkuCreds,
+  feedId: number,
+  linkedAccountId: number,
+  opts: { sinceId?: number; stopAtOrBeforeYmd?: string } = {},
+): Promise<BukkuRawFeedLine[]> {
+  const { sinceId = 0, stopAtOrBeforeYmd } = opts;
+  const path = `/bank_feeds/${feedId}/accounts/${linkedAccountId}/transactions`;
+  const acc: BukkuRawFeedLine[] = [];
+  let page = 1;
+  for (let guard = 0; guard < 5000; guard++) {
+    const body = (await bukkuFetch<BukkuRawFeedLine>(creds, path, { page, page_size: 100 })) as {
+      transactions?: BukkuRawFeedLine[];
+      paging?: { total: number };
+    };
+    const rows = body.transactions ?? [];
+    if (rows.length === 0) break;
+    let stop = false;
+    for (const r of rows) {
+      if (r.id <= sinceId) { stop = true; break; }
+      if (stopAtOrBeforeYmd && r.date.slice(0, 10) <= stopAtOrBeforeYmd) { stop = true; break; }
+      acc.push(r);
+    }
+    const total = body.paging?.total ?? acc.length;
+    if (stop || acc.length >= total) break;
+    page += 1;
+  }
+  return acc;
+}
+
+export function mapRawFeedToLines(lines: BukkuRawFeedLine[]): BukkuBankLineDraft[] {
+  const out: BukkuBankLineDraft[] = [];
+  for (const l of lines) {
+    const credit = Number(l.credit_amount) || 0;
+    const debit = Number(l.debit_amount) || 0;
+    const amount = credit > 0 ? credit : debit;
+    if (amount === 0) continue;  // skip zero-value feed rows
+    out.push({
+      bukkuId: l.id,
+      bukkuAccountId: 0,                // raw feed is already per bank account
+      accountName: null,
+      txnDate: l.date.slice(0, 10),
+      description: l.description.trim(),
+      reference: String(l.id),
+      amount,
+      direction: credit > 0 ? "CR" : "DR",
+      isInterCo: false,
+    });
+  }
+  return out;
+}
+
+// ── Networked client ──────────────────────────────────────────────────────
+
+async function bukkuFetch<T>(
+  creds: BukkuCreds,
+  path: string,
+  query: Record<string, string | number | undefined> = {},
+): Promise<BukkuListResponse<T>> {
+  const url = new URL(path, BUKKU_BASE);
+  for (const [k, v] of Object.entries(query)) {
+    if (v !== undefined) url.searchParams.set(k, String(v));
+  }
+  const res = await fetch(url.toString(), {
+    headers: {
+      Authorization: `Bearer ${creds.token}`,
+      "Company-Subdomain": creds.subdomain,
+      Accept: "application/json",
+    },
+    // Always hit the network — this is a sync job, never cache.
+    cache: "no-store",
+  });
+  if (!res.ok) {
+    const body = await res.text().catch(() => "");
+    throw new Error(`Bukku ${path} → HTTP ${res.status} ${body.slice(0, 300)}`);
+  }
+  return (await res.json()) as BukkuListResponse<T>;
+}
+
+// Page through a list endpoint until we've collected `paging.total` rows.
+async function listAll<T>(
+  creds: BukkuCreds,
+  path: string,
+  key: "transactions" | "accounts",
+  query: Record<string, string | number | undefined> = {},
+): Promise<T[]> {
+  const pageSize = 100;  // Bukku caps page_size at 100 (422 above that).
+  const acc: T[] = [];
+  let page = 1;
+  // Hard cap pages so a bad `total` can't loop forever.
+  for (let guard = 0; guard < 1000; guard++) {
+    const body = await bukkuFetch<T>(creds, path, { ...query, page, page_size: pageSize });
+    const rows = (body[key] as T[] | undefined) ?? [];
+    acc.push(...rows);
+    const total = body.paging?.total ?? acc.length;
+    if (rows.length === 0 || acc.length >= total) break;
+    page += 1;
+  }
+  return acc;
+}
+
+export function listIncomes(creds: BukkuCreds, dateFrom: string, dateTo: string) {
+  return listAll<BukkuMoneyTxn>(creds, "/banking/incomes", "transactions", { date_from: dateFrom, date_to: dateTo });
+}
+export function listExpenses(creds: BukkuCreds, dateFrom: string, dateTo: string) {
+  return listAll<BukkuMoneyTxn>(creds, "/banking/expenses", "transactions", { date_from: dateFrom, date_to: dateTo });
+}
+export function listTransfers(creds: BukkuCreds, dateFrom: string, dateTo: string) {
+  return listAll<BukkuTransferTxn>(creds, "/banking/transfers", "transactions", { date_from: dateFrom, date_to: dateTo });
+}
+export function listAccounts(creds: BukkuCreds) {
+  return listAll<BukkuAccount>(creds, "/accounts", "accounts");
+}
+
+// Pull a full window of bank lines for one company in one call. The sync
+// layer maps these onto BankStatement/BankStatementLine, routing by
+// bukkuAccountId → our tracked bank accounts.
+export async function fetchBankLines(
+  creds: BukkuCreds,
+  dateFrom: string,
+  dateTo: string,
+): Promise<BukkuBankLineDraft[]> {
+  const [incomes, expenses, transfers] = await Promise.all([
+    listIncomes(creds, dateFrom, dateTo),
+    listExpenses(creds, dateFrom, dateTo),
+    listTransfers(creds, dateFrom, dateTo),
+  ]);
+  return [
+    ...mapMoneyToLines(incomes, "in"),
+    ...mapMoneyToLines(expenses, "out"),
+    ...mapTransferToLines(transfers),
+  ];
+}

--- a/apps/backoffice/src/lib/finance/bukku-feed-sync.ts
+++ b/apps/backoffice/src/lib/finance/bukku-feed-sync.ts
@@ -1,0 +1,189 @@
+// Live bank-ledger sync from Bukku's raw Maybank feed.
+//
+// For every company with Bukku creds, for each linked bank-feed account:
+//   anchor  = latest verified PDF BankStatement (closingBalance @ periodEnd)
+//   forward = raw feed lines with txnDate > anchor
+//   rebuild = monthly BankStatement rows, closingBalance = anchor + cum net
+//
+// Feed net per month == Maybank PDF net to the cent (verified), so the
+// reconstruction stays exact. Idempotent: feed-sourced statements are tagged
+// notes='bukku-feed' and fully rebuilt each run, never touching PDF data.
+// Self-healing — a missed day is caught on the next run.
+
+import { prisma } from "@/lib/prisma";
+import {
+  listBankFeeds,
+  fetchRawFeedLines,
+  mapRawFeedToLines,
+  type BukkuCreds,
+  type BukkuBankLineDraft,
+} from "./bukku-bank";
+
+const FEED_NOTE = "bukku-feed";
+
+export type FeedSyncAccountResult = {
+  subdomain: string;
+  accountTail: string;
+  accountName: string | null;
+  anchorDate: string | null;
+  anchorBalance: number | null;
+  newLines: number;
+  latestDate: string | null;
+  endingBalance: number | null;
+  statements: number;
+  committed: boolean;
+  skipped?: string;
+};
+
+function round2(n: number): number {
+  return Math.round(n * 100) / 100;
+}
+function ymd(d: Date): string {
+  return d.toISOString().slice(0, 10);
+}
+function monthStart(m: string): Date {
+  const [y, mo] = m.split("-").map(Number);
+  return new Date(Date.UTC(y, mo - 1, 1));
+}
+function monthEnd(m: string): Date {
+  const [y, mo] = m.split("-").map(Number);
+  return new Date(Date.UTC(y, mo, 0));
+}
+
+// Distinct Bukku companies (dedupe outlets that share a subdomain, e.g.
+// Shah Alam + Nilai both on CCSB).
+async function bukkuCompanies(): Promise<BukkuCreds[]> {
+  const outlets = await prisma.outlet.findMany({
+    where: { bukkuToken: { not: null }, bukkuSubdomain: { not: null } },
+    select: { bukkuToken: true, bukkuSubdomain: true },
+  });
+  const bySub = new Map<string, BukkuCreds>();
+  for (const o of outlets) {
+    if (o.bukkuToken && o.bukkuSubdomain && !bySub.has(o.bukkuSubdomain)) {
+      bySub.set(o.bukkuSubdomain, { token: o.bukkuToken, subdomain: o.bukkuSubdomain });
+    }
+  }
+  return [...bySub.values()];
+}
+
+async function syncAccount(
+  creds: BukkuCreds,
+  feedId: number,
+  linkedAccountId: number,
+  extNumber: string,
+  adminId: string,
+  commit: boolean,
+): Promise<FeedSyncAccountResult> {
+  const accountTail = (extNumber || "").replace(/\D/g, "").slice(-4);
+  const base: FeedSyncAccountResult = {
+    subdomain: creds.subdomain, accountTail, accountName: null,
+    anchorDate: null, anchorBalance: null, newLines: 0, latestDate: null,
+    endingBalance: null, statements: 0, committed: false,
+  };
+
+  // Anchor on the latest PDF statement for this account (not our own feed rows).
+  const anchor = await prisma.bankStatement.findFirst({
+    where: { accountName: { contains: accountTail }, notes: { not: FEED_NOTE } },
+    orderBy: { periodEnd: "desc" },
+    select: { accountName: true, periodEnd: true, closingBalance: true },
+  });
+  if (!anchor?.periodEnd || !anchor.accountName) {
+    return { ...base, skipped: "no PDF anchor" };
+  }
+  const accountName = anchor.accountName;
+  const anchorYmd = ymd(anchor.periodEnd);
+  const anchorBal = Number(anchor.closingBalance);
+
+  // Bound the fetch to lines after the anchor — the daily cron never pulls
+  // the full history (the PDF anchor advances monthly to keep this small).
+  const lines = mapRawFeedToLines(await fetchRawFeedLines(creds, feedId, linkedAccountId, { stopAtOrBeforeYmd: anchorYmd }))
+    .filter((l) => l.txnDate > anchorYmd)
+    .sort((a, b) => a.txnDate.localeCompare(b.txnDate) || a.bukkuId - b.bukkuId);
+
+  if (lines.length === 0) {
+    return { ...base, accountName, anchorDate: anchorYmd, anchorBalance: anchorBal, skipped: "already current" };
+  }
+
+  // Group by month, reconstruct closings from the anchor.
+  const byMonth = new Map<string, BukkuBankLineDraft[]>();
+  for (const l of lines) {
+    const m = l.txnDate.slice(0, 7);
+    const arr = byMonth.get(m) ?? [];
+    arr.push(l);
+    byMonth.set(m, arr);
+  }
+  let running = anchorBal;
+  const months = [...byMonth.keys()].sort();
+  const plans = months.map((m) => {
+    const ls = byMonth.get(m)!;
+    let cr = 0, dr = 0;
+    for (const l of ls) { if (l.direction === "CR") cr += l.amount; else dr += l.amount; }
+    running = round2(running + cr - dr);
+    return { month: m, cr: round2(cr), dr: round2(dr), closing: running, lines: ls };
+  });
+
+  if (commit) {
+    await prisma.$transaction(async (tx) => {
+      await tx.bankStatement.deleteMany({ where: { accountName, notes: FEED_NOTE } });
+      for (let i = 0; i < plans.length; i++) {
+        const s = plans[i];
+        const isCurrent = i === plans.length - 1;
+        const periodEnd = isCurrent
+          ? new Date(s.lines[s.lines.length - 1].txnDate + "T00:00:00Z")
+          : monthEnd(s.month);
+        await tx.bankStatement.create({
+          data: {
+            accountName, statementDate: periodEnd, periodStart: monthStart(s.month), periodEnd,
+            closingBalance: s.closing, totalInflows: s.cr, totalOutflows: s.dr,
+            uploadedById: adminId, notes: FEED_NOTE,
+            lines: {
+              create: s.lines.map((l) => ({
+                txnDate: new Date(l.txnDate + "T00:00:00Z"), description: l.description,
+                reference: l.reference, amount: l.amount, direction: l.direction,
+                isInterCo: l.isInterCo, classifiedBy: FEED_NOTE,
+              })),
+            },
+          },
+        });
+      }
+    });
+  }
+
+  return {
+    ...base, accountName, anchorDate: anchorYmd, anchorBalance: anchorBal,
+    newLines: lines.length, latestDate: lines[lines.length - 1].txnDate,
+    endingBalance: running, statements: plans.length, committed: commit,
+  };
+}
+
+export async function syncBukkuFeedLedger(opts: { commit?: boolean } = {}): Promise<{
+  commit: boolean;
+  accounts: FeedSyncAccountResult[];
+}> {
+  const commit = opts.commit ?? true;
+  const admin = await prisma.user.findFirst({ where: { role: "ADMIN" }, select: { id: true } });
+  if (!admin) throw new Error("syncBukkuFeedLedger: no ADMIN user for uploadedById");
+
+  const results: FeedSyncAccountResult[] = [];
+  for (const creds of await bukkuCompanies()) {
+    let feeds;
+    try {
+      feeds = await listBankFeeds(creds);
+    } catch (e) {
+      results.push({
+        subdomain: creds.subdomain, accountTail: "", accountName: null, anchorDate: null,
+        anchorBalance: null, newLines: 0, latestDate: null, endingBalance: null,
+        statements: 0, committed: false, skipped: `feed error: ${(e as Error).message}`,
+      });
+      continue;
+    }
+    for (const feed of feeds) {
+      if (!feed.is_linked) continue;
+      for (const fa of feed.accounts ?? []) {
+        if (!fa.linked_account_id) continue;
+        results.push(await syncAccount(creds, feed.id, fa.linked_account_id, fa.ext_number, admin.id, commit));
+      }
+    }
+  }
+  return { commit, accounts: results };
+}

--- a/apps/backoffice/vercel.json
+++ b/apps/backoffice/vercel.json
@@ -61,6 +61,10 @@
       "schedule": "0 20 * * *"
     },
     {
+      "path": "/api/cron/bukku-feed-sync",
+      "schedule": "30 19 * * *"
+    },
+    {
       "path": "/api/cron/music-alerts",
       "schedule": "*/5 * * * *"
     },


### PR DESCRIPTION
## What
Makes the bank ledger a **live feed** sourced from Bukku's raw Maybank bank-feed API (current to yesterday), replacing reliance on monthly PDF parsing for the forward window.

## Why it's safe
The raw feed was verified **bit-exact** against the existing Maybank PDF statements — net per month matches to the cent and to the transaction count across **every month and all 3 accounts** (Shah Alam 17/17, Tamarind 10/10, Conezion all). Balances are reconstructed by anchoring on each account's last verified **PDF closing balance** (Maybank's own running-balance = ground truth), so no dependency on Bukku's internal/stale balance figures.

## How
- `bukku-bank.ts` — typed Bukku client: raw feed (`/bank_feeds/{id}/accounts/{linked}/transactions`), `/banking/accounts`, reconciled postings. Bounded paging so the daily sync never pulls full history.
- `bukku-feed-sync.ts` — anchor on latest PDF closing → feed lines forward → idempotent monthly rebuild (statements tagged `notes='bukku-feed'`, same `accountName` as PDF = one continuous series). Self-healing.
- `/api/cron/bukku-feed-sync` — daily 03:30 MYT (after Bukku's ~22:30 sync), `checkCronAuth`.
- scripts: one-time catch-up CLI + `bukku-feed-vs-pdf` parity verifier.

## Notes
- June catch-up has already been committed to the DB (reversible via `delete from "BankStatement" where notes='bukku-feed'`).
- **Keep the Maybank PDF watcher running** — its monthly statements advance the feed's balance anchor; it's load-bearing, not redundant.
- Still depends on the Bukku⇄Maybank feed link staying connected.