### PR TITLE
feat(ops): scorecard as UTILITY template (was MARKETING, ~5x cheaper)

### DIFF
--- a/apps/backoffice/src/app/api/ops/workspace/templates/route.ts
+++ b/apps/backoffice/src/app/api/ops/workspace/templates/route.ts
@@ -45,9 +45,13 @@ const TEMPLATE_DEFS = [
     sample: "Switch to the new opening checklist from tomorrow — Ammar",
   },
   {
-    name: "ops_scoreboard",
-    body: "Your scoreboard\n\n{{1}}\n\nFull board in BackOffice. Let's move the number this week.",
-    sample: "capture 18% (tgt 70%) · upsell 6% (tgt 10%) · crew 18% · top Badri 47%",
+    // Renamed from ops_scoreboard, which Meta classified MARKETING because of the
+    // motivational copy ("Let's move the number this week"). This is a dry,
+    // data-only status report so Meta classifies it UTILITY (~5x cheaper). No
+    // call-to-action, no urgency, no cheerleading — just the numbers.
+    name: "ops_scorecard",
+    body: "Weekly performance summary.\n\n{{1}}\n\nThe full breakdown is in BackOffice.",
+    sample: "Phone number collection 42% (target 70%), upsell 6% (target 10%), crew average 31%, top Nuralia 47%",
   },
   {
     name: "ops_nudge",

--- a/apps/backoffice/src/lib/ops-pulse/config.ts
+++ b/apps/backoffice/src/lib/ops-pulse/config.ts
@@ -219,7 +219,9 @@ export const TEMPLATES = {
   // Ad-hoc directive/announcement fanned out to staff from the workspace.
   instruction: process.env.OPS_PULSE_TPL_INSTRUCTION || "ops_instruction",
   // Weekly performance scoreboard (cashier DM / leader digest).
-  scoreboard: process.env.OPS_PULSE_TPL_SCOREBOARD || "ops_scoreboard",
+  // ops_scorecard (not ops_scoreboard): the old one was classified MARKETING by
+  // Meta; the new dry, data-only template is UTILITY (~5x cheaper).
+  scoreboard: process.env.OPS_PULSE_TPL_SCOREBOARD || "ops_scorecard",
   // Real-time staff nudge (clock-in / stock count).
   nudge: process.env.OPS_PULSE_TPL_NUDGE || "ops_nudge",
   // Multi-line list: headline + one item per line (audit / review / digests).

--- a/apps/backoffice/src/lib/ops-scoreboard/render.ts
+++ b/apps/backoffice/src/lib/ops-scoreboard/render.ts
@@ -41,12 +41,13 @@ export function renderCashierBoard(
   if (best && best.employeeId !== c.employeeId && best.captureRate !== null)
     ctx.push(`top this week ${best.name.split(" ")[0]} ${best.captureRate}%`);
 
-  const body = [...metrics];
-  if (ctx.length) body.push(`${ctx.join(", ")}.`);
-  body.push('Ask every customer "nombor untuk points?" before they pay.');
-
-  const text = [`Your scoreboard, ${c.name.split(" ")[0]}`, "", ...body].join("\n");
-  return { text, var: body.join("\n") };
+  const data = [...metrics];
+  if (ctx.length) data.push(`${ctx.join(", ")}.`);
+  // The template {{1}} carries DRY DATA only (no coaching CTA) so ops_scorecard
+  // stays UTILITY-classified. The coaching line lives in the in-window text only.
+  const coaching = 'Ask every customer "nombor untuk points?" before they pay.';
+  const text = [`Your scoreboard, ${c.name.split(" ")[0]}`, "", ...data, "", coaching].join("\n");
+  return { text, var: data.join("\n") };
 }
 
 // ── Manager board (per outlet) ───────────────────────────────────────────


### PR DESCRIPTION
Meta classified ops_scoreboard as MARKETING (~5x the utility rate) because of motivational copy ('Let's move the number this week'). New **ops_scorecard** template is dry/data-only ('Weekly performance summary. {{1}}. Full breakdown in BackOffice'), no CTA, and the {{1}} variable carries metrics only (coaching tip moved to the in-window text). Sender repointed via TEMPLATES.scoreboard default. After merge I'll submit it and confirm Meta classifies it UTILITY.