### PR TITLE
fix(procurement): PO creation fails with orderNumber NaN collision (CC-CC001-AITEST)

### DIFF
--- a/apps/backoffice/src/app/api/inventory/ai-decisions/execute/route.ts
+++ b/apps/backoffice/src/app/api/inventory/ai-decisions/execute/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
 import { getUserFromHeaders } from "@/lib/auth";
+import { nextOrderNumber } from "@/lib/inventory/order-number";
 
 // ─── POST /api/inventory/ai-decisions/execute ───────────────────────────
 // Executes AI decisions: creates real draft POs or transfers in the DB.
@@ -24,8 +25,7 @@ export async function POST(req: NextRequest) {
       };
 
       const outlet = await prisma.outlet.findUniqueOrThrow({ where: { id: outletId }, select: { code: true } });
-      const count = await prisma.order.count({ where: { outletId } });
-      const orderNumber = `CC-${outlet.code}-${String(count + 1).padStart(4, "0")}`;
+      const orderNumber = await nextOrderNumber(outlet.code);
 
       const totalAmount = items.reduce((s, i) => s + i.quantity * i.unitPrice, 0);
 
@@ -68,8 +68,7 @@ export async function POST(req: NextRequest) {
       const created = [];
       for (const po of purchaseOrders) {
         const outlet = await prisma.outlet.findUniqueOrThrow({ where: { id: po.outletId }, select: { code: true } });
-        const count = await prisma.order.count({ where: { outletId: po.outletId } });
-        const orderNumber = `CC-${outlet.code}-${String(count + 1).padStart(4, "0")}`;
+        const orderNumber = await nextOrderNumber(outlet.code);
         const totalAmount = po.items.reduce((s, i) => s + i.quantity * i.unitPrice, 0);
 
         const order = await prisma.order.create({

--- a/apps/backoffice/src/app/api/inventory/orders/route.ts
+++ b/apps/backoffice/src/app/api/inventory/orders/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse, NextRequest } from "next/server";
 import { prisma } from "@/lib/prisma";
 import { getUserFromHeaders } from "@/lib/auth";
+import { nextOrderNumberBase } from "@/lib/inventory/order-number";
 
 export async function GET(req: NextRequest) {
   const caller = await getUserFromHeaders(req.headers);
@@ -224,17 +225,14 @@ export async function POST(req: NextRequest) {
       0,
     );
 
-    // Retry loop to handle orderNumber collisions
+    // Highest existing NUMERIC suffix for this outlet's prefix (a string MAX / COUNT are unsafe —
+    // see nextOrderNumberBase). Computed once; the retry loop below bumps by `attempt` on collision.
+    const { prefix, lastNum } = await nextOrderNumberBase(outlet.code);
+
+    // Retry loop to handle orderNumber collisions (concurrent same-outlet creates).
     let order;
     for (let attempt = 0; attempt < 5; attempt++) {
-      const maxResult = await prisma.order.aggregate({
-        where: { orderNumber: { startsWith: `CC-${outlet.code}-` } },
-        _max: { orderNumber: true },
-      });
-      const lastNum = maxResult._max.orderNumber
-        ? parseInt(maxResult._max.orderNumber.split("-").pop() || "0")
-        : 0;
-      const orderNumber = `CC-${outlet.code}-${String(lastNum + 1 + attempt).padStart(4, "0")}`;
+      const orderNumber = `${prefix}${String(lastNum + 1 + attempt).padStart(4, "0")}`;
 
       try {
         order = await prisma.order.create({

--- a/apps/backoffice/src/lib/inventory/agents/resource-po.ts
+++ b/apps/backoffice/src/lib/inventory/agents/resource-po.ts
@@ -1,5 +1,6 @@
 import { prisma } from "@/lib/prisma";
 import { boundedReorderQty } from "@/lib/inventory/order-validation";
+import { nextOrderNumber } from "@/lib/inventory/order-number";
 
 // When the supplier-chat agent removes a line because the supplier is out of
 // stock, the need would otherwise vanish (stockout risk). createReSourcePO opens
@@ -88,8 +89,7 @@ export async function createReSourcePO(opts: {
 
   try {
     const outlet = await prisma.outlet.findUniqueOrThrow({ where: { id: opts.outletId }, select: { code: true } });
-    const count = await prisma.order.count({ where: { outletId: opts.outletId } });
-    const orderNumber = `CC-${outlet.code}-${String(count + 1).padStart(4, "0")}`;
+    const orderNumber = await nextOrderNumber(outlet.code);
     const order = await prisma.order.create({
       data: {
         orderNumber,

--- a/apps/backoffice/src/lib/inventory/order-number.ts
+++ b/apps/backoffice/src/lib/inventory/order-number.ts
@@ -1,0 +1,36 @@
+import { prisma } from "@/lib/prisma";
+
+/**
+ * Robust next-PO-number generator. POs are numbered `CC-<outletCode>-<NNNN>`.
+ *
+ * Do NOT derive the next number from a string MAX(orderNumber) or a row COUNT:
+ *  - String MAX picks a stray NON-numeric suffix (e.g. a leftover test order "CC-CC001-AITEST")
+ *    because letters sort above digits → parseInt → NaN → every generated number becomes
+ *    "CC-<code>-0NaN" and then collides forever (NaN + n is still NaN). This was a live bug.
+ *  - COUNT(*)+1 drifts from the real max the moment a row is deleted or a non-sequential number
+ *    exists, and two callers using different schemes (composer vs agent) generate clashing
+ *    numbers in the shared namespace.
+ *
+ * Instead: read the existing numbers for this outlet's prefix, keep only the digit suffixes, and
+ * take the numeric max. Returns the prefix + the highest number so callers can add 1 (and retry
+ * on a collision).
+ */
+export async function nextOrderNumberBase(outletCode: string): Promise<{ prefix: string; lastNum: number }> {
+  const prefix = `CC-${outletCode}-`;
+  const existing = await prisma.order.findMany({
+    where: { orderNumber: { startsWith: prefix } },
+    select: { orderNumber: true },
+  });
+  let lastNum = 0;
+  for (const e of existing) {
+    const suffix = e.orderNumber.slice(prefix.length);
+    if (/^\d+$/.test(suffix)) lastNum = Math.max(lastNum, parseInt(suffix, 10));
+  }
+  return { prefix, lastNum };
+}
+
+/** The next single PO number for an outlet (caller handles any rare concurrent collision). */
+export async function nextOrderNumber(outletCode: string): Promise<string> {
+  const { prefix, lastNum } = await nextOrderNumberBase(outletCode);
+  return `${prefix}${String(lastNum + 1).padStart(4, "0")}`;
+}


### PR DESCRIPTION
**Bug** (from the screenshot): creating a PO for **Celsius Coffee Putrajaya** failed with `Unique constraint failed on the fields: (orderNumber)`, even though the route already retries 5× on collision.

**Root cause:** Putrajaya's outlet code is `CC001`, and its highest order number (by string MAX) is **`CC-CC001-AITEST`** — a leftover *test* order. The generator did `parseInt(maxOrderNumber.split('-').pop())` → `parseInt('AITEST')` = **NaN**. Every generated number became `CC-CC001-0NaN`, and since `NaN + attempt` is still `NaN`, **all 5 retries produced the identical colliding number** → the error. (`AITEST` wins the string MAX because letters sort above digits.)

**Fix:** new shared helper `lib/inventory/order-number.ts` that takes the max of the **numeric** suffixes only (ignoring non-numeric ones). Applied to all three generators in the `CC-<code>-` namespace so they're consistent:
- **orders POST** (the composer path that failed) — number computed once, retry loop bumps by `attempt`.
- **resource-po.ts** + **ai-decisions/execute** — these used `COUNT(*)+1`, a *different* scheme that drifts from the real max and would clash with the composer; now unified on the robust helper.

Note: the `CC-CC001-AITEST` row is now harmless (ignored), but it's a stray AI-test order worth deleting — say the word and I'll remove it.

Typecheck + lint clean.