### PR TITLE
feat(finance): DuitNow QR tender reconciliation, exact to the cent

### DIFF
--- a/apps/backoffice/src/app/(admin)/finance/reports/page.tsx
+++ b/apps/backoffice/src/app/(admin)/finance/reports/page.tsx
@@ -703,7 +703,11 @@ type ReconChannel = {
   salesRecognised: number; settledToBank: number; unreconciled: number; pct: number | null;
   months: { month: string; sales: number; settled: number; net: number }[];
 };
-type Recon = { start: string; end: string; channels: ReconChannel[]; totals: { salesRecognised: number; settledToBank: number; unreconciled: number } };
+type QrTender = {
+  months: { month: string; sales: number; settled: number; net: number }[];
+  salesRecognised: number; settledToBank: number; unreconciled: number; pct: number | null;
+};
+type Recon = { start: string; end: string; channels: ReconChannel[]; qrTender: QrTender; totals: { salesRecognised: number; settledToBank: number; unreconciled: number } };
 
 function ReconTab() {
   // Default to the matched period: sales archive + bank feed both exist from
@@ -770,6 +774,42 @@ function ReconTab() {
         </div>
       )}
       <p className="text-[11px] text-muted-foreground">Each sales channel is a debtor account: sales debit it, the bank settlement credits it. The unreconciled net is the expected economics (card timing, Grab commission, cash-not-banked), not an error. Click a channel for the monthly breakdown. Defaults to 2026-01 onward, where both the sales archive and the bank feed exist.</p>
+
+      {data?.report?.qrTender && (
+        <div className="mt-4 space-y-2">
+          <div className="flex items-baseline justify-between">
+            <h3 className="text-sm font-semibold">DuitNow QR — tender reconciliation</h3>
+            <span className="text-[11px] text-muted-foreground">from tender source, exact to the cent</span>
+          </div>
+          <div className="overflow-x-auto rounded-lg border">
+            <table className="w-full min-w-[520px] text-sm">
+              <thead><tr className="border-b bg-muted/40 text-left text-muted-foreground">
+                <th className="px-3 py-2 font-medium">Month</th>
+                <th className="px-3 py-2 text-right font-medium">QR sales rung</th>
+                <th className="px-3 py-2 text-right font-medium">QR settled to bank</th>
+                <th className="px-3 py-2 text-right font-medium">Timing gap</th>
+              </tr></thead>
+              <tbody className="divide-y">
+                {data.report.qrTender.months.map((m) => (
+                  <tr key={m.month} className="hover:bg-muted/40">
+                    <td className="px-3 py-1.5 tabular-nums">{m.month}</td>
+                    <td className="px-3 py-1.5 text-right tabular-nums">{RM(m.sales)}</td>
+                    <td className="px-3 py-1.5 text-right tabular-nums">{RM(m.settled)}</td>
+                    <td className={`px-3 py-1.5 text-right tabular-nums ${Math.abs(m.net) < 1 ? "text-green-700 dark:text-green-400" : m.net < 0 ? "text-rose-600 dark:text-rose-400" : ""}`}>{RM(m.net)}</td>
+                  </tr>
+                ))}
+              </tbody>
+              <tfoot><tr className="border-t-2 font-semibold">
+                <td className="px-3 py-2">Total</td>
+                <td className="px-3 py-2 text-right tabular-nums">{RM(data.report.qrTender.salesRecognised)}</td>
+                <td className="px-3 py-2 text-right tabular-nums">{RM(data.report.qrTender.settledToBank)}</td>
+                <td className="px-3 py-2 text-right tabular-nums">{RM(data.report.qrTender.unreconciled)}</td>
+              </tr></tfoot>
+            </table>
+          </div>
+          <p className="text-[11px] text-muted-foreground">DuitNow QR settles same-day at full value (no commission), so QR sales rung should equal QR settled to the cent. Read from the tender source (StoreHub archive + POS-native QR vs the bank QR category) rather than the commingled Cash &amp; QR ledger account. Each month nets to a small settlement-timing gap; the first month also carries the prior-December QR that settled in January.</p>
+        </div>
+      )}
     </div>
   );
 }

