### PR TITLE
feat(ops): checklist nudge to individual owner (shift role + clock-in)

### DIFF
--- a/apps/backoffice/src/app/api/cron/ops-nudge-checklist/route.ts
+++ b/apps/backoffice/src/app/api/cron/ops-nudge-checklist/route.ts
@@ -1,0 +1,34 @@
+import { NextRequest, NextResponse } from "next/server";
+import { checkCronAuth } from "@celsius/shared";
+import { runChecklistNudges } from "@/lib/ops-nudges";
+
+export const dynamic = "force-dynamic";
+export const maxDuration = 60;
+
+/**
+ * GET /api/cron/ops-nudge-checklist — checklist-not-done nudge to the INDIVIDUAL owner.
+ *
+ * Owner resolved by role + clock-in: the present person rostered to the matching
+ * role (OPENING/CLOSING) at the outlet today owns it (an explicit assignedToId wins
+ * if that person clocked in). No one in that role on shift → the shift lead; no lead
+ * → a managers digest. Roster is the plan, CLOCK-IN is the truth — an absent person
+ * is never blamed for a task they weren't there for. Same-day, recently overdue
+ * (grace–3h) so the owner is still on shift and can act. Deduped per checklist.
+ * Runs every 15 min. OPS_NUDGES_MODE (off|shadow|armed, default armed).
+ * Design: docs/design/checklist-individual-accountability.md.
+ */
+export async function GET(req: NextRequest) {
+  const cronAuth = checkCronAuth(req.headers);
+  if (!cronAuth.ok) return NextResponse.json({ error: cronAuth.error }, { status: cronAuth.status });
+  try {
+    const result = await runChecklistNudges();
+    console.log(
+      `[cron/ops-nudge-checklist] mode=${result.mode} items=${result.items} staff=${result.staffSent} mgr=${result.managerSent}`,
+    );
+    return NextResponse.json({ ok: true, ...result });
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : "ops-nudge-checklist failed";
+    console.error("[cron/ops-nudge-checklist]", msg);
+    return NextResponse.json({ error: msg }, { status: 500 });
+  }
+}

--- a/apps/backoffice/src/lib/ops-nudges/index.ts
+++ b/apps/backoffice/src/lib/ops-nudges/index.ts
@@ -20,6 +20,7 @@ import { recordBreach } from "@/lib/ops-pulse/ledger";
 import { resolveRecipients, resolveOutletTeam, resolveOutletSupervisors } from "@/lib/ops-pulse/router";
 import { sendClockInNudge, sendStockCountNudge, sendOpsDigest, sendAuditNudge, sendReviewNudge } from "@/lib/ops-pulse/sender";
 import type { Assignee, Breach, RouteKey } from "@/lib/ops-pulse/types";
+import { THRESHOLDS } from "@/lib/ops-pulse/config";
 
 export type NudgesMode = "off" | "shadow" | "armed";
 // Default ARMED (owner go-live 2026-06-28, "full auto"). Kill switch / staging
@@ -311,4 +312,152 @@ export async function runReviewNudges(now = new Date()): Promise<NudgeRunResult>
   const headline = `${managerLines.length} new guest review${managerLines.length === 1 ? "" : "s"} need a response`;
   const managerSent = await sendManagerDigestToOps(headline, managerLines, mode);
   return { mode, ranAt, items: managerLines.length, staffSent, managerSent };
