### PR TITLE
feat(reviews): flag happy-but-fixable 4-5★ reviews to ops over WhatsApp

### DIFF
--- a/apps/backoffice/src/app/api/cron/reviews-auto-reply/route.ts
+++ b/apps/backoffice/src/app/api/cron/reviews-auto-reply/route.ts
@@ -3,10 +3,16 @@ import { checkCronAuth } from "@celsius/shared";
 import { getUserFromHeaders } from "@/lib/auth";
 import { prisma } from "@/lib/prisma";
 import { fetchGoogleReviews, replyToReview } from "@/lib/reviews/gbp";
-import { generateReply, POSITIVE_THRESHOLD } from "@/lib/reviews/auto-reply";
+import { generateReply, extractImprovement, POSITIVE_THRESHOLD } from "@/lib/reviews/auto-reply";
 
 export const dynamic = "force-dynamic";
 export const maxDuration = 300;
+
+// While we reply to each happy (4-5★) review, also catch any fixable point
+// buried in the praise and flag it for the ops review-nudge (WhatsApp). Default
+// on; set REVIEWS_IMPROVEMENT_FLAGS_ENABLED=false to pause without a deploy.
+const IMPROVEMENT_FLAGS_ENABLED =
+  (process.env.REVIEWS_IMPROVEMENT_FLAGS_ENABLED || "true").toLowerCase() !== "false";
 
 // Scheduled auto-reply for POSITIVE (4-5★) Google reviews only.
 //
@@ -30,6 +36,7 @@ type OutletResult = {
   candidates: number;
   posted: number;
   failed: number;
+  flagged: number; // happy reviews with a fixable point, surfaced to ops
   error?: string;
 };
 
@@ -53,6 +60,7 @@ export async function GET(req: NextRequest) {
   const results: OutletResult[] = [];
   let totalPosted = 0;
   let totalFailed = 0;
+  let totalFlagged = 0;
 
   for (const outlet of connected) {
     if (totalPosted >= MAX_TOTAL) break;
@@ -73,6 +81,7 @@ export async function GET(req: NextRequest) {
 
       let posted = 0;
       let failed = 0;
+      let flagged = 0;
 
       for (const review of candidates) {
         if (posted >= MAX_PER_OUTLET || totalPosted + posted >= MAX_TOTAL) break;
@@ -94,6 +103,39 @@ export async function GET(req: NextRequest) {
             reply,
           );
           posted++;
+
+          // Happy-but-fixable: read the praise for a concrete point and flag it
+          // for the ops review-nudge. Isolated — a classifier slip never fails
+          // the reply we just posted. Skip comment-less ratings (nothing to read).
+          if (IMPROVEMENT_FLAGS_ENABLED && review.comment?.trim()) {
+            try {
+              const verdict = await extractImprovement({
+                rating: review.rating,
+                comment: review.comment,
+                outletName: outlet.name,
+              });
+              if (verdict.actionable) {
+                await prisma.reviewImprovementFlag.upsert({
+                  where: { reviewId: review.id },
+                  create: {
+                    reviewId: review.id,
+                    outletId: outlet.id,
+                    reviewerName: review.reviewer.name,
+                    rating: review.rating,
+                    comment: review.comment,
+                    point: verdict.point,
+                  },
+                  update: { point: verdict.point },
+                });
+                flagged++;
+              }
+            } catch (cErr) {
+              console.error(
+                `[reviews-auto-reply] improvement-flag failed for review ${review.id} (${outlet.name}):`,
+                cErr,
+              );
+            }
+          }
         } catch (err) {
           console.error(
             `[reviews-auto-reply] failed for review ${review.id} (${outlet.name}):`,
@@ -105,12 +147,14 @@ export async function GET(req: NextRequest) {
 
       totalPosted += posted;
       totalFailed += failed;
+      totalFlagged += flagged;
       results.push({
         outletId: outlet.id,
         outletName: outlet.name,
         candidates: candidates.length,
         posted,
         failed,
+        flagged,
       });
     } catch (err) {
       console.error(
@@ -123,6 +167,7 @@ export async function GET(req: NextRequest) {
         candidates: 0,
         posted: 0,
         failed: 0,
+        flagged: 0,
         error: "fetch_failed",
       });
     }
@@ -134,6 +179,7 @@ export async function GET(req: NextRequest) {
     max_per_outlet: MAX_PER_OUTLET,
     total_posted: totalPosted,
     total_failed: totalFailed,
+    total_flagged: totalFlagged,
     results,
   });
 }

--- a/apps/backoffice/src/lib/ops-nudges/index.ts
+++ b/apps/backoffice/src/lib/ops-nudges/index.ts
@@ -309,7 +309,9 @@ export async function runReviewNudges(now = new Date()): Promise<NudgeRunResult>
     if (team.length === 0) console.warn(`[ops-nudge:review] no on-shift team for ${outletName} — only managers notified`);
   }
 
-  const headline = `${managerLines.length} new guest review${managerLines.length === 1 ? "" : "s"} need a response`;
+  // "need attention" not "need a response": the list mixes reviews awaiting a
+  // reply with happy-but-fixable notes (already auto-replied) that just want action.
+  const headline = `${managerLines.length} guest review${managerLines.length === 1 ? "" : "s"} need attention`;
   const managerSent = await sendManagerDigestToOps(headline, managerLines, mode);
   return { mode, ranAt, items: managerLines.length, staffSent, managerSent };
 }

--- a/apps/backoffice/src/lib/ops-pulse/detectors.ts
+++ b/apps/backoffice/src/lib/ops-pulse/detectors.ts
@@ -207,6 +207,36 @@ export async function detectReviews(now: Date): Promise<Breach[]> {
     });
   }
 
