### PR TITLE
finance(recon): wage exclusion from AP-match + auto payment slips

### DIFF
--- a/apps/backoffice/src/app/api/cron/ap-match-apply/route.ts
+++ b/apps/backoffice/src/app/api/cron/ap-match-apply/route.ts
@@ -7,6 +7,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { applyApMatches } from "@/lib/finance/ap-match";
 import { applyVerifiedReview } from "@/lib/finance/agents/ap-verifier";
+import { createWagePaymentSlips } from "@/lib/finance/payment-slips";
 import { checkCronAuth } from "@celsius/shared";
 
 export const dynamic = "force-dynamic";
@@ -21,11 +22,15 @@ export async function GET(req: NextRequest) {
     // 2) review tier — LLM verifier judges the gray zone; confident confirms
     //    auto-clear, rejects drop, only true uncertainties stay for a human.
     const review = await applyVerifiedReview({ commit: true, sinceDays: 120 });
+    // 3) wages have no invoice — document them with auto payment slips so they
+    //    leave the unmatched pile with a supporting doc instead of a match.
+    const slips = await createWagePaymentSlips({ commit: true });
     return NextResponse.json({
       autoApplied: auto.applied,
       reviewConfirmedApplied: review.confirmedApplied,
       reviewRejected: review.rejected,
       reviewUncertain: review.uncertain,
+      paymentSlipsCreated: slips.created,
     });
   } catch (err) {
     console.error("[cron/ap-match-apply]", err);

--- a/apps/backoffice/src/lib/finance/ap-match.ts
+++ b/apps/backoffice/src/lib/finance/ap-match.ts
@@ -18,6 +18,18 @@
 //   tiers: AUTO ≥ 0.85 (needs amount-exact AND name) · REVIEW ≥ 0.55 · else none
 
 import { prisma } from "@/lib/prisma";
+import type { CashCategory } from "@celsius/db";
+
+// Categories that can never be the settlement of a SUPPLIER invoice — wages
+// (PT Week / part-timers), full-time salary, statutory (EPF/SOCSO/tax), director
+// draws, financing, bank fees, petty-cash float. These collided on amount with
+// real invoices and produced false matches; they're documented by a payment
+// slip (payment-slips.ts) instead of an AP match. Inter-co is already excluded.
+const NON_SUPPLIER_CATEGORIES: CashCategory[] = [
+  "PARTIMER", "EMPLOYEE_SALARY", "STATUTORY_PAYMENT", "TAX",
+  "DIRECTORS_ALLOWANCE", "ADTD", "LOAN", "CAPITAL", "DIVIDEND",
+  "BANK_FEE", "PETTY_CASH",
+];
 
 export type MatchTier = "auto" | "review";
 export type ApMatch = {
@@ -82,12 +94,17 @@ export async function proposeApMatches(opts: { sinceDays?: number } = {}): Promi
     },
   });
 
-  // Candidate bank outflows: DR, not inter-co, in the window. We only care about
-  // lines that aren't already a confidently-typed non-supplier expense (payroll,
-  // rent, etc. are pulse categories) — but to be safe we consider all DR and let
-  // the score gate it.
+  // Candidate bank outflows: DR, not inter-co, in the window, and NOT a category
+  // that can never have a supplier invoice — wages ("PT Week"), statutory, tax,
+  // director draws, financing, bank fees. Those collide on amount with real
+  // invoices and were the main source of false matches; they're documented by a
+  // payment slip instead (see payment-slips.ts), not an AP match. Null/unknown
+  // categories stay in the pool — those are exactly the OTHER_OUTFLOW pile to match.
   const lines = await prisma.bankStatementLine.findMany({
-    where: { direction: "DR", isInterCo: false, txnDate: { gte: since }, apInvoiceId: null },
+    where: {
+      direction: "DR", isInterCo: false, txnDate: { gte: since }, apInvoiceId: null,
+      OR: [{ category: null }, { category: { notIn: NON_SUPPLIER_CATEGORIES } }],
+    },
     select: { id: true, description: true, amount: true, txnDate: true, category: true },
   });
 

