### PR TITLE
fix(invoices): Due Today uses Malaysia date, not the server's UTC date

### DIFF
--- a/apps/backoffice/src/app/(admin)/inventory/invoices/page.tsx
+++ b/apps/backoffice/src/app/(admin)/inventory/invoices/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { formatRM } from "@celsius/shared";
+import { mytTodayStr } from "@/lib/inventory/myt-today";
 
 import { useState, useEffect, useRef, useCallback } from "react";
 import { Button } from "@/components/ui/button";
@@ -335,7 +336,7 @@ export default function InvoicesPage() {
   const dueTodayCount = data?.dueTodayCount ?? 0;
   const dueTodayAmount = data?.dueTodayAmount ?? 0;
 
-  const today = new Date().toISOString().split("T")[0];
+  const today = mytTodayStr();
 
   // Bank filter is still applied client-side (it's a free-text contains check
   // on supplier/claimant bank names — not worth a server roundtrip). cardFilter
@@ -735,7 +736,7 @@ export default function InvoicesPage() {
     setAttachRecon(null);
     setShowVariances(false);
     setAttachVarianceReason("");
-    const today = new Date().toISOString().split("T")[0];
+    const today = mytTodayStr();
     const termDays = parsePaymentTermDays(inv.supplierPaymentTerms);
     setAttachForm({
       invoiceNumber: "",
@@ -904,7 +905,7 @@ export default function InvoicesPage() {
     if (!rejectingInvoice) return;
     setRejectSaving(true);
     try {
-      const today = new Date().toISOString().split("T")[0];
+      const today = mytTodayStr();
       const oldRef = rejectingInvoice.paymentRef ?? "n/a";
       const stamp = `[Rejected ${today} — was ref: ${oldRef}]${rejectReason.trim() ? ": " + rejectReason.trim() : ""}`;
       const newNotes = rejectingInvoice.notes ? `${rejectingInvoice.notes}\n\n${stamp}` : stamp;

--- a/apps/backoffice/src/app/api/inventory/invoices/export/route.ts
+++ b/apps/backoffice/src/app/api/inventory/invoices/export/route.ts
@@ -3,6 +3,7 @@ import type { Prisma } from "@celsius/db";
 import * as XLSX from "xlsx";
 import { prisma } from "@/lib/prisma";
 import { getUserFromHeaders } from "@/lib/auth";
+import { mytTodayRange } from "@/lib/inventory/myt-today";
 
 export const runtime = "nodejs"; // xlsx needs Node
 
@@ -33,8 +34,8 @@ export async function GET(req: NextRequest) {
   const UNPAID_STATUSES = ["DRAFT", "INITIATED", "PENDING", "PARTIALLY_PAID", "DEPOSIT_PAID", "OVERDUE"];
 
   const now = new Date();
-  const todayStart = new Date(now.getFullYear(), now.getMonth(), now.getDate());
-  const todayEnd = new Date(todayStart.getTime() + 86400000);
+  // MYT calendar day (see lib/inventory/myt-today) — keep Due Today / overdue consistent with the API.
+  const { start: todayStart, end: todayEnd } = mytTodayRange();
 
   // Mirror the list route: overdue = unpaid past due, including the two-leg
   // states (DEPOSIT_PAID / PARTIALLY_PAID) whose balance is past due. Status

--- a/apps/backoffice/src/app/api/inventory/invoices/reconciliation/route.ts
+++ b/apps/backoffice/src/app/api/inventory/invoices/reconciliation/route.ts
@@ -2,6 +2,7 @@ import { NextResponse, NextRequest } from "next/server";
 import { prisma } from "@/lib/prisma";
 import { getUserFromHeaders } from "@/lib/auth";
 import { activeFlags, flagLabel, type InvoiceFlag } from "@/lib/inventory/flag-detector";
+import { mytTodayRange } from "@/lib/inventory/myt-today";
 
 // GET /api/inventory/invoices/reconciliation
 //
@@ -59,7 +60,7 @@ export async function GET(req: NextRequest) {
   if (!caller) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
 
   const now = new Date();
-  const todayStart = new Date(now.getFullYear(), now.getMonth(), now.getDate());
+  const todayStart = mytTodayRange().start; // MYT calendar midnight (see lib/inventory/myt-today)
 
   // Optional supplier filter — same repeated-param shape as the invoices list.
   const supplierIds = req.nextUrl.searchParams.getAll("supplier").filter(Boolean);

--- a/apps/backoffice/src/app/api/inventory/invoices/route.ts
+++ b/apps/backoffice/src/app/api/inventory/invoices/route.ts
@@ -3,6 +3,7 @@ import type { Prisma } from "@celsius/db";
 import { prisma } from "@/lib/prisma";
 import { getUserFromHeaders } from "@/lib/auth";
 import { detectCreationFlags } from "@/lib/inventory/flag-detector";
+import { mytTodayRange } from "@/lib/inventory/myt-today";
 
 export async function GET(req: NextRequest) {
   const caller = await getUserFromHeaders(req.headers);
@@ -20,9 +21,10 @@ export async function GET(req: NextRequest) {
   // over `tab` when they conflict — the user explicitly clicked a card.
   const cardFilter = req.nextUrl.searchParams.get("cardFilter") || "";
 
-  const _now = new Date();
-  const _todayStart = new Date(_now.getFullYear(), _now.getMonth(), _now.getDate());
-  const _todayEnd = new Date(_todayStart.getTime() + 86400000);
+  // "Today" is the MALAYSIA calendar day (UTC+8), not the server's UTC day — otherwise invoices
+  // due today drop out of the Due Today card every Malaysia morning (00:00–08:00 MYT, when UTC is
+  // still yesterday). See lib/inventory/myt-today.
+  const { start: _todayStart, end: _todayEnd } = mytTodayRange();
 
   // "Overdue" semantically = anything unpaid past its due date. The OVERDUE
   // status auto-rollover only flips PENDING → OVERDUE (line below); INITIATED

--- a/apps/backoffice/src/lib/inventory/myt-today.ts
+++ b/apps/backoffice/src/lib/inventory/myt-today.ts
@@ -1,0 +1,23 @@
+// The business runs in Malaysia (UTC+8). Invoice due/issue dates are stored as midnight of the
+// calendar date the user picked (e.g. 2026-06-30 00:00:00, read back as UTC midnight). Computing
+// "today" from the server's clock — `new Date(y, m, d)` on Vercel resolves to UTC — mis-buckets
+// everything between Malaysia midnight and 08:00, when UTC is still "yesterday": invoices due
+// today in Malaysia fall outside the window and vanish from the Due Today card/filter. These
+// helpers key "today" to the MALAYSIA date instead. Pure (no deps) — usable on server + client.
+
+const MYT_OFFSET_MS = 8 * 60 * 60 * 1000;
+
+/** Today's Malaysia calendar date as "YYYY-MM-DD" (for date-only string comparisons). */
+export function mytTodayStr(): string {
+  return new Date(Date.now() + MYT_OFFSET_MS).toISOString().slice(0, 10);
+}
+
+/**
+ * [start, end) for the current Malaysia day, as UTC-midnight Dates — matching how dueDate/issueDate
+ * are stored, so `dueDate: { gte: start, lt: end }` selects invoices due *today in Malaysia*, and
+ * `dueDate: { lt: start }` is genuinely overdue.
+ */
+export function mytTodayRange(): { start: Date; end: Date } {
+  const start = new Date(`${mytTodayStr()}T00:00:00.000Z`);
+  return { start, end: new Date(start.getTime() + 86400000) };
+}


### PR DESCRIPTION
**Bug (raised repeatedly):** invoices due *today* — including DEPOSIT_PAID ones with a balance due today — don't appear in the **Due Today** card/filter.

**Root cause — timezone.** I confirmed it on the live data: right now it's `2026-06-30 07:37 MYT` but only `2026-06-29 23:37 UTC`. "Today" was computed as `new Date(y, m, d)` — **server-local, which is UTC on Vercel** — so the Due Today window was **29 June**. The three invoices have `dueDate = 2026-06-30 00:00`, which falls *just outside* the 29-June window (`in_utc_today = false`) — and they aren't overdue either, so they show nowhere. This happens **every Malaysia morning** (00:00–08:00 MYT, when UTC hasn't rolled over) — which is why it kept recurring.

**Fix.** New shared `lib/inventory/myt-today.ts`:
- `mytTodayRange()` → `[start, end)` for the current **Malaysia** day, as UTC-midnight Dates (matching how `dueDate` is stored).
- `mytTodayStr()` → MYT `YYYY-MM-DD`.

Applied to all 5 sites that computed "today" in UTC: the invoices **API** (the card), the **export**, the **reconciliation** overdue calc, and the **client** page's 3 `today` comparisons. The status set was already correct (DEPOSIT_PAID is in `UNPAID_STATUSES`) — it was purely the date window.

Verified against the live rows: with the MYT window the three IV-0205x invoices now fall inside `[2026-06-30, 2026-07-01)` → Due Today. Typecheck + lint clean.