### PR TITLE
hr(staff): port performance allowance v2 to the staff PWA

### DIFF
--- a/apps/staff/src/app/(ops)/hr/page.tsx
+++ b/apps/staff/src/app/(ops)/hr/page.tsx
@@ -14,14 +14,27 @@ type HRStatus = {
   outletId: string | null;
 };
 
+type AllowanceLever = {
+  key: string;
+  label: string;
+  applicable: boolean;
+  score: number;
+  tier: "under" | "ok" | "perform";
+  slice: number;
+  earned: number;
+  detail: string;
+};
 type AllowanceBreakdown = {
-  isFullTime: boolean;
+  eligible: boolean;
   period: { year: number; month: number; daysElapsed: number; daysRemaining: number };
-  attendance: { base: number; earned: number; tip: string; metrics: { lateCount: number; absentCount: number } };
-  performance: { base: number; earned: number; score: number; mode: string; eligible: boolean; breakdown: { checklists: number; reviews: number; audit: number }; tip: string };
+  pool: number;
+  levers: AllowanceLever[];
+  performanceEarned: number;
+  attendance: { deductions: { kind: string; label: string; amount: number; date?: string }[]; lateCount: number; absentCount: number; total: number };
   reviewPenalty: { total: number; entries: { id: string; reviewDate: string; rating: number; amount: number }[] };
   totalEarned: number;
   totalMax: number;
+  tip: string;
 };
 
 const MONTHS = ["January", "February", "March", "April", "May", "June", "July", "August", "September", "October", "November", "December"];
