### PR TITLE
finance: Google Ads director-reimbursement claims -> DIGITAL_ADS (stop double-count)

### DIFF
--- a/apps/backoffice/src/lib/finance/bank-line-classifier.ts
+++ b/apps/backoffice/src/lib/finance/bank-line-classifier.ts
@@ -138,6 +138,14 @@ const OUTFLOW_RULES: Rule[] = [
   // CELSIUS COFFEE SDN.* <purpose>" pattern. The leading entity name
   // is just routing; the meaningful info is in the suffix. Match the
   // actual purpose so these end up in real categories.
+  //
+  // Google Ads is fronted personally by the director (Ammar) and reimbursed as
+  // an "Ads claim"/"Google Ads" transfer. The ACTUAL spend is already booked
+  // from the ads module (ads_metric_daily), so these reimbursements must land
+  // in DIGITAL_ADS = deduped out of bank opex (else double-count). This MUST
+  // come before purpose_staff_claim (/CLAIM/), software_saas (/GOOGLE/) and
+  // directors_ammar (/AMMAR BIN SHAHRIN/), which would otherwise grab them.
+  { name: "marketing_ads_claim",      match: /\bGOOGLE\s*ADS\b|\bADS?\s*CLAIMS?\b|\bCLAIMS?\s*ADS?\b/i, direction: "DR", category: "DIGITAL_ADS" as CashCategory },
   { name: "purpose_stat_pay",         match: /\b(STAT\s*PAY|STATUTORY)\b/i,           direction: "DR", category: "STATUTORY_PAYMENT" as CashCategory },
   { name: "purpose_inventory",        match: /\bINVENTORY\b/i,                        direction: "DR", category: "RAW_MATERIALS" as CashCategory },
   { name: "purpose_digital_ads",      match: /\bDIGITAL\s*ADS?\b/i,                   direction: "DR", category: "DIGITAL_ADS" as CashCategory },


### PR DESCRIPTION
Owner input: **Google Ads is paid personally by Ammar Shahrin and claimed back** from the company.

## Problem
The actual Google Ads spend is already booked from the ads module (`ads_metric_daily`, ~RM17-20k/mo, complete Jan-Jun). But the bank **reimbursement** transfers to Ammar (`Google Ads ...`, `Ads claim ...`) were classified all over the place:
- `/GOOGLE/` SaaS rule grabbed `Google Ads ...` → **SOFTWARE** (14 lines, RM54,302)
- `/CLAIM/` rule grabbed `Ads claim ...` → **STAFF_CLAIM** (5 lines, RM13,687)
- **OTHER_OUTFLOW** (1, RM3,156) and **DIRECTORS_ALLOWANCE** (6, RM16,710)

The SOFTWARE + STAFF_CLAIM + OTHER lines are counted as opex **on top of** the ads-module marketing line → **~RM71k of Google Ads double-counted** over 6 months (opex overstated, profit understated).

## Fix
- New early rule `marketing_ads_claim` matching `GOOGLE ADS` / `ADS CLAIM(S)` / `CLAIM(S) ADS` → **DIGITAL_ADS**, placed ahead of staff-claim, software and directors-ammar so it wins.
- `DIGITAL_ADS` is deduped out of bank opex in the P&L (the ads module is authoritative), so each ringgit of Google Ads is now counted exactly once.
- 26 existing rows backfilled to `DIGITAL_ADS` in the DB.

Marketing line stays = Google Ads (ads module) + SMS Niaga; the director reimbursement is no longer a second expense.

## Test
- Rule-literal edit; CI typecheck/lint/build cover it.