### PR TITLE
fix(finance): bukku-feed-sync every 6h (was a day behind)

### DIFF
--- a/apps/backoffice/vercel.json
+++ b/apps/backoffice/vercel.json
@@ -62,7 +62,7 @@
     },
     {
       "path": "/api/cron/bukku-feed-sync",
-      "schedule": "30 19 * * *"
+      "schedule": "0 */6 * * *"
     },
     {
       "path": "/api/cron/music-alerts",


### PR DESCRIPTION
The daily cron fired fine (200) but at 03:30 MYT Bukku hadn't yet synced the prior day's transactions — they land later in the MYT morning — so the ledger sat ~a day stale. Switch to every 6h (`0 */6 * * *`); the sync is bounded (only post-anchor lines) and idempotent, so frequent runs are cheap and safe.