### PR TITLE
fix(procurement): never send a non-receipt as POP + atomic mark-paid

### DIFF
--- a/apps/backoffice/src/app/api/inventory/invoices/[id]/route.ts
+++ b/apps/backoffice/src/app/api/inventory/invoices/[id]/route.ts
@@ -221,10 +221,25 @@ export async function PATCH(req: NextRequest, { params }: { params: Promise<{ id
       }
     }
 
-    const invoice = await prisma.invoice.update({
-      where: { id },
-      data,
-    });
+    // Make the full-PAID transition ATOMIC. The early guard above is a read-then-write
+    // (TOCTOU): two concurrent mark-paid requests (double-click / stale client / a second
+    // tab, or a paymentAmount that completes the invoice with no status param) could both
+    // pass it and both write PAID — resetting paidAt and firing the POP auto-send twice.
+    // Gate the write on the row still NOT being PAID so exactly one wins; the loser gets the
+    // same 409. Non-payment edits keep the plain update. (Mirrors the Telegram path's guard.)
+    let invoice: Awaited<ReturnType<typeof prisma.invoice.update>>;
+    if (data.status === "PAID") {
+      const res = await prisma.invoice.updateMany({
+        where: { id, status: { not: "PAID" } },
+        data,
+      });
+      if (res.count === 0) {
+        return NextResponse.json({ error: "Invoice is already paid." }, { status: 409 });
+      }
+      invoice = await prisma.invoice.findUniqueOrThrow({ where: { id } });
+    } else {
+      invoice = await prisma.invoice.update({ where: { id }, data });
+    }
 
     // When transitioning to PAID/DEPOSIT_PAID, run the flag detector against
     // the freshly-attached payment data so the UI can surface any duplicates.

--- a/apps/backoffice/src/lib/inventory/procurement-whatsapp.ts
+++ b/apps/backoffice/src/lib/inventory/procurement-whatsapp.ts
@@ -52,10 +52,14 @@ export async function sendProofOfPayment(invoiceId: string): Promise<Procurement
   const phone = invoice.supplier?.phone?.trim();
   if (!phone) return { sent: false, reason: "no-supplier-phone" };
 
-  // DIRECT public URL of the receipt (the last POP photo) — WhatsApp fetches
-  // this for the document header, so it must be the real file URL, never the
-  // popShortLink redirect (the media fetcher won't follow it).
-  const popUrl = invoice.photos?.[invoice.photos.length - 1];
+  // DIRECT public URL of the real payment RECEIPT — WhatsApp fetches it for the document
+  // header, so it must be the real file URL (never the popShortLink redirect, which the
+  // media fetcher won't follow). Only ever send a document stored under the `/pop/` path
+  // (file-naming.popStoragePath); an invoice image or any other attachment must NEVER go
+  // out as "proof of payment". If the invoice was marked paid with no receipt on file,
+  // there's nothing legitimate to send — skip WITHOUT stamping popSentAt, so the real
+  // receipt can still go out once it's uploaded.
+  const popUrl = (invoice.photos ?? []).filter((p) => p.includes("/pop/")).pop();
   if (!popUrl) return { sent: false, reason: "no-pop-document" };
 
   const amount = `RM ${Number(invoice.amount).toFixed(2)}`;


### PR DESCRIPTION
Two money/outward-facing safety fixes from the full-flow QA.

## ① POP can no longer send the wrong document
`sendProofOfPayment` sent `photos[last]` with no check it was actually a receipt — and the "Mark Paid" dialog doesn't require a receipt upload. So marking a supplier invoice paid **without** re-uploading the bank slip would send the supplier their **own invoice image** labelled as proof of payment, and stamp `popSentAt` (permanently blocking the real POP).

Now it only ever sends a document stored under the `/pop/` path (where every real receipt lives — Telegram intake, PDF splitter, `popStoragePath`). If there's no `/pop/` receipt, it returns `no-pop-document` and **does not** stamp `popSentAt`, so the genuine receipt can still send once uploaded.

## ② Mark-paid is now atomic
The invoices PATCH did a read-then-write: the "already PAID" check (`findUnique`) and the write (`update`) were separate, so two concurrent requests (double-click / stale client / second tab, or a `paymentAmount` that completes the invoice with no status param) could both pass and both write PAID — resetting `paidAt` and firing the POP auto-send twice. The full-PAID write is now a single `updateMany` gated on `status != 'PAID'`; the loser gets a 409. This mirrors the Telegram payment path, which already did it this way.

## Verify
Typecheck + lint clean. Not runtime-tested here (the send path needs `PROCUREMENT_WHATSAPP_ENABLED` + a live payment); ① fails safe (sends nothing rather than the wrong thing), ② only narrows a race window.

🤖 Generated with [Claude Code](https://claude.com/claude-code)