+  // Happy-but-fixable (4-5★): the review was auto-replied, but the auto-reply
+  // cron caught a concrete improvement in the praise. Surface it so a good
+  // review's fixable point isn't lost. LOW severity (informational, not an
+  // incident); copy stays positive so the team reads it as a tip, not a blame.
+  const flags = await prisma.reviewImprovementFlag.findMany({
+    where: { status: "open", createdAt: { gte: since } },
+    select: {
+      id: true,
+      outletId: true,
+      rating: true,
+      point: true,
+      outlet: { select: { name: true, status: true } },
+    },
+    orderBy: { createdAt: "asc" },
+    take: 100,
+  });
+  for (const fl of flags) {
+    if (fl.outlet.status !== "ACTIVE") continue;
+    breaches.push({
+      signal: "REVIEW",
+      outletId: fl.outletId,
+      outletName: fl.outlet.name,
+      severity: "LOW",
+      routeKey: "operations",
+      dedupeKey: `REVIEW:IMP:${fl.id}`,
+      summary: `${fl.rating}★ happy guest with a fixable note at ${fl.outlet.name}: ${clip(fl.point, 160)}`,
+      detail: { source: "positive_improvement", flagId: fl.id, rating: fl.rating },
+    });
+  }
+
   return breaches;
 }
 

