### PR TITLE
finance(reports): Trial Balance + General Ledger (Bukku parity)

### DIFF
--- a/apps/backoffice/src/app/(admin)/finance/reports/page.tsx
+++ b/apps/backoffice/src/app/(admin)/finance/reports/page.tsx
@@ -544,8 +544,113 @@ function AuditorPack() {
 
 // ─── Page shell ─────────────────────────────────────────────────
 
+// ─── Trial Balance tab ──────────────────────────────────────────
+type TbRow = { code: string; name: string; type: string; debit: number; credit: number };
+type Tb = { asOf: string; rows: TbRow[]; totalDebit: number; totalCredit: number; balanced: boolean };
+
+function TbTab({ onDrill }: { onDrill: (code: string) => void }) {
+  const [asOf, setAsOf] = useState(todayMyt());
+  const { data, isLoading } = useFetch<{ report: Tb }>(`/api/finance/reports/trial-balance?asOf=${asOf}`);
+  return (
+    <div className="space-y-3">
+      <div className="flex flex-wrap items-end gap-2">
+        <label className="text-xs text-muted-foreground">As of
+          <input type="date" value={asOf} onChange={(e) => setAsOf(e.target.value)} className="ml-2 rounded border px-2 py-1 text-sm" />
+        </label>
+        {data?.report && (
+          <span className={`ml-auto rounded px-2 py-1 text-xs font-medium ${data.report.balanced ? "bg-green-500/10 text-green-700 dark:text-green-400" : "bg-red-500/10 text-red-600"}`}>
+            {data.report.balanced ? "Balanced" : "Out of balance"}
+          </span>
+        )}
+      </div>
+      {isLoading || !data?.report ? <div className="py-12 text-center text-sm text-muted-foreground">Loading…</div> : (
+        <div className="overflow-x-auto rounded-lg border">
+          <table className="w-full min-w-[560px] text-sm">
+            <thead><tr className="border-b bg-muted/40 text-left text-muted-foreground">
+              <th className="px-3 py-2 font-medium">Code</th><th className="px-3 py-2 font-medium">Account</th>
+              <th className="px-3 py-2 text-right font-medium">Debit</th><th className="px-3 py-2 text-right font-medium">Credit</th>
+            </tr></thead>
+            <tbody className="divide-y">
+              {data.report.rows.map((r) => (
+                <tr key={r.code} className="cursor-pointer hover:bg-muted/40" onClick={() => onDrill(r.code)} title="Open in General Ledger">
+                  <td className="whitespace-nowrap px-3 py-1.5 text-xs text-muted-foreground tabular-nums">{r.code}</td>
+                  <td className="px-3 py-1.5">{r.name}</td>
+                  <td className="px-3 py-1.5 text-right tabular-nums">{r.debit ? RM(r.debit) : ""}</td>
+                  <td className="px-3 py-1.5 text-right tabular-nums">{r.credit ? RM(r.credit) : ""}</td>
+                </tr>
+              ))}
+            </tbody>
+            <tfoot><tr className="border-t-2 font-semibold">
+              <td className="px-3 py-2" colSpan={2}>Total</td>
+              <td className="px-3 py-2 text-right tabular-nums">{RM(data.report.totalDebit)}</td>
+              <td className="px-3 py-2 text-right tabular-nums">{RM(data.report.totalCredit)}</td>
+            </tr></tfoot>
+          </table>
+        </div>
+      )}
+      <p className="text-[11px] text-muted-foreground">Click any account to open its General Ledger. Fills in as the bank→GL bridge posts.</p>
+    </div>
+  );
+}
+
+// ─── General Ledger tab ─────────────────────────────────────────
+type GlEntry = { date: string; txnType: string; description: string; debit: number; credit: number; balance: number };
+type Gl = { accountCode: string; accountName: string; start: string; end: string; opening: number; entries: GlEntry[]; closing: number; totalDebit: number; totalCredit: number };
+
+function GlTab({ account, setAccount }: { account: string; setAccount: (c: string) => void }) {
+  const [start, setStart] = useState(thisMonthStart());
+  const [end, setEnd] = useState(todayMyt());
+  const { data, isLoading } = useFetch<{ report: Gl }>(`/api/finance/reports/general-ledger?account=${encodeURIComponent(account)}&start=${start}&end=${end}`);
+  return (
+    <div className="space-y-3">
+      <div className="flex flex-wrap items-end gap-2">
+        <label className="text-xs text-muted-foreground">Account
+          <input value={account} onChange={(e) => setAccount(e.target.value.trim())} placeholder="e.g. 6000-01" className="ml-2 w-28 rounded border px-2 py-1 text-sm tabular-nums" />
+        </label>
+        <label className="text-xs text-muted-foreground">From
+          <input type="date" value={start} onChange={(e) => setStart(e.target.value)} className="ml-2 rounded border px-2 py-1 text-sm" />
+        </label>
+        <label className="text-xs text-muted-foreground">To
+          <input type="date" value={end} onChange={(e) => setEnd(e.target.value)} className="ml-2 rounded border px-2 py-1 text-sm" />
+        </label>
+      </div>
+      {isLoading || !data?.report ? <div className="py-12 text-center text-sm text-muted-foreground">Loading…</div> : (
+        <div className="overflow-x-auto rounded-lg border">
+          <div className="border-b bg-muted/40 px-3 py-2 text-sm font-medium">{data.report.accountCode} · {data.report.accountName}</div>
+          <table className="w-full min-w-[640px] text-sm">
+            <thead><tr className="border-b text-left text-muted-foreground">
+              <th className="px-3 py-2 font-medium">Date</th><th className="px-3 py-2 font-medium">Description</th>
+              <th className="px-3 py-2 text-right font-medium">Debit</th><th className="px-3 py-2 text-right font-medium">Credit</th><th className="px-3 py-2 text-right font-medium">Balance</th>
+            </tr></thead>
+            <tbody className="divide-y">
+              <tr className="bg-muted/20 text-muted-foreground"><td className="px-3 py-1.5" colSpan={4}>Opening balance</td><td className="px-3 py-1.5 text-right tabular-nums">{RM(data.report.opening)}</td></tr>
+              {data.report.entries.map((e, i) => (
+                <tr key={i} className="hover:bg-muted/40">
+                  <td className="whitespace-nowrap px-3 py-1.5 text-xs text-muted-foreground tabular-nums">{e.date}</td>
+                  <td className="px-3 py-1.5 text-xs">{e.description}</td>
+                  <td className="px-3 py-1.5 text-right tabular-nums">{e.debit ? RM(e.debit) : ""}</td>
+                  <td className="px-3 py-1.5 text-right tabular-nums">{e.credit ? RM(e.credit) : ""}</td>
+                  <td className="px-3 py-1.5 text-right tabular-nums">{RM(e.balance)}</td>
+                </tr>
+              ))}
+              {data.report.entries.length === 0 && <tr><td colSpan={5} className="px-3 py-4 text-center text-xs text-muted-foreground">No movements in this period.</td></tr>}
+            </tbody>
+            <tfoot><tr className="border-t-2 font-semibold">
+              <td className="px-3 py-2" colSpan={2}>Period total / closing</td>
+              <td className="px-3 py-2 text-right tabular-nums">{RM(data.report.totalDebit)}</td>
+              <td className="px-3 py-2 text-right tabular-nums">{RM(data.report.totalCredit)}</td>
+              <td className="px-3 py-2 text-right tabular-nums">{RM(data.report.closing)}</td>
+            </tr></tfoot>
+          </table>
+        </div>
+      )}
+    </div>
+  );
+}
+
 export default function FinanceReportsPage() {
-  const [tab, setTab] = useState<"pnl" | "bs" | "cf" | "audit">("pnl");
+  const [tab, setTab] = useState<"pnl" | "bs" | "cf" | "tb" | "gl" | "audit">("pnl");
+  const [glAccount, setGlAccount] = useState("1000-01"); // shared so TB rows can drill into GL
 
   return (
     <div className="space-y-4 p-3 sm:p-6">
@@ -562,6 +667,8 @@ export default function FinanceReportsPage() {
             { id: "pnl", label: "Profit & Loss" },
             { id: "bs", label: "Balance Sheet" },
             { id: "cf", label: "Cash Flow" },
+            { id: "tb", label: "Trial Balance" },
+            { id: "gl", label: "General Ledger" },
             { id: "audit", label: "Auditor pack" },
           ].map((t) => (
             <button
@@ -589,6 +696,8 @@ export default function FinanceReportsPage() {
       {tab === "pnl" && <PnlTab />}
       {tab === "bs" && <BsTab />}
       {tab === "cf" && <CfTab />}
+      {tab === "tb" && <TbTab onDrill={(code) => { setGlAccount(code); setTab("gl"); }} />}
+      {tab === "gl" && <GlTab account={glAccount} setAccount={setGlAccount} />}
       {tab === "audit" && <AuditorPack />}
     </div>
   );

--- a/apps/backoffice/src/app/api/finance/reports/general-ledger/route.ts
+++ b/apps/backoffice/src/app/api/finance/reports/general-ledger/route.ts
@@ -1,0 +1,29 @@
+// GET /api/finance/reports/general-ledger?account=CODE&start=&end=&companyId=...
+
+import { NextRequest, NextResponse } from "next/server";
+import { requireAuth } from "@/lib/auth";
+import { buildGeneralLedger } from "@/lib/finance/reports/gl-reports";
+import { getActiveCompanyId } from "@/lib/finance/companies";
+
+export const dynamic = "force-dynamic";
+export const maxDuration = 60;
+
+export async function GET(req: NextRequest) {
+  const auth = await requireAuth(req);
+  if (auth.error) return auth.error;
+  if (!["OWNER", "ADMIN"].includes(auth.user.role)) return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  const url = new URL(req.url);
+  const account = url.searchParams.get("account");
+  const start = url.searchParams.get("start");
+  const end = url.searchParams.get("end");
+  const companyId = url.searchParams.get("companyId") ?? (await getActiveCompanyId());
+  if (!account) return NextResponse.json({ error: "account code required" }, { status: 400 });
+  if (!start || !end || !/^\d{4}-\d{2}-\d{2}$/.test(start) || !/^\d{4}-\d{2}-\d{2}$/.test(end)) {
+    return NextResponse.json({ error: "start, end (YYYY-MM-DD) required" }, { status: 400 });
+  }
+  try {
+    return NextResponse.json({ report: await buildGeneralLedger({ companyId, accountCode: account, start, end }) });
+  } catch (err) {
+    return NextResponse.json({ error: err instanceof Error ? err.message : String(err) }, { status: 500 });
+  }
+}

--- a/apps/backoffice/src/app/api/finance/reports/trial-balance/route.ts
+++ b/apps/backoffice/src/app/api/finance/reports/trial-balance/route.ts
@@ -1,0 +1,24 @@
+// GET /api/finance/reports/trial-balance?asOf=YYYY-MM-DD&companyId=...
+
+import { NextRequest, NextResponse } from "next/server";
+import { requireAuth } from "@/lib/auth";
+import { buildTrialBalance } from "@/lib/finance/reports/gl-reports";
+import { getActiveCompanyId } from "@/lib/finance/companies";
+
+export const dynamic = "force-dynamic";
+export const maxDuration = 60;
+
+export async function GET(req: NextRequest) {
+  const auth = await requireAuth(req);
+  if (auth.error) return auth.error;
+  if (!["OWNER", "ADMIN"].includes(auth.user.role)) return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  const url = new URL(req.url);
+  const asOf = url.searchParams.get("asOf");
+  const companyId = url.searchParams.get("companyId") ?? (await getActiveCompanyId());
+  if (!asOf || !/^\d{4}-\d{2}-\d{2}$/.test(asOf)) return NextResponse.json({ error: "asOf (YYYY-MM-DD) required" }, { status: 400 });
+  try {
+    return NextResponse.json({ report: await buildTrialBalance({ companyId, asOf }) });
+  } catch (err) {
+    return NextResponse.json({ error: err instanceof Error ? err.message : String(err) }, { status: 500 });
+  }
+}

--- a/apps/backoffice/src/lib/finance/reports/gl-reports.ts
+++ b/apps/backoffice/src/lib/finance/reports/gl-reports.ts
@@ -1,0 +1,132 @@
+// Trial Balance + General Ledger — the two foundational GL reports Bukku has
+// and we lacked. Both read the posted double-entry ledger (fin_transactions +
+// fin_journal_lines), now that the bank→GL bridge populates it.
+//
+//   Trial Balance  — every account's net balance on its natural side; total
+//                    debits must equal total credits (the GL's self-proof).
+//   General Ledger — one account's movements over a period with a running
+//                    balance (the drill-down behind any figure).
+
+import { getFinanceClient } from "../supabase";
+
+function round2(n: number): number {
+  return Math.round(n * 100) / 100;
+}
+
+type AccountMeta = { name: string; type: string };
+
+async function loadAccounts(): Promise<Map<string, AccountMeta>> {
+  const client = getFinanceClient();
+  const { data } = await client.from("fin_accounts").select("code, name, type");
+  return new Map((data ?? []).map((a) => [a.code as string, { name: a.name as string, type: a.type as string }]));
+}
+
+// Posted transaction ids for a company up to (and optionally from) a date.
+async function postedTxns(companyId: string, opts: { from?: string; to: string }): Promise<Map<string, { date: string; description: string; type: string }>> {
+  const client = getFinanceClient();
+  let q = client
+    .from("fin_transactions")
+    .select("id, txn_date, description, txn_type")
+    .eq("company_id", companyId)
+    .eq("status", "posted")
+    .lte("txn_date", opts.to);
+  if (opts.from) q = q.gte("txn_date", opts.from);
+  const { data } = await q;
+  return new Map((data ?? []).map((t) => [t.id as string, { date: t.txn_date as string, description: (t.description as string) ?? "", type: (t.txn_type as string) ?? "" }]));
+}
+
+async function* journalLinesFor(txnIds: string[], accountCode?: string) {
+  const client = getFinanceClient();
+  for (let i = 0; i < txnIds.length; i += 200) {
+    const chunk = txnIds.slice(i, i + 200);
+    let q = client.from("fin_journal_lines").select("transaction_id, account_code, debit, credit, memo").in("transaction_id", chunk);
+    if (accountCode) q = q.eq("account_code", accountCode);
+    const { data } = await q;
+    yield (data ?? []) as { transaction_id: string; account_code: string; debit: number; credit: number; memo: string | null }[];
+  }
+}
+
+// ─── Trial Balance ──────────────────────────────────────────────────────────
+
+export type TbRow = { code: string; name: string; type: string; debit: number; credit: number };
+export type TrialBalance = {
+  companyId: string; asOf: string;
+  rows: TbRow[];
+  totalDebit: number; totalCredit: number; balanced: boolean;
+};
+
+export async function buildTrialBalance(input: { companyId: string; asOf: string }): Promise<TrialBalance> {
+  const meta = await loadAccounts();
+  const txns = await postedTxns(input.companyId, { to: input.asOf });
+  const net = new Map<string, number>(); // account → debit−credit
+  for await (const lines of journalLinesFor([...txns.keys()])) {
+    for (const l of lines) {
+      net.set(l.account_code, round2((net.get(l.account_code) ?? 0) + Number(l.debit) - Number(l.credit)));
+    }
+  }
+
+  const rows: TbRow[] = [];
+  let totalDebit = 0, totalCredit = 0;
+  for (const [code, bal] of [...net.entries()].sort((a, b) => a[0].localeCompare(b[0]))) {
+    if (Math.abs(bal) < 0.005) continue;
+    const m = meta.get(code);
+    const debit = bal > 0 ? round2(bal) : 0;
+    const credit = bal < 0 ? round2(-bal) : 0;
+    rows.push({ code, name: m?.name ?? "(unknown account)", type: m?.type ?? "?", debit, credit });
+    totalDebit = round2(totalDebit + debit);
+    totalCredit = round2(totalCredit + credit);
+  }
+  return { companyId: input.companyId, asOf: input.asOf, rows, totalDebit, totalCredit, balanced: Math.abs(totalDebit - totalCredit) < 0.01 };
+}
+
+// ─── General Ledger (one account, with running balance) ─────────────────────
+
+export type GlEntry = { date: string; txnType: string; description: string; memo: string | null; debit: number; credit: number; balance: number };
+export type GeneralLedger = {
+  companyId: string; accountCode: string; accountName: string; type: string;
+  start: string; end: string;
+  opening: number; entries: GlEntry[]; closing: number;
+  totalDebit: number; totalCredit: number;
+};
+
+export async function buildGeneralLedger(input: { companyId: string; accountCode: string; start: string; end: string }): Promise<GeneralLedger> {
+  const meta = await loadAccounts();
+  const am = meta.get(input.accountCode);
+
+  // Opening balance = net of everything strictly before `start` (for B/S accounts
+  // this is the carried balance; for P&L accounts the period-to-date prior).
+  const before = await postedTxns(input.companyId, { to: dayBefore(input.start) });
+  let opening = 0;
+  for await (const lines of journalLinesFor([...before.keys()], input.accountCode)) {
+    for (const l of lines) opening = round2(opening + Number(l.debit) - Number(l.credit));
+  }
+
+  const inPeriod = await postedTxns(input.companyId, { from: input.start, to: input.end });
+  const raw: { date: string; txnType: string; description: string; memo: string | null; debit: number; credit: number }[] = [];
+  for await (const lines of journalLinesFor([...inPeriod.keys()], input.accountCode)) {
+    for (const l of lines) {
+      const t = inPeriod.get(l.transaction_id)!;
+      raw.push({ date: t.date, txnType: t.type, description: t.description, memo: l.memo, debit: round2(Number(l.debit)), credit: round2(Number(l.credit)) });
+    }
+  }
+  raw.sort((a, b) => (a.date < b.date ? -1 : a.date > b.date ? 1 : 0));
+
+  let running = opening, totalDebit = 0, totalCredit = 0;
+  const entries: GlEntry[] = raw.map((r) => {
+    running = round2(running + r.debit - r.credit);
+    totalDebit = round2(totalDebit + r.debit);
+    totalCredit = round2(totalCredit + r.credit);
+    return { ...r, balance: running };
+  });
+
+  return {
+    companyId: input.companyId, accountCode: input.accountCode, accountName: am?.name ?? "(unknown)", type: am?.type ?? "?",
+    start: input.start, end: input.end, opening: round2(opening), entries, closing: running, totalDebit, totalCredit,
+  };
+}
+
+function dayBefore(ymd: string): string {
+  const d = new Date(`${ymd}T00:00:00Z`);
+  d.setUTCDate(d.getUTCDate() - 1);
+  return d.toISOString().slice(0, 10);
+}


### PR DESCRIPTION
First batch of the Bukku feature-gap closure: the two standard GL reports Bukku has and we lacked.

## Added
- **Trial Balance** — every account's net balance on its natural side (debit/credit columns) with a **balanced** check (total debits = total credits). The ledger's self-proof.
- **General Ledger** — one account's movements over a date range with opening balance, each entry, and a **running balance**. The drill-down behind any P&L/BS figure.

Both read the posted ledger (`fin_transactions` + `fin_journal_lines`), so they fill in as the bank→GL bridge posts. `reports/gl-reports.ts` builders, two API routes, two new tabs on the Reports page (TB rows click through into the GL).

## Still to close (from the Bukku comparison)
Aged Payables, Aged Receivables, the bank-reconciliation close, and a contacts/statements module — next batches.

## Test
- Pure read builders; CI typecheck/build cover them.