### PR TITLE
feat(ops): grease trap = shared accountability

### DIFF
--- a/apps/backoffice/src/lib/ops-nudges/index.ts
+++ b/apps/backoffice/src/lib/ops-nudges/index.ts
@@ -335,7 +335,7 @@ const SOP_STATION: Record<string, "barista" | "kitchen" | "lead" | "cleaning" | 
   "coffee calibration": "barista",
   "fridge & storage": "kitchen",
   "first food out": "kitchen",
-  "grease trap cleaning": "kitchen",
+  "grease trap cleaning": "shared",
   "ice machine cleaning": "kitchen",
   "pest control check": "kitchen",
   "opening checklist": "shared",


### PR DESCRIPTION
Grease trap cleaning is heavy collective work — moved from kitchen-individual to 'shared' (every present person on shift accountable), same as opening/closing. One-line SOP_STATION change. Typecheck clean.