--- a/apps/backoffice/src/lib/reviews/auto-reply.ts
+++ b/apps/backoffice/src/lib/reviews/auto-reply.ts
@@ -67,3 +67,59 @@ Reply:`;
   const text = response.content[0];
   return text.type === "text" ? text.text.trim() : "";
 }
+
+export type ImprovementVerdict = {
+  actionable: boolean;
+  // Short, concrete improvement phrase when actionable (e.g. "wifi kept
+  // dropping", "slow service at peak"); empty when not.
+  point: string;
+};
+
+/**
+ * Read a HAPPY (4-5★) review and decide whether — under the praise — it carries
+ * a concrete, fixable operational point worth flagging to the team. Pure praise
+ * ("best coffee in town!"), vague vibes, or off-topic comments are NOT
+ * actionable. Cheap, fast model; returns strict JSON we parse defensively.
+ */
+export async function extractImprovement(review: {
+  rating: number;
+  comment: string;
+  outletName: string;
+}): Promise<ImprovementVerdict> {
+  const comment = review.comment.trim();
+  if (!comment) return { actionable: false, point: "" };
+
+  const prompt = `A customer left a ${review.rating}/5 review for Celsius Coffee (${review.outletName}), a café in Malaysia. The review is POSITIVE overall, but happy customers sometimes still mention something that could be better ("great coffee, but the wifi kept dropping", "sedap tapi lambat sikit"). The comment may be in English or Malay.
+
+Decide if there is a SPECIFIC, ACTIONABLE thing the café could fix or improve — something concrete the team can act on (speed, cleanliness, wifi, seating, temperature, portion, noise, parking, a specific staff interaction, a menu gap, etc.).
+
+NOT actionable: pure praise, generic vibes, compliments, "nothing", or anything the café can't act on (e.g. "wish it were closer to my house").
+
+Reply with ONLY a JSON object, no other text:
+{"actionable": true/false, "point": "<short concrete phrase, max 8 words; empty string if not actionable>"}
+
+Do not use em-dashes or en-dashes in the point; use commas or "and".
+
+Review: ${comment}
+
+JSON:`;
+
+  const response = await anthropic.messages.create({
+    model: "claude-haiku-4-5-20251001",
+    max_tokens: 120,
+    messages: [{ role: "user", content: prompt }],
+  });
+
+  const text = response.content[0];
+  const raw = text.type === "text" ? text.text.trim() : "";
+  try {
+    const match = raw.match(/\{[\s\S]*\}/);
+    if (!match) return { actionable: false, point: "" };
+    const parsed = JSON.parse(match[0]) as { actionable?: unknown; point?: unknown };
+    const point = typeof parsed.point === "string" ? parsed.point.trim() : "";
+    const actionable = parsed.actionable === true && point.length > 0;
+    return { actionable, point: actionable ? point : "" };
+  } catch {
+    return { actionable: false, point: "" };
+  }
+}

--- a/packages/db/prisma/migrations/20260630_review_improvement_flag/migration.sql
+++ b/packages/db/prisma/migrations/20260630_review_improvement_flag/migration.sql
@@ -1,0 +1,31 @@
+-- Happy-but-fixable review flag. A 4-5★ Google review auto-replies (no draft),
+-- so the auto-reply cron asks the model whether the comment carries an
+-- actionable point and lands it here when it does; the ops review-nudge then
+-- surfaces it on WhatsApp. Captured for reproducibility per
+-- docs/database-migrations.md (never auto-run; apply via Supabase SQL editor /
+-- MCP). Matches model ReviewImprovementFlag in packages/db/prisma/schema.prisma.
+
+CREATE TABLE "ReviewImprovementFlag" (
+    "id" TEXT NOT NULL,
+    "reviewId" TEXT NOT NULL,
+    "outletId" TEXT NOT NULL,
+    "reviewerName" TEXT,
+    "rating" INTEGER NOT NULL,
+    "comment" TEXT,
+    "point" TEXT NOT NULL,
+    "status" TEXT NOT NULL DEFAULT 'open',
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT "ReviewImprovementFlag_pkey" PRIMARY KEY ("id")
+);
+
+CREATE UNIQUE INDEX "ReviewImprovementFlag_reviewId_key" ON "ReviewImprovementFlag"("reviewId");
+CREATE INDEX "ReviewImprovementFlag_status_createdAt_idx" ON "ReviewImprovementFlag"("status", "createdAt");
+CREATE INDEX "ReviewImprovementFlag_outletId_idx" ON "ReviewImprovementFlag"("outletId");
+
+ALTER TABLE "ReviewImprovementFlag"
+    ADD CONSTRAINT "ReviewImprovementFlag_outletId_fkey"
+    FOREIGN KEY ("outletId") REFERENCES "Outlet"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- Server-only table (Prisma/service role). Enable RLS with no public policies so
+-- anon/authenticated keys can't read it, matching OpsAlert/ReviewReplyDraft.
+ALTER TABLE "ReviewImprovementFlag" ENABLE ROW LEVEL SECURITY;

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -103,6 +103,7 @@ model Outlet {
   reviewSettings    ReviewSettings?
   internalFeedbacks InternalFeedback[]
   reviewReplyDrafts ReviewReplyDraft[]
+  reviewImprovementFlags ReviewImprovementFlag[]
   geoGridScans      GeoGridScan[]
   geoGridKeywords   GeoGridKeyword[]
   reviewDailySnapshots ReviewDailySnapshot[]
@@ -1391,6 +1392,31 @@ model ReviewReplyDraft {
   updatedAt    DateTime  @updatedAt
 
   @@index([status])
+  @@index([outletId])
+}
+
+// Happy-but-fixable signal. A 4-5★ Google review is auto-replied (no draft), so
+// any improvement buried in the praise ("great coffee, but the wifi kept
+// dropping") would otherwise be lost. At reply time the auto-reply cron asks the
+// model whether the comment carries an actionable point; if so it lands here and
+// the ops review-nudge surfaces it on WhatsApp. One row per GBP review
+// (reviewId unique) so re-runs never re-flag. Status drives a future BackOffice
+// "what happy guests want improved" list. Table created by manual SQL migration;
+// never `prisma db push`.
+model ReviewImprovementFlag {
+  id           String   @id @default(uuid())
+  reviewId     String   @unique // GBP review id (idempotency anchor)
+  outletId     String
+  outlet       Outlet   @relation(fields: [outletId], references: [id])
+  reviewerName String?
+  rating       Int // 4 or 5
+  comment      String? // the full review text
+  point        String // the extracted improvement (short, e.g. "wifi kept dropping")
+  // open(needs attention) | ack(seen) | dismissed(not actionable after all)
+  status       String   @default("open")
+  createdAt    DateTime @default(now())
+
+  @@index([status, createdAt])
   @@index([outletId])
 }
 


### PR DESCRIPTION
## Why
4-5★ Google reviews get auto-replied and never create a draft, so a fixable point hidden in a good review ("loved it, but service was slow at peak") was silently lost. This catches them.

## How
While the daily auto-reply cron replies to each happy review, it now also asks the model whether the comment has a concrete, actionable point. If yes → a `ReviewImprovementFlag` row, and the **existing** ops review-nudge surfaces it on WhatsApp (same routing as reviews today: on-shift team + ops/managers). No new cron, no new send path.

- **DB**: new `ReviewImprovementFlag` (reviewId unique = idempotent), manual SQL migration, RLS enabled to match peer tables. Applied to prod.
- **Classifier**: `extractImprovement()` — cheap Haiku call, strict JSON, defensive parse. Pure praise / vague vibes are not actionable. Malay + English.
- **Cron**: classification is isolated in its own try/catch — a slip never fails the reply we just posted. Gated by `REVIEWS_IMPROVEMENT_FLAGS_ENABLED` (default on, flip off to pause without a deploy).
- **Detector**: LOW-severity REVIEW breach, positive em-dash-free copy so the team reads it as a tip.
- **Copy**: digest headline softened to "need attention" (list now mixes reply-needed + already-replied-fixable).

## Notes
- Forward-looking: only reviews replied from now on get classified (already-replied history isn't re-scanned, to avoid re-calling the LLM over the full backlog every run).
- Cost: ~1 Haiku call per happy review with a comment, once, at reply time. Negligible at review volume.