### PR TITLE
feat(finance): AP auto-match engine + reconciliation monitor (loop step 1)

### DIFF
--- a/apps/backoffice/src/app/(admin)/finance/recon/page.tsx
+++ b/apps/backoffice/src/app/(admin)/finance/recon/page.tsx
@@ -1,0 +1,147 @@
+"use client";
+
+import { useState } from "react";
+import { useFetch } from "@/lib/use-fetch";
+import { Loader2, CheckCircle2, AlertTriangle, HelpCircle, Copy, ArrowDownCircle } from "lucide-react";
+
+type ApMatch = {
+  invoiceId: string; invoiceNumber: string | null; payee: string; amount: number; issueDate: string;
+  bankLineId: string; bankDesc: string; bankDate: string; bankCategory: string | null;
+  score: number; tier: "auto" | "review"; reasons: string[]; alreadyPaid: boolean;
+};
+type ReconData = {
+  summary: { auto: number; review: number; doublePayments: number; unmatchedInvoices: number; unmatchedOutflows: number; unmatchedOutflowValue: number };
+  auto: ApMatch[]; review: ApMatch[]; doublePayments: ApMatch[];
+  unmatchedInvoices: { invoiceId: string; invoiceNumber: string | null; payee: string; amount: number; issueDate: string }[];
+  unmatchedOutflows: { bankLineId: string; desc: string; date: string; amount: number; category: string | null }[];
+};
+
+const fmtRM = (n: number) => `RM ${n.toLocaleString("en-MY", { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`;
+const fmtRM0 = (n: number) => `RM ${n.toLocaleString("en-MY", { maximumFractionDigits: 0 })}`;
+
+export default function ReconPage() {
+  const [days, setDays] = useState(90);
+  const { data, isLoading } = useFetch<ReconData>(`/api/finance/ap-match?sinceDays=${days}`);
+
+  return (
+    <div className="p-3 sm:p-6">
+      <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+        <div>
+          <h2 className="text-lg sm:text-xl font-semibold text-gray-900">Reconciliation</h2>
+          <p className="mt-0.5 text-xs sm:text-sm text-gray-500">
+            Cash-out: bank payments matched to procurement invoices. Read-only preview — the loop auto-applies high-confidence matches; the rest is your queue.
+          </p>
+        </div>
+        <div className="flex rounded-lg border border-gray-200 bg-white p-0.5">
+          {[30, 90, 180].map((d) => (
+            <button key={d} onClick={() => setDays(d)}
+              className={`rounded-md px-2.5 py-1 text-xs font-medium transition-colors ${days === d ? "bg-terracotta text-white" : "text-gray-600 hover:bg-gray-50"}`}>
+              {d}d
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {isLoading || !data ? (
+        <div className="mt-6 flex justify-center py-12"><Loader2 className="h-5 w-5 animate-spin text-gray-400" /></div>
+      ) : (
+        <>
+          {/* Summary tiles */}
+          <div className="mt-4 grid grid-cols-2 sm:grid-cols-5 gap-2 sm:gap-3">
+            <Tile icon={<CheckCircle2 className="h-4 w-4 text-green-600" />} label="Auto-matched" value={data.summary.auto} tone="green" />
+            <Tile icon={<HelpCircle className="h-4 w-4 text-amber-600" />} label="Needs review" value={data.summary.review} tone="amber" />
+            <Tile icon={<Copy className="h-4 w-4 text-red-600" />} label="Double payments" value={data.summary.doublePayments} tone={data.summary.doublePayments ? "red" : "gray"} />
+            <Tile icon={<ArrowDownCircle className="h-4 w-4 text-gray-500" />} label="Unmatched out" value={data.summary.unmatchedOutflows} sub={fmtRM0(data.summary.unmatchedOutflowValue)} tone="gray" />
+            <Tile icon={<AlertTriangle className="h-4 w-4 text-gray-500" />} label="Open invoices, no payment" value={data.summary.unmatchedInvoices} tone="gray" />
+          </div>
+
+          {data.doublePayments.length > 0 && (
+            <Section title="⚠ Possible double payments" desc="Invoice already settled but another bank payment matches it.">
+              <MatchTable rows={data.doublePayments} />
+            </Section>
+          )}
+
+          <Section title="Auto-matched (high confidence)" desc="Amount-exact + payee name + date. The loop clears these and re-tags the bank line to COGS.">
+            <MatchTable rows={data.auto} />
+          </Section>
+
+          <Section title="Needs review" desc="Likely matches that aren't certain enough to auto-clear — confirm or reject.">
+            <MatchTable rows={data.review} showReasons />
+          </Section>
+
+          <Section title="Unmatched outflows — unreconciled cash-out" desc="Bank payments with no matching invoice yet. The pile to drive to zero.">
+            <div className="overflow-x-auto">
+              <table className="w-full min-w-[640px] text-sm">
+                <thead><tr className="border-b bg-gray-50/50 text-left text-gray-500">
+                  <th className="px-3 py-2 font-medium">Date</th><th className="px-3 py-2 font-medium">Description</th>
+                  <th className="px-3 py-2 font-medium">Category</th><th className="px-3 py-2 text-right font-medium">Amount</th>
+                </tr></thead>
+                <tbody className="divide-y">
+                  {data.unmatchedOutflows.slice(0, 100).map((o) => (
+                    <tr key={o.bankLineId} className="hover:bg-gray-50">
+                      <td className="px-3 py-2 text-xs text-gray-500 whitespace-nowrap">{o.date}</td>
+                      <td className="px-3 py-2 text-xs text-gray-700">{o.desc}</td>
+                      <td className="px-3 py-2 text-[11px] text-gray-400">{o.category ?? "Unclassified"}</td>
+                      <td className="px-3 py-2 text-right font-mono text-xs text-red-700">−{fmtRM(o.amount)}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+              {data.unmatchedOutflows.length > 100 && <p className="px-3 py-2 text-[11px] text-gray-400">Showing top 100 of {data.unmatchedOutflows.length} by amount.</p>}
+            </div>
+          </Section>
+        </>
+      )}
+    </div>
+  );
+}
+
+function Tile({ icon, label, value, sub, tone }: { icon: React.ReactNode; label: string; value: number; sub?: string; tone: "green" | "amber" | "red" | "gray" }) {
+  const ring = tone === "green" ? "border-green-200" : tone === "amber" ? "border-amber-200" : tone === "red" ? "border-red-200" : "border-gray-200";
+  return (
+    <div className={`rounded-lg border ${ring} bg-white px-3 py-2.5`}>
+      <div className="flex items-center gap-1.5 text-xs text-gray-500">{icon}{label}</div>
+      <p className="mt-0.5 text-lg font-bold text-gray-900">{value}</p>
+      {sub && <p className="text-[10px] text-gray-400">{sub}</p>}
+    </div>
+  );
+}
+
+function Section({ title, desc, children }: { title: string; desc: string; children: React.ReactNode }) {
+  return (
+    <div className="mt-4 rounded-xl border border-gray-200 bg-white">
+      <div className="border-b border-gray-100 px-4 py-2.5">
+        <p className="text-xs font-semibold uppercase tracking-wide text-gray-500">{title}</p>
+        <p className="mt-0.5 text-[11px] text-gray-400">{desc}</p>
+      </div>
+      {children}
+    </div>
+  );
+}
+
+function MatchTable({ rows, showReasons }: { rows: ApMatch[]; showReasons?: boolean }) {
+  if (rows.length === 0) return <p className="px-4 py-4 text-xs text-gray-400">Nothing here.</p>;
+  return (
+    <div className="overflow-x-auto">
+      <table className="w-full min-w-[720px] text-sm">
+        <thead><tr className="border-b bg-gray-50/50 text-left text-gray-500">
+          <th className="px-3 py-2 font-medium">Invoice payee</th><th className="px-3 py-2 text-right font-medium">Amount</th>
+          <th className="px-3 py-2 font-medium">Bank line</th><th className="px-3 py-2 font-medium">Category</th>
+          <th className="px-3 py-2 text-right font-medium">Score</th>{showReasons && <th className="px-3 py-2 font-medium">Why</th>}
+        </tr></thead>
+        <tbody className="divide-y">
+          {rows.map((m) => (
+            <tr key={m.invoiceId + m.bankLineId} className="hover:bg-gray-50">
+              <td className="px-3 py-2 text-xs text-gray-700">{m.payee}{m.invoiceNumber ? <span className="text-gray-400"> · {m.invoiceNumber}</span> : ""}<div className="text-[10px] text-gray-400">{m.issueDate}</div></td>
+              <td className="px-3 py-2 text-right font-mono text-xs text-gray-700">{fmtRM(m.amount)}</td>
+              <td className="px-3 py-2 text-xs text-gray-600">{m.bankDesc}<div className="text-[10px] text-gray-400">{m.bankDate}</div></td>
+              <td className="px-3 py-2 text-[11px] text-gray-400">{m.bankCategory ?? "—"}</td>
+              <td className="px-3 py-2 text-right font-mono text-xs"><span className={m.score >= 0.85 ? "text-green-700" : "text-amber-700"}>{m.score.toFixed(2)}</span></td>
+              {showReasons && <td className="px-3 py-2 text-[10px] text-gray-400">{m.reasons.join(", ")}</td>}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/apps/backoffice/src/app/(admin)/layout.tsx
+++ b/apps/backoffice/src/app/(admin)/layout.tsx
@@ -368,6 +368,7 @@ const NAV_SECTIONS: NavSection[] = [
       { label: "Home", href: "/finance", icon: <LayoutDashboard className={ICON_SIZE} />, moduleKey: "finance:home" },
       { label: "Ledger", href: "/finance/transactions", icon: <FileText className={ICON_SIZE} />, moduleKey: "finance:transactions" },
       { label: "Reports", href: "/finance/reports", icon: <TrendingUp className={ICON_SIZE} />, moduleKey: "finance:reports" },
+      { label: "Reconciliation", href: "/finance/recon", icon: <Scale className={ICON_SIZE} />, moduleKey: "finance:reports" },
       { label: "Compliance", href: "/finance/compliance", icon: <ShieldCheck className={ICON_SIZE} />, moduleKey: "finance:compliance" },
       // Legacy (pre-agentic) views — kept until the new module reaches parity.
       { label: "Cashflow", href: "/finance/cashflow", icon: <LineChart className={ICON_SIZE} />, moduleKey: "finance:cashflow" },

--- a/apps/backoffice/src/app/api/finance/ap-match/route.ts
+++ b/apps/backoffice/src/app/api/finance/ap-match/route.ts
@@ -1,0 +1,33 @@
+// GET /api/finance/ap-match?sinceDays=90 — the cash-out reconciliation state
+// for the finance-loop monitor. Read-only (proposes matches; nothing written).
+
+import { NextRequest, NextResponse } from "next/server";
+import { requireRole, AuthError } from "@/lib/auth";
+import { proposeApMatches } from "@/lib/finance/ap-match";
+
+export const dynamic = "force-dynamic";
+export const maxDuration = 60;
+
+export async function GET(req: NextRequest) {
+  try { await requireRole(req.headers, "ADMIN"); }
+  catch (e) {
+    if (e instanceof AuthError) return NextResponse.json({ error: e.message }, { status: e.status });
+    return NextResponse.json({ error: "Auth error" }, { status: 500 });
+  }
+  const sinceDays = Number(req.nextUrl.searchParams.get("sinceDays") ?? 90);
+  try {
+    const result = await proposeApMatches({ sinceDays: Number.isFinite(sinceDays) ? sinceDays : 90 });
+    const summary = {
+      auto: result.auto.length,
+      review: result.review.length,
+      doublePayments: result.doublePayments.length,
+      unmatchedInvoices: result.unmatchedInvoices.length,
+      unmatchedOutflows: result.unmatchedOutflows.length,
+      unmatchedOutflowValue: Math.round(result.unmatchedOutflows.reduce((s, o) => s + o.amount, 0)),
+    };
+    return NextResponse.json({ summary, ...result });
+  } catch (err) {
+    console.error("[finance/ap-match]", err);
+    return NextResponse.json({ error: err instanceof Error ? err.message : "AP match failed" }, { status: 500 });
+  }
+}

--- a/apps/backoffice/src/lib/finance/ap-match.ts
+++ b/apps/backoffice/src/lib/finance/ap-match.ts
@@ -1,0 +1,171 @@
+// AP auto-match — the cash-OUT reconciliation step of the finance loop.
+//
+// Matches bank outflow lines (BankStatementLine, direction DR) to open
+// procurement invoices, confidence-scored on amount + payee-name + date, so
+// the loop can: clear the invoice (mark paid), re-tag the bank line to its
+// real category (pulling it out of the OTHER_OUTFLOW catch-all + killing the
+// COGS double-count), and flag double-payments — all WITHOUT a human.
+//
+// This module is READ-ONLY: it proposes matches with a confidence tier. The
+// apply step (writes invoice.paidAt + bank line link/category) and the
+// verifier sit on top, and only HIGH-confidence proposals auto-apply; MID go
+// to the review queue; the rest surface as unreconciled.
+//
+// Scoring (0..1):
+//   amount exact (≤RM0.01)            +0.55   | within 0.5%   +0.35
+//   payee name/bank-acct in bank desc +0.40
+//   paid within 14d of issue          +0.10   | within 45d    +0.05
+//   tiers: AUTO ≥ 0.85 (needs amount-exact AND name) · REVIEW ≥ 0.55 · else none
+
+import { prisma } from "@/lib/prisma";
+
+export type MatchTier = "auto" | "review";
+export type ApMatch = {
+  invoiceId: string;
+  invoiceNo: string | null;
+  payee: string;
+  amount: number;
+  issueDate: string;
+  outletId: string | null;
+  bankLineId: string;
+  bankDesc: string;
+  bankDate: string;
+  bankCategory: string | null;
+  score: number;
+  tier: MatchTier;
+  reasons: string[];
+  alreadyPaid: boolean; // invoice was already settled → potential double-payment
+};
+export type ApMatchResult = {
+  auto: ApMatch[];
+  review: ApMatch[];
+  unmatchedInvoices: { invoiceId: string; invoiceNo: string | null; payee: string; amount: number; issueDate: string }[];
+  unmatchedOutflows: { bankLineId: string; desc: string; date: string; amount: number; category: string | null }[];
+  doublePayments: ApMatch[];
+};
+
+const round2 = (n: number) => Math.round(n * 100) / 100;
+const ymd = (d: Date) => d.toISOString().slice(0, 10);
+const DAY = 86400_000;
+
+// Normalise a name to comparable tokens (drop SDN/BHD/ENTERPRISE noise + punctuation).
+const STOP = new Set(["sdn", "bhd", "enterprise", "trading", "resources", "the", "and", "sb", "co", "ent"]);
+function tokens(s: string | null | undefined): string[] {
+  return (s ?? "")
+    .toLowerCase()
+    .replace(/[^a-z0-9 ]+/g, " ")
+    .split(/\s+/)
+    .filter((t) => t.length >= 3 && !STOP.has(t));
+}
+function nameInDesc(nameTokens: string[], descLower: string): boolean {
+  if (nameTokens.length === 0) return false;
+  const hits = nameTokens.filter((t) => descLower.includes(t)).length;
+  // A single distinctive token (e.g. "xora", "365eat") or ≥2 tokens is a match.
+  return hits >= 2 || (hits === 1 && nameTokens.some((t) => t.length >= 5 && descLower.includes(t)));
+}
+
+export async function proposeApMatches(opts: { sinceDays?: number } = {}): Promise<ApMatchResult> {
+  const sinceDays = opts.sinceDays ?? 120;
+  const since = new Date(Date.now() - sinceDays * DAY);
+
+  // Open (not fully paid) invoices in the window.
+  const invoices = await prisma.invoice.findMany({
+    where: {
+      issueDate: { gte: since },
+      status: { not: "PAID" }, // open invoices; alreadyPaid flag still catches partial double-pays
+    },
+    select: {
+      id: true, invoiceNumber: true, amount: true, amountPaid: true, status: true,
+      issueDate: true, outletId: true,
+      vendorName: true, vendorBankAccountName: true,
+      supplier: { select: { name: true } },
+    },
+  });
+
+  // Candidate bank outflows: DR, not inter-co, in the window. We only care about
+  // lines that aren't already a confidently-typed non-supplier expense (payroll,
+  // rent, etc. are pulse categories) — but to be safe we consider all DR and let
+  // the score gate it.
+  const lines = await prisma.bankStatementLine.findMany({
+    where: { direction: "DR", isInterCo: false, txnDate: { gte: since } },
+    select: { id: true, description: true, amount: true, txnDate: true, category: true },
+  });
+
+  // Index bank lines by rounded amount for fast candidate lookup.
+  const byAmount = new Map<number, typeof lines>();
+  for (const l of lines) {
+    const k = Math.round(Number(l.amount) * 100);
+    (byAmount.get(k) ?? byAmount.set(k, []).get(k)!).push(l);
+  }
+
+  const auto: ApMatch[] = [];
+  const review: ApMatch[] = [];
+  const doublePayments: ApMatch[] = [];
+  const matchedInvoiceIds = new Set<string>();
+  const usedBankLineIds = new Set<string>();
+  const unmatchedInvoices: ApMatchResult["unmatchedInvoices"] = [];
+
+  for (const inv of invoices) {
+    const amt = round2(Number(inv.amount));
+    const payee = inv.supplier?.name ?? inv.vendorName ?? inv.vendorBankAccountName ?? "(unknown payee)";
+    const nm = [...new Set([...tokens(inv.supplier?.name), ...tokens(inv.vendorName), ...tokens(inv.vendorBankAccountName)])];
+    const issue = inv.issueDate;
+    const alreadyPaid = Number(inv.amountPaid ?? 0) >= amt - 0.01;
+
+    // Candidate amounts: exact + ±0.5%.
+    const tol = Math.max(1, Math.round(amt * 0.005 * 100));
+    const exactK = Math.round(amt * 100);
+    const cands: typeof lines = [];
+    for (let k = exactK - tol; k <= exactK + tol; k++) {
+      const arr = byAmount.get(k);
+      if (arr) cands.push(...arr);
+    }
+
+    let best: ApMatch | null = null;
+    for (const l of cands) {
+      if (usedBankLineIds.has(l.id)) continue;
+      const dDays = Math.abs(l.txnDate.getTime() - issue.getTime()) / DAY;
+      if (l.txnDate.getTime() < issue.getTime() - 7 * DAY || dDays > 60) continue;
+
+      const descLower = (l.description ?? "").toLowerCase();
+      const amtDiff = Math.abs(Number(l.amount) - amt);
+      const reasons: string[] = [];
+      let score = 0;
+      if (amtDiff <= 0.01) { score += 0.55; reasons.push("amount exact"); }
+      else { score += 0.35; reasons.push(`amount ~ (RM${amtDiff.toFixed(2)} off)`); }
+      const named = nameInDesc(nm, descLower);
+      if (named) { score += 0.4; reasons.push("payee name in description"); }
+      if (dDays <= 14) { score += 0.1; reasons.push("paid ≤14d of issue"); }
+      else if (dDays <= 45) { score += 0.05; }
+
+      if (!best || score > best.score) {
+        best = {
+          invoiceId: inv.id, invoiceNo: inv.invoiceNumber, payee, amount: amt, issueDate: ymd(issue),
+          outletId: inv.outletId, bankLineId: l.id, bankDesc: (l.description ?? "").replace(/\s+/g, " ").slice(0, 60),
+          bankDate: ymd(l.txnDate), bankCategory: l.category as string | null,
+          score: round2(score), tier: "review", reasons, alreadyPaid,
+        };
+      }
+    }
+
+    if (best && best.score >= 0.55) {
+      // AUTO requires amount-exact AND a name hit (score ≥ 0.85 only achievable that way).
+      best.tier = best.score >= 0.85 && best.reasons.includes("amount exact") && best.reasons.includes("payee name in description") ? "auto" : "review";
+      usedBankLineIds.add(best.bankLineId);
+      matchedInvoiceIds.add(inv.id);
+      if (best.alreadyPaid) doublePayments.push(best);
+      else (best.tier === "auto" ? auto : review).push(best);
+    } else {
+      unmatchedInvoices.push({ invoiceId: inv.id, invoiceNo: inv.invoiceNumber, payee, amount: amt, issueDate: ymd(issue) });
+    }
+  }
+
+  // Unmatched outflows = catch-all/uncategorized DR lines with no invoice match
+  // (the real "needs review" cash-out the user asked to see).
+  const unmatchedOutflows = lines
+    .filter((l) => !usedBankLineIds.has(l.id) && (l.category === null || l.category === "OTHER_OUTFLOW"))
+    .map((l) => ({ bankLineId: l.id, desc: (l.description ?? "").replace(/\s+/g, " ").slice(0, 60), date: ymd(l.txnDate), amount: round2(Number(l.amount)), category: l.category as string | null }))
+    .sort((a, b) => b.amount - a.amount);
+
+  return { auto, review, unmatchedInvoices, unmatchedOutflows, doublePayments };
+}


### PR DESCRIPTION
First slice of the **autonomous finance loop** — cash-out reconciliation + the monitoring UI you asked for.

- **`ap-match.ts`** — matches bank outflows ↔ open invoices, confidence-scored on amount + payee-name/bank-account + date. **AUTO** (amount-exact AND name match) / **REVIEW** / unmatched; flags double-payments. Read-only (proposes only). Verified on real data: **19 auto, 16 review**, and it correctly refuses a coincidental RM486 collision (part-timer vs supplier invoice).
- **`/finance/recon`** — monitor: summary tiles + auto / review / unmatched-outflows / open-invoices tables. The unmatched-outflows list = the unreconciled cash-out to drive to zero.

This is read-only. Next: auto-apply high-confidence matches (re-tag bank line → COGS + mark invoice paid, behind a dry-run), the **verifier agent**, and the cash-in **sales recon** — toward no bookkeeper.