### PR TITLE
fix(ops): ops_list 4 item-lines + more text (Meta variable-ratio rule)

### DIFF
--- a/apps/backoffice/src/app/api/ops/workspace/templates/route.ts
+++ b/apps/backoffice/src/app/api/ops/workspace/templates/route.ts
@@ -58,19 +58,20 @@ const TEMPLATE_DEFS = [
     sample: "Clock in for your 8:00am shift at Putrajaya — you haven't yet.",
   },
   {
-    // Multi-line LIST: a headline ({{1}}) + up to five item lines ({{2}}..{{6}}),
+    // Multi-line LIST: a headline ({{1}}) + up to four item lines ({{2}}..{{5}}),
     // each on its OWN line — the only way to get real line breaks (a single param
-    // can't contain newlines). Fixed text wraps the variables (Meta rejects a body
-    // that starts/ends with one); unused item lines are padded blank at send time.
+    // can't contain newlines). Generous fixed text wraps the variables: Meta
+    // rejects a body that starts/ends with a variable AND one with "too many
+    // variables for its length", so the wrapper keeps the text:variable ratio high.
+    // Unused item lines are padded blank at send time.
     name: "ops_list",
-    body: "Celsius ops update:\n\n{{1}}\n\n{{2}}\n{{3}}\n{{4}}\n{{5}}\n{{6}}\n\nReply DONE once it's sorted.",
+    body: "Celsius ops update. Here are the things that need your attention, please take a look:\n\n{{1}}\n\n{{2}}\n{{3}}\n{{4}}\n{{5}}\n\nSort these out and reply DONE once they're handled. The full list is always in BackOffice.",
     sample: [
       "8 audits due this week",
       "Barista station audit overdue at Tamarind",
       "Barista station audit overdue at Shah Alam",
       "Barista station audit overdue at Nilai",
-      "Barista station audit overdue at Putrajaya",
-      "...and 4 more in BackOffice",
+      "...and 5 more in BackOffice",
     ],
   },
 ] as const;

--- a/apps/backoffice/src/lib/ops-pulse/sender.ts
+++ b/apps/backoffice/src/lib/ops-pulse/sender.ts
@@ -136,8 +136,8 @@ export async function sendProactive(
   return ff;
 }
 
-// Number of item-lines in the ops_list template ({{2}}..{{6}}).
-const LIST_SLOTS = 5;
+// Number of item-lines in the ops_list template ({{2}}..{{5}}).
+const LIST_SLOTS = 4;
 // Non-breaking space pads unused slots (WhatsApp rejects empty params) and renders
 // as a near-blank line; sanitizeParam is not applied to it so it survives.
 const LIST_PAD = "\u00A0";


### PR DESCRIPTION
Meta rejected the ops_list template synchronously: 'too many variables for its length'. Dropped to 4 item-lines (5 variables total) and added more fixed wrapper text so the text:variable ratio passes. LIST_SLOTS 5 -> 4.