### PR TITLE
fix(hr): stop auto-clockout of staff who never left the geofence

### DIFF
--- a/apps/backoffice/src/app/api/cron/attendance-auto-close/route.ts
+++ b/apps/backoffice/src/app/api/cron/attendance-auto-close/route.ts
@@ -69,18 +69,29 @@ export async function GET(req: NextRequest) {
 
     // Get last ping (any kind) and last in-zone ping
     const [lastPingResp, lastInZoneResp] = await Promise.all([
-      hrSupabaseAdmin.from("hr_attendance_pings").select("created_at").eq("attendance_log_id", log.id).order("created_at", { ascending: false }).limit(1).maybeSingle(),
+      hrSupabaseAdmin.from("hr_attendance_pings").select("created_at, in_zone").eq("attendance_log_id", log.id).order("created_at", { ascending: false }).limit(1).maybeSingle(),
       hrSupabaseAdmin.from("hr_attendance_pings").select("created_at").eq("attendance_log_id", log.id).eq("in_zone", true).order("created_at", { ascending: false }).limit(1).maybeSingle(),
     ]);
 
     const lastPingAt = lastPingResp.data?.created_at ? new Date(lastPingResp.data.created_at) : null;
     const lastInZoneAt = lastInZoneResp.data?.created_at ? new Date(lastInZoneResp.data.created_at) : null;
+    // Is the MOST RECENT ping an out-of-zone ping? This is the only reliable
+    // evidence that the staffer has actually left the outlet.
+    const latestPingOutOfZone = lastPingResp.data?.in_zone === false;
 
     let closeAt: Date | null = null;
     let reason: string | null = null;
 
-    // Rule A: Last in-zone ping was long ago (has pings but stopped being in-zone)
-    if (lastInZoneAt && lastPingAt) {
+    // Rule A: Staffer has actually left the zone and not returned within grace.
+    //
+    // We require the LATEST ping to be out-of-zone — not merely "the last
+    // in-zone ping is stale". The app pings only on geofence boundary
+    // crossings (enter/exit) plus once at clock-in, never continuously, so a
+    // staffer working *inside* the zone all shift produces no new pings. The
+    // old "in-zone ping is older than grace" test misread that silence as an
+    // exit and auto-clocked-out people who never left (truncating the shift to
+    // ~0h mid-shift). Absence of pings ≠ left the outlet.
+    if (lastInZoneAt && lastPingAt && latestPingOutOfZone) {
       const inZoneAgoMin = (now.getTime() - lastInZoneAt.getTime()) / 60000;
       if (inZoneAgoMin > graceMin) {
         closeAt = lastInZoneAt;


### PR DESCRIPTION
## Problem

Staff were being auto-clocked-out **mid-shift while still working at the outlet**, with the shift truncated to ~0 hours.

The cause is **Rule A** in the attendance auto-close cron (`apps/backoffice/src/app/api/cron/attendance-auto-close/route.ts`). It closed a log for `geofence_exit` whenever the *last in-zone ping* was older than the grace window (30 min):

```js
if (lastInZoneAt && lastPingAt) {
  const inZoneAgoMin = (now - lastInZoneAt) / 60000;
  if (inZoneAgoMin > graceMin) { closeAt = lastInZoneAt; reason = "geofence_exit"; }
}
```

But the apps **only ping on geofence boundary crossings** (enter/exit) plus once at clock-in — never continuously. A staffer working *inside* the zone for their whole shift produces **no new pings after clock-in**. Rule A read that silence as "they left", and `closeAt = lastInZoneAt` (≈ clock-in time) truncated a live shift to ~0h. The scheduled-end floor didn't help because mid-shift `scheduled_end` is in the future.

## Fix

Require the **most recent ping to actually be out-of-zone** (`in_zone = false`) before closing for `geofence_exit`. Absence of pings is no longer treated as leaving the outlet.

- Added `in_zone` to the latest-ping query and derived `latestPingOutOfZone`.
- Rule A now gates on `latestPingOutOfZone` in addition to the stale-in-zone check.

Genuinely forgotten/abandoned shifts are still closed by the other rules — no-pings-stale (B), past-scheduled-end (C), and outlet-closed (D) — so nothing is left open indefinitely.

## Testing

- `npx tsc --noEmit` on the changed file shows no errors from this change (remaining errors are pre-existing, from uninstalled deps / ungenerated Prisma client in this environment).
- Logic walkthrough: staffer inside zone all shift → latest ping `in_zone=true` → Rule A skipped → closed instead by scheduled-end/outlet-close rules at a correct time. Staffer who crosses the exit boundary → exit event emits an out-of-zone ping → Rule A fires correctly after grace.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01B7WiKCn4NpWzaka6ZtjB6z)_