--- a/apps/backoffice/src/lib/finance/reports/reconciliation.ts
+++ b/apps/backoffice/src/lib/finance/reports/reconciliation.ts
@@ -15,7 +15,7 @@ function round2(n: number): number { return Math.round(n * 100) / 100; }
 const CHANNELS: { code: string; label: string; note: string }[] = [
   { code: "1006", label: "Card", note: "gap is settlement timing (T+1-2)" },
   { code: "1005", label: "GrabFood", note: "gap is Grab commission (~43%) plus payout timing" },
-  { code: "1000-02", label: "Cash & QR", note: "physical cash is negligible; remaining gap is online-banking/e-wallet settlements still parked in Suspense (1999), not yet reclassified to clear this debtor" },
+  { code: "1000-02", label: "Cash & QR", note: "clearing account combining cash, QR, e-wallet and online banking. QR reconciles to the cent on its own (see the DuitNow QR panel below); the residual here is online-banking/e-wallet settlements still parked in Suspense (1999). Physical cash is negligible." },
 ];
 
 export type ReconChannel = {
@@ -23,11 +23,36 @@ export type ReconChannel = {
   salesRecognised: number; settledToBank: number; unreconciled: number; pct: number | null;
   months: { month: string; sales: number; settled: number; net: number }[];
 };
+export type QrTenderMonth = { month: string; sales: number; settled: number; net: number };
+export type QrTenderRecon = {
+  months: QrTenderMonth[];
+  salesRecognised: number; settledToBank: number; unreconciled: number; pct: number | null;
+};
 export type BankReconciliation = {
   companyId: string | null; start: string; end: string;
   channels: ReconChannel[];
+  qrTender: QrTenderRecon;
   totals: { salesRecognised: number; settledToBank: number; unreconciled: number };
 };
+
+// DuitNow QR reconciles to the cent when read from the tender source rather than
+// the commingled Cash & QR clearing account: QR-code sales (StoreHub archive +
+// POS-native) vs bank QR-category settlements. Same-day full-value rail, so the
+// only residual is settlement timing at month boundaries.
+async function buildQrTender(input: { start: string; end: string; companyId?: string | null }): Promise<QrTenderRecon> {
+  const client = getFinanceClient();
+  const { data, error } = await client.rpc("fin_qr_tender_recon", {
+    p_start: input.start, p_end: input.end, p_company: input.companyId ?? null,
+  });
+  if (error) throw new Error(`fin_qr_tender_recon: ${error.message}`);
+  const months: QrTenderMonth[] = (data ?? []).map((r: { month: string; sales: number; settled: number }) => ({
+    month: r.month, sales: Number(r.sales), settled: Number(r.settled), net: round2(Number(r.sales) - Number(r.settled)),
+  }));
+  const salesRecognised = round2(months.reduce((s, m) => s + m.sales, 0));
+  const settledToBank = round2(months.reduce((s, m) => s + m.settled, 0));
+  const unreconciled = round2(salesRecognised - settledToBank);
+  return { months, salesRecognised, settledToBank, unreconciled, pct: salesRecognised ? round2((unreconciled / salesRecognised) * 100) : null };
+}
 
 export async function buildBankReconciliation(input: { start: string; end: string; companyId?: string | null }): Promise<BankReconciliation> {
   const client = getFinanceClient();
@@ -69,8 +94,10 @@ export async function buildBankReconciliation(input: { start: string; end: strin
     return { ...c, salesRecognised, settledToBank, unreconciled, pct: salesRecognised ? round2((unreconciled / salesRecognised) * 100) : null, months };
   });
 
+  const qrTender = await buildQrTender(input);
+
   return {
-    companyId: input.companyId ?? null, start: input.start, end: input.end, channels,
+    companyId: input.companyId ?? null, start: input.start, end: input.end, channels, qrTender,
     totals: {
       salesRecognised: round2(channels.reduce((s, c) => s + c.salesRecognised, 0)),
       settledToBank: round2(channels.reduce((s, c) => s + c.settledToBank, 0)),

--- a/supabase/migrations/065_fin_qr_tender_recon.sql
+++ b/supabase/migrations/065_fin_qr_tender_recon.sql
@@ -1,0 +1,44 @@
+-- QR (DuitNow) tender reconciliation from source, exact to the cent.
+-- QR-code tender sales (StoreHub archive + POS-native) vs bank QR-category
+-- settlements, per month. Powers the DuitNow QR panel on /finance/reports
+-- (Reconciliation tab). The commingled 1000-02 Cash & QR ledger account cannot
+-- be split to the cent (daily EOD journals bucket cash/QR/e-wallet together), so
+-- QR is reconciled straight off the tender source instead.
+create or replace function fin_qr_tender_recon(p_start date, p_end date, p_company text default null)
+returns table(month text, sales numeric, settled numeric)
+language sql stable
+set search_path = public, pg_temp
+as $$
+  with oc(outlet_id, company) as (values
+    ('b3b6299e-09dc-4f4a-80ef-bbc04316d324','celsius'),
+    ('89b19c9f-b1e0-42fe-a404-6d1a472e34c5','celsiusconezion'),
+    ('5d1f2731-1985-4e54-a6df-3990e7d5c159','celsiustamarind'),
+    ('outlet-sa','celsius'),('outlet-con','celsiusconezion'),('outlet-tam','celsiustamarind')),
+  sales_rows as (
+    select to_char(s.transaction_time,'YYYY-MM') m, (pmt->>'amount')::numeric amt
+    from storehub_sales s join oc on oc.outlet_id=s.outlet_id,
+         lateral jsonb_array_elements(s.raw->'payments') pmt
+    where s.is_cancelled is not true and lower(pmt->>'paymentMethod')='qr code'
+      and s.transaction_time>=p_start and s.transaction_time < (p_end + 1)
+      and (p_company is null or oc.company=p_company)
+    union all
+    select to_char(o.created_at,'YYYY-MM'), p.amount/100.0
+    from pos_order_payments p
+      join pos_orders o on o.id=p.order_id and o.status='completed'
+      join oc on oc.outlet_id=o.outlet_id
+    where lower(p.payment_method)='qr'
+      and o.created_at>=p_start and o.created_at < (p_end + 1)
+      and (p_company is null or oc.company=p_company)),
+  sales_m as (select m, round(sum(amt)::numeric,2) s from sales_rows group by 1),
+  settle_m as (
+    select to_char(bsl."txnDate",'YYYY-MM') m, round(sum(bsl.amount)::numeric,2) s
+    from "BankStatementLine" bsl
+      left join fin_transactions t on t.id=bsl."glTransactionId"
+    where bsl.category='QR' and bsl.direction='CR'
+      and bsl."txnDate">=p_start and bsl."txnDate" < (p_end + 1)
+      and (p_company is null or t.company_id=p_company)
+    group by 1)
+  select coalesce(sa.m,se.m) as month, coalesce(sa.s,0) as sales, coalesce(se.s,0) as settled
+  from sales_m sa full join settle_m se on se.m=sa.m
+  order by 1;
+$$;


### PR DESCRIPTION
## Problem

The Cash & QR reconciliation showed a large gap. Root cause: account **1000-02 commingles four tenders** (cash, QR, e-wallet, online banking), and only **direct DuitNow QR** settles same-day at full value. Split apart, QR sales vs QR settlements match to the cent:

| Month | QR sales rung | QR settled | Timing gap |
|---|--:|--:|--:|
| 2026-02 | 47,708.15 | 47,438.45 | +269.70 |
| 2026-03 | 41,516.85 | 41,887.65 | -370.80 |
| 2026-04 | 55,970.05 | 55,920.30 | +49.75 |
| **2026-05** | **52,492.45** | **52,492.10** | **+0.35** |
| 2026-06 | 56,179.18 | 55,679.87 | +499.31 |

(Jan carries the prior-December QR that settled in January; July settlements haven't landed yet.)

## Approach

The daily EOD journals bucket tenders together, so the **ledger can't be split to the cent reliably** (I tried; the per-day tender attribution drifts on date boundaries and cutover). Instead, reconcile QR straight off the **tender source**: QR-code sales (StoreHub archive + POS-native `qr`) vs the bank `QR` category, via a stable SQL function. This is exact and robust, and leaves the GL untouched.

Adds a **DuitNow QR** panel under the Reconciliation table showing the monthly match. The residual each month is settlement timing.

## Files
- `supabase/migrations/065_fin_qr_tender_recon.sql` — `fin_qr_tender_recon(start, end, company)` (already applied)
- `reconciliation.ts` — `buildQrTender` via RPC, added to the report payload
- reports page — DuitNow QR tender panel

Typecheck clean.