### PR TITLE
feat(procurement): ASSIST proposes invoice revisions to approve

### DIFF
--- a/apps/backoffice/src/app/(admin)/inventory/supplier-chats/page.tsx
+++ b/apps/backoffice/src/app/(admin)/inventory/supplier-chats/page.tsx
@@ -103,6 +103,15 @@ type Detail = {
     paymentModel?: string;
     popDeliveryCritical?: boolean;
     poAction: { type: string; poItemId: string | null; itemName: string | null; newQuantity: number | null; note: string | null } | null;
+    invoiceAction: {
+      invoiceId: string;
+      invoiceNumber: string;
+      orderNumber: string;
+      fromAmount: number;
+      toAmount: number | null;
+      fromNumber: string;
+      toNumber: string | null;
+    } | null;
     at: string;
   } | null;
   agentReSource?: { orderId: string | null; supplierName: string; orderNumber: string; qty: number; unit: string; existing: boolean } | null;
@@ -623,6 +632,32 @@ export default function SupplierChatsPage() {
     }
   }
 
+  // Approve the agent's proposed invoice REVISION — the server applies the stamped amount/number
+  // change to the invoice (and refuses if it's already paid). ASSIST does the work; you only decide.
+  async function applyInvoiceRevision() {
+    const p = detail?.agentProposal;
+    if (!selected || applying || !p?.invoiceAction?.invoiceId) return;
+    setApplying(true);
+    setApplyError(null);
+    try {
+      const res = await fetch(`/api/inventory/supplier-chats/${selected}/apply-proposal`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ messageId: p.messageId, action: "apply_invoice_revision" }),
+      });
+      const json = await res.json().catch(() => ({}));
+      if (!res.ok) {
+        setApplyError(json.error ?? "Apply failed");
+        return;
+      }
+      mutateDetail();
+    } catch {
+      setApplyError("Network error");
+    } finally {
+      setApplying(false);
+    }
+  }
+
   // Clear the "Agent suggests" banner once you've handled it your own way (paid the
   // invoice, replied yourself, no PO change) — the resolution for escalations that have
   // no auto-appliable PO action, so the banner isn't a dead-end redirect.
@@ -952,7 +987,27 @@ export default function SupplierChatsPage() {
                       </div>
                     )}
                     <div className="text-[12px] text-foreground">
