### PR TITLE
fix(finance): P&L drill-down actually shows the records behind each line

### DIFF
--- a/apps/backoffice/src/app/(admin)/finance/reports/page.tsx
+++ b/apps/backoffice/src/app/(admin)/finance/reports/page.tsx
@@ -259,7 +259,7 @@ function PnlTab() {
             <SheetTitle>{drillCode} — drill down</SheetTitle>
           </SheetHeader>
           {drillCode && data && (
-            <DrillDown code={drillCode} start={data.report.start} end={data.report.end} />
+            <DrillDown code={drillCode} start={data.report.start} end={data.report.end} outletId={outletId || undefined} />
           )}
         </SheetContent>
       </Sheet>
@@ -267,14 +267,14 @@ function PnlTab() {
   );
 }
 
-function DrillDown({ code, start, end }: { code: string; start: string; end: string }) {
+function DrillDown({ code, start, end, outletId }: { code: string; start: string; end: string; outletId?: string }) {
   const { data, isLoading } = useFetch<{ lines: DrillLine[] }>(
-    `/api/finance/reports/drilldown?accountCode=${code}&start=${start}&end=${end}`
+    `/api/finance/reports/drilldown?accountCode=${encodeURIComponent(code)}&start=${start}&end=${end}${outletId ? `&outletId=${outletId}` : ""}`
   );
   if (isLoading) return <div className="p-6"><Loader2 className="h-5 w-5 animate-spin" /></div>;
   if (!data) return null;
   if (data.lines.length === 0) {
-    return <div className="p-6 text-sm text-muted-foreground">No journals in this period.</div>;
+    return <div className="p-6 text-sm text-muted-foreground">No entries in this period.</div>;
   }
   return (
     <div className="overflow-y-auto p-6">
@@ -302,6 +302,17 @@ function DrillDown({ code, start, end }: { code: string; start: string; end: str
               </tr>
             ))}
           </tbody>
+          <tfoot>
+            <tr className="border-t-2 font-semibold">
+              <td className="px-3 py-2" colSpan={2}>Total ({data.lines.length} entries)</td>
+              <td className="whitespace-nowrap px-3 py-2 text-right tabular-nums">
+                {RM(data.lines.reduce((s, l) => s + l.debit, 0))}
+              </td>
+              <td className="whitespace-nowrap px-3 py-2 text-right tabular-nums">
+                {RM(data.lines.reduce((s, l) => s + l.credit, 0))}
+              </td>
+            </tr>
+          </tfoot>
         </table>
       </div>
     </div>

--- a/apps/backoffice/src/app/api/finance/reports/drilldown/route.ts
+++ b/apps/backoffice/src/app/api/finance/reports/drilldown/route.ts
@@ -1,11 +1,18 @@
-// GET /api/finance/reports/drilldown?accountCode=...&start=...&end=...&companyId=...
+// GET /api/finance/reports/drilldown?accountCode=...&start=...&end=...&companyId=...&outletId=...
+//
+// Two kinds of code arrive here: real GL account codes (Balance Sheet / ledger
+// P&L) drill into fin_journal_lines; the sourced P&L's synthetic codes (REV-*,
+// PROC, MKT-*, BANK:*) drill into the operational records the line was built
+// from — the ledger has no rows for those, so they'd otherwise come back empty.
 
 import { NextRequest, NextResponse } from "next/server";
 import { requireAuth } from "@/lib/auth";
 import { pnlDrillDown } from "@/lib/finance/reports/pnl";
+import { sourcedPnlDrillDown, isSourcedPnlCode } from "@/lib/finance/reports/pnl-sourced-drill";
 import { getActiveCompanyId } from "@/lib/finance/companies";
 
 export const dynamic = "force-dynamic";
+export const maxDuration = 60;
 
 export async function GET(req: NextRequest) {
   const auth = await requireAuth(req);
@@ -17,10 +24,13 @@ export async function GET(req: NextRequest) {
   const accountCode = url.searchParams.get("accountCode");
   const start = url.searchParams.get("start");
   const end = url.searchParams.get("end");
+  const outletId = url.searchParams.get("outletId");
   const companyId = url.searchParams.get("companyId") ?? (await getActiveCompanyId());
   if (!accountCode || !start || !end) {
     return NextResponse.json({ error: "accountCode, start, end required" }, { status: 400 });
   }
-  const lines = await pnlDrillDown({ companyId, accountCode, start, end });
+  const lines = isSourcedPnlCode(accountCode)
+    ? await sourcedPnlDrillDown({ companyId, code: accountCode, start, end, outletId })
+    : await pnlDrillDown({ companyId, accountCode, start, end });
   return NextResponse.json({ accountCode, start, end, lines });
 }

--- a/apps/backoffice/src/lib/finance/reports/pnl-sourced-drill.ts
+++ b/apps/backoffice/src/lib/finance/reports/pnl-sourced-drill.ts
@@ -1,0 +1,257 @@
+// Drill-down for the SOURCED P&L. Its line codes (REV-*, PROC, INV-*, MKT-*,
+// BANK:*) are synthetic — they don't exist in the GL — so the ledger drill
+// (pnlDrillDown) always came back empty for them. Each code here drills into
+// the records the P&L line was actually built from, using the SAME queries as
+// buildSourcedPnl so the drill total ties to the line amount.
+//
+//   REV-*          → unified sales (per MYT day, per channel)
+//   PROC           → procurement invoices in the period
+//   INV-OPEN/CLOSE → the stock-count valuation used for the boundary
+//   MKT-ADS        → Google Ads daily spend
+//   MKT-GRAB-PROMO → merchant-funded Grab promos (per day)
+//   MKT-GRAB-ADS   → manually entered GrabAds spend rows
+//   MKT-GRAB-COMM  → the commission estimate (rate × gross)
+//   BANK:<CAT>     → the classified bank-statement lines themselves
+
+import { prisma } from "@/lib/prisma";
+import { Prisma, type CashCategory } from "@prisma/client";
+import { getFinanceClient } from "../supabase";
+import { getUnifiedSalesForOutlet } from "@/app/api/sales/_lib/unified-sales";
+
+const round2 = (n: number) => Math.round(n * 100) / 100;
+const dStart = (s: string) => new Date(`${s}T00:00:00.000Z`);
+const dEnd = (s: string) => new Date(`${s}T23:59:59.999Z`);
+
+export type DrillLine = {
+  transactionId: string;
+  txnDate: string;
+  description: string;
+  amount: number;
+  debit: number;
+  credit: number;
+};
+
+// Mirrors BANK_ACCOUNT_SUFFIX in pnl-sourced.ts.
+const BANK_ACCOUNT_SUFFIX: Record<string, string> = {
+  celsius: "4384",
+  celsiusconezion: "2644",
+  celsiustamarind: "9345",
+};
+
+export function isSourcedPnlCode(code: string): boolean {
+  return /^(REV-|PROC$|INV-|MKT-|BANK:)/.test(code);
+}
+
+async function companyOutlets(companyId: string, outletId?: string | null): Promise<string[]> {
+  const client = getFinanceClient();
+  const { data } = await client.from("fin_outlet_companies").select("outlet_id").eq("company_id", companyId);
+  const all = (data ?? []).map((r) => r.outlet_id as string);
+  return outletId && all.includes(outletId) ? [outletId] : all;
+}
+
+// Revenue lines: unified sales aggregated per MYT day for the code's channel.
+async function drillRevenue(code: string, companyId: string, start: string, end: string, outletId?: string | null): Promise<DrillLine[]> {
+  const outletIds = await companyOutlets(companyId, outletId);
+  if (!outletIds.length) return [];
+  const outlets = await prisma.outlet.findMany({
+    where: { id: { in: outletIds } },
+    select: { id: true, name: true, loyaltyOutletId: true, pickupStoreId: true, posNativeCutoverAt: true },
+  });
+  const match = (lbl: string, isQR: boolean, channel: string): boolean => {
+    const l = lbl.toLowerCase();
+    if (code === "REV-GRAB") return /grab/.test(l);
+    if (code === "REV-PANDA") return /panda/.test(l);
+    if (/grab|panda/.test(l)) return false;
+    const online = isQR || channel === "delivery";
+    return code === "REV-ONLINE" ? online : !online;
+  };
+  // day|outlet → {orders, amount}
+  const agg = new Map<string, { day: string; outlet: string; n: number; amt: number }>();
+  for (const o of outlets) {
+    const sales = await getUnifiedSalesForOutlet(
+      { outletId: o.id, storehubStoreId: null, loyaltyOutletId: o.loyaltyOutletId, pickupStoreId: o.pickupStoreId, cutoverAt: o.posNativeCutoverAt },
+      dStart(start),
+      dEnd(end),
+    );
+    for (const s of sales) {
+      if (!match(s.channelLabel ?? "", s.isDeliveryQR, s.channel)) continue;
+      const day = new Date(new Date(s.ts).getTime() + 8 * 3600_000).toISOString().slice(0, 10); // MYT day
+      const k = `${day}|${o.name}`;
+      const cur = agg.get(k) ?? { day, outlet: o.name, n: 0, amt: 0 };
+      cur.n++; cur.amt += s.total;
+      agg.set(k, cur);
+    }
+  }
+  return [...agg.values()]
+    .sort((a, b) => a.day.localeCompare(b.day) || a.outlet.localeCompare(b.outlet))
+    .map((r) => ({
+      transactionId: `rev-${r.day}-${r.outlet}`,
+      txnDate: r.day,
+      description: `${r.outlet} — ${r.n} orders`,
+      amount: round2(r.amt),
+      debit: 0,
+      credit: round2(r.amt),
+    }));
+}
+
+// PROC: the procurement invoices summed into the purchases line.
+async function drillPurchases(companyId: string, start: string, end: string, outletId?: string | null): Promise<DrillLine[]> {
+  const outletIds = await companyOutlets(companyId, outletId);
+  if (!outletIds.length) return [];
+  const invoices = await prisma.invoice.findMany({
+    where: { issueDate: { gte: dStart(start), lte: dEnd(end) }, outletId: { in: outletIds } },
+    select: { id: true, invoiceNumber: true, issueDate: true, amount: true, vendorName: true, supplier: { select: { name: true } }, outlet: { select: { name: true } } },
+    orderBy: { issueDate: "asc" },
+    take: 500,
+  });
+  return invoices.map((inv) => ({
+    transactionId: inv.id,
+    txnDate: inv.issueDate.toISOString().slice(0, 10),
+    description: `${inv.supplier?.name ?? inv.vendorName ?? "(no vendor)"} · ${inv.invoiceNumber} · ${inv.outlet?.name ?? ""}`.trim(),
+    amount: round2(Number(inv.amount)),
+    debit: round2(Number(inv.amount)),
+    credit: 0,
+  }));
+}
+
+// MKT-ADS: Google Ads spend per day.
+async function drillAds(start: string, end: string): Promise<DrillLine[]> {
+  const rows = await prisma.adsMetricDaily.groupBy({
+    by: ["date"],
+    where: { date: { gte: dStart(start), lte: dEnd(end) } },
+    _sum: { costMicros: true },
+    orderBy: { date: "asc" },
+  });
+  return rows
+    .map((r) => ({ day: r.date.toISOString().slice(0, 10), amt: round2(Number(r._sum.costMicros ?? 0) / 1_000_000) }))
+    .filter((r) => r.amt !== 0)
+    .map((r) => ({
+      transactionId: `ads-${r.day}`,
+      txnDate: r.day,
+      description: "Google Ads spend",
+      amount: r.amt,
+      debit: r.amt,
+      credit: 0,
+    }));
+}
+
+// Bridge Outlet UUIDs → loyalty ids (pos_orders / grab_ads_spend key).
+async function loyaltyIds(outletIds: string[]): Promise<{ id: string; name: string }[]> {
+  if (!outletIds.length) return [];
+  const rows = await prisma.$queryRaw<{ loyalty_id: string; name: string }[]>(Prisma.sql`
+    SELECT "loyaltyOutletId" AS loyalty_id, name FROM "Outlet"
+    WHERE id IN (${Prisma.join(outletIds)}) AND "loyaltyOutletId" IS NOT NULL
+  `);
+  return rows.map((r) => ({ id: r.loyalty_id, name: r.name }));
+}
+
+async function drillGrabPromo(companyId: string, start: string, end: string, outletId?: string | null): Promise<DrillLine[]> {
+  const lids = await loyaltyIds(await companyOutlets(companyId, outletId));
+  if (!lids.length) return [];
+  const rows = await prisma.$queryRaw<{ day: string; outlet_id: string; n: bigint; promo_sen: bigint }[]>(Prisma.sql`
+    SELECT created_at::date::text AS day, outlet_id, COUNT(*) AS n, COALESCE(SUM(grab_merchant_promo), 0) AS promo_sen
+    FROM pos_orders
+    WHERE source = 'grabfood' AND status = 'completed' AND grab_merchant_promo > 0
+      AND outlet_id IN (${Prisma.join(lids.map((l) => l.id))})
+      AND created_at::date BETWEEN ${start}::date AND ${end}::date
+    GROUP BY 1, 2 ORDER BY 1, 2
+  `);
+  const nameOf = new Map(lids.map((l) => [l.id, l.name]));
+  return rows.map((r) => ({
+    transactionId: `grabpromo-${r.day}-${r.outlet_id}`,
+    txnDate: r.day,
+    description: `${nameOf.get(r.outlet_id) ?? r.outlet_id} — merchant-funded promo on ${Number(r.n)} orders`,
+    amount: round2(Number(r.promo_sen) / 100),
+    debit: round2(Number(r.promo_sen) / 100),
+    credit: 0,
+  }));
+}
+
+async function drillGrabAds(companyId: string, start: string, end: string, outletId?: string | null): Promise<DrillLine[]> {
+  const lids = await loyaltyIds(await companyOutlets(companyId, outletId));
+  if (!lids.length) return [];
+  const rows = await prisma.$queryRaw<{ id: string; outlet_id: string; period_start: string; period_end: string; amount_sen: number; note: string | null }[]>(Prisma.sql`
+    SELECT id, outlet_id, period_start::text, period_end::text, amount_sen, note
+    FROM grab_ads_spend
+    WHERE outlet_id IN (${Prisma.join(lids.map((l) => l.id))})
+      AND period_start BETWEEN ${start}::date AND ${end}::date
+    ORDER BY period_start
+  `);
+  const nameOf = new Map(lids.map((l) => [l.id, l.name]));
+  return rows.map((r) => ({
+    transactionId: r.id,
+    txnDate: r.period_start,
+    description: `${nameOf.get(r.outlet_id) ?? r.outlet_id} — GrabAds ${r.period_start} to ${r.period_end}${r.note ? ` (${r.note})` : ""}`,
+    amount: round2(r.amount_sen / 100),
+    debit: round2(r.amount_sen / 100),
+    credit: 0,
+  }));
+}
+
+// BANK:<CAT> — the classified bank lines behind the opex line.
+async function drillBank(cat: string, companyId: string, start: string, end: string, outletId?: string | null): Promise<DrillLine[]> {
+  const suffix = BANK_ACCOUNT_SUFFIX[companyId];
+  if (!suffix) return [];
+  const lines = await prisma.bankStatementLine.findMany({
+    where: {
+      direction: "DR",
+      txnDate: { gte: dStart(start), lte: dEnd(end) },
+      statement: { accountName: { contains: suffix } },
+      apInvoiceId: null,
+      category: cat === "NULL" ? null : (cat as CashCategory),
+      ...(outletId ? { outletId } : {}),
+    },
+    select: { id: true, txnDate: true, description: true, amount: true },
+    orderBy: { txnDate: "asc" },
+    take: 400,
+  });
+  return lines.map((l) => ({
+    transactionId: l.id,
+    txnDate: l.txnDate.toISOString().slice(0, 10),
+    description: l.description ?? "(no description)",
+    amount: round2(Number(l.amount)),
+    debit: round2(Number(l.amount)),
+    credit: 0,
+  }));
+}
+
+export async function sourcedPnlDrillDown(args: {
+  companyId: string;
+  code: string;
+  start: string;
+  end: string;
+  outletId?: string | null;
+}): Promise<DrillLine[]> {
+  const { companyId, code, start, end, outletId } = args;
+  if (code.startsWith("REV-")) return drillRevenue(code, companyId, start, end, outletId);
+  if (code === "PROC") return drillPurchases(companyId, start, end, outletId);
+  if (code === "MKT-ADS") return drillAds(start, end);
+  if (code === "MKT-GRAB-PROMO") return drillGrabPromo(companyId, start, end, outletId);
+  if (code === "MKT-GRAB-ADS") return drillGrabAds(companyId, start, end, outletId);
+  if (code.startsWith("BANK:")) return drillBank(code.slice(5), companyId, start, end, outletId);
+  if (code === "MKT-GRAB-COMM") {
+    // Estimate, not transactions: recompute the base so the drawer explains it.
+    const rev = await drillRevenue("REV-GRAB", companyId, start, end, outletId);
+    const gross = round2(rev.reduce((s, r) => s + r.amount, 0));
+    const est = round2(gross * 0.30);
+    return [{
+      transactionId: "grab-comm-estimate",
+      txnDate: end,
+      description: `Estimated commission: 30% of RM${gross.toFixed(2)} gross GrabFood sales in this period. Exact per-order commission lives in the Grab settlement report.`,
+      amount: est,
+      debit: est,
+      credit: 0,
+    }];
+  }
+  if (code.startsWith("INV-")) {
+    return [{
+      transactionId: `inv-${code}`,
+      txnDate: code === "INV-OPEN" ? start : end,
+      description: "Inventory valuation from the nearest finalized full stock count (valued at cheapest active supplier cost). See the count date and item coverage in the line name; the count itself lives in Procurement → Stock Counts.",
+      amount: 0,
+      debit: 0,
+      credit: 0,
+    }];
+  }
+  return [];
+}


### PR DESCRIPTION
## Problem (found by checking the live page)

Clicking a P&L category opened the drawer but always read **"No journals in this period"**. The drilldown API queries `fin_journal_lines` by account code, but the sourced P&L uses synthetic codes (`REV-INSTORE`, `PROC`, `MKT-GRAB-COMM`, `BANK:RENT`…) that don't exist in the GL — so the categorisation click has never worked on the P&L. This was the unresolved part of the reports-UX ask.

## Fix

New `pnl-sourced-drill.ts` drills each synthetic code into the records the line was **actually built from**, using the same queries as `buildSourcedPnl` so the drill total ties to the line amount:

| Code | Drills into |
|---|---|
| `REV-*` | unified sales per MYT day per outlet, with order counts |
| `PROC` | the procurement invoices (vendor · invoice no · outlet) |
| `MKT-ADS` | Google Ads daily spend |
| `MKT-GRAB-PROMO` | merchant-funded Grab promos per day per outlet |
| `MKT-GRAB-ADS` | GrabAds spend entries |
| `MKT-GRAB-COMM` | the estimate explained (rate × recomputed gross) |
| `BANK:<CAT>` | the classified bank-statement lines themselves (cap 400) |
| `INV-*` | pointer to the stock-count valuation |

The drilldown route dispatches: sourced codes → source drill; real GL codes (Balance Sheet drill) → ledger as before. The per-outlet P&L passes `outletId` so the drill scope matches the report scope. The drawer gains a total row (entry count + debit/credit sums) so it visibly ties to the P&L line.

Typecheck clean, lint clean (0 errors).