### PR TITLE
feat(finance): cash-in sales recon in the monitor (loop step 3)

### DIFF
--- a/apps/backoffice/src/app/(admin)/finance/recon/page.tsx
+++ b/apps/backoffice/src/app/(admin)/finance/recon/page.tsx
@@ -9,11 +9,18 @@ type ApMatch = {
   bankLineId: string; bankDesc: string; bankDate: string; bankCategory: string | null;
   score: number; tier: "auto" | "review"; reasons: string[]; alreadyPaid: boolean;
 };
+type CashIn = {
+  from: string; to: string; salesGross: number; settlementsTotal: number; gap: number; gapPct: number | null;
+  settlementsByChannel: { channel: string; amount: number; n: number }[];
+  salesByChannel: { channel: string; amount: number }[];
+  grab: { gross: number; settled: number; deductionPct: number | null };
+};
 type ReconData = {
   summary: { auto: number; review: number; doublePayments: number; unmatchedInvoices: number; unmatchedOutflows: number; unmatchedOutflowValue: number };
   auto: ApMatch[]; review: ApMatch[]; doublePayments: ApMatch[];
   unmatchedInvoices: { invoiceId: string; invoiceNumber: string | null; payee: string; amount: number; issueDate: string }[];
   unmatchedOutflows: { bankLineId: string; desc: string; date: string; amount: number; category: string | null }[];
+  cashIn: CashIn;
 };
 
 const fmtRM = (n: number) => `RM ${n.toLocaleString("en-MY", { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`;
