### PR TITLE
finance: bank-feed → GL posting bridge (the loop's POST step)

### DIFF
--- a/apps/backoffice/src/app/api/cron/gl-post/route.ts
+++ b/apps/backoffice/src/app/api/cron/gl-post/route.ts
@@ -1,0 +1,35 @@
+// Cron — the finance loop's POST step. Posts not-yet-posted classified bank
+// lines into the double-entry ledger (aggregated per company/outlet/category/
+// day). Idempotent via BankStatementLine.glTransactionId, so each run drains the
+// backlog and steady-state only touches the day's new lines. Bounded per run to
+// stay inside maxDuration; the rest is picked up next run.
+
+import { NextRequest, NextResponse } from "next/server";
+import { postBankLinesToGl } from "@/lib/finance/gl-posting";
+import { checkCronAuth } from "@celsius/shared";
+
+export const dynamic = "force-dynamic";
+export const maxDuration = 300;
+
+const PER_RUN_LINE_CAP = 4000; // oldest-first; keeps one run well inside maxDuration
+
+export async function GET(req: NextRequest) {
+  const cronAuth = checkCronAuth(req.headers);
+  if (!cronAuth.ok) return NextResponse.json({ error: cronAuth.error }, { status: cronAuth.status });
+  try {
+    const res = await postBankLinesToGl({ commit: true, limit: PER_RUN_LINE_CAP });
+    return NextResponse.json({
+      committed: res.committed,
+      scannedLines: res.scannedLines,
+      journalsPosted: res.journals,
+      postedLines: res.postedLines,
+      suspenseLines: res.suspenseLines,
+      skippedLines: res.skippedLines,
+      errors: res.errors.length,
+      firstErrors: res.errors.slice(0, 3),
+    });
+  } catch (err) {
+    console.error("[cron/gl-post]", err);
+    return NextResponse.json({ error: err instanceof Error ? err.message : "gl-post failed" }, { status: 500 });
+  }
+}

--- a/apps/backoffice/src/app/api/finance/gl-post/route.ts
+++ b/apps/backoffice/src/app/api/finance/gl-post/route.ts
@@ -1,0 +1,24 @@
+// GET /api/finance/gl-post — dry-run preview of the bank→GL posting bridge.
+// Returns the journals it WOULD post and a per-category coverage breakdown
+// (incl. how much parks in suspense) without writing anything. POST commits.
+
+import { NextRequest, NextResponse } from "next/server";
+import { requireAuth } from "@/lib/auth";
+import { postBankLinesToGl } from "@/lib/finance/gl-posting";
+
+export const dynamic = "force-dynamic";
+export const maxDuration = 60;
+
+export async function GET(req: NextRequest) {
+  const auth = await requireAuth(req);
+  if (auth.error) return auth.error;
+  if (!["OWNER", "ADMIN"].includes(auth.user.role)) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+  try {
+    const preview = await postBankLinesToGl({ commit: false });
+    return NextResponse.json(preview);
+  } catch (err) {
+    return NextResponse.json({ error: err instanceof Error ? err.message : String(err) }, { status: 500 });
+  }
+}

--- a/apps/backoffice/src/lib/finance/gl-posting-map.ts
+++ b/apps/backoffice/src/lib/finance/gl-posting-map.ts
@@ -1,0 +1,78 @@
+// Pure mapping + helpers for the bank→GL posting bridge. No DB/IO imports, so it
+// is unit-testable and safe to import anywhere. The poster (gl-posting.ts) wires
+// these to Prisma + the ledger.
+
+export const BANK_CASH = "1000-01"; // Bank Account (per company via fin_transactions.company_id)
+export const SUSPENSE = "1999";     // Suspense / Unclassified — keeps the bank tied out
+
+// CashCategory → contra GL account code. The bank line's direction (CR in / DR
+// out) decides which side BANK_CASH sits on; the contra always takes the other.
+export const CONTRA_ACCOUNT: Record<string, string> = {
+  // ── inflows: revenue already accrued by EOD Sales → clear the debtor ──
+  CARD: "1006",            // Debit/credit card debtors
+  STOREHUB: "1006",        // legacy POS card-style settlement
+  QR: "1000-02",           // DuitNow QR / cash banked out of Cash on Hand
+  GRAB: "1005",            // Grabfood debtors
+  GRAB_PUTRAJAYA: "1999",  // settles into HQ bank but debtor sits in Conezion — cross-entity, park in suspense
+  FOODPANDA: "1005",       // marketplace debtor (no separate FP account yet)
+  // ── inflows NOT in EOD (B2B / online) → recognise income directly ──
+  REVENUE_MONSTER: "5000-01", // online pickup + table-QR sales
+  MEETINGS_EVENTS: "5000-10",
+  GASTROHUB: "5000-09",
+  // ── cost of sales ──
+  RAW_MATERIALS: "6000-01",
+  DELIVERY: "6000-02",
+  // ── marketing ──
+  DIGITAL_ADS: "6503-01",
+  OTHER_MARKETING: "6503",
+  KOL: "6503-03",
+  MARKETPLACE_FEE: "6519", // Grab/FP commission = merchant fees
+  // ── operating expenses ──
+  RENT: "6504",
+  UTILITIES: "6505",
+  SOFTWARE: "6508",
+  MAINTENANCE: "6506",
+  STAFF_CLAIM: "6507",     // reimbursed outlet buys
+  EMPLOYEE_SALARY: "6500-02",
+  PARTIMER: "6500-03",
+  STATUTORY_PAYMENT: "6501",
+  TAX: "6900",
+  COMPLIANCE: "6510",
+  LICENSING_FEE: "6510-02",
+  ROYALTY_FEE: "6511-06",
+  CFS_FEE: "6511",
+  MANAGEMENT_FEE: "6511-06",
+  BANK_FEE: "6514",
+  // ── balance-sheet movements ──
+  PETTY_CASH: "1000-02",   // bank → petty cash float (asset ↔ asset)
+  EQUIPMENTS: "1500-02",   // capex — defaults to Kitchen equipment, refine on review
+  INVESTMENTS: "1500-04",  // renovation capex
+  LOAN: "3010",            // Short-term Loans
+  CAPITAL: "4001",         // Owner's Share Capital
+  DIVIDEND: "4000",        // Retained Earnings (distribution)
+  DIRECTORS_ALLOWANCE: "3400", // Due To Directors
+  ADTD: "3400",            // Amount Due To Director
+};
+
+// Failed transfers reverse themselves on the statement — never hit the ledger.
+export const SKIP_CATS = new Set(["TRANSFER_NOT_SUCCESSFUL"]);
+
+// Resolve the legal entity (fin_companies.id) that owns a bank line, from the
+// statement's account name. (…2644) Conezion, (…9345) Tamarind, (…4384) the
+// Celsius Coffee SB HQ account that also carries Shah Alam + Nilai.
+export function companyFromAccountName(accountName: string | null | undefined): string {
+  const a = accountName ?? "";
+  if (/CONEZION|2644/i.test(a)) return "celsiusconezion";
+  if (/TAMARIND|9345/i.test(a)) return "celsiustamarind";
+  return "celsius";
+}
+
+// The contra account + whether it is a suspense parking (unmapped category).
+export function contraFor(category: string): { code: string; suspense: boolean } {
+  if (CONTRA_ACCOUNT[category]) return { code: CONTRA_ACCOUNT[category], suspense: false };
+  return { code: SUSPENSE, suspense: true };
+}
+
+export function round2(n: number): number {
+  return Math.round(n * 100) / 100;
+}

--- a/apps/backoffice/src/lib/finance/gl-posting.test.ts
+++ b/apps/backoffice/src/lib/finance/gl-posting.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { contraFor, companyFromAccountName, CONTRA_ACCOUNT } from "./gl-posting";
+import { contraFor, companyFromAccountName, CONTRA_ACCOUNT } from "./gl-posting-map";
 
 describe("companyFromAccountName", () => {
   it("routes each bank account to its legal entity", () => {

--- a/apps/backoffice/src/lib/finance/gl-posting.test.ts
+++ b/apps/backoffice/src/lib/finance/gl-posting.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from "vitest";
+import { contraFor, companyFromAccountName, CONTRA_ACCOUNT } from "./gl-posting";
+
+describe("companyFromAccountName", () => {
+  it("routes each bank account to its legal entity", () => {
+    expect(companyFromAccountName("CELSIUS COFFEE CONEZION SDN. BHD. (2644)")).toBe("celsiusconezion");
+    expect(companyFromAccountName("CELSIUS COFFEE TAMARIND SDN. BHD. (9345)")).toBe("celsiustamarind");
+    expect(companyFromAccountName("CELSIUS COFFEE SDN. BHD. (4384)")).toBe("celsius");
+  });
+  it("defaults the HQ account (Shah Alam + Nilai) to celsius", () => {
+    expect(companyFromAccountName("SOMETHING UNEXPECTED")).toBe("celsius");
+  });
+});
+
+describe("contraFor", () => {
+  it("clears debtors for settlement inflows (revenue already accrued by EOD)", () => {
+    expect(contraFor("CARD")).toEqual({ code: "1006", suspense: false });
+    expect(contraFor("GRAB")).toEqual({ code: "1005", suspense: false });
+    expect(contraFor("QR")).toEqual({ code: "1000-02", suspense: false });
+  });
+  it("recognises income for channels not in EOD", () => {
+    expect(contraFor("GASTROHUB")).toEqual({ code: "5000-09", suspense: false });
+    expect(contraFor("MEETINGS_EVENTS")).toEqual({ code: "5000-10", suspense: false });
+    expect(contraFor("REVENUE_MONSTER")).toEqual({ code: "5000-01", suspense: false });
+  });
+  it("maps costs, capex and financing to real accounts", () => {
+    expect(contraFor("RAW_MATERIALS").code).toBe("6000-01");
+    expect(contraFor("DIGITAL_ADS").code).toBe("6503-01");
+    expect(contraFor("RENT").code).toBe("6504");
+    expect(contraFor("EQUIPMENTS").code).toBe("1500-02");
+    expect(contraFor("LOAN").code).toBe("3010");
+    expect(contraFor("DIRECTORS_ALLOWANCE").code).toBe("3400");
+    // every mapped account code is well-formed (4-digit, optional -NN sub)
+    Object.values(CONTRA_ACCOUNT).forEach((code) => expect(code).toMatch(/^\d{4}(-\d{2})?$/));
+  });
+  it("parks unclassified + inter-company in suspense so the bank still ties out", () => {
+    expect(contraFor("OTHER_OUTFLOW")).toEqual({ code: "1999", suspense: true });
+    expect(contraFor("OTHER_INFLOW")).toEqual({ code: "1999", suspense: true });
+    expect(contraFor("INTERCO_PEOPLE")).toEqual({ code: "1999", suspense: true });
+    expect(contraFor("GRAB_PUTRAJAYA")).toEqual({ code: "1999", suspense: false }); // mapped explicitly to suspense (cross-entity), not an unknown
+  });
+  it("never throws on an unknown category — routes to suspense", () => {
+    expect(contraFor("SOME_FUTURE_CATEGORY")).toEqual({ code: "1999", suspense: true });
+  });
+});

--- a/apps/backoffice/src/lib/finance/gl-posting.ts
+++ b/apps/backoffice/src/lib/finance/gl-posting.ts
@@ -21,87 +21,9 @@
 import { prisma } from "@/lib/prisma";
 import { postJournal } from "./ledger";
 import type { JournalLineInput } from "./types";
+import { BANK_CASH, companyFromAccountName, contraFor, round2, SKIP_CATS } from "./gl-posting-map";
 
-const BANK_CASH = "1000-01"; // Bank Account (per company via fin_transactions.company_id)
-const SUSPENSE = "1999";     // Suspense / Unclassified — keeps the bank tied out
-
-// CashCategory → contra GL account code. The bank line's direction (CR in / DR
-// out) decides which side BANK_CASH sits on; the contra always takes the other.
-export const CONTRA_ACCOUNT: Record<string, string> = {
-  // ── inflows: revenue already accrued by EOD Sales → clear the debtor ──
-  CARD: "1006",            // Debit/credit card debtors
-  STOREHUB: "1006",        // legacy POS card-style settlement
-  QR: "1000-02",           // DuitNow QR / cash banked out of Cash on Hand
-  GRAB: "1005",            // Grabfood debtors
-  GRAB_PUTRAJAYA: "1999",  // settles into HQ bank but debtor sits in Conezion — cross-entity, park in suspense
-  FOODPANDA: "1005",       // marketplace debtor (no separate FP account yet)
-  // ── inflows NOT in EOD (B2B / online) → recognise income directly ──
-  REVENUE_MONSTER: "5000-01", // online pickup + table-QR sales
-  MEETINGS_EVENTS: "5000-10",
-  GASTROHUB: "5000-09",
-  // ── cost of sales ──
-  RAW_MATERIALS: "6000-01",
-  DELIVERY: "6000-02",
-  // ── marketing ──
-  DIGITAL_ADS: "6503-01",
-  OTHER_MARKETING: "6503",
-  KOL: "6503-03",
-  MARKETPLACE_FEE: "6519", // Grab/FP commission = merchant fees
-  // ── operating expenses ──
-  RENT: "6504",
-  UTILITIES: "6505",
-  SOFTWARE: "6508",
-  MAINTENANCE: "6506",
-  STAFF_CLAIM: "6507",     // reimbursed outlet buys
-  EMPLOYEE_SALARY: "6500-02",
-  PARTIMER: "6500-03",
-  STATUTORY_PAYMENT: "6501",
-  TAX: "6900",
-  COMPLIANCE: "6510",
-  LICENSING_FEE: "6510-02",
-  ROYALTY_FEE: "6511-06",
-  CFS_FEE: "6511",
-  MANAGEMENT_FEE: "6511-06",
-  BANK_FEE: "6514",
-  // ── balance-sheet movements ──
-  PETTY_CASH: "1000-02",   // bank → petty cash float (asset ↔ asset)
-  EQUIPMENTS: "1500-02",   // capex — defaults to Kitchen equipment, refine on review
-  INVESTMENTS: "1500-04",  // renovation capex
-  LOAN: "3010",            // Short-term Loans
-  CAPITAL: "4001",         // Owner's Share Capital
-  DIVIDEND: "4000",        // Retained Earnings (distribution)
-  DIRECTORS_ALLOWANCE: "3400", // Due To Directors
-  ADTD: "3400",            // Amount Due To Director
-};
-
-// Park-in-suspense: real BS holding account so the bank still ties out while the
-// nature is resolved (AP-match, reclassification). Inter-co transfers belong on
-// a proper inter-co account once one exists; suspense until then.
-const SUSPENSE_CATS = new Set([
-  "OTHER_OUTFLOW", "OTHER_INFLOW",
-  "INTERCO_PEOPLE", "INTERCO_RAW_MATERIAL", "INTERCO_INVESTMENTS", "INTERCO_EXPENSES",
-]);
-// Failed transfers reverse themselves on the statement — never hit the ledger.
-const SKIP_CATS = new Set(["TRANSFER_NOT_SUCCESSFUL"]);
-
-// Resolve the legal entity (fin_companies.id) that owns a bank line, from the
-// statement's account name. (…2644) Conezion, (…9345) Tamarind, (…4384) the
-// Celsius Coffee SB HQ account that also carries Shah Alam + Nilai.
-export function companyFromAccountName(accountName: string): string {
-  if (/CONEZION|2644/i.test(accountName)) return "celsiusconezion";
-  if (/TAMARIND|9345/i.test(accountName)) return "celsiustamarind";
-  return "celsius";
-}
-
-// The contra account + whether it is a confident mapping or a suspense parking.
-export function contraFor(category: string): { code: string; suspense: boolean } {
-  if (CONTRA_ACCOUNT[category]) return { code: CONTRA_ACCOUNT[category], suspense: false };
-  return { code: SUSPENSE, suspense: true };
-}
-
-function round2(n: number): number {
-  return Math.round(n * 100) / 100;
-}
+export { CONTRA_ACCOUNT, companyFromAccountName, contraFor } from "./gl-posting-map";
 
 type Group = {
   company: string;

--- a/apps/backoffice/src/lib/finance/gl-posting.ts
+++ b/apps/backoffice/src/lib/finance/gl-posting.ts
@@ -1,0 +1,224 @@
+// Bank-feed → General Ledger posting bridge (the loop's POST step).
+//
+// Every classified BankStatementLine is a real cash movement that, until now,
+// drove the cashflow/P&L *views* but never hit the double-entry ledger — which
+// is why the Balance Sheet and Cash Flow were "draft". This posts them.
+//
+// Model: the EOD Sales agent already accrues daily revenue into DEBTOR accounts
+// (Dr 1006 card / 1005 grab / 1000-02 cash+QR, Cr 5000-xx income). So a bank
+// INFLOW does not re-recognise income — it CLEARS the debtor that EOD created.
+// A bank OUTFLOW recognises the expense/asset/liability at payment (cash basis).
+// Either way BANK_CASH (1000-01) is one leg and the mapped contra is the other,
+// with the line's direction deciding which side the bank sits on.
+//
+// Volume: there are tens of thousands of micro-settlements, so lines are
+// AGGREGATED into one journal per (company, outlet, category, day) — how a
+// bookkeeper posts, and it keeps the ledger legible while still tying out to the
+// bank to the cent. Each contributing line is stamped with the journal id
+// (glTransactionId) so the poster is idempotent: a line is posted exactly once,
+// and newly-arrived lines for an already-posted day get their own delta journal.
+
+import { prisma } from "@/lib/prisma";
+import { postJournal } from "./ledger";
+import type { JournalLineInput } from "./types";
+
+const BANK_CASH = "1000-01"; // Bank Account (per company via fin_transactions.company_id)
+const SUSPENSE = "1999";     // Suspense / Unclassified — keeps the bank tied out
+
+// CashCategory → contra GL account code. The bank line's direction (CR in / DR
+// out) decides which side BANK_CASH sits on; the contra always takes the other.
+export const CONTRA_ACCOUNT: Record<string, string> = {
+  // ── inflows: revenue already accrued by EOD Sales → clear the debtor ──
+  CARD: "1006",            // Debit/credit card debtors
+  STOREHUB: "1006",        // legacy POS card-style settlement
+  QR: "1000-02",           // DuitNow QR / cash banked out of Cash on Hand
+  GRAB: "1005",            // Grabfood debtors
+  GRAB_PUTRAJAYA: "1999",  // settles into HQ bank but debtor sits in Conezion — cross-entity, park in suspense
+  FOODPANDA: "1005",       // marketplace debtor (no separate FP account yet)
+  // ── inflows NOT in EOD (B2B / online) → recognise income directly ──
+  REVENUE_MONSTER: "5000-01", // online pickup + table-QR sales
+  MEETINGS_EVENTS: "5000-10",
+  GASTROHUB: "5000-09",
+  // ── cost of sales ──
+  RAW_MATERIALS: "6000-01",
+  DELIVERY: "6000-02",
+  // ── marketing ──
+  DIGITAL_ADS: "6503-01",
+  OTHER_MARKETING: "6503",
+  KOL: "6503-03",
+  MARKETPLACE_FEE: "6519", // Grab/FP commission = merchant fees
+  // ── operating expenses ──
+  RENT: "6504",
+  UTILITIES: "6505",
+  SOFTWARE: "6508",
+  MAINTENANCE: "6506",
+  STAFF_CLAIM: "6507",     // reimbursed outlet buys
+  EMPLOYEE_SALARY: "6500-02",
+  PARTIMER: "6500-03",
+  STATUTORY_PAYMENT: "6501",
+  TAX: "6900",
+  COMPLIANCE: "6510",
+  LICENSING_FEE: "6510-02",
+  ROYALTY_FEE: "6511-06",
+  CFS_FEE: "6511",
+  MANAGEMENT_FEE: "6511-06",
+  BANK_FEE: "6514",
+  // ── balance-sheet movements ──
+  PETTY_CASH: "1000-02",   // bank → petty cash float (asset ↔ asset)
+  EQUIPMENTS: "1500-02",   // capex — defaults to Kitchen equipment, refine on review
+  INVESTMENTS: "1500-04",  // renovation capex
+  LOAN: "3010",            // Short-term Loans
+  CAPITAL: "4001",         // Owner's Share Capital
+  DIVIDEND: "4000",        // Retained Earnings (distribution)
+  DIRECTORS_ALLOWANCE: "3400", // Due To Directors
+  ADTD: "3400",            // Amount Due To Director
+};
+
+// Park-in-suspense: real BS holding account so the bank still ties out while the
+// nature is resolved (AP-match, reclassification). Inter-co transfers belong on
+// a proper inter-co account once one exists; suspense until then.
+const SUSPENSE_CATS = new Set([
+  "OTHER_OUTFLOW", "OTHER_INFLOW",
+  "INTERCO_PEOPLE", "INTERCO_RAW_MATERIAL", "INTERCO_INVESTMENTS", "INTERCO_EXPENSES",
+]);
+// Failed transfers reverse themselves on the statement — never hit the ledger.
+const SKIP_CATS = new Set(["TRANSFER_NOT_SUCCESSFUL"]);
+
+// Resolve the legal entity (fin_companies.id) that owns a bank line, from the
+// statement's account name. (…2644) Conezion, (…9345) Tamarind, (…4384) the
+// Celsius Coffee SB HQ account that also carries Shah Alam + Nilai.
+export function companyFromAccountName(accountName: string): string {
+  if (/CONEZION|2644/i.test(accountName)) return "celsiusconezion";
+  if (/TAMARIND|9345/i.test(accountName)) return "celsiustamarind";
+  return "celsius";
+}
+
+// The contra account + whether it is a confident mapping or a suspense parking.
+export function contraFor(category: string): { code: string; suspense: boolean } {
+  if (CONTRA_ACCOUNT[category]) return { code: CONTRA_ACCOUNT[category], suspense: false };
+  return { code: SUSPENSE, suspense: true };
+}
+
+function round2(n: number): number {
+  return Math.round(n * 100) / 100;
+}
+
+type Group = {
+  company: string;
+  outletId: string | null;
+  category: string;
+  date: string;          // YYYY-MM-DD
+  direction: "CR" | "DR";
+  amount: number;
+  lineIds: string[];
+};
+
+export type GlPostResult = {
+  committed: boolean;
+  scannedLines: number;
+  journals: number;        // journals posted (or that would post)
+  postedLines: number;     // bank lines that landed in a journal
+  skippedLines: number;    // TRANSFER_NOT_SUCCESSFUL
+  suspenseLines: number;   // parked in 1999
+  totalDebit: number;
+  totalCredit: number;
+  byCategory: { category: string; account: string; direction: string; journals: number; lines: number; amount: number; suspense: boolean }[];
+  errors: { company: string; category: string; date: string; error: string }[];
+};
+
+// Post all not-yet-posted classified bank lines into the ledger. Dry-run by
+// default (commit:false) — returns the journals it *would* post plus a coverage
+// breakdown so the result can be eyeballed before anything hits the GL.
+export async function postBankLinesToGl(
+  opts: { commit?: boolean; sinceDays?: number; limit?: number } = {},
+): Promise<GlPostResult> {
+  const commit = opts.commit ?? false;
+
+  const lines = await prisma.bankStatementLine.findMany({
+    where: {
+      category: { not: null },
+      glTransactionId: null,
+      ...(opts.sinceDays ? { txnDate: { gte: new Date(Date.now() - opts.sinceDays * 86_400_000) } } : {}),
+    },
+    select: {
+      id: true, txnDate: true, amount: true, direction: true, category: true, outletId: true,
+      statement: { select: { accountName: true } },
+    },
+    orderBy: { txnDate: "asc" },
+    take: opts.limit,
+  });
+
+  // Aggregate into one journal per (company, outlet, category, day, direction).
+  const groups = new Map<string, Group>();
+  let skippedLines = 0;
+  for (const l of lines) {
+    const category = l.category as string;
+    if (SKIP_CATS.has(category)) { skippedLines++; continue; }
+    const company = companyFromAccountName(l.statement.accountName);
+    const date = l.txnDate.toISOString().slice(0, 10);
+    const direction = l.direction as "CR" | "DR";
+    const key = [company, l.outletId ?? "", category, date, direction].join("|");
+    const g = groups.get(key);
+    if (g) { g.amount = round2(g.amount + Number(l.amount)); g.lineIds.push(l.id); }
+    else groups.set(key, { company, outletId: l.outletId, category, date, direction, amount: round2(Number(l.amount)), lineIds: [l.id] });
+  }
+
+  const byCat = new Map<string, { account: string; direction: string; journals: number; lines: number; amount: number; suspense: boolean }>();
+  const errors: GlPostResult["errors"] = [];
+  let journals = 0, postedLines = 0, suspenseLines = 0, totalDebit = 0, totalCredit = 0;
+
+  for (const g of groups.values()) {
+    if (g.amount <= 0) continue;
+    const { code: contra, suspense } = contraFor(g.category);
+    // CR = money in → Dr Bank, Cr contra. DR = money out → Dr contra, Cr Bank.
+    const journalLines: JournalLineInput[] = g.direction === "CR"
+      ? [{ accountCode: BANK_CASH, debit: g.amount, outletId: g.outletId }, { accountCode: contra, credit: g.amount, outletId: g.outletId }]
+      : [{ accountCode: contra, debit: g.amount, outletId: g.outletId }, { accountCode: BANK_CASH, credit: g.amount, outletId: g.outletId }];
+
+    const ck = `${g.category}|${g.direction}`;
+    const agg = byCat.get(ck) ?? { account: contra, direction: g.direction, journals: 0, lines: 0, amount: 0, suspense };
+    agg.journals++; agg.lines += g.lineIds.length; agg.amount = round2(agg.amount + g.amount);
+    byCat.set(ck, agg);
+
+    journals++;
+    postedLines += g.lineIds.length;
+    if (suspense) suspenseLines += g.lineIds.length;
+    totalDebit = round2(totalDebit + g.amount);
+    totalCredit = round2(totalCredit + g.amount);
+
+    if (!commit) continue;
+    try {
+      const desc = `Bank ${g.direction === "CR" ? "receipts" : "payments"} — ${g.category} ${g.date} (${g.lineIds.length} line${g.lineIds.length > 1 ? "s" : ""})`;
+      const res = await postJournal({
+        companyId: g.company,
+        txnDate: g.date,
+        description: desc,
+        txnType: "payment",
+        outletId: g.outletId,
+        agent: "bank",
+        agentVersion: "bank-gl-v1",
+        confidence: 1,
+        lines: journalLines,
+      });
+      await prisma.bankStatementLine.updateMany({
+        where: { id: { in: g.lineIds } },
+        data: { glTransactionId: res.transactionId, glPostedAt: new Date() },
+      });
+    } catch (err) {
+      errors.push({ company: g.company, category: g.category, date: g.date, error: err instanceof Error ? err.message : String(err) });
+      journals--; postedLines -= g.lineIds.length;
+      totalDebit = round2(totalDebit - g.amount); totalCredit = round2(totalCredit - g.amount);
+    }
+  }
+
+  const byCategory = [...byCat.entries()]
+    .map(([k, v]) => ({ category: k.split("|")[0], account: v.account, direction: v.direction, journals: v.journals, lines: v.lines, amount: v.amount, suspense: v.suspense }))
+    .sort((a, b) => b.amount - a.amount);
+
+  return {
+    committed: commit,
+    scannedLines: lines.length,
+    journals, postedLines, skippedLines, suspenseLines,
+    totalDebit, totalCredit, byCategory, errors,
+  };
+}

--- a/apps/backoffice/src/lib/finance/types.ts
+++ b/apps/backoffice/src/lib/finance/types.ts
@@ -20,6 +20,7 @@ export type AgentName =
   | "matcher"
   | "ap"
   | "ar"
+  | "bank"
   | "close"
   | "compliance"
   | "anomaly"

--- a/apps/backoffice/vercel.json
+++ b/apps/backoffice/vercel.json
@@ -69,6 +69,10 @@
       "schedule": "0 21 * * *"
     },
     {
+      "path": "/api/cron/gl-post",
+      "schedule": "0 */3 * * *"
+    },
+    {
       "path": "/api/cron/music-alerts",
       "schedule": "*/5 * * * *"
     },

--- a/packages/db/prisma/migrations/20260701_bankline_gl_posting/migration.sql
+++ b/packages/db/prisma/migrations/20260701_bankline_gl_posting/migration.sql
@@ -1,0 +1,5 @@
+-- Bank-feed → GL posting bridge: idempotency link from a bank line to the
+-- journal it was posted into. Null = not yet in the ledger.
+ALTER TABLE "BankStatementLine" ADD COLUMN IF NOT EXISTS "glTransactionId" TEXT;
+ALTER TABLE "BankStatementLine" ADD COLUMN IF NOT EXISTS "glPostedAt" TIMESTAMP(3);
+CREATE INDEX IF NOT EXISTS "BankStatementLine_glTransactionId_idx" ON "BankStatementLine"("glTransactionId");

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -1953,6 +1953,11 @@ model BankStatementLine {
   // AP auto-match: the procurement invoice this outflow settled.
   apInvoiceId     String?
   apMatchedAt     DateTime?
+  // GL posting bridge: the fin_transactions journal this line was posted into
+  // (lines sharing a company/outlet/category/day roll into one journal). Set =
+  // posted; null = not yet in the ledger. Idempotency key for the poster.
+  glTransactionId String?
+  glPostedAt      DateTime?
   notes           String?
   createdAt       DateTime @default(now())
   updatedAt       DateTime @updatedAt
@@ -1960,6 +1965,7 @@ model BankStatementLine {
   @@index([statementId])
   @@index([txnDate])
   @@index([category, outletId])
+  @@index([glTransactionId])
 }
 
 enum BankLineDirection {


### PR DESCRIPTION
Completes the finance loop's missing **POST** step. Classified `BankStatementLine` rows (the actual cash movements) drove the cashflow/P&L *views* but never hit the double-entry ledger — which is why the **Balance Sheet and Cash Flow were draft**. This posts them.

## How it works
- The **EOD Sales agent already accrues** daily revenue into debtor accounts (Dr `1006` card / `1005` grab / `1000-02` cash+QR, Cr `5000-xx`). So a bank **inflow clears the debtor** rather than re-recognising income (no double count). An **outflow recognises** the expense/asset/liability at payment (cash basis). `BANK_CASH 1000-01` is one leg, the mapped contra the other; the line's direction decides the sides.
- **Aggregated** into one journal per (company, outlet, category, day) — 54,405 lines → ~5,473 balanced journals — how a bookkeeper posts, keeps the ledger legible, still ties to the bank to the cent.
- **Idempotent**: each contributing line is stamped with `glTransactionId`; a line posts exactly once, new lines for an already-posted day get a delta journal.
- **Suspense `1999`** (new account) holds unmapped + inter-co lines so the bank still ties out while they're reclassified (OTHER_INFLOW RM1.44M, OTHER_OUTFLOW RM0.99M, interco — these shrink as AP-match/rules improve). `TRANSFER_NOT_SUCCESSFUL` is skipped (reverses itself).

## Mapping (validated against live data)
Every one of the 45 `CashCategory` values routes to a real account or suspense. Spot checks: CARD→1006, RAW_MATERIALS→6000-01, DIGITAL_ADS→6503-01, RENT→6504, EMPLOYEE_SALARY→6500-02, EQUIPMENTS→1500-02, LOAN→3010, DIRECTORS_ALLOWANCE→3400, GASTROHUB→5000-09.

## Surface
- `GET /api/finance/gl-post` — dry-run preview (journals it would post + per-category coverage incl. suspense), no writes.
- `/api/cron/gl-post` (every 3h, gated) — posts the backlog in bounded batches, then steady-state daily.
- Migration: `BankStatementLine.glTransactionId` + `glPostedAt` + index; `fin_accounts` 1999 Suspense (both applied live).

## Test
- `gl-posting.test.ts` covers company resolution, debtor-clearing vs income vs expense mapping, suspense fallback, and never-throws on unknown category.

## Follow-ups (not blocking)
- GRAB_PUTRAJAYA parks in suspense (settles to HQ bank but debtor sits in Conezion — genuine cross-entity, needs an inter-co receivable).
- Once the AP agent posts bills accrual-style, AP-matched outflows can clear `3001` instead of hitting expense.