+}
+
+// ── 5. Checklist not done → DM the INDIVIDUAL owner (role + clock-in resolved) ──
+// Owner = the clocked-in person rostered to the matching role (OPENING→"opening",
+// CLOSING→"closing") at the outlet today; an explicit Checklist.assignedToId wins if
+// that person clocked in. No one in that role on shift → the shift lead; no lead →
+// a managers digest. ROSTER IS THE PLAN, CLOCK-IN IS THE TRUTH — never nudge an
+// absent person about a task they weren't there for (the no-show is its own signal).
+// Same-day + recently overdue only (grace–3h) so the owner is still on shift and can
+// actually do it. Deduped per checklist (ledger) → one nudge per checklist instance.
+// Design: docs/design/checklist-individual-accountability.md.
+const CHECKLIST_LEAD_ROLES = new Set(["supervisor", "manager", "barista lead", "kitchen lead"]);
+const CHECKLIST_OWNER_WINDOW_MS = 3 * 3_600_000;
+
+export async function runChecklistNudges(now = new Date()): Promise<NudgeRunResult> {
+  const mode = nudgesMode();
+  const ranAt = now.toISOString();
+  if (mode === "off") return { mode, ranAt, items: 0, staffSent: 0, managerSent: 0 };
+
+  const ymd = new Date(now.getTime() + 8 * 3_600_000).toISOString().slice(0, 10);
+  const dayStart = new Date(`${ymd}T00:00:00+08:00`);
+  const dayEnd = new Date(dayStart.getTime() + 86_400_000);
+  const overdueCutoff = new Date(now.getTime() - THRESHOLDS.checklist.graceMinutes * 60_000);
+  const windowStart = new Date(Math.max(dayStart.getTime(), now.getTime() - CHECKLIST_OWNER_WINDOW_MS));
+
+  const overdue = await prisma.checklist.findMany({
+    where: { status: { in: ["PENDING", "IN_PROGRESS"] }, dueAt: { gte: windowStart, lt: overdueCutoff } },
+    select: {
+      id: true,
+      outletId: true,
+      shift: true,
+      assignedToId: true,
+      outlet: { select: { name: true, status: true } },
+      sop: { select: { title: true } },
+    },
+    orderBy: { dueAt: "asc" },
+    take: 200,
+  });
+  const active = overdue.filter((c) => c.outletId && c.outlet?.status === "ACTIVE");
+  if (active.length === 0) return { mode, ranAt, items: 0, staffSent: 0, managerSent: 0 };
+
+  // Today's published roster (role per person) + today's clock-ins, batched once
+  // (all active outlets; each checklist is matched to its outlet in JS below).
+  const roster = await prisma.$queryRaw<
+    Array<{ outlet_id: string; role_type: string; user_id: string; name: string; phone: string | null }>
+  >`
+    SELECT sch.outlet_id, lower(s.role_type) AS role_type, u.id AS user_id, u.name, u.phone
+    FROM hr_schedule_shifts s
+    JOIN hr_schedules sch ON sch.id = s.schedule_id
+    JOIN "User" u ON u.id = s.user_id
+    WHERE s.shift_date = ${ymd}::date AND sch.published_at IS NOT NULL AND u.status = 'ACTIVE'
+  `;
+  const clockRows = await prisma.$queryRaw<Array<{ user_id: string }>>`
+    SELECT DISTINCT user_id FROM hr_attendance_logs WHERE clock_in >= ${dayStart} AND clock_in < ${dayEnd}
+  `;
+  const clockedIn = new Set(clockRows.map((r) => r.user_id));
+  const present = roster.filter((r) => r.phone && clockedIn.has(r.user_id));
+
+  type Item = { id: string; label: string; outletId: string; outletName: string };
+  const byOwner = new Map<string, { name: string; phone: string; items: Item[] }>();
+  const unowned = new Map<string, { name: string; items: Item[] }>();
+
+  for (const c of active) {
+    const role = c.shift === "OPENING" ? "opening" : c.shift === "CLOSING" ? "closing" : null;
+    const item: Item = {
+      id: c.id,
+      label: `${c.sop?.title ?? "Checklist"} (${String(c.shift).toLowerCase()})`,
+      outletId: c.outletId,
+      outletName: c.outlet!.name,
+    };
+    // Explicit assignment wins if that person is present; else the present person
+    // rostered to the matching role.
+    let owner = present.find((r) => r.outlet_id === c.outletId && r.user_id === c.assignedToId) ?? null;
+    if (!owner && role) owner = present.find((r) => r.outlet_id === c.outletId && r.role_type === role) ?? null;
+    if (owner?.phone) {
+      const o = byOwner.get(owner.user_id) ?? { name: owner.name, phone: owner.phone, items: [] };
+      o.items.push(item);
+      byOwner.set(owner.user_id, o);
+    } else {
+      const u = unowned.get(c.outletId) ?? { name: c.outlet!.name, items: [] };
+      u.items.push(item);
+      unowned.set(c.outletId, u);
+    }
+  }
+
+  const mkBreach = (it: Item): Breach => ({
+    signal: "CHECKLIST",
+    outletId: it.outletId,
+    outletName: it.outletName,
+    severity: "MED",
+    routeKey: "operations",
+    dedupeKey: `CHECKLIST_NUDGE:${it.id}`,
+    summary: `${it.label} overdue — ${it.outletName}`,
+    detail: { checklistId: it.id },
+  });
+
+  let staffSent = 0;
+  let items = 0;
+  const managerLines: string[] = [];
+
+  // Owners get DM'd their own overdue items (deduped per checklist).
+  for (const [userId, o] of byOwner) {
+    const fresh: Item[] = [];
+    for (const it of o.items) {
+      const { isNew } = await recordBreach(mkBreach(it), { userId, name: o.name, phone: o.phone, role: "staff", fallback: false });
+      if (isNew) fresh.push(it);
+    }
+    if (fresh.length === 0) continue;
+    items += fresh.length;
+    if (mode === "shadow") {
+      console.log("[ops-nudge:checklist:shadow]", JSON.stringify({ to: o.name, items: fresh.map((f) => f.label) }));
+      continue;
+    }
+    const first = o.name.split(" ")[0];
+    const r = await sendOpsDigest(
+      o.phone,
+      `Hi ${first}, your checklist${fresh.length === 1 ? "" : "s"} ${fresh.length === 1 ? "is" : "are"} overdue, please complete:`,
+      fresh.map((f) => f.label),
+    );
+    if (r.ok) staffSent += 1;
+  }
+
+  // No present owner for the role → the shift lead; no lead → managers digest.
+  for (const [outletId, u] of unowned) {
+    const fresh: Item[] = [];
+    for (const it of u.items) {
+      const { isNew } = await recordBreach(mkBreach(it), null);
+      if (isNew) fresh.push(it);
+    }
+    if (fresh.length === 0) continue;
+    items += fresh.length;
+    const lead = present.find((r) => r.outlet_id === outletId && CHECKLIST_LEAD_ROLES.has(r.role_type));
+    if (mode === "shadow") {
+      console.log("[ops-nudge:checklist:shadow:unowned]", JSON.stringify({ outlet: u.name, lead: lead?.name ?? null, items: fresh.map((f) => f.label) }));
+      managerLines.push(...fresh.map((f) => `${u.name}: ${f.label}`));
+      continue;
+    }
+    if (lead?.phone) {
+      const r = await sendOpsDigest(lead.phone, `No one on shift is assigned to these overdue checklists at ${u.name}:`, fresh.map((f) => f.label));
+      if (r.ok) staffSent += 1;
+    } else {
+      managerLines.push(...fresh.map((f) => `${u.name}: ${f.label} (no one on shift to own it)`));
+    }
+  }
+
+  const headline = `${managerLines.length} overdue checklist${managerLines.length === 1 ? "" : "s"} with no owner on shift`;
+  const managerSent = await sendManagerDigestToOps(headline, managerLines, mode);
+  return { mode, ranAt, items, staffSent, managerSent };
 }

