### PR TITLE
Fix stock count: apply package conversion factor to base UOM

### DIFF
--- a/apps/staff/src/app/api/stock-checks/[id]/finalize/route.ts
+++ b/apps/staff/src/app/api/stock-checks/[id]/finalize/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse, NextRequest } from "next/server";
-import { isCleanCount } from "@celsius/db";
+import { isCleanCount, baseQtyByProduct } from "@celsius/db";
 import { prisma } from "@/lib/prisma";
 import { setStockBalance } from "@/lib/stock";
 import { getSession } from "@/lib/auth";
@@ -31,6 +31,7 @@ export async function POST(req: NextRequest, { params }: { params: Promise<{ id:
           productPackageId: true,
           expectedQty: true,
           countedQty: true,
+          productPackage: { select: { conversionFactor: true } },
         },
       },
     },
@@ -88,19 +89,40 @@ export async function POST(req: NextRequest, { params }: { params: Promise<{ id:
     return NextResponse.json({ error: "Already finalized by someone else" }, { status: 409 });
   }
 
+  // Convert each counted line from package units to the product's base UOM
+  // (StockBalance is tracked in base UOM everywhere else — receiving, wastage,
+  // inventory, par levels). Counting "22 packets" must land as 22 × pack size,
+  // not a raw 22. Lines for the same product are summed into one base total.
+  const baseTotals = baseQtyByProduct(
+    count.items
+      .filter((i) => i.countedQty != null)
+      .map((i) => ({
+        productId: i.productId,
+        countedQty: i.countedQty,
+        conversionFactor: i.productPackage?.conversionFactor ?? 1,
+      })),
+  );
+  const productIds = [...baseTotals.keys()];
+
+  // A physical count is authoritative for total on-hand, so it writes to the
+  // canonical per-product row (productPackageId = null) that receiving and
+  // wastage also use. Zero out any leftover per-package balance rows for these
+  // products first, otherwise the inventory reader — which sums across all
+  // package rows — would double-count them against the fresh base total.
+  if (productIds.length > 0) {
+    await prisma.stockBalance.updateMany({
+      where: { outletId: count.outletId, productId: { in: productIds }, productPackageId: { not: null } },
+      data: { quantity: 0, lastUpdated: now },
+    });
+  }
+
   // Run stock balance updates — chunked at 20 to bound concurrency.
-  const itemsToUpdate = count.items.filter((i) => i.countedQty != null);
   const CHUNK = 20;
-  for (let i = 0; i < itemsToUpdate.length; i += CHUNK) {
-    const chunk = itemsToUpdate.slice(i, i + CHUNK);
+  for (let i = 0; i < productIds.length; i += CHUNK) {
+    const chunk = productIds.slice(i, i + CHUNK);
     await Promise.all(
-      chunk.map((it) =>
-        setStockBalance(
-          count.outletId,
-          it.productId,
-          Number(it.countedQty),
-          it.productPackageId ?? null,
-        ),
+      chunk.map((productId) =>
+        setStockBalance(count.outletId, productId, baseTotals.get(productId)!, null),
       ),
     );
   }

--- a/apps/staff/src/app/api/stock-checks/route.ts
+++ b/apps/staff/src/app/api/stock-checks/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse, NextRequest } from "next/server";
-import { isCleanCount } from "@celsius/db";
+import { isCleanCount, baseQtyByProduct } from "@celsius/db";
 import { prisma } from "@/lib/prisma";
 import { setStockBalance } from "@/lib/stock";
 import { getSession } from "@/lib/auth";
@@ -105,23 +105,42 @@ export async function POST(req: NextRequest) {
     },
   });
 
-  // Update stock balances from counted quantities. Monthly counts can have
-  // 200+ items — firing them all in parallel exhausts the Supavisor pool
-  // and the Vercel function times out before responding (the StockCount
-  // insert above still succeeds, so the user sees "submit doesn't work"
-  // and keeps tapping, producing duplicate StockCount rows). Chunked to
-  // bound concurrency.
-  const itemsToUpdate = items.filter(
-    (item: { countedQty?: number | null }) =>
-      item.countedQty !== null && item.countedQty !== undefined,
-  ) as Array<{ productId: string; countedQty: number; productPackageId?: string | null }>;
+  // Update stock balances from counted quantities. Counts happen in package
+  // units ("22 packets") but StockBalance is tracked in the product's base UOM,
+  // so multiply each line by its package conversionFactor before storing and
+  // write to the canonical per-product row (productPackageId = null) that
+  // receiving and wastage use. Reads conversionFactor off the created items,
+  // which include productPackage.
+  const baseTotals = baseQtyByProduct(
+    stockCount.items
+      .filter((i) => i.countedQty != null)
+      .map((i) => ({
+        productId: i.productId,
+        countedQty: i.countedQty,
+        conversionFactor: i.productPackage?.conversionFactor ?? 1,
+      })),
+  );
+  const productIds = [...baseTotals.keys()];
 
+  // Zero any leftover per-package balance rows for these products so the
+  // inventory reader (which sums across package rows) doesn't double-count
+  // them against the fresh base total.
+  if (productIds.length > 0) {
+    await prisma.stockBalance.updateMany({
+      where: { outletId, productId: { in: productIds }, productPackageId: { not: null } },
+      data: { quantity: 0, lastUpdated: now },
+    });
+  }
+
+  // Monthly counts can have 200+ items — firing them all in parallel exhausts
+  // the Supavisor pool and the Vercel function times out before responding.
+  // Chunked to bound concurrency.
   const CHUNK_SIZE = 20;
-  for (let i = 0; i < itemsToUpdate.length; i += CHUNK_SIZE) {
-    const chunk = itemsToUpdate.slice(i, i + CHUNK_SIZE);
+  for (let i = 0; i < productIds.length; i += CHUNK_SIZE) {
+    const chunk = productIds.slice(i, i + CHUNK_SIZE);
     await Promise.all(
-      chunk.map((item) =>
-        setStockBalance(outletId, item.productId, item.countedQty, item.productPackageId ?? null),
+      chunk.map((productId) =>
+        setStockBalance(outletId, productId, baseTotals.get(productId)!, null),
       ),
     );
   }

--- a/packages/db/src/__tests__/stock-count.test.ts
+++ b/packages/db/src/__tests__/stock-count.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect } from "vitest";
+import { baseQtyByProduct, countDiscrepancies, isCleanCount } from "../stock-count";
+
+describe("baseQtyByProduct", () => {
+  it("multiplies the counted package qty by its conversion factor", () => {
+    // The reported bug: 22 packets of black napkin, 50 pcs per packet.
+    // Must store 1100 base units, not a raw 22.
+    const totals = baseQtyByProduct([
+      { productId: "napkin", countedQty: 22, conversionFactor: 50 },
+    ]);
+    expect(totals.get("napkin")).toBe(1100);
+  });
+
+  it("treats a missing/undefined conversion factor as 1 (base UOM)", () => {
+    const totals = baseQtyByProduct([
+      { productId: "milk", countedQty: 7 },
+      { productId: "sugar", countedQty: 3, conversionFactor: undefined },
+    ]);
+    expect(totals.get("milk")).toBe(7);
+    expect(totals.get("sugar")).toBe(3);
+  });
+
+  it("treats a zero or negative conversion factor as 1 (guards bad data)", () => {
+    const totals = baseQtyByProduct([
+      { productId: "a", countedQty: 4, conversionFactor: 0 },
+      { productId: "b", countedQty: 4, conversionFactor: -3 },
+    ]);
+    expect(totals.get("a")).toBe(4);
+    expect(totals.get("b")).toBe(4);
+  });
+
+  it("sums multiple package lines for the same product into one base total", () => {
+    // Same product counted in two packages: 2 cartons (×24) + 5 bottles (×1).
+    const totals = baseQtyByProduct([
+      { productId: "cola", countedQty: 2, conversionFactor: 24 },
+      { productId: "cola", countedQty: 5, conversionFactor: 1 },
+    ]);
+    expect(totals.get("cola")).toBe(53);
+  });
+
+  it("ignores lines with a null counted qty (not yet counted)", () => {
+    const totals = baseQtyByProduct([
+      { productId: "x", countedQty: null, conversionFactor: 10 },
+    ]);
+    expect(totals.has("x")).toBe(false);
+  });
+
+  it("accepts Decimal-like string/object quantities and factors", () => {
+    const totals = baseQtyByProduct([
+      { productId: "y", countedQty: "3", conversionFactor: "12" },
+      { productId: "z", countedQty: { toString: () => "1.5" }, conversionFactor: { toString: () => "2" } },
+    ]);
+    expect(totals.get("y")).toBe(36);
+    expect(totals.get("z")).toBe(3);
+  });
+});
+
+describe("countDiscrepancies / isCleanCount", () => {
+  it("flags only counted items whose known baseline differs", () => {
+    expect(
+      countDiscrepancies([
+        { expectedQty: 10, countedQty: 10 }, // match
+        { expectedQty: 10, countedQty: 8 }, // variance
+        { expectedQty: null, countedQty: 5 }, // no baseline → can't flag
+      ]),
+    ).toBe(1);
+  });
+
+  it("treats a count with no baselines as clean (auto-approve)", () => {
+    expect(isCleanCount([{ expectedQty: null, countedQty: 5 }])).toBe(true);
+  });
+});

--- a/packages/db/src/stock-count.ts
+++ b/packages/db/src/stock-count.ts
@@ -44,3 +44,40 @@ export function countDiscrepancies(items: VarianceItem[]): number {
 export function isCleanCount(items: VarianceItem[]): boolean {
   return countDiscrepancies(items) === 0;
 }
+
+export interface CountedLine {
+  productId: string;
+  /** Quantity as physically counted — in the *package's* units, not base UOM. */
+  countedQty: QtyLike;
+  /**
+   * The counted package's conversion factor (base-UOM units per package). A
+   * missing/invalid/≤0 factor is treated as 1 (item counted directly in its
+   * base UOM, or an un-packaged item).
+   */
+  conversionFactor?: QtyLike;
+}
+
+/**
+ * Convert counted lines into base-UOM totals per product.
+ *
+ * Staff count in whatever package they physically handle ("22 packets"), but
+ * StockBalance is tracked in the product's base UOM (see the wastage/inventory
+ * routes: "Stock is tracked in product baseUom"). Each line must therefore be
+ * multiplied by its package conversionFactor before it lands in a balance —
+ * skipping this stored 22 base units for "22 packets" instead of 22 × pack size.
+ *
+ * Lines with a null countedQty are ignored (not yet counted). Multiple lines
+ * for the same product — e.g. the same item counted in two packages — are
+ * summed, so the result is the product's full on-hand in base UOM.
+ */
+export function baseQtyByProduct(lines: CountedLine[]): Map<string, number> {
+  const totals = new Map<string, number>();
+  for (const line of lines) {
+    const counted = toNum(line.countedQty);
+    if (counted === null) continue;
+    const cf = toNum(line.conversionFactor);
+    const factor = cf === null || cf <= 0 ? 1 : cf;
+    totals.set(line.productId, (totals.get(line.productId) ?? 0) + counted * factor);
+  }
+  return totals;
+}


### PR DESCRIPTION
## What & why

QA of the stock-count logic surfaced a unit-conversion bug that matches the reported symptom: keying in **22 packets** of black napkin records only **22** on hand instead of 22 × pack size.

Stock counts are entered in **package units** ("22 packets"), but `StockBalance.quantity` is tracked in each product's **base UOM** everywhere else in the system — receiving, wastage (`// Stock is tracked in product baseUom`), the inventory reader, and the par-level calc all assume base units. The count → balance path never applied the package `conversionFactor`:

- `finalize` and the legacy `POST /api/stock-checks` wrote the raw `countedQty` straight into `StockBalance`, so 22 packets became 22 base units.
- They also wrote to a **package-keyed** balance row (`productPackageId = pkg`), while receiving/wastage write to the **null-keyed** per-product row. The inventory reader sums across all rows per product, so the count row and the receiving row got added together in mismatched units.

## Changes

- **`packages/db/src/stock-count.ts`** — new pure `baseQtyByProduct()` helper: converts counted lines to base UOM via `conversionFactor` (a missing / ≤0 factor defaults to 1, i.e. counted directly in base UOM), and sums lines per product.
- **`apps/staff/.../stock-checks/[id]/finalize/route.ts`** and **`apps/staff/.../stock-checks/route.ts`** — both now select the package `conversionFactor`, aggregate to a per-product base total, write it to the canonical per-product row (`productPackageId = null`), and zero any stale per-package rows so the inventory sum can't double-count.
- **`packages/db/src/__tests__/stock-count.test.ts`** — unit tests for the conversion (incl. the reported napkin case), zero/negative-factor guards, multi-package summing, Decimal-like inputs, plus existing discrepancy helpers.

## Testing

- `npx vitest run packages/db` → 8 passing.
- Full app typecheck not run here (dependencies aren't installed in this environment); edits mirror existing Prisma access patterns in the same files.

## Also flagged (not changed — needs a product decision)

`expectedQty` is never populated on the collaborative counting path (`/items`), so `countDiscrepancies` always sees a null baseline → every count auto-approves straight to `REVIEWED` and the manager review queue never fills. This may be intentional "blind count" behaviour, but it makes the entire `SUBMITTED`/review branch dead. Happy to seed `expectedQty` from the current `StockBalance` at count time if that queue is meant to work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01SrjfLzrbEAQdNUBgawNqE5)_