-                      {detail.agentProposal.poAction ? (
+                      {detail.agentProposal.invoiceAction ? (
+                        <>
+                          <span className="font-medium">Revised invoice</span>
+                          {detail.agentProposal.invoiceAction.orderNumber && <> · {detail.agentProposal.invoiceAction.orderNumber}</>}
+                          <div className="mt-0.5">
+                            {detail.agentProposal.invoiceAction.toAmount != null && (
+                              <>
+                                Amount RM{detail.agentProposal.invoiceAction.fromAmount.toFixed(2)} →{" "}
+                                <span className="font-semibold">RM{detail.agentProposal.invoiceAction.toAmount.toFixed(2)}</span>
+                              </>
+                            )}
+                            {detail.agentProposal.invoiceAction.toNumber && (
+                              <>
+                                {detail.agentProposal.invoiceAction.toAmount != null && " · "}
+                                No. {detail.agentProposal.invoiceAction.fromNumber} →{" "}
+                                <span className="font-semibold">{detail.agentProposal.invoiceAction.toNumber}</span>
+                              </>
+                            )}
+                          </div>
+                        </>
+                      ) : detail.agentProposal.poAction ? (
                         <>
                           {detail.agentProposal.poAction.type === "substitute_item" && "Substitution offered"}
                           {detail.agentProposal.poAction.type === "cancel_order" && "Cancel requested"}
@@ -967,16 +1022,30 @@ export default function SupplierChatsPage() {
                       )}
                     </div>
                     <div className="mt-1 text-[10.5px] text-muted-foreground">
-                      Held for review: {detail.agentProposal.escalationReason}. The agent did not change the PO.
+                      Held for review: {detail.agentProposal.escalationReason}.{" "}
+                      {detail.agentProposal.invoiceAction
+                        ? "The agent did not change the invoice — approve to apply."
+                        : "The agent did not change the PO."}
                     </div>
                     {(() => {
                       const pa = detail.agentProposal.poAction;
+                      const ia = detail.agentProposal.invoiceAction;
                       const canApply =
                         !!pa?.poItemId &&
                         !!detail.agentProposal.orderId &&
                         (pa.type === "remove_item" || pa.type === "reduce_qty");
                       return (
                         <div className="mt-2 flex items-center gap-2">
+                          {ia && (
+                            <button
+                              onClick={applyInvoiceRevision}
+                              disabled={applying}
+                              className="inline-flex items-center gap-1 rounded bg-amber-600 px-2 py-1 text-[11px] font-medium text-white hover:bg-amber-700 disabled:opacity-50"
+                            >
+                              {applying ? <Loader2 size={11} className="animate-spin" /> : <Check size={11} />}
+                              Approve: update invoice
+                            </button>
+                          )}
                           {canApply && (
                             <button
                               onClick={applyProposal}

--- a/apps/backoffice/src/app/api/inventory/supplier-chats/[key]/apply-proposal/route.ts
+++ b/apps/backoffice/src/app/api/inventory/supplier-chats/[key]/apply-proposal/route.ts
@@ -55,6 +55,52 @@ export async function POST(req: NextRequest, { params }: { params: Promise<{ key
     return NextResponse.json({ ok: true, dismissed: true });
   }
 
+  // Apply a supplier-sent invoice REVISION the agent proposed (amount and/or number).
+  // SAFE by construction: the values come from the agent-stamped proposal on THIS message
+  // (never the request body), and a PAID / part-paid invoice is refused outright — money has
+  // moved, so a human edits it manually. Only amount + invoiceNumber change; status/payment never.
+  if (action === "apply_invoice_revision") {
+    const proposal = (raw.proposal ?? {}) as Record<string, unknown>;
+    const invoiceAction = (proposal.invoiceAction ?? null) as
+      | { invoiceId?: string; invoiceNumber?: string; toAmount?: number | null; toNumber?: string | null }
+      | null;
+    if (!invoiceAction?.invoiceId) {
+      return NextResponse.json({ error: "No invoice revision on this proposal." }, { status: 400 });
+    }
+    const invoice = await prisma.invoice.findUnique({
+      where: { id: invoiceAction.invoiceId },
+      select: { id: true, invoiceNumber: true, amount: true, status: true, amountPaid: true },
+    });
+    if (!invoice) return NextResponse.json({ error: "Invoice not found" }, { status: 404 });
+    if (invoice.status === "PAID" || Number(invoice.amountPaid ?? 0) > 0) {
+      return NextResponse.json(
+        { error: `Invoice ${invoice.invoiceNumber} is already paid/part-paid — edit it manually.` },
+        { status: 400 },
+      );
+    }
+    const data: { amount?: number; invoiceNumber?: string } = {};
+    if (typeof invoiceAction.toAmount === "number" && invoiceAction.toAmount > 0) data.amount = invoiceAction.toAmount;
+    if (typeof invoiceAction.toNumber === "string" && invoiceAction.toNumber.trim()) {
+      data.invoiceNumber = invoiceAction.toNumber.trim().slice(0, 64);
+    }
+    if (Object.keys(data).length === 0) {
+      return NextResponse.json({ error: "Nothing to apply (no new amount or number)." }, { status: 400 });
+    }
+    try {
+      await prisma.invoice.update({ where: { id: invoice.id }, data });
+    } catch (e) {
+      // e.g. a unique invoiceNumber collision — surface it rather than 500.
+      return NextResponse.json({ error: e instanceof Error ? e.message : "Update failed" }, { status: 400 });
+    }
+    await prisma.whatsAppMessage.update({
+      where: { id: message.id },
+      data: {
+        raw: { ...raw, proposalResolved: true, invoiceRevisionApplied: true, resolvedById: caller.id, resolvedAt: new Date().toISOString() },
+      },
+    });
+    return NextResponse.json({ ok: true, action, invoiceId: invoice.id, applied: data });
+  }
+
   // Apply path: needs the order + line, and only the two low-risk edits.
   if (!orderId || !poItemId) {
     return NextResponse.json({ error: "orderId and poItemId are required to apply" }, { status: 400 });

--- a/apps/backoffice/src/app/api/inventory/supplier-chats/[key]/route.ts
+++ b/apps/backoffice/src/app/api/inventory/supplier-chats/[key]/route.ts
@@ -156,6 +156,16 @@ export async function GET(req: NextRequest, { params }: { params: Promise<{ key:
       newQuantity: number | null;
       note: string | null;
     } | null;
+    // A supplier-sent revised invoice: the concrete amount/number change to approve.
+    invoiceAction: {
+      invoiceId: string;
+      invoiceNumber: string;
+      orderNumber: string;
+      fromAmount: number;
+      toAmount: number | null;
+      fromNumber: string;
+      toNumber: string | null;
+    } | null;
     at: string;
   } | null = null;
   const lastOutbound = await prisma.whatsAppMessage.findFirst({
@@ -177,6 +187,7 @@ export async function GET(req: NextRequest, { params }: { params: Promise<{ key:
   if (raw && raw.escalated === true && raw.proposalResolved !== true && raw.proposal && typeof raw.proposal === "object") {
     const p = raw.proposal as Record<string, unknown>;
     const pa = (p.poAction ?? null) as Record<string, unknown> | null;
+    const ia = (p.invoiceAction ?? null) as Record<string, unknown> | null;
     agentProposal = {
       messageId: lastOutbound!.id,
       orderId: typeof p.orderId === "string" ? p.orderId : null,
@@ -194,6 +205,18 @@ export async function GET(req: NextRequest, { params }: { params: Promise<{ key:
             note: typeof pa.note === "string" ? pa.note : null,
           }
         : null,
+      invoiceAction:
+        ia && typeof ia.invoiceId === "string"
+          ? {
+              invoiceId: ia.invoiceId,
+              invoiceNumber: String(ia.invoiceNumber ?? ""),
+              orderNumber: String(ia.orderNumber ?? ""),
+              fromAmount: typeof ia.fromAmount === "number" ? ia.fromAmount : 0,
+              toAmount: typeof ia.toAmount === "number" ? ia.toAmount : null,
+              fromNumber: String(ia.fromNumber ?? ""),
+              toNumber: typeof ia.toNumber === "string" ? ia.toNumber : null,
+            }
+          : null,
       at: lastOutbound!.timestamp.toISOString(),
     };
   }

--- a/apps/backoffice/src/lib/inventory/agents/supplier-chat-agent.ts
+++ b/apps/backoffice/src/lib/inventory/agents/supplier-chat-agent.ts
@@ -268,6 +268,7 @@ export async function handleSupplierMessage(evt: SupplierMessageEvent): Promise<
     const appliedActions: PoActionType[] = [];
     let deliveryUpdated: string | null = null;
     let invoiceCaptured = false;
+    let invoiceRevision: InvoiceRevision | null = null;
     type ReSource = { orderId: string; supplierName: string; orderNumber: string; qty: number; unit: string; existing: boolean };
     let reSource: ReSource | null = null;
     const reSources: ReSource[] = [];
@@ -279,11 +280,16 @@ export async function handleSupplierMessage(evt: SupplierMessageEvent): Promise<
     // (by billed total, not just the most-recent open one) and dedups per-PO itself, so the
     // most-recent-PO `invoices.length` guard is gone — pass the most-recent as the fallback.
     if (decision.capture_invoice) {
-      invoiceCaptured = await captureInvoice(
+      const cap = await captureInvoice(
         { id: order.id, orderNumber: order.orderNumber, outletId: order.outletId, totalAmount: order.totalAmount, status: order.status },
         supplier.id,
         evt.mediaId ?? null,
       );
+      invoiceCaptured = cap.captured;
+      invoiceRevision = cap.revision;
+      // A revised invoice is never auto-applied — force a human gate (ASSIST already escalates;
+      // this also holds AUTO suppliers) so it surfaces as an Approve/Reject proposal.
+      if (invoiceRevision) escalate = true;
     }
 
     // Snapshot exactly what the agent saw — used by the pre-send gate now, and recorded
@@ -417,6 +423,20 @@ export async function handleSupplierMessage(evt: SupplierMessageEvent): Promise<
                   note: decision.po_action.note,
                 }
               : null,
+          // A supplier-sent REVISED invoice → the concrete update for a human to approve
+          // (apply-proposal patches the invoice; never touches a PAID one). ASSIST does the work,
+          // staff only decides. See assist-mode-principle.
+          invoiceAction: invoiceRevision
+            ? {
+                invoiceId: invoiceRevision.invoiceId,
+                invoiceNumber: invoiceRevision.invoiceNumber,
+                orderNumber: invoiceRevision.orderNumber,
+                fromAmount: invoiceRevision.fromAmount,
+                toAmount: invoiceRevision.toAmount,
+                fromNumber: invoiceRevision.fromNumber,
+                toNumber: invoiceRevision.toNumber,
+              }
+            : null,
         }
       : null;
 
@@ -606,11 +626,25 @@ function visionMime(
  * fetched or parsed (or the total is unreadable), we fall back to the old
  * provisional capture (amount = PO total). Always DRAFT → never triggers payment.
  */
+// A supplier-sent REVISED invoice on a bill we already have on file — surfaced as an ASSIST
+// proposal ("update X → Y", a human approves), never auto-applied and never touching a PAID
+// invoice. null toAmount/toNumber = that field is unchanged (or unreadable).
+type InvoiceRevision = {
+  invoiceId: string;
+  invoiceNumber: string;
+  orderNumber: string;
+  fromAmount: number;
+  toAmount: number | null;
+  fromNumber: string;
+  toNumber: string | null;
+};
+type CaptureResult = { captured: boolean; revision: InvoiceRevision | null };
+
 async function captureInvoice(
   order: { id: string; orderNumber: string; outletId: string; totalAmount: unknown; status: OrderStatus | null },
   supplierId: string,
   mediaId: string | null,
-): Promise<boolean> {
+): Promise<CaptureResult> {
   // ── Try to read the document for a real amount/number/date ──
   let extractedTotal: number | null = null;
   let extractedNumber: string | null = null;
@@ -650,6 +684,7 @@ async function captureInvoice(
   // that total, instead of always the most-recent open PO (which mis-filed invoices onto
   // the newest order). Fall back to the passed `order` when nothing matches / is unreadable.
   let target: { id: string; orderNumber: string; outletId: string; totalAmount: unknown; status: OrderStatus | null } = order;
+  let targetConfident = false; // target came from a real billed-total match (not the fallback)
   if (extractedTotal != null) {
     const openPos = await prisma.order.findMany({
       where: { supplierId, orderType: "PURCHASE_ORDER", status: { in: OPEN_ORDER_STATUSES } },
@@ -659,14 +694,75 @@ async function captureInvoice(
     const match = openPos.find(
       (p) => Math.abs(Number(p.totalAmount) - extractedTotal!) <= Math.max(1, Number(p.totalAmount) * 0.02),
     );
-    if (match) target = match;
+    if (match) {
+      target = match;
+      targetConfident = true;
+    }
   }
 
-  // Dedup: one captured invoice per PO. Skips a burst of images for the same bill / a
-  // re-send (the unique invoiceNumber backstops the truly-simultaneous race).
-  if ((await prisma.invoice.count({ where: { orderId: target.id } })) > 0) {
+  // Already on file? A re-send of the same bill → skip silently (the original dedup). But a
+  // REVISED bill — the same invoice number with a corrected amount, or a re-issued number on the
+  // same confidently-matched PO — is surfaced as an ASSIST proposal for a human to approve the
+  // update, never silently dropped and never auto-edited. We NEVER propose touching a PAID invoice.
+  const amtChanged = (oldAmount: number) =>
+    extractedTotal != null && Math.abs(oldAmount - extractedTotal) > Math.max(1, oldAmount * 0.02);
+
+  // (1) Strong signal: this supplier already has an invoice with this exact number, but the
+  //     amount changed → a corrected bill. High precision, independent of PO matching.
+  const priorSameNo = extractedNumber
+    ? await prisma.invoice.findFirst({
+        where: { supplierId, invoiceNumber: extractedNumber },
+        orderBy: { createdAt: "desc" },
+        select: { id: true, invoiceNumber: true, amount: true, status: true, order: { select: { orderNumber: true } } },
+      })
+    : null;
+  if (priorSameNo && priorSameNo.status !== "PAID" && amtChanged(Number(priorSameNo.amount))) {
+    console.log(
+      `[supplier-agent] invoice REVISION (amount) ${priorSameNo.invoiceNumber}: ${Number(priorSameNo.amount)} → ${extractedTotal}`,
+    );
+    return {
+      captured: false,
+      revision: {
+        invoiceId: priorSameNo.id,
+        invoiceNumber: priorSameNo.invoiceNumber,
+        orderNumber: priorSameNo.order?.orderNumber ?? target.orderNumber,
+        fromAmount: Number(priorSameNo.amount),
+        toAmount: extractedTotal,
+        fromNumber: priorSameNo.invoiceNumber,
+        toNumber: null,
+      },
+    };
+  }
+
+  // Dedup anchor: the invoice already filed against this PO.
+  const priorOnPo = await prisma.invoice.findFirst({
+    where: { orderId: target.id },
+    orderBy: { createdAt: "desc" },
+    select: { id: true, invoiceNumber: true, amount: true, status: true },
+  });
+  if (priorOnPo) {
+    // (2) Re-issued invoice number on the SAME billed-total-matched PO (and it's not the same
+    //     number we already matched in (1)) → a replacement invoice: propose the number/amount update.
+    const numberChanged = !!extractedNumber && extractedNumber !== priorOnPo.invoiceNumber;
+    if (targetConfident && priorOnPo.status !== "PAID" && numberChanged && !priorSameNo) {
+      console.log(
+        `[supplier-agent] invoice REVISION (number) po=${target.orderNumber} ${priorOnPo.invoiceNumber} → ${extractedNumber}`,
+      );
+      return {
+        captured: false,
+        revision: {
+          invoiceId: priorOnPo.id,
+          invoiceNumber: priorOnPo.invoiceNumber,
+          orderNumber: target.orderNumber,
+          fromAmount: Number(priorOnPo.amount),
+          toAmount: amtChanged(Number(priorOnPo.amount)) ? extractedTotal : null,
+          fromNumber: priorOnPo.invoiceNumber,
+          toNumber: extractedNumber,
+        },
+      };
+    }
     console.log(`[supplier-agent] invoice capture skipped — ${target.orderNumber} already has an invoice`);
-    return false;
+    return { captured: false, revision: null };
   }
 
   const amount = extractedTotal ?? (Number(target.totalAmount) || 0);
@@ -721,14 +817,14 @@ async function captureInvoice(
       `[supplier-agent] invoice captured id=${created.id} no=${invoiceNumber} po=${target.orderNumber} ` +
         `amount=${amount} extracted=${!provisional} prefilled=${prefilled.join("|") || "-"} flags=${flags.length}`,
     );
-    return true;
+    return { captured: true, revision: null };
   } catch (e) {
     // Unique invoiceNumber collision (already captured) or any write error.
     console.warn(
       "[supplier-agent] invoice capture skipped:",
       e instanceof Error ? e.message : e,
     );
-    return false;
+    return { captured: false, revision: null };
   }
 }
 


### PR DESCRIPTION
## What

A supplier sends a **revised / replacement invoice** for a bill we already captured. Until now the agent silently skipped it and replied *"we'll review it on our end"* — leaving staff to hunt down what changed and re-key it. That defeats the point of ASSIST: **the agent should do the work, the human only decides.**

Now the agent reads the revised document, works out exactly what changed, and surfaces a concrete approve/reject:

> **Agent suggests — Revised invoice · CC-PJ-0123**
> Amount RM426.00 → **RM450.00**
> _[Approve: update invoice]  [Open PO]  [Mark handled]_

One click applies it. "Mark handled" is the reject.

## How it's detected (high-precision on purpose)

In `captureInvoice`, instead of returning a bare skip:
- **Same invoice number, materially different amount** → propose the amount update (anchored on the exact number — bulletproof).
- **Re-issued number on the same billed-total-matched PO** → propose the number update (only when the PO match was confident).
- Same number + same amount (a re-send) → still skips silently, as before.
- Both number *and* amount changed with no confident anchor → falls through to normal capture (pre-existing behaviour, not regressed).

A revision forces `escalate = true` — ASSIST already escalates; this also gates **AUTO** so an invoice is *never* auto-edited.

## Why it's safe to apply from chat

The new `apply_invoice_revision` branch in the apply-proposal route:
- Takes the new amount/number from the **agent-stamped proposal on the message**, never from the request body.
- **Refuses any PAID / part-paid invoice outright** — money has moved, so a human edits it manually.
- Changes only `amount` + `invoiceNumber`; `status` and payment fields are never touched.
- Stamps `proposalResolved` so it can't be applied twice.

## Files
- `supplier-chat-agent.ts` — detect the revision, stamp `invoiceAction` on the proposal
- `supplier-chats/[key]/route.ts` — surface `invoiceAction` to the workspace
- `supplier-chats/[key]/apply-proposal/route.ts` — guarded apply (PAID-block, server-side values)
- `supplier-chats/page.tsx` — banner render + Approve button

## Verify before relying on it
Typecheck + lint pass. Not runtime-tested here (needs a real revised invoice through the WhatsApp flow). Suggest verifying on **one ASSIST supplier**: send a corrected invoice for an open, unpaid bill → confirm the banner shows the right `from → to` and Approve updates the invoice; confirm a PAID invoice is refused.

🤖 Generated with [Claude Code](https://claude.com/claude-code)