@@ -54,6 +61,36 @@ export default function ReconPage() {
             <Tile icon={<ArrowDownCircle className="h-4 w-4 text-gray-500" />} label="Unmatched out" value={data.summary.unmatchedOutflows} sub={fmtRM0(data.summary.unmatchedOutflowValue)} tone="gray" />
             <Tile icon={<AlertTriangle className="h-4 w-4 text-gray-500" />} label="Open invoices, no payment" value={data.summary.unmatchedInvoices} tone="gray" />
           </div>
+
+          {/* CASH-IN: sales rung up vs settlements received */}
+          <Section title={`Cash-in — sales vs settlements (${data.cashIn.from} → ${data.cashIn.to})`} desc="What the POS rang up vs what landed in the bank. The gap is fees + platform commission + cash-not-banked + settlement timing.">
+            <div className="grid grid-cols-3 gap-3 px-4 py-3">
+              <div><p className="text-[11px] text-gray-500">Sales rung up</p><p className="font-mono text-sm font-semibold text-gray-900">{fmtRM(data.cashIn.salesGross)}</p></div>
+              <div><p className="text-[11px] text-gray-500">Settled to bank</p><p className="font-mono text-sm font-semibold text-gray-900">{fmtRM(data.cashIn.settlementsTotal)}</p></div>
+              <div><p className="text-[11px] text-gray-500">Gap</p><p className={`font-mono text-sm font-semibold ${Math.abs(data.cashIn.gapPct ?? 0) > 12 ? "text-red-600" : "text-amber-600"}`}>{fmtRM(data.cashIn.gap)}{data.cashIn.gapPct != null && <span className="text-[11px] font-normal text-gray-400"> ({data.cashIn.gapPct}%)</span>}</p></div>
+            </div>
+            <div className="overflow-x-auto border-t border-gray-100">
+              <table className="w-full min-w-[480px] text-sm">
+                <thead><tr className="border-b bg-gray-50/50 text-left text-gray-500">
+                  <th className="px-3 py-2 font-medium">Channel</th><th className="px-3 py-2 text-right font-medium">Settled</th><th className="px-3 py-2 text-right font-medium">Txns</th>
+                </tr></thead>
+                <tbody className="divide-y">
+                  {data.cashIn.settlementsByChannel.map((c) => (
+                    <tr key={c.channel} className="hover:bg-gray-50">
+                      <td className="px-3 py-1.5 text-xs text-gray-700">{c.channel}</td>
+                      <td className="px-3 py-1.5 text-right font-mono text-xs text-green-700">+{fmtRM(c.amount)}</td>
+                      <td className="px-3 py-1.5 text-right text-[11px] text-gray-400">{c.n}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+            {data.cashIn.grab.deductionPct != null && (
+              <p className={`border-t border-gray-100 px-4 py-2 text-[11px] ${data.cashIn.grab.deductionPct > 45 ? "text-red-600" : "text-gray-500"}`}>
+                Grab: gross {fmtRM(data.cashIn.grab.gross)} vs settled {fmtRM(data.cashIn.grab.settled)} → <strong>{data.cashIn.grab.deductionPct}% deducted</strong> at source (commission + promos + timing){data.cashIn.grab.deductionPct > 45 ? " — high, review" : ""}.
+              </p>
+            )}
+          </Section>
 
           {data.doublePayments.length > 0 && (
             <Section title="⚠ Possible double payments" desc="Invoice already settled but another bank payment matches it.">

--- a/apps/backoffice/src/app/api/finance/ap-match/route.ts
+++ b/apps/backoffice/src/app/api/finance/ap-match/route.ts
@@ -4,6 +4,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { requireRole, AuthError } from "@/lib/auth";
 import { proposeApMatches } from "@/lib/finance/ap-match";
+import { cashInRecon } from "@/lib/finance/sales-recon";
 
 export const dynamic = "force-dynamic";
 export const maxDuration = 60;
@@ -16,7 +17,10 @@ export async function GET(req: NextRequest) {
   }
   const sinceDays = Number(req.nextUrl.searchParams.get("sinceDays") ?? 90);
   try {
-    const result = await proposeApMatches({ sinceDays: Number.isFinite(sinceDays) ? sinceDays : 90 });
+    const [result, cashIn] = await Promise.all([
+      proposeApMatches({ sinceDays: Number.isFinite(sinceDays) ? sinceDays : 90 }),
+      cashInRecon({ sinceDays: Number.isFinite(sinceDays) ? sinceDays : 90 }),
+    ]);
     const summary = {
       auto: result.auto.length,
       review: result.review.length,
@@ -25,7 +29,7 @@ export async function GET(req: NextRequest) {
       unmatchedOutflows: result.unmatchedOutflows.length,
       unmatchedOutflowValue: Math.round(result.unmatchedOutflows.reduce((s, o) => s + o.amount, 0)),
     };
-    return NextResponse.json({ summary, ...result });
+    return NextResponse.json({ summary, ...result, cashIn });
   } catch (err) {
     console.error("[finance/ap-match]", err);
     return NextResponse.json({ error: err instanceof Error ? err.message : "AP match failed" }, { status: 500 });

--- a/apps/backoffice/src/lib/finance/sales-recon.ts
+++ b/apps/backoffice/src/lib/finance/sales-recon.ts
@@ -1,0 +1,87 @@
+// Cash-IN reconciliation — the RECONCILE box of the finance loop.
+//
+// Ties what the POS rang up (gross sales, the cutover-aware unified source) to
+// what actually landed in the bank (settlements, the classified sales-inflow
+// categories). The gap is fees + platform commission + cash-not-deposited +
+// settlement timing — and the loop's job is to make sure that gap is EXPLAINED,
+// flagging any channel where money rung up never arrived.
+//
+// v1 is period-level per channel; per-day settlement-date matching and the
+// full Card/QR/Revenue-Monster tender split are refinements (the sales source
+// gives fulfilment channel, not tender). Grab is the high-value case: gross
+// sales vs net payout exposes the commission+marketing taken at source.
+
+import { prisma } from "@/lib/prisma";
+import { getUnifiedSalesForOutlet } from "@/app/api/sales/_lib/unified-sales";
+
+const round2 = (n: number) => Math.round(n * 100) / 100;
+const ymd = (d: Date) => d.toISOString().slice(0, 10);
+
+const SALES_INFLOW = ["CARD", "QR", "STOREHUB", "GRAB", "GRAB_PUTRAJAYA", "FOODPANDA", "MEETINGS_EVENTS", "GASTROHUB", "REVENUE_MONSTER"] as const;
+
+export type CashInRecon = {
+  from: string; to: string;
+  settlementsByChannel: { channel: string; amount: number; n: number }[];
+  settlementsTotal: number;
+  salesGross: number;
+  salesByChannel: { channel: string; amount: number }[];
+  gap: number;            // sales − settlements (fees/commission/cash/timing)
+  gapPct: number | null;
+  grab: { gross: number; settled: number; deductionPct: number | null }; // commission+marketing taken at source
+};
+
+export async function cashInRecon(opts: { sinceDays?: number } = {}): Promise<CashInRecon> {
+  const sinceDays = opts.sinceDays ?? 30;
+  const to = new Date();
+  const from = new Date(to.getTime() - sinceDays * 86400_000);
+
+  // ── Settlements: classified sales-inflow bank credits in the window ──
+  const grouped = await prisma.bankStatementLine.groupBy({
+    by: ["category"],
+    where: { direction: "CR", isInterCo: false, txnDate: { gte: from, lte: to }, category: { in: SALES_INFLOW as unknown as never[] } },
+    _sum: { amount: true }, _count: true,
+  });
+  const settlementsByChannel = grouped
+    .map((g) => ({ channel: String(g.category), amount: round2(Number(g._sum?.amount ?? 0)), n: g._count }))
+    .filter((s) => s.amount > 0)
+    .sort((a, b) => b.amount - a.amount);
+  const settlementsTotal = round2(settlementsByChannel.reduce((s, c) => s + c.amount, 0));
+  const grabSettled = round2(settlementsByChannel.filter((c) => c.channel.startsWith("GRAB")).reduce((s, c) => s + c.amount, 0));
+
+  // ── Sales: gross rung up across all outlets (cutover-aware) ──
+  const outlets = await prisma.outlet.findMany({
+    where: { OR: [{ loyaltyOutletId: { not: null } }, { pickupStoreId: { not: null } }] },
+    select: { id: true, loyaltyOutletId: true, pickupStoreId: true, posNativeCutoverAt: true },
+  });
+  const perOutlet = await Promise.all(
+    outlets.map((o) =>
+      getUnifiedSalesForOutlet({ outletId: o.id, storehubStoreId: null, loyaltyOutletId: o.loyaltyOutletId, pickupStoreId: o.pickupStoreId, cutoverAt: o.posNativeCutoverAt }, from, to),
+    ),
+  );
+  const sales = { instore: 0, online: 0, grab: 0, foodpanda: 0 };
+  for (const list of perOutlet) {
+    for (const s of list) {
+      const lbl = (s.channelLabel ?? "").toLowerCase();
+      if (/grab/.test(lbl)) sales.grab += s.total;
+      else if (/panda/.test(lbl)) sales.foodpanda += s.total;
+      else if (s.isDeliveryQR || s.channel === "delivery") sales.online += s.total;
+      else sales.instore += s.total;
+    }
+  }
+  const salesGross = round2(sales.instore + sales.online + sales.grab + sales.foodpanda);
+  const salesByChannel = [
+    { channel: "In-store (card/QR/cash)", amount: round2(sales.instore) },
+    { channel: "Online (Revenue Monster)", amount: round2(sales.online) },
+    { channel: "GrabFood", amount: round2(sales.grab) },
+    { channel: "FoodPanda", amount: round2(sales.foodpanda) },
+  ].filter((c) => c.amount > 0);
+
+  const gap = round2(salesGross - settlementsTotal);
+  const grabGross = round2(sales.grab);
+  return {
+    from: ymd(from), to: ymd(to),
+    settlementsByChannel, settlementsTotal, salesGross, salesByChannel,
+    gap, gapPct: salesGross > 0 ? round2((gap / salesGross) * 100) : null,
+    grab: { gross: grabGross, settled: grabSettled, deductionPct: grabGross > 0 ? round2(((grabGross - grabSettled) / grabGross) * 100) : null },
+  };
+}


### PR DESCRIPTION
The **RECONCILE box, cash-in side**. Ties POS gross sales to bank settlements and surfaces the gap (fees + commission + cash + timing) per channel.

- **`cashInRecon()`** — settlements by channel, sales by channel, gap %, and the **Grab gross-vs-net deduction** (commission + promos taken at source).
- Wired into the recon monitor (`/finance/recon` Cash-in panel).
- **Verified:** May–Jun sales RM639k vs settled RM605k = **5.2% gap**; flags Grab's **61% implied deduction** as high for review.

Read-only. v1 is period-level; per-day settlement-date matching + the full Card/QR/RM tender split are refinements.