### PR TITLE
fix(hr): enable RLS on hr_attendance_logs (+ switch anon reads to service-role)

### DIFF
--- a/apps/staff/src/app/api/hr/attendance/route.ts
+++ b/apps/staff/src/app/api/hr/attendance/route.ts
@@ -1,6 +1,9 @@
 import { NextRequest, NextResponse } from "next/server";
 import { getSession } from "@/lib/auth";
-import { supabase } from "@/lib/supabase";
+// Service-role: the route authenticates via getSession and filters every query
+// by session.id, so it doesn't rely on RLS. Using the anon client would break
+// once RLS is enabled on hr_attendance_logs (migration 064) — no anon policy.
+import { supabaseAdmin as supabase } from "@/lib/supabase";
 
 export const dynamic = "force-dynamic";
 

--- a/apps/staff/src/app/api/hr/my-reviews/route.ts
+++ b/apps/staff/src/app/api/hr/my-reviews/route.ts
@@ -1,6 +1,9 @@
 import { NextResponse } from "next/server";
 import { getSession } from "@/lib/auth";
-import { supabase } from "@/lib/supabase";
+// Service-role: authenticated via getSession and every query is constrained to
+// the caller's own shifts / attributed reviews server-side. The anon client
+// would return nothing for hr_attendance_logs once RLS is enabled (mig 064).
+import { supabaseAdmin as supabase } from "@/lib/supabase";
 import { prisma } from "@/lib/prisma";
 
 export const dynamic = "force-dynamic";

--- a/supabase/migrations/064_rls_hr_attendance_logs.sql
+++ b/supabase/migrations/064_rls_hr_attendance_logs.sql
@@ -1,0 +1,16 @@
+-- Enable RLS on hr_attendance_logs (parent of hr_attendance_pings, which was
+-- already RLS-enabled in 20260502_rls_sensitive_tables). The parent holds the
+-- more sensitive data — GPS coords, selfie photo paths, PII-correlated
+-- timestamps — yet had RLS OFF, so the anon key could read the whole table.
+--
+-- Deny-all by default: no policy is added, so anon/authenticated get nothing.
+-- Every server route reads/writes this table through the SERVICE-ROLE client
+-- (supabaseAdmin), which bypasses RLS, and authenticates + scopes each query in
+-- app code. The two staff routes that previously used the anon client
+-- (hr/attendance, hr/my-reviews) were switched to service-role in the same
+-- change.
+--
+-- DEPLOY ORDER: apply this AFTER the code switching those two routes to
+-- service-role is live in production — otherwise their anon SELECTs return
+-- nothing (no policy) and the attendance history / my-reviews screens go blank.
+ALTER TABLE hr_attendance_logs ENABLE ROW LEVEL SECURITY;


### PR DESCRIPTION
Closes the last P1 from the HR QA audit.

## Problem
`hr_attendance_pings` was RLS-enabled (in `20260502_rls_sensitive_tables`) but its **parent `hr_attendance_logs` was not** — even though it holds the more sensitive data (GPS coords, selfie photo paths, PII-correlated timestamps). With RLS off, the anon key could read the entire table.

## Change
- Two staff routes read the table via the **anon** client: `hr/attendance` and `hr/my-reviews`. Both already authenticate via `getSession` and scope every query to the caller's own `user_id` / shifts, so they don't rely on RLS for correctness. Switched both to the **service-role** client (consistent with `clock`, `ping`, `allowances`).
- **Migration 064** enables RLS on `hr_attendance_logs` (deny-all; no policy — service-role bypasses, anon gets nothing).

## ⚠️ Deploy order
Apply migration 064 **only after this code is live in production.** If RLS is enabled while the old anon-client code is still running, the anon `SELECT`s return nothing and the attendance-history / my-reviews screens go blank. (I have **not** applied it to prod — it's committed as tracked SQL to run post-deploy, same pattern as migration 063.)

## Testing
Import-only swaps to an already-used client; no logic change. `tsc` noise in this env is the usual uninstalled-deps set, none from these edits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01B7WiKCn4NpWzaka6ZtjB6z)_