### PR TITLE
fix(test): unblock CI — stale verifier prompt assertion

### DIFF
--- a/apps/backoffice/src/lib/inventory/agents/verifier.test.ts
+++ b/apps/backoffice/src/lib/inventory/agents/verifier.test.ts
@@ -46,7 +46,7 @@ describe("buildVerifierPrompt", () => {
     expect(p).toContain("CC-KL-0001");
     expect(p).toContain("Caramel Syrup");
     expect(p).toContain("caramel syrup takde bos");
-    expect(p).toContain("PO action: remove_item");
+    expect(p).toContain("PO action(s): remove_item");
     expect(p).toContain("re-sourced to alt supplier (DRAFT): true");
     expect(p).toContain("2026-06-26");
   });


### PR DESCRIPTION
The `test` job has been failing on every PR because `verifier.test.ts` asserts the old `PO action:` label, but `buildVerifierPrompt` was relabelled to `PO action(s):` (multi-action support) without updating the test. One-line assertion fix; `vitest` now green (8/8). No production code touched.