### PR TITLE
fix(finance): Revenue Monster settlements clear the Cash & QR debtor, not income

### DIFF
--- a/apps/backoffice/src/lib/finance/gl-posting-map.ts
+++ b/apps/backoffice/src/lib/finance/gl-posting-map.ts
@@ -15,8 +15,8 @@ export const CONTRA_ACCOUNT: Record<string, string> = {
   GRAB: "1005",            // Grabfood debtors
   GRAB_PUTRAJAYA: "1999",  // settles into HQ bank but debtor sits in Conezion — cross-entity, park in suspense
   FOODPANDA: "1005",       // marketplace debtor (no separate FP account yet)
+  REVENUE_MONSTER: "1000-02", // RM terminal settling pickup/table QR+e-wallet sales already accrued by EOD → clears the Cash & QR debtor (crediting income here double-counted revenue)
   // ── inflows NOT in EOD (B2B / online) → recognise income directly ──
-  REVENUE_MONSTER: "5000-01", // online pickup + table-QR sales
   MEETINGS_EVENTS: "5000-10",
   GASTROHUB: "5000-09",
   // ── cost of sales ──

--- a/apps/backoffice/src/lib/finance/gl-posting.test.ts
+++ b/apps/backoffice/src/lib/finance/gl-posting.test.ts
@@ -48,7 +48,9 @@ describe("contraFor", () => {
   it("recognises income for channels not in EOD", () => {
     expect(contraFor("GASTROHUB")).toEqual({ code: "5000-09", suspense: false });
     expect(contraFor("MEETINGS_EVENTS")).toEqual({ code: "5000-10", suspense: false });
-    expect(contraFor("REVENUE_MONSTER")).toEqual({ code: "5000-01", suspense: false });
+  });
+  it("clears the Cash & QR debtor for Revenue Monster settlements (already accrued by EOD)", () => {
+    expect(contraFor("REVENUE_MONSTER")).toEqual({ code: "1000-02", suspense: false });
   });
   it("maps costs, capex and financing to real accounts", () => {
     expect(contraFor("RAW_MATERIALS").code).toBe("6000-01");


### PR DESCRIPTION
## Problem

The Cash & QR reconciliation showed a large unreconciled gap. Investigation found it is **not unbanked cash** (physical cash is only RM1,055, 0.3% of the RM365k). The `REVENUE_MONSTER` bank category was mapped to **5000-01 income** on the assumption its settlements were online/table-QR sales not captured by EOD.

But those pickup/table orders **are** recognised by the EOD/AR agent (`Dr debtor / Cr income`). So crediting income again when the Revenue Monster settlement lands:
- **double-counted revenue**, and
- left the **1000-02 Cash & QR debtor open** (the settlement never cleared the accrued sale), which is exactly the recon gap.

## Fix

Remap `REVENUE_MONSTER` → **1000-02**, so the terminal settlement clears the accrued Cash & QR debtor, the same way `QR`/`CARD`/`GRAB` settlements already clear theirs.

`REVENUE_MONSTER` is the only bank category posting to 5000-01, so the remap is clean. A follow-up data pass reclassifies the 33 already-posted journals (RM34,581.72, all 2026).

## Files
- `gl-posting-map.ts` — CONTRA_ACCOUNT: REVENUE_MONSTER 5000-01 → 1000-02
- `gl-posting.test.ts` — updated expectation

Typecheck + unit tests pass (13/13).