### PR TITLE
fix(hr): never lock a barista out of clock-in + block double clock-in

### DIFF
--- a/apps/staff/src/app/(ops)/hr/clock/page.tsx
+++ b/apps/staff/src/app/(ops)/hr/clock/page.tsx
@@ -21,9 +21,13 @@ type ClockStatus = {
 };
 
 export default function ClockPage() {
-  const { data: status, mutate } = useFetch<ClockStatus>("/api/hr/clock");
-  const [loading, setLoading] = useState(false);
   const [gps, setGps] = useState<{ lat: number; lng: number } | null>(null);
+  // Pass GPS to the status call so a multi-outlet staffer sees the geofence for
+  // the outlet they're ACTUALLY at (GET picks nearest by coords), not a fallback.
+  const { data: status, mutate } = useFetch<ClockStatus>(
+    gps ? `/api/hr/clock?lat=${gps.lat}&lng=${gps.lng}` : "/api/hr/clock",
+  );
+  const [loading, setLoading] = useState(false);
   const [gpsError, setGpsError] = useState<string | null>(null);
   const [gpsLoading, setGpsLoading] = useState(true);
   const [result, setResult] = useState<{ success: boolean; message: string; withinGeofence?: boolean } | null>(null);
@@ -312,17 +316,17 @@ export default function ClockPage() {
       )}
 
       {/* Clock Button */}
-      {/* Clock-in requires being within geofence; clock-out allowed anywhere */}
+      {/* SOFT CONTROL: clock-in is NEVER hard-blocked (a barista must never be
+          locked out of starting their shift). Off-zone / no-GPS clock-ins go
+          through and the server tags them for review. Clock-out still needs GPS
+          to satisfy the same-outlet gate; if it's missing the server explains why. */}
       <button
         onClick={handleClock}
         disabled={
           loading ||
           gpsLoading ||
           !status ||
-          !!gpsError ||
-          !gps ||
-          (!cameraReady && !cameraError) ||
-          (!isClockedIn && !!status?.geofence && !withinZone)
+          (!cameraReady && !cameraError)
         }
         className={`flex h-32 w-32 flex-col items-center justify-center rounded-full shadow-lg transition-all active:scale-95 disabled:opacity-50 ${
           isClockedIn
@@ -345,17 +349,19 @@ export default function ClockPage() {
         )}
       </button>
 
-      {/* GPS required warning */}
+      {/* GPS warning — soft for clock-in, required for clock-out (server gate) */}
       {gpsError && (
-        <p className="mt-3 text-center text-xs font-medium text-red-600">
-          Location permission is required to clock in. Please enable it in your browser settings.
+        <p className="mt-3 text-center text-xs font-medium text-amber-700">
+          {isClockedIn
+            ? "Location is needed to clock out. Enable it in your browser settings, or ask your manager to clock you out."
+            : "No location detected. You can still clock in, but it will be flagged for review."}
         </p>
       )}
 
-      {/* Outside geofence warning */}
+      {/* Outside geofence — clock-in still allowed, just flagged */}
       {!isClockedIn && !gpsLoading && !gpsError && status?.geofence && !withinZone && (
         <p className="mt-3 text-center text-xs font-medium text-amber-700">
-          You must be at {status.geofence.name} to clock in. {distanceInfo}.
+          You are {distanceInfo} from {status.geofence.name}. You can still clock in, but it will be flagged for review.
         </p>
       )}
 

--- a/apps/staff/src/app/api/hr/clock/route.ts
+++ b/apps/staff/src/app/api/hr/clock/route.ts
@@ -241,6 +241,11 @@ export async function POST(req: NextRequest) {
       .single();
 
     if (error) {
+      // 23505 = the one-open-log-per-user partial unique index: a concurrent
+      // clock-in (double tap / retry) beat this one. Treat as already clocked in.
+      if ((error as { code?: string }).code === "23505") {
+        return NextResponse.json({ error: "Already clocked in" }, { status: 400 });
+      }
       return NextResponse.json({ error: error.message }, { status: 500 });
     }
 

--- a/supabase/migrations/062_attendance_one_open_log.sql
+++ b/supabase/migrations/062_attendance_one_open_log.sql
@@ -1,0 +1,12 @@
+-- Prevent a double clock-in creating two overlapping OPEN logs.
+--
+-- The clock-in guard is a non-atomic check-then-insert: two rapid taps, a retry,
+-- or a flaky-network resubmit can both pass the "already clocked in?" SELECT
+-- before either INSERT lands, leaving a user with two open logs. Clock-out then
+-- closes only the newest, and the cron auto-closes the orphan later at the wrong
+-- time = a phantom second shift with wrong hours. This partial unique index lets
+-- the DB reject the second open log; the route maps the 23505 conflict to a
+-- friendly "Already clocked in".
+CREATE UNIQUE INDEX IF NOT EXISTS hr_attendance_logs_one_open_per_user
+  ON hr_attendance_logs (user_id)
+  WHERE clock_out IS NULL;


### PR DESCRIPTION
Dispute-hardening batch 2 of 3 (clock reliability). Stacked on #671 — review/merge that first.

## Fixes
- **Clock-in is never hard-blocked (P1).** The button was `disabled` on out-of-zone or GPS error, which defeated the server's existing warn+allow+tag soft-control. A barista whose GPS drifts past the 100m zone (indoor drift) or whose permission hiccups literally could not start their shift → no record → marked absent → pay dispute. Now off-zone / no-GPS clock-ins go through and are tagged (`app_offsite` / `app_nogps`) for review. Clock-**out** still needs GPS for the same-outlet gate; the copy now explains why instead of showing a dead button.
- **Status call passes GPS (L2)** so a multi-outlet staffer is checked against the outlet they're actually at, not the no-GPS fallback zone.
- **Double clock-in blocked (F6).** The check-then-insert guard is not atomic; a double tap / retry could create two overlapping open logs (phantom second shift auto-closed later at the wrong time). Migration **062** adds a partial unique index `one-open-log-per-user`; the route maps the 23505 conflict to "Already clocked in". Verified no existing duplicate open logs before applying.

## Verification
- `tsc --noEmit` clean on staff. Migration 062 applied to prod (no dup-open-log conflicts).

## Remaining (batch 3)
- `hr-photos` bucket is public — make private + signed URLs (F5, security).
- Manager manual clock-out + adjust-hours + time-edit in the attendance review UI (P2).