### PR TITLE
finance: run the loop on the firing cron (Vercel 40-cron cap)

### DIFF
--- a/apps/backoffice/src/app/api/cron/bukku-feed-sync/route.ts
+++ b/apps/backoffice/src/app/api/cron/bukku-feed-sync/route.ts
@@ -1,33 +1,58 @@
-// Daily cron — pulls Bukku's raw Maybank feed for every connected company
-// and rebuilds the live bank ledger forward from each account's last PDF
-// closing balance. Idempotent + self-healing (see syncBukkuFeedLedger).
-// Scheduled after Bukku's nightly bank-feed sync (~22:30 MYT).
+// Finance-loop cron — runs the whole pipeline every 6h on ONE schedule, because
+// Vercel caps the project's cron jobs and the standalone gl-post / ap-match-apply
+// crons silently never registered (43 > the 40-cron limit). Chaining them here,
+// onto the bukku-feed-sync cron that DOES fire, guarantees the loop runs:
+//
+//   1. INGEST   — pull Bukku's raw Maybank feed → classified BankStatementLine
+//   2. MATCH    — AP-match supplier outflows ↔ procurement invoices (auto + LLM)
+//   3. SLIPS    — auto payment slips for wage lines (no invoice)
+//   4. POST     — post classified bank lines into the double-entry GL
+//
+// Every step is independent (try/caught) so one failure never blocks the rest.
+// Each is idempotent + bounded, so re-running every 6h is safe and drains the
+// backlog over a few runs.
 
 import { NextRequest, NextResponse } from "next/server";
 import { syncBukkuFeedLedger } from "@/lib/finance/bukku-feed-sync";
+import { applyApMatches } from "@/lib/finance/ap-match";
+import { applyVerifiedReview } from "@/lib/finance/agents/ap-verifier";
+import { createWagePaymentSlips } from "@/lib/finance/payment-slips";
+import { postBankLinesToGl } from "@/lib/finance/gl-posting";
 import { checkCronAuth } from "@celsius/shared";
 
 export const dynamic = "force-dynamic";
 export const maxDuration = 300;
 
+const GL_LINES_PER_RUN = 3000; // bounded so the whole loop stays inside maxDuration
+
 export async function GET(req: NextRequest) {
   const cronAuth = checkCronAuth(req.headers);
   if (!cronAuth.ok) return NextResponse.json({ error: cronAuth.error }, { status: cronAuth.status });
 
-  try {
+  const out: Record<string, unknown> = {};
+  const step = async (name: string, fn: () => Promise<unknown>) => {
+    try { out[name] = await fn(); }
+    catch (err) { out[name] = { error: err instanceof Error ? err.message : String(err) }; console.error(`[finance-loop:${name}]`, err); }
+  };
+
+  // 1. ingest the bank feed (must run first — the rest acts on its output)
+  await step("feed", async () => {
     const { accounts } = await syncBukkuFeedLedger({ commit: true });
-    const summary = {
-      accounts: accounts.length,
-      committed: accounts.filter((a) => a.committed).length,
-      newLines: accounts.reduce((s, a) => s + a.newLines, 0),
-      skipped: accounts.filter((a) => a.skipped).map((a) => `${a.subdomain}/${a.accountTail}: ${a.skipped}`),
-    };
-    return NextResponse.json({ summary, accounts });
-  } catch (err) {
-    console.error("[cron/bukku-feed-sync]", err);
-    return NextResponse.json(
-      { error: err instanceof Error ? err.message : "feed sync failed" },
-      { status: 500 },
-    );
-  }
+    return { accounts: accounts.length, newLines: accounts.reduce((s, a) => s + a.newLines, 0) };
+  });
+  // 2. match supplier outflows → invoices (rules tier, then LLM verifier tier)
+  await step("apMatchAuto", async () => ({ applied: (await applyApMatches({ commit: true, sinceDays: 120 })).applied }));
+  await step("apMatchReview", async () => {
+    const r = await applyVerifiedReview({ commit: true, sinceDays: 120 });
+    return { confirmed: r.confirmedApplied, rejected: r.rejected, uncertain: r.uncertain };
+  });
+  // 3. payment slips for wage lines (no invoice to match)
+  await step("paymentSlips", async () => ({ created: (await createWagePaymentSlips({ commit: true })).created }));
+  // 4. post the classified bank lines into the GL (bounded; drains over runs)
+  await step("glPost", async () => {
+    const r = await postBankLinesToGl({ commit: true, limit: GL_LINES_PER_RUN });
+    return { journals: r.journals, postedLines: r.postedLines, suspenseLines: r.suspenseLines, errors: r.errors.length };
+  });
+
+  return NextResponse.json(out);
 }

--- a/apps/backoffice/vercel.json
+++ b/apps/backoffice/vercel.json
@@ -65,14 +65,6 @@
       "schedule": "0 */6 * * *"
     },
     {
-      "path": "/api/cron/ap-match-apply",
-      "schedule": "0 21 * * *"
-    },
-    {
-      "path": "/api/cron/gl-post",
-      "schedule": "0 */3 * * *"
-    },
-    {
       "path": "/api/cron/music-alerts",
       "schedule": "*/5 * * * *"
     },


### PR DESCRIPTION
## The bug behind an empty GL
The GL bridge (#657) and AP auto-apply were correct but **never ran**: the project has **43 cron entries, over Vercel's 40-cron limit**, so the last-added `gl-post` and `ap-match-apply` crons silently never registered. Result: 0 of 54,405 bank lines posted, AP never auto-applied. No error logs — they were simply never invoked, while neighbours (e.g. `bukku-feed-sync`) fire every 6h.

## Fix
Chain the whole finance loop into the `bukku-feed-sync` cron that **does** fire (every 6h):
1. **ingest** — Bukku feed → classified bank lines
2. **match** — AP-match outflows ↔ invoices (rules + LLM verifier)
3. **slips** — payment slips for wage lines
4. **post** — bank lines → GL (control/inter-co accounts per #664), bounded 3,000 lines/run

Each step is independent (try/caught), idempotent, and bounded, so re-running every 6h is safe and drains the 54k backlog over a few runs. Removed the two dead cron entries (43 → 41); the routes stay for manual use.

## Effect
On the next `bukku-feed-sync` run, the GL starts posting with the Bukku-aligned control + inter-co mapping, and the AP pile starts clearing against the 599 imported invoices.