### PR TITLE
feat(finance): daily bank balance as the cashflow hero, with comparison

### DIFF
--- a/apps/backoffice/src/app/(admin)/finance/cashflow/DailyBalancePanel.tsx
+++ b/apps/backoffice/src/app/(admin)/finance/cashflow/DailyBalancePanel.tsx
@@ -1,0 +1,304 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import {
+  LineChart, Line, XAxis, YAxis, CartesianGrid, Tooltip, Legend, ReferenceDot, ResponsiveContainer,
+} from "recharts";
+import { Wallet, TrendingDown, TrendingUp } from "lucide-react";
+
+// Daily bank-balance hero for the Cashflow page. Reads the reconstructed
+// daily-balance series (consolidated + per-account + forward projection) and
+// offers two views, the bank-balance analogue of Sales Compare:
+//   • Timeline  — continuous end-of-day balance over a window, with the
+//                 forward projection bridged on and the lowest point marked.
+//   • Compare   — overlay calendar periods (months or weeks) aligned by
+//                 day-index, so you can eyeball this month's cash curve vs
+//                 last month's.
+// All filtering is client-side over the 12-month series the API already sends.
+
+export type DailyBalance = {
+  asOf: string | null;
+  accounts: string[];
+  consolidated: { date: string; balance: number }[];
+  perAccount: { account: string; points: { date: string; balance: number }[] }[];
+  projected: { date: string; balance: number }[];
+  minPoint: { date: string; balance: number } | null;
+};
+
+const PALETTE = ["#C2452D", "#3B82F6", "#10B981", "#F59E0B", "#8B5CF6", "#EC4899", "#06B6D4", "#84CC16"];
+const fmtRM = (n: number) => `RM ${n.toLocaleString("en-MY", { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`;
+const fmtRMk = (n: number) => (Math.abs(n) >= 1000 ? `${(n / 1000).toFixed(0)}K` : `${n}`);
+const MONTHS = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"];
+const DOW = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"];
+
+function fmtDay(d: string) {
+  const dt = new Date(d + "T12:00:00+08:00");
+  return `${dt.getDate()} ${MONTHS[dt.getMonth()]}`;
+}
+function todayMyt() {
+  return new Date(Date.now() + 8 * 3600_000).toISOString().slice(0, 10);
+}
+function addDays(d: string, n: number) {
+  const dt = new Date(d + "T12:00:00+08:00");
+  dt.setDate(dt.getDate() + n);
+  return dt.toISOString().slice(0, 10);
+}
+// Monday-based weekday index 0..6.
+function dowIndex(d: string) {
+  const day = new Date(d + "T12:00:00+08:00").getDay();
+  return day === 0 ? 6 : day - 1;
+}
+
+type Mode = "timeline" | "compare";
+type Source = "combined" | "each" | string; // "each" = per-account lines
+type WindowKey = "30" | "90" | "180" | "365" | "max";
+type CompareKey = "mom" | "m3" | "wow" | "w4";
+
+const WINDOWS: { key: WindowKey; label: string; days: number | null }[] = [
+  { key: "30", label: "30D", days: 30 },
+  { key: "90", label: "90D", days: 90 },
+  { key: "180", label: "6M", days: 180 },
+  { key: "365", label: "12M", days: 365 },
+  { key: "max", label: "Max", days: null },
+];
+const COMPARES: { key: CompareKey; label: string; unit: "month" | "week"; count: number }[] = [
+  { key: "mom", label: "Month vs last", unit: "month", count: 2 },
+  { key: "m3", label: "Last 3 months", unit: "month", count: 3 },
+  { key: "wow", label: "Week vs last", unit: "week", count: 2 },
+  { key: "w4", label: "Last 4 weeks", unit: "week", count: 4 },
+];
+
+export default function DailyBalancePanel({ db }: { db: DailyBalance }) {
+  const [mode, setMode] = useState<Mode>("timeline");
+  const [source, setSource] = useState<Source>("combined");
+  const [windowKey, setWindowKey] = useState<WindowKey>("90");
+  const [compareKey, setCompareKey] = useState<CompareKey>("mom");
+  const [showProjection, setShowProjection] = useState(true);
+
+  const hasData = db.consolidated.length > 0 || db.perAccount.some((a) => a.points.length > 0);
+
+  // The single active series for combined / single-account selections.
+  const activeSeries = useMemo<{ date: string; balance: number }[]>(() => {
+    if (source === "combined" || source === "each") return db.consolidated;
+    return db.perAccount.find((a) => a.account === source)?.points ?? [];
+  }, [db, source]);
+
+  // ── Timeline rows ────────────────────────────────────────────────────────
+  const timeline = useMemo(() => {
+    const today = todayMyt();
+    const win = WINDOWS.find((w) => w.key === windowKey)!;
+    const start = win.days ? addDays(today, -win.days) : "0000-00-00";
+
+    if (source === "each") {
+      const byDate = new Map<string, Record<string, number | string>>();
+      for (const acc of db.perAccount) {
+        for (const p of acc.points) {
+          if (p.date < start) continue;
+          const row = byDate.get(p.date) ?? { date: p.date };
+          row[acc.account] = p.balance;
+          byDate.set(p.date, row);
+        }
+      }
+      const rows = [...byDate.values()].sort((a, b) => String(a.date).localeCompare(String(b.date)));
+      const series = db.accounts.map((a, i) => ({ key: a, name: a, color: PALETTE[i % PALETTE.length], dashed: false }));
+      return { rows, series, projectedMin: null as null };
+    }
+
+    // Combined or single account → one "actual" line, optional projection.
+    const byDate = new Map<string, { date: string; actual: number | null; projected: number | null }>();
+    for (const p of activeSeries) {
+      if (p.date < start) continue;
+      byDate.set(p.date, { date: p.date, actual: p.balance, projected: null });
+    }
+    const series = [{ key: "actual", name: source === "combined" ? "Actual" : source, color: "#C2452D", dashed: false }];
+    // Projection only meaningful for the combined position.
+    if (showProjection && source === "combined" && activeSeries.length && db.projected.length) {
+      const lastActual = activeSeries[activeSeries.length - 1];
+      byDate.set(lastActual.date, { date: lastActual.date, actual: lastActual.balance, projected: lastActual.balance });
+      for (const p of db.projected) {
+        const row = byDate.get(p.date) ?? { date: p.date, actual: null, projected: null };
+        row.projected = p.balance;
+        byDate.set(p.date, row);
+      }
+      series.push({ key: "projected", name: "Projected", color: "#9CA3AF", dashed: true });
+    }
+    const rows = [...byDate.values()].sort((a, b) => a.date.localeCompare(b.date));
+    return { rows, series, projectedMin: null };
+  }, [db, source, activeSeries, windowKey, showProjection]);
+
+  // ── Compare rows (period overlay aligned by day-index) ───────────────────
+  const compare = useMemo(() => {
+    // Compare needs a single base series; "each" falls back to combined.
+    const series = source === "each" || source === "combined"
+      ? db.consolidated
+      : (db.perAccount.find((a) => a.account === source)?.points ?? []);
+    const cfg = COMPARES.find((c) => c.key === compareKey)!;
+    const today = todayMyt();
+    const byDate = new Map(series.map((p) => [p.date, p.balance]));
+
+    // Build the period buckets (most recent first), each a label + its date range.
+    type Period = { label: string; color: string; from: string; to: string };
+    const periods: Period[] = [];
+    if (cfg.unit === "month") {
+      const now = new Date(today + "T12:00:00+08:00");
+      for (let i = 0; i < cfg.count; i++) {
+        const d = new Date(now.getFullYear(), now.getMonth() - i, 1);
+        const from = `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-01`;
+        const last = new Date(d.getFullYear(), d.getMonth() + 1, 0);
+        const to = `${last.getFullYear()}-${String(last.getMonth() + 1).padStart(2, "0")}-${String(last.getDate()).padStart(2, "0")}`;
+        periods.push({ label: `${MONTHS[d.getMonth()]} ${d.getFullYear()}`, color: PALETTE[i % PALETTE.length], from, to });
+      }
+    } else {
+      // Weeks (Mon–Sun).
+      let monday = today;
+      while (dowIndex(monday) !== 0) monday = addDays(monday, -1);
+      for (let i = 0; i < cfg.count; i++) {
+        const from = addDays(monday, -7 * i);
+        const to = addDays(from, 6);
+        periods.push({ label: `${fmtDay(from)}`, color: PALETTE[i % PALETTE.length], from, to });
+      }
+    }
+
+    const axisLen = cfg.unit === "month" ? 31 : 7;
+    const rows: Record<string, number | string | null>[] = [];
+    for (let idx = 0; idx < axisLen; idx++) {
+      const row: Record<string, number | string | null> = { idx: cfg.unit === "month" ? idx + 1 : DOW[idx] };
+      for (const p of periods) {
+        const date = cfg.unit === "month"
+          ? `${p.from.slice(0, 8)}${String(idx + 1).padStart(2, "0")}`
+          : addDays(p.from, idx);
+        const inRange = date >= p.from && date <= p.to && date <= today;
+        row[p.label] = inRange && byDate.has(date) ? byDate.get(date)! : null;
+      }
+      rows.push(row);
+    }
+    return { rows, periods };
+  }, [db, source, compareKey]);
+
+  // ── Summary chips (from the active series, within the timeline window) ────
+  const stats = useMemo(() => {
+    const today = todayMyt();
+    const win = WINDOWS.find((w) => w.key === windowKey)!;
+    const start = win.days ? addDays(today, -win.days) : "0000-00-00";
+    const pts = activeSeries.filter((p) => p.date >= start);
+    if (pts.length === 0) return null;
+    const latest = pts[pts.length - 1];
+    const first = pts[0];
+    let min = pts[0];
+    for (const p of pts) if (p.balance < min.balance) min = p;
+    const change = latest.balance - first.balance;
+    return { latest, min, change };
+  }, [activeSeries, windowKey]);
+
+  const segBtn = (active: boolean) =>
+    `rounded-md px-2.5 py-1 text-xs font-medium transition-colors ${active ? "bg-terracotta text-white" : "text-gray-600 hover:bg-gray-50"}`;
+
+  return (
+    <div className="rounded-xl border border-gray-200 bg-white p-4">
+      {/* Title + mode */}
+      <div className="mb-3 flex flex-wrap items-center justify-between gap-2">
+        <div className="flex items-center gap-2">
+          <div className="flex h-8 w-8 items-center justify-center rounded-lg bg-terracotta/10">
+            <Wallet className="h-4 w-4 text-terracotta" />
+          </div>
+          <div>
+            <h3 className="text-sm font-semibold text-gray-900">Daily bank balance</h3>
+            <p className="text-[11px] text-gray-400">
+              Reconstructed end-of-day cash position{db.asOf ? `, actuals through ${fmtDay(db.asOf)}` : ""}. Account-level — not affected by the outlet filter.
+            </p>
+          </div>
+        </div>
+        <div className="flex rounded-lg border border-gray-200 bg-white p-0.5">
+          <button onClick={() => setMode("timeline")} className={segBtn(mode === "timeline")}>Timeline</button>
+          <button onClick={() => setMode("compare")} className={segBtn(mode === "compare")}>Compare</button>
+        </div>
+      </div>
+
+      {/* Filter bar */}
+      <div className="mb-3 flex flex-wrap items-center gap-2">
+        {/* Source */}
+        <select
+          value={source}
+          onChange={(e) => setSource(e.target.value)}
+          className="rounded-lg border border-gray-200 bg-white px-2.5 py-1.5 text-xs text-gray-700"
+        >
+          <option value="combined">All accounts (combined)</option>
+          {mode === "timeline" && <option value="each">By account (overlay)</option>}
+          {db.accounts.map((a) => <option key={a} value={a}>{a}</option>)}
+        </select>
+
+        {mode === "timeline" ? (
+          <>
+            <div className="flex rounded-lg border border-gray-200 bg-white p-0.5">
+              {WINDOWS.map((w) => (
+                <button key={w.key} onClick={() => setWindowKey(w.key)} className={segBtn(windowKey === w.key)}>{w.label}</button>
+              ))}
+            </div>
+            {source === "combined" && (
+              <label className="flex items-center gap-1.5 text-xs text-gray-600">
+                <input type="checkbox" checked={showProjection} onChange={(e) => setShowProjection(e.target.checked)} className="rounded border-gray-300 text-terracotta focus:ring-terracotta" />
+                Projection
+              </label>
+            )}
+          </>
+        ) : (
+          <div className="flex flex-wrap rounded-lg border border-gray-200 bg-white p-0.5">
+            {COMPARES.map((c) => (
+              <button key={c.key} onClick={() => setCompareKey(c.key)} className={segBtn(compareKey === c.key)}>{c.label}</button>
+            ))}
+          </div>
+        )}
+      </div>
+
+      {/* Summary chips */}
+      {stats && (
+        <div className="mb-3 flex flex-wrap gap-x-5 gap-y-1 text-[11px] text-gray-500">
+          <span>Latest: <span className="font-mono font-semibold text-gray-800">{fmtRM(stats.latest.balance)}</span></span>
+          <span>
+            Lowest: <span className={`font-mono font-semibold ${stats.min.balance < 10000 ? "text-amber-600" : "text-gray-800"}`}>{fmtRM(stats.min.balance)}</span>{" "}
+            <span className="text-gray-400">({fmtDay(stats.min.date)})</span>
+          </span>
+          <span className="flex items-center gap-1">
+            Change:
+            <span className={`font-mono font-semibold ${stats.change >= 0 ? "text-green-600" : "text-red-600"}`}>
+              {stats.change >= 0 ? <TrendingUp className="inline h-3 w-3" /> : <TrendingDown className="inline h-3 w-3" />} {stats.change >= 0 ? "+" : ""}{fmtRM(stats.change)}
+            </span>
+          </span>
+        </div>
+      )}
+
+      {!hasData ? (
+        <div className="py-12 text-center text-sm text-gray-400">No bank-statement data yet.</div>
+      ) : mode === "timeline" ? (
+        <ResponsiveContainer width="100%" height={320}>
+          <LineChart data={timeline.rows} margin={{ top: 5, right: 12, left: 4, bottom: 0 }}>
+            <CartesianGrid strokeDasharray="3 3" stroke="#f0f0f0" />
+            <XAxis dataKey="date" tickFormatter={(d) => fmtDay(String(d))} tick={{ fontSize: 11 }} tickLine={false} axisLine={false} interval="preserveStartEnd" minTickGap={36} />
+            <YAxis tick={{ fontSize: 11 }} tickLine={false} axisLine={false} width={52} tickFormatter={(v) => fmtRMk(Number(v))} />
+            <Tooltip labelFormatter={(l) => fmtDay(String(l))} formatter={(v, n) => [v == null ? "—" : fmtRM(v as number), n]} contentStyle={{ borderRadius: 10, border: "1px solid #e5e7eb", fontSize: 12 }} />
+            <Legend wrapperStyle={{ fontSize: 12, paddingTop: 8 }} />
+            {timeline.series.map((s) => (
+              <Line key={s.key} type="monotone" dataKey={s.key} name={s.name} stroke={s.color} strokeWidth={2} strokeDasharray={s.dashed ? "5 4" : undefined} dot={false} connectNulls />
+            ))}
+            {source === "combined" && db.minPoint && (
+              <ReferenceDot x={db.minPoint.date} y={db.minPoint.balance} r={4} fill={db.minPoint.balance < 0 ? "#dc2626" : "#F59E0B"} stroke="white" strokeWidth={1.5} />
+            )}
+          </LineChart>
+        </ResponsiveContainer>
+      ) : (
+        <ResponsiveContainer width="100%" height={320}>
+          <LineChart data={compare.rows} margin={{ top: 5, right: 12, left: 4, bottom: 0 }}>
+            <CartesianGrid strokeDasharray="3 3" stroke="#f0f0f0" />
+            <XAxis dataKey="idx" tick={{ fontSize: 11 }} tickLine={false} axisLine={false} minTickGap={12} />
+            <YAxis tick={{ fontSize: 11 }} tickLine={false} axisLine={false} width={52} tickFormatter={(v) => fmtRMk(Number(v))} />
+            <Tooltip formatter={(v, n) => [v == null ? "—" : fmtRM(v as number), n]} contentStyle={{ borderRadius: 10, border: "1px solid #e5e7eb", fontSize: 12 }} />
+            <Legend wrapperStyle={{ fontSize: 12, paddingTop: 8 }} />
+            {compare.periods.map((p) => (
+              <Line key={p.label} type="monotone" dataKey={p.label} name={p.label} stroke={p.color} strokeWidth={2} dot={false} connectNulls />
+            ))}
+          </LineChart>
+        </ResponsiveContainer>
+      )}
+    </div>
+  );
+}

