### PR TITLE
fix(ops): pulse-system review fixes — stop the midnight 86-blast + latent traps

### DIFF
--- a/apps/backoffice/src/app/api/ops/workspace/templates/route.ts
+++ b/apps/backoffice/src/app/api/ops/workspace/templates/route.ts
@@ -5,10 +5,6 @@ export const dynamic = "force-dynamic";
 export const runtime = "nodejs";
 
 const GRAPH = "https://graph.facebook.com/v23.0";
-// Temporary read-only access key so the setup can be verified server-side
-// without a browser session. Lists only template metadata (names/statuses) —
-// no secrets. Safe to remove once template setup is confirmed.
-const DIAG_KEY = "celsius-tpl-9Fb3xq";
 
 // The ops-pulse template set, created via ?action=create. Bodies are emoji-free
 // with a single {{1}} variable carrying the one-line "count · item · item"
@@ -83,10 +79,9 @@ const TEMPLATE_DEFS = [
 // GET — list the WABA's WhatsApp message templates with their approval status,
 // so an owner can see what's approved before wiring a template into ops-pulse.
 export async function GET(req: NextRequest) {
-  const key = req.nextUrl.searchParams.get("key");
   const session = await getSession();
   const owner = !!session && (session.role === "OWNER" || session.role === "ADMIN");
-  if (!owner && key !== DIAG_KEY) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  if (!owner) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
 
   const waba = process.env.WHATSAPP_WABA_ID;
   const token = process.env.WHATSAPP_ACCESS_TOKEN;

--- a/apps/backoffice/src/lib/hr/agents/checklist-linker.ts
+++ b/apps/backoffice/src/lib/hr/agents/checklist-linker.ts
@@ -106,12 +106,19 @@ export async function linkChecklistsToSchedule(scheduleId: string): Promise<Link
         orderBy: { stepNumber: "asc" },
       });
 
-      // Calculate due time
+      // Calculate due time. times[] are Malaysia wall-clock (MYT, UTC+8) — convert
+      // to UTC for storage (-480 min), matching the staff generator's calcDueAt.
+      // The old setUTCHours(h, m) stored the MYT time AS UTC, i.e. 8h late: an
+      // 18:00 task came due 02:00 MYT and nudged the wrong (empty) shift at 3am.
+      // dueMinutes falls back to 60 like the staff path, so dueMinutes=0 schedules
+      // still get a deadline instead of silently escaping the overdue detectors.
       let dueAt: Date | undefined;
