### PR TITLE
feat(finance): expense GrabFood commission in the P&L

### DIFF
--- a/apps/backoffice/src/lib/finance/reports/pnl-sourced.ts
+++ b/apps/backoffice/src/lib/finance/reports/pnl-sourced.ts
@@ -40,6 +40,16 @@ const BANK_NONOPEX = new Set([                                                  
   "INTERCO_EXPENSES", "INVESTMENTS", "EQUIPMENTS", "ADTD", "TRANSFER_NOT_SUCCESSFUL",
 ]);
 
+// GrabFood revenue is booked GROSS in income, but Grab deducts a commission
+// (marketplace fee) at source before paying out — so it never appears in the
+// bank feed and must be recognised as a cost here, else Grab margin is wildly
+// overstated. This is an ESTIMATE at a flat rate; the exact per-order
+// commission lives in the GrabFood Partner settlement report (TODO: source it
+// from the API and replace this estimate). Commission is the selling company's
+// cost, so it attributes to whichever company booked the Grab revenue —
+// independent of which bank account the net payout lands in.
+const GRAB_COMMISSION_RATE = 0.30;
+
 function humanCat(c: string | null): string {
   if (!c) return "Unclassified";
   return c.toLowerCase().replace(/_/g, " ").replace(/\b\w/g, (m) => m.toUpperCase());
@@ -165,6 +175,23 @@ export async function buildSourcedPnl(input: {
         totalExpenses += grabAds;
       }
     }
+  }
+
+  // GrabFood commission (marketplace fee) — estimated on the gross Grab
+  // revenue booked above, since Grab nets it out before payout (never in the
+  // bank feed). Find the Grab income code(s) and apply the rate.
+  const grabGross = [...incomeByCode.entries()]
+    .filter(([code]) => /grab/i.test(incomeName.get(code) ?? code))
+    .reduce((s, [, v]) => s + v, 0);
+  if (grabGross > 0) {
+    const grabComm = round2(grabGross * GRAB_COMMISSION_RATE);
+    expenseLines.push({
+      code: "MKT-GRAB-COMM",
+      name: `Marketplace fee — GrabFood commission (est. ${Math.round(GRAB_COMMISSION_RATE * 100)}%)`,
+      amount: grabComm,
+      parentCode: null,
+    });
+    totalExpenses += grabComm;
   }
 
   // Bank-classified outflows for this company's account.


### PR DESCRIPTION
GrabFood revenue is booked **gross**, but Grab nets its commission out **at source** before payout — so it never appears in the bank feed and was never costed, overstating Grab margin by the commission rate.

Adds a **marketplace-fee** expense line = rate × gross Grab revenue, attributed to the **selling** company (so Putrajaya's commission lands on Conezion's P&L even though the net cash settles in the HQ account).

- Flat-rate **estimate**, label shows `(est. 30%)` so it reads as one; ~RM7.7k/mo that was previously missing.
- TODO: replace the estimate with the exact per-order commission from the GrabFood Partner settlement API.

Grab marketing (promos + ads) was already costed separately; this adds the commission half you flagged.