### PR TITLE
finance(reports): Aged Payables (Bukku parity)

### DIFF
--- a/apps/backoffice/src/app/(admin)/finance/reports/page.tsx
+++ b/apps/backoffice/src/app/(admin)/finance/reports/page.tsx
@@ -648,8 +648,57 @@ function GlTab({ account, setAccount }: { account: string; setAccount: (c: strin
   );
 }
 
+// ─── Aged Payables tab ──────────────────────────────────────────
+type AgedRow = { vendor: string; count: number; current: number; d1_30: number; d31_60: number; d61_90: number; d90_plus: number; total: number };
+type AgedPayables = { asOf: string; rows: AgedRow[]; totals: { current: number; d1_30: number; d31_60: number; d61_90: number; d90_plus: number }; grandTotal: number; invoiceCount: number };
+const AP_COLS: { key: keyof AgedPayables["totals"]; label: string }[] = [
+  { key: "current", label: "Current" }, { key: "d1_30", label: "1–30" }, { key: "d31_60", label: "31–60" },
+  { key: "d61_90", label: "61–90" }, { key: "d90_plus", label: "90+" },
+];
+
+function ApTab() {
+  const [asOf, setAsOf] = useState(todayMyt());
+  const { data, isLoading } = useFetch<{ report: AgedPayables }>(`/api/finance/reports/aged-payables?asOf=${asOf}`);
+  return (
+    <div className="space-y-3">
+      <div className="flex flex-wrap items-end gap-2">
+        <label className="text-xs text-muted-foreground">As of
+          <input type="date" value={asOf} onChange={(e) => setAsOf(e.target.value)} className="ml-2 rounded border px-2 py-1 text-sm" />
+        </label>
+        {data?.report && <span className="ml-auto text-xs text-muted-foreground">{data.report.invoiceCount} open bills · <span className="font-medium text-foreground">{RM(data.report.grandTotal)}</span> outstanding</span>}
+      </div>
+      {isLoading || !data?.report ? <div className="py-12 text-center text-sm text-muted-foreground">Loading…</div> : (
+        <div className="overflow-x-auto rounded-lg border">
+          <table className="w-full min-w-[720px] text-sm">
+            <thead><tr className="border-b bg-muted/40 text-left text-muted-foreground">
+              <th className="px-3 py-2 font-medium">Supplier</th>
+              {AP_COLS.map((c) => <th key={c.key} className="px-3 py-2 text-right font-medium">{c.label}</th>)}
+              <th className="px-3 py-2 text-right font-medium">Total</th>
+            </tr></thead>
+            <tbody className="divide-y">
+              {data.report.rows.map((r) => (
+                <tr key={r.vendor} className="hover:bg-muted/40">
+                  <td className="px-3 py-1.5">{r.vendor} <span className="text-[10px] text-muted-foreground">({r.count})</span></td>
+                  {AP_COLS.map((c) => <td key={c.key} className={`px-3 py-1.5 text-right tabular-nums ${c.key === "d90_plus" && r[c.key] ? "text-red-600" : ""}`}>{r[c.key] ? RM(r[c.key]) : ""}</td>)}
+                  <td className="px-3 py-1.5 text-right font-medium tabular-nums">{RM(r.total)}</td>
+                </tr>
+              ))}
+            </tbody>
+            <tfoot><tr className="border-t-2 font-semibold">
+              <td className="px-3 py-2">Total</td>
+              {AP_COLS.map((c) => <td key={c.key} className="px-3 py-2 text-right tabular-nums">{RM(data.report.totals[c.key])}</td>)}
+              <td className="px-3 py-2 text-right tabular-nums">{RM(data.report.grandTotal)}</td>
+            </tr></tfoot>
+          </table>
+        </div>
+      )}
+      <p className="text-[11px] text-muted-foreground">Open supplier bills by how overdue they are (from due date). Aged Receivables is not shown — sales settle same-day via card/QR/grab, so there is no open receivables ledger.</p>
+    </div>
+  );
+}
+
 export default function FinanceReportsPage() {
-  const [tab, setTab] = useState<"pnl" | "bs" | "cf" | "tb" | "gl" | "audit">("pnl");
+  const [tab, setTab] = useState<"pnl" | "bs" | "cf" | "tb" | "gl" | "ap" | "audit">("pnl");
   const [glAccount, setGlAccount] = useState("1000-01"); // shared so TB rows can drill into GL
 
   return (
@@ -669,6 +718,7 @@ export default function FinanceReportsPage() {
             { id: "cf", label: "Cash Flow" },
             { id: "tb", label: "Trial Balance" },
             { id: "gl", label: "General Ledger" },
+            { id: "ap", label: "Aged Payables" },
             { id: "audit", label: "Auditor pack" },
           ].map((t) => (
             <button
@@ -698,6 +748,7 @@ export default function FinanceReportsPage() {
       {tab === "cf" && <CfTab />}
       {tab === "tb" && <TbTab onDrill={(code) => { setGlAccount(code); setTab("gl"); }} />}
       {tab === "gl" && <GlTab account={glAccount} setAccount={setGlAccount} />}
+      {tab === "ap" && <ApTab />}
       {tab === "audit" && <AuditorPack />}
     </div>
   );

--- a/apps/backoffice/src/app/api/finance/reports/aged-payables/route.ts
+++ b/apps/backoffice/src/app/api/finance/reports/aged-payables/route.ts
@@ -1,0 +1,21 @@
+// GET /api/finance/reports/aged-payables?asOf=YYYY-MM-DD
+
+import { NextRequest, NextResponse } from "next/server";
+import { requireAuth } from "@/lib/auth";
+import { buildAgedPayables } from "@/lib/finance/reports/aging";
+
+export const dynamic = "force-dynamic";
+export const maxDuration = 60;
+
+export async function GET(req: NextRequest) {
+  const auth = await requireAuth(req);
+  if (auth.error) return auth.error;
+  if (!["OWNER", "ADMIN"].includes(auth.user.role)) return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  const asOf = new URL(req.url).searchParams.get("asOf");
+  if (!asOf || !/^\d{4}-\d{2}-\d{2}$/.test(asOf)) return NextResponse.json({ error: "asOf (YYYY-MM-DD) required" }, { status: 400 });
+  try {
+    return NextResponse.json({ report: await buildAgedPayables({ asOf }) });
+  } catch (err) {
+    return NextResponse.json({ error: err instanceof Error ? err.message : String(err) }, { status: 500 });
+  }
+}

--- a/apps/backoffice/src/lib/finance/reports/aging.ts
+++ b/apps/backoffice/src/lib/finance/reports/aging.ts
@@ -1,0 +1,72 @@
+// Aged Payables — outstanding supplier bills bucketed by how overdue they are
+// (Current / 1-30 / 31-60 / 61-90 / 90+), per vendor. The AP report Bukku has
+// and we lacked. Reads the procurement Invoice table directly, so it works now
+// (independent of the GL). Aged Receivables has no real source here — the
+// business settles sales same-day via card/QR/grab debtors, so there is no open
+// customer-invoice ledger to age.
+
+import { prisma } from "@/lib/prisma";
+
+function round2(n: number): number {
+  return Math.round(n * 100) / 100;
+}
+
+type Bucket = "current" | "d1_30" | "d31_60" | "d61_90" | "d90_plus";
+export type AgedVendorRow = {
+  vendor: string;
+  count: number;
+  current: number; d1_30: number; d31_60: number; d61_90: number; d90_plus: number;
+  total: number;
+};
+export type AgedPayables = {
+  asOf: string;
+  rows: AgedVendorRow[];
+  totals: { current: number; d1_30: number; d31_60: number; d61_90: number; d90_plus: number };
+  grandTotal: number;
+  invoiceCount: number;
+};
+
+function bucketFor(daysOverdue: number): Bucket {
+  if (daysOverdue <= 0) return "current";
+  if (daysOverdue <= 30) return "d1_30";
+  if (daysOverdue <= 60) return "d31_60";
+  if (daysOverdue <= 90) return "d61_90";
+  return "d90_plus";
+}
+
+export async function buildAgedPayables(input: { asOf: string }): Promise<AgedPayables> {
+  const asOfDate = new Date(`${input.asOf}T23:59:59Z`);
+  const invoices = await prisma.invoice.findMany({
+    where: { status: { notIn: ["PAID", "DRAFT"] } },
+    select: {
+      amount: true, amountPaid: true, dueDate: true, issueDate: true,
+      vendorName: true, supplier: { select: { name: true } },
+    },
+  });
+
+  const byVendor = new Map<string, AgedVendorRow>();
+  const totals = { current: 0, d1_30: 0, d31_60: 0, d61_90: 0, d90_plus: 0 };
+  let grandTotal = 0, invoiceCount = 0;
+
+  for (const inv of invoices) {
+    const outstanding = round2(Number(inv.amount) - Number(inv.amountPaid ?? 0));
+    if (outstanding <= 0.005) continue;
+    const vendor = inv.supplier?.name ?? inv.vendorName ?? "(no vendor)";
+    const due = inv.dueDate ?? inv.issueDate;
+    const daysOverdue = due ? Math.floor((asOfDate.getTime() - new Date(due).getTime()) / 86_400_000) : 0;
+    const bucket = bucketFor(daysOverdue);
+
+    const r = byVendor.get(vendor) ?? { vendor, count: 0, current: 0, d1_30: 0, d31_60: 0, d61_90: 0, d90_plus: 0, total: 0 };
+    r[bucket] = round2(r[bucket] + outstanding);
+    r.total = round2(r.total + outstanding);
+    r.count++;
+    byVendor.set(vendor, r);
+
+    totals[bucket] = round2(totals[bucket] + outstanding);
+    grandTotal = round2(grandTotal + outstanding);
+    invoiceCount++;
+  }
+
+  const rows = [...byVendor.values()].sort((a, b) => b.total - a.total);
+  return { asOf: input.asOf, rows, totals, grandTotal, invoiceCount };
+}


### PR DESCRIPTION
Next Bukku-gap report: **Aged Payables**.

Outstanding supplier bills bucketed **Current / 1–30 / 31–60 / 61–90 / 90+** by how overdue they are (from due date), grouped per supplier with a totals row. Reads the procurement Invoice table directly, so it works immediately (no dependency on the GL draining).

Surfaces the real AP position: **~RM477k overdue + RM248k pending** across ~660 open bills — 90+ column flagged red.

**Aged Receivables** is intentionally omitted: the business settles sales same-day via card/QR/grab (cleared as debtors in the GL), so there is no open customer-invoice ledger to age. Noted in the UI.

Remaining Bukku gaps after this: the **bank-reconciliation close** (tie ledger bank to statement) and a **contacts/statements** module.

## Test
- Pure read builder; CI typecheck/build cover it.