--- a/apps/backoffice/src/lib/ops-pulse/config.ts
+++ b/apps/backoffice/src/lib/ops-pulse/config.ts
@@ -154,11 +154,11 @@ export const NOCLOCKIN_ENABLED = (process.env.OPS_PULSE_NOCLOCKIN_ENABLED || "fa
 // Signals that ALSO nudge the on-shift outlet team (not just the discipline
 // lead), because the team is accountable for what happened on their shift —
 // stock take (they do the work), bad reviews (they served it), phone capture
-// (they ask for the number) and checklists (they complete them). The on-shift
-// roster includes that shift's lead. Comma-separated; override via
-// OPS_PULSE_TEAM_NOTIFY_SIGNALS.
+// (they ask for the number). The on-shift roster includes that shift's lead.
+// (Checklist is no longer here — it's a dedicated INDIVIDUAL-owner nudge now.)
+// Comma-separated; override via OPS_PULSE_TEAM_NOTIFY_SIGNALS.
 export const TEAM_NOTIFY_SIGNALS: Set<string> = new Set(
-  (process.env.OPS_PULSE_TEAM_NOTIFY_SIGNALS || "STOCK_COUNT,REVIEW,PHONE_CAPTURE,CHECKLIST")
+  (process.env.OPS_PULSE_TEAM_NOTIFY_SIGNALS || "STOCK_COUNT,REVIEW,PHONE_CAPTURE")
     .split(",")
     .map((s) => s.trim().toUpperCase())
     .filter(Boolean),

--- a/apps/backoffice/src/lib/ops-pulse/index.ts
+++ b/apps/backoffice/src/lib/ops-pulse/index.ts
@@ -203,11 +203,11 @@ export async function runDailyPulse(now = new Date()): Promise<PulseRunResult> {
   // they fire on the real-time pulse the moment they happen, so re-listing them
   // a day later would just double-page. Excluded here by category.
   //
-  // Clock-in, stock count, and audit are now owned by the dedicated ops-nudges
-  // loops (which DM staff + the lead). Excluded here so the daily digest doesn't
-  // double-ping the leads. The daily pulse keeps its unique routine signals
-  // (checklist, POS-open, phone capture, restock).
-  const NUDGE_OWNED = new Set(["NO_CLOCK_IN", "STOCK_COUNT", "AUDIT"]);
+  // Clock-in, stock count, audit, and checklist are now owned by the dedicated
+  // ops-nudges loops (which DM the individual owner / on-shift team + the lead).
+  // Excluded here so the daily digest doesn't double-ping. The daily pulse keeps
+  // its unique routine signals (POS-open, phone capture, restock).
+  const NUDGE_OWNED = new Set(["NO_CLOCK_IN", "STOCK_COUNT", "AUDIT", "CHECKLIST"]);
   const breaches = (await detectAll(now)).filter(
     (b) => categoryFor(b.signal) === "routine" && !NUDGE_OWNED.has(b.signal),
   );

--- a/apps/backoffice/vercel.json
+++ b/apps/backoffice/vercel.json
@@ -133,6 +133,10 @@
       "schedule": "*/5 * * * *"
     },
     {
+      "path": "/api/cron/ops-nudge-checklist",
+      "schedule": "*/15 * * * *"
+    },
+    {
       "path": "/api/cron/geogrid-keywords",
       "schedule": "0 6 1 * *"
     },


### PR DESCRIPTION
Approach A from the office-hours design doc. Moves CHECKLIST from the (shadow) daily pulse into a dedicated armed nudge that DMs the **individual owner**:

- Owner = clocked-in person rostered to the matching role (OPENING/CLOSING) at the outlet today; explicit `assignedToId` wins if present.
- No one in role on shift -> the **shift lead**; no lead -> managers digest. **Roster is the plan, clock-in is the truth** — an absent person is never blamed.
- Same-day, recently overdue (grace-3h) so the owner can still act. Deduped per checklist. Cron */15.
- Wiring: CHECKLIST added to NUDGE_OWNED (out of the daily pulse), removed from TEAM_NOTIFY.

Caveats: unassigned MIDDAY items -> lead (individual midday needs the station model, v2). Effectiveness scales with clock-in adoption (only ~4 clocked in today -> mostly escalates for now). Typecheck clean.