### PR TITLE
fix(hr): auth impersonation, zeroed payroll, and cross-outlet authz leaks

### DIFF
--- a/apps/backoffice/src/app/api/hr/employees/[id]/access/route.ts
+++ b/apps/backoffice/src/app/api/hr/employees/[id]/access/route.ts
@@ -15,6 +15,20 @@ export async function PATCH(req: NextRequest, { params }: { params: Promise<{ id
   const { id } = await params;
   const body = await req.json();
 
+  // Privilege-escalation guard: the OWNER role is OWNER-only to grant or touch.
+  // Without this an ADMIN could PATCH { role: "OWNER" } on themselves (or plant
+  // a new OWNER) and inherit the OWNER bypass everywhere, or reset an existing
+  // OWNER's PIN/password to take over the top account.
+  if (session.role !== "OWNER") {
+    if (body.role === "OWNER") {
+      return NextResponse.json({ error: "Only an OWNER can assign the OWNER role" }, { status: 403 });
+    }
+    const targetUser = await prisma.user.findUnique({ where: { id }, select: { role: true } });
+    if (targetUser?.role === "OWNER") {
+      return NextResponse.json({ error: "Only an OWNER can modify an OWNER account" }, { status: 403 });
+    }
+  }
+
   // Lockout guard: prevent demoting / deactivating the last remaining OWNER.
   // Also prevent OWNERs from accidentally demoting themselves without a
   // second OWNER on the account.

--- a/apps/backoffice/src/app/api/hr/performance/route.ts
+++ b/apps/backoffice/src/app/api/hr/performance/route.ts
@@ -3,7 +3,7 @@ import { getSession } from "@/lib/auth";
 import { hrSupabaseAdmin } from "@/lib/hr/supabase";
 import { prisma } from "@/lib/prisma";
 import { fetchGoogleReviews } from "@/lib/reviews/gbp";
-import { resolveVisibleUserIds } from "@/lib/hr/scope";
+import { resolveVisibleUserIds, getAccessibleOutletIds } from "@/lib/hr/scope";
 
 export const dynamic = "force-dynamic";
 
@@ -16,6 +16,8 @@ export async function GET(req: NextRequest) {
   }
 
   const visibleIds = await resolveVisibleUserIds(session);
+  // null = OWNER/ADMIN (all outlets); otherwise the caller's accessible outlets.
+  const accessibleOutletIds = await getAccessibleOutletIds(session);
 
   const { searchParams } = new URL(req.url);
   const now = new Date();
@@ -29,8 +31,12 @@ export async function GET(req: NextRequest) {
   const monthStartIso = `${monthStart}T00:00:00Z`;
   const monthEndIso = `${monthEnd}T23:59:59Z`;
 
-  // MANAGER with empty subtree → return empty early.
-  if (visibleIds !== null && visibleIds.length === 0) {
+  // MANAGER with empty subtree → return empty early. Also reject an outletId the
+  // caller can't access: outletFilter feeds the audit-report and GBP-review
+  // blocks directly, so an unvalidated value leaked another outlet's audit notes
+  // and review text.
+  const outOfScopeOutlet = outletFilter != null && accessibleOutletIds !== null && !accessibleOutletIds.includes(outletFilter);
+  if ((visibleIds !== null && visibleIds.length === 0) || outOfScopeOutlet) {
     return NextResponse.json({ period: { year, month, start: monthStart, end: monthEnd }, staff: [], reviews: [], auditMentions: [] });
   }
 

--- a/apps/backoffice/src/app/api/hr/review-penalties/route.ts
+++ b/apps/backoffice/src/app/api/hr/review-penalties/route.ts
@@ -2,7 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { getSession } from "@/lib/auth";
 import { hrSupabaseAdmin } from "@/lib/hr/supabase";
 import { prisma } from "@/lib/prisma";
-import { resolveVisibleUserIds } from "@/lib/hr/scope";
+import { resolveVisibleUserIds, getAccessibleOutletIds } from "@/lib/hr/scope";
 
 export const dynamic = "force-dynamic";
 
@@ -16,10 +16,18 @@ export async function GET(req: NextRequest) {
   }
 
   const visibleIds = await resolveVisibleUserIds(session);
+  // null = OWNER/ADMIN (all outlets); otherwise the caller's accessible outlets.
+  const accessibleOutletIds = await getAccessibleOutletIds(session);
 
   const { searchParams } = new URL(req.url);
   const status = searchParams.get("status") || "pending";
   const outletId = searchParams.get("outletId");
+
+  // A MANAGER passing an outlet they don't manage gets nothing (was: the param
+  // was honored unchecked, leaking another outlet's pending penalties).
+  if (outletId && accessibleOutletIds !== null && !accessibleOutletIds.includes(outletId)) {
+    return NextResponse.json({ items: [] });
+  }
 
   let q = hrSupabaseAdmin
     .from("hr_review_penalty")
@@ -34,11 +42,15 @@ export async function GET(req: NextRequest) {
   const { data, error } = await q;
   if (error) return NextResponse.json({ error: error.message }, { status: 500 });
 
-  // MANAGER scoping: show all pending (they need to triage & attribute),
-  // and for applied/dismissed only rows where attributed_user_ids ∩ subtree is non-empty.
+  // MANAGER scoping: pending rows are limited to the manager's accessible
+  // outlets (was: EVERY pending row company-wide was returned — leaking other
+  // outlets' review_text, reviewer_name, penalty amounts, and suggested-staff
+  // PII). Applied/dismissed rows show only where attributed_user_ids ∩ subtree.
   const filteredData = visibleIds !== null
-    ? (data || []).filter((r: { status: string; attributed_user_ids: string[] | null }) => {
-        if (r.status === "pending") return true;
+    ? (data || []).filter((r: { status: string; outlet_id: string; attributed_user_ids: string[] | null }) => {
+        if (r.status === "pending") {
+          return accessibleOutletIds === null || accessibleOutletIds.includes(r.outlet_id);
+        }
         const attributed = r.attributed_user_ids || [];
         return attributed.some((u) => visibleIds.includes(u));
       })

--- a/apps/backoffice/src/lib/hr/agents/payroll-calculator.ts
+++ b/apps/backoffice/src/lib/hr/agents/payroll-calculator.ts
@@ -123,7 +123,12 @@ export async function calculatePayroll(month: number, year: number): Promise<Pay
     .select("*")
     .gte("clock_in", startDate)
     .lt("clock_in", endDate)
-    .neq("final_status", "rejected");
+    // NULL-safe "not rejected": PostgREST `.neq` compiles to `final_status <>
+    // 'rejected'`, which is FALSE for NULL rows and silently drops them — but
+    // the AI-auto-approved happy path is exactly `final_status = NULL` (see the
+    // paying-out rules above). Dropping those means unpaid shifts. Keep NULL +
+    // any non-rejected value; exclude only explicit rejections.
+    .or("final_status.is.null,final_status.neq.rejected");
 
   // Group attendance by user
   const attendanceByUser = new Map<string, typeof attendance>();

--- a/apps/staff/src/app/api/hr/clock/route.ts
+++ b/apps/staff/src/app/api/hr/clock/route.ts
@@ -6,7 +6,7 @@ import { getUser } from "@/lib/auth";
 // before RLS even runs.
 import { supabaseAdmin as supabase } from "@/lib/supabase";
 import { haversineDistance, GEOFENCE_RADIUS_METERS } from "@/lib/hr/constants";
-import { mytDateString, mytInstant } from "@/lib/hr/hours";
+import { deriveHours, mytDateString, mytDayOfWeek, mytInstant } from "@/lib/hr/hours";
 import type { AttendanceLog, GeofenceZone } from "@/lib/hr/types";
 
 export const dynamic = "force-dynamic";
@@ -317,7 +317,25 @@ export async function POST(req: NextRequest) {
 
     const clockOut = new Date();
     const clockIn = new Date(activeLog.clock_in);
-    const totalHours = (clockOut.getTime() - clockIn.getTime()) / (1000 * 60 * 60);
+
+    // Pay-hours split via the shared engine — the SAME one the auto-close cron
+    // and AI processor use. Previously a normal clock-out wrote total_hours
+    // ONLY, leaving regular_hours/overtime_hours NULL; payroll sums
+    // regular_hours, so every app clock-out paid 0 hours. Derive them here so a
+    // clean clock-out pays immediately.
+    const [profileResp, holidayResp] = await Promise.all([
+      supabase.from("hr_employee_profiles").select("employment_type, rest_day").eq("user_id", session.id).maybeSingle(),
+      supabase.from("hr_public_holidays").select("date").eq("date", mytDateString(clockIn)).maybeSingle(),
+    ]);
+    const restDay = profileResp.data?.rest_day == null ? 0 : Number(profileResp.data.rest_day);
+    const derived = deriveHours({
+      clockIn,
+      clockOut,
+      employmentType: profileResp.data?.employment_type || "full_time",
+      isPublicHoliday: !!holidayResp.data,
+      isRestDay: mytDayOfWeek(clockIn) === restDay,
+    });
+    const totalHours = derived.totalHours;
 
     const photoUrl = photo ? await uploadPhoto(photo, "out") : null;
 
@@ -329,7 +347,10 @@ export async function POST(req: NextRequest) {
         clock_out_lng: longitude ?? null,
         clock_out_method: "app",
         clock_out_photo_url: photoUrl,
-        total_hours: Math.round(totalHours * 100) / 100,
+        total_hours: totalHours,
+        regular_hours: derived.regularHours,
+        overtime_hours: derived.overtimeHours,
+        overtime_type: derived.overtimeType,
       })
       .eq("id", activeLog.id)
       .select()

--- a/packages/auth/src/require-auth.ts
+++ b/packages/auth/src/require-auth.ts
@@ -9,17 +9,21 @@ import type { SessionUser, UserRole } from "./types";
 import { AuthError } from "./types";
 
 /**
- * Read user from middleware-injected headers (proxy pattern).
+ * SECURITY (was an authentication bypass): this previously returned a fully
+ * authenticated session straight from UNVERIFIED `x-user-*` request headers
+ * (the "trusted proxy" pattern). But no app in this monorepo injects those
+ * headers, and nothing strips them on the way in — so the only way they were
+ * ever populated was an attacker forging them. Sending `x-user-id: <victim>`
+ * impersonated any user on every route that resolved auth via `getUser`
+ * (staff clock-in/out, attendance, ping, …).
+ *
+ * It is intentionally inert now — auth must come from a verified JWT (bearer or
+ * cookie). Kept as an exported no-op so existing imports keep compiling; if a
+ * genuine trusted-proxy deployment is ever added, reintroduce header trust ONLY
+ * behind a shared secret the proxy signs and the edge strips inbound.
  */
-export function getUserFromHeaders(headers: Headers): SessionUser | null {
-  const id = headers.get("x-user-id");
-  if (!id) return null;
-  return {
-    id,
-    name: headers.get("x-user-name") || "",
-    role: (headers.get("x-user-role") || "STAFF") as UserRole,
-    outletId: headers.get("x-user-outlet") || headers.get("x-user-branch") || null,
-  };
+export function getUserFromHeaders(_headers: Headers): SessionUser | null {
+  return null;
 }
 
 /**
@@ -45,12 +49,12 @@ export async function getUserFromBearer(headers: Headers): Promise<SessionUser |
 }
 
 /**
- * Get the authenticated user from headers (proxy), bearer token (native),
- * or cookie (web). Proxy headers win, then bearer, then cookie.
+ * Get the authenticated user from a verified JWT — bearer token (native app)
+ * or cookie (web). Unverified `x-user-*` headers are NOT trusted (see
+ * getUserFromHeaders): they were an impersonation vector and no proxy sets them.
  */
 export async function getUser(headers: Headers): Promise<SessionUser | null> {
   return (
-    getUserFromHeaders(headers) ||
     (await getUserFromBearer(headers)) ||
     getUserFromCookie(headers)
   );


### PR DESCRIPTION
Fixes from the HR-module QA audit. Three independent concerns, one commit each.

## 1. Auth impersonation (P0) — `packages/auth/src/require-auth.ts`
`getUser()` called `getUserFromHeaders()` first, trusting `x-user-id/role/outlet` straight off the request. **Nothing in the monorepo sets those headers** and the staff middleware never strips them, so the only way they were ever populated was an attacker forging them — `x-user-id: <victim>` impersonated any user on every `getUser` route (staff clock-in/out, attendance, ping). `checkCsrf` also skips CSRF when any `Authorization: Bearer …` header is present, so `Bearer x` + a forged `x-user-id` sailed through.
**Fix:** `getUserFromHeaders` is now inert; `getUser` resolves only via a verified JWT (bearer/cookie). Provably safe — legitimate traffic never set `x-user-*`, so the header path only returned non-null for forged requests. Backoffice/POS have their own JWT-validating `getUserFromHeaders` and are unaffected.

## 2. Payroll paid 0 hours (P0) — `payroll-calculator.ts`, `clock/route.ts`
Confirmed on live data: **every closed June log summed to 0.0 pay-hours.** Two causes:
- `.neq("final_status","rejected")` compiles to `final_status <> 'rejected'`, which drops `NULL` rows — but the AI-auto-approved happy path is exactly `final_status = NULL` (which the code comment says must pay). → NULL-safe `.or(is.null, neq.rejected)`.
- A normal clock-out wrote `total_hours` only, leaving `regular_hours`/`overtime_hours` NULL; payroll sums `regular_hours` → 0. → clock-out now runs the shared `deriveHours` engine (same as the auto-close cron / AI processor), keyed on MYT day type + employment type + rest day + public holiday.

## 3. Cross-outlet authz leaks + privilege escalation (P1) — `access`, `review-penalties`, `performance`
- **access:** OWNER role is now OWNER-only to grant/modify — an ADMIN could self-escalate to OWNER or reset an existing OWNER's credentials.
- **review-penalties:** pending rows were returned company-wide to any MANAGER (review text, reviewer names, penalty amounts, suggested-staff PII). Now scoped to accessible outlets + `outletId` validated.
- **performance:** unvalidated `outletId` leaked another outlet's audit notes and GBP review text. Now rejected when out of scope.

## Not included (follow-ups from the same audit)
- `scheduled_end` NULL on all logs (roster→attendance link) — the deeper root cause behind truncated auto-closes; needs a backfill + published-roster stamp.
- Background geofence ping sends outlet-center coords not device coords (`staff-native/lib/hr/tasks.ts`).
- RLS disabled on `hr_attendance_logs`; `adjustedHours` unbounded; radius default 100 vs 150; native attendance list shape mismatch; cross-midnight lateness in `performance`.

## Testing
`tsc --noEmit` on the changed files shows no errors from these changes (remaining errors are pre-existing: uninstalled deps / ungenerated Prisma client in this environment). Payroll and clock-out changes reuse the existing shared `deriveHours` engine, so an app clock-out now pays identically to an auto-closed log.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01B7WiKCn4NpWzaka6ZtjB6z)_