--- a/apps/backoffice/src/app/(admin)/finance/cashflow/page.tsx
+++ b/apps/backoffice/src/app/(admin)/finance/cashflow/page.tsx
@@ -3,7 +3,8 @@
 import { useState, useMemo } from "react";
 import Link from "next/link";
 import { useFetch } from "@/lib/use-fetch";
-import { Loader2, AlertTriangle, Banknote, Settings, ArrowRight, TrendingDown, TrendingUp, ChevronDown, X } from "lucide-react";
+import { Loader2, AlertTriangle, Banknote, ArrowRight, TrendingDown, TrendingUp, ChevronDown, X } from "lucide-react";
+import DailyBalancePanel from "./DailyBalancePanel";
 
 type Outlet = { id: string; name: string; code: string };
 
@@ -39,6 +40,15 @@ type MonthlyHistory = {
 
 type ProjectedMin = { closing: number; weekStart: string; weekEnd: string };
 
+type DailyBalance = {
+  asOf: string | null;
+  accounts: string[];
+  consolidated: { date: string; balance: number }[];
+  perAccount: { account: string; points: { date: string; balance: number }[] }[];
+  projected: { date: string; balance: number }[];
+  minPoint: { date: string; balance: number } | null;
+};
+
 type OperatingCashFlow = {
   month: string;
   sales: { card: number; qr: number; storehub: number; grab: number; foodpanda: number; gastrohub: number; meetings: number; total: number };
@@ -64,6 +74,7 @@ type CashflowResult = {
   operatingCashFlow: OperatingCashFlow[];
   cashGeneration: CashGeneration;
   projectedMin: ProjectedMin | null;
+  dailyBalance: DailyBalance | null;
   buckets: CashflowBucket[];
   warnings: string[];
 };
@@ -75,6 +86,10 @@ function fmtMYR(n: number): string {
 }
 function fmtMYR2(n: number): string {
   return new Intl.NumberFormat("en-MY", { style: "currency", currency: "MYR", maximumFractionDigits: 2 }).format(n);
+}
+function fmtDay(dateStr: string): string {
+  const d = new Date(dateStr + "T12:00:00+08:00");
+  return `${d.getDate()} ${d.toLocaleString("en-MY", { month: "short" })}`;
 }
 function shortRange(start: string, end: string): string {
   const s = new Date(start);
@@ -188,9 +203,6 @@ export default function CashflowPage() {
           <Link href="/finance/bank-statements" className="inline-flex items-center gap-1.5 rounded-md border border-gray-200 bg-white px-3 py-1.5 text-xs font-medium text-gray-700 hover:bg-gray-50">
             <Banknote className="h-3.5 w-3.5" /> Bank Statements
           </Link>
-          <Link href="/finance/recurring-expenses" className="inline-flex items-center gap-1.5 rounded-md border border-gray-200 bg-white px-3 py-1.5 text-xs font-medium text-gray-700 hover:bg-gray-50">
-            <Settings className="h-3.5 w-3.5" /> Recurring
-          </Link>
         </div>
       </div>
 
@@ -198,6 +210,14 @@ export default function CashflowPage() {
         <div className="mt-6 flex justify-center py-12"><Loader2 className="h-5 w-5 animate-spin text-gray-400" /></div>
       ) : (
         <>
+          {/* Daily bank balance — the hero. Account-level cash position over
+              time, with period-overlay comparison and forward projection. */}
+          {data.dailyBalance && (
+            <div className="mt-4">
+              <DailyBalancePanel db={data.dailyBalance} />
+            </div>
+          )}
+
           {/* Headline — Cash Generation. The primary KPI. */}
           <div className="mt-4 grid grid-cols-2 sm:grid-cols-5 gap-2 sm:gap-3">
             <div className="rounded-lg border border-gray-200 bg-white px-3 py-2.5">

--- a/apps/backoffice/src/lib/finance/cashflow.ts
+++ b/apps/backoffice/src/lib/finance/cashflow.ts
@@ -119,6 +119,22 @@ export type CashflowResult = {
   // for "should I be worried?" decisions. Inspired by QuickBooks'
   // Cash Flow Projector minimum-balance highlighting.
   projectedMin: { closing: number; weekStart: string; weekEnd: string } | null;
+  // Daily reconstructed bank balance — the "actual" running cash position,
+  // walked day-by-day from each account's prior closing balance + its
+  // transaction lines. Consolidated = sum across accounts on days where
+  // every account has a reconstructed balance (so we never undercount).
+  // `projected` continues past today using the weekly forward buckets,
+  // linearly interpolated to a daily cadence so it overlays the actuals
+  // on a single date axis. Bank balance is an account-level concept and
+  // is NOT outlet-filterable, so this block ignores the outlet filter.
+  dailyBalance: {
+    asOf: string | null;            // last actual day with consolidated data
+    accounts: string[];             // account labels present in the series
+    consolidated: { date: string; balance: number }[];
+    perAccount: { account: string; points: { date: string; balance: number }[] }[];
+    projected: { date: string; balance: number }[];
+    minPoint: { date: string; balance: number } | null;  // lowest actual consolidated balance
+  } | null;
   buckets: CashflowBucket[];
   warnings: string[];
 };
@@ -741,12 +757,13 @@ export async function computeCashflow(opts: {
   // transfers between Celsius entities — without that, a transfer to
   // an internal account we don't track shows as "cash burned" when
   // it isn't.
-  const [monthlyHistory, operatingCashFlow, minByMonth] = await Promise.all([
+  const [monthlyHistory, operatingCashFlow, dailyBalances] = await Promise.all([
     loadMonthlyHistory(),
     loadOperatingCashFlow(),
-    loadMinBalancePerMonth(),
+    buildDailyBalances(12),
   ]);
   // Merge min balance into monthlyHistory rows
+  const minByMonth = minBalancePerMonth(dailyBalances.dailyConsolidated);
   for (const row of monthlyHistory) {
     const m = minByMonth.get(row.month);
     if (m) {
@@ -754,6 +771,10 @@ export async function computeCashflow(opts: {
       row.minBalanceDate = m.date;
     }
   }
+  // Daily balance chart series — actuals + forward projection overlay.
+  // Account-level, so it ignores the outlet filter by design.
+  const dailyBalance = buildDailyBalanceSeries(dailyBalances);
+  dailyBalance.projected = buildProjectedDaily(ymd(today), opening.amount, buckets);
   const cashGeneration = summariseCashGeneration(monthlyHistory, opening.amount);
   // Projected min balance — lowest closing across the projection horizon
   const projectedMin = buckets.length === 0 ? null : buckets.reduce<{ closing: number; weekStart: string; weekEnd: string } | null>(
@@ -791,6 +812,7 @@ export async function computeCashflow(opts: {
     operatingCashFlow,
     cashGeneration,
     projectedMin,
+    dailyBalance,
     buckets,
     warnings,
   };
@@ -888,18 +910,25 @@ async function loadMonthlyHistory(): Promise<CashflowResult["monthlyHistory"]> {
     });
 }
 
-// Reconstruct daily consolidated balance (sum across accounts) and
-// return min per month. Uses prior month's closingBalance as the
-// starting balance and walks forward day-by-day applying lines and
-// carrying balance when there's no activity. Skips months where any
-// account has no prior closing (we can't anchor the reconstruction).
+type DailyBalances = {
+  // account → (YYYY-MM-DD → end-of-day balance)
+  dailyByAccount: Map<string, Map<string, number>>;
+  // YYYY-MM-DD → consolidated balance (only days where ALL accounts report)
+  dailyConsolidated: Map<string, number>;
+  accounts: string[];
+};
+
+// Reconstruct daily balance per account (and the consolidated sum). Uses
+// each account's prior-month closingBalance as the anchor and walks
+// forward day-by-day applying lines, carrying the balance over days with
+// no activity. Skips a month for an account when it has no prior closing
+// (we can't anchor the reconstruction).
 //
-// QuickBooks-style: their Cash Flow Projector highlights minimum
-// projected balance — same idea here for the past, so finance can
-// see "we got down to RM 20,676 on Feb 11" not just "Feb net was X".
-async function loadMinBalancePerMonth(): Promise<Map<string, { min: number; date: string }>> {
+// Shared by loadMinBalancePerMonth (past minimum) and the daily-balance
+// chart series — computed once per request and threaded into both.
+async function buildDailyBalances(monthsBack = 12): Promise<DailyBalances> {
   const since = new Date();
-  since.setMonth(since.getMonth() - 12);
+  since.setMonth(since.getMonth() - monthsBack);
 
   const statements = await prisma.bankStatement.findMany({
     where: { periodStart: { gte: since } },
@@ -995,7 +1024,12 @@ async function loadMinBalancePerMonth(): Promise<Map<string, { min: number; date
     if (allHave) dailyConsolidated.set(day, sum);
   }
 
-  // Min per month
+  return { dailyByAccount, dailyConsolidated, accounts };
+}
+
+// Lowest consolidated balance hit within each month — QuickBooks-style,
+// so finance sees "we got down to RM 20,676 on Feb 11" not just the net.
+function minBalancePerMonth(dailyConsolidated: Map<string, number>): Map<string, { min: number; date: string }> {
   const minByMonth = new Map<string, { min: number; date: string }>();
   for (const [day, bal] of dailyConsolidated.entries()) {
     const month = day.slice(0, 7);
@@ -1003,6 +1037,66 @@ async function loadMinBalancePerMonth(): Promise<Map<string, { min: number; date
     if (!cur || bal < cur.min) minByMonth.set(month, { min: round2(bal), date: day });
   }
   return minByMonth;
+}
+
+// Shape the reconstructed balances into the chart series: sorted daily
+// consolidated line, per-account lines, and the all-time minimum point.
+// `__default__` (statements with no accountName) is relabelled for display.
+function buildDailyBalanceSeries(db: DailyBalances): NonNullable<CashflowResult["dailyBalance"]> {
+  const label = (a: string) => (a === "__default__" ? "Unlabelled" : a);
+  const sortByDate = (a: { date: string }, b: { date: string }) => a.date.localeCompare(b.date);
+
+  const consolidated = Array.from(db.dailyConsolidated.entries())
+    .map(([date, balance]) => ({ date, balance: round2(balance) }))
+    .sort(sortByDate);
+
+  const perAccount = db.accounts.map((account) => ({
+    account: label(account),
+    points: Array.from((db.dailyByAccount.get(account) ?? new Map<string, number>()).entries())
+      .map(([date, balance]) => ({ date, balance: round2(balance) }))
+      .sort(sortByDate),
+  }));
+
+  const minPoint = consolidated.reduce<{ date: string; balance: number } | null>(
+    (acc, p) => (acc == null || p.balance < acc.balance ? p : acc),
+    null,
+  );
+
+  return {
+    asOf: consolidated.length ? consolidated[consolidated.length - 1].date : null,
+    accounts: db.accounts.map(label),
+    consolidated,
+    perAccount,
+    projected: [],   // filled by computeCashflow from the forward buckets
+    minPoint,
+  };
+}
+
+// Linearly interpolate the weekly forward buckets into a daily projected
+// balance line, anchored at today's opening balance so it overlays the
+// reconstructed actuals continuously on a single date axis.
+function buildProjectedDaily(
+  asOf: string,
+  openingAmount: number,
+  buckets: CashflowBucket[],
+): { date: string; balance: number }[] {
+  const anchors = [
+    { date: asOf, balance: openingAmount },
+    ...buckets.map((b) => ({ date: b.weekEnd, balance: b.closing })),
+  ];
+  const out: { date: string; balance: number }[] = [];
+  for (let i = 0; i < anchors.length - 1; i++) {
+    const a = anchors[i];
+    const b = anchors[i + 1];
+    const span = Math.max(1, Math.round((Date.parse(b.date) - Date.parse(a.date)) / DAY_MS));
+    for (let d = 0; d < span; d++) {
+      const t = new Date(Date.parse(a.date) + d * DAY_MS);
+      out.push({ date: ymd(t), balance: round2(a.balance + ((b.balance - a.balance) * d) / span) });
+    }
+  }
+  const last = anchors[anchors.length - 1];
+  out.push({ date: last.date, balance: round2(last.balance) });
+  return out;
 }
 
 // Operating Cash Flow per month — sourced from classified bank lines.


### PR DESCRIPTION
Leads the Cashflow page with the reconstructed **daily bank-balance** position (now live to yesterday via the Bukku feed) — the bank-balance analogue of Sales Compare.

**Two account-level views:**
- **Timeline** — end-of-day balance over a window, forward projection bridged on, lowest point marked.
- **Compare** — overlay calendar periods (months/weeks) aligned by day-index.

**Filters:** account scope (combined / per-account overlay / single entity), time window (30D/90D/6M/12M/Max), comparison presets (month-vs-last, last 3 months, week-vs-last, last 4 weeks), projection toggle. Summary chips: latest balance, lowest (with date), change over window.

All filtering is client-side over the 12-month daily series the API already returns; replaces the old single-toggle inline chart. `page.tsx` also drops the now-unused Settings/Recurring header links (incidental, already in the working tree).