--- a/apps/backoffice/src/lib/finance/payment-slips.ts
+++ b/apps/backoffice/src/lib/finance/payment-slips.ts
@@ -1,0 +1,119 @@
+// Wage / non-supplier outflows (PT-week part-timers, full-time salary) have no
+// supplier invoice to reconcile against. Instead of leaving them unmatched, the
+// loop auto-generates a PAYMENT SLIP — the wage-equivalent of an invoice — as a
+// fin_documents row keyed to the bank line. Every cash-out then has a supporting
+// doc, and these stop polluting the AP review queue (the matcher already skips
+// these categories; see ap-match.ts NON_SUPPLIER_CATEGORIES).
+
+import { randomUUID } from "crypto";
+import { prisma } from "@/lib/prisma";
+import { getFinanceClient } from "./supabase";
+import { companyFromAccountName } from "./gl-posting-map";
+
+// Categories that get a payment slip (wage runs paid straight from the bank).
+const SLIP_CATEGORIES = ["PARTIMER", "EMPLOYEE_SALARY"] as const;
+
+function round2(n: number): number {
+  return Math.round(n * 100) / 100;
+}
+function ymd(d: Date): string {
+  return d.toISOString().slice(0, 10);
+}
+
+// Best-effort pay-period label from the bank narrative ("PT Week 23", "Salary Jun").
+function parsePeriod(desc: string): string | null {
+  const wk = desc.match(/\b(?:PT\s*)?(?:WEEK|WK)\s*(\d{1,2})\b/i);
+  if (wk) return `Week ${wk[1]}`;
+  const mon = desc.match(/\b(JAN|FEB|MAR|APR|MAY|JUN|JUL|AUG|SEP|OCT|NOV|DEC)[A-Z]*\b/i);
+  return mon ? mon[0].slice(0, 3) : null;
+}
+
+export type PaymentSlipResult = {
+  committed: boolean;
+  scanned: number;
+  created: number;
+  alreadySlipped: number;
+  byCategory: { category: string; created: number; amount: number }[];
+};
+
+// Create payment slips for wage bank lines that don't have one yet. Idempotent:
+// a slip's source_ref is the bank line id, so re-runs only fill gaps. Dry-run by
+// default.
+export async function createWagePaymentSlips(
+  opts: { commit?: boolean; sinceDays?: number } = {},
+): Promise<PaymentSlipResult> {
+  const commit = opts.commit ?? false;
+
+  const lines = await prisma.bankStatementLine.findMany({
+    where: {
+      direction: "DR",
+      category: { in: [...SLIP_CATEGORIES] },
+      ...(opts.sinceDays ? { txnDate: { gte: new Date(Date.now() - opts.sinceDays * 86_400_000) } } : {}),
+    },
+    select: {
+      id: true, txnDate: true, description: true, amount: true, category: true, outletId: true,
+      statement: { select: { accountName: true } },
+    },
+    orderBy: { txnDate: "desc" },
+  });
+
+  const client = getFinanceClient();
+
+  // Which of these already have a slip? (source_ref = bank line id)
+  const existing = new Set<string>();
+  const ids = lines.map((l) => l.id);
+  for (let i = 0; i < ids.length; i += 500) {
+    const chunk = ids.slice(i, i + 500);
+    if (!chunk.length) break;
+    const { data, error } = await client
+      .from("fin_documents")
+      .select("source_ref")
+      .eq("doc_type", "payment_slip")
+      .in("source_ref", chunk);
+    if (error) throw error;
+    (data ?? []).forEach((d: { source_ref: string | null }) => { if (d.source_ref) existing.add(d.source_ref); });
+  }
+
+  const toCreate = lines.filter((l) => !existing.has(l.id));
+
+  const byCat = new Map<string, { created: number; amount: number }>();
+  for (const l of toCreate) {
+    const cat = l.category as string;
+    const agg = byCat.get(cat) ?? { created: 0, amount: 0 };
+    agg.created++; agg.amount = round2(agg.amount + Number(l.amount));
+    byCat.set(cat, agg);
+  }
+
+  if (commit && toCreate.length) {
+    const rows = toCreate.map((l) => ({
+      id: randomUUID(),
+      source: "bank-feed",
+      source_ref: l.id,
+      doc_type: "payment_slip",
+      outlet_id: l.outletId ?? null,
+      company_id: companyFromAccountName(l.statement.accountName),
+      raw_text: l.description,
+      metadata: {
+        category: l.category,
+        amount: round2(Number(l.amount)),
+        period: parsePeriod(l.description ?? ""),
+        bankDesc: (l.description ?? "").replace(/\s+/g, " ").trim().slice(0, 120),
+        txnDate: ymd(l.txnDate),
+      },
+      status: "auto",
+      received_at: l.txnDate.toISOString(),
+    }));
+    for (let i = 0; i < rows.length; i += 500) {
+      const { error } = await client.from("fin_documents").insert(rows.slice(i, i + 500));
+      if (error) throw error;
+    }
+  }
+
+  return {
+    committed: commit,
+    scanned: lines.length,
+    created: toCreate.length,
+    alreadySlipped: existing.size,
+    byCategory: [...byCat.entries()].map(([category, v]) => ({ category, created: v.created, amount: v.amount })).sort((a, b) => b.amount - a.amount),
+  };
+}


### PR DESCRIPTION
Continues the reconciliation work. Two linked changes so the cash-out pile reconciles correctly:

## 1. AP-match excludes non-supplier categories
Wages (`PARTIMER` / PT Week, `EMPLOYEE_SALARY`), `STATUTORY_PAYMENT`, `TAX`, director draws (`DIRECTORS_ALLOWANCE`/`ADTD`), financing (`LOAN`/`CAPITAL`/`DIVIDEND`), `BANK_FEE`, `PETTY_CASH` can **never** be the settlement of a supplier invoice — they collided on amount and produced false matches. The matcher now filters them out of the candidate pool. Null/unknown categories stay in — those are exactly the OTHER_OUTFLOW pile we *want* matched.

## 2. Auto payment slips for wages
`payment-slips.ts` → `createWagePaymentSlips()` generates a **payment slip** (the wage-equivalent of an invoice) as a `fin_documents` row (`doc_type='payment_slip'`, keyed to the bank line, idempotent on `source_ref`, period parsed from the narrative). So a wage payment is documented by a slip rather than sitting unmatched or wrongly matched. Wired into the `ap-match-apply` cron. **1,607 wage lines (RM1.2M)** get slipped on the first run; 0 exist today.

This leaves the genuine-supplier OTHER_OUTFLOW lines as the real matching target. Follow-up (not in this PR): auto-draft a payable for supplier outflows with no invoice on file.

## Test
- Mapping/exclusion are typed against `CashCategory`; CI typecheck/build cover it.