### PR TITLE
feat(hr): manager can fix clock times / manually clock out

### DIFF
--- a/apps/backoffice/src/app/(admin)/hr/attendance/page.tsx
+++ b/apps/backoffice/src/app/(admin)/hr/attendance/page.tsx
@@ -2,7 +2,7 @@
 
 import { useFetch } from "@/lib/use-fetch";
 import { useState } from "react";
-import { AlertTriangle, CheckCircle2, MapPinOff, Clock, Timer, Loader2, ImageOff } from "lucide-react";
+import { AlertTriangle, CheckCircle2, MapPinOff, Clock, Timer, Loader2, ImageOff, PencilLine } from "lucide-react";
 import { usePrompt } from "@celsius/ui";
 import { HrPageHeader } from "@/components/hr/page-header";
 import type { AttendanceLog } from "@/lib/hr/types";
@@ -26,7 +26,46 @@ export default function AttendanceReviewPage() {
   const { data, mutate } = useFetch<{ logs: EnrichedLog[]; count: number }>(`/api/hr/attendance?status=${filter}`);
   const [reviewingId, setReviewingId] = useState<string | null>(null);
   const [previewUrl, setPreviewUrl] = useState<string | null>(null);
+  // "Fix times" inline editor: which log is being edited + its MYT-input values.
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [editCI, setEditCI] = useState("");
+  const [editCO, setEditCO] = useState("");
   const { prompt, PromptDialog } = usePrompt();
+
+  // datetime-local <-> UTC ISO, treating the input as Malaysia wall time (UTC+8).
+  const toMytInput = (iso: string | null): string =>
+    !iso ? "" : new Date(new Date(iso).getTime() + 8 * 3600 * 1000).toISOString().slice(0, 16);
+  const fromMytInput = (v: string): string | null => {
+    if (!v) return null;
+    const ms = Date.parse(`${v}:00+08:00`);
+    return Number.isNaN(ms) ? null : new Date(ms).toISOString();
+  };
+
+  const openEditor = (log: EnrichedLog) => {
+    setEditingId(log.id);
+    setEditCI(toMytInput(log.clock_in));
+    setEditCO(toMytInput(log.clock_out));
+  };
+
+  const handleSetTimes = async (id: string) => {
+    const clockInIso = fromMytInput(editCI);
+    const clockOutIso = fromMytInput(editCO);
+    if (!clockOutIso) return; // a clock-out time is required
+    setReviewingId(id);
+    try {
+      const res = await fetch("/api/hr/attendance", {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ id, action: "set_times", clockIn: clockInIso, clockOut: clockOutIso }),
+      });
+      if (res.ok) {
+        setEditingId(null);
+        mutate();
+      }
+    } finally {
+      setReviewingId(null);
+    }
+  };
 
   const handleReview = async (id: string, action: "acknowledge" | "excuse" | "reject", excuseReason?: string) => {
     setReviewingId(id);
@@ -166,7 +205,61 @@ export default function AttendanceReviewPage() {
                 >
                   Reject
                 </button>
+                <button
+                  onClick={() => (editingId === log.id ? setEditingId(null) : openEditor(log))}
+                  disabled={reviewingId === log.id}
+                  title={log.clock_out ? "Correct the clock in / out times" : "Manually clock this staffer out"}
+                  className="flex items-center gap-1 rounded-lg border border-gray-300 bg-white px-3 py-1.5 text-xs font-medium text-gray-700 hover:bg-muted disabled:opacity-50"
+                >
+                  <PencilLine className="h-3 w-3" />
+                  {log.clock_out ? "Fix times" : "Clock out"}
+                </button>
               </div>
+
+              {/* Fix-times editor: manual clock-out for an open log, or a time
+                  correction. Hours recompute server-side via the shared engine. */}
+              {editingId === log.id && (
+                <div className="mt-3 space-y-2 rounded-lg border bg-muted/40 p-3">
+                  <div className="flex flex-col gap-2 sm:flex-row">
+                    <label className="flex-1 text-xs font-medium text-muted-foreground">
+                      Clock in (MYT)
+                      <input
+                        type="datetime-local"
+                        value={editCI}
+                        onChange={(e) => setEditCI(e.target.value)}
+                        className="mt-1 w-full rounded-md border bg-card px-2 py-1 text-sm text-foreground"
+                      />
+                    </label>
+                    <label className="flex-1 text-xs font-medium text-muted-foreground">
+                      Clock out (MYT)
+                      <input
+                        type="datetime-local"
+                        value={editCO}
+                        onChange={(e) => setEditCO(e.target.value)}
+                        className="mt-1 w-full rounded-md border bg-card px-2 py-1 text-sm text-foreground"
+                      />
+                    </label>
+                  </div>
+                  <div className="flex items-center gap-2">
+                    <button
+                      onClick={() => handleSetTimes(log.id)}
+                      disabled={reviewingId === log.id || !editCO}
+                      className="flex items-center gap-1 rounded-lg bg-terracotta px-3 py-1.5 text-xs font-medium text-white hover:bg-terracotta-dark disabled:opacity-50"
+                    >
+                      {reviewingId === log.id ? <Loader2 className="h-3 w-3 animate-spin" /> : <CheckCircle2 className="h-3 w-3" />}
+                      Save times
+                    </button>
+                    <button
+                      onClick={() => setEditingId(null)}
+                      disabled={reviewingId === log.id}
+                      className="rounded-lg border border-gray-300 bg-white px-3 py-1.5 text-xs font-medium text-gray-700 hover:bg-muted disabled:opacity-50"
+                    >
+                      Cancel
+                    </button>
+                    <span className="text-[11px] text-muted-foreground">Hours recompute automatically. Times are Malaysia time.</span>
+                  </div>
+                </div>
+              )}
             </div>
           ))}
         </div>

