### PR TITLE
fix(hr): make attendance selfies private (signed URLs)

### DIFF
--- a/apps/backoffice/src/app/api/hr/attendance/route.ts
+++ b/apps/backoffice/src/app/api/hr/attendance/route.ts
@@ -3,6 +3,7 @@ import { getSession } from "@/lib/auth";
 import { hrSupabaseAdmin } from "@/lib/hr/supabase";
 import { prisma } from "@/lib/prisma";
 import { getAccessibleOutletIds } from "@/lib/hr/scope";
+import { signAttendancePhotos } from "@/lib/hr/photos";
 
 export const dynamic = "force-dynamic";
 
@@ -86,10 +87,18 @@ export async function GET(req: NextRequest) {
   const userMap = new Map(users.map((u) => [u.id, u]));
   const outletMap = new Map(outlets.map((o) => [o.id, o.name]));
 
-  const enriched = (data || []).map((log: { user_id: string; outlet_id: string }) => {
+  // Attendance selfies live in a PRIVATE bucket — swap the stored path for a
+  // short-lived signed URL so the review UI can render them without exposure.
+  const photoMap = await signAttendancePhotos(
+    (data || []).flatMap((l: { clock_in_photo_url: string | null; clock_out_photo_url: string | null }) => [l.clock_in_photo_url, l.clock_out_photo_url]),
+  );
+
+  const enriched = (data || []).map((log: { user_id: string; outlet_id: string; clock_in_photo_url: string | null; clock_out_photo_url: string | null }) => {
     const u = userMap.get(log.user_id);
     return {
       ...log,
+      clock_in_photo_url: log.clock_in_photo_url ? (photoMap.get(log.clock_in_photo_url) ?? null) : null,
+      clock_out_photo_url: log.clock_out_photo_url ? (photoMap.get(log.clock_out_photo_url) ?? null) : null,
       user_name: u?.fullName || u?.name || null,
       user_nickname: u?.name || null,
       outlet_name: outletMap.get(log.outlet_id) || null,

--- a/apps/backoffice/src/app/api/hr/employees/route.ts
+++ b/apps/backoffice/src/app/api/hr/employees/route.ts
@@ -3,6 +3,7 @@ import { getSession } from "@/lib/auth";
 import { hrSupabaseAdmin } from "@/lib/hr/supabase";
 import { prisma } from "@/lib/prisma";
 import { resolveVisibleUserIds } from "@/lib/hr/scope";
+import { signAttendancePhotos } from "@/lib/hr/photos";
 
 export const dynamic = "force-dynamic";
 
@@ -94,6 +95,13 @@ export async function GET() {
     if (row.clock_in_photo_url && !firstPhotoByUser.has(row.user_id)) {
       firstPhotoByUser.set(row.user_id, row.clock_in_photo_url);
     }
+  }
+  // Private bucket → sign the stored path so the avatar renders (30-min URL).
+  const signedPhotos = await signAttendancePhotos(Array.from(firstPhotoByUser.values()));
+  for (const [uid, stored] of firstPhotoByUser) {
+    const signed = signedPhotos.get(stored);
+    if (signed) firstPhotoByUser.set(uid, signed);
+    else firstPhotoByUser.delete(uid);
   }
 
   // Onboarding progress per user: count of completed tasks vs applicable

--- a/apps/backoffice/src/lib/hr/photos.ts
+++ b/apps/backoffice/src/lib/hr/photos.ts
@@ -1,0 +1,53 @@
+// Signed-URL access for attendance selfies.
+//
+// hr-photos holds staff clock-in/out selfies (biometric + GPS-correlated). The
+// bucket must be PRIVATE — so instead of a public URL we mint a short-lived signed
+// URL at read time. Handles BOTH storage formats: new rows store the object PATH,
+// legacy rows stored a full public URL (we strip back to the path before signing).
+import { hrSupabaseAdmin } from "./supabase";
+
+const BUCKET = "hr-photos";
+const MARKER = "/hr-photos/";
+const SIGNED_TTL_SECONDS = 60 * 30; // 30 min — long enough for a review session
+
+/** Reduce a stored value (path OR legacy public URL) to the object path. */
+function toObjectPath(stored: string): string {
+  const i = stored.indexOf(MARKER);
+  return i >= 0 ? stored.slice(i + MARKER.length) : stored;
+}
+
+/**
+ * Batch-sign attendance photo values. Returns a Map keyed by the ORIGINAL stored
+ * value → signed URL (so callers can look up by whatever they hold). Nulls and
+ * un-signable paths are simply absent from the map (caller renders no photo).
+ */
+export async function signAttendancePhotos(values: (string | null | undefined)[]): Promise<Map<string, string>> {
+  const out = new Map<string, string>();
+  const originals = Array.from(new Set(values.filter((v): v is string => !!v)));
+  if (originals.length === 0) return out;
+
+  const pathToOriginals = new Map<string, string[]>();
+  for (const original of originals) {
+    const path = toObjectPath(original);
+    const list = pathToOriginals.get(path) ?? [];
+    list.push(original);
+    pathToOriginals.set(path, list);
+  }
+
+  const paths = Array.from(pathToOriginals.keys());
+  const { data, error } = await hrSupabaseAdmin.storage.from(BUCKET).createSignedUrls(paths, SIGNED_TTL_SECONDS);
+  if (error || !data) return out;
+
+  for (const row of data) {
+    if (!row.signedUrl || row.error || !row.path) continue;
+    for (const original of pathToOriginals.get(row.path) ?? []) out.set(original, row.signedUrl);
+  }
+  return out;
+}
+
+/** Sign a single stored value (path or legacy URL). Null-safe. */
+export async function signAttendancePhoto(stored: string | null | undefined): Promise<string | null> {
+  if (!stored) return null;
+  const { data } = await hrSupabaseAdmin.storage.from(BUCKET).createSignedUrl(toObjectPath(stored), SIGNED_TTL_SECONDS);
+  return data?.signedUrl ?? null;
+}

--- a/apps/staff/src/app/api/hr/clock/route.ts
+++ b/apps/staff/src/app/api/hr/clock/route.ts
@@ -193,11 +193,10 @@ export async function POST(req: NextRequest) {
         return null;
       }
 
-      const { data: urlData } = supabase.storage
-        .from("hr-photos")
-        .getPublicUrl(path);
-
-      return urlData.publicUrl;
+      // Store the object PATH — the bucket is private, so the backoffice mints a
+      // short-lived signed URL at read time. Legacy rows hold a full public URL;
+      // the signer strips either form back to the path, so both keep working.
+      return path;
     } catch {
       return null;
     }

--- a/supabase/migrations/063_hr_photos_private.sql
+++ b/supabase/migrations/063_hr_photos_private.sql
@@ -1,0 +1,12 @@
+-- Make the attendance-selfie bucket PRIVATE.
+--
+-- hr-photos held clock-in/out selfies (biometric + GPS-correlated timestamps) at
+-- guessable public URLs (attendance/{user_id}/in_{ms}.jpg) — a PDPA exposure. The
+-- backoffice now mints short-lived signed URLs at read time (see lib/hr/photos.ts),
+-- and the staff clock route stores the object PATH instead of a public URL.
+--
+-- DEPLOY ORDER: apply this AFTER the signed-URL code is live. createSignedUrl works
+-- on a public bucket too, so deploying the code first (still public) then flipping
+-- private here has no broken-image window. Applying it before deploy would 404 the
+-- selfies in the currently-deployed review UI.
+UPDATE storage.buckets SET public = false WHERE id = 'hr-photos';


### PR DESCRIPTION
Dispute-hardening batch 3 of 3 (security). Stacked on #672 → #671.

## Problem
`hr-photos` is a **public** bucket holding staff clock-in/out selfies (biometric + GPS-correlated timestamps) at guessable URLs `attendance/{user_id}/in_{ms}.jpg`. PDPA / privacy exposure.

## Fix
- Staff clock route stores the object **path**, not a public URL.
- New `lib/hr/photos.ts` mints short-lived (30-min) **signed URLs** at read time, wired into the attendance review route and the employees-avatar route. The signer strips a legacy full URL back to its path, so existing rows keep rendering.
- Migration **063** flips the bucket private.

## Deploy order (important)
Apply migration 063 **after** this code is live. `createSignedUrl` works on a public bucket too, so deploy-then-flip has no broken-image window; flipping before deploy would 404 the selfies in the currently-deployed review UI. **Not yet applied to prod.**

## Out of scope
`checklist-photos` is also public (separate feature) — flagged for follow-up, not fixed here.

## Verification
`tsc --noEmit` clean on backoffice + staff.