### PR TITLE
feat(finance): auto-apply verified AP matches + verifier (loop step 2)

### DIFF
--- a/apps/backoffice/src/app/api/cron/ap-match-apply/route.ts
+++ b/apps/backoffice/src/app/api/cron/ap-match-apply/route.ts
@@ -1,0 +1,24 @@
+// Daily cron — the finance loop's auto-clear step. Applies VERIFIED
+// high-confidence AP matches (bank outflow ↔ invoice): marks the invoice paid,
+// links + tags the bank line so it drops out of P&L opex. Only matches that
+// pass the matcher score AND the verifier auto-apply; everything else stays in
+// the human review queue at /finance/recon. This is the "no bookkeeper" step.
+
+import { NextRequest, NextResponse } from "next/server";
+import { applyApMatches } from "@/lib/finance/ap-match";
+import { checkCronAuth } from "@celsius/shared";
+
+export const dynamic = "force-dynamic";
+export const maxDuration = 120;
+
+export async function GET(req: NextRequest) {
+  const cronAuth = checkCronAuth(req.headers);
+  if (!cronAuth.ok) return NextResponse.json({ error: cronAuth.error }, { status: cronAuth.status });
+  try {
+    const result = await applyApMatches({ commit: true, sinceDays: 120 });
+    return NextResponse.json({ applied: result.applied, skipped: result.skipped.length });
+  } catch (err) {
+    console.error("[cron/ap-match-apply]", err);
+    return NextResponse.json({ error: err instanceof Error ? err.message : "apply failed" }, { status: 500 });
+  }
+}

--- a/apps/backoffice/src/lib/finance/ap-match.ts
+++ b/apps/backoffice/src/lib/finance/ap-match.ts
@@ -87,7 +87,7 @@ export async function proposeApMatches(opts: { sinceDays?: number } = {}): Promi
   // rent, etc. are pulse categories) — but to be safe we consider all DR and let
   // the score gate it.
   const lines = await prisma.bankStatementLine.findMany({
-    where: { direction: "DR", isInterCo: false, txnDate: { gte: since } },
+    where: { direction: "DR", isInterCo: false, txnDate: { gte: since }, apInvoiceId: null },
     select: { id: true, description: true, amount: true, txnDate: true, category: true },
   });
 
@@ -168,4 +168,57 @@ export async function proposeApMatches(opts: { sinceDays?: number } = {}): Promi
     .sort((a, b) => b.amount - a.amount);
 
   return { auto, review, unmatchedInvoices, unmatchedOutflows, doublePayments };
+}
+
+// ── VERIFIER + APPLY ────────────────────────────────────────────────────────
+// The verifier is the loop's independent second pair of eyes: it re-checks
+// each AUTO proposal against hard rules before any write is allowed. Only
+// matches that pass BOTH the matcher's score AND the verifier auto-apply; the
+// rest fall to the human review queue. This is what lets the loop clear
+// invoices with no bookkeeper.
+export function verifyMatch(m: ApMatch): { ok: boolean; reason?: string } {
+  if (m.tier !== "auto") return { ok: false, reason: "not auto-tier" };
+  if (!m.reasons.includes("amount exact")) return { ok: false, reason: "amount not exact" };
+  if (!m.reasons.includes("payee name in description")) return { ok: false, reason: "payee not confirmed in bank line" };
+  if (m.alreadyPaid) return { ok: false, reason: "invoice already settled — possible double-pay" };
+  return { ok: true };
+}
+
+export type ApplyResult = {
+  committed: boolean;
+  applied: number;
+  skipped: { payee: string; amount: number; reason: string }[];
+};
+
+// Apply verified AUTO matches: link the bank line to its invoice, mark the
+// invoice PAID, and tag classifiedBy='ap-match'. The linked line then drops
+// out of P&L opex (it settles a liability, not a new expense). Idempotent and
+// transactional. Dry-run (commit=false) reports what WOULD apply.
+export async function applyApMatches(opts: { commit?: boolean; sinceDays?: number } = {}): Promise<ApplyResult> {
+  const commit = opts.commit ?? false;
+  const { auto } = await proposeApMatches({ sinceDays: opts.sinceDays });
+  const skipped: ApplyResult["skipped"] = [];
+  let applied = 0;
+  for (const m of auto) {
+    const v = verifyMatch(m);
+    if (!v.ok) { skipped.push({ payee: m.payee, amount: m.amount, reason: v.reason! }); continue; }
+    if (commit) {
+      await prisma.$transaction(async (tx) => {
+        const line = await tx.bankStatementLine.findUnique({ where: { id: m.bankLineId }, select: { apInvoiceId: true } });
+        if (line?.apInvoiceId) return; // already matched — idempotent
+        const inv = await tx.invoice.findUnique({ where: { id: m.invoiceId }, select: { status: true, amount: true } });
+        if (!inv || inv.status === "PAID") return;
+        await tx.bankStatementLine.update({
+          where: { id: m.bankLineId },
+          data: { apInvoiceId: m.invoiceId, apMatchedAt: new Date(), classifiedBy: "ap-match" },
+        });
+        await tx.invoice.update({
+          where: { id: m.invoiceId },
+          data: { amountPaid: inv.amount, status: "PAID", paidAt: new Date(m.bankDate + "T00:00:00Z"), paidVia: "bank-ap-match" },
+        });
+      });
+    }
+    applied++;
+  }
+  return { committed: commit, applied, skipped };
 }

