### PR TITLE
fix(pos): gate snoozed (86'd) items out of pairing suggestions

### DIFF
--- a/apps/backoffice/src/app/api/pos/loyalty/suggest-pairs/route.ts
+++ b/apps/backoffice/src/app/api/pos/loyalty/suggest-pairs/route.ts
@@ -18,11 +18,32 @@ export async function POST(req: NextRequest) {
       process.env.NEXT_PUBLIC_SUPABASE_URL!,
       process.env.SUPABASE_SERVICE_ROLE_KEY || process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
     );
+
+    // The POS apps (register + customer display) send the LOYALTY outlet id,
+    // but the shared engine's "86" overlay reads outlet_product_availability,
+    // which is keyed by STORE SLUG (e.g. "shah-alam"). Resolve loyalty id →
+    // store slug here so snoozed items are actually dropped from suggestions —
+    // otherwise an item hidden from the menu still surfaces in "Pair with a
+    // Bite" and the customer can order it. Falls back to the raw id if the
+    // outlet can't be resolved (preserves combo outlet-targeting, which stores
+    // both keys). The slug also matches combo outlet_ids, same as the web path.
+    const loyaltyOutletId: string | null = body?.outlet_id ?? null;
+    let outletId = loyaltyOutletId;
+    if (loyaltyOutletId) {
+      const { data: os } = await supabase
+        .from("outlet_settings")
+        .select("store_id")
+        .eq("loyalty_outlet_id", loyaltyOutletId)
+        .maybeSingle();
+      const storeId = (os as { store_id?: string } | null)?.store_id;
+      if (storeId) outletId = storeId;
+    }
+
     const { pairs, round } = await suggestPairs({
       supabase,
       cartProductIds: Array.isArray(body?.cart_product_ids) ? body.cart_product_ids : [],
       usualProductIds: Array.isArray(body?.usual_product_ids) ? body.usual_product_ids : [],
-      outletId: body?.outlet_id ?? null,
+      outletId,
       channel: "pos",
     });
     return NextResponse.json({ pairs, round });

--- a/apps/order/src/app/cart/_CartUpsell.tsx
+++ b/apps/order/src/app/cart/_CartUpsell.tsx
@@ -12,8 +12,12 @@ type Pair = { id: string; name: string; basePrice: number; image: string | null;
  * (drinks cart → a bite, etc.) via /api/suggest-pairs, personalized by member.
  * Cards link to the product page (one tap to add, same flow as the best-seller
  * rail). Renders nothing until it has a suggestion, so it never adds noise.
+ *
+ * outletId (the store slug) is forwarded so the shared engine can drop items
+ * that are 86'd / snoozed at this outlet — otherwise a snoozed item, hidden
+ * from the menu, would still surface here and let the customer order it.
  */
-export function CartUpsell({ productIds, loyaltyId }: { productIds: string[]; loyaltyId: string | null }) {
+export function CartUpsell({ productIds, loyaltyId, outletId }: { productIds: string[]; loyaltyId: string | null; outletId: string | null }) {
   const [pairs, setPairs] = useState<Pair[]>([]);
   const key = productIds.slice().sort().join(",");
 
@@ -23,14 +27,15 @@ export function CartUpsell({ productIds, loyaltyId }: { productIds: string[]; lo
     fetch("/api/suggest-pairs", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ cart_product_ids: productIds, member: loyaltyId }),
+      body: JSON.stringify({ cart_product_ids: productIds, member: loyaltyId, outlet_id: outletId }),
     })
       .then((r) => r.json())
       .then((j) => { if (!cancelled) setPairs(Array.isArray(j?.pairs) ? j.pairs : []); })
       .catch(() => { if (!cancelled) setPairs([]); });
     return () => { cancelled = true; };
-    // Re-fetch when the cart contents change (key) or the member resolves.
-  }, [key, loyaltyId]); // eslint-disable-line react-hooks/exhaustive-deps
+    // Re-fetch when the cart contents change (key), the member resolves, or the
+    // selected outlet changes (different outlet = different 86 list).
+  }, [key, loyaltyId, outletId]); // eslint-disable-line react-hooks/exhaustive-deps
 
   if (pairs.length === 0) return null;
 

--- a/apps/order/src/app/cart/_CartView.tsx
+++ b/apps/order/src/app/cart/_CartView.tsx
@@ -455,7 +455,7 @@ export function CartView({ bestSellers = [] }: { bestSellers?: BestSeller[] }) {
 
       {/* Basket-targeted upsell — "goes well with your order" (drinks → a bite,
           personalized by member). Reactive to the cart contents. */}
-      <CartUpsell productIds={items.map((i) => i.productId)} loyaltyId={loyaltyId} />
+      <CartUpsell productIds={items.map((i) => i.productId)} loyaltyId={loyaltyId} outletId={outletId} />
 
       {reward ? (
         <div


### PR DESCRIPTION
## Problem

Items that are **snoozed / "86'd"** at an outlet (an `outlet_product_availability` row with `is_available=false`) are correctly hidden from the **menu tab**, but they were still appearing in the **pairing** rails ("Pair with a Bite" / "Goes well with your order"). Because pairing didn't gate them, a customer on QR table pay or in the apps could still add and order an item the outlet had marked out of stock.

## Root cause

The shared `suggestPairs` engine *does* drop per-outlet 86'd items, via an `outlet_product_availability` overlay — but that table is keyed by **store slug** (e.g. `shah-alam`), and the overlay only runs when a matching `outletId` is supplied. Two callers never matched that key:

- **Order app (QR table pay / web pickup)** — the cart upsell (`_CartUpsell.tsx`) called `/api/suggest-pairs` with **no `outlet_id` at all**, so the 86 overlay was skipped entirely.
- **pos-native register + customer display** — both send the **loyalty outlet id**, which the slug-keyed 86 table can't match, so the overlay found nothing.

`pickup-native` was already safe: its product-page `PairWith` builds suggestions from the already-snooze-filtered menu, and its cart upsell already passes the store slug.

## Changes

- **`apps/order`** — `_CartView.tsx` forwards the selected outlet to `_CartUpsell`, which now sends `outlet_id` (the store slug) to `/api/suggest-pairs`, and re-fetches when the outlet changes. The route already reads `outlet_id`.
- **`apps/backoffice`** — `/api/pos/loyalty/suggest-pairs` resolves the incoming **loyalty outlet id → store slug** (`outlet_settings.store_id`) before calling the engine, so the 86 overlay matches. Falls back to the raw id when the outlet can't be resolved. The slug also matches combo `outlet_ids` (which store both keys), consistent with the web path — so combo targeting is unaffected. This single change covers both the register and the customer display.

## Testing

- Traced every customer-facing pairing surface; confirmed `pickup-native` already filters and the two fixed paths now receive the slug the 86 overlay needs.
- A full typecheck isn't possible in this container (app `node_modules` aren't installed), but the changes use the same `string | null` types as surrounding code and add no new type surface.

### Suggested manual verification
1. In the backoffice Availability matrix, 86 a product at an outlet.
2. Order app (that outlet): confirm it's gone from the menu **and** no longer appears in the cart "Goes well with your order" rail.
3. POS register / customer display (that outlet): confirm the snoozed item no longer shows in "Pair with a Bite".

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01H8yhE3f3tZJoa1gk8ZRgQV)_