--- a/apps/backoffice/src/app/api/hr/attendance/route.ts
+++ b/apps/backoffice/src/app/api/hr/attendance/route.ts
@@ -4,6 +4,7 @@ import { hrSupabaseAdmin } from "@/lib/hr/supabase";
 import { prisma } from "@/lib/prisma";
 import { getAccessibleOutletIds } from "@/lib/hr/scope";
 import { signAttendancePhotos } from "@/lib/hr/photos";
+import { deriveHours, mytDateString, mytDayOfWeek } from "@/lib/hr/hours";
 
 export const dynamic = "force-dynamic";
 
@@ -116,12 +117,14 @@ export async function PATCH(req: NextRequest) {
   }
 
   const body = await req.json();
-  const { id, action, adjustedHours, notes, excuseReason } = body as {
+  const { id, action, adjustedHours, notes, excuseReason, clockIn, clockOut } = body as {
     id: string;
-    action: "acknowledge" | "excuse" | "approve" | "reject" | "adjust";
+    action: "acknowledge" | "excuse" | "approve" | "reject" | "adjust" | "set_times";
     adjustedHours?: number;
     notes?: string;
     excuseReason?: string;
+    clockIn?: string; // ISO — new clock-in (set_times)
+    clockOut?: string; // ISO — new clock-out / manual clock-out (set_times)
   };
 
   if (!id) {
@@ -132,7 +135,7 @@ export async function PATCH(req: NextRequest) {
   // 'adjust' can preserve the original overtime_type (PH/rest-day/weekday).
   const { data: existingLog } = await hrSupabaseAdmin
     .from("hr_attendance_logs")
-    .select("outlet_id, overtime_type")
+    .select("user_id, outlet_id, clock_in, clock_out, overtime_type")
     .eq("id", id)
     .maybeSingle();
   if (!existingLog) {
@@ -146,6 +149,68 @@ export async function PATCH(req: NextRequest) {
         { status: 403 },
       );
     }
+  }
+
+  // set_times: the manager fixes the real clock-in/out (or manually clocks out a
+  // stranded staffer). Hours recompute via the SAME deriveHours engine as a normal
+  // clock-out, so a corrected log pays identically. The corrected clock-in flows
+  // into the allowance lateness naturally (not force-excused).
+  if (action === "set_times") {
+    const newClockInIso = clockIn || existingLog.clock_in;
+    const newClockOutIso = clockOut || existingLog.clock_out;
+    if (!newClockOutIso) {
+      return NextResponse.json({ error: "A clock-out time is required" }, { status: 400 });
+    }
+    const ci = new Date(newClockInIso);
+    const co = new Date(newClockOutIso);
+    if (isNaN(ci.getTime()) || isNaN(co.getTime())) {
+      return NextResponse.json({ error: "Invalid clock-in/out time" }, { status: 400 });
+    }
+    if (co.getTime() < ci.getTime()) {
+      return NextResponse.json({ error: "Clock-out must be after clock-in" }, { status: 400 });
+    }
+    if (co.getTime() - ci.getTime() > 24 * 3600 * 1000) {
+      return NextResponse.json({ error: "Shift can't exceed 24 hours — check the times" }, { status: 400 });
+    }
+    const { data: prof } = await hrSupabaseAdmin
+      .from("hr_employee_profiles")
+      .select("employment_type, rest_day")
+      .eq("user_id", existingLog.user_id)
+      .maybeSingle();
+    const employmentType = prof?.employment_type || "full_time";
+    const restDay = prof?.rest_day == null ? 0 : Number(prof.rest_day);
+    const mytDate = mytDateString(ci);
+    const { data: ph } = await hrSupabaseAdmin
+      .from("hr_public_holidays").select("date").eq("date", mytDate).maybeSingle();
+    const derived = deriveHours({
+      clockIn: ci,
+      clockOut: co,
+      employmentType,
+      isPublicHoliday: !!ph,
+      isRestDay: mytDayOfWeek(ci) === restDay,
+    });
+    const wasOpen = !existingLog.clock_out;
+    const { data: updated, error: setErr } = await hrSupabaseAdmin
+      .from("hr_attendance_logs")
+      .update({
+        clock_in: ci.toISOString(),
+        clock_out: co.toISOString(),
+        clock_out_method: "manual",
+        total_hours: derived.totalHours,
+        regular_hours: derived.regularHours,
+        overtime_hours: derived.overtimeHours,
+        overtime_type: derived.overtimeType,
+        final_status: "adjusted",
+        ai_status: "reviewed",
+        reviewed_by: session.id,
+        reviewed_at: new Date().toISOString(),
+        review_notes: notes || (wasOpen ? "Manager manual clock-out" : "Manager corrected clock in/out times"),
+      })
+      .eq("id", id)
+      .select()
+      .single();
+    if (setErr) return NextResponse.json({ error: setErr.message }, { status: 500 });
+    return NextResponse.json({ log: updated });
   }
 
   const updateData: Record<string, unknown> = {


### PR DESCRIPTION
Dispute-hardening: the manager resolution path (P2). Stacked on #673 → #672 → #671.

## Problem
The clock-out geofence gate can strand a staffer (just outside the 100m zone, GPS drift), and a wrong log had **no manual resolution** before payroll. The clock-out error message even told staff to "ask your manager to clock you out manually" — but that action did not exist. The review UI only had Acknowledge / Excuse / Reject.

## Fix
A "Fix times" / "Clock out" action on each attendance log in the review page:
- **Manual clock-out** for an open log — set the real clock-out time.
- **Correct clock-in and/or clock-out** on any log.

Hours recompute server-side via the shared `deriveHours` engine (same regular/OT split as a normal clock-out, MYT day-type), so a corrected log pays identically. The corrected clock-in flows into the allowance lateness naturally (not force-excused). New PATCH action `set_times` with after-clock-in + 24h sanity guards; inputs are Malaysia time. Manager outlet-scope enforcement unchanged.

## Verification
`tsc --noEmit` + `eslint` clean on backoffice. (Auth-gated admin page; verified via typecheck + CI build, not a live preview.)