### PR TITLE
feat(ops): bring POS-not-open + menu-86 live as a dedicated nudge

### DIFF
--- a/apps/backoffice/src/app/api/cron/ops-nudge-store/route.ts
+++ b/apps/backoffice/src/app/api/cron/ops-nudge-store/route.ts
@@ -1,0 +1,35 @@
+import { NextRequest, NextResponse } from "next/server";
+import { checkCronAuth } from "@celsius/shared";
+import { runStoreStatusNudges } from "@/lib/ops-nudges";
+
+export const dynamic = "force-dynamic";
+export const maxDuration = 60;
+
+/**
+ * GET /api/cron/ops-nudge-store — store-status nudge.
+ *
+ * Brings the two previously-dark ops-pulse signals live on the dedicated-nudge
+ * tier (without arming the whole legacy pulse, which would race the specialized
+ * clock-in/checklist routing through the shared ledger):
+ *   • POS not opened — an active outlet past its open time with no till session
+ *     (HIGH: the outlet isn't trading, straight lost revenue).
+ *   • Menu 86'd — items snoozed off the menu (MED: lost attach + a stale menu).
+ * Sends the outlet's on-shift team + a digest to the managers (ops leads). The
+ * ledger dedupes per (outlet, day), so each fires at most once a day no matter
+ * how often the cron runs. Every 15 min so a late open is caught soon after the
+ * open time. OPS_NUDGES_MODE (off|shadow|armed), default armed.
+ * Design: docs/design/ops-performance-loop.md.
+ */
+export async function GET(req: NextRequest) {
+  const cronAuth = checkCronAuth(req.headers);
+  if (!cronAuth.ok) return NextResponse.json({ error: cronAuth.error }, { status: cronAuth.status });
+  try {
+    const result = await runStoreStatusNudges();
+    console.log(`[cron/ops-nudge-store] mode=${result.mode} items=${result.items} staff=${result.staffSent} mgr=${result.managerSent}`);
+    return NextResponse.json({ ok: true, ...result });
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : "ops-nudge-store failed";
+    console.error("[cron/ops-nudge-store]", msg);
+    return NextResponse.json({ error: msg }, { status: 500 });
+  }
+}

--- a/apps/backoffice/src/lib/ops-nudges/index.ts
+++ b/apps/backoffice/src/lib/ops-nudges/index.ts
@@ -15,7 +15,7 @@
 // WhatsApp's 24h rule until ops_nudge is approved.
 
 import { prisma } from "@/lib/prisma";
-import { findNoClockInBreaches, detectOutletAudit, detectSkillTraining, detectReviews } from "@/lib/ops-pulse/detectors";
+import { findNoClockInBreaches, detectOutletAudit, detectSkillTraining, detectReviews, detectPosNotOpen, detectMenuSnoozed } from "@/lib/ops-pulse/detectors";
 import { recordBreach } from "@/lib/ops-pulse/ledger";
 import { resolveRecipients, resolveOutletTeam, resolveOutletSupervisors } from "@/lib/ops-pulse/router";
 import { sendClockInNudge, sendStockCountNudge, sendOpsDigest, sendAuditNudge, sendReviewNudge } from "@/lib/ops-pulse/sender";
@@ -545,4 +545,73 @@ export async function runChecklistNudges(now = new Date()): Promise<NudgeRunResu
   const headline = `${managerLines.length} overdue checklist${managerLines.length === 1 ? "" : "s"} with no owner on shift`;
   const managerSent = await sendManagerDigestToOps(headline, managerLines, mode);
   return { mode, ranAt, items, staffSent, managerSent };
