### PR TITLE
fix(hr): P1/P2 attendance fixes — geofence ping, radius, native list, lateness, adjust bounds, roster

### DIFF
--- a/apps/backoffice/src/app/api/hr/attendance/route.ts
+++ b/apps/backoffice/src/app/api/hr/attendance/route.ts
@@ -232,6 +232,12 @@ export async function PATCH(req: NextRequest) {
   } else if (action === "reject") {
     updateData.final_status = "rejected";
   } else if (action === "adjust" && adjustedHours != null) {
+    // Bound the manager-entered value — it flows straight into payroll
+    // (total/regular/OT). Without this a typo or malicious value (negative,
+    // 9999) inflates OT pay or writes nonsense hours. (set_times already caps.)
+    if (!Number.isFinite(adjustedHours) || adjustedHours < 0 || adjustedHours > 24) {
+      return NextResponse.json({ error: "adjustedHours must be between 0 and 24" }, { status: 400 });
+    }
     // Preserve the original overtime classification so a manager-adjusted
     // rest-day / public-holiday shift doesn't silently become a weekday 1.5x
     // line in payroll. OT hours always floor to whole numbers per policy.

--- a/apps/backoffice/src/app/api/hr/performance/route.ts
+++ b/apps/backoffice/src/app/api/hr/performance/route.ts
@@ -4,6 +4,7 @@ import { hrSupabaseAdmin } from "@/lib/hr/supabase";
 import { prisma } from "@/lib/prisma";
 import { fetchGoogleReviews } from "@/lib/reviews/gbp";
 import { resolveVisibleUserIds, getAccessibleOutletIds } from "@/lib/hr/scope";
+import { computeLateMinutes } from "@/lib/hr/hours";
 
 export const dynamic = "force-dynamic";
 
@@ -65,7 +66,7 @@ export async function GET(req: NextRequest) {
   // vs scheduled_start below).
   const { data: attendance } = await hrSupabaseAdmin
     .from("hr_attendance_logs")
-    .select("user_id, outlet_id, clock_in, clock_out, scheduled_start, regular_hours, overtime_hours, ai_flags, final_status, excused")
+    .select("user_id, outlet_id, clock_in, clock_out, scheduled_start, scheduled_date, regular_hours, overtime_hours, ai_flags, final_status, excused")
     .gte("clock_in", monthStartIso)
     .lte("clock_in", monthEndIso);
 
@@ -252,23 +253,14 @@ export async function GET(req: NextRequest) {
     });
   });
 
