### PR TITLE
fix(procurement): don't chase suppliers about weeks-old un-received POs (missing-GRN, not late delivery)

### DIFF
--- a/apps/backoffice/src/lib/inventory/exec/intent-responder.ts
+++ b/apps/backoffice/src/lib/inventory/exec/intent-responder.ts
@@ -233,11 +233,17 @@ async function maybeSendToSupplier(phone: string, text: string): Promise<boolean
 /** POs whose promised delivery date has passed with no GRN → chase for a fresh ETA. */
 async function chaseMissedPromises(): Promise<number> {
   const now = new Date();
+  // Only chase a RECENTLY-overdue delivery. A PO weeks past its date with still no GRN is almost
+  // always a missing-receiving (ops didn't record the goods), NOT a late delivery — chasing the
+  // supplier for a "new ETA" on a 6-week-old PO is wrong and looks disorganised. Beyond this
+  // window it's left for ops to reconcile (the goods likely arrived and just need receiving).
+  const CHASE_MAX_OVERDUE_DAYS = 7;
+  const chaseFloor = new Date(now.getTime() - CHASE_MAX_OVERDUE_DAYS * 24 * 60 * 60 * 1000);
   const overdue = await prisma.order.findMany({
     where: {
       orderType: "PURCHASE_ORDER",
       status: { in: AWAITING_STATUSES },
-      deliveryDate: { lt: now },
+      deliveryDate: { lt: now, gte: chaseFloor },
       receivings: { none: {} },
     },
     take: 30,


### PR DESCRIPTION
**Issue (screenshot):** the AUTO agent was messaging *Jiju Cakes To Share* a "new ETA?" follow-up on POs expected **mid-May** (6 weeks ago). Those weren't undelivered — the goods arrived and **ops never did the receiving (GRN)**, so the system still showed them as awaiting delivery and the chaser nagged the supplier.

**Cause:** `chaseMissedPromises` ([intent-responder.ts](apps/backoffice/src/lib/inventory/exec/intent-responder.ts)) selected **any** PO with `deliveryDate < now` + no receiving — **no lower bound**. When a supplier was flipped to AUTO, it swept the entire backlog of old un-received POs at once.

**Fix:** only chase a **recently** overdue delivery (≤ 7 days past the expected date). A PO further past with still no GRN is a missing-receiving (ops) issue, not a late delivery, so the supplier isn't bothered — it's left for ops to reconcile/receive. Dedup + AUTO-only gating unchanged.

Note: this stops the *symptom*. The root cause is the un-GRN'd backlog — those POs will keep showing as "awaiting delivery" until ops records the receivings. I can pull the list of old un-received POs so they can be cleared. Typecheck + lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)