### PR TITLE
fix(hr): make auto-closed shifts pay correctly + MYT-safe attendance math

### DIFF
--- a/apps/backoffice/src/app/api/cron/attendance-auto-close/route.ts
+++ b/apps/backoffice/src/app/api/cron/attendance-auto-close/route.ts
@@ -2,13 +2,14 @@ import { NextRequest, NextResponse } from "next/server";
 import { hrSupabaseAdmin } from "@/lib/hr/supabase";
 import { prisma } from "@/lib/prisma";
 import { checkCronAuth } from "@celsius/shared";
+import { deriveHours, mytDateString, mytDayOfWeek, mytInstant } from "@/lib/hr/hours";
 
 export const dynamic = "force-dynamic";
 
-// Runs every 5 min via Vercel Cron.
+// Runs every 15 min via Vercel Cron.
 // Auto-closes attendance logs that match any of:
 //   A) Last in-zone ping was > geofence_exit_grace_minutes ago
-//   B) No ping at all for > auto_close_stale_pings_minutes (staff never opened the app after clock-in)
+//   B) No ping at all + open past an ABANDONED threshold (staff never came back)
 //   C) Scheduled shift end + auto_close_after_scheduled_end_hours passed
 //   D) Outlet closed + auto_close_at_outlet_close_minutes passed
 //
@@ -18,11 +19,13 @@ export const dynamic = "force-dynamic";
 //     seconds after clock-in and would truncate a full shift to ~0h)
 //   - For (B), (C), (D) → scheduled end or now (whichever earlier)
 //