@@ -190,69 +203,62 @@ export default function HRHomePage() {
             </div>
           </div>
 
-          {/* Attendance bar */}
-          <div className="mb-3 rounded-xl bg-white/70 p-3">
-            <div className="mb-1 flex items-center justify-between text-sm">
+          {!allowance.eligible ? (
+            <div className="rounded-xl bg-white/70 p-3 text-sm text-gray-500">
               <div className="flex items-center gap-1.5">
-                <Clock className="h-4 w-4 text-blue-600" />
-                <span className="font-medium">Attendance</span>
+                <Sparkles className="h-4 w-4" />
+                <span>{allowance.tip || "Performance allowance is for full-time staff only."}</span>
               </div>
-              <span className="font-semibold">RM {allowance.attendance.earned} / RM {allowance.attendance.base}</span>
-            </div>
-            <div className="mb-1.5 h-2 overflow-hidden rounded-full bg-gray-200">
-              <div
-                className="h-full rounded-full bg-blue-500 transition-all"
-                style={{ width: `${(allowance.attendance.earned / allowance.attendance.base) * 100}%` }}
-              />
-            </div>
-            <p className="text-xs text-gray-600">{allowance.attendance.tip}</p>
-          </div>
-
-          {/* Performance bar — FT only */}
-          {allowance.performance.eligible ? (
-            <div className="mb-3 rounded-xl bg-white/70 p-3">
-              <div className="mb-1 flex items-center justify-between text-sm">
-                <div className="flex items-center gap-1.5">
-                  <Sparkles className="h-4 w-4 text-amber-600" />
-                  <span className="font-medium">Performance</span>
-                  <span className="text-xs text-gray-400">· score {allowance.performance.score}/100</span>
-                </div>
-                <span className="font-semibold">RM {allowance.performance.earned} / RM {allowance.performance.base}</span>
-              </div>
-              <div className="mb-1.5 h-2 overflow-hidden rounded-full bg-gray-200">
-                <div
-                  className="h-full rounded-full bg-amber-500 transition-all"
-                  style={{ width: allowance.performance.base > 0 ? `${(allowance.performance.earned / allowance.performance.base) * 100}%` : "0%" }}
-                />
-              </div>
-              <div className="mb-1 flex items-center gap-3 text-[11px] text-gray-500">
-                <span>Checklists {allowance.performance.breakdown.checklists}</span>
-                <span>Reviews {allowance.performance.breakdown.reviews}</span>
-                <span>Audit {allowance.performance.breakdown.audit}</span>
-              </div>
-              <p className="text-xs text-gray-600">{allowance.performance.tip}</p>
             </div>
           ) : (
-            <div className="mb-3 rounded-xl bg-white/70 p-3">
-              <div className="flex items-center gap-1.5 text-sm text-gray-500">
-                <Sparkles className="h-4 w-4" />
-                <span>Performance allowance — full-time staff only</span>
+            <>
+              {/* Earn levers — each scored on its own KPI */}
+              <div className="mb-3 space-y-2">
+                {allowance.levers.filter((l) => l.applicable).map((l) => {
+                  const barColor = l.tier === "perform" ? "bg-green-500" : l.tier === "ok" ? "bg-amber-500" : "bg-red-500";
+                  const pct = l.slice > 0 ? Math.round((l.earned / l.slice) * 100) : 0;
+                  return (
+                    <div key={l.key} className="rounded-xl bg-white/70 p-3">
+                      <div className="mb-1 flex items-center justify-between text-sm">
+                        <span className="font-medium">{l.label}</span>
+                        <span className="font-semibold">RM {l.earned} / {l.slice}</span>
+                      </div>
+                      <div className="mb-1.5 h-2 overflow-hidden rounded-full bg-gray-200">
+                        <div className={`h-full rounded-full ${barColor} transition-all`} style={{ width: `${pct}%` }} />
+                      </div>
+                      <p className="text-[11px] text-gray-600">{l.detail}</p>
+                    </div>
+                  );
+                })}
+                {allowance.levers.some((l) => !l.applicable) && (
+                  <p className="px-1 text-[11px] text-gray-400">
+                    Not counted for you: {allowance.levers.filter((l) => !l.applicable).map((l) => l.label).join(", ")} (shared across your other areas).
+                  </p>
+                )}
               </div>
-            </div>
-          )}
 
-          {/* Review penalty line */}
-          {allowance.reviewPenalty.total > 0 && (
-            <div className="rounded-xl bg-red-50 p-3">
-              <div className="mb-1 flex items-center justify-between text-sm">
-                <div className="flex items-center gap-1.5">
-                  <AlertTriangle className="h-4 w-4 text-red-600" />
-                  <span className="font-medium text-red-700">Review penalty</span>
+              {/* Deductions */}
+              {(allowance.attendance.total > 0 || allowance.reviewPenalty.total > 0) && (
+                <div className="rounded-xl bg-red-50 p-3">
+                  <div className="mb-1 flex items-center justify-between text-sm">
+                    <div className="flex items-center gap-1.5">
+                      <AlertTriangle className="h-4 w-4 text-red-600" />
+                      <span className="font-medium text-red-700">Deductions</span>
+                    </div>
+                    <span className="font-semibold text-red-700">−RM {allowance.attendance.total + allowance.reviewPenalty.total}</span>
+                  </div>
+                  <p className="text-xs text-red-600">
+                    {[
+                      allowance.attendance.lateCount > 0 ? `${allowance.attendance.lateCount} late` : null,
+                      allowance.attendance.absentCount > 0 ? `${allowance.attendance.absentCount} absence` : null,
+                      allowance.reviewPenalty.total > 0 ? `${allowance.reviewPenalty.entries.length} review penalty` : null,
+                    ].filter(Boolean).join(", ")} this month.
+                  </p>
                 </div>
-                <span className="font-semibold text-red-700">−RM {allowance.reviewPenalty.total}</span>
-              </div>
-              <p className="text-xs text-red-600">{allowance.reviewPenalty.entries.length} bad review{allowance.reviewPenalty.entries.length !== 1 ? "s" : ""} attributed this month.</p>
-            </div>
+              )}
+
+              <p className="mt-2 px-1 text-xs text-gray-600">{allowance.tip}</p>
+            </>
           )}
         </div>
       )}

--- a/apps/staff/src/lib/hr/allowances.ts
+++ b/apps/staff/src/lib/hr/allowances.ts
@@ -1,334 +1,393 @@
-// Staff-app allowance computation. Mirrors logic in apps/backoffice/src/lib/hr/allowances.ts
-// Divergence: staff app has no GBP credentials, so the "reviews" component of the performance
-// score falls back to neutral (60). Review-penalty deductions still apply (they're rows in
-// hr_review_penalty, readable via shared Supabase).
-import { supabase } from "../supabase";
+// Performance Allowance v2 — shared engine (backoffice + staff apps).
+//
+// Model (FT only — part-time / contract / intern not eligible):
+//   ONE performance pool (default RM200) split into 4 EARN levers. Each lever is
+//   scored on its OWN KPI (not a uniform %), and pays its slice in 3 steps
+//   (nothing / half / full):
+//     • Checklist (RM80) = your completion %  → ≥90% full · 70-89% half · <70% none   (all roles)
+//     • Phone capture (RM40) = capture rate vs the outlet's target
+//           → ≥70% of target full · 50-69% half · <50% none   (FRONT-OF-HOUSE only)
+//     • Serving time (RM40) = AVERAGE serve time on your shifts
+//           → ≤15 min full · 15-20 min half · >20 min none   (all roles, shift-wide)
+//     • Audit (RM40) = your outlet's audit overallScore this month
+//           → ≥70% full · 50-69% half · <50% none   (all roles, shift-wide; follows phone tier)
+//   A lever that doesn't apply to a person (kitchen never runs the register)
+//   drops and its RM REDISTRIBUTES across their applicable levers.
+//
+//   Then DEDUCT off the earned total (floor RM0, no caps):
+//     • Lateness   = flat penalty once past the grace window
+//     • Absence    = no-show on a scheduled shift, or > absent-threshold late
+//     • Negative reviews = manager-approved hr_review_penalty rows (RM10 each)
+import { supabaseAdmin } from "../supabase";
 import { prisma } from "../prisma";
-import { formatRM } from "@celsius/shared";
+
+// Phone capture is a FRONT-OF-HOUSE lever (kitchen does no phone collection).
+const FOH_POSITIONS = ["Barista", "Barista Lead", "Supervisor", "Shift Lead", "Manager", "Cashier"];
+// An FOH person who barely ran the register also drops phone (not zeroed for it).
+const MIN_REGISTER_ORDERS = 20;
+
+export type AllowanceRules = {
+  pool: number;
+  leverChecklist: number;
+  leverPhone: number;
+  leverServing: number;
+  leverAudit: number;
+  checklistFullPct: number;
+  checklistHalfPct: number;
+  phoneTargetUpliftPp: number;
+  phoneDefaultBaselinePct: number;
+  phoneFullPct: number; // achievement-vs-target % for full
+  phoneHalfPct: number;
+  servingFullMinutes: number; // avg serve time <= this → full
+  servingHalfMinutes: number;
+  latenessGraceMinutes: number;
+  latenessPenalty: number;
+  latenessAbsentMinutes: number;
+  absentPenalty: number;
+};
+
+export type AllowanceLeverKey = "checklist" | "phone" | "serving" | "audit";
+export type AllowanceTier = "under" | "ok" | "perform";
+
+export type AllowanceLever = {
+  key: AllowanceLeverKey;
+  label: string;
+  applicable: boolean;
+  score: number; // a 0-100 display proxy (completion %, achievement %); see `detail` for the real metric
+  tier: AllowanceTier;
+  slice: number;
+  earned: number;
+  detail: string;
+};
+
+export type AllowanceDeduction = { kind: "late" | "absent" | "review"; label: string; amount: number; date?: string };
 
 export type AllowanceBreakdown = {
   userId: string;
   employmentType: string | null;
   isFullTime: boolean;
+  eligible: boolean;
   period: { year: number; month: number; daysElapsed: number; daysRemaining: number };
-  attendance: {
-    base: number;
-    earned: number;
-    penalties: { kind: string; label: string; amount: number; date?: string }[];
-    metrics: { lateCount: number; absentCount: number; earlyOutCount: number; missedClockoutCount: number; exceededBreakCount: number };
-    tip: string;
-  };
-  performance: {
-    base: number;
-    earned: number;
-    score: number;
-    mode: "tiered" | "linear";
-    eligible: boolean;
-    breakdown: { checklists: number; reviews: number; audit: number };
-    tip: string;
-  };
-  reviewPenalty: {
-    total: number;
-    entries: { id: string; reviewDate: string; rating: number; amount: number; reviewText?: string | null }[];
-  };
+  pool: number;
+  levers: AllowanceLever[];
+  performanceEarned: number;
+  attendance: { deductions: AllowanceDeduction[]; lateCount: number; absentCount: number; total: number };
+  reviewPenalty: { total: number; entries: { id: string; reviewDate: string; rating: number; amount: number; reviewText?: string | null }[] };
   totalEarned: number;
   totalMax: number;
+  tip: string;
 };
 
-async function loadRules() {
-  const { data } = await supabase
+export async function loadAllowanceRules(): Promise<AllowanceRules> {
+  const { data } = await supabaseAdmin
     .from("hr_company_settings")
-    .select("attendance_allowance_amount, attendance_penalty_absent, attendance_penalty_early_out, attendance_penalty_missed_clockout, attendance_penalty_exceeded_break, attendance_late_tier_1_max_minutes, attendance_late_tier_2_max_minutes, attendance_late_tier_3_max_minutes, attendance_late_tier_4_max_minutes, attendance_late_tier_2_penalty, attendance_late_tier_3_penalty, attendance_late_tier_4_penalty, attendance_early_out_threshold_minutes, performance_allowance_amount, performance_allowance_mode, performance_tier_full_threshold, performance_tier_half_threshold, performance_tier_quarter_threshold, perf_weight_checklists, perf_weight_reviews, perf_weight_audit, review_penalty_amount")
+    .select(
+      "performance_allowance_amount, perf_lever_checklist, perf_lever_phone, perf_lever_serving, perf_lever_audit, checklist_full_pct, checklist_half_pct, perf_tier_perform_pct, perf_tier_ok_pct, phone_capture_target_uplift_pp, phone_capture_default_baseline_pct, serving_full_minutes, serving_half_minutes, attendance_lateness_grace_minutes, attendance_lateness_penalty, attendance_lateness_absent_minutes, attendance_penalty_absent",
+    )
     .limit(1)
     .maybeSingle();
   return {
-    attBase: Number(data?.attendance_allowance_amount ?? 100),
-    penAbsent: Number(data?.attendance_penalty_absent ?? 20),
-    penEarlyOut: Number(data?.attendance_penalty_early_out ?? 10),
-    penMissedClockout: Number(data?.attendance_penalty_missed_clockout ?? 5),
-    penExceededBreak: Number(data?.attendance_penalty_exceeded_break ?? 3),
-    lateTier1Max: Number(data?.attendance_late_tier_1_max_minutes ?? 5),
-    lateTier2Max: Number(data?.attendance_late_tier_2_max_minutes ?? 15),
-    lateTier3Max: Number(data?.attendance_late_tier_3_max_minutes ?? 30),
-    lateTier4Max: Number(data?.attendance_late_tier_4_max_minutes ?? 60),
-    lateTier2Pen: Number(data?.attendance_late_tier_2_penalty ?? 5),
-    lateTier3Pen: Number(data?.attendance_late_tier_3_penalty ?? 10),
-    lateTier4Pen: Number(data?.attendance_late_tier_4_penalty ?? 15),
-    earlyOutThresh: Number(data?.attendance_early_out_threshold_minutes ?? 30),
-    perfBase: Number(data?.performance_allowance_amount ?? 100),
-    perfMode: (data?.performance_allowance_mode as "tiered" | "linear") ?? "tiered",
-    tierFull: Number(data?.performance_tier_full_threshold ?? 85),
-    tierHalf: Number(data?.performance_tier_half_threshold ?? 70),
-    tierQuarter: Number(data?.performance_tier_quarter_threshold ?? 60),
-    weightChecklists: Number(data?.perf_weight_checklists ?? 40),
-    weightReviews: Number(data?.perf_weight_reviews ?? 30),
-    weightAudit: Number(data?.perf_weight_audit ?? 30),
+    pool: Number(data?.performance_allowance_amount ?? 200),
+    leverChecklist: Number(data?.perf_lever_checklist ?? 80),
+    leverPhone: Number(data?.perf_lever_phone ?? 40),
+    leverServing: Number(data?.perf_lever_serving ?? 40),
+    leverAudit: Number(data?.perf_lever_audit ?? 40),
+    checklistFullPct: Number(data?.checklist_full_pct ?? 90),
+    checklistHalfPct: Number(data?.checklist_half_pct ?? 70),
+    phoneTargetUpliftPp: Number(data?.phone_capture_target_uplift_pp ?? 15),
+    phoneDefaultBaselinePct: Number(data?.phone_capture_default_baseline_pct ?? 40),
+    phoneFullPct: Number(data?.perf_tier_perform_pct ?? 70),
+    phoneHalfPct: Number(data?.perf_tier_ok_pct ?? 50),
+    servingFullMinutes: Number(data?.serving_full_minutes ?? 15),
+    servingHalfMinutes: Number(data?.serving_half_minutes ?? 20),
+    latenessGraceMinutes: Number(data?.attendance_lateness_grace_minutes ?? 10),
+    latenessPenalty: Number(data?.attendance_lateness_penalty ?? 10),
+    latenessAbsentMinutes: Number(data?.attendance_lateness_absent_minutes ?? 60),
+    absentPenalty: Number(data?.attendance_penalty_absent ?? 20),
   };
 }
 
-export async function computeAllowances(userId: string, year: number, month: number): Promise<AllowanceBreakdown> {
-  const r = await loadRules();
+function payoutOf(tier: AllowanceTier, slice: number): number {
+  if (tier === "perform") return slice;
+  if (tier === "ok") return Math.round((slice / 2) * 100) / 100;
+  return 0;
+}
+
+const LEVER_LABEL: Record<AllowanceLeverKey, string> = {
+  checklist: "Checklist completion",
+  phone: "Phone capture",
+  serving: "Serving time",
+  audit: "Audit score",
+};
+
+type RawLever = { tier: AllowanceTier; applicable: boolean; detail: string; score: number };
+type AttendanceLog = { clock_in: string; clock_out: string | null; scheduled_start: string | null; outlet_id: string | null; excused: boolean | null };
+
+export async function computeAllowances(
+  userId: string,
+  year: number,
+  month: number,
+  rules?: AllowanceRules,
+): Promise<AllowanceBreakdown> {
+  const r: AllowanceRules = { ...(rules ?? (await loadAllowanceRules())) };
+
   const monthStart = `${year}-${String(month).padStart(2, "0")}-01`;
   const monthEndDate = new Date(year, month, 0);
   const monthEnd = monthEndDate.toISOString().slice(0, 10);
+  const monthStartIso = `${monthStart}T00:00:00Z`;
+  const monthEndIso = `${monthEnd}T23:59:59Z`;
   const today = new Date();
-  const isCurrent = today.getFullYear() === year && today.getMonth() + 1 === month;
-  const endForElapsed = isCurrent ? today : monthEndDate;
+  const isCurrentMonth = today.getFullYear() === year && today.getMonth() + 1 === month;
+  const endForElapsed = isCurrentMonth ? today : monthEndDate;
   const daysElapsed = Math.min(endForElapsed.getDate(), monthEndDate.getDate());
   const daysRemaining = Math.max(0, monthEndDate.getDate() - daysElapsed);
 
-  // Employment type
-  const { data: profile } = await supabase
+  const { data: profile } = await supabaseAdmin
     .from("hr_employee_profiles")
-    .select("employment_type")
+    .select("employment_type, schedule_required, position")
     .eq("user_id", userId)
     .maybeSingle();
   const employmentType = profile?.employment_type ?? null;
   const isFullTime = employmentType === "full_time";
+  const scheduleRequired = profile?.schedule_required !== false;
+  const eligible = isFullTime && scheduleRequired;
+  const isFoh = FOH_POSITIONS.includes((profile?.position ?? "").trim());
 
-  const [attResp, schedResp, leavesResp, rpResp] = await Promise.all([
-    supabase.from("hr_attendance_logs").select("id, clock_in, clock_out, ai_flags, scheduled_start, scheduled_end, excused").eq("user_id", userId).gte("clock_in", `${monthStart}T00:00:00Z`).lte("clock_in", `${monthEnd}T23:59:59Z`),
-    supabase.from("hr_schedule_shifts").select("shift_date, start_time, end_time").eq("user_id", userId).gte("shift_date", monthStart).lte("shift_date", monthEnd),
-    supabase.from("hr_leave_requests").select("start_date, end_date").eq("user_id", userId).in("status", ["approved", "ai_approved"]).gte("start_date", monthStart).lte("end_date", monthEnd),
-    supabase.from("hr_review_penalty").select("id, review_date, rating, penalty_amount, review_text, attributed_user_ids").eq("status", "applied").gte("review_date", monthStart).lte("review_date", monthEnd).contains("attributed_user_ids", [userId]),
+  const { data: logsRaw } = await supabaseAdmin
+    .from("hr_attendance_logs")
+    .select("clock_in, clock_out, scheduled_start, outlet_id, excused")
+    .eq("user_id", userId)
+    .gte("clock_in", monthStartIso)
+    .lte("clock_in", monthEndIso);
+  const logs = (logsRaw || []) as AttendanceLog[];
+
+  if (!eligible) {
+    return {
+      userId, employmentType, isFullTime, eligible: false,
+      period: { year, month, daysElapsed, daysRemaining },
+      pool: r.pool,
+      levers: (["checklist", "phone", "serving", "audit"] as AllowanceLeverKey[]).map((k) => ({
+        key: k, label: LEVER_LABEL[k], applicable: false, score: 0, tier: "under" as AllowanceTier, slice: 0, earned: 0, detail: "Not eligible",
+      })),
+      performanceEarned: 0,
+      attendance: { deductions: [], lateCount: 0, absentCount: 0, total: 0 },
+      reviewPenalty: { total: 0, entries: [] },
+      totalEarned: 0, totalMax: 0,
+      tip: isFullTime ? "Not applicable — schedule not required for this role." : "Performance allowance is for full-time staff only.",
+    };
+  }
+
+  const user = await prisma.user.findUnique({ where: { id: userId }, select: { outletId: true } });
+  const outletId = user?.outletId ?? null;
+  // pos_orders.outlet_id is the loyalty id (e.g. "outlet-con"); HR uses Outlet UUID.
+  const outletUuids = Array.from(new Set([outletId, ...logs.map((l) => l.outlet_id)].filter((x): x is string => !!x)));
+  const outletRows = outletUuids.length
+    ? await prisma.outlet.findMany({ where: { id: { in: outletUuids } }, select: { id: true, loyaltyOutletId: true } })
+    : [];
+  const loyaltyByUuid = new Map(outletRows.map((o) => [o.id, o.loyaltyOutletId]));
+  const myLoyaltyOutlet = outletId ? (loyaltyByUuid.get(outletId) ?? null) : null;
+
+  // Outlet UUIDs the person actually worked (for shift-wide audit attribution).
+  const workedOutletUuids = Array.from(new Set(logs.map((l) => l.outlet_id).filter((x): x is string => !!x)));
+
+  // ── EARN: score each lever on its OWN KPI ─────────────────────────────────
+  const [rawChecklist, rawPhone, rawServing, rawAudit] = await Promise.all([
+    scoreChecklist(userId, outletId, monthStartIso, monthEndIso, r),
+    isFoh
+      ? scorePhoneCapture(userId, myLoyaltyOutlet, monthStartIso, monthEndIso, r)
+      : Promise.resolve<RawLever>({ tier: "under", applicable: false, detail: "not a front-of-house role", score: 0 }),
+    scoreServingTime(logs, loyaltyByUuid, monthStartIso, monthEndIso, r),
+    scoreAudit(workedOutletUuids, monthStartIso, monthEndIso, r),
   ]);
+  const raw: Record<AllowanceLeverKey, RawLever> = { checklist: rawChecklist, phone: rawPhone, serving: rawServing, audit: rawAudit };
+  const baseSlice: Record<AllowanceLeverKey, number> = { checklist: r.leverChecklist, phone: r.leverPhone, serving: r.leverServing, audit: r.leverAudit };
 
-  const logs = (attResp.data || []) as { id: string; clock_in: string; clock_out: string | null; ai_flags: string[] | null; scheduled_start: string | null; scheduled_end: string | null; excused?: boolean }[];
-  const scheduled = (schedResp.data || []) as { shift_date: string; start_time: string; end_time: string }[];
-  const leaves = (leavesResp.data || []) as { start_date: string; end_date: string }[];
+  const keys: AllowanceLeverKey[] = ["checklist", "phone", "serving", "audit"];
+  const applicableBase = keys.filter((k) => raw[k].applicable).reduce((s, k) => s + baseSlice[k], 0);
+  const levers: AllowanceLever[] = keys.map((k) => {
+    const applicable = raw[k].applicable && applicableBase > 0;
+    const slice = applicable ? Math.round((r.pool * baseSlice[k]) / applicableBase) : 0;
+    return {
+      key: k, label: LEVER_LABEL[k], applicable, score: raw[k].score, tier: raw[k].tier, slice,
+      earned: applicable ? payoutOf(raw[k].tier, slice) : 0,
+      detail: applicable ? raw[k].detail : `n/a — ${raw[k].detail} (RM redistributed)`,
+    };
+  });
+  const performanceEarned = Math.round(levers.reduce((s, l) => s + l.earned, 0) * 100) / 100;
 
+  // ── DEDUCT: lateness + absence ────────────────────────────────────────────
+  const { data: scheduled } = await supabaseAdmin
+    .from("hr_schedule_shifts").select("shift_date").eq("user_id", userId)
+    .gte("shift_date", monthStart).lte("shift_date", monthEnd);
+  const { data: leaves } = await supabaseAdmin
+    .from("hr_leave_requests").select("start_date, end_date").eq("user_id", userId)
+    .in("status", ["approved", "ai_approved"]).gte("start_date", monthStart).lte("end_date", monthEnd);
   const leaveDays = new Set<string>();
-  leaves.forEach((l) => {
-    const s = new Date(l.start_date);
-    const e = new Date(l.end_date);
-    for (let d = new Date(s); d <= e; d.setDate(d.getDate() + 1)) {
-      leaveDays.add(d.toISOString().slice(0, 10));
-    }
+  (leaves || []).forEach((l: { start_date: string; end_date: string }) => {
+    const s = new Date(l.start_date + "T00:00:00Z");
+    const e = new Date(l.end_date + "T00:00:00Z");
+    for (let d = new Date(s); d <= e; d.setUTCDate(d.getUTCDate() + 1)) leaveDays.add(d.toISOString().slice(0, 10));
   });
 
-  const penalties: AllowanceBreakdown["attendance"]["penalties"] = [];
-  const metrics = { lateCount: 0, absentCount: 0, earlyOutCount: 0, missedClockoutCount: 0, exceededBreakCount: 0 };
-
-  const applyLateTier = (lateMin: number, date?: string) => {
-    if (lateMin > r.lateTier4Max) {
-      penalties.push({ kind: "absent", label: `Very late (${Math.round(lateMin)}m) — counted as absent`, amount: r.penAbsent, date });
-      metrics.absentCount++;
-    } else if (lateMin > r.lateTier3Max) {
-      penalties.push({ kind: "late", label: `Late ${Math.round(lateMin)}m (tier 4)`, amount: r.lateTier4Pen, date });
-      metrics.lateCount++;
-    } else if (lateMin > r.lateTier2Max) {
-      penalties.push({ kind: "late", label: `Late ${Math.round(lateMin)}m (tier 3)`, amount: r.lateTier3Pen, date });
-      metrics.lateCount++;
-    } else if (lateMin > r.lateTier1Max) {
-      penalties.push({ kind: "late", label: `Late ${Math.round(lateMin)}m (tier 2)`, amount: r.lateTier2Pen, date });
-      metrics.lateCount++;
-    }
-  };
-
-  // clock_in is stored as UTC timestamptz. Convert to Malaysian local date
-  // (UTC+8) so morning shifts (7:30am MYT = 23:30 UTC previous day) match
-  // the schedule's shift_date correctly.
-  const toMytDate = (iso: string | null | undefined): string => {
-    if (!iso) return "";
-    const d = new Date(iso);
-    // Offset to MYT and take the YYYY-MM-DD portion
-    return new Date(d.getTime() + 8 * 3600 * 1000).toISOString().slice(0, 10);
-  };
-
+  const toMytDate = (iso: string | null | undefined): string =>
+    !iso ? "" : new Date(new Date(iso).getTime() + 8 * 3600 * 1000).toISOString().slice(0, 10);
   const computeLateMin = (clockInIso: string, schedStart: string | null): number => {
     if (!schedStart) return 0;
-    const d = new Date(clockInIso);
-    const myt = new Date(d.getTime() + 8 * 3600 * 1000);
-    const h = myt.getUTCHours(), m = myt.getUTCMinutes();
+    const myt = new Date(new Date(clockInIso).getTime() + 8 * 3600 * 1000);
     const [sh, sm] = schedStart.split(":").map(Number);
-    const delta = (h * 60 + m) - (sh * 60 + (sm || 0));
-    return delta > 0 ? delta : 0;
+    return Math.max(0, (myt.getUTCHours() * 60 + myt.getUTCMinutes()) - (sh * 60 + (sm || 0)));
   };
+
+  const deductions: AllowanceDeduction[] = [];
+  let lateCount = 0, absentCount = 0;
   for (const log of logs) {
-    // Manager-excused logs skip all penalty calculations.
     if (log.excused) continue;
     const date = toMytDate(log.clock_in);
-    applyLateTier(computeLateMin(log.clock_in, log.scheduled_start), date);
-
-    if (!log.clock_out) {
-      penalties.push({ kind: "missed_clockout", label: "Missed clock-out", amount: r.penMissedClockout, date });
-      metrics.missedClockoutCount++;
-    } else if (log.scheduled_end) {
-      const earlyMin = (new Date(log.scheduled_end).getTime() - new Date(log.clock_out).getTime()) / 60000;
-      if (earlyMin > r.earlyOutThresh) {
-        penalties.push({ kind: "early_out", label: `Left ${Math.round(earlyMin)}m early`, amount: r.penEarlyOut, date });
-        metrics.earlyOutCount++;
-      }
-    }
-    if (Array.isArray(log.ai_flags) && log.ai_flags.includes("exceeded_break")) {
-      penalties.push({ kind: "exceeded_break", label: "Exceeded break", amount: r.penExceededBreak, date });
-      metrics.exceededBreakCount++;
+    const lateMin = computeLateMin(log.clock_in, log.scheduled_start);
+    if (lateMin > r.latenessAbsentMinutes) {
+      deductions.push({ kind: "absent", label: `Very late (${Math.round(lateMin)}m) — counted as absent`, amount: r.absentPenalty, date });
+      absentCount++;
+    } else if (lateMin > r.latenessGraceMinutes) {
+      deductions.push({ kind: "late", label: `Late ${Math.round(lateMin)}m`, amount: r.latenessPenalty, date });
+      lateCount++;
     }
   }
-
   const loggedDates = new Set(logs.map((l) => toMytDate(l.clock_in)));
   const todayIso = today.toISOString().slice(0, 10);
-  for (const sh of scheduled) {
-    if (sh.shift_date >= todayIso) continue;
-    if (loggedDates.has(sh.shift_date)) continue;
-    if (leaveDays.has(sh.shift_date)) continue;
-    penalties.push({ kind: "absent", label: "No-show", amount: r.penAbsent, date: sh.shift_date });
-    metrics.absentCount++;
+  for (const sh of (scheduled || [])) {
+    if (sh.shift_date >= todayIso || loggedDates.has(sh.shift_date) || leaveDays.has(sh.shift_date)) continue;
+    deductions.push({ kind: "absent", label: "No-show (scheduled, didn't clock in)", amount: r.absentPenalty, date: sh.shift_date });
+    absentCount++;
   }
+  const attendanceTotal = deductions.reduce((s, d) => s + d.amount, 0);
 
-  const attendanceBase = isFullTime ? r.attBase : 0;
-  const attendanceEarned = Math.max(
-    0,
-    attendanceBase - (isFullTime ? penalties.reduce((s, p) => s + p.amount, 0) : 0),
-  );
-
-  let attendanceTip: string;
-  if (!isFullTime) {
-    attendanceTip = "Attendance allowance is for full-time staff only.";
-  } else if (metrics.absentCount > 0) {
-    attendanceTip = `You missed ${metrics.absentCount} shift${metrics.absentCount > 1 ? "s" : ""}. Attend the rest to protect your allowance.`;
-  } else if (metrics.lateCount > 0) {
-    attendanceTip = `Be on time for the next ${Math.min(3, daysRemaining)} clock-ins to stay on track.`;
-  } else if (metrics.earlyOutCount > 0) {
-    attendanceTip = "Avoid leaving before your scheduled end-time.";
-  } else {
-    attendanceTip = "Perfect attendance — keep it up!";
-  }
-
-  // Performance (FT only)
-  const { score, parts } = isFullTime
-    ? await computeScore(userId, year, month, r)
-    : { score: 0, parts: { checklists: 0, reviews: 0, audit: 0 } };
-
-  let performanceEarned = 0;
-  if (!isFullTime) {
-    performanceEarned = 0;
-  } else if (r.perfMode === "linear") {
-    performanceEarned = Math.round(r.perfBase * (score / 100) * 100) / 100;
-  } else {
-    if (score >= r.tierFull) performanceEarned = r.perfBase;
-    else if (score >= r.tierHalf) performanceEarned = r.perfBase / 2;
-    else if (score >= r.tierQuarter) performanceEarned = r.perfBase / 4;
-    else performanceEarned = 0;
-  }
-
-  let performanceTip = "";
-  if (!isFullTime) {
-    performanceTip = "Performance allowance is for full-time staff only.";
-  } else if (r.perfMode === "tiered") {
-    if (score < r.tierQuarter) performanceTip = `Reach ${r.tierQuarter}+ to earn RM ${r.perfBase / 4}.`;
-    else if (score < r.tierHalf) performanceTip = `Reach ${r.tierHalf}+ for RM ${r.perfBase / 2}.`;
-    else if (score < r.tierFull) performanceTip = `Reach ${r.tierFull}+ for the full RM ${r.perfBase}.`;
-    else performanceTip = "Top tier — amazing!";
-  } else {
-    performanceTip = `Every point = ${formatRM((r.perfBase / 100))}.`;
-  }
-
-  // Review penalty
-  const reviewPenaltyEntries = (rpResp.data || []).map((row: { id: string; review_date: string; rating: number; penalty_amount: number; review_text: string | null }) => ({
-    id: row.id,
-    reviewDate: row.review_date,
-    rating: row.rating,
-    amount: Number(row.penalty_amount),
-    reviewText: row.review_text,
+  // ── DEDUCT: manager-approved negative reviews ─────────────────────────────
+  const { data: rpRows } = await supabaseAdmin
+    .from("hr_review_penalty")
+    .select("id, review_date, rating, penalty_amount, review_text")
+    .eq("status", "applied").gte("review_date", monthStart).lte("review_date", monthEnd)
+    .contains("attributed_user_ids", [userId]);
+  const reviewEntries = (rpRows || []).map((row: { id: string; review_date: string; rating: number; penalty_amount: number; review_text: string | null }) => ({
+    id: row.id, reviewDate: row.review_date, rating: row.rating, amount: Number(row.penalty_amount), reviewText: row.review_text,
   }));
-  const reviewPenaltyTotal = reviewPenaltyEntries.reduce((s, e) => s + e.amount, 0);
+  const reviewTotal = reviewEntries.reduce((s, e) => s + e.amount, 0);
 
-  const totalEarned = Math.max(0, attendanceEarned + performanceEarned - reviewPenaltyTotal);
+  const totalEarned = Math.max(0, performanceEarned - attendanceTotal - reviewTotal);
 
   return {
-    userId,
-    employmentType,
-    isFullTime,
+    userId, employmentType, isFullTime, eligible: true,
     period: { year, month, daysElapsed, daysRemaining },
-    attendance: { base: attendanceBase, earned: attendanceEarned, penalties, metrics, tip: attendanceTip },
-    performance: {
-      base: isFullTime ? r.perfBase : 0,
-      earned: performanceEarned,
-      score,
-      mode: r.perfMode,
-      eligible: isFullTime,
-      breakdown: parts,
-      tip: performanceTip,
-    },
-    reviewPenalty: { total: reviewPenaltyTotal, entries: reviewPenaltyEntries },
+    pool: r.pool, levers, performanceEarned,
+    attendance: { deductions, lateCount, absentCount, total: attendanceTotal },
+    reviewPenalty: { total: reviewTotal, entries: reviewEntries },
     totalEarned: Math.round(totalEarned * 100) / 100,
-    totalMax: isFullTime ? r.attBase + r.perfBase : 0,
+    totalMax: r.pool,
+    tip: buildTip(levers, lateCount, absentCount, reviewTotal, daysRemaining),
   };
 }
 
-async function computeScore(
-  userId: string,
-  year: number,
-  month: number,
-  r: Awaited<ReturnType<typeof loadRules>>,
-): Promise<{ score: number; parts: { checklists: number; reviews: number; audit: number } }> {
-  const monthStart = `${year}-${String(month).padStart(2, "0")}-01`;
-  const monthEnd = new Date(year, month, 0).toISOString().slice(0, 10);
-  const monthStartIso = `${monthStart}T00:00:00Z`;
-  const monthEndIso = `${monthEnd}T23:59:59Z`;
+function buildTip(levers: AllowanceLever[], lateCount: number, absentCount: number, reviewTotal: number, daysRemaining: number): string {
+  if (absentCount > 0) return `You've missed ${absentCount} scheduled shift${absentCount > 1 ? "s" : ""} — each costs your allowance. Attend all remaining shifts.`;
+  const weakest = levers.filter((l) => l.applicable && l.tier !== "perform")[0];
+  if (weakest) return `Push your ${weakest.label.toLowerCase()} (${weakest.detail}) to the full mark to unlock RM${weakest.slice}.`;
+  if (lateCount > 0) return `Be on time for the next ${Math.min(3, daysRemaining)} clock-ins to protect your allowance.`;
+  if (reviewTotal > 0) return "A negative review was deducted this month — keep service quality high.";
+  return "All levers at full — full allowance on track. Keep it up!";
+}
 
-  const user = await prisma.user.findUnique({ where: { id: userId }, select: { name: true, fullName: true, outletId: true } });
-  if (!user?.outletId) return { score: 0, parts: { checklists: 0, reviews: 0, audit: 0 } };
+// ── Lever scorers (each applies its OWN KPI to decide the tier) ───────────────
 
-  // Checklists — team-avg relative within outlet
-  let checklistScore = 50;
-  try {
-    const outletChecklists = await prisma.checklist.findMany({
-      where: { outletId: user.outletId, createdAt: { gte: new Date(monthStartIso), lte: new Date(monthEndIso) }, assignedToId: { not: null } },
-      select: { status: true, assignedToId: true },
-    });
-    const byUser = new Map<string, { total: number; done: number }>();
-    for (const c of outletChecklists) {
-      if (!c.assignedToId) continue;
-      const entry = byUser.get(c.assignedToId) || { total: 0, done: 0 };
-      entry.total++;
-      if (c.status === "COMPLETED") entry.done++;
-      byUser.set(c.assignedToId, entry);
+// Checklist: your completion %. ≥ full% → full · ≥ half% → half · else none.
+async function scoreChecklist(userId: string, outletId: string | null, monthStartIso: string, monthEndIso: string, r: AllowanceRules): Promise<RawLever> {
+  const rows = await prisma.checklist.findMany({
+    where: { assignedToId: userId, createdAt: { gte: new Date(monthStartIso), lte: new Date(monthEndIso) }, ...(outletId ? { outletId } : {}) },
+    select: { status: true },
+  });
+  if (rows.length === 0) return { tier: "under", applicable: false, detail: "no checklists assigned", score: 0 };
+  const done = rows.filter((c) => c.status === "COMPLETED").length;
+  const pct = Math.round((done / rows.length) * 100);
+  const tier: AllowanceTier = pct >= r.checklistFullPct ? "perform" : pct >= r.checklistHalfPct ? "ok" : "under";
+  return { tier, applicable: true, detail: `${done}/${rows.length} done (${pct}%)`, score: pct };
+}
+
+// Phone capture: capture rate vs the outlet target (trailing-90d baseline + uplift).
+// Achievement = capture/target. ≥ full% → full · ≥ half% → half · else none.
+async function scorePhoneCapture(userId: string, loyaltyOutletId: string | null, monthStartIso: string, monthEndIso: string, r: AllowanceRules): Promise<RawLever> {
+  const { data: mine } = await supabaseAdmin
+    .from("pos_orders").select("customer_phone, loyalty_phone").eq("employee_id", userId)
+    .gte("created_at", monthStartIso).lte("created_at", monthEndIso);
+  const total = (mine || []).length;
+  if (total < MIN_REGISTER_ORDERS) return { tier: "under", applicable: false, detail: `not a register operator (${total} orders)`, score: 0 };
+  const captured = (mine || []).filter((o: { customer_phone: string | null; loyalty_phone: string | null }) => o.customer_phone || o.loyalty_phone).length;
+  const myRate = (captured / total) * 100;
+
+  let baseline = r.phoneDefaultBaselinePct;
+  if (loyaltyOutletId) {
+    const since = new Date(Date.now() - 90 * 24 * 3600 * 1000).toISOString();
+    const { data: outletRows } = await supabaseAdmin
+      .from("pos_orders").select("customer_phone, loyalty_phone").eq("outlet_id", loyaltyOutletId).gte("created_at", since);
+    const oTotal = (outletRows || []).length;
+    if (oTotal >= 50) {
+      const oCap = (outletRows || []).filter((o: { customer_phone: string | null; loyalty_phone: string | null }) => o.customer_phone || o.loyalty_phone).length;
+      baseline = (oCap / oTotal) * 100;
     }
-    const rates = Array.from(byUser.values()).filter((v) => v.total > 0).map((v) => (v.done / v.total) * 100);
-    const teamAvg = rates.length > 0 ? rates.reduce((a, b) => a + b, 0) / rates.length : 0;
-    const mine = byUser.get(userId);
-    const myRate = mine && mine.total > 0 ? (mine.done / mine.total) * 100 : 0;
-    if (rates.length === 0 || teamAvg === 0) checklistScore = 50;
-    else if (myRate >= teamAvg) checklistScore = 100;
-    else checklistScore = Math.max(0, (myRate / teamAvg) * 100);
-  } catch { /* ignore */ }
+  }
+  const target = Math.min(95, baseline + r.phoneTargetUpliftPp);
+  const achievement = Math.min(100, Math.round((myRate / target) * 100));
+  const tier: AllowanceTier = achievement >= r.phoneFullPct ? "perform" : achievement >= r.phoneHalfPct ? "ok" : "under";
+  return { tier, applicable: true, detail: `${Math.round(myRate)}% vs ${Math.round(target)}% target`, score: achievement };
+}
 
-  // Reviews — staff app has no GBP access, neutral default
-  const reviewScore = 60;
+// Serving time (shift-wide): AVERAGE serve time (served_at - created_at) over the
+// orders at your outlet(s) during the shifts you worked.
+// avg ≤ full-min → full · ≤ half-min → half · else none.
+async function scoreServingTime(logs: AttendanceLog[], loyaltyByUuid: Map<string, string | null>, monthStartIso: string, monthEndIso: string, r: AllowanceRules): Promise<RawLever> {
+  const windows = logs
+    .filter((l) => l.outlet_id && l.clock_in && loyaltyByUuid.get(l.outlet_id))
+    .map((l) => ({ outlet: loyaltyByUuid.get(l.outlet_id as string) as string, start: new Date(l.clock_in).getTime(), end: new Date(l.clock_out ?? new Date().toISOString()).getTime() }))
+    .filter((w) => w.end >= w.start);
+  if (windows.length === 0) return { tier: "under", applicable: false, detail: "no shifts worked", score: 0 };
 
-  // Audit
-  let auditPositive = 0;
-  let auditNegative = 0;
-  try {
-    const auditReports = await prisma.auditReport.findMany({
-      where: { completedAt: { gte: new Date(monthStartIso), lte: new Date(monthEndIso) }, status: "COMPLETED" },
-      select: { overallScore: true, overallNotes: true, items: { select: { notes: true, rating: true } } },
-    });
-    const tokens = [user?.name, user?.fullName, user?.name?.split(/\s+/)[0], user?.fullName?.split(/\s+/)[0]].filter((t): t is string => !!t && t.length >= 3);
-    for (const rpt of auditReports) {
-      const txt = [rpt.overallNotes || "", ...(rpt.items || []).map((i) => i.notes || "")].join(" \n ");
-      if (!txt.trim()) continue;
-      const hit = tokens.some((t) => new RegExp(`\\b${t.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}\\b`, "i").test(txt));
-      if (!hit) continue;
-      const sc = rpt.overallScore ? Number(rpt.overallScore) : null;
-      const itemRatings = (rpt.items || []).map((i) => i.rating).filter((x): x is number => x != null);
-      const avgItem = itemRatings.length > 0 ? itemRatings.reduce((a, b) => a + b, 0) / itemRatings.length : null;
-      if ((sc !== null && sc >= 80) || (avgItem !== null && avgItem >= 4)) auditPositive++;
-      else if ((sc !== null && sc < 60) || (avgItem !== null && avgItem <= 2)) auditNegative++;
-    }
-  } catch { /* ignore */ }
-  const auditScore = Math.max(0, Math.min(100, 70 + auditPositive * 10 - auditNegative * 20));
+  const outlets = Array.from(new Set(windows.map((w) => w.outlet)));
+  const { data: orders } = await supabaseAdmin
+    .from("pos_orders").select("created_at, served_at, outlet_id")
+    .in("outlet_id", outlets).not("served_at", "is", null)
+    .gte("created_at", monthStartIso).lte("created_at", monthEndIso);
 
-  const wSum = r.weightChecklists + r.weightReviews + r.weightAudit;
-  const wC = r.weightChecklists / wSum;
-  const wR = r.weightReviews / wSum;
-  const wA = r.weightAudit / wSum;
-  const score = Math.round(checklistScore * wC + reviewScore * wR + auditScore * wA);
+  let total = 0, sumMs = 0;
+  for (const o of (orders || []) as { created_at: string; served_at: string; outlet_id: string }[]) {
+    const servedMs = new Date(o.served_at).getTime();
+    const createdMs = new Date(o.created_at).getTime();
+    if (servedMs < createdMs) continue;
+    if (!windows.some((w) => w.outlet === o.outlet_id && servedMs >= w.start && servedMs <= w.end)) continue;
+    total++;
+    sumMs += servedMs - createdMs;
+  }
+  if (total === 0) return { tier: "under", applicable: false, detail: "no served orders on your shifts", score: 0 };
+  const avgMin = (sumMs / total) / 60000;
+  const tier: AllowanceTier = avgMin <= r.servingFullMinutes ? "perform" : avgMin <= r.servingHalfMinutes ? "ok" : "under";
+  // display proxy: 100 at/under full, scaling down past it (for the UI bar only)
+  const score = Math.max(0, Math.min(100, Math.round((r.servingFullMinutes / avgMin) * 100)));
+  return { tier, applicable: true, detail: `avg ${avgMin.toFixed(1)}min over ${total} orders`, score };
+}
 
-  return {
-    score: Math.max(0, Math.min(100, score)),
-    parts: { checklists: Math.round(checklistScore), reviews: Math.round(reviewScore), audit: Math.round(auditScore) },
-  };
+// Audit (shift-wide): the average completed-audit overallScore for the outlet(s)
+// you worked this month. Scored on the same tier as phone capture (>=70% full,
+// >=50% half). AuditReport.outletId is the Outlet UUID (same space as HR).
+async function scoreAudit(workedOutletUuids: string[], monthStartIso: string, monthEndIso: string, r: AllowanceRules): Promise<RawLever> {
+  if (workedOutletUuids.length === 0) return { tier: "under", applicable: false, detail: "no shifts worked", score: 0 };
+  const reports = await prisma.auditReport.findMany({
+    where: {
+      outletId: { in: workedOutletUuids },
+      status: "COMPLETED",
+      overallScore: { not: null },
+      completedAt: { gte: new Date(monthStartIso), lte: new Date(monthEndIso) },
+    },
+    select: { overallScore: true },
+  });
+  if (reports.length === 0) return { tier: "under", applicable: false, detail: "no audits at your outlet this month", score: 0 };
+  const avg = Math.round(reports.reduce((s, a) => s + Number(a.overallScore), 0) / reports.length);
+  // Follows phone capture's tier (perf/ok thresholds).
+  const tier: AllowanceTier = avg >= r.phoneFullPct ? "perform" : avg >= r.phoneHalfPct ? "ok" : "under";
+  return { tier, applicable: true, detail: `${reports.length} audit${reports.length > 1 ? "s" : ""} avg ${avg}%`, score: avg };
 }


### PR DESCRIPTION
Follow-up to #646. The staff PWA had its **own divergent copy** of the allowance engine, still computing the OLD two-allowance model. This ports it to the v2 model so staff see exactly what they're paid on ("track it live in the staff app", per the rollout memo).

- **lib/hr/allowances.ts** — `computeAllowances` now runs the v2 engine: one RM200 pool, 4 KPI levers (checklist ≥90% / phone vs outlet target, FOH-only / serving avg ≤15 min, shift-wide / audit, shift-wide), inapplicable-lever redistribution, lateness/absence/≤3★-review deductions. Same logic as backoffice; uses the staff app's `supabaseAdmin` (service-role — also unblocks this read past the RLS lockdown) + `prisma` + the `Outlet.loyaltyOutletId` bridge for pos_orders joins.
- **(ops)/hr/page.tsx** — renders the new per-lever bars (tier-coloured, RM earned/slice) + a single Deductions line.

staff-native still has its own old copy (separate follow-up). These three engines should collapse to one shared module eventually.