### PR TITLE
Fix receiving conversion, COGS packaging split + procurement-loop review findings

### DIFF
--- a/apps/backoffice/src/app/(admin)/inventory/supplier-chats/page.tsx
+++ b/apps/backoffice/src/app/(admin)/inventory/supplier-chats/page.tsx
@@ -94,6 +94,9 @@ type Detail = {
     unpaidInvoices: { id: string; invoiceNumber: string; balance: number; status: string; dueDate: string | null; overdue: boolean }[];
   };
   windowOpen: boolean;
+  // The approved new-order prompt template is configured, so "Create & send"
+  // works cold: prompt goes out now, PO block follows when the supplier replies.
+  canColdPrompt?: boolean;
   humanHandling: boolean;
   messages: Msg[];
   agentProposal?: {
@@ -1246,11 +1249,18 @@ export default function SupplierChatsPage() {
                       </button>
                       <button
                         onClick={() => createPO(true)}
-                        disabled={poBusy || !detail.windowOpen}
-                        title={detail.windowOpen ? "" : "24h window closed — create a draft, then send via template"}
+                        disabled={poBusy || (!detail.windowOpen && !detail.canColdPrompt)}
+                        title={
+                          detail.windowOpen
+                            ? ""
+                            : detail.canColdPrompt
+                              ? "Window closed — sends a new-order prompt now; the full PO follows automatically when they reply"
+                              : "24h window closed and no order-prompt template configured (PROCUREMENT_PO_PROMPT_TEMPLATE) — create a draft instead"
+                        }
                         className="flex flex-1 items-center justify-center gap-1 rounded-md bg-primary px-2 py-1.5 text-[12px] font-medium text-primary-foreground hover:bg-primary/90 disabled:opacity-50"
                       >
-                        {poBusy ? <Loader2 size={13} className="animate-spin" /> : <Send size={13} />} Create &amp; send
+                        {poBusy ? <Loader2 size={13} className="animate-spin" /> : <Send size={13} />}{" "}
+                        {detail.windowOpen ? <>Create &amp; send</> : detail.canColdPrompt ? <>Create &amp; prompt</> : <>Create &amp; send</>}
                       </button>
                     </div>
                   </div>

--- a/apps/backoffice/src/app/api/inventory/receivings/route.ts
+++ b/apps/backoffice/src/app/api/inventory/receivings/route.ts
@@ -1,4 +1,5 @@
 import { NextResponse, NextRequest } from "next/server";
+import { baseQtyByProduct } from "@celsius/db";
 import { prisma } from "@/lib/prisma";
 import { adjustStockBalance } from "@/lib/stock";
 import { getUserFromHeaders } from "@/lib/auth";
@@ -167,10 +168,35 @@ export async function POST(req: NextRequest) {
     },
   });
 