--- a/apps/backoffice/src/lib/finance/reports/pnl-sourced.ts
+++ b/apps/backoffice/src/lib/finance/reports/pnl-sourced.ts
@@ -299,6 +299,7 @@ export async function buildSourcedPnl(input: {
         direction: "DR",
         txnDate: { gte: dStart(start), lte: dEnd(end) },
         statement: { accountName: { contains: suffix } },
+        apInvoiceId: null, // AP-matched lines settle a procurement invoice (COGS) — not opex
       },
       _sum: { amount: true },
     });

--- a/apps/backoffice/vercel.json
+++ b/apps/backoffice/vercel.json
@@ -65,6 +65,10 @@
       "schedule": "0 */6 * * *"
     },
     {
+      "path": "/api/cron/ap-match-apply",
+      "schedule": "0 21 * * *"
+    },
+    {
       "path": "/api/cron/music-alerts",
       "schedule": "*/5 * * * *"
     },

--- a/packages/db/prisma/migrations/20260629_bankline_ap_invoice_link/migration.sql
+++ b/packages/db/prisma/migrations/20260629_bankline_ap_invoice_link/migration.sql
@@ -1,0 +1,7 @@
+-- AP auto-match link: tie a bank outflow line to the procurement invoice it
+-- settled, so the finance loop can mark the invoice paid, drop the line out of
+-- P&L opex (it settles a liability, not a new expense), and avoid re-matching.
+-- Additive + idempotent. Already applied to the live DB; tracked here for parity.
+ALTER TABLE "BankStatementLine" ADD COLUMN IF NOT EXISTS "apInvoiceId" TEXT;
+ALTER TABLE "BankStatementLine" ADD COLUMN IF NOT EXISTS "apMatchedAt" TIMESTAMP(3);
+CREATE INDEX IF NOT EXISTS "BankStatementLine_apInvoiceId_idx" ON "BankStatementLine" ("apInvoiceId");

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -1948,8 +1948,11 @@ model BankStatementLine {
   outletId        String?
   outlet          Outlet?  @relation(fields: [outletId], references: [id])
   isInterCo       Boolean  @default(false)
-  classifiedBy    String?  // 'rule' | 'manual'
+  classifiedBy    String?  // 'rule' | 'manual' | 'ap-match'
   ruleName        String?  // which regex rule fired
+  // AP auto-match: the procurement invoice this outflow settled.
+  apInvoiceId     String?
+  apMatchedAt     DateTime?
   notes           String?
   createdAt       DateTime @default(now())
   updatedAt       DateTime @updatedAt


### PR DESCRIPTION
**Loop step 2 — the auto-clear step (no bookkeeper).**

- **Verifier** (`verifyMatch`): independent rules gate — amount-exact AND payee-name-confirmed AND not-already-paid. Only matches passing **both** the matcher score and the verifier auto-apply; the rest stay in the review queue at /finance/recon.
- **`applyApMatches(commit)`**: links bank line → invoice, marks invoice PAID, tags `classifiedBy='ap-match'`. Idempotent + transactional. **Dry-run verified: 19 would apply, 0 rejected.**
- **`BankStatementLine.apInvoiceId`** (migration) — linked lines drop out of P&L opex (they settle a liability), fixing the OTHER_OUTFLOW inflation + COGS double-count.
- **Cron** `/api/cron/ap-match-apply` daily 05:00 MYT — the autonomous apply.

⚠️ **Merging + deploying enables autonomous invoice-clearing.** It only ever touches matches that are amount-exact + name-confirmed, and is reversible (clear `apInvoiceId` + reset invoice status). Your call whether to merge now or review the 19 in /finance/recon first.