### PR TITLE
feat(hr): pay part-timer weekly payroll from clock-in/out hours (flat)

### DIFF
--- a/apps/backoffice/src/app/(admin)/hr/payroll/weekly/page.tsx
+++ b/apps/backoffice/src/app/(admin)/hr/payroll/weekly/page.tsx
@@ -167,8 +167,8 @@ export default function WeeklyPayrollPage() {
         <h1 className="text-2xl font-bold">Weekly Payroll (Part-Timers)</h1>
       </div>
       <p className="text-sm text-muted-foreground">
-        Part-time payroll runs Mon–Sun, paid the following week. Gross = scheduled hours
-        (from the published roster) × hourly rate. OT is added by managers as ad-hoc adjustments.
+        Part-time payroll runs Mon–Sun, paid the following week. Gross = clocked hours
+        (from the staff app clock-in/out, break excluded) × hourly rate. Flat rate, no OT premium.
       </p>
 
       {/* Compute Controls */}
@@ -398,7 +398,8 @@ type WeeklyPreflightIssue = { code: string; severity: "block" | "warn"; message:
 type WeeklyPreflightRow = {
   user_id: string;
   name: string;
-  scheduled_shifts: number;
+  logged_shifts: number;
+  logged_hours: number;
   skipped: boolean;
   skip_reason: string | null;
   issues: WeeklyPreflightIssue[];
@@ -407,14 +408,13 @@ type WeeklyPreflightRow = {
 type WeeklyPreflightSummary = {
   total_part_timers: number;
   payable: number;
-  not_scheduled: number;
+  no_clockins: number;
   blocked: number;
   warning: number;
   skipped: number;
   final_payroll: number;
-  published_schedules: number;
-  published_shifts: number;
-  draft_schedules: number;
+  total_logged_shifts: number;
+  total_logged_hours: number;
 };
 
 function WeeklyPreflightPanel({ weekStart }: { weekStart: string }) {
@@ -427,25 +427,25 @@ function WeeklyPreflightPanel({ weekStart }: { weekStart: string }) {
     return (
       <div className="mt-4 rounded-md border bg-gray-50 p-3 text-xs text-gray-500">
         <Loader2 className="mr-2 inline h-3 w-3 animate-spin" />
-        Checking roster + readiness…
+        Checking clock-ins + readiness…
       </div>
     );
   }
 
   const { summary, rows } = data;
   const issuesOnly = rows.filter((r) => r.status === "blocked" || r.status === "warning");
-  const noRoster = summary.published_schedules === 0;
+  const noClockData = summary.total_logged_shifts === 0;
 
   return (
     <div className="mt-4 rounded-md border bg-gray-50 p-3">
       <div className="flex flex-wrap items-center gap-2 text-xs">
         <span className="font-semibold uppercase tracking-wide text-gray-500">Pre-run check</span>
-        <Pill color="blue" label={`${summary.published_shifts} scheduled shifts`} />
+        <Pill color="blue" label={`${summary.total_logged_shifts} clocked shifts · ${summary.total_logged_hours}h`} />
         <Pill color="emerald" label={`${summary.payable} payable`} />
         {summary.warning > 0 && <Pill color="amber" label={`${summary.warning} warning`} />}
         {summary.blocked > 0 && <Pill color="red" label={`${summary.blocked} blocked`} />}
-        {summary.not_scheduled > 0 && (
-          <Pill color="gray" label={`${summary.not_scheduled} not scheduled`} />
+        {summary.no_clockins > 0 && (
+          <Pill color="gray" label={`${summary.no_clockins} no clock-ins`} />
         )}
         {summary.final_payroll > 0 && (
           <Pill color="amber" label={`${summary.final_payroll} final payroll`} />
@@ -453,20 +453,18 @@ function WeeklyPreflightPanel({ weekStart }: { weekStart: string }) {
         {summary.skipped > 0 && <Pill color="gray" label={`${summary.skipped} prior-cycle resigners`} />}
       </div>
 
-      {noRoster ? (
+      {noClockData ? (
         <p className="mt-1 text-xs font-medium text-red-700">
-          ⚠ No published schedule covers this week. Publish the roster
-          {summary.draft_schedules > 0 ? " (you have draft schedules — publish them)" : ""}
-          {" "}before computing payroll.
+          ⚠ No part-timer has clocked in this week yet. Compute will produce zero rows.
         </p>
       ) : summary.payable === 0 ? (
         <p className="mt-1 text-xs text-amber-700">
-          Roster is published but no part-timer is scheduled. Compute will produce zero rows.
+          Part-timers clocked in, but none are payable (check hourly rates). Compute will produce zero rows.
         </p>
       ) : issuesOnly.length === 0 ? (
         <p className="mt-1 text-xs text-emerald-700">
           ✓ {summary.payable} part-timer{summary.payable === 1 ? "" : "s"} ready
-          ({summary.published_shifts} shift{summary.published_shifts === 1 ? "" : "s"}).
+          ({summary.total_logged_shifts} shift{summary.total_logged_shifts === 1 ? "" : "s"}, {summary.total_logged_hours}h).
         </p>
       ) : (
         <>
@@ -493,7 +491,7 @@ function WeeklyPreflightPanel({ weekStart }: { weekStart: string }) {
                     <Link href={`/hr/employees/${r.user_id}`} className="font-medium text-blue-600 hover:underline">
                       {r.name}
                     </Link>
-                    <span className="text-gray-400">· {r.scheduled_shifts} shift{r.scheduled_shifts === 1 ? "" : "s"}</span>
+                    <span className="text-gray-400">· {r.logged_shifts} shift{r.logged_shifts === 1 ? "" : "s"} · {r.logged_hours}h</span>
                   </div>
                   <ul className="ml-4 mt-1 list-disc space-y-0.5 text-[10px] text-gray-600">
                     {r.issues.map((i) => (

--- a/apps/backoffice/src/app/api/hr/payroll/weekly/preflight/route.ts
+++ b/apps/backoffice/src/app/api/hr/payroll/weekly/preflight/route.ts
@@ -2,14 +2,15 @@ import { NextRequest, NextResponse } from "next/server";
 import { getSession } from "@/lib/auth";
 import { hrSupabaseAdmin } from "@/lib/hr/supabase";
 import { prisma } from "@/lib/prisma";
+import { breakHoursFor } from "@/lib/hr/hours";
 
 export const dynamic = "force-dynamic";
 
-// Pre-run readiness for the WEEKLY (part-timer) cycle. Surfaces:
-//  - Global: any published schedule covering this week? if not, nothing to pay.
-//  - Per-PT: hourly_rate set? scheduled this week? bank account? final payroll?
+// Pre-run readiness for the WEEKLY (part-timer) cycle — CLOCK-BASED. Surfaces:
+//  - Per-PT: hourly_rate set? clocked any shifts this week? bank account? final payroll?
 //
-// Schedule-based: only PTs with shifts in a PUBLISHED roster are paid.
+// Part-timers are paid for the hours they CLOCK on the staff app, so readiness is
+// "did they clock in this week", not "is there a published roster".
 //
 // GET /api/hr/payroll/weekly/preflight?week_start=YYYY-MM-DD
 type Issue = { code: string; severity: "block" | "warn"; message: string };
@@ -32,6 +33,8 @@ export async function GET(req: NextRequest) {
   end.setUTCDate(end.getUTCDate() + 6);
   const periodStart = weekStart;
   const periodEnd = end.toISOString().slice(0, 10);
+  const weekStartIso = `${periodStart}T00:00:00+08:00`;
+  const weekEndIso = `${periodEnd}T23:59:59+08:00`;
 
   // 1. Profiles + linked users
   const { data: profiles } = await hrSupabaseAdmin
@@ -50,47 +53,29 @@ export async function GET(req: NextRequest) {
     : [];
   const userMap = new Map(users.map((u) => [u.id, u]));
 
-  // 2. Published schedules + shifts in this week
-  const { data: schedules } = await hrSupabaseAdmin
-    .from("hr_schedules")
-    .select("id, status")
-    .eq("status", "published")
-    .lte("week_start", periodEnd)
-    .gte("week_end", periodStart);
-  const scheduleIds = (schedules || []).map((s: { id: string }) => s.id);
-
-  const { data: shifts } = scheduleIds.length
+  // 2. Clocked (closed) attendance for these PTs in the MYT week.
+  type Log = { user_id: string; clock_in: string; clock_out: string | null; total_hours: number | string | null; final_status: string | null };
+  const { data: logs } = userIds.length
     ? await hrSupabaseAdmin
-        .from("hr_schedule_shifts")
-        .select("user_id, shift_date")
-        .in("schedule_id", scheduleIds)
-        .gte("shift_date", periodStart)
-        .lte("shift_date", periodEnd)
-    : { data: [] as Array<{ user_id: string; shift_date: string }> };
+        .from("hr_attendance_logs")
+        .select("user_id, clock_in, clock_out, total_hours, final_status")
+        .in("user_id", userIds)
+        .gte("clock_in", weekStartIso)
+        .lte("clock_in", weekEndIso)
+        .not("clock_out", "is", null)
+    : { data: [] as Log[] };
 
   const shiftCountByUser = new Map<string, number>();
-  for (const s of shifts || []) {
-    shiftCountByUser.set(s.user_id, (shiftCountByUser.get(s.user_id) || 0) + 1);
+  const hoursByUser = new Map<string, number>();
+  for (const l of (logs || []) as Log[]) {
+    if (l.final_status === "rejected") continue;
+    shiftCountByUser.set(l.user_id, (shiftCountByUser.get(l.user_id) || 0) + 1);
+    const totalH = l.total_hours != null
+      ? Number(l.total_hours)
+      : Math.max(0, (new Date(l.clock_out as string).getTime() - new Date(l.clock_in).getTime()) / 3600000);
+    const worked = Math.max(0, totalH - breakHoursFor("part_time", totalH));
+    hoursByUser.set(l.user_id, (hoursByUser.get(l.user_id) || 0) + worked);
   }
-
-  // 3. Also detect PTs with shifts in a DRAFT schedule (so we can warn that
-  // the roster needs publishing before they get paid).
-  const { data: draftSchedules } = await hrSupabaseAdmin
-    .from("hr_schedules")
-    .select("id")
-    .neq("status", "published")
-    .lte("week_start", periodEnd)
-    .gte("week_end", periodStart);
-  const draftScheduleIds = (draftSchedules || []).map((s: { id: string }) => s.id);
-  const { data: draftShifts } = draftScheduleIds.length
-    ? await hrSupabaseAdmin
-        .from("hr_schedule_shifts")
-        .select("user_id")
-        .in("schedule_id", draftScheduleIds)
-        .gte("shift_date", periodStart)
-        .lte("shift_date", periodEnd)
-    : { data: [] as Array<{ user_id: string }> };
-  const draftUserIds = new Set((draftShifts || []).map((s: { user_id: string }) => s.user_id));
 
   type Profile = {
     user_id: string;
@@ -106,15 +91,16 @@ export async function GET(req: NextRequest) {
     const resignDate = p.end_date || p.resigned_at || null;
     const resignedBefore = resignDate && resignDate < periodStart;
     const isFinalCycle = !!resignDate && !resignedBefore && resignDate <= periodEnd;
-    const shiftCount = shiftCountByUser.get(p.user_id) || 0;
-    const inDraftOnly = shiftCount === 0 && draftUserIds.has(p.user_id);
+    const loggedShifts = shiftCountByUser.get(p.user_id) || 0;
+    const loggedHours = Math.round((hoursByUser.get(p.user_id) || 0) * 100) / 100;
 
     // Resigned in a prior cycle — won't appear at all.
     if (resignedBefore) {
       return {
         user_id: p.user_id,
         name: u?.fullName || u?.name || p.user_id.slice(0, 8),
-        scheduled_shifts: 0,
+        logged_shifts: 0,
+        logged_hours: 0,
         skipped: true,
         skip_reason: `resigned ${resignDate} (paid in prior cycle)`,
         issues: [] as Issue[],
@@ -135,25 +121,16 @@ export async function GET(req: NextRequest) {
     if (Number(p.hourly_rate || 0) <= 0) {
       issues.push({ code: "missing_hourly_rate", severity: "block", message: "No hourly rate set" });
     }
-    if (shiftCount === 0 && !inDraftOnly) {
-      // Not on the published roster at all — by design no payment line.
-      // Surface as a soft note rather than a warning so HR isn't alarmed
-      // when half the cohort isn't scheduled this week.
+    if (loggedShifts === 0) {
+      // No clock-ins this week — by design no payment line. Soft note.
       issues.push({
-        code: "not_scheduled",
+        code: "no_clockins",
         severity: "warn",
-        message: "Not scheduled this week — no payroll line will be created.",
-      });
-    }
-    if (inDraftOnly) {
-      issues.push({
-        code: "draft_only",
-        severity: "warn",
-        message: "Has shifts in a DRAFT schedule. Publish the roster before computing.",
+        message: "No clock-ins this week — no payroll line will be created.",
       });
     }
 
-    if (shiftCount > 0 && (!u?.bankName || !u?.bankAccountNumber)) {
+    if (loggedShifts > 0 && (!u?.bankName || !u?.bankAccountNumber)) {
       issues.push({
         code: "missing_bank",
         severity: "warn",
@@ -169,7 +146,8 @@ export async function GET(req: NextRequest) {
     return {
       user_id: p.user_id,
       name: u?.fullName || u?.name || p.user_id.slice(0, 8),
-      scheduled_shifts: shiftCount,
+      logged_shifts: loggedShifts,
+      logged_hours: loggedHours,
       skipped: false,
       skip_reason: null,
       issues,
@@ -179,15 +157,14 @@ export async function GET(req: NextRequest) {
 
   const summary = {
     total_part_timers: rows.length,
-    payable: rows.filter((r) => r.scheduled_shifts > 0 && r.status !== "blocked").length,
-    not_scheduled: rows.filter((r) => r.scheduled_shifts === 0 && r.status !== "skipped").length,
+    payable: rows.filter((r) => r.logged_shifts > 0 && r.status !== "blocked").length,
+    no_clockins: rows.filter((r) => r.logged_shifts === 0 && r.status !== "skipped").length,
     blocked: rows.filter((r) => r.status === "blocked").length,
     warning: rows.filter((r) => r.status === "warning").length,
     skipped: rows.filter((r) => r.status === "skipped").length,
     final_payroll: rows.filter((r) => r.issues.some((i) => i.code === "final_payroll")).length,
-    published_schedules: scheduleIds.length,
-    published_shifts: (shifts || []).length,
-    draft_schedules: draftScheduleIds.length,
+    total_logged_shifts: (rows as { logged_shifts: number }[]).reduce((s, r) => s + r.logged_shifts, 0),
+    total_logged_hours: Math.round((rows as { logged_hours: number }[]).reduce((s, r) => s + r.logged_hours, 0) * 100) / 100,
   };
 
   return NextResponse.json({ summary, rows });

--- a/apps/backoffice/src/app/api/hr/payroll/weekly/route.ts
+++ b/apps/backoffice/src/app/api/hr/payroll/weekly/route.ts
@@ -184,9 +184,10 @@ export async function PATCH(req: NextRequest) {
     : Number(existing.computation_details?.hourly_rate || 0);
   const newOtHours = ot_hours !== undefined ? Number(ot_hours) : Number(existing.total_ot_hours || 0);
 
-  // Recompute gross from hours × rate (+ OT @ 1.5x). Keep it simple for PT.
+  // Flat hourly for part-timers: every hour (including any manually-added "OT"
+  // hours) pays the same rate — no OT premium. Gross = (hours + ot) × rate.
   const regPay = newHours * newRate;
-  const otPay = newOtHours * newRate * 1.5;
+  const otPay = newOtHours * newRate;
   const newGross = Math.round((regPay + otPay) * 100) / 100;
 
   const compDetails = {

--- a/apps/backoffice/src/lib/hr/agents/payroll-calculator-weekly.ts
+++ b/apps/backoffice/src/lib/hr/agents/payroll-calculator-weekly.ts
@@ -1,4 +1,5 @@
 import { hrSupabaseAdmin } from "../supabase";
+import { breakHoursFor, mytDateString } from "../hours";
 
 type WeeklyPayrollResult = {
   payrollRunId: string;
@@ -8,21 +9,23 @@ type WeeklyPayrollResult = {
 };
 
 /**
- * Weekly Payroll Calculator (Part-Timers) — SCHEDULE-BASED.
+ * Weekly Payroll Calculator (Part-Timers) — CLOCK-BASED, FLAT HOURLY.
  *
- * Per Celsius policy, part-timers are paid for the shifts they were SCHEDULED
- * for in a published roster, NOT for actual attendance. If a PT no-shows, that
- * is handled separately via review-penalties / not re-scheduling them. If they
- * clock OT beyond their scheduled shift, a manager adds it as an ad-hoc
- * adjustment line on the run.
+ * Part-timers are paid for the hours they actually CLOCK on the Celsius staff app
+ * (clock-in to clock-out), at their flat hourly_rate. No OT premium for the PT
+ * cohort — every clocked working hour pays the same rate. The unpaid break is
+ * excluded using the same rule the attendance engine applies (part-timer: 30 min
+ * if the shift is over 4 hours), so pay reflects worked time, not gross clock time.
  *
- * Pay basis: sum of (end_time − start_time − break_minutes) per shift_date in
- * the Mon–Sun period, across PUBLISHED schedules only. Multiplied by the
- * employee's hourly_rate.
+ * Pay basis per PT for the Mon–Sun (MYT) week:
+ *   workedHours(log) = totalHours(log) − break        (totalHours = clock_out − clock_in)
+ *   gross           = Σ workedHours × hourly_rate
+ * Only CLOSED logs count (need a clock-out to have hours); REJECTED logs are
+ * excluded (a manager marked them bogus). Open/still-clocked-in logs are skipped.
  *
- * No EPF/SOCSO/EIS/PCB applied at this layer — the Celsius part-timer cohort
- * is below thresholds. If you onboard a senior part-timer above the threshold,
- * add statutory math here mirroring the monthly calculator.
+ * No EPF/SOCSO/EIS/PCB at this layer — the Celsius part-timer cohort is below
+ * thresholds. If you onboard a senior part-timer above the threshold, add
+ * statutory math here mirroring the monthly calculator.
  */
 export async function calculateWeeklyPayroll(
   weekStart: string, // ISO date (YYYY-MM-DD), must be a Monday
@@ -37,8 +40,12 @@ export async function calculateWeeklyPayroll(
   periodEnd.setUTCDate(periodEnd.getUTCDate() + 6);
   const periodStartStr = weekStart;
   const periodEndStr = periodEnd.toISOString().slice(0, 10);
+  // MYT week window: Monday 00:00 to Sunday 23:59:59 Malaysia time (not UTC), so a
+  // late-evening or pre-8am clock-in lands in the right week.
+  const weekStartIso = `${periodStartStr}T00:00:00+08:00`;
+  const weekEndIso = `${periodEndStr}T23:59:59+08:00`;
 
-  // 1. Part-timer profiles (only ones with hourly rate set are payable).
+  // 1. Part-timer profiles.
   const { data: profiles } = await hrSupabaseAdmin
     .from("hr_employee_profiles")
     .select("user_id, hourly_rate, end_date, resigned_at")
@@ -47,45 +54,31 @@ export async function calculateWeeklyPayroll(
   if (!profiles || profiles.length === 0) {
     throw new Error("No part-time employees found.");
   }
+  const ptIds = profiles.map((p: { user_id: string }) => p.user_id);
 
-  // 2. PUBLISHED schedules covering this week. Draft/unpublished schedules
-  // are not paid — the roster has to be committed before staff get paid for it.
-  const { data: schedules } = await hrSupabaseAdmin
-    .from("hr_schedules")
-    .select("id, week_start, week_end, status")
-    .eq("status", "published")
-    .lte("week_start", periodEndStr)
-    .gte("week_end", periodStartStr);
-  const scheduleIds = (schedules || []).map((s: { id: string }) => s.id);
-
-  // 3. Scheduled shifts for those schedules, falling on dates within the cycle.
-  const { data: shifts } = scheduleIds.length
+  // 2. Clocked attendance for those PTs in the MYT week. Closed logs only.
+  type Log = { user_id: string; clock_in: string; clock_out: string | null; total_hours: number | string | null; final_status: string | null };
+  const { data: logsRaw } = ptIds.length
     ? await hrSupabaseAdmin
-        .from("hr_schedule_shifts")
-        .select("user_id, shift_date, start_time, end_time, break_minutes")
-        .in("schedule_id", scheduleIds)
-        .gte("shift_date", periodStartStr)
-        .lte("shift_date", periodEndStr)
-    : { data: [] as Array<{
-        user_id: string; shift_date: string; start_time: string;
-        end_time: string; break_minutes: number | null;
-      }> };
+        .from("hr_attendance_logs")
+        .select("user_id, clock_in, clock_out, total_hours, final_status")
+        .in("user_id", ptIds)
+        .gte("clock_in", weekStartIso)
+        .lte("clock_in", weekEndIso)
+        .not("clock_out", "is", null)
+    : { data: [] as Log[] };
 
-  type Shift = {
-    user_id: string;
-    shift_date: string;
-    start_time: string;
-    end_time: string;
-    break_minutes: number | null;
-  };
-  const shiftsByUser = new Map<string, Shift[]>();
-  for (const s of (shifts || []) as Shift[]) {
-    const list = shiftsByUser.get(s.user_id) || [];
-    list.push(s);
-    shiftsByUser.set(s.user_id, list);
+  const logsByUser = new Map<string, Log[]>();
+  let paidLogCount = 0;
+  for (const l of (logsRaw || []) as Log[]) {
+    if (l.final_status === "rejected") continue; // bogus entry — don't pay
+    const list = logsByUser.get(l.user_id) || [];
+    list.push(l);
+    logsByUser.set(l.user_id, list);
+    paidLogCount++;
   }
 
-  // 4. Wipe existing draft/computed weekly run for this period.
+  // 3. Wipe existing draft/computed weekly run for this period.
   await hrSupabaseAdmin
     .from("hr_payroll_runs")
     .delete()
@@ -107,17 +100,22 @@ export async function calculateWeeklyPayroll(
 
   if (runError) throw new Error(`Failed to create payroll run: ${runError.message}`);
 
-  // 5. Per-employee compute.
+  // 4. Per-employee compute (flat hourly on worked = clocked − break).
   let totalGross = 0;
   const payrollItems: Record<string, unknown>[] = [];
-  let staffWithNoShifts = 0;
+  let staffWithNoClockins = 0;
 
   for (const profile of profiles) {
-    // Resigned before this cycle → don't include.
-    // Use end_date (last working day) for payroll cutoff, not the letter-submission date.
+    // Resigned before this cycle → don't include. Use end_date (last working day).
     const resignDate = profile.end_date || profile.resigned_at || null;
     if (resignDate && resignDate < periodStartStr) {
       continue;
+    }
+
+    const userLogs = logsByUser.get(profile.user_id) || [];
+    if (userLogs.length === 0) {
+      staffWithNoClockins++;
+      continue; // No clock-ins this week — no payroll line.
     }
 
     const hourlyRate = Number(profile.hourly_rate) || 0;
@@ -126,33 +124,27 @@ export async function calculateWeeklyPayroll(
       continue;
     }
 
-    const userShifts = shiftsByUser.get(profile.user_id) || [];
-    if (userShifts.length === 0) {
-      staffWithNoShifts++;
-      continue; // Don't insert empty rows for PTs not scheduled this week.
+    let workedHours = 0;
+    const logDetails: Array<{ date: string; hours: number; start: string; end: string }> = [];
+    for (const l of userLogs) {
+      const clockIn = new Date(l.clock_in);
+      const clockOut = new Date(l.clock_out as string);
+      const totalH = l.total_hours != null
+        ? Number(l.total_hours)
+        : Math.max(0, (clockOut.getTime() - clockIn.getTime()) / 3600000);
+      const worked = Math.max(0, Math.round((totalH - breakHoursFor("part_time", totalH)) * 100) / 100);
+      workedHours += worked;
+      logDetails.push({ date: mytDateString(l.clock_in), hours: worked, start: clockIn.toISOString(), end: clockOut.toISOString() });
     }
-
-    let totalHours = 0;
-    const shiftDetails: Array<{ date: string; hours: number; start: string; end: string }> = [];
-    for (const sh of userShifts) {
-      const hours = computeShiftHours(sh.start_time, sh.end_time, sh.break_minutes ?? 0);
-      totalHours += hours;
-      shiftDetails.push({
-        date: sh.shift_date,
-        hours: Math.round(hours * 100) / 100,
-        start: sh.start_time,
-        end: sh.end_time,
-      });
-    }
-    totalHours = Math.round(totalHours * 100) / 100;
-    const gross = Math.round(totalHours * hourlyRate * 100) / 100;
+    workedHours = Math.round(workedHours * 100) / 100;
+    const gross = Math.round(workedHours * hourlyRate * 100) / 100;
     totalGross += gross;
 
     payrollItems.push({
       payroll_run_id: run.id,
       user_id: profile.user_id,
       basic_salary: gross,
-      total_regular_hours: totalHours,
+      total_regular_hours: workedHours,
       total_ot_hours: 0,
       ot_1x_amount: 0,
       ot_1_5x_amount: 0,
@@ -174,10 +166,10 @@ export async function calculateWeeklyPayroll(
         hourly_rate: hourlyRate,
         employment_type: "part_time",
         cycle: "weekly",
-        basis: "scheduled",
-        scheduled_hours: totalHours,
-        shift_count: shiftDetails.length,
-        shifts: shiftDetails,
+        basis: "clocked",
+        worked_hours: workedHours,
+        attendance_records: logDetails.length,
+        shifts: logDetails,
       },
     });
   }
@@ -198,22 +190,17 @@ export async function calculateWeeklyPayroll(
       total_deductions: 0,
       total_net: totalGross,
       total_employer_cost: 0,
-      ai_notes: `${payrollItems.length} part-timers paid for ${(shifts || []).length} scheduled shifts. Gross: RM ${totalGross.toLocaleString()}`,
+      ai_notes: `${payrollItems.length} part-timers paid for ${paidLogCount} clocked shifts. Gross: RM ${totalGross.toLocaleString()}`,
     })
     .eq("id", run.id);
 
   notes.push(
     `${payrollItems.length} part-timer${payrollItems.length === 1 ? "" : "s"} processed for ${periodStartStr} to ${periodEndStr} ` +
-    `(${(shifts || []).length} scheduled shifts, RM ${totalGross.toLocaleString()} gross).`,
+    `(${paidLogCount} clocked shifts, RM ${totalGross.toLocaleString()} gross).`,
   );
-  if (staffWithNoShifts > 0) {
+  if (staffWithNoClockins > 0) {
     notes.push(
-      `${staffWithNoShifts} part-timer${staffWithNoShifts === 1 ? "" : "s"} not scheduled this week — no payroll line created.`,
-    );
-  }
-  if (scheduleIds.length === 0) {
-    notes.push(
-      `⚠ No published schedules found for this week. Publish the roster before computing payroll.`,
+      `${staffWithNoClockins} part-timer${staffWithNoClockins === 1 ? "" : "s"} had no clock-ins this week — no payroll line created.`,
     );
   }
 
@@ -223,21 +210,4 @@ export async function calculateWeeklyPayroll(
     totalGross,
     notes,
   };
-}
-
-/**
- * Decimal hours between start_time and end_time, minus break_minutes.
- * Times are HH:MM:SS strings. Overnight shifts (end < start) wrap to next day.
- * Result is clamped at 0 so a malformed shift doesn't produce negative pay.
- */
-function computeShiftHours(start: string, end: string, breakMinutes: number): number {
-  const toMinutes = (t: string) => {
-    const [h, m] = t.split(":").map(Number);
-    return h * 60 + (m || 0);
-  };
-  const startMin = toMinutes(start);
-  let endMin = toMinutes(end);
-  if (endMin <= startMin) endMin += 24 * 60; // overnight
-  const grossMin = endMin - startMin - (breakMinutes || 0);
-  return Math.max(0, grossMin / 60);
 }


### PR DESCRIPTION
Part-timers are now paid for the hours they actually **clock** on the staff app, not their rostered hours.

## Problem
The weekly (part-timer) payroll was **schedule-based**: it summed rostered shift hours from `hr_schedule_shifts` × hourly rate. So a part-timer rostered 6h who clocked in late and worked 4h was still paid 6h. Policy is now: pay for clocked hours.

## Change
- **Calculator** (`payroll-calculator-weekly.ts`) sources hours from `hr_attendance_logs` — closed, non-rejected logs whose clock-in falls in the Mon–Sun **MYT** week. Worked hours = `total_hours − break` (part-timer break rule via the shared `breakHoursFor` helper), paid **flat** at `hourly_rate`, **no OT premium** (per decision). Derives worked hours straight from the clock timestamps so it doesn't depend on the attendance processor having back-filled `regular_hours`.
- **Preflight** repointed to clock-based readiness (clocked shifts + hours this week; hourly-rate = block, no-bank = warn) instead of "is a roster published".
- **Weekly page** copy + pre-run panel now describe clocked hours; the details "Shifts" column reads the clocked-log count.
- **Adjust PATCH** pays manually-added "OT" hours at the flat rate too (was 1.5×).

The full run → review → adjust → confirm → bank-file → mark-paid workflow is unchanged; only the hours source changed.

## Verification
- `tsc --noEmit` + `eslint` clean (backoffice).
- Live dry-run on the current MYT week: 6 part-timers clocked, 30.23 payable hours, the 2 still-open logs and any rejected logs correctly excluded. Pre-July weeks show ~0 (PT clock-in only started 1 July), as expected.
- Ties into the earlier F1 fix (#671) so auto-closed shifts carry correct hours into pay.

## Deferred (per request)
Part-timers still can't see weekly payslips in the staff app — the payslips page filters by month/year, which are null for weekly runs. Flagged as the next step if you want them to have visibility.