### PR TITLE
finance: GastroHub→Nilai / Kiddytopia→IOI Mall attribution + marketing AP verify

### DIFF
--- a/apps/backoffice/src/lib/finance/agents/ap-verifier.ts
+++ b/apps/backoffice/src/lib/finance/agents/ap-verifier.ts
@@ -22,7 +22,7 @@ export type ApVerdict = {
   reason: string;
 };
 
-const SYSTEM = `You verify whether a bank payment settles a specific supplier invoice for a coffee chain. Be strict: a matching amount alone is NOT enough — Malaysian bank lines for salaries, part-timer wages ("PT Week"), rent, owner transfers, and unrelated vendors frequently collide on amount. Confirm ONLY if the bank line's payee/reference clearly corresponds to the invoice's supplier. Reject if the bank line is plainly a different kind of payment (payroll, rent, transfer, a different company). Use "uncertain" when you genuinely cannot tell. Output ONLY JSON: {"verdict":"confirm|reject|uncertain","confidence":0.0,"reason":"one short line"}.`;
+const SYSTEM = `You verify whether a bank payment settles a specific vendor invoice for a coffee chain. The invoice may be for raw materials, packaging, services, MARKETING (e.g. PXL Marketing, agencies, KOLs), rent, or equipment — all are valid vendor invoices. Be strict: a matching amount alone is NOT enough — Malaysian bank lines for salaries, part-timer wages ("PT Week"), statutory payments (EPF/SOCSO), owner draws, and unrelated companies frequently collide on amount. Confirm ONLY if the bank line's payee/reference clearly corresponds to the invoice's vendor (e.g. invoice "PXL Marketing" matches bank "PXL MARKETING SDN"). Reject if the bank line is plainly a different kind of payment (payroll/PT-week, statutory, an internal transfer, or a different company). Use "uncertain" when you genuinely cannot tell. Output ONLY JSON: {"verdict":"confirm|reject|uncertain","confidence":0.0,"reason":"one short line"}.`;
 
 function buildPrompt(m: ApMatch): string {
   return `# Invoice

--- a/apps/backoffice/src/lib/finance/bank-line-classifier.ts
+++ b/apps/backoffice/src/lib/finance/bank-line-classifier.ts
@@ -41,10 +41,14 @@ export type ClassifyResult = {
 //
 // Outlet codes returned here match the Outlet.code values used elsewhere.
 function inferOutlet(desc: string): string | null {
+  // Channel-specific outlets (both in Celsius Coffee SB / acct 4384):
+  // GastroHub settles for Nilai; Kiddytopia is the IOI Mall events venue.
+  if (/\bGYRO\s*GASTRO\b/i.test(desc)) return "CF Nilai";
+  if (/\bKIDDYTOPIA\b/i.test(desc)) return "CF IOI Mall";
   if (/\bTAMARIND\b/i.test(desc) || /\bCELSIUSCOFFEE\s*T\b/i.test(desc)) return "CC003";
   if (/\bCONEZION\b/i.test(desc) || /\bCELSIUSCOFFEE\s*C\b/i.test(desc)) return "CC001";
-  if (/\bCELSIUSCOFFEE\s*SA\b/i.test(desc)) return null;       // Shah Alam — outlet code unknown to me
-  if (/\bCELSIUSCOFFEE\s*N\b/i.test(desc)) return null;        // Nilai — same
+  if (/\bCELSIUSCOFFEE\s*SA\b/i.test(desc)) return "CC002";    // Shah Alam
+  if (/\bCELSIUSCOFFEE\s*N\b/i.test(desc)) return "CF Nilai";  // Nilai
   if (/\bCELSIUSCOFFEE\s*P\b/i.test(desc)) return "CC001";     // Putrajaya = Conezion in current data
   return null;
 }


### PR DESCRIPTION
## What

Two tightenings to the finance loop, from the latest channel-mapping inputs.

### 1. Outlet attribution for off-POS channels
`inferOutlet` in the bank-line classifier now tags:
- **GYRO GASTRO** settlements (GastroHub) → **Nilai** (`CF Nilai`)
- **KIDDYTOPIA** → **IOI Mall** (`CF IOI Mall`)

Both are Celsius Coffee SB outlets. Also resolves the **Shah Alam** (`CC002`) and **Nilai** (`CF Nilai`) codes that were previously returned as null. Existing rows backfilled directly in the DB: 21 GastroHub lines (RM74.4k) and 9 Kiddytopia lines (RM10.7k), so per-outlet P&L and cash-in recon now attribute these channels correctly.

### 2. Marketing-aware AP verifier
The LLM verifier prompt was supplier/COGS-narrow. Broadened it to confirm **any vendor invoice** including marketing (PXL Marketing, agencies, KOLs), services, rent, and equipment, while keeping the strict payee-must-match guard against amount collisions (payroll, statutory, transfers). Marketing invoices (PXL, BEST, Shriyo) are already in the Invoice table, so the generic AP matcher already proposes them; this stops the confirmable ones from falling to the human queue. Google Ads spend stays sourced from the ads module in the P&L (bank DIGITAL_ADS deduped against it).

## Test
- `tsc --noEmit` clean on backoffice.