-      if (sopSchedule.dueMinutes > 0 && sopSchedule.times.length > 0) {
+      if (sopSchedule.times.length > 0) {
         const [h, m] = sopSchedule.times[0].split(":").map(Number);
-        dueAt = new Date(shiftDate);
-        dueAt.setUTCHours(h, m + sopSchedule.dueMinutes, 0, 0);
+        if (Number.isFinite(h) && Number.isFinite(m)) {
+          const mytMinutes = h * 60 + m + (sopSchedule.dueMinutes || 60);
+          dueAt = new Date(shiftDate.getTime() + (mytMinutes - 480) * 60_000);
+        }
       }
 
       await prisma.checklist.create({

--- a/apps/backoffice/src/lib/ops-nudges/index.ts
+++ b/apps/backoffice/src/lib/ops-nudges/index.ts
@@ -504,12 +504,17 @@ export async function runChecklistNudges(now = new Date()): Promise<NudgeRunResu
   let items = 0;
   const managerLines: string[] = [];
 
-  // Owners get DM'd their own overdue items (deduped per checklist).
+  // Owners get DM'd their own overdue items (deduped per checklist). Shadow must
+  // never write the ledger — a shadow-recorded breach would silence the real nudge
+  // after re-arming (the row already exists, isNew=false).
   for (const [userId, o] of byOwner) {
-    const fresh: Item[] = [];
-    for (const it of o.items) {
-      const { isNew } = await recordBreach(mkBreach(it, userId), { userId, name: o.name, phone: o.phone, role: "staff", fallback: false });
-      if (isNew) fresh.push(it);
+    let fresh: Item[] = o.items;
+    if (mode === "armed") {
+      fresh = [];
+      for (const it of o.items) {
+        const { isNew } = await recordBreach(mkBreach(it, userId), { userId, name: o.name, phone: o.phone, role: "staff", fallback: false });
+        if (isNew) fresh.push(it);
+      }
     }
     if (fresh.length === 0) continue;
     items += fresh.length;
@@ -529,10 +534,13 @@ export async function runChecklistNudges(now = new Date()): Promise<NudgeRunResu
   // Unowned = NO ONE present at the outlet (the lead is already in the pool
   // fallback above, so a present lead would have become the owner). → managers.
   for (const [, u] of unowned) {
-    const fresh: Item[] = [];
-    for (const it of u.items) {
-      const { isNew } = await recordBreach(mkBreach(it, "mgr"), null);
-      if (isNew) fresh.push(it);
+    let fresh: Item[] = u.items;
+    if (mode === "armed") {
+      fresh = [];
+      for (const it of u.items) {
+        const { isNew } = await recordBreach(mkBreach(it, "mgr"), null);
+        if (isNew) fresh.push(it);
+      }
     }
     if (fresh.length === 0) continue;
     items += fresh.length;
@@ -556,15 +564,17 @@ export async function runChecklistNudges(now = new Date()): Promise<NudgeRunResu
 // We bring them live HERE, on the proven dedicated-nudge tier, rather than arming
 // the whole pulse — that would race the specialized clock-in/checklist routing
 // through the shared ledger. Reuses the same detectors (still shadow in the pulse)
-// + the ledger for dedupe (each is keyed per outlet/day, so at most one a day) +
-// the WhatsApp sender. Cron: every 15 min (catches a late open soon after open
-// time). OPS_NUDGES_MODE (off | shadow | armed).
+// + the ledger for dedupe (POS-open per outlet/day; menu-86 per snoozed-SET, so an
+// unchanged 86 list alerts once, not nightly) + the WhatsApp sender. Cron: every
+// 15 min (catches a late open soon after open time). Menu-86 sends are gated to
+// outlet business hours — the per-day key used to roll at midnight and blast the
+// roster at 00:30 (14 msgs, 2026-07-01). OPS_NUDGES_MODE (off | shadow | armed).
 export async function runStoreStatusNudges(now = new Date()): Promise<NudgeRunResult> {
   const mode = nudgesMode();
   const ranAt = now.toISOString();
   if (mode === "off") return { mode, ranAt, items: 0, staffSent: 0, managerSent: 0 };
 
-  const [posNot, menu] = await Promise.all([
+  const [posNot, menuAll] = await Promise.all([
     detectPosNotOpen(now).catch((e) => {
       console.error("[ops-nudge:store] pos-not-open detector failed:", e);
       return [] as Breach[];
@@ -574,6 +584,32 @@ export async function runStoreStatusNudges(now = new Date()): Promise<NudgeRunRe
       return [] as Breach[];
     }),
   ]);
+
+  // Menu-86 is only worth a ping while the outlet is trading (someone can fix it);
+  // outside business hours, hold it — the detector re-finds it next run, and the
+  // set-keyed dedupe means it still alerts exactly once. POS-not-open needs no
+  // gate: the detector only fires after the outlet's own open time.
+  let menu = menuAll;
+  if (menuAll.length > 0) {
+    const hours = await prisma.outlet.findMany({
+      where: { id: { in: [...new Set(menuAll.map((b) => b.outletId))] } },
+      select: { id: true, openTime: true, closeTime: true },
+    });
+    const hoursById = new Map(hours.map((o) => [o.id, o]));
+    const myt = new Date(now.getTime() + 8 * 3_600_000);
+    const nowMin = myt.getUTCHours() * 60 + myt.getUTCMinutes();
+    const toMinOr = (t: string | null | undefined, fallback: number): number => {
+      const [h, m] = (t ?? "").split(":").map(Number);
+      return Number.isFinite(h) && Number.isFinite(m) ? h * 60 + m : fallback;
+    };
+    menu = menuAll.filter((b) => {
+      const o = hoursById.get(b.outletId);
+      const open = toMinOr(o?.openTime, 8 * 60);
+      const close = toMinOr(o?.closeTime, 22 * 60);
+      return nowMin >= open && nowMin <= close;
+    });
+  }
+
   const breaches = [...posNot, ...menu];
   if (breaches.length === 0) return { mode, ranAt, items: 0, staffSent: 0, managerSent: 0 };
 
@@ -593,9 +629,10 @@ export async function runStoreStatusNudges(now = new Date()): Promise<NudgeRunRe
   }
   if (managerLines.length === 0) return { mode, ranAt, items: 0, staffSent: 0, managerSent: 0 };
 
-  // The on-shift team gets their own outlet's lines (they can open the till / fix
-  // the 86). If nobody's clocked in (common when the till isn't open), the team is
-  // empty and the managers still get it.
+  // The crew on shift right now gets their own outlet's lines (they can open the
+  // till / fix the 86) — resolveOutletTeam filters the roster to shifts covering
+  // this moment. No covering shift published → team is empty and the managers
+  // still get it via the digest below.
   let staffSent = 0;
   for (const [outletId, g] of byOutlet) {
     if (mode === "shadow") {
@@ -605,7 +642,7 @@ export async function runStoreStatusNudges(now = new Date()): Promise<NudgeRunRe
     const team = await resolveOutletTeam(outletId, now);
     for (const t of team) {
       if (!t.phone) continue;
-      const r = await sendOpsDigest(t.phone, `Store status — ${g.name}`, g.lines);
+      const r = await sendOpsDigest(t.phone, `Store status at ${g.name}:`, g.lines);
       if (r.ok) staffSent += 1;
       else console.error(`[ops-nudge:store] team nudge to ${t.name} failed:`, r.error);
     }

--- a/apps/backoffice/src/lib/ops-pulse/config.ts
+++ b/apps/backoffice/src/lib/ops-pulse/config.ts
@@ -41,6 +41,24 @@ export const REALTIME_SIGNALS: Set<string> = new Set(
     .filter(Boolean),
 );
 
+// Signals now owned end-to-end by the dedicated ops-nudges tier (specialized
+// per-person routing + ledger dedupe). BOTH pulse paths must exclude these:
+// the realtime pulse shares dedupeKeys with the nudges for most of them, so
+// arming it would either double-page (CHECKLIST — keys differ) or first-writer-
+// wins and randomly suppress the nudge tier's routing (REVIEW / NO_CLOCK_IN /
+// POS_NOT_OPEN / MENU_SNOOZED — keys match); the daily pulse has no ledger and
+// would simply re-list what the nudges already sent. The pulse keeps only its
+// un-owned signals (PHONE_CAPTURE, RESTOCK_NEEDED, RECEIVING).
+export const NUDGE_OWNED_SIGNALS: Set<string> = new Set([
+  "NO_CLOCK_IN",
+  "STOCK_COUNT",
+  "AUDIT",
+  "CHECKLIST",
+  "REVIEW",
+  "POS_NOT_OPEN",
+  "MENU_SNOOZED",
+]);
+
 export const THRESHOLDS = {
   phoneCapture: {
     // Breach if the day's completed-order phone-capture rate for an outlet is

--- a/apps/backoffice/src/lib/ops-pulse/detectors.ts
+++ b/apps/backoffice/src/lib/ops-pulse/detectors.ts
@@ -511,24 +511,34 @@ export async function detectMenuSnoozed(now: Date): Promise<Breach[]> {
     }
   }
 
-  const countBySlug = new Map<string, number>();
+  const itemsBySlug = new Map<string, string[]>();
   for (const row of rows) {
     if (!row.outlet_id) continue;
     if (row.product_id && disabled.has(row.product_id)) continue; // globally off-menu
-    countBySlug.set(row.outlet_id, (countBySlug.get(row.outlet_id) ?? 0) + 1);
+    (itemsBySlug.get(row.outlet_id) ?? itemsBySlug.set(row.outlet_id, []).get(row.outlet_id)!).push(row.product_id ?? "?");
   }
-  if (countBySlug.size === 0) return [];
+  if (itemsBySlug.size === 0) return [];
 
   const outlets = await prisma.outlet.findMany({
-    where: { status: "ACTIVE", pickupStoreId: { in: [...countBySlug.keys()] } },
+    where: { status: "ACTIVE", pickupStoreId: { in: [...itemsBySlug.keys()] } },
     select: { id: true, name: true, pickupStoreId: true },
   });
 
-  const { ymd } = mytToday(now);
+  // Dedupe on the SET of snoozed items, not the calendar day: an unchanged 86
+  // list alerts exactly once (a per-day key re-fired at the first cron tick after
+  // midnight — 14 messages at 00:30, 2026-07-01). Any change to the set (item
+  // added or restored) is a new key and re-alerts.
+  const sig = (ids: string[]): string => {
+    const s = [...ids].sort().join(",");
+    let h = 5381;
+    for (let i = 0; i < s.length; i++) h = ((h << 5) + h + s.charCodeAt(i)) | 0;
+    return (h >>> 0).toString(36);
+  };
   const minItems = THRESHOLDS.menuSnooze.minItems;
   const breaches: Breach[] = [];
   for (const o of outlets) {
-    const n = o.pickupStoreId ? countBySlug.get(o.pickupStoreId) ?? 0 : 0;
+    const items = o.pickupStoreId ? itemsBySlug.get(o.pickupStoreId) ?? [] : [];
+    const n = items.length;
     if (n < minItems) continue;
     breaches.push({
       signal: "MENU_SNOOZED",
@@ -536,7 +546,7 @@ export async function detectMenuSnoozed(now: Date): Promise<Breach[]> {
       outletName: o.name,
       severity: "MED",
       routeKey: "operations",
-      dedupeKey: `MENU_SNOOZED:${o.id}:${ymd}`,
+      dedupeKey: `MENU_SNOOZED:${o.id}:${sig(items)}`,
       summary: `${n} menu item${n === 1 ? "" : "s"} snoozed (86'd) at ${o.name}`,
       detail: { snoozed: n },
     });
@@ -645,7 +655,15 @@ export async function detectPosNotOpen(now: Date): Promise<Breach[]> {
   const due = outlets.filter((o) => {
     if (!o.openTime || !o.loyaltyOutletId) return false;
     if (o.daysOpen && o.daysOpen.length > 0 && !o.daysOpen.includes(dow)) return false; // closed today
-    const open = new Date(`${ymd}T${o.openTime}:00+08:00`);
+    // openTime is a free-form string ("8:00", "08:00:00" both occur via the PATCH
+    // API) — normalize to HH:MM; an unparseable value would otherwise make an
+    // Invalid Date whose NaN comparison silently excludes the outlet forever.
+    const [hh = "", mm = ""] = o.openTime.split(":");
+    const open = new Date(`${ymd}T${hh.padStart(2, "0")}:${(mm || "00").slice(0, 2).padStart(2, "0")}:00+08:00`);
+    if (Number.isNaN(open.getTime())) {
+      console.warn(`[ops-pulse] outlet ${o.name} has unparseable openTime "${o.openTime}" — skipped from POS-open check`);
+      return false;
+    }
     return now.getTime() > open.getTime() + grace * 60_000;
   });
   if (due.length === 0) return [];

--- a/apps/backoffice/src/lib/ops-pulse/index.ts
+++ b/apps/backoffice/src/lib/ops-pulse/index.ts
@@ -7,7 +7,7 @@
 //            escalates any incident sitting unacked past the SLA to the owner.
 
 import { prisma } from "@/lib/prisma";
-import { pulseMode, dailyMode, REALTIME_SIGNALS, THRESHOLDS, categoryFor, TEAM_NOTIFY_SIGNALS } from "./config";
+import { pulseMode, dailyMode, REALTIME_SIGNALS, NUDGE_OWNED_SIGNALS, THRESHOLDS, categoryFor, TEAM_NOTIFY_SIGNALS } from "./config";
 import {
   detectPhoneCapture,
   detectChecklist,
@@ -97,9 +97,12 @@ export async function runOpsPulse(now = new Date()): Promise<PulseRunResult> {
     return { mode, ranAt: now.toISOString(), breachCount: 0, routed: [], sent: 0, escalated: 0 };
   }
 
-  // Real-time tier only — the fast pulse alerts on the instant signals (reviews,
-  // menu-snoozed, …); everything else surfaces in the daily digest.
-  const breaches = (await detectAll(now)).filter((b) => REALTIME_SIGNALS.has(b.signal));
+  // Real-time tier only, minus the signals the dedicated nudges own end-to-end —
+  // arming this pulse must never race the nudge tier through the shared ledger
+  // (see NUDGE_OWNED_SIGNALS). Leaves the pulse's own signals (e.g. RECEIVING).
+  const breaches = (await detectAll(now)).filter(
+    (b) => REALTIME_SIGNALS.has(b.signal) && !NUDGE_OWNED_SIGNALS.has(b.signal),
+  );
   const routed = await routeAll(breaches, now);
 
   // ── SHADOW: log what we *would* page; never message anyone, never persist. ──
@@ -203,13 +206,13 @@ export async function runDailyPulse(now = new Date()): Promise<PulseRunResult> {
   // they fire on the real-time pulse the moment they happen, so re-listing them
   // a day later would just double-page. Excluded here by category.
   //
-  // Clock-in, stock count, audit, and checklist are now owned by the dedicated
-  // ops-nudges loops (which DM the individual owner / on-shift team + the lead).
-  // Excluded here so the daily digest doesn't double-ping. The daily pulse keeps
-  // its unique routine signals (POS-open, phone capture, restock).
-  const NUDGE_OWNED = new Set(["NO_CLOCK_IN", "STOCK_COUNT", "AUDIT", "CHECKLIST"]);
+  // Clock-in, stock count, audit, checklist, POS-open, and 86'd items are now
+  // owned by the dedicated ops-nudges loops (which DM the individual owner /
+  // on-shift team + the lead). Excluded here (shared NUDGE_OWNED_SIGNALS) so the
+  // daily digest doesn't double-ping. The daily pulse keeps its unique routine
+  // signals (phone capture, restock).
   const breaches = (await detectAll(now)).filter(
-    (b) => categoryFor(b.signal) === "routine" && !NUDGE_OWNED.has(b.signal),
+    (b) => categoryFor(b.signal) === "routine" && !NUDGE_OWNED_SIGNALS.has(b.signal),
   );
   const routed = await routeAll(breaches, now);
 

--- a/apps/backoffice/src/lib/ops-pulse/router.ts
+++ b/apps/backoffice/src/lib/ops-pulse/router.ts
@@ -67,21 +67,40 @@ export async function resolveOwner(): Promise<Assignee | null> {
   return { userId: owner.id, name: owner.name, phone: owner.phone, role: owner.role, fallback: false };
 }
 
-// The on-shift OUTLET TEAM today — staff on a published shift at this outlet, for
-// work the team itself does (e.g. stock take). Resolved to active users with a
-// phone. Empty when no roster is published for the outlet today.
+// The OUTLET TEAM on shift RIGHT NOW — staff on a published shift at this outlet
+// whose rostered window covers the current MYT time (a 15:30-23:30 closer is not
+// on the team for an 08:15 alert, and vice versa). Rostered = accountable; we
+// deliberately do NOT require a clock-in here (adoption is ~18%, requiring it
+// would empty the team). Resolved to active users with a phone. Empty when no
+// covering shift is published for the outlet right now.
 export async function resolveOutletTeam(outletId: string, now: Date): Promise<Assignee[]> {
   if (!outletId) return [];
-  const ymd = new Date(now.getTime() + 8 * 3_600_000).toISOString().slice(0, 10);
-  const rows = await prisma.$queryRaw<Array<{ user_id: string | null }>>`
-    SELECT DISTINCT s.user_id
+  const myt = new Date(now.getTime() + 8 * 3_600_000);
+  const ymd = myt.toISOString().slice(0, 10);
+  const nowMin = myt.getUTCHours() * 60 + myt.getUTCMinutes();
+  const rows = await prisma.$queryRaw<
+    Array<{ user_id: string | null; start_time: string | null; end_time: string | null }>
+  >`
+    SELECT DISTINCT s.user_id, s.start_time::text AS start_time, s.end_time::text AS end_time
     FROM hr_schedule_shifts s
     JOIN hr_schedules sch ON sch.id = s.schedule_id
     WHERE sch.outlet_id = ${outletId}
       AND sch.published_at IS NOT NULL
       AND s.shift_date = ${ymd}::date
   `;
-  const ids = rows.map((r) => r.user_id).filter((x): x is string => !!x);
+  // "HH:MM[:SS]" → minutes since midnight; unknown windows fail open (included).
+  const toMin = (t: string | null): number | null => {
+    if (!t) return null;
+    const [h, m] = t.split(":").map(Number);
+    return Number.isFinite(h) && Number.isFinite(m) ? h * 60 + m : null;
+  };
+  const covers = (r: { start_time: string | null; end_time: string | null }): boolean => {
+    const s = toMin(r.start_time);
+    const e = toMin(r.end_time);
+    if (s === null || e === null) return true;
+    return e >= s ? nowMin >= s && nowMin <= e : nowMin >= s || nowMin <= e; // overnight shift
+  };
+  const ids = [...new Set(rows.filter(covers).map((r) => r.user_id).filter((x): x is string => !!x))];
   if (ids.length === 0) return [];
   const users = await prisma.user.findMany({
     where: { id: { in: ids }, status: "ACTIVE", phone: { not: null } },


### PR DESCRIPTION
## Why
Rigorous review of the ops-pulse/ops-nudges subsystem (races, timezone, send-path specialists + live-DB verification) found one **confirmed-live** bug and several latent traps. Live: **14 WhatsApps at 00:30 MYT last night** — `MENU_SNOOZED` dedupes per calendar day, the day rolls at midnight, and the */15 store cron runs all night, so every night an item stays 86'd the whole roster gets a midnight blast. Fastest route to staff blocking the ops number (→ WABA quality drop → templates paused).

## Fixes
| Finding | Fix |
|---|---|
| Midnight 86-blast (live) | Dedupe on the snoozed-item **set** (re-alert only on change) + business-hours gate (openTime–closeTime) in `runStoreStatusNudges` |
| Team = whole day roster | `resolveOutletTeam` filters to shifts covering **now** (overnight-aware); evening crew no longer gets 8am alerts |
| Cross-tier arming trap | Shared `NUDGE_OWNED_SIGNALS` excluded from both pulse paths — arming `OPS_PULSE_MODE` can no longer double-page or race the nudges through the shared ledger |
| Shadow writes ledger | Checklist runner's `recordBreach` now armed-only (shadow-recorded rows silenced real nudges after re-arm) |
| Linker dueAt 8h late | MYT→UTC conversion matching the staff generator + `dueMinutes || 60` fallback. Latent: verified **zero** live rows carry the bad signature, no backfill needed |
| Unparseable openTime silently disables POS-open check | Normalize + warn |
| DIAG_KEY auth bypass | Removed (template setup confirmed done) |

## Verified
- `tsc --noEmit` clean.
- Live query confirmed the 00:30 blast (14 msgs) and that all 2,762 checklists carry the correct staff-path dueAt signature.
- First deploy will re-alert each outlet's *current* 86 set once (new key format), during business hours only — expected, one legit alert.

Remaining review findings (delivery-confirmation lifecycle, scoreboard Monday window, name-based recipient routing, em-dash sweep) are tracked separately — the delivery lifecycle belongs to the tier-3 consequence-loop design (docs/design/ops-realtime-consequence-loop.md).