### PR TITLE
fix(ops): don't escalate positive-review improvement tips to the owner

### DIFF
--- a/apps/backoffice/src/lib/ops-pulse/ledger.ts
+++ b/apps/backoffice/src/lib/ops-pulse/ledger.ts
@@ -88,12 +88,18 @@ export interface EscalatableAlert {
 // NO_CLOCK_IN, POS_NOT_OPEN. MENU_SNOOZED is real-time but self-clears, so it's
 // excluded. AUDIT/skill escalation is pending the routine-ledger path (they're
 // daily, not real-time, so they aren't persisted here yet).
+//
+// Exception: LOW-severity REVIEW alerts are the happy-but-fixable notes from
+// positive reviews (negatives are always MED/HIGH). They're improvement TIPS,
+// not incidents — nobody acks a tip, so without this they'd all bubble to the
+// owner after the SLA. Keep them with the team/managers; never escalate.
 export async function findEscalatable(slaMinutes: number, now: Date): Promise<EscalatableAlert[]> {
   const cutoff = new Date(now.getTime() - slaMinutes * 60_000);
   return prisma.opsAlert.findMany({
     where: {
       status: "OPEN",
       signal: { in: ["CHECKLIST", "REVIEW", "RECEIVING", "NO_CLOCK_IN", "POS_NOT_OPEN"] },
+      NOT: { signal: "REVIEW", severity: "LOW" }, // positive-review improvement tips don't escalate
       escalatedAt: null,
       sentAt: { not: null, lt: cutoff },
     },


### PR DESCRIPTION
## Why
Found during end-to-end QA of the happy-but-fixable review loop (#633). Those improvement notes share the `REVIEW` signal with negative reviews, so they inherited the owner-escalation path in `findEscalatable`: any OPEN alert unacked past the SLA escalates to the owner. Nobody acks an improvement *tip*, so every "service was a bit slow" note from a 4-5★ review would bubble up to the owner as an unhandled incident — not the intent (these are low-priority tips, not incidents).

## Fix
Improvement notes are the **only** LOW-severity `REVIEW` alerts (negatives are always MED/HIGH per `detectReviews`), so:
```js
NOT: { signal: "REVIEW", severity: "LOW" }
```
in `findEscalatable`. They still go to the on-shift team + ops/managers (Ariff, Adam) — they just never page the owner.

## Verified
- `tsc --noEmit` clean.
- Invariant confirmed: in `detectReviews`, negative reviews are `HIGH` (≤1★) / `MED`; positive-improvement flags are `LOW`. So the guard targets exactly the improvement tips, nothing else.