### PR TITLE
finance(recon): GL bridge → control + inter-co accounts (Bukku-aligned)

### DIFF
--- a/apps/backoffice/src/lib/finance/gl-posting-map.ts
+++ b/apps/backoffice/src/lib/finance/gl-posting-map.ts
@@ -33,9 +33,10 @@ export const CONTRA_ACCOUNT: Record<string, string> = {
   SOFTWARE: "6508",
   MAINTENANCE: "6506",
   STAFF_CLAIM: "6507",     // reimbursed outlet buys
-  EMPLOYEE_SALARY: "6500-02",
-  PARTIMER: "6500-03",
-  STATUTORY_PAYMENT: "6501",
+  PARTIMER: "6500-03",     // part-timer wages → expense (Bukku books these direct)
+  // EMPLOYEE_SALARY + STATUTORY_PAYMENT are NOT here — they route through
+  // CONTROL accounts (3008/3004-3007) in resolveContra(), the way Bukku books
+  // them: the bank payment clears a liability the payroll run accrued.
   TAX: "6900",
   COMPLIANCE: "6510",
   LICENSING_FEE: "6510-02",
@@ -71,6 +72,40 @@ export function companyFromAccountName(accountName: string | null | undefined): 
 export function contraFor(category: string): { code: string; suspense: boolean } {
   if (CONTRA_ACCOUNT[category]) return { code: CONTRA_ACCOUNT[category], suspense: false };
   return { code: SUSPENSE, suspense: true };
+}
+
+const INTERCO_CATS = new Set([
+  "INTERCO_PEOPLE", "INTERCO_RAW_MATERIAL", "INTERCO_INVESTMENTS", "INTERCO_EXPENSES",
+]);
+
+// Which related-company "Due to/from" account an inter-co line belongs to, read
+// from the counterparty named in the bank narrative.
+function intercoAccount(descUpper: string): string {
+  if (/TAMARIND|TAMAR/.test(descUpper)) return "3600-00";
+  if (/CONEZION|\bCONE\b/.test(descUpper)) return "3600-01";
+  if (/CELSIUS\s*COFFEE\s*SDN|\bCCSB\b/.test(descUpper)) return "3600-02";
+  return "3600"; // generic inter-company current account
+}
+
+// Resolve the contra account for a bank line — the accurate version that mirrors
+// how Bukku books things, using the description where the category alone is too
+// coarse:
+//   • EMPLOYEE_SALARY  → 3008 Salary Control          (cleared by payroll accrual)
+//   • STATUTORY_PAYMENT→ 3004/3005/3006/3007 by type  (EPF/SOCSO/EIS/PCB control)
+//   • INTERCO_*        → 3600-xx Due to/from <entity>  (not suspense)
+//   • everything else  → the static CONTRA_ACCOUNT map
+export function resolveContra(category: string, description: string): { code: string; suspense: boolean } {
+  const d = (description || "").toUpperCase();
+  if (category === "EMPLOYEE_SALARY") return { code: "3008", suspense: false };
+  if (category === "STATUTORY_PAYMENT") {
+    if (/\bEPF\b|KWSP/.test(d)) return { code: "3004", suspense: false };
+    if (/SOCSO|PERKESO/.test(d)) return { code: "3005", suspense: false };
+    if (/\bEIS\b|\bSIP\b/.test(d)) return { code: "3006", suspense: false };
+    if (/\bPCB\b|\bMTD\b|LHDN|HASIL|INLAND\s*REVENUE/.test(d)) return { code: "3007", suspense: false };
+    return { code: "3008", suspense: false }; // unspecified statutory → salary control
+  }
+  if (INTERCO_CATS.has(category)) return { code: intercoAccount(d), suspense: false };
+  return contraFor(category);
 }
 
 export function round2(n: number): number {

--- a/apps/backoffice/src/lib/finance/gl-posting.test.ts
+++ b/apps/backoffice/src/lib/finance/gl-posting.test.ts
@@ -1,5 +1,32 @@
 import { describe, it, expect } from "vitest";
-import { contraFor, companyFromAccountName, CONTRA_ACCOUNT } from "./gl-posting-map";
+import { contraFor, companyFromAccountName, CONTRA_ACCOUNT, resolveContra } from "./gl-posting-map";
+
+describe("resolveContra — Bukku-accurate control / inter-co routing", () => {
+  it("routes full-time salary to the Salary Control liability (cleared by payroll accrual)", () => {
+    expect(resolveContra("EMPLOYEE_SALARY", "SALARY DEC 2025").code).toBe("3008");
+  });
+  it("keeps part-timer wages as a direct expense (matches Bukku)", () => {
+    expect(resolveContra("PARTIMER", "PT Week 51/25").code).toBe("6500-03");
+  });
+  it("splits statutory by type into the right control account", () => {
+    expect(resolveContra("STATUTORY_PAYMENT", "KWSP/EPF DEC").code).toBe("3004");
+    expect(resolveContra("STATUTORY_PAYMENT", "PERKESO SOCSO").code).toBe("3005");
+    expect(resolveContra("STATUTORY_PAYMENT", "EIS SIP").code).toBe("3006");
+    expect(resolveContra("STATUTORY_PAYMENT", "LHDN PCB MTD").code).toBe("3007");
+    expect(resolveContra("STATUTORY_PAYMENT", "statutory misc").code).toBe("3008");
+  });
+  it("routes inter-company to the right Due to/from account by counterparty", () => {
+    expect(resolveContra("INTERCO_PEOPLE", "TRANSFER TO A/C CELSIUS COFFEE TAMARIND").code).toBe("3600-00");
+    expect(resolveContra("INTERCO_EXPENSES", "TRANSFER FR A/C CONEZION").code).toBe("3600-01");
+    expect(resolveContra("INTERCO_RAW_MATERIAL", "to celsius coffee sdn bhd").code).toBe("3600-02");
+    expect(resolveContra("INTERCO_INVESTMENTS", "unknown counterparty").code).toBe("3600");
+  });
+  it("falls through to the static map for everything else", () => {
+    expect(resolveContra("RAW_MATERIALS", "").code).toBe("6000-01");
+    expect(resolveContra("DIRECTORS_ALLOWANCE", "").code).toBe("3400");
+    expect(resolveContra("OTHER_OUTFLOW", "").suspense).toBe(true);
+  });
+});
 
 describe("companyFromAccountName", () => {
   it("routes each bank account to its legal entity", () => {

--- a/apps/backoffice/src/lib/finance/gl-posting.ts
+++ b/apps/backoffice/src/lib/finance/gl-posting.ts
@@ -21,14 +21,16 @@
 import { prisma } from "@/lib/prisma";
 import { postJournal } from "./ledger";
 import type { JournalLineInput } from "./types";
-import { BANK_CASH, companyFromAccountName, contraFor, round2, SKIP_CATS } from "./gl-posting-map";
+import { BANK_CASH, companyFromAccountName, resolveContra, round2, SKIP_CATS } from "./gl-posting-map";
 
-export { CONTRA_ACCOUNT, companyFromAccountName, contraFor } from "./gl-posting-map";
+export { CONTRA_ACCOUNT, companyFromAccountName, contraFor, resolveContra } from "./gl-posting-map";
 
 type Group = {
   company: string;
   outletId: string | null;
-  category: string;
+  contra: string;        // resolved contra account (control/inter-co/expense/…)
+  suspense: boolean;
+  category: string;      // representative category, for labelling
   date: string;          // YYYY-MM-DD
   direction: "CR" | "DR";
   amount: number;
@@ -63,14 +65,16 @@ export async function postBankLinesToGl(
       ...(opts.sinceDays ? { txnDate: { gte: new Date(Date.now() - opts.sinceDays * 86_400_000) } } : {}),
     },
     select: {
-      id: true, txnDate: true, amount: true, direction: true, category: true, outletId: true,
+      id: true, txnDate: true, amount: true, direction: true, category: true, description: true, outletId: true,
       statement: { select: { accountName: true } },
     },
     orderBy: { txnDate: "asc" },
     take: opts.limit,
   });
 
-  // Aggregate into one journal per (company, outlet, category, day, direction).
+  // Resolve the contra account per line (so statutory splits by type and inter-co
+  // routes by counterparty), then aggregate into one journal per
+  // (company, outlet, CONTRA account, day, direction).
   const groups = new Map<string, Group>();
   let skippedLines = 0;
   for (const l of lines) {
@@ -79,10 +83,11 @@ export async function postBankLinesToGl(
     const company = companyFromAccountName(l.statement.accountName);
     const date = l.txnDate.toISOString().slice(0, 10);
     const direction = l.direction as "CR" | "DR";
-    const key = [company, l.outletId ?? "", category, date, direction].join("|");
+    const { code: contra, suspense } = resolveContra(category, l.description ?? "");
+    const key = [company, l.outletId ?? "", contra, date, direction].join("|");
     const g = groups.get(key);
     if (g) { g.amount = round2(g.amount + Number(l.amount)); g.lineIds.push(l.id); }
-    else groups.set(key, { company, outletId: l.outletId, category, date, direction, amount: round2(Number(l.amount)), lineIds: [l.id] });
+    else groups.set(key, { company, outletId: l.outletId, contra, suspense, category, date, direction, amount: round2(Number(l.amount)), lineIds: [l.id] });
   }
 
   const byCat = new Map<string, { account: string; direction: string; journals: number; lines: number; amount: number; suspense: boolean }>();
@@ -91,26 +96,26 @@ export async function postBankLinesToGl(
 
   for (const g of groups.values()) {
     if (g.amount <= 0) continue;
-    const { code: contra, suspense } = contraFor(g.category);
+    const contra = g.contra;
     // CR = money in → Dr Bank, Cr contra. DR = money out → Dr contra, Cr Bank.
     const journalLines: JournalLineInput[] = g.direction === "CR"
       ? [{ accountCode: BANK_CASH, debit: g.amount, outletId: g.outletId }, { accountCode: contra, credit: g.amount, outletId: g.outletId }]
       : [{ accountCode: contra, debit: g.amount, outletId: g.outletId }, { accountCode: BANK_CASH, credit: g.amount, outletId: g.outletId }];
 
-    const ck = `${g.category}|${g.direction}`;
-    const agg = byCat.get(ck) ?? { account: contra, direction: g.direction, journals: 0, lines: 0, amount: 0, suspense };
+    const ck = `${g.category}|${contra}|${g.direction}`;
+    const agg = byCat.get(ck) ?? { account: contra, direction: g.direction, journals: 0, lines: 0, amount: 0, suspense: g.suspense };
     agg.journals++; agg.lines += g.lineIds.length; agg.amount = round2(agg.amount + g.amount);
     byCat.set(ck, agg);
 
     journals++;
     postedLines += g.lineIds.length;
-    if (suspense) suspenseLines += g.lineIds.length;
+    if (g.suspense) suspenseLines += g.lineIds.length;
     totalDebit = round2(totalDebit + g.amount);
     totalCredit = round2(totalCredit + g.amount);
 
     if (!commit) continue;
     try {
-      const desc = `Bank ${g.direction === "CR" ? "receipts" : "payments"} — ${g.category} ${g.date} (${g.lineIds.length} line${g.lineIds.length > 1 ? "s" : ""})`;
+      const desc = `Bank ${g.direction === "CR" ? "receipts" : "payments"} — ${g.category}→${contra} ${g.date} (${g.lineIds.length} line${g.lineIds.length > 1 ? "s" : ""})`;
       const res = await postJournal({
         companyId: g.company,
         txnDate: g.date,


### PR DESCRIPTION
Step 1 of aligning our bank reconciliation with how Bukku actually books it (learned from a full year of Bukku's reconciled ledger, 100% reconciled).

## What changes
`resolveContra(category, description)` replaces the flat category→account map for three cases Bukku handles differently:
- **Full-time salary → `3008` Salary Control** (a liability the payroll run accrues), not direct `6500-02` expense.
- **Statutory → `3004/3005/3006/3007`** (EPF / SOCSO / EIS / PCB control) split by type from the narrative.
- **Inter-company → `3600-xx` Due to/from <entity>** by counterparty (Tamarind `3600-00`, Conezion `3600-01`, SB `3600-02`), instead of Suspense.

Journals now group by the **resolved contra account** (so statutory and inter-co split correctly), not by category. Part-timer stays a direct `6500-03` expense (matches Bukku); card/QR/grab still clear debtors.

## Why
Bukku's reconciliation runs payroll/statutory through control accounts and inter-co through 3600 'due to/from' accounts. Without this we mis-booked salary as expense (double-counts once payroll is accrued) and dumped RM-hundreds-of-thousands of inter-co into Suspense.

## Notes
- `fin_accounts` 3600-xx added directly (Supabase-managed, like the suspense account). 3004-3008 already existed.
- **Step 2** is wiring the payroll accrual (the credit side of the control accounts). Until then the control accounts carry a debit balance *by design* — this PR lays the account structure.
- Already-posted bank journals (from the draining backlog) used the old map; a reset+repost after deploy applies the new mapping (operational follow-up).

## Test
- `resolveContra` covered: salary→3008, part-timer→6500-03, statutory split, inter-co by counterparty, fall-through to the static map.