-  // Update stock balances (parallel) — track per package
+  // Update stock balances. Goods are received in a package unit ("12 bottles"),
+  // but StockBalance is tracked in base UOM — multiply each line by its package
+  // conversionFactor and increment the canonical per-product row
+  // (productPackageId = null), matching stock counts and the staff app.
+  const recvPkgIds = [
+    ...new Set(
+      (items as Array<{ productPackageId?: string }>)
+        .map((i) => i.productPackageId)
+        .filter((id): id is string => id != null),
+    ),
+  ];
+  const cfMap = new Map<string, number>();
+  if (recvPkgIds.length > 0) {
+    const pkgs = await prisma.productPackage.findMany({
+      where: { id: { in: recvPkgIds } },
+      select: { id: true, conversionFactor: true },
+    });
+    for (const p of pkgs) cfMap.set(p.id, Number(p.conversionFactor));
+  }
+  const baseTotals = baseQtyByProduct(
+    (items as Array<{ productId: string; productPackageId?: string; receivedQty: number }>).map((i) => ({
+      productId: i.productId,
+      countedQty: i.receivedQty,
+      conversionFactor: i.productPackageId ? cfMap.get(i.productPackageId) ?? 1 : 1,
+    })),
+  );
   await Promise.all(
-    items.map((item: { productId: string; productPackageId?: string; receivedQty: number }) =>
-      adjustStockBalance(outletId, item.productId, item.receivedQty, item.productPackageId),
+    [...baseTotals].map(([productId, baseQty]) =>
+      adjustStockBalance(outletId, productId, baseQty, null),
     ),
   );
 

--- a/apps/backoffice/src/app/api/inventory/reports/cogs/route.ts
+++ b/apps/backoffice/src/app/api/inventory/reports/cogs/route.ts
@@ -48,9 +48,24 @@ export async function GET(req: NextRequest) {
     const menuIngredients = await prisma.menuIngredient.findMany({
       include: {
         menu: { select: { id: true, name: true, category: true } },
-        product: { select: { id: true, name: true, baseUom: true, itemType: true } },
+        product: {
+          select: {
+            id: true,
+            name: true,
+            baseUom: true,
+            itemType: true,
+            group: { select: { name: true } },
+          },
+        },
       },
     });
+
+    // A BOM line is "packaging" if the product is tagged itemType=PACKAGING OR
+    // sits in a packaging item-group. In practice nothing is tagged
+    // itemType=PACKAGING yet (cups/lids/bags are classified by group), so the
+    // itemType-only check folded all packaging cost into ingredient cost.
+    const isPackaging = (p: { itemType: string; group: { name: string } | null }) =>
+      p.itemType === "PACKAGING" || /packag/i.test(p.group?.name ?? "");
 
     // 3. Fetch cheapest active SupplierProduct price per product (with package conversion)
     // Exclude ADHOC supplier and zero-price entries to get real costs
@@ -93,7 +108,7 @@ export async function GET(req: NextRequest) {
       existing.push({
         productId: mi.productId,
         quantityUsed: Number(mi.quantityUsed),
-        isPackaging: mi.product.itemType === "PACKAGING",
+        isPackaging: isPackaging(mi.product),
         serviceMode: mi.serviceMode,
       });
       recipeMap.set(mi.menuId, existing);

--- a/apps/backoffice/src/app/api/inventory/supplier-chats/[key]/apply-proposal/route.ts
+++ b/apps/backoffice/src/app/api/inventory/supplier-chats/[key]/apply-proposal/route.ts
@@ -115,7 +115,7 @@ export async function POST(req: NextRequest, { params }: { params: Promise<{ key
   // The line must belong to THIS order, and the order must be open.
   const item = await prisma.orderItem.findFirst({
     where: { id: poItemId, orderId },
-    select: { id: true, unitPrice: true, order: { select: { status: true, orderNumber: true } } },
+    select: { id: true, unitPrice: true, quantity: true, order: { select: { status: true, orderNumber: true } } },
   });
   if (!item) return NextResponse.json({ error: "PO line not found on this order" }, { status: 404 });
   if (item.order.status === "COMPLETED" || item.order.status === "CANCELLED") {
@@ -125,6 +125,18 @@ export async function POST(req: NextRequest, { params }: { params: Promise<{ key
   if (action === "reduce_qty") {
     if (typeof newQuantity !== "number" || newQuantity <= 0) {
       return NextResponse.json({ error: "reduce_qty needs a positive newQuantity" }, { status: 400 });
+    }
+    // A reduce must LOWER the line. Escalated proposals can carry a model misread
+    // (e.g. "ada 50 je" read as qty 50 on a 5-unit line) — the agent refused to
+    // auto-apply it for exactly this reason, so the approval path must not apply
+    // it blind either. Also covers the line having been edited since the proposal.
+    if (newQuantity >= Number(item.quantity)) {
+      return NextResponse.json(
+        {
+          error: `Proposed quantity ${newQuantity} doesn't reduce the line (current ${Number(item.quantity)}) — likely a misread. Edit the PO manually if the increase is intended.`,
+        },
+        { status: 400 },
+      );
     }
     await prisma.orderItem.update({
       where: { id: item.id },

--- a/apps/backoffice/src/app/api/inventory/supplier-chats/[key]/route.ts
+++ b/apps/backoffice/src/app/api/inventory/supplier-chats/[key]/route.ts
@@ -136,6 +136,13 @@ export async function GET(req: NextRequest, { params }: { params: Promise<{ key:
   const windowOpen =
     !!lastInbound && Date.now() - +new Date(lastInbound.timestamp) < 24 * 60 * 60 * 1000;
 
+  // Cold sends are workable when the approved new-order prompt template is
+  // configured: "Create & send" outside the window sends the template prompt,
+  // and the PO block follows automatically when the supplier's reply reopens
+  // the window (sendPendingPurchaseOrders on the webhook). Lets the UI keep
+  // the button enabled instead of dead-ending into the manual flow.
+  const canColdPrompt = !!process.env.PROCUREMENT_PO_PROMPT_TEMPLATE?.trim();
+
   // Surface the supplier-chat agent's latest open proposal: only when the most
   // recent message WE sent was an agent escalation (a holding reply with a
   // structured proposal) and the supplier hasn't been answered by a human since.
@@ -236,5 +243,5 @@ export async function GET(req: NextRequest, { params }: { params: Promise<{ key:
     };
   }
 
-  return NextResponse.json({ key, supplierId, supplier, context, windowOpen, humanHandling, messages, agentProposal, agentReSource });
+  return NextResponse.json({ key, supplierId, supplier, context, windowOpen, canColdPrompt, humanHandling, messages, agentProposal, agentReSource });
 }

--- a/apps/backoffice/src/app/api/whatsapp/webhook/route.ts
+++ b/apps/backoffice/src/app/api/whatsapp/webhook/route.ts
@@ -24,6 +24,7 @@ import { handleReminderAck } from "@/lib/ops-reminders";
 import { handleInstructionAck } from "@/lib/ops-instructions";
 import { handleOutletDeliveryReply } from "@/lib/inventory/exec/outlet-delivery-check";
 import { handleSupplierMessage } from "@/lib/inventory/agents/supplier-chat-agent";
+import { sendPendingPurchaseOrders } from "@/lib/inventory/procurement-po-send";
 
 // GET — webhook verification handshake.
 export async function GET(request: NextRequest) {
@@ -154,6 +155,13 @@ export async function POST(request: NextRequest) {
             type: msg.type,
             mediaId: msg.document?.id ?? msg.image?.id ?? null,
           });
+        }
+        // 4) Queued PO delivery: this inbound just (re)opened the supplier's 24h
+        // window — deliver any PO blocks waiting behind a cold-send template
+        // prompt (raw.poPromptFor with no raw.poSentFor). Best-effort, internally
+        // deduped, never throws.
+        if (isNewInbound) {
+          await sendPendingPurchaseOrders(msg.from);
         }
       }
       for (const status of value.statuses ?? []) {

--- a/apps/backoffice/src/lib/inventory/agents/human-approval.ts
+++ b/apps/backoffice/src/lib/inventory/agents/human-approval.ts
@@ -86,6 +86,16 @@ export async function tryApplyHumanApproval(
     let result: ApprovalResult;
 
     if (pa.type === "reduce_qty" && typeof pa.newQuantity === "number" && pa.newQuantity > 0) {
+      // A reduce must LOWER the line — same ceiling as the agent's own applyPoAction.
+      // Escalated proposals can carry a model misread (e.g. "ada 50 je" read as qty 50
+      // on a 5-unit line); a bare "ok" in chat must never apply that blind and raise
+      // committed spend. Leave the proposal unresolved so the inbox still surfaces it.
+      if (pa.newQuantity >= Number(item.quantity)) {
+        console.warn(
+          `[human-approval] refused reduce_qty ${pa.newQuantity} >= current ${Number(item.quantity)} (${item.product?.name}) — needs manual review`,
+        );
+        return null;
+      }
       await prisma.orderItem.update({
         where: { id: item.id },
         data: { quantity: pa.newQuantity, totalPrice: Number(item.unitPrice) * pa.newQuantity },
@@ -145,7 +155,12 @@ async function applySubstitution(
   const sps = item.order.supplierId
     ? await prisma.supplierProduct.findMany({
         where: { supplierId: item.order.supplierId, isActive: true, price: { gt: 0 }, product: { isActive: true } },
-        select: { price: true, productPackageId: true, product: { select: { id: true, name: true } } },
+        select: {
+          price: true,
+          productPackageId: true,
+          product: { select: { id: true, name: true } },
+          productPackage: { select: { conversionFactor: true, packageLabel: true } },
+        },
       })
     : [];
   // The replacement = a supplier product (not the OOS one) whose name appears in the offer.
@@ -155,7 +170,13 @@ async function applySubstitution(
 
   await prisma.orderItem.delete({ where: { id: item.id } });
   if (repl) {
-    const qty = Number(item.quantity);
+    // Match the GOODS quantity, not the line count: the old line's package can differ
+    // from the replacement's (5 × 1kg bags ≠ 5 × 500g packs). Convert the removed line
+    // to base units, then into the replacement's package units, rounding up so we never
+    // under-order the recipe need.
+    const replConvRaw = repl.productPackage ? Number(repl.productPackage.conversionFactor) : 1;
+    const replConv = replConvRaw > 0 ? replConvRaw : 1;
+    const qty = Math.max(1, Math.ceil(baseQty / replConv));
     await prisma.orderItem.create({
       data: {
         orderId,
@@ -166,7 +187,8 @@ async function applySubstitution(
         totalPrice: Number(repl.price) * qty,
       },
     });
-    return { applied: "substitute_item", detail: `${item.product?.name} → ${repl.product.name} (${qty})` };
+    const unit = repl.productPackage?.packageLabel ?? "unit";
+    return { applied: "substitute_item", detail: `${item.product?.name} → ${repl.product.name} (${qty} ${unit})` };
   }
   // Couldn't price the replacement on this supplier → cover the need elsewhere.
   const rs = await reSource(item.productId, item.product?.name ?? "item", baseQty, item.order, callerId);

--- a/apps/backoffice/src/lib/inventory/agents/supplier-chat-agent.ts
+++ b/apps/backoffice/src/lib/inventory/agents/supplier-chat-agent.ts
@@ -587,13 +587,15 @@ async function applyPoAction(
     return { type: "none" };
   }
 
-  // Recompute the order total from the remaining lines.
-  const remaining = await prisma.orderItem.findMany({
-    where: { orderId },
-    select: { totalPrice: true },
-  });
-  const total = remaining.reduce((s, i) => s + Number(i.totalPrice), 0);
-  await prisma.order.update({ where: { id: orderId }, data: { totalAmount: total } });
+  // Recompute the order total from the remaining lines (+ keep the delivery charge —
+  // dropping it here understated totals and broke the ±2% invoice-total matching).
+  const [remaining, order] = await Promise.all([
+    prisma.orderItem.findMany({ where: { orderId }, select: { totalPrice: true } }),
+    prisma.order.findUnique({ where: { id: orderId }, select: { deliveryCharge: true } }),
+  ]);
+  const itemsTotal = remaining.reduce((s, i) => s + Number(i.totalPrice), 0);
+  const dc = order?.deliveryCharge ? Number(order.deliveryCharge) : 0;
+  await prisma.order.update({ where: { id: orderId }, data: { totalAmount: itemsTotal + dc } });
   return { type: action.type, removed };
 }
 

--- a/apps/backoffice/src/lib/inventory/exec/intent-responder.ts
+++ b/apps/backoffice/src/lib/inventory/exec/intent-responder.ts
@@ -176,29 +176,52 @@ async function handleSoa(
   return { outstanding, count: lines.length, sent };
 }
 
-/** Draft the week's order for a supplier that asked — their below-reorder lines. */
+/**
+ * Draft the week's order for a supplier that asked — their below-reorder lines,
+ * in the PACKAGE units the supplier sells (never bare base-unit numbers: a
+ * shortfall of 22,000 ml must read "22 Bottle (1000ml)", not "22000"). Skips
+ * outlet lines already covered by an open PO so we don't double-order.
+ */
 async function draftWeeklyOrder(supplierId: string, name: string): Promise<string | null> {
   const sps = await prisma.supplierProduct.findMany({
     where: { supplierId, isActive: true },
-    select: { productId: true, product: { select: { name: true } } },
+    select: {
+      productId: true,
+      product: { select: { name: true, baseUom: true } },
+      productPackage: { select: { conversionFactor: true, packageLabel: true } },
+    },
   });
   if (!sps.length) return null;
   const productIds = sps.map((s) => s.productId);
-  const nameById = new Map(sps.map((s) => [s.productId, s.product?.name ?? "?"]));
+  const spById = new Map(sps.map((s) => [s.productId, s]));
 
-  const [pars, stocks] = await Promise.all([
+  const [pars, stocks, openLines] = await Promise.all([
     prisma.parLevel.findMany({ where: { productId: { in: productIds } }, select: { productId: true, outletId: true, reorderPoint: true, parLevel: true } }),
     prisma.stockBalance.findMany({ where: { productId: { in: productIds } }, select: { productId: true, outletId: true, quantity: true } }),
+    // Lines already on an open PO (any supplier) — same coverage rule as the exec's
+    // OOS check, so the draft never re-orders what's already coming.
+    prisma.orderItem.findMany({
+      where: {
+        productId: { in: productIds },
+        order: { orderType: "PURCHASE_ORDER", status: { in: ["DRAFT", "PENDING_APPROVAL", "APPROVED", ...AWAITING_STATUSES, "PARTIALLY_RECEIVED"] as OrderStatus[] } },
+      },
+      select: { productId: true, order: { select: { outletId: true } } },
+    }),
   ]);
   const stockMap = new Map<string, number>();
   for (const s of stocks) {
     const k = `${s.productId}_${s.outletId}`;
     stockMap.set(k, (stockMap.get(k) ?? 0) + Number(s.quantity));
   }
-  // Aggregate the shortfall per product across outlets.
+  const covered = new Set<string>();
+  for (const l of openLines) if (l.order) covered.add(`${l.productId}_${l.order.outletId}`);
+
+  // Aggregate the shortfall per product across outlets (base units).
   const need = new Map<string, number>();
   for (const p of pars) {
-    const stock = stockMap.get(`${p.productId}_${p.outletId}`) ?? 0;
+    const k = `${p.productId}_${p.outletId}`;
+    if (covered.has(k)) continue;
+    const stock = stockMap.get(k) ?? 0;
     if (stock <= Number(p.reorderPoint)) {
       const short = Math.max(Number(p.parLevel) - stock, 0);
       if (short > 0) need.set(p.productId, (need.get(p.productId) ?? 0) + short);
@@ -210,7 +233,14 @@ async function draftWeeklyOrder(supplierId: string, name: string): Promise<strin
   const items = [...need.entries()]
     .sort((a, b) => b[1] - a[1])
     .slice(0, 10)
-    .map(([pid, qty]) => `• ${nameById.get(pid)} — ${Math.round(qty)}`);
+    .map(([pid, baseQty]) => {
+      const sp = spById.get(pid);
+      const convRaw = sp?.productPackage ? Number(sp.productPackage.conversionFactor) : 1;
+      const conv = convRaw > 0 ? convRaw : 1;
+      const pkgQty = Math.max(1, Math.ceil(baseQty / conv));
+      const unit = sp?.productPackage?.packageLabel ?? sp?.product?.baseUom ?? "unit";
+      return `• ${sp?.product?.name ?? "?"} — ${pkgQty} ${unit}`;
+    });
   return `Hi ${name}, yes please — boleh prepare:\n${items.join("\n")}\nThank you! 🙏`;
 }
 

--- a/apps/backoffice/src/lib/inventory/exec/proactive-order.ts
+++ b/apps/backoffice/src/lib/inventory/exec/proactive-order.ts
@@ -8,6 +8,7 @@
  */
 import { prisma } from "@/lib/prisma";
 import { boundedReorderQty } from "@/lib/inventory/order-validation";
+import { nextOrderNumber } from "@/lib/inventory/order-number";
 
 export const PROACTIVE_NOTE_PREFIX = "Auto reorder by procurement exec";
 
@@ -70,8 +71,11 @@ export async function createReorderDraftPO(opts: {
   const unitPrice = Number(best.a.price);
   try {
     const outlet = await prisma.outlet.findUniqueOrThrow({ where: { id: opts.outletId }, select: { code: true } });
-    const count = await prisma.order.count({ where: { outletId: opts.outletId } });
-    const orderNumber = `CC-${outlet.code}-${String(count + 1).padStart(4, "0")}`;
+    // Max-suffix helper, NOT COUNT(*)+1 — a count drifts behind the real max the moment a
+    // row is deleted or another scheme numbers ahead, and then every daily exec run
+    // collides on the @unique orderNumber and silently creates nothing (the count never
+    // advances past the collision). See order-number.ts — this exact bug was live once.
+    const orderNumber = await nextOrderNumber(outlet.code);
     const order = await prisma.order.create({
       data: {
         orderNumber,

--- a/apps/backoffice/src/lib/inventory/procurement-po-send.ts
+++ b/apps/backoffice/src/lib/inventory/procurement-po-send.ts
@@ -11,6 +11,7 @@
  * template to invite a reply (which opens the window so the PO block can follow); else the
  * cold send is skipped + logged. Never throws.
  */
+import { Prisma } from "@celsius/db";
 import { prisma } from "@/lib/prisma";
 import { sendWhatsAppText, sendWhatsAppTemplate } from "@/lib/whatsapp";
 import { recordOutboundMessage } from "@/lib/whatsapp-store";
@@ -185,5 +186,99 @@ export async function sendPurchaseOrder(order: PoForSend): Promise<void> {
     console.log(`[po-send] po=${order.orderNumber} supplier=${supplier.name} sent=${res.ok}`);
   } catch (err) {
     console.error("[po-send] error:", err instanceof Error ? err.message : err);
+  }
+}
+
+const PENDING_LOOKBACK_MS = 14 * 24 * 60 * 60 * 1000;
+
+/**
+ * Deliver PO blocks that were queued behind a closed 24h window.
+ *
+ * The cold path sends a template PROMPT (raw.poPromptFor) inviting the supplier
+ * to reply; the reply opens the window — and THIS is what then sends the actual
+ * PO block. Without it the prompt was a dead end: nothing consumed the reply,
+ * so a cold "Create & send" left the PO marked SENT but never delivered.
+ *
+ * Called from the WhatsApp webhook on every new inbound (best-effort, never
+ * throws). Matches the supplier by the same last-8-digits rule as the store,
+ * finds their recent POs that got a prompt but no block, and re-runs
+ * sendPurchaseOrder — which now sees the window open, sends the block, and
+ * stamps raw.poSentFor (its own dedup, so redeliveries are safe).
+ */
+export async function sendPendingPurchaseOrders(fromNumber: string): Promise<void> {
+  try {
+    if (!enabled()) return;
+    const tail = digits(fromNumber).slice(-8);
+    if (tail.length < 8) return;
+
+    // Prisma can't filter on "last 8 digits of a free-text phone" — fetch active
+    // suppliers and match in JS (same rule as whatsapp-store).
+    const all = await prisma.supplier.findMany({
+      where: { phone: { not: null }, status: "ACTIVE" },
+      select: { id: true, name: true, phone: true },
+    });
+    const supplier = all.find((s) => {
+      const sd = digits(s.phone);
+      return sd.length >= 8 && sd.slice(-8) === tail;
+    });
+    if (!supplier) return;
+
+    // Prompted-but-undelivered POs for this supplier (recent only).
+    const since = new Date(Date.now() - PENDING_LOOKBACK_MS);
+    const [prompted, delivered] = await Promise.all([
+      prisma.whatsAppMessage.findMany({
+        where: {
+          direction: "outbound",
+          supplierId: supplier.id,
+          timestamp: { gte: since },
+          raw: { path: ["poPromptFor"], not: Prisma.DbNull },
+        },
+        select: { raw: true },
+      }),
+      prisma.whatsAppMessage.findMany({
+        where: {
+          direction: "outbound",
+          supplierId: supplier.id,
+          timestamp: { gte: since },
+          raw: { path: ["poSentFor"], not: Prisma.DbNull },
+        },
+        select: { raw: true },
+      }),
+    ]);
+    const sentIds = new Set(delivered.map((m) => String((m.raw as Record<string, unknown>)?.poSentFor ?? "")));
+    const pendingIds = [
+      ...new Set(
+        prompted
+          .map((m) => String((m.raw as Record<string, unknown>)?.poPromptFor ?? ""))
+          .filter((id) => id && !sentIds.has(id)),
+      ),
+    ];
+    if (!pendingIds.length) return;
+
+    const orders = await prisma.order.findMany({
+      where: { id: { in: pendingIds }, status: { in: ["APPROVED", "SENT", "CONFIRMED", "AWAITING_DELIVERY"] } },
+      select: {
+        id: true,
+        orderNumber: true,
+        deliveryDate: true,
+        outlet: { select: { name: true, address: true } },
+        supplier: { select: { id: true, name: true, phone: true, automationMode: true } },
+        items: {
+          select: {
+            quantity: true,
+            product: { select: { name: true, baseUom: true } },
+            productPackage: { select: { packageLabel: true } },
+          },
+        },
+      },
+    });
+    for (const order of orders) {
+      await sendPurchaseOrder(order); // window is open now; dedups via poSentFor
+    }
+    if (orders.length) {
+      console.log(`[po-send] window opened by ${supplier.name} — delivered ${orders.length} queued PO block(s)`);
+    }
+  } catch (err) {
+    console.error("[po-send] pending-send error:", err instanceof Error ? err.message : err);
   }
 }

--- a/apps/staff/src/app/api/receivings/route.ts
+++ b/apps/staff/src/app/api/receivings/route.ts
@@ -1,4 +1,5 @@
 import { NextResponse, NextRequest } from "next/server";
+import { baseQtyByProduct } from "@celsius/db";
 import { prisma } from "@/lib/prisma";
 import { adjustStockBalance } from "@/lib/stock";
 import { getSession } from "@/lib/auth";
@@ -88,6 +89,9 @@ export async function POST(req: NextRequest) {
 
   // PO ordered quantities by product+package, used to backfill orderedQty.
   const orderedQtyMap = new Map<string, number>();
+  // PO package per product — receivings are counted in the PO's package unit,
+  // so we use this to convert receivedQty to base UOM before touching stock.
+  const poPkgMap = new Map<string, string | null>();
   const resolveOrderedQty = (i: { productId: string; productPackageId?: string; orderedQty?: number }): number | null => {
     if (i.orderedQty !== undefined && i.orderedQty !== null) return i.orderedQty;
     if (!orderId) return null;
@@ -122,6 +126,7 @@ export async function POST(req: NextRequest) {
     });
     for (const oi of poItems) {
       orderedQtyMap.set(`${oi.productId}::${oi.productPackageId ?? ""}`, Number(oi.quantity));
+      if (!poPkgMap.has(oi.productId)) poPkgMap.set(oi.productId, oi.productPackageId ?? null);
     }
 
     const hasShort = items.some((i: { productId: string; productPackageId?: string; orderedQty?: number; receivedQty: number }) => {
@@ -153,10 +158,38 @@ export async function POST(req: NextRequest) {
     },
   });
 
-  // Update stock balances (parallel)
+  // Update stock balances. Goods are received in the PO's package unit
+  // ("12 bottles"), but StockBalance is tracked in base UOM, so multiply each
+  // line by its package conversionFactor before incrementing the canonical
+  // per-product row (productPackageId = null) — same rule as stock counts.
+  const recvPkgIds = [
+    ...new Set(
+      (items as Array<{ productId: string; productPackageId?: string }>)
+        .map((i) => i.productPackageId ?? poPkgMap.get(i.productId) ?? null)
+        .filter((id): id is string => id != null),
+    ),
+  ];
+  const cfMap = new Map<string, number>();
+  if (recvPkgIds.length > 0) {
+    const pkgs = await prisma.productPackage.findMany({
+      where: { id: { in: recvPkgIds } },
+      select: { id: true, conversionFactor: true },
+    });
+    for (const p of pkgs) cfMap.set(p.id, Number(p.conversionFactor));
+  }
+  const baseTotals = baseQtyByProduct(
+    (items as Array<{ productId: string; productPackageId?: string; receivedQty: number }>).map((i) => {
+      const pkgId = i.productPackageId ?? poPkgMap.get(i.productId) ?? null;
+      return {
+        productId: i.productId,
+        countedQty: i.receivedQty,
+        conversionFactor: pkgId ? cfMap.get(pkgId) ?? 1 : 1,
+      };
+    }),
+  );
   await Promise.all(
-    items.map((item: { productId: string; receivedQty: number }) =>
-      adjustStockBalance(outletId, item.productId, item.receivedQty),
+    [...baseTotals].map(([productId, baseQty]) =>
+      adjustStockBalance(outletId, productId, baseQty, null),
     ),
   );
 


### PR DESCRIPTION
Follow-up to #670. Three sets of fixes from the same QA effort.

## 1. Receiving — apply package conversion factor to base UOM

Receiving had the identical bug to #670, on the higher-frequency flow (872 receivings, active daily). Both the staff and backoffice routes now multiply each line by its package `conversionFactor` (shared `baseQtyByProduct` helper) and increment the canonical per-product balance row (`productPackageId = null`). Staff derives the package from the PO line; backoffice uses the line's `productPackageId`.

## 2. COGS report — classify packaging by item-group

`totalPackagingCogs` was always RM 0 because no products carry `itemType=PACKAGING` (packaging is classified by item-group). Now detects either. Total COGS unchanged (RM 104,614.58); split verified: packaging RM 1,009 / ingredient RM 103,605.

## 3. Procurement-loop review findings (approval guardrails, units, PO numbering)

From the loop codebase review — the two worst let the **approval paths re-introduce the risks the agent's guardrails escalate to avoid**:

- **Reduce ceiling on both approval paths** (`human-approval.ts` chat "ok" + `apply-proposal` inbox button): a `reduce_qty` must lower the line. Escalated proposals can carry a model misread ("ada 50 je" → qty 50 on a 5-unit line); both paths applied it blind, silently **raising committed spend**. Chat approval now refuses (proposal stays unresolved for the inbox); the inbox returns a clear 400.
- **Substitution converts through base units**: the approved swap copied the old line's package qty onto a replacement whose package can differ (5 × 1kg became 5 × 500g). Now old line → base units → ceil into the replacement's package units.
- **Vendor-push weekly draft** sends package units with labels ("22 Bottle (1000ml)") instead of bare base-unit numbers ("22000"), and skips outlet lines already covered by an open PO (same rule as the exec's OOS check).
- **Exec proactive PO numbering** uses the shared `nextOrderNumber` max-suffix helper instead of `COUNT(*)+1` — the documented past live bug; on drift every daily run collided on the `@unique` orderNumber and silently created nothing.
- **Agent auto-edits keep `deliveryCharge`** in the recomputed PO total (was summing lines only, understating totals and breaking ±2% invoice matching; approval paths already did this correctly).

## Testing
- `npx vitest run packages/db apps/backoffice/src/lib/inventory` → 47 passing (order-validation, verifier, consumption, payment-model, usage-variance suites).
- Full app typecheck not run here (deps not installed in this environment); edits mirror existing patterns in the same files.

## Review findings NOT fixed here (need a design decision)
- Agent PO-edit targeting picks the most recent open PO — multi-outlet suppliers can get edits on the wrong PO (needs a matching strategy decision).
- Chat-agent / intent-responder can double-reply to "any order this week?" from suppliers with an open PO.
- Daily exec brief is burned when the send fails, and can only deliver inside a 24h window (needs an approved Meta template to work cold).
- `boundedReorderQty` floors at 1 package even when the max-level cap is 0.
- `procurement-po-send` still honors the legacy `PROCUREMENT_AGENT_ALLOWLIST` env alongside the newer per-supplier `automationMode` dial.

🤖 Generated with [Claude Code](https://claude.com/claude-code)