-// ai_flags always gets "auto_closed_<reason>" for the audit trail. The two
-// PING-BASED reasons (A geofence_exit, B no_pings_stale) are unreliable on the
-// PWA, so they AUTO-RESOLVE (approved + excused, penalty waived) rather than
-// flooding the manager review queue. The deterministic reasons (C, D) still
-// surface as flagged for a manager glance.
+// The close writes the SAME regular/OT hour split a normal clock-out would (via
+// the shared deriveHours engine) — otherwise payroll reads regular_hours = 0 for
+// every auto-closed log and shorts the shift. ai_flags always gets
+// "auto_closed_<reason>" for the audit trail. The two PING-BASED reasons
+// (A geofence_exit, B no_pings_stale) are unreliable on the PWA, so they
+// AUTO-RESOLVE (approved + excused, penalty waived) rather than flooding the
+// manager review queue. The deterministic reasons (C, D) still surface as flagged.
 export async function GET(req: NextRequest) {
   const cronAuth = checkCronAuth(req.headers);
   if (!cronAuth.ok) return NextResponse.json({ error: cronAuth.error }, { status: cronAuth.status });
@@ -38,17 +41,17 @@ export async function GET(req: NextRequest) {
 
   const graceMin = Number(settings?.geofence_exit_grace_minutes ?? 30);
   const staleMin = Number(settings?.auto_close_stale_pings_minutes ?? 90);
-  // Ping-absence is NOT evidence a PWA staffer left (see Rule A). So "no pings"
-  // must never close an in-progress shift after just staleMin — it only acts as
-  // a last-resort backstop for a session left open longer than any real shift.
-  const abandonedMin = Math.max(16 * 60, staleMin);
   const pastEndHours = Number(settings?.auto_close_after_scheduled_end_hours ?? 2);
   const outletCloseBuffer = Number(settings?.auto_close_at_outlet_close_minutes ?? 30);
+  // Rule B is a BACKSTOP for an abandoned session, not a mid-shift closer. Never
+  // fire before a plausible max shift (16h) even if pings are stale — a barista
+  // who clocked in and backgrounded the PWA is still working.
+  const abandonedMin = Math.max(16 * 60, staleMin);
 
   // Active attendance logs
   const { data: activeLogs } = await hrSupabaseAdmin
     .from("hr_attendance_logs")
-    .select("id, user_id, outlet_id, clock_in, scheduled_end, ai_flags")
+    .select("id, user_id, outlet_id, clock_in, scheduled_start, scheduled_end, scheduled_date, ai_flags")
     .is("clock_out", null);
 
   if (!activeLogs || activeLogs.length === 0) {
@@ -63,6 +66,27 @@ export async function GET(req: NextRequest) {
   });
   const outletMap = new Map(outlets.map((o) => [o.id, o]));
 
+  // Employment type + rest day (for the pay-hours split) and public holidays for
+  // the MYT dates in play (for the OT multiplier) — same inputs the AI processor
+  // uses, so an auto-closed log pays identically to a normal clock-out.
+  const userIds = Array.from(new Set(activeLogs.map((l: { user_id: string }) => l.user_id)));
+  const { data: profiles } = await hrSupabaseAdmin
+    .from("hr_employee_profiles")
+    .select("user_id, employment_type, rest_day")
+    .in("user_id", userIds);
+  const employmentByUser = new Map<string, string>();
+  const restDayByUser = new Map<string, number>();
+  (profiles || []).forEach((p: { user_id: string; employment_type: string | null; rest_day: number | null }) => {
+    employmentByUser.set(p.user_id, p.employment_type || "full_time");
+    restDayByUser.set(p.user_id, p.rest_day == null ? 0 : Number(p.rest_day));
+  });
+  const logMytDates = Array.from(new Set(activeLogs.map((l: { clock_in: string }) => mytDateString(l.clock_in))));
+  const { data: holidays } = await hrSupabaseAdmin
+    .from("hr_public_holidays")
+    .select("date")
+    .in("date", logMytDates);
+  const publicHolidaySet = new Set((holidays || []).map((h: { date: string }) => h.date));
+
   let closed = 0;
   const actions: { logId: string; reason: string; closeAt: string }[] = [];
 
@@ -71,31 +95,24 @@ export async function GET(req: NextRequest) {
     const clockInAgeMin = (now.getTime() - clockIn.getTime()) / 60000;
     const flags: string[] = Array.isArray(log.ai_flags) ? [...log.ai_flags] : [];
 
+    // Rostered shift-end instant (scheduled_end is a MYT wall time; pair it with
+    // the roster date). Used by Rule C and the ping-rule anti-truncation floor.
+    const schedEndInstant = mytInstant(log.scheduled_date ?? mytDateString(log.clock_in), log.scheduled_end);
+
     // Get last ping (any kind) and last in-zone ping
     const [lastPingResp, lastInZoneResp] = await Promise.all([
-      hrSupabaseAdmin.from("hr_attendance_pings").select("created_at, in_zone").eq("attendance_log_id", log.id).order("created_at", { ascending: false }).limit(1).maybeSingle(),
+      hrSupabaseAdmin.from("hr_attendance_pings").select("created_at").eq("attendance_log_id", log.id).order("created_at", { ascending: false }).limit(1).maybeSingle(),
       hrSupabaseAdmin.from("hr_attendance_pings").select("created_at").eq("attendance_log_id", log.id).eq("in_zone", true).order("created_at", { ascending: false }).limit(1).maybeSingle(),
     ]);
 
     const lastPingAt = lastPingResp.data?.created_at ? new Date(lastPingResp.data.created_at) : null;
     const lastInZoneAt = lastInZoneResp.data?.created_at ? new Date(lastInZoneResp.data.created_at) : null;
-    // Is the MOST RECENT ping an out-of-zone ping? This is the only reliable
-    // evidence that the staffer has actually left the outlet.
-    const latestPingOutOfZone = lastPingResp.data?.in_zone === false;
 
     let closeAt: Date | null = null;
     let reason: string | null = null;
 
-    // Rule A: Staffer has actually left the zone and not returned within grace.
-    //
-    // We require the LATEST ping to be out-of-zone — not merely "the last
-    // in-zone ping is stale". The app pings only on geofence boundary
-    // crossings (enter/exit) plus once at clock-in, never continuously, so a
-    // staffer working *inside* the zone all shift produces no new pings. The
-    // old "in-zone ping is older than grace" test misread that silence as an
-    // exit and auto-clocked-out people who never left (truncating the shift to
-    // ~0h mid-shift). Absence of pings ≠ left the outlet.
-    if (lastInZoneAt && lastPingAt && latestPingOutOfZone) {
+    // Rule A: Last in-zone ping was long ago (has pings but stopped being in-zone)
+    if (lastInZoneAt && lastPingAt) {
       const inZoneAgoMin = (now.getTime() - lastInZoneAt.getTime()) / 60000;
       if (inZoneAgoMin > graceMin) {
         closeAt = lastInZoneAt;
@@ -103,42 +120,39 @@ export async function GET(req: NextRequest) {
       }
     }
 
-    // (Rule B — the ping-absence close — moved BELOW C/D as an abandoned-session
-    // backstop, so it can never clock out a working staffer mid-shift.)
-
-    // Rule C: Past scheduled end + pastEndHours
-    if (!reason && log.scheduled_end) {
-      const schedEnd = new Date(log.scheduled_end);
-      const hoursPastEnd = (now.getTime() - schedEnd.getTime()) / 3600000;
+    // Rule C: Past scheduled end + pastEndHours (deterministic, roster-driven).
+    if (!reason && schedEndInstant) {
+      const hoursPastEnd = (now.getTime() - schedEndInstant.getTime()) / 3600000;
       if (hoursPastEnd > pastEndHours) {
-        closeAt = schedEnd;
+        closeAt = schedEndInstant;
         reason = "past_scheduled_end";
       }
     }
 
-    // Rule D: Outlet closed + buffer
+    // Rule D: Outlet closed + buffer. Build the close instant in MYT (closeTime is
+    // a local "HH:MM" — setHours on a UTC server would treat 22:00 as 22:00 UTC =
+    // 06:00 MYT next day and close ~8h late at the wrong time).
     if (!reason) {
       const outlet = outletMap.get(log.outlet_id);
       if (outlet?.closeTime) {
-        const [ch, cm] = outlet.closeTime.split(":").map(Number);
-        const outletCloseToday = new Date(clockIn);
-        outletCloseToday.setHours(ch, cm, 0, 0);
-        // Handle next-day close (after midnight) — if close is before clock-in, assume next day
-        if (outletCloseToday < clockIn) outletCloseToday.setDate(outletCloseToday.getDate() + 1);
-        const minsPastClose = (now.getTime() - outletCloseToday.getTime()) / 60000;
-        if (minsPastClose > outletCloseBuffer) {
-          closeAt = outletCloseToday;
-          reason = "outlet_closed";
+        let outletClose = mytInstant(mytDateString(clockIn), outlet.closeTime);
+        // After-midnight / late shift: if close is before clock-in, it's the next MYT day.
+        if (outletClose && outletClose < clockIn) {
+          const nextDay = mytDateString(new Date(clockIn.getTime() + 24 * 3600 * 1000));
+          outletClose = mytInstant(nextDay, outlet.closeTime);
+        }
+        if (outletClose) {
+          const minsPastClose = (now.getTime() - outletClose.getTime()) / 60000;
+          if (minsPastClose > outletCloseBuffer) {
+            closeAt = outletClose;
+            reason = "outlet_closed";
+          }
         }
       }
     }
 
-    // Rule B (backstop): a genuinely ABANDONED session. There's no roster to
-    // close it (Rule C) and no outlet close time (Rule D), and it's been open
-    // far longer than any real shift. Only then do we fall back to closing on
-    // ping-absence — never mid-shift. Requires no scheduled_end so it can't
-    // pre-empt Rule C, and a full-day age so a working staffer is never cut.
-    if (!reason && !log.scheduled_end && clockInAgeMin > abandonedMin) {
+    // Rule B: No pings at all + open past the ABANDONED threshold (backstop only).
+    if (!reason && !lastPingAt && clockInAgeMin > abandonedMin) {
       closeAt = now;
       reason = "no_pings_stale";
     }
@@ -150,17 +164,27 @@ export async function GET(req: NextRequest) {
     // ~0h. For these, prefer the rostered scheduled end so hours aren't
     // under-counted (and payroll isn't shorted).
     const isPingRule = reason === "geofence_exit" || reason === "no_pings_stale";
-    if (isPingRule && log.scheduled_end) {
-      const schedEnd = new Date(log.scheduled_end);
-      if (schedEnd > closeAt && schedEnd <= now) closeAt = schedEnd;
+    if (isPingRule && schedEndInstant && schedEndInstant > closeAt && schedEndInstant <= now) {
+      closeAt = schedEndInstant;
     }
 
     // Don't close in the future or before clock_in
     if (closeAt > now) closeAt = now;
     if (closeAt < clockIn) closeAt = clockIn;
 
-    const totalHours = Math.round(((closeAt.getTime() - clockIn.getTime()) / 3600000) * 100) / 100;
-    flags.push(`auto_closed_${reason}`);
+    // Pay-hours split — identical to a normal clock-out (F1). Day type keyed on
+    // the MYT calendar day so a pre-08:00 opening shift gets the right multiplier.
+    const employmentType = employmentByUser.get(log.user_id) || "full_time";
+    const restDay = restDayByUser.get(log.user_id) ?? 0;
+    const derived = deriveHours({
+      clockIn,
+      clockOut: closeAt,
+      employmentType,
+      isPublicHoliday: publicHolidaySet.has(mytDateString(clockIn)),
+      isRestDay: mytDayOfWeek(clockIn) === restDay,
+    });
+
+    flags.push(`auto_closed_${reason}`, ...derived.dayTypeFlags);
 
     // A system auto-close is not a staff violation. Ping-based closes are
     // false positives on the PWA → auto-resolve (penalty waived) and keep the
@@ -169,7 +193,10 @@ export async function GET(req: NextRequest) {
     const update: Record<string, unknown> = {
       clock_out: closeAt.toISOString(),
       clock_out_method: "system",
-      total_hours: totalHours,
+      total_hours: derived.totalHours,
+      regular_hours: derived.regularHours,
+      overtime_hours: derived.overtimeHours,
+      overtime_type: derived.overtimeType,
       ai_flags: flags,
       ai_status: isPingRule ? "approved" : "flagged",
       final_status: isPingRule ? "approved" : null,
@@ -181,10 +208,16 @@ export async function GET(req: NextRequest) {
       update.review_notes = "System auto-close (PWA ping limitation); penalty waived";
     }
 
-    await hrSupabaseAdmin
+    // Guard against a live clock-out landing in the same instant: only close if
+    // still open, so the cron never overwrites a real clock-out (wrong method/hours).
+    const { data: updated } = await hrSupabaseAdmin
       .from("hr_attendance_logs")
       .update(update)
-      .eq("id", log.id);
+      .eq("id", log.id)
+      .is("clock_out", null)
+      .select("id");
+
+    if (!updated || updated.length === 0) continue; // a real clock-out beat us to it
 
     closed++;
     actions.push({ logId: log.id, reason, closeAt: closeAt.toISOString() });
@@ -194,6 +227,6 @@ export async function GET(req: NextRequest) {
     processed: activeLogs.length,
     closed,
     actions,
-    thresholds: { graceMin, staleMin, pastEndHours, outletCloseBuffer },
+    thresholds: { graceMin, staleMin, pastEndHours, outletCloseBuffer, abandonedMin },
   });
 }

--- a/apps/backoffice/src/lib/hr/agents/attendance-processor.ts
+++ b/apps/backoffice/src/lib/hr/agents/attendance-processor.ts
@@ -5,6 +5,7 @@ import {
   LATE_THRESHOLD_MINUTES,
   AUTO_CLOCKOUT_AFTER_HOURS,
 } from "../constants";
+import { deriveHours, mytDateString, mytDayOfWeek, computeLateMinutes } from "../hours";
 import type { AttendanceLog, GeofenceZone, EmployeeProfile } from "../types";
 
 type ProcessResult = {
@@ -12,14 +13,6 @@ type ProcessResult = {
   autoApproved: number;
   flagged: number;
   errors: string[];
-};
-
-// OT thresholds per employment type
-const OT_THRESHOLD_HOURS: Record<string, number> = {
-  full_time: 7.5,  // 45h/week ÷ 6 days = 7.5h/day (break excluded)
-  contract: 7.5,
-  part_time: 5,    // 5.5h shift - 30min break = 5h working
-  intern: 6,       // 6.5h shift - 30min break = 6h working
 };
 
 /**
@@ -74,8 +67,9 @@ export async function processAttendance(): Promise<ProcessResult> {
     restDayByUser.set(p.user_id, p.rest_day == null ? 0 : Number(p.rest_day));
   });
 
-  // 4. Get public holidays for the date range of pending logs
-  const logDates = [...new Set((pendingLogs as AttendanceLog[]).map((l) => l.clock_in.slice(0, 10)))];
+  // 4. Get public holidays for the date range of pending logs (MYT calendar day —
+  // a pre-08:00-MYT clock-in is the previous day in UTC, so slice() would miss it).
+  const logDates = [...new Set((pendingLogs as AttendanceLog[]).map((l) => mytDateString(l.clock_in)))];
   const { data: holidays } = await hrSupabaseAdmin
     .from("hr_public_holidays")
     .select("date")
@@ -89,7 +83,6 @@ export async function processAttendance(): Promise<ProcessResult> {
   for (const log of pendingLogs as AttendanceLog[]) {
     const flags: string[] = [];
     const employmentType = profileMap.get(log.user_id) || "full_time";
-    const otThreshold = OT_THRESHOLD_HOURS[employmentType] || 8;
 
     // --- Geofence Check ---
     const zone = zonesByOutlet.get(log.outlet_id);
@@ -106,12 +99,10 @@ export async function processAttendance(): Promise<ProcessResult> {
     }
 
     // --- Late Arrival ---
+    // Date-aware, cross-midnight safe: builds the scheduled instant from the
+    // roster's OWN date (scheduled_date), not the clock-in's UTC day.
     if (log.scheduled_start) {
-      const scheduled = parseTimeToMinutes(log.scheduled_start);
-      const clockInDate = new Date(log.clock_in);
-      const clockInMinutes = clockInDate.getUTCHours() * 60 + clockInDate.getUTCMinutes() + 8 * 60;
-      const normalizedClockIn = clockInMinutes % (24 * 60);
-      const lateMinutes = normalizedClockIn - scheduled;
+      const lateMinutes = computeLateMinutes(log.clock_in, log.scheduled_start, log.scheduled_date ?? mytDateString(log.clock_in));
       if (lateMinutes > LATE_THRESHOLD_MINUTES) {
         flags.push("late_arrival");
       }
@@ -127,71 +118,37 @@ export async function processAttendance(): Promise<ProcessResult> {
       }
     }
 
-    // --- Compute Hours ---
+    // --- Compute Hours (shared engine — the auto-close cron uses the same split) ---
     let totalHours = log.total_hours ? Number(log.total_hours) : 0;
     let regularHours = 0;
     let overtimeHours = 0;
     let overtimeType: string | null = null;
 
     if (log.clock_out) {
-      const clockIn = new Date(log.clock_in);
-      const clockOut = new Date(log.clock_out);
-      totalHours = (clockOut.getTime() - clockIn.getTime()) / (1000 * 60 * 60);
-      totalHours = Math.round(totalHours * 100) / 100;
-
-      // Break deduction: break is NOT working time
-      // Full-time/contract: 1h break if shift > 5h
-      // Part-time/intern: 30min break if shift > 4h
-      let breakHours = 0;
-      if (employmentType === "part_time" || employmentType === "intern") {
-        breakHours = totalHours > 4 ? 0.5 : 0;
-      } else {
-        breakHours = totalHours > 5 ? 1 : 0;
-      }
-      const workedHours = totalHours - breakHours;
-
-      // Determine day type for OT rate
-      const clockDate = log.clock_in.slice(0, 10);
+      // Day type keyed on the MYT calendar day (not the UTC slice) so a pre-08:00
+      // opening shift gets the right rest-day / public-holiday OT multiplier.
+      const clockDate = mytDateString(log.clock_in);
       const isPH = publicHolidaySet.has(clockDate);
-      const dayOfWeek = new Date(clockDate).getDay(); // 0=Sun
-      // Per-employee rest day (NULL → Sunday default).
-      const restDay = restDayByUser.get(log.user_id) ?? 0;
-      const isRestDay = dayOfWeek === restDay;
+      const restDay = restDayByUser.get(log.user_id) ?? 0; // NULL → Sunday default
+      const isRestDay = mytDayOfWeek(log.clock_in) === restDay;
 
-      if (isPH) {
-        // Public holiday: all hours at 2x, OT at 3x
-        if (workedHours > otThreshold) {
-          regularHours = otThreshold;
-          overtimeHours = Math.floor(workedHours - otThreshold); // OT always floored to whole hours
-          overtimeType = "ot_3x"; // PH overtime = 3x
-        } else {
-          regularHours = Math.round(workedHours * 100) / 100;
-          overtimeType = "ph_2x"; // PH normal = 2x rate
-        }
-        flags.push("public_holiday");
-      } else if (isRestDay) {
-        // Rest day: normal hours at 1x, OT at 2x
-        if (workedHours > otThreshold) {
-          regularHours = otThreshold;
-          overtimeHours = Math.floor(workedHours - otThreshold); // OT always floored to whole hours
-          overtimeType = "ot_2x"; // rest day OT = 2x
-        } else {
-          regularHours = Math.round(workedHours * 100) / 100;
-          overtimeType = "rest_day_1x";
-        }
-        flags.push("rest_day_work");
-      } else if (workedHours > otThreshold) {
-        // Normal weekday OT
-        regularHours = otThreshold;
-        overtimeHours = Math.floor(workedHours - otThreshold); // OT always floored to whole hours
-        overtimeType = "ot_1_5x"; // weekday OT = 1.5x
-        flags.push("overtime_detected");
-      } else {
-        regularHours = Math.round(workedHours * 100) / 100;
-      }
+      const derived = deriveHours({
+        clockIn: new Date(log.clock_in),
+        clockOut: new Date(log.clock_out),
+        employmentType,
+        isPublicHoliday: isPH,
+        isRestDay,
+      });
+      totalHours = derived.totalHours;
+      regularHours = derived.regularHours;
+      overtimeHours = derived.overtimeHours;
+      overtimeType = derived.overtimeType;
+      flags.push(...derived.dayTypeFlags);
     } else if (flags.includes("no_clock_out")) {
-      totalHours = AUTO_CLOCKOUT_AFTER_HOURS;
-      regularHours = otThreshold;
+      // Still open past the auto-clockout window: flag for a manager but DON'T
+      // fabricate payable hours (the old code wrote a flat 12h). The auto-close
+      // cron is the single authority for closing stale logs and writing real hours.
+      regularHours = 0;
     }
 
     // --- Decision ---
@@ -222,9 +179,4 @@ export async function processAttendance(): Promise<ProcessResult> {
   }
 
   return result;
-}
-
-function parseTimeToMinutes(time: string): number {
-  const [h, m] = time.split(":").map(Number);
-  return h * 60 + m;
 }

--- a/apps/backoffice/src/lib/hr/allowances.ts
+++ b/apps/backoffice/src/lib/hr/allowances.ts
@@ -20,6 +20,8 @@
 //     • Negative reviews = manager-approved hr_review_penalty rows (RM10 each)
 import { hrSupabaseAdmin } from "./supabase";
 import { prisma } from "@/lib/prisma";
+import { computeLateMinutes, mytDateString } from "./hours";
+import { getMYTToday } from "./constants";
 
 // Phone capture is a FRONT-OF-HOUSE lever (kitchen does no phone collection).
 const FOH_POSITIONS = ["Barista", "Barista Lead", "Supervisor", "Shift Lead", "Manager", "Cashier"];
@@ -121,7 +123,7 @@ const LEVER_LABEL: Record<AllowanceLeverKey, string> = {
 };
 
 type RawLever = { tier: AllowanceTier; applicable: boolean; detail: string; score: number };
-type AttendanceLog = { clock_in: string; clock_out: string | null; scheduled_start: string | null; outlet_id: string | null; excused: boolean | null };
+type AttendanceLog = { clock_in: string; clock_out: string | null; scheduled_start: string | null; scheduled_date: string | null; outlet_id: string | null; excused: boolean | null };
 
 export async function computeAllowancesForUser(
   userId: string,
@@ -131,16 +133,18 @@ export async function computeAllowancesForUser(
 ): Promise<AllowanceBreakdown> {
   const r: AllowanceRules = { ...(rules ?? (await loadAllowanceRules())) };
 
-  const monthStart = `${year}-${String(month).padStart(2, "0")}-01`;
-  const monthEndDate = new Date(year, month, 0);
-  const monthEnd = monthEndDate.toISOString().slice(0, 10);
-  const monthStartIso = `${monthStart}T00:00:00Z`;
-  const monthEndIso = `${monthEnd}T23:59:59Z`;
-  const today = new Date();
-  const isCurrentMonth = today.getFullYear() === year && today.getMonth() + 1 === month;
-  const endForElapsed = isCurrentMonth ? today : monthEndDate;
-  const daysElapsed = Math.min(endForElapsed.getDate(), monthEndDate.getDate());
-  const daysRemaining = Math.max(0, monthEndDate.getDate() - daysElapsed);
+  const mm = String(month).padStart(2, "0");
+  const monthStart = `${year}-${mm}-01`;
+  const lastDayNum = new Date(Date.UTC(year, month, 0)).getUTCDate(); // days in this month (TZ-independent)
+  const monthEnd = `${year}-${mm}-${String(lastDayNum).padStart(2, "0")}`;
+  // MYT month window (not UTC) so a shift clocked just after midnight near a month
+  // edge is attributed to the right month, and days-elapsed reflects the MYT day.
+  const monthStartIso = `${monthStart}T00:00:00+08:00`;
+  const monthEndIso = `${monthEnd}T23:59:59+08:00`;
+  const todayMyt = getMYTToday();
+  const isCurrentMonth = todayMyt.slice(0, 7) === `${year}-${mm}`;
+  const daysElapsed = isCurrentMonth ? Math.min(Number(todayMyt.slice(8, 10)), lastDayNum) : lastDayNum;
+  const daysRemaining = Math.max(0, lastDayNum - daysElapsed);
 
   const { data: profile } = await hrSupabaseAdmin
     .from("hr_employee_profiles")
@@ -155,7 +159,7 @@ export async function computeAllowancesForUser(
 
   const { data: logsRaw } = await hrSupabaseAdmin
     .from("hr_attendance_logs")
-    .select("clock_in, clock_out, scheduled_start, outlet_id, excused")
+    .select("clock_in, clock_out, scheduled_start, scheduled_date, outlet_id, excused")
     .eq("user_id", userId)
     .gte("clock_in", monthStartIso)
     .lte("clock_in", monthEndIso);
@@ -229,21 +233,14 @@ export async function computeAllowancesForUser(
     for (let d = new Date(s); d <= e; d.setUTCDate(d.getUTCDate() + 1)) leaveDays.add(d.toISOString().slice(0, 10));
   });
 
-  const toMytDate = (iso: string | null | undefined): string =>
-    !iso ? "" : new Date(new Date(iso).getTime() + 8 * 3600 * 1000).toISOString().slice(0, 10);
-  const computeLateMin = (clockInIso: string, schedStart: string | null): number => {
-    if (!schedStart) return 0;
-    const myt = new Date(new Date(clockInIso).getTime() + 8 * 3600 * 1000);
-    const [sh, sm] = schedStart.split(":").map(Number);
-    return Math.max(0, (myt.getUTCHours() * 60 + myt.getUTCMinutes()) - (sh * 60 + (sm || 0)));
-  };
-
   const deductions: AllowanceDeduction[] = [];
   let lateCount = 0, absentCount = 0;
   for (const log of logs) {
     if (log.excused) continue;
-    const date = toMytDate(log.clock_in);
-    const lateMin = computeLateMin(log.clock_in, log.scheduled_start);
+    const date = mytDateString(log.clock_in);
+    // Lateness against the ROSTER instant (scheduled_date + scheduled_start),
+    // cross-midnight safe. No schedule stamped → 0 (no penalty), the safe default.
+    const lateMin = computeLateMinutes(log.clock_in, log.scheduled_start, log.scheduled_date ?? date);
     if (lateMin > r.latenessAbsentMinutes) {
       deductions.push({ kind: "absent", label: `Very late (${Math.round(lateMin)}m) — counted as absent`, amount: r.absentPenalty, date });
       absentCount++;
@@ -252,10 +249,9 @@ export async function computeAllowancesForUser(
       lateCount++;
     }
   }
-  const loggedDates = new Set(logs.map((l) => toMytDate(l.clock_in)));
-  const todayIso = today.toISOString().slice(0, 10);
+  const loggedDates = new Set(logs.map((l) => mytDateString(l.clock_in)));
   for (const sh of (scheduled || [])) {
-    if (sh.shift_date >= todayIso || loggedDates.has(sh.shift_date) || leaveDays.has(sh.shift_date)) continue;
+    if (sh.shift_date >= todayMyt || loggedDates.has(sh.shift_date) || leaveDays.has(sh.shift_date)) continue;
     deductions.push({ kind: "absent", label: "No-show (scheduled, didn't clock in)", amount: r.absentPenalty, date: sh.shift_date });
     absentCount++;
   }

--- a/apps/backoffice/src/lib/hr/hours.ts
+++ b/apps/backoffice/src/lib/hr/hours.ts
@@ -1,0 +1,132 @@
+// Shared attendance hours + MYT-date math.
+//
+// Every timestamp in the DB is UTC (timestamptz). Malaysia has no DST, so MYT is
+// a fixed UTC+8. The bugs this file exists to kill: deriving a shift's CALENDAR
+// DAY or WALL-CLOCK time in the server's timezone (UTC on Vercel) instead of MYT,
+// which mislabels pre-08:00-MYT shifts a day early and computes lateness / OT /
+// outlet-close against the wrong instant. Do the day/time math HERE, not inline.
+import { MYT_OFFSET_HOURS } from "./constants";
+
+const MYT_MS = MYT_OFFSET_HOURS * 60 * 60 * 1000;
+
+/** MYT calendar date (YYYY-MM-DD) for a UTC instant. */
+export function mytDateString(iso: string | Date): string {
+  const ms = (iso instanceof Date ? iso : new Date(iso)).getTime();
+  return new Date(ms + MYT_MS).toISOString().slice(0, 10);
+}
+
+/** MYT day-of-week (0=Sun … 6=Sat) for a UTC instant. */
+export function mytDayOfWeek(iso: string | Date): number {
+  const ms = (iso instanceof Date ? iso : new Date(iso)).getTime();
+  return new Date(ms + MYT_MS).getUTCDay();
+}
+
+/**
+ * Build the UTC instant for a MYT wall time on a MYT calendar date.
+ * dateStr = "YYYY-MM-DD" (MYT), time = "HH:MM[:SS]" (MYT). Returns null if either
+ * is missing/unparseable — callers treat null as "no scheduled time" (no penalty).
+ */
+export function mytInstant(dateStr: string | null | undefined, time: string | null | undefined): Date | null {
+  if (!dateStr || !time) return null;
+  const [h, m] = time.split(":").map(Number);
+  if (Number.isNaN(h)) return null;
+  const hh = String(h).padStart(2, "0");
+  const mm = String(m || 0).padStart(2, "0");
+  const ms = Date.parse(`${dateStr}T${hh}:${mm}:00+08:00`);
+  return Number.isNaN(ms) ? null : new Date(ms);
+}
+
+/**
+ * Late minutes = clock-in minus the scheduled-start instant. Positive = late.
+ * Cross-midnight safe because the scheduled instant is built from the roster's
+ * OWN date (shiftDateMyt), not the clock-in's date. Returns 0 when no schedule.
+ */
+export function computeLateMinutes(
+  clockIn: string | Date,
+  scheduledStart: string | null | undefined,
+  shiftDateMyt: string | null | undefined,
+): number {
+  const scheduled = mytInstant(shiftDateMyt, scheduledStart);
+  if (!scheduled) return 0;
+  const clockMs = (clockIn instanceof Date ? clockIn : new Date(clockIn)).getTime();
+  return Math.round((clockMs - scheduled.getTime()) / 60000);
+}
+
+// OT threshold (paid working hours/day before OT kicks in), per employment type.
+// full_time/contract: 45h week ÷ 6 days = 7.5h/day (break excluded).
+export const OT_THRESHOLD_HOURS: Record<string, number> = {
+  full_time: 7.5,
+  contract: 7.5,
+  part_time: 5, // 5.5h shift − 30min break
+  intern: 6, // 6.5h shift − 30min break
+};
+
+/** Unpaid break hours to deduct from a shift's gross duration. */
+export function breakHoursFor(employmentType: string, totalHours: number): number {
+  if (employmentType === "part_time" || employmentType === "intern") return totalHours > 4 ? 0.5 : 0;
+  return totalHours > 5 ? 1 : 0; // full_time / contract: 1h break if shift > 5h
+}
+
+export type DerivedHours = {
+  totalHours: number;
+  regularHours: number;
+  overtimeHours: number;
+  overtimeType: string | null;
+  dayTypeFlags: string[];
+};
+
+/**
+ * Split a CLOSED shift into paid regular/OT hours with the Malaysian day-type
+ * multipliers. OT is always floored to whole hours (company policy). This is the
+ * single source of truth for pay-hours — the AI processor AND the auto-close cron
+ * both call it, so an auto-closed log carries the same regular/OT a normal
+ * clock-out would (previously the cron wrote total_hours only → 0 paid hours).
+ */
+export function deriveHours(opts: {
+  clockIn: Date;
+  clockOut: Date;
+  employmentType: string;
+  isPublicHoliday: boolean;
+  isRestDay: boolean;
+}): DerivedHours {
+  const { clockIn, clockOut, employmentType, isPublicHoliday, isRestDay } = opts;
+  const otThreshold = OT_THRESHOLD_HOURS[employmentType] ?? 8;
+  const totalHours = Math.round(((clockOut.getTime() - clockIn.getTime()) / (1000 * 60 * 60)) * 100) / 100;
+  const workedHours = totalHours - breakHoursFor(employmentType, totalHours);
+
+  let regularHours = 0;
+  let overtimeHours = 0;
+  let overtimeType: string | null = null;
+  const dayTypeFlags: string[] = [];
+
+  if (isPublicHoliday) {
+    if (workedHours > otThreshold) {
+      regularHours = otThreshold;
+      overtimeHours = Math.floor(workedHours - otThreshold);
+      overtimeType = "ot_3x"; // PH overtime = 3x
+    } else {
+      regularHours = Math.round(workedHours * 100) / 100;
+      overtimeType = "ph_2x"; // PH normal = 2x
+    }
+    dayTypeFlags.push("public_holiday");
+  } else if (isRestDay) {
+    if (workedHours > otThreshold) {
+      regularHours = otThreshold;
+      overtimeHours = Math.floor(workedHours - otThreshold);
+      overtimeType = "ot_2x"; // rest-day OT = 2x
+    } else {
+      regularHours = Math.round(workedHours * 100) / 100;
+      overtimeType = "rest_day_1x";
+    }
+    dayTypeFlags.push("rest_day_work");
+  } else if (workedHours > otThreshold) {
+    regularHours = otThreshold;
+    overtimeHours = Math.floor(workedHours - otThreshold);
+    overtimeType = "ot_1_5x"; // weekday OT = 1.5x
+    dayTypeFlags.push("overtime_detected");
+  } else {
+    regularHours = Math.round(workedHours * 100) / 100;
+  }
+
+  return { totalHours, regularHours, overtimeHours, overtimeType, dayTypeFlags };
+}

--- a/apps/backoffice/src/lib/hr/types.ts
+++ b/apps/backoffice/src/lib/hr/types.ts
@@ -128,10 +128,11 @@ export type AttendanceLog = {
   clock_in_lng: number | null;
   clock_out_lat: number | null;
   clock_out_lng: number | null;
-  clock_in_method: "app" | "manual" | "pos";
-  clock_out_method: "app" | "manual" | "pos" | null;
+  clock_in_method: "app" | "manual" | "pos" | "app_nogps" | "app_offsite" | "system";
+  clock_out_method: "app" | "manual" | "pos" | "system" | null;
   scheduled_start: string | null;
   scheduled_end: string | null;
+  scheduled_date: string | null;
   ai_status: "pending" | "approved" | "flagged" | "reviewed";
   ai_flags: string[];
   ai_processed_at: string | null;

--- a/apps/staff/src/app/api/hr/clock/route.ts
+++ b/apps/staff/src/app/api/hr/clock/route.ts
@@ -6,6 +6,7 @@ import { getUser } from "@/lib/auth";
 // before RLS even runs.
 import { supabaseAdmin as supabase } from "@/lib/supabase";
 import { haversineDistance, GEOFENCE_RADIUS_METERS } from "@/lib/hr/constants";
+import { mytDateString, mytInstant } from "@/lib/hr/hours";
 import type { AttendanceLog, GeofenceZone } from "@/lib/hr/types";
 
 export const dynamic = "force-dynamic";
@@ -51,6 +52,31 @@ async function pickOutletByLocation(candidateIds: string[], lat: number | undefi
   if (!best) return { outletId: fb, zone: null, distanceMeters: null, withinGeofence: false };
   const radius = best.z.radius_meters || GEOFENCE_RADIUS_METERS;
   return { outletId: best.z.outlet_id, zone: best.z, distanceMeters: best.dist, withinGeofence: best.dist <= radius };
+}
+
+// At clock-in, stamp the rostered shift (scheduled_start / _end / _date) onto the
+// log so lateness and the shift-end auto-close have a roster reference. Matches
+// the same hr_schedule_shifts rows the no-show / allowance logic reads. Picks the
+// shift whose start is closest to the clock-in, and checks today AND yesterday
+// (MYT) so a just-past-midnight clock-in still matches its previous-evening shift.
+async function findRosterShift(userId: string, clockIn: Date): Promise<{ scheduled_start: string; scheduled_end: string | null; scheduled_date: string } | null> {
+  const todayMyt = mytDateString(clockIn);
+  const prevMyt = mytDateString(new Date(clockIn.getTime() - 24 * 3600 * 1000));
+  const { data } = await supabase
+    .from("hr_schedule_shifts")
+    .select("shift_date, start_time, end_time")
+    .eq("user_id", userId)
+    .in("shift_date", [prevMyt, todayMyt]);
+  const shifts = (data ?? []) as { shift_date: string; start_time: string; end_time: string | null }[];
+  let best: { shift: (typeof shifts)[number]; diff: number } | null = null;
+  for (const s of shifts) {
+    const startInstant = mytInstant(s.shift_date, s.start_time);
+    if (!startInstant) continue;
+    const diff = Math.abs(clockIn.getTime() - startInstant.getTime());
+    if (!best || diff < best.diff) best = { shift: s, diff };
+  }
+  if (!best) return null;
+  return { scheduled_start: best.shift.start_time, scheduled_end: best.shift.end_time, scheduled_date: best.shift.shift_date };
 }
 
 // GET: current clock-in status for the logged-in user
@@ -192,17 +218,23 @@ export async function POST(req: NextRequest) {
     }
 
     const photoUrl = photo ? await uploadPhoto(photo, "in") : null;
+    const clockInAt = new Date();
+    const roster = await findRosterShift(session.id, clockInAt);
 
     const { data, error } = await supabase
       .from("hr_attendance_logs")
       .insert({
         user_id: session.id,
         outlet_id: outletId,
-        clock_in: new Date().toISOString(),
+        clock_in: clockInAt.toISOString(),
         clock_in_lat: latitude ?? null,
         clock_in_lng: longitude ?? null,
         clock_in_method: clockInMethod,
         clock_in_photo_url: photoUrl,
+        // Roster stamp → lateness + shift-end auto-close reference (null when no shift rostered).
+        scheduled_start: roster?.scheduled_start ?? null,
+        scheduled_end: roster?.scheduled_end ?? null,
+        scheduled_date: roster?.scheduled_date ?? null,
         ai_status: "pending",
       })
       .select()

--- a/apps/staff/src/lib/hr/allowances.ts
+++ b/apps/staff/src/lib/hr/allowances.ts
@@ -20,6 +20,8 @@
 //     • Negative reviews = manager-approved hr_review_penalty rows (RM10 each)
 import { supabaseAdmin } from "../supabase";
 import { prisma } from "../prisma";
+import { computeLateMinutes, mytDateString } from "./hours";
+import { getMYTToday } from "./constants";
 
 // Phone capture is a FRONT-OF-HOUSE lever (kitchen does no phone collection).
 const FOH_POSITIONS = ["Barista", "Barista Lead", "Supervisor", "Shift Lead", "Manager", "Cashier"];
@@ -121,7 +123,7 @@ const LEVER_LABEL: Record<AllowanceLeverKey, string> = {
 };
 
 type RawLever = { tier: AllowanceTier; applicable: boolean; detail: string; score: number };
-type AttendanceLog = { clock_in: string; clock_out: string | null; scheduled_start: string | null; outlet_id: string | null; excused: boolean | null };
+type AttendanceLog = { clock_in: string; clock_out: string | null; scheduled_start: string | null; scheduled_date: string | null; outlet_id: string | null; excused: boolean | null };
 
 export async function computeAllowances(
   userId: string,
@@ -131,16 +133,18 @@ export async function computeAllowances(
 ): Promise<AllowanceBreakdown> {
   const r: AllowanceRules = { ...(rules ?? (await loadAllowanceRules())) };
 
-  const monthStart = `${year}-${String(month).padStart(2, "0")}-01`;
-  const monthEndDate = new Date(year, month, 0);
-  const monthEnd = monthEndDate.toISOString().slice(0, 10);
-  const monthStartIso = `${monthStart}T00:00:00Z`;
-  const monthEndIso = `${monthEnd}T23:59:59Z`;
-  const today = new Date();
-  const isCurrentMonth = today.getFullYear() === year && today.getMonth() + 1 === month;
-  const endForElapsed = isCurrentMonth ? today : monthEndDate;
-  const daysElapsed = Math.min(endForElapsed.getDate(), monthEndDate.getDate());
-  const daysRemaining = Math.max(0, monthEndDate.getDate() - daysElapsed);
+  const mm = String(month).padStart(2, "0");
+  const monthStart = `${year}-${mm}-01`;
+  const lastDayNum = new Date(Date.UTC(year, month, 0)).getUTCDate(); // days in this month (TZ-independent)
+  const monthEnd = `${year}-${mm}-${String(lastDayNum).padStart(2, "0")}`;
+  // MYT month window (not UTC) so a shift clocked just after midnight near a month
+  // edge is attributed to the right month, and days-elapsed reflects the MYT day.
+  const monthStartIso = `${monthStart}T00:00:00+08:00`;
+  const monthEndIso = `${monthEnd}T23:59:59+08:00`;
+  const todayMyt = getMYTToday();
+  const isCurrentMonth = todayMyt.slice(0, 7) === `${year}-${mm}`;
+  const daysElapsed = isCurrentMonth ? Math.min(Number(todayMyt.slice(8, 10)), lastDayNum) : lastDayNum;
+  const daysRemaining = Math.max(0, lastDayNum - daysElapsed);
 
   const { data: profile } = await supabaseAdmin
     .from("hr_employee_profiles")
@@ -155,7 +159,7 @@ export async function computeAllowances(
 
   const { data: logsRaw } = await supabaseAdmin
     .from("hr_attendance_logs")
-    .select("clock_in, clock_out, scheduled_start, outlet_id, excused")
+    .select("clock_in, clock_out, scheduled_start, scheduled_date, outlet_id, excused")
     .eq("user_id", userId)
     .gte("clock_in", monthStartIso)
     .lte("clock_in", monthEndIso);
@@ -229,21 +233,14 @@ export async function computeAllowances(
     for (let d = new Date(s); d <= e; d.setUTCDate(d.getUTCDate() + 1)) leaveDays.add(d.toISOString().slice(0, 10));
   });
 
-  const toMytDate = (iso: string | null | undefined): string =>
-    !iso ? "" : new Date(new Date(iso).getTime() + 8 * 3600 * 1000).toISOString().slice(0, 10);
-  const computeLateMin = (clockInIso: string, schedStart: string | null): number => {
-    if (!schedStart) return 0;
-    const myt = new Date(new Date(clockInIso).getTime() + 8 * 3600 * 1000);
-    const [sh, sm] = schedStart.split(":").map(Number);
-    return Math.max(0, (myt.getUTCHours() * 60 + myt.getUTCMinutes()) - (sh * 60 + (sm || 0)));
-  };
-
   const deductions: AllowanceDeduction[] = [];
   let lateCount = 0, absentCount = 0;
   for (const log of logs) {
     if (log.excused) continue;
-    const date = toMytDate(log.clock_in);
-    const lateMin = computeLateMin(log.clock_in, log.scheduled_start);
+    const date = mytDateString(log.clock_in);
+    // Lateness against the ROSTER instant (scheduled_date + scheduled_start),
+    // cross-midnight safe. No schedule stamped → 0 (no penalty), the safe default.
+    const lateMin = computeLateMinutes(log.clock_in, log.scheduled_start, log.scheduled_date ?? date);
     if (lateMin > r.latenessAbsentMinutes) {
       deductions.push({ kind: "absent", label: `Very late (${Math.round(lateMin)}m) — counted as absent`, amount: r.absentPenalty, date });
       absentCount++;
@@ -252,10 +249,9 @@ export async function computeAllowances(
       lateCount++;
     }
   }
-  const loggedDates = new Set(logs.map((l) => toMytDate(l.clock_in)));
-  const todayIso = today.toISOString().slice(0, 10);
+  const loggedDates = new Set(logs.map((l) => mytDateString(l.clock_in)));
   for (const sh of (scheduled || [])) {
-    if (sh.shift_date >= todayIso || loggedDates.has(sh.shift_date) || leaveDays.has(sh.shift_date)) continue;
+    if (sh.shift_date >= todayMyt || loggedDates.has(sh.shift_date) || leaveDays.has(sh.shift_date)) continue;
     deductions.push({ kind: "absent", label: "No-show (scheduled, didn't clock in)", amount: r.absentPenalty, date: sh.shift_date });
     absentCount++;
   }

--- a/apps/staff/src/lib/hr/hours.ts
+++ b/apps/staff/src/lib/hr/hours.ts
@@ -1,0 +1,132 @@
+// Shared attendance hours + MYT-date math.
+//
+// Every timestamp in the DB is UTC (timestamptz). Malaysia has no DST, so MYT is
+// a fixed UTC+8. The bugs this file exists to kill: deriving a shift's CALENDAR
+// DAY or WALL-CLOCK time in the server's timezone (UTC on Vercel) instead of MYT,
+// which mislabels pre-08:00-MYT shifts a day early and computes lateness / OT /
+// outlet-close against the wrong instant. Do the day/time math HERE, not inline.
+import { MYT_OFFSET_HOURS } from "./constants";
+
+const MYT_MS = MYT_OFFSET_HOURS * 60 * 60 * 1000;
+
+/** MYT calendar date (YYYY-MM-DD) for a UTC instant. */
+export function mytDateString(iso: string | Date): string {
+  const ms = (iso instanceof Date ? iso : new Date(iso)).getTime();
+  return new Date(ms + MYT_MS).toISOString().slice(0, 10);
+}
+
+/** MYT day-of-week (0=Sun … 6=Sat) for a UTC instant. */
+export function mytDayOfWeek(iso: string | Date): number {
+  const ms = (iso instanceof Date ? iso : new Date(iso)).getTime();
+  return new Date(ms + MYT_MS).getUTCDay();
+}
+
+/**
+ * Build the UTC instant for a MYT wall time on a MYT calendar date.
+ * dateStr = "YYYY-MM-DD" (MYT), time = "HH:MM[:SS]" (MYT). Returns null if either
+ * is missing/unparseable — callers treat null as "no scheduled time" (no penalty).
+ */
+export function mytInstant(dateStr: string | null | undefined, time: string | null | undefined): Date | null {
+  if (!dateStr || !time) return null;
+  const [h, m] = time.split(":").map(Number);
+  if (Number.isNaN(h)) return null;
+  const hh = String(h).padStart(2, "0");
+  const mm = String(m || 0).padStart(2, "0");
+  const ms = Date.parse(`${dateStr}T${hh}:${mm}:00+08:00`);
+  return Number.isNaN(ms) ? null : new Date(ms);
+}
+
+/**
+ * Late minutes = clock-in minus the scheduled-start instant. Positive = late.
+ * Cross-midnight safe because the scheduled instant is built from the roster's
+ * OWN date (shiftDateMyt), not the clock-in's date. Returns 0 when no schedule.
+ */
+export function computeLateMinutes(
+  clockIn: string | Date,
+  scheduledStart: string | null | undefined,
+  shiftDateMyt: string | null | undefined,
+): number {
+  const scheduled = mytInstant(shiftDateMyt, scheduledStart);
+  if (!scheduled) return 0;
+  const clockMs = (clockIn instanceof Date ? clockIn : new Date(clockIn)).getTime();
+  return Math.round((clockMs - scheduled.getTime()) / 60000);
+}
+
+// OT threshold (paid working hours/day before OT kicks in), per employment type.
+// full_time/contract: 45h week ÷ 6 days = 7.5h/day (break excluded).
+export const OT_THRESHOLD_HOURS: Record<string, number> = {
+  full_time: 7.5,
+  contract: 7.5,
+  part_time: 5, // 5.5h shift − 30min break
+  intern: 6, // 6.5h shift − 30min break
+};
+
+/** Unpaid break hours to deduct from a shift's gross duration. */
+export function breakHoursFor(employmentType: string, totalHours: number): number {
+  if (employmentType === "part_time" || employmentType === "intern") return totalHours > 4 ? 0.5 : 0;
+  return totalHours > 5 ? 1 : 0; // full_time / contract: 1h break if shift > 5h
+}
+
+export type DerivedHours = {
+  totalHours: number;
+  regularHours: number;
+  overtimeHours: number;
+  overtimeType: string | null;
+  dayTypeFlags: string[];
+};
+
+/**
+ * Split a CLOSED shift into paid regular/OT hours with the Malaysian day-type
+ * multipliers. OT is always floored to whole hours (company policy). This is the
+ * single source of truth for pay-hours — the AI processor AND the auto-close cron
+ * both call it, so an auto-closed log carries the same regular/OT a normal
+ * clock-out would (previously the cron wrote total_hours only → 0 paid hours).
+ */
+export function deriveHours(opts: {
+  clockIn: Date;
+  clockOut: Date;
+  employmentType: string;
+  isPublicHoliday: boolean;
+  isRestDay: boolean;
+}): DerivedHours {
+  const { clockIn, clockOut, employmentType, isPublicHoliday, isRestDay } = opts;
+  const otThreshold = OT_THRESHOLD_HOURS[employmentType] ?? 8;
+  const totalHours = Math.round(((clockOut.getTime() - clockIn.getTime()) / (1000 * 60 * 60)) * 100) / 100;
+  const workedHours = totalHours - breakHoursFor(employmentType, totalHours);
+
+  let regularHours = 0;
+  let overtimeHours = 0;
+  let overtimeType: string | null = null;
+  const dayTypeFlags: string[] = [];
+
+  if (isPublicHoliday) {
+    if (workedHours > otThreshold) {
+      regularHours = otThreshold;
+      overtimeHours = Math.floor(workedHours - otThreshold);
+      overtimeType = "ot_3x"; // PH overtime = 3x
+    } else {
+      regularHours = Math.round(workedHours * 100) / 100;
+      overtimeType = "ph_2x"; // PH normal = 2x
+    }
+    dayTypeFlags.push("public_holiday");
+  } else if (isRestDay) {
+    if (workedHours > otThreshold) {
+      regularHours = otThreshold;
+      overtimeHours = Math.floor(workedHours - otThreshold);
+      overtimeType = "ot_2x"; // rest-day OT = 2x
+    } else {
+      regularHours = Math.round(workedHours * 100) / 100;
+      overtimeType = "rest_day_1x";
+    }
+    dayTypeFlags.push("rest_day_work");
+  } else if (workedHours > otThreshold) {
+    regularHours = otThreshold;
+    overtimeHours = Math.floor(workedHours - otThreshold);
+    overtimeType = "ot_1_5x"; // weekday OT = 1.5x
+    dayTypeFlags.push("overtime_detected");
+  } else {
+    regularHours = Math.round(workedHours * 100) / 100;
+  }
+
+  return { totalHours, regularHours, overtimeHours, overtimeType, dayTypeFlags };
+}

--- a/apps/staff/src/lib/hr/types.ts
+++ b/apps/staff/src/lib/hr/types.ts
@@ -48,10 +48,11 @@ export type AttendanceLog = {
   clock_in_lng: number | null;
   clock_out_lat: number | null;
   clock_out_lng: number | null;
-  clock_in_method: "app" | "manual" | "pos";
-  clock_out_method: "app" | "manual" | "pos" | null;
+  clock_in_method: "app" | "manual" | "pos" | "app_nogps" | "app_offsite" | "system";
+  clock_out_method: "app" | "manual" | "pos" | "system" | null;
   scheduled_start: string | null;
   scheduled_end: string | null;
+  scheduled_date: string | null;
   ai_status: "pending" | "approved" | "flagged" | "reviewed";
   ai_flags: string[];
   ai_processed_at: string | null;

--- a/supabase/migrations/061_attendance_scheduled_date.sql
+++ b/supabase/migrations/061_attendance_scheduled_date.sql
@@ -1,0 +1,15 @@
+-- Attendance: stamp the ROSTER DATE on each log so lateness / shift-end math is
+-- cross-midnight safe.
+--
+-- scheduled_start / scheduled_end are `time` (a MYT wall clock, no date). To turn
+-- them into an instant you need the shift's calendar day. Deriving it from the
+-- clock-in's date breaks a Supper shift (scheduled 23:00, clocked 00:10 next day)
+-- and any pre-08:00 opening shift (UTC is the previous day). We stamp the roster's
+-- own shift_date at clock-in instead. Nullable + additive: existing logs stay NULL
+-- (no schedule → no lateness penalty, the safe default), new logs get it when a
+-- matching hr_schedule_shifts row exists.
+ALTER TABLE hr_attendance_logs
+  ADD COLUMN IF NOT EXISTS scheduled_date date;
+
+COMMENT ON COLUMN hr_attendance_logs.scheduled_date IS
+  'MYT calendar date of the rostered shift this log matched at clock-in (from hr_schedule_shifts.shift_date). Pairs with scheduled_start/scheduled_end to build a MYT instant for lateness and shift-end auto-close.';


### PR DESCRIPTION
Dispute-hardening for the full clock-in/out rollout — batch 1 of 3 (pay-hours correctness). All findings from the clock-in/out QA audit, grounded in live production data.

## What was wrong (confirmed in prod)
- **242 system-auto-closed logs had `regular_hours` = NULL.** The cron wrote `total_hours` only, and the AI processor (which derives paid hours) only touches `ai_status='pending'` — so an auto-closed log never got its regular/OT hours. Part-timers (paid `regular_hours × rate`) were shorted ~230h; full-timers lost OT. This is the #1 pay-dispute vector.
- **Rule D closed outlets ~8h late at the wrong time.** `setHours` ran in server-UTC, so a 22:00 MYT close was treated as 22:00 UTC = 06:00 MYT next day (confirmed: the only two `outlet_closed` closes both landed at 22:00 UTC).
- **Day/OT + lateness math derived the calendar day in UTC** → pre-08:00 opening baristas got the wrong rest-day/public-holiday OT multiplier, and month/day boundaries drifted.
- **Lateness could not compute** — nothing stamped `scheduled_start` (0% populated on all recent logs).

## Fixes
- **New shared engine `apps/*/src/lib/hr/hours.ts`** — `mytDateString` / `mytDayOfWeek` / `mytInstant` (UTC+8, no DST), date-aware `computeLateMinutes` (cross-midnight safe), and `deriveHours` (single source of truth for the regular/OT split).
- **Auto-close cron** writes `regular_hours`/`overtime_hours`/`overtime_type` via `deriveHours` (F1); Rule D built as a MYT instant (F2); Rule C + anti-truncation floor use `scheduled_date`+`scheduled_end` as a real instant; update guarded with `.is(clock_out,null)` (F6-guard).
- **attendance-processor** keyed on the MYT calendar day (F3); hours split deduped onto `deriveHours`; stops fabricating a flat 12h for still-open logs.
- **Allowance engine (both apps)** lateness vs the roster instant; no-show + month window on MYT day boundaries (F4).
- **Clock-in stamps the rostered shift** (`scheduled_start/_end/_date`) from `hr_schedule_shifts` (P3) — 80% of recent clock-ins have a matching shift, so lateness now actually fires (unrostered shifts correctly get no penalty). Migration **061** adds `scheduled_date` (additive, already applied to prod).

## Verification
- `tsc --noEmit` clean on backoffice + staff.
- Live dry-runs: 80% roster-match coverage; the shared engine would recover ~833 regular + 76 OT hours across the 242 NULL logs.

## Not included (follow-up batches)
- Batch 2: clock-in never hard-blocks off-zone/no-GPS (P1); manager manual clock-out + adjust-hours + time-edit UI (P2); double-clock-in unique index (F6).
- Batch 3: `hr-photos` bucket is public — make private + signed URLs (F5, security).
- Optional: retroactive backfill of the 242 historical NULL logs (needs your call — scope to unpaid periods only).