### PR TITLE
feat(finance): per-outlet P&L filter (contribution margin)

### DIFF
--- a/apps/backoffice/src/app/(admin)/finance/reports/page.tsx
+++ b/apps/backoffice/src/app/(admin)/finance/reports/page.tsx
@@ -101,7 +101,9 @@ function SectionHeader({ label }: { label: string }) {
 function PnlTab() {
   const [start, setStart] = useState(thisMonthStart());
   const [end, setEnd] = useState(todayMyt());
-  const qs = useMemo(() => `start=${start}&end=${end}`, [start, end]);
+  const [outletId, setOutletId] = useState("");
+  const { data: outlets } = useFetch<{ id: string; name: string }[]>("/api/settings/outlets");
+  const qs = useMemo(() => `start=${start}&end=${end}${outletId ? `&outletId=${outletId}` : ""}`, [start, end, outletId]);
   const { data, error, isLoading, mutate } = useFetch<{ report: PnlReport }>(
     `/api/finance/reports/pnl?${qs}`
   );
@@ -123,10 +125,24 @@ function PnlTab() {
           onChange={(e) => setEnd(e.target.value)}
           className="h-8 rounded-md border bg-background px-2 text-sm"
         />
+        <select
+          value={outletId}
+          onChange={(e) => setOutletId(e.target.value)}
+          className="h-8 rounded-md border bg-background px-2 text-sm"
+          title="Per-outlet scopes revenue + COGS + outlet-tagged costs (contribution margin; shared opex stays company-level)"
+        >
+          <option value="">All outlets (company)</option>
+          {(outlets ?? []).map((o) => <option key={o.id} value={o.id}>{o.name}</option>)}
+        </select>
         <Button onClick={() => mutate()} variant="outline" size="sm">
           Refresh
         </Button>
       </div>
+      {outletId && (
+        <p className="text-[11px] text-amber-600">
+          Per-outlet view: revenue + COGS + outlet-tagged costs only (contribution margin). Shared/HQ opex is paid from the entity account and can&apos;t be split per outlet.
+        </p>
+      )}
 
       {isLoading && <Loader2 className="h-5 w-5 animate-spin text-muted-foreground" />}
       {error && (

--- a/apps/backoffice/src/app/api/finance/reports/pnl/route.ts
+++ b/apps/backoffice/src/app/api/finance/reports/pnl/route.ts
@@ -18,11 +18,12 @@ export async function GET(req: NextRequest) {
   const start = url.searchParams.get("start");
   const end = url.searchParams.get("end");
   const companyId = url.searchParams.get("companyId") ?? (await getActiveCompanyId());
+  const outletId = url.searchParams.get("outletId") ?? undefined;
   if (!start || !end || !/^\d{4}-\d{2}-\d{2}$/.test(start) || !/^\d{4}-\d{2}-\d{2}$/.test(end)) {
     return NextResponse.json({ error: "start, end (YYYY-MM-DD) required" }, { status: 400 });
   }
   try {
-    const report = await buildSourcedPnl({ companyId, start, end });
+    const report = await buildSourcedPnl({ companyId, start, end, outletId });
     return NextResponse.json({ report });
   } catch (err) {
     return NextResponse.json(

--- a/apps/backoffice/src/lib/finance/reports/pnl-sourced.ts
+++ b/apps/backoffice/src/lib/finance/reports/pnl-sourced.ts
@@ -132,15 +132,21 @@ export async function buildSourcedPnl(input: {
   companyId: string;
   start: string;
   end: string;
+  outletId?: string; // when set, scope to one outlet — revenue + COGS + the
+                     // outlet-TAGGED bank costs only. Shared/HQ opex (paid from
+                     // the entity account, untagged) can't be split per outlet,
+                     // so a per-outlet view is a contribution margin, not net.
 }): Promise<PnlReport> {
-  const { companyId, start, end } = input;
+  const { companyId, start, end, outletId } = input;
   const client = getFinanceClient();
   const defaultCompany = await getDefaultCompanyId();
 
-  // Company's outlets (UUIDs) — drive both revenue and COGS.
+  // Company's outlets (UUIDs) — drive both revenue and COGS. Narrow to one when
+  // an outlet filter is set (and it belongs to the company).
   const { data: oc } = await client
     .from("fin_outlet_companies").select("outlet_id").eq("company_id", companyId);
-  const outletIds = (oc ?? []).map((r) => r.outlet_id as string);
+  const companyOutletIds = (oc ?? []).map((r) => r.outlet_id as string);
+  const outletIds = outletId && companyOutletIds.includes(outletId) ? [outletId] : companyOutletIds;
 
   // ─── INCOME: actual GROSS sales, cutover-aware (StoreHub history + POS-native
   // + pickup) — the SAME source the sales dashboard uses. Replaces the
@@ -300,6 +306,7 @@ export async function buildSourcedPnl(input: {
         txnDate: { gte: dStart(start), lte: dEnd(end) },
         statement: { accountName: { contains: suffix } },
         apInvoiceId: null, // AP-matched lines settle a procurement invoice (COGS) — not opex
+        ...(outletId ? { outletId } : {}), // per-outlet: only outlet-tagged costs
       },
       _sum: { amount: true },
     });


### PR DESCRIPTION
Your 'reports can't diff by outlet' ask. The P&L was company-only; adds an **outlet filter**:
- Scopes **revenue + COGS + outlet-tagged bank costs** to one outlet → **per-outlet contribution margin**.
- Shared/HQ opex (rent, salary paid from the entity account, untagged) can't be split per outlet, so the UI flags the per-outlet view as contribution margin, not net.
- Outlet dropdown on the Reports → P&L tab.