### PR TITLE
fix(procurement): auto-resolve same-claimant staff-claim POPs across outlets

### DIFF
--- a/apps/backoffice/src/app/api/inventory/telegram/webhook/route.ts
+++ b/apps/backoffice/src/app/api/inventory/telegram/webhook/route.ts
@@ -744,22 +744,38 @@ async function resolvePop(
   }
 
   if (candidates.length > 1) {
-    // Finance pays identical-amount staff claims individually (e.g. Ariff has
-    // two RM 10 claims at MT2, receives two separate RM 10 transfers). When
-    // all candidates are the same claimant's STAFF_CLAIM at the same outlet,
-    // consume the oldest one instead of asking to disambiguate — next POP
-    // picks up the next one.
+    // Finance pays identical-amount staff claims individually (e.g. Ariff has several RM 35
+    // claims, each reimbursed by its own RM 35 transfer). For a STAFF reimbursement the payee is
+    // the PERSON, not the outlet — a RM 35 transfer to Ariff settles one of his RM 35 claims no
+    // matter which outlet the purchase was at. So consume the OLDEST claim whose amount EXACTLY
+    // equals the POP when every such exact-amount candidate is the same claimant's STAFF_CLAIM:
+    //   - exact-amount only, so a RM 35.00 POP can never grab a RM 35.20 claim;
+    //   - single claimant, so it never settles the wrong person.
+    // Next POP picks up the next one. Falls back to the same-outlet rule, then to ask-to-pick.
     // eslint-disable-next-line @typescript-eslint/no-explicit-any -- legacy untyped DB row (ratchet: reduce, never add)
     const allStaffClaim = candidates.every((c: any) => c.paymentType === "STAFF_CLAIM");
     // eslint-disable-next-line @typescript-eslint/no-explicit-any -- legacy untyped DB row (ratchet: reduce, never add)
     const claimantIds = new Set(candidates.map((c: any) => c.order?.claimedBy?.id));
     // eslint-disable-next-line @typescript-eslint/no-explicit-any -- legacy untyped DB row (ratchet: reduce, never add)
     const outletIds = new Set(candidates.map((c: any) => c.outletId));
-    if (allStaffClaim && claimantIds.size === 1 && !claimantIds.has(undefined) && outletIds.size === 1) {
-      candidates = [...candidates].sort(
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any -- legacy untyped DB row (ratchet: reduce, never add)
-        (a: any, b: any) => new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime(),
-      ).slice(0, 1);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- legacy untyped DB row (ratchet: reduce, never add)
+    const exact = candidates.filter((c: any) => Math.abs(Number(c.amount) - amount) < 0.005);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- legacy untyped DB row (ratchet: reduce, never add)
+    const exactClaimantIds = new Set(exact.map((c: any) => c.order?.claimedBy?.id));
+    const exactAllStaffOneClaimant =
+      exact.length >= 1 &&
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- legacy untyped DB row (ratchet: reduce, never add)
+      exact.every((c: any) => c.paymentType === "STAFF_CLAIM") &&
+      exactClaimantIds.size === 1 && !exactClaimantIds.has(undefined);
+    const byOldest =
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- legacy untyped DB row (ratchet: reduce, never add)
+      (a: any, b: any) => new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime();
+    if (exactAllStaffOneClaimant) {
+      // Same claimant, exact amount, ANY outlet → consume the oldest exact-amount claim.
+      candidates = [...exact].sort(byOldest).slice(0, 1);
+    } else if (allStaffClaim && claimantIds.size === 1 && !claimantIds.has(undefined) && outletIds.size === 1) {
+      // Same claimant + same outlet (any amount within tolerance) → consume the oldest.
+      candidates = [...candidates].sort(byOldest).slice(0, 1);
     } else {
       // Cap at 8 buttons (Telegram's practical limit per message is generous
       // but huge keyboards are unreadable on mobile).


### PR DESCRIPTION
## Problem
A POP for a staff reimbursement (e.g. RM35 to Ariff) was landing in "tap to pick" instead of auto-settling, whenever his same-amount claims spanned **different outlets**. Example that triggered it:
- `GB27062026` — CC001 / Putrajaya · RM35.00
- `3521…02` — Ariff · RM35.00
- `3518…03` — CC003 / Tamarind · RM**35.20**

The existing auto-resolve only fired when all candidates were the same claimant's `STAFF_CLAIM` **at the same outlet** — so two outlets (and a RM35.20 in the mix) made it bail.

## Fix
For a staff reimbursement the payee is the **person, not the outlet** — a RM35 transfer to Ariff settles one of his RM35 claims no matter where the purchase was. The matcher now also consumes the **oldest claim whose amount exactly equals the POP** when every exact-amount candidate is the same claimant's `STAFF_CLAIM`:
- **exact-amount only** → a RM35.00 POP can never grab the RM35.20 claim
- **single claimant** → it never settles the wrong person

The original same-outlet rule stays as a fallback. This only **adds** auto-matches — anything genuinely ambiguous (mixed payees, a supplier invoice at the same amount, two different claimants) still falls through to ask-to-pick.

## Verify
Typecheck + lint clean. Not runtime-tested (needs a real POP through Telegram); the change is guarded (exact amount + single claimant) and, being additive, can't make a previously-safe pick unsafe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)