+}
+
+// ── 6. Store status: POS-not-open + menu 86'd → on-shift team + managers ──────
+// The two ops-pulse signals that have no dedicated owner and so went dark while
+// the legacy pulse sat in shadow:
+//   • POS_NOT_OPEN — an active outlet past its open time with no till session
+//     (HIGH: the outlet isn't trading — straight lost revenue).
+//   • MENU_SNOOZED — items 86'd off the menu (MED: lost attach + a stale menu).
+// We bring them live HERE, on the proven dedicated-nudge tier, rather than arming
+// the whole pulse — that would race the specialized clock-in/checklist routing
+// through the shared ledger. Reuses the same detectors (still shadow in the pulse)
+// + the ledger for dedupe (each is keyed per outlet/day, so at most one a day) +
+// the WhatsApp sender. Cron: every 15 min (catches a late open soon after open
+// time). OPS_NUDGES_MODE (off | shadow | armed).
+export async function runStoreStatusNudges(now = new Date()): Promise<NudgeRunResult> {
+  const mode = nudgesMode();
+  const ranAt = now.toISOString();
+  if (mode === "off") return { mode, ranAt, items: 0, staffSent: 0, managerSent: 0 };
+
+  const [posNot, menu] = await Promise.all([
+    detectPosNotOpen(now).catch((e) => {
+      console.error("[ops-nudge:store] pos-not-open detector failed:", e);
+      return [] as Breach[];
+    }),
+    detectMenuSnoozed(now).catch((e) => {
+      console.error("[ops-nudge:store] menu-snoozed detector failed:", e);
+      return [] as Breach[];
+    }),
+  ]);
+  const breaches = [...posNot, ...menu];
+  if (breaches.length === 0) return { mode, ranAt, items: 0, staffSent: 0, managerSent: 0 };
+
+  // Dedupe per breach (armed) so the 15-min cron nudges each once a day. Group the
+  // fresh ones by outlet for the on-shift team, and collect all for the manager digest.
+  const byOutlet = new Map<string, { name: string; lines: string[] }>();
+  const managerLines: string[] = [];
+  for (const b of breaches) {
+    if (mode === "armed") {
+      const { isNew } = await recordBreach(b, null);
+      if (!isNew) continue;
+    }
+    managerLines.push(b.summary);
+    const g = byOutlet.get(b.outletId) ?? { name: b.outletName, lines: [] };
+    g.lines.push(b.summary);
+    byOutlet.set(b.outletId, g);
+  }
+  if (managerLines.length === 0) return { mode, ranAt, items: 0, staffSent: 0, managerSent: 0 };
+
+  // The on-shift team gets their own outlet's lines (they can open the till / fix
+  // the 86). If nobody's clocked in (common when the till isn't open), the team is
+  // empty and the managers still get it.
+  let staffSent = 0;
+  for (const [outletId, g] of byOutlet) {
+    if (mode === "shadow") {
+      console.log("[ops-nudge:store:shadow]", JSON.stringify({ outlet: g.name, lines: g.lines }));
+      continue;
+    }
+    const team = await resolveOutletTeam(outletId, now);
+    for (const t of team) {
+      if (!t.phone) continue;
+      const r = await sendOpsDigest(t.phone, `Store status — ${g.name}`, g.lines);
+      if (r.ok) staffSent += 1;
+      else console.error(`[ops-nudge:store] team nudge to ${t.name} failed:`, r.error);
+    }
+  }
+
+  const headline = `${managerLines.length} store status alert${managerLines.length === 1 ? "" : "s"} need attention`;
+  const managerSent = await sendManagerDigestToOps(headline, managerLines, mode);
+  return { mode, ranAt, items: managerLines.length, staffSent, managerSent };
 }

--- a/apps/backoffice/vercel.json
+++ b/apps/backoffice/vercel.json
@@ -141,6 +141,10 @@
       "schedule": "*/15 * * * *"
     },
     {
+      "path": "/api/cron/ops-nudge-store",
+      "schedule": "*/15 * * * *"
+    },
+    {
       "path": "/api/cron/geogrid-keywords",
       "schedule": "0 6 1 * *"
     },


### PR DESCRIPTION
## Why
Ops Workspace audit found two ops-pulse signals were dark (the legacy pulse sits in shadow and they have no dedicated nudge): **POS-not-open** (an outlet past open time with no till session — lost revenue) and **menu-86'd** (items snoozed off the menu). Nobody was alerted to either.

## How
New `runStoreStatusNudges` + `/api/cron/ops-nudge-store` (every 15 min). Reuses the existing `detectPosNotOpen` (HIGH) and `detectMenuSnoozed` (MED) detectors on the **dedicated-nudge tier** — deliberately *not* by arming `OPS_PULSE_MODE`, which would race the specialized clock-in/checklist routing through the shared ledger. Sends the on-shift team + a managers digest; the ledger dedupes per (outlet, day) so each fires at most once a day. Gated by `OPS_NUDGES_MODE` (armed).

## Verified live before shipping
- TSC clean.
- All 4 outlets configured: openTime 08:00, daysOpen all week, loyalty-linked.
- Menu signal live now: 41 items 86'd across 3 outlets.
- Till activity: Putrajaya/Shah Alam/Tamarind open daily; **Nilai = 0 sessions in 3 days** → will flag daily until confirmed in/out of scope.

## Tuning notes (follow-ups, not blockers)
- `posOpen.graceMinutes = 0` (owner-set) → an outlet opening even a few min late flags. Bump to ~15 if noisy.
- Nilai scope decision needed.
- 41 86'd items may include stale availability worth cleaning.