-  // Attendance aggregates — compute lateness inline from clock_in vs
-  // scheduled_start (the scheduled_start column holds HH:MM:SS for the
-  // expected start time of that shift; clock_in is a full UTC timestamp).
-  const computeLateMin = (clockInIso: string, schedStart: string | null): number => {
-    if (!schedStart) return 0;
-    const d = new Date(clockInIso);
-    // Convert to MYT to compare against scheduled_start (stored in MYT)
-    const myt = new Date(d.getTime() + 8 * 3600 * 1000);
-    const h = myt.getUTCHours(), m = myt.getUTCMinutes();
-    const [sh, sm] = schedStart.split(":").map(Number);
-    const delta = (h * 60 + m) - (sh * 60 + (sm || 0));
-    return delta > 0 ? delta : 0;
-  };
-  (attendance || []).forEach((a: { user_id: string; clock_in: string; scheduled_start: string | null; regular_hours: number | null; overtime_hours: number | null; final_status: string | null }) => {
+  // Attendance aggregates — lateness via the shared cross-midnight-safe helper.
+  // The previous inline version compared only the MYT wall-clock of clock_in
+  // against scheduled_start with NO date component, so a shift rostered 23:00
+  // and clocked in 00:10 next day read as "on time" (or wildly wrong).
+  (attendance || []).forEach((a: { user_id: string; clock_in: string; scheduled_start: string | null; scheduled_date: string | null; regular_hours: number | null; overtime_hours: number | null; final_status: string | null }) => {
     const p = perfMap.get(a.user_id);
     if (!p) return;
-    const lateMin = computeLateMin(a.clock_in, a.scheduled_start);
+    const lateMin = Math.max(0, computeLateMinutes(a.clock_in, a.scheduled_start, a.scheduled_date));
     p.clockIns += 1;
     if (lateMin > 0) p.lateCount += 1;
     p.totalLateMinutes += lateMin;

--- a/apps/staff-native/app/(staff)/clock.tsx
+++ b/apps/staff-native/app/(staff)/clock.tsx
@@ -194,7 +194,7 @@ export default function ClockScreen() {
         )
       : null;
   const inZone =
-    zone && distance != null ? distance <= (zone.radius_meters ?? 150) : false;
+    zone && distance != null ? distance <= (zone.radius_meters ?? 100) : false;
   const canClockIn = !clockedIn && (!zone || inZone);
 
   return (

--- a/apps/staff-native/app/(staff)/hr/attendance.tsx
+++ b/apps/staff-native/app/(staff)/hr/attendance.tsx
@@ -9,7 +9,7 @@ export default function AttendanceScreen() {
     queryKey: ["hr-attendance", 30],
     queryFn: () => fetchAttendance(30),
   });
-  const items = data?.attendance ?? [];
+  const items = data?.logs ?? [];
   const stats = data?.stats;
 
   return (

--- a/apps/staff-native/lib/hr/api.ts
+++ b/apps/staff-native/lib/hr/api.ts
@@ -82,7 +82,9 @@ export type AttendanceItem = {
 };
 
 export type AttendanceResponse = {
-  attendance: AttendanceItem[];
+  // The API returns `logs` (matches the web staff app). This was previously
+  // typed/read as `attendance`, so the native list was always empty.
+  logs: AttendanceItem[];
   stats?: {
     totalHours: number;
     totalOT: number;

--- a/apps/staff-native/lib/hr/geofence.ts
+++ b/apps/staff-native/lib/hr/geofence.ts
@@ -10,7 +10,9 @@ export async function startGeofencing(zones: GeofenceZone[]) {
       identifier: `outlet:${z.name}`,
       latitude: Number(z.latitude),
       longitude: Number(z.longitude),
-      radius: z.radius_meters ?? 150,
+      // Match the server default (GEOFENCE_RADIUS_METERS = 100). A 150 fallback
+      // here disagreed with the server's in/out verdict and the clock-out gate.
+      radius: z.radius_meters ?? 100,
       notifyOnEnter: true,
       notifyOnExit: true,
     }));

--- a/apps/staff-native/lib/hr/tasks.ts
+++ b/apps/staff-native/lib/hr/tasks.ts
@@ -41,6 +41,20 @@ async function backgroundPing(
   lat?: number,
   lng?: number,
 ) {
+  // Prefer the DEVICE's actual position over whatever coords the caller passed.
+  // Geofence events hand us the region (outlet) center, so pinging with those
+  // always reads in_zone and the server never sees a real out-of-zone ping —
+  // defeating geofence-exit detection. Fall back to the passed coords only if a
+  // fresh fix isn't available.
+  try {
+    const loc = await Location.getCurrentPositionAsync({
+      accuracy: Location.Accuracy.Balanced,
+    });
+    lat = loc.coords.latitude;
+    lng = loc.coords.longitude;
+  } catch {
+    // keep the passed-in coords as a last resort
+  }
   if (lat == null || lng == null) return;
   const token = await getToken();
   if (!token) return;

--- a/apps/staff/src/app/api/hr/clock/route.ts
+++ b/apps/staff/src/app/api/hr/clock/route.ts
@@ -64,8 +64,11 @@ async function findRosterShift(userId: string, clockIn: Date): Promise<{ schedul
   const prevMyt = mytDateString(new Date(clockIn.getTime() - 24 * 3600 * 1000));
   const { data } = await supabase
     .from("hr_schedule_shifts")
-    .select("shift_date, start_time, end_time")
+    // Only stamp from a PUBLISHED roster (same filter the /hr/shifts route uses)
+    // so a draft shift's times don't drive lateness / auto-close.
+    .select("shift_date, start_time, end_time, hr_schedules!inner(status)")
     .eq("user_id", userId)
+    .eq("hr_schedules.status", "published")
     .in("shift_date", [prevMyt, todayMyt]);
   const shifts = (data ?? []) as { shift_date: string; start_time: string; end_time: string | null }[];
   let best: { shift: (typeof shifts)[number]; diff: number } | null = null;


### PR DESCRIPTION
Batch of P1/P2 fixes from the HR-module QA audit (the follow-ups after the P0 auth/payroll PR #679).

## Staff / native — clock & geofence
- **Background geofence ping sent the outlet-center coords** (`region.lat/lng`), so every ping read `in_zone` and the server never saw a real out-of-zone ping — geofence-exit detection was inert. Now fetches the device's actual position (falls back to the passed coords). `staff-native/lib/hr/tasks.ts`
- **Radius default mismatch** — native fell back to 150m, server to 100m, so on a null-radius zone the app said "in zone" while the clock-out gate blocked at 100m. Native now falls back to 100. `geofence.ts`, `clock.tsx`
- **Native Attendance screen always empty** — it read `{attendance}` but the API returns `{logs}`. Aligned the type + read site. `staff-native/lib/hr/api.ts`, `attendance.tsx`
- **`findRosterShift`** now only stamps `scheduled_*` from a **published** roster (same filter as `/hr/shifts`), so a draft shift's times don't drive lateness/auto-close. `staff/.../hr/clock/route.ts`

## Backoffice
- **`adjust` action** rejects `adjustedHours` outside `[0,24]`/non-finite before it writes total/regular/OT to payroll (a typo or malicious `9999`/negative went straight through). `hr/attendance/route.ts`
- **Cross-midnight lateness** in `performance` — replaced the inline calc (MYT wall-clock only, no date) with the shared cross-midnight-safe `computeLateMinutes` + `scheduled_date`, so a 23:00 shift clocked in 00:10 next day is no longer scored on-time. `hr/performance/route.ts`

## Handled outside this PR (in progress)
- **Backfills** (DB, not code): re-derive `regular_hours` on June logs; stamp `scheduled_*` on historical logs from the roster.
- **RLS on `hr_attendance_logs`** — needs the anon reads in `my-reviews`/`attendance` switched to service-role first; separate PR.

## Testing
`tsc --noEmit` on the changed files: no errors from these changes (remaining errors are pre-existing — ungenerated Prisma client / uninstalled deps / ad-hoc jsx flag in this env). Reuses existing shared helpers (`computeLateMinutes`, the `!inner` published-roster join pattern from `/hr/shifts`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01B7WiKCn4NpWzaka6ZtjB6z)_