### PR TITLE
fix(hr): re-apply geofence-exit auto-close guard (regressed after #625)

### DIFF
--- a/apps/backoffice/src/app/api/cron/attendance-auto-close/route.ts
+++ b/apps/backoffice/src/app/api/cron/attendance-auto-close/route.ts
@@ -8,7 +8,7 @@ export const dynamic = "force-dynamic";
 
 // Runs every 15 min via Vercel Cron.
 // Auto-closes attendance logs that match any of:
-//   A) Last in-zone ping was > geofence_exit_grace_minutes ago
+//   A) Most recent ping is OUT-of-zone + last in-zone ping > geofence_exit_grace_minutes ago
 //   B) No ping at all + open past an ABANDONED threshold (staff never came back)
 //   C) Scheduled shift end + auto_close_after_scheduled_end_hours passed
 //   D) Outlet closed + auto_close_at_outlet_close_minutes passed
@@ -101,18 +101,30 @@ export async function GET(req: NextRequest) {
 
     // Get last ping (any kind) and last in-zone ping
     const [lastPingResp, lastInZoneResp] = await Promise.all([
-      hrSupabaseAdmin.from("hr_attendance_pings").select("created_at").eq("attendance_log_id", log.id).order("created_at", { ascending: false }).limit(1).maybeSingle(),
+      hrSupabaseAdmin.from("hr_attendance_pings").select("created_at, in_zone").eq("attendance_log_id", log.id).order("created_at", { ascending: false }).limit(1).maybeSingle(),
       hrSupabaseAdmin.from("hr_attendance_pings").select("created_at").eq("attendance_log_id", log.id).eq("in_zone", true).order("created_at", { ascending: false }).limit(1).maybeSingle(),
     ]);
 
     const lastPingAt = lastPingResp.data?.created_at ? new Date(lastPingResp.data.created_at) : null;
     const lastInZoneAt = lastInZoneResp.data?.created_at ? new Date(lastInZoneResp.data.created_at) : null;
+    // Is the MOST RECENT ping an out-of-zone ping? This is the only reliable
+    // evidence that the staffer has actually left the outlet.
+    const latestPingOutOfZone = lastPingResp.data?.in_zone === false;
 
     let closeAt: Date | null = null;
     let reason: string | null = null;
 
-    // Rule A: Last in-zone ping was long ago (has pings but stopped being in-zone)
-    if (lastInZoneAt && lastPingAt) {
+    // Rule A: Staffer has actually left the zone and not returned within grace.
+    //
+    // We require the LATEST ping to be out-of-zone — not merely "the last
+    // in-zone ping is stale". The app pings only on geofence boundary crossings
+    // (enter/exit) plus once at clock-in, never continuously, so a staffer
+    // working *inside* the zone all shift produces no new pings. The old
+    // "in-zone ping older than grace" test misread that silence as an exit and
+    // auto-clocked-out people who never left (truncating the shift to ~0h,
+    // because scheduled_end — the only floor — is usually null). Absence of
+    // pings ≠ left the outlet.
+    if (lastInZoneAt && lastPingAt && latestPingOutOfZone) {
       const inZoneAgoMin = (now.getTime() - lastInZoneAt.getTime()) / 60000;
       if (inZoneAgoMin > graceMin) {
         closeAt = lastInZoneAt;


### PR DESCRIPTION
## Why this is needed again

The Rule A fix merged in #625 was **silently reverted**. Later HR PRs (#668, #671, #674) were branched off an older `main`, modified the same `attendance-auto-close/route.ts`, and on merge overwrote the guard. Current `main`/production (`6716033`) has the **old** Rule A back:

```js
// Rule A: Last in-zone ping was long ago
if (lastInZoneAt && lastPingAt) {
  if ((now - lastInZoneAt)/60000 > graceMin) { closeAt = lastInZoneAt; reason = "geofence_exit"; }
}
```

**Confirmed still firing in production today:** log `86b87edc` clocked in 2026-07-01 01:28, all 3 pings in-zone (`out_pings = 0`), yet auto-closed as `geofence_exit` at 01:33 (reviewed 10:45) → ~0h. Live-data check: **49 of 89** `geofence_exit` closes are truncated to <15 min, and every affected log has `scheduled_end = null`, so the anti-truncation floor added in #671 has nothing to floor to.

## Fix

Re-apply the guard on top of current `main`:
- Select `in_zone` on the latest ping and derive `latestPingOutOfZone`.
- Rule A now requires the **most recent ping to actually be out-of-zone** before closing for `geofence_exit`. Absence of pings is no longer read as leaving the outlet.
- Header comment updated to match.

The later pay-split / MYT / scheduled-end-floor logic (#671) and the Rule B backstop reorder (#668) are untouched — this only re-tightens Rule A's gate.

## Follow-ups (not in this PR)
- **Root cause worth its own fix:** `scheduled_end` is null on all attendance logs — the roster never links to them, which disables Rule C and the truncation floor.
- Historical junk logs (the pre-existing 0h `geofence_exit` rows) are being cleaned up separately per the maintainer's direction.

## Testing
- `tsc --noEmit` on the changed file: no errors from this change (remaining errors are pre-existing, from uninstalled deps / ungenerated Prisma client in this environment).
- Walkthrough: all-in-zone shift → latest ping `in_zone=true` → Rule A skipped → closed by scheduled-end/outlet-close instead. Real exit → exit boundary emits an out-of-zone ping → Rule A fires after grace.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01B7WiKCn4NpWzaka6ZtjB6z)_