### PR TITLE
feat(ui): WhatsApp-style date dividers in chat threads

### DIFF
--- a/apps/backoffice/src/app/(admin)/inventory/supplier-chats/page.tsx
+++ b/apps/backoffice/src/app/(admin)/inventory/supplier-chats/page.tsx
@@ -1,6 +1,8 @@
 "use client";
 
-import { useState, useEffect, useRef, type ReactNode } from "react";
+import { useState, useEffect, useRef, Fragment, type ReactNode } from "react";
+import { ChatDateDivider } from "@/components/chat-date-divider";
+import { mytDayKey, chatDayLabel } from "@/lib/chat-day";
 import { useSearchParams } from "next/navigation";
 import { useFetch } from "@/lib/use-fetch";
 import { formatRM } from "@celsius/shared";
@@ -915,9 +917,13 @@ export default function SupplierChatsPage() {
               {detail.messages.length === 0 && (
                 <p className="m-auto text-xs text-muted-foreground">No messages in this thread yet.</p>
               )}
-              {detail.messages.map((m) => (
+              {detail.messages.map((m, i) => {
+                const showDivider =
+                  i === 0 || mytDayKey(detail.messages[i - 1].timestamp) !== mytDayKey(m.timestamp);
+                return (
+                <Fragment key={m.id}>
+                {showDivider && <ChatDateDivider label={chatDayLabel(m.timestamp)} />}
                 <div
-                  key={m.id}
                   className={`group flex items-center gap-1.5 ${
                     m.direction === "outbound" ? "flex-row-reverse self-end" : "self-start"
                   } max-w-[80%]`}
@@ -972,7 +978,9 @@ export default function SupplierChatsPage() {
                     <Reply size={13} />
                   </button>
                 </div>
-              ))}
+                </Fragment>
+                );
+              })}
               {/* Agent's ASSIST suggestion — inline at the bottom of the thread, in the
                   conversation flow, instead of off in the side panel. */}
               {detail.agentProposal && (

--- a/apps/backoffice/src/app/(admin)/ops/chat-inbox/_MessagesPanel.tsx
+++ b/apps/backoffice/src/app/(admin)/ops/chat-inbox/_MessagesPanel.tsx
@@ -1,7 +1,9 @@
 "use client";
 
-import { useEffect, useMemo, useState } from "react";
+import { Fragment, useEffect, useMemo, useState } from "react";
 import { Card } from "@/components/ui/card";
+import { ChatDateDivider } from "@/components/chat-date-divider";
+import { mytDayKey, chatDayLabel } from "@/lib/chat-day";
 import { Badge } from "@/components/ui/badge";
 import { Input } from "@/components/ui/input";
 import { Loader2, Activity, ArrowUpRight, ArrowDownLeft, RefreshCw, AlertTriangle } from "lucide-react";
@@ -134,10 +136,17 @@ export default function MessagesPanel() {
           <div className="rounded-lg border border-dashed p-8 text-center text-sm text-muted-foreground">No messages match these filters.</div>
         ) : (
           <ul className="space-y-1.5">
-            {messages.map((m) => {
+            {messages.map((m, i) => {
               const failed = m.status === "failed";
+              const showDivider = i === 0 || mytDayKey(messages[i - 1].at) !== mytDayKey(m.at);
               return (
-                <li key={m.id} className={"rounded-lg border p-2.5 " + (failed ? "border-red-200 bg-red-50/40" : "bg-card")}>
+                <Fragment key={m.id}>
+                {showDivider && (
+                  <li>
+                    <ChatDateDivider label={chatDayLabel(m.at)} />
+                  </li>
+                )}
+                <li className={"rounded-lg border p-2.5 " + (failed ? "border-red-200 bg-red-50/40" : "bg-card")}>
                   <div className="flex items-center gap-1.5">
                     {m.direction === "out" ? (
                       <ArrowUpRight className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
@@ -153,6 +162,7 @@ export default function MessagesPanel() {
                   </div>
                   <div className="mt-1 whitespace-pre-wrap break-words pl-5 text-xs text-muted-foreground line-clamp-4">{m.body || `<${m.type}>`}</div>
                 </li>
+                </Fragment>
               );
             })}
           </ul>

--- a/apps/backoffice/src/components/chat-date-divider.tsx
+++ b/apps/backoffice/src/components/chat-date-divider.tsx
@@ -1,0 +1,11 @@
+// WhatsApp-style centered date pill that separates message groups by day.
+// Pair with mytDayKey/chatDayLabel from @/lib/chat-day to decide when to render one.
+export function ChatDateDivider({ label }: { label: string }) {
+  return (
+    <div className="my-1 flex justify-center">
+      <span className="rounded-full border bg-background/80 px-2.5 py-0.5 text-[10px] font-medium text-muted-foreground shadow-sm">
+        {label}
+      </span>
+    </div>
+  );
+}

--- a/apps/backoffice/src/lib/chat-day.ts
+++ b/apps/backoffice/src/lib/chat-day.ts
@@ -1,0 +1,25 @@
+// WhatsApp-style day grouping for chat threads. Computed in MYT (UTC+8) — the
+// business runs there while timestamps are stored UTC — so a message at 00:30 MYT
+// groups under the right calendar day, not the previous UTC one. See myt-today.ts.
+const MYT_OFFSET = 8 * 60 * 60 * 1000;
+
+const ms = (iso: string | Date) => (typeof iso === "string" ? Date.parse(iso) : iso.getTime());
+
+/** The MYT calendar day (YYYY-MM-DD) a UTC instant falls on — the day-boundary key. */
+export function mytDayKey(iso: string | Date): string {
+  return new Date(ms(iso) + MYT_OFFSET).toISOString().slice(0, 10);
+}
+
+/** "Today" / "Yesterday" / weekday (within the past week) / "3 June 2026". */
+export function chatDayLabel(iso: string | Date): string {
+  const key = mytDayKey(iso);
+  const diffDays = Math.round((Date.parse(mytDayKey(new Date())) - Date.parse(key)) / 86400000);
+  if (diffDays === 0) return "Today";
+  if (diffDays === 1) return "Yesterday";
+  // Format the MYT-shifted instant in UTC so the wall-clock fields read as MYT.
+  const shifted = new Date(ms(iso) + MYT_OFFSET);
+  if (diffDays > 1 && diffDays < 7) {
+    return shifted.toLocaleDateString("en-MY", { weekday: "long", timeZone: "UTC" });
+  }
+  return shifted.toLocaleDateString("en-GB", { day: "numeric", month: "long", year: "numeric", timeZone: "UTC" });
+}


### PR DESCRIPTION
## What
Long message threads ran together with nothing marking where one day ends and the next begins. Now there's a centered date pill between message groups — **Today / Yesterday / Saturday / 3 June 2026** — exactly like WhatsApp.

Applied in both places you asked for:
- **Purchase Orders** — the supplier-chat thread (`supplier-chats/page.tsx`)
- **Ops workspace** — the chat-inbox message monitor (`ops/chat-inbox/_MessagesPanel.tsx`)

## How
Two small shared pieces:
- `lib/chat-day.ts` — `mytDayKey` (the day-boundary key) + `chatDayLabel` (the WhatsApp-style label)
- `components/chat-date-divider.tsx` — the centered pill

Each renderer inserts a divider before a message whenever its day differs from the previous message's. Works for both orderings (supplier-chats is ascending, the ops feed is newest-first).

**MYT-aware** — the business runs UTC+8 while timestamps are stored UTC, so a message at 00:30 MYT correctly groups under that day, not the previous UTC one. Verified the boundary (17:00 UTC → groups under the next MYT day), the relative labels (Today/Yesterday/weekday/full date), and that same-day messages share a group with no divider between them.

## Verify
Typecheck + lint clean; day-label logic unit-verified. Visual: open a supplier thread or the ops message monitor with messages spanning a couple of days and you'll see the dividers. (Not browser-previewed here — the backoffice dev server needs prod DB + auth env.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)