### PR TITLE
fix(finance): stop GL double-posting on feed rebuilds + classifier v2

### DIFF
--- a/apps/backoffice/src/lib/finance/bank-line-classifier.test.ts
+++ b/apps/backoffice/src/lib/finance/bank-line-classifier.test.ts
@@ -49,4 +49,38 @@ describe("bank-line-classifier", () => {
     expect(cr("MISC CREDIT NO PATTERN").category).toBe("OTHER_INFLOW");
     expect(dr("TRANSFER FR A/C SOME UNKNOWN VENDOR XYZ").isInterCo).toBe(false);
   });
+
+  it("sees through Maybank's glued 20-char sender prefix", () => {
+    // Beneficiary field: "Celsius Coffee Putra" (exactly 20 chars) runs straight
+    // into the payee, so \b-anchored supplier rules miss without the strip pass.
+    expect(dr("CELSIUS COFFEE PUTRAYOW SENG SDN BHD*YSIV-2601").category).toBe("RAW_MATERIALS");
+    expect(dr("CELSIUS COFFEE TAMARCOLLECTIVE PROJECT *IV-1234").category).toBe("RAW_MATERIALS");
+    expect(dr("CELSIUS COFFEE PUTRATMM RESOURCES *1-260601").category).toBe("RAW_MATERIALS");
+    expect(dr("CELSIUS COFFEE PUTRAJG PACIFIC FOODS SD* ").category).toBe("RAW_MATERIALS");
+  });
+
+  it("classifies purpose suffixes that run into references", () => {
+    expect(dr("TRANSFER FR A/C ENCIK AZLAND ZULFIZ Q1 DIVIDENDQ1 2 MBB").category).toBe("DIVIDEND");
+    expect(dr("TRANSFER FR A/C AAS TAXATION SDN. B TAX FORMC").category).toBe("TAX");
+    expect(dr("CELSIUSCOFFEE SB ASSOCIATES * HALF AUDIT FEE").category).toBe("COMPLIANCE");
+    expect(dr("ELECTRONIC REMITTANCE - GIR RENTOKIL INITIAL (M").category).toBe("MAINTENANCE");
+  });
+
+  it("classifies the newly named suppliers", () => {
+    expect(dr("TRANSFER FR A/C JIJUS CAKES TO SHAR IV CELSIUS COFFEE PUTRA").category).toBe("RAW_MATERIALS");
+    expect(dr("CELSIUS COFFEE SHAH BGS TRADING SDN. BH*KIV").category).toBe("RAW_MATERIALS");
+    expect(dr("TRANSFER FR A/C THE MILK MINISTRY #1-14819").category).toBe("RAW_MATERIALS");
+    expect(dr("TRANSFER FR A/C ELITE PAC SDN BHD IV-123").category).toBe("RAW_MATERIALS");
+    expect(dr("TRANSFER FR A/C KUALA LUMPUR FRIED CELSIUS COFFEE PUTRA").category).toBe("RAW_MATERIALS");
+  });
+
+  it("classifies unknown payees via the supplier registry hints", () => {
+    const hints = ["ACME BEANS ROASTERY"];
+    const hit = classifyBankLine({ description: "CELSIUS COFFEE PUTRAACME BEANS ROASTERY*INV9", amount: 100, direction: "DR", vendorHints: hints });
+    expect(hit.category).toBe("RAW_MATERIALS");
+    expect(hit.ruleName).toBe("vendor_registry");
+    // hints never override a real rule, and never apply to inflows
+    expect(classifyBankLine({ description: "TRANSFER FR A/C TUJUAN GEMILANG rent", amount: 100, direction: "DR", vendorHints: ["TUJUAN GEMILANG"] }).category).toBe("RENT");
+    expect(classifyBankLine({ description: "SOME ACME BEANS ROASTERY REFUND", amount: 100, direction: "CR", vendorHints: hints }).category).toBe("OTHER_INFLOW");
+  });
 });

--- a/apps/backoffice/src/lib/finance/bank-line-classifier.ts
+++ b/apps/backoffice/src/lib/finance/bank-line-classifier.ts
@@ -22,6 +22,11 @@ export type ClassifyInput = {
   // Account this line came from. Used as a fallback for outlet inference
   // when the description doesn't carry an outlet prefix (e.g. EPF Payment).
   accountKey?: string;
+  // Normalized supplier names from the procurement registry (uppercased,
+  // single-spaced). When the rules miss on an outflow, a description containing
+  // one of these classifies as RAW_MATERIALS — so onboarding a supplier in
+  // procurement is enough for their payments to classify, no rule edit needed.
+  vendorHints?: string[];
 };
 
 export type ClassifyResult = {
@@ -165,8 +170,17 @@ const OUTFLOW_RULES: Rule[] = [
   { name: "purpose_kol",              match: /\bKOL\b|\bINFLUENCER\b/i,               direction: "DR", category: "KOL" as CashCategory },
   { name: "purpose_renovation",       match: /\bRENOVATION\b|\bRENOVATE\b/i,          direction: "DR", category: "INVESTMENTS" as CashCategory },
   { name: "purpose_legal",            match: /\bLEGAL\s*FEE|\bASHRAF\s*&\s*PARTNERS|\bLAWYER\b/i, direction: "DR", category: "COMPLIANCE" as CashCategory },
-  { name: "purpose_dividend",         match: /\bDIVIDEND\b|\bDIVIDE\b/i,              direction: "DR", category: "DIVIDEND" as CashCategory },
+  // No trailing boundary: Maybank purpose suffixes run straight into references
+  // ("DIVIDENDQ1 2"), which a \b after the word would reject.
+  { name: "purpose_dividend",         match: /\bDIVIDEN/i,                            direction: "DR", category: "DIVIDEND" as CashCategory },
   { name: "purpose_cfs_contract",     match: /\bCFS\s*CONTRACT\b|\bCFS\s*FEE\b/i,     direction: "DR", category: "CFS_FEE" as CashCategory },
+  { name: "purpose_audit",            match: /\bAUDIT\s*FEE\b|\bAUDIT\b/i,            direction: "DR", category: "COMPLIANCE" as CashCategory },
+  { name: "purpose_tax_agent",        match: /\bTAXATION\b|\bTAX\s*(FORM|AGENT|FILING)/i, direction: "DR", category: "TAX" as CashCategory },
+
+  // Facility services — pest control / cleaning / small works contractors.
+  { name: "maint_rentokil",   match: /\bRENTOKIL\b/i,      direction: "DR", category: "MAINTENANCE" as CashCategory },
+  { name: "maint_cleanhero",  match: /\bCLEANHERO\b/i,     direction: "DR", category: "MAINTENANCE" as CashCategory },
+  { name: "maint_simple_axe", match: /\bSIMPLE\s*AXE\b/i,  direction: "DR", category: "MAINTENANCE" as CashCategory },
 
   // Statutory — EPF / SOCSO / EIS / KWSP / PERKESO / LHDN tax
   { name: "statutory_epf",   match: /\b(EPF|KWSP|M2UBEPF)\b/i,            direction: "DR", category: "STATUTORY_PAYMENT" as CashCategory },
@@ -258,6 +272,11 @@ const OUTFLOW_RULES: Rule[] = [
   { name: "raw_eighty_eight",   match: /\bEIGHTY\s*EIGHT\s*FAHREN/i, direction: "DR", category: "RAW_MATERIALS" as CashCategory },
   { name: "raw_mikofee",        match: /\bMIKOFEE\b/i,               direction: "DR", category: "RAW_MATERIALS" as CashCategory },
   { name: "raw_unique_paper",   match: /\bUNIQUE\s*PAPER\b/i,        direction: "DR", category: "RAW_MATERIALS" as CashCategory },
+  { name: "raw_jijus_cakes",    match: /JIJUS?\s*CAKES/i,            direction: "DR", category: "RAW_MATERIALS" as CashCategory },
+  { name: "raw_bgs_trading",    match: /\bBGS\s*TRADING/i,           direction: "DR", category: "RAW_MATERIALS" as CashCategory },
+  { name: "raw_milk_ministry",  match: /MILK\s*MINISTRY/i,           direction: "DR", category: "RAW_MATERIALS" as CashCategory },
+  { name: "raw_elite_pac",      match: /ELITE\s*PAC\b/i,             direction: "DR", category: "RAW_MATERIALS" as CashCategory },
+  { name: "raw_kl_fried",       match: /KUALA\s*LUMPUR\s*FRIED/i,    direction: "DR", category: "RAW_MATERIALS" as CashCategory },
 
   // Staff weekly payroll — "SCC Week NN" transfers to named employees.
   { name: "salary_scc_week",    match: /\bSCC\s*WE/i,                direction: "DR", category: "EMPLOYEE_SALARY" as CashCategory },
@@ -297,16 +316,44 @@ export function classifyBankLine(input: ClassifyInput): ClassifyResult {
   const norm = desc.toUpperCase().replace(/\s+/g, " ").trim();
   const intercoCounterparty = INTERCO_COUNTERPARTY.test(norm);
 
+  // Maybank's beneficiary field glues a fixed-width 20-char sender name straight
+  // onto the payee — "CELSIUS COFFEE PUTRAYOW SENG SDN BHD*…" — which defeats
+  // every \b-anchored rule ("PUTRAYOW" is one word). When the description starts
+  // with the sender prefix, also match against the string with those 20 chars
+  // stripped, so the payee is rule-visible. Rule priority still wins: each rule
+  // is tried on both variants before moving to the next rule.
+  const candidates = [norm];
+  const rawUpper = desc.toUpperCase().trimStart();
+  if (/^CELSIUS\s?COFFEE/.test(rawUpper) && rawUpper.length > 20) {
+    const stripped = rawUpper.slice(20).replace(/\s+/g, " ").trim();
+    if (stripped) candidates.push(stripped);
+  }
+
   const rules = input.direction === "CR" ? INFLOW_RULES : OUTFLOW_RULES;
   for (const rule of rules) {
     if (rule.direction && rule.direction !== input.direction) continue;
-    if (rule.match.test(norm)) {
+    if (candidates.some((c) => rule.match.test(c))) {
       return {
         category: rule.category,
         outletCode: inferOutlet(desc),
         isInterCo: (rule.isInterCo ?? false) || intercoCounterparty,
         ruleName: rule.name,
       };
+    }
+  }
+
+  // Supplier registry: an outflow whose payee is a known procurement supplier
+  // is a goods purchase even when no hardcoded rule names them.
+  if (input.direction === "DR" && input.vendorHints?.length) {
+    for (const hint of input.vendorHints) {
+      if (candidates.some((c) => c.includes(hint))) {
+        return {
+          category: "RAW_MATERIALS" as CashCategory,
+          outletCode: inferOutlet(desc),
+          isInterCo: intercoCounterparty,
+          ruleName: "vendor_registry",
+        };
+      }
     }
   }
 

--- a/apps/backoffice/src/lib/finance/bukku-feed-sync.ts
+++ b/apps/backoffice/src/lib/finance/bukku-feed-sync.ts
@@ -51,6 +51,27 @@ function monthEnd(m: string): Date {
   return new Date(Date.UTC(y, mo, 0));
 }
 
+// Normalized procurement supplier names for the classifier's vendor-registry
+// pass: onboarding a supplier is enough for their bank payments to classify as
+// RAW_MATERIALS — no classifier rule edit needed. Names are uppercased,
+// single-spaced, stripped of "THE " and a trailing SDN BHD; short results are
+// dropped (too collision-prone against bank references).
+async function supplierVendorHints(): Promise<string[]> {
+  const suppliers = await prisma.supplier.findMany({
+    where: { supplierCode: { not: "ADHOC" } },
+    select: { name: true },
+  });
+  const hints = new Set<string>();
+  for (const s of suppliers) {
+    const n = s.name.toUpperCase().replace(/\s+/g, " ").trim()
+      .replace(/^THE /, "")
+      .replace(/\s*SDN\.?\s*BHD\.?\s*$/, "")
+      .trim();
+    if (n.length >= 6) hints.add(n);
+  }
+  return [...hints];
+}
+
 // Distinct Bukku companies (dedupe outlets that share a subdomain, e.g.
 // Shah Alam + Nilai both on CCSB).
 async function bukkuCompanies(): Promise<BukkuCreds[]> {
@@ -127,8 +148,9 @@ async function syncAccount(
     // Outlet hints come from the line description (CONEZION / TAMARIND / etc.).
     const outlets = await prisma.outlet.findMany({ select: { id: true, code: true } });
     const codeToId = new Map(outlets.map((o) => [o.code, o.id]));
+    const vendorHints = await supplierVendorHints();
     const classify = (l: BukkuBankLineDraft) => {
-      const cls = classifyBankLine({ description: l.description, reference: l.reference, amount: l.amount, direction: l.direction, accountKey: accountName });
+      const cls = classifyBankLine({ description: l.description, reference: l.reference, amount: l.amount, direction: l.direction, accountKey: accountName, vendorHints });
       return {
         category: cls.category,
         outletId: cls.outletCode ? codeToId.get(cls.outletCode) ?? null : null,
@@ -137,7 +159,31 @@ async function syncAccount(
         ruleName: cls.ruleName,
       };
     };
+    // A rebuilt line is the SAME bank transaction as the row it replaces, so
+    // downstream state must survive the wipe: GL journal links (else the poster
+    // re-posts the whole window every run = duplicate journals), AP matches,
+    // and human classifications. Feed lines re-create in a deterministic order
+    // (txnDate, bukkuId), so a per-key occurrence queue restores state even
+    // when two lines share date+amount+description.
+    const lineKey = (l: { txnDate: Date; direction: string; amount: unknown; description: string }) =>
+      `${ymd(l.txnDate)}|${l.direction}|${Number(l.amount).toFixed(2)}|${l.description}`;
     await prisma.$transaction(async (tx) => {
+      const oldLines = await tx.bankStatementLine.findMany({
+        where: { statement: { accountName, notes: FEED_NOTE } },
+        select: {
+          txnDate: true, amount: true, direction: true, description: true,
+          category: true, classifiedBy: true, ruleName: true, isInterCo: true, outletId: true,
+          glTransactionId: true, glPostedAt: true, apInvoiceId: true, apMatchedAt: true,
+        },
+        orderBy: [{ txnDate: "asc" }, { id: "asc" }],
+      });
+      const carry = new Map<string, typeof oldLines>();
+      for (const l of oldLines) {
+        const k = lineKey(l);
+        const q = carry.get(k);
+        if (q) q.push(l); else carry.set(k, [l]);
+      }
+
       await tx.bankStatement.deleteMany({ where: { accountName, notes: FEED_NOTE } });
       for (let i = 0; i < plans.length; i++) {
         const s = plans[i];
@@ -164,7 +210,38 @@ async function syncAccount(
           },
         });
       }
-    });
+
+      // Restore carried state onto the recreated lines. Batched by identical
+      // payload — most lines share a glTransactionId (one journal per day), so
+      // this is a handful of updateMany calls, not one per line.
+      if (carry.size) {
+        const fresh = await tx.bankStatementLine.findMany({
+          where: { statement: { accountName, notes: FEED_NOTE } },
+          select: { id: true, txnDate: true, amount: true, direction: true, description: true },
+          orderBy: [{ txnDate: "asc" }, { id: "asc" }],
+        });
+        type CarryData = Record<string, unknown>;
+        const batches = new Map<string, { data: CarryData; ids: string[] }>();
+        for (const nl of fresh) {
+          const old = carry.get(lineKey(nl))?.shift();
+          if (!old) continue;
+          const data: CarryData = {};
+          if (old.glTransactionId) { data.glTransactionId = old.glTransactionId; data.glPostedAt = old.glPostedAt; }
+          if (old.apInvoiceId) { data.apInvoiceId = old.apInvoiceId; data.apMatchedAt = old.apMatchedAt; }
+          if (old.classifiedBy && old.classifiedBy !== "rule") {
+            data.category = old.category; data.classifiedBy = old.classifiedBy; data.ruleName = old.ruleName;
+            data.isInterCo = old.isInterCo; data.outletId = old.outletId;
+          }
+          if (!Object.keys(data).length) continue;
+          const bk = JSON.stringify(data);
+          const b = batches.get(bk);
+          if (b) b.ids.push(nl.id); else batches.set(bk, { data, ids: [nl.id] });
+        }
+        for (const b of batches.values()) {
+          await tx.bankStatementLine.updateMany({ where: { id: { in: b.ids } }, data: b.data });
+        }
+      }
+    }, { timeout: 120_000, maxWait: 15_000 });
   }
 
   return {

--- a/apps/backoffice/src/lib/finance/gl-posting.ts
+++ b/apps/backoffice/src/lib/finance/gl-posting.ts
@@ -14,14 +14,38 @@
 // Volume: there are tens of thousands of micro-settlements, so lines are
 // AGGREGATED into one journal per (company, outlet, category, day) — how a
 // bookkeeper posts, and it keeps the ledger legible while still tying out to the
-// bank to the cent. Each contributing line is stamped with the journal id
-// (glTransactionId) so the poster is idempotent: a line is posted exactly once,
-// and newly-arrived lines for an already-posted day get their own delta journal.
+// bank to the cent.
+//
+// Idempotency is TWO-layered, because line ids are not stable: the Bukku feed
+// sync rebuilds its whole window (delete + recreate) every run, which would
+// otherwise re-post the window as fresh journals each cycle (this is exactly
+// what triple-counted June 2026 before).
+//   1. Line layer — each posted line is stamped glTransactionId, so a stamped
+//      line is never posted again (and the feed sync now carries stamps across
+//      its rebuild).
+//   2. Journal layer — each journal's identity is DETERMINISTIC:
+//      source_doc_id = md5(company|outlet|contra|day|direction). If a journal
+//      for the group already exists, it is REUSED: unlinked (rebuilt) lines are
+//      re-stamped onto it, and genuinely new lines for an already-posted day
+//      fold in by updating the journal amount (additive).
+// A GC pass then deletes bank journals no line references (orphans left by
+// rebuilds under older rules) — run only when the backlog fully drained, so a
+// bounded run never deletes journals whose lines it hasn't reached yet.
 
+import { createHash } from "crypto";
 import { prisma } from "@/lib/prisma";
 import { postJournal } from "./ledger";
+import { getFinanceClient } from "./supabase";
 import type { JournalLineInput } from "./types";
 import { BANK_CASH, companyFromAccountName, resolveContra, round2, SKIP_CATS } from "./gl-posting-map";
+
+// Deterministic journal identity for a (company, outlet, contra, day, direction)
+// aggregate. Formatted as a UUID so it fits fin_transactions.source_doc_id and
+// matches postgres md5(text)::uuid — SQL backfills can reproduce it exactly.
+export function bankJournalKey(company: string, outletId: string | null, contra: string, date: string, direction: string): string {
+  const h = createHash("md5").update(`bank-gl|${company}|${outletId ?? ""}|${contra}|${date}|${direction}`).digest("hex");
+  return `${h.slice(0, 8)}-${h.slice(8, 12)}-${h.slice(12, 16)}-${h.slice(16, 20)}-${h.slice(20)}`;
+}
 
 export { CONTRA_ACCOUNT, companyFromAccountName, contraFor, resolveContra } from "./gl-posting-map";
 
@@ -41,6 +65,8 @@ export type GlPostResult = {
   committed: boolean;
   scannedLines: number;
   journals: number;        // journals posted (or that would post)
+  reusedJournals: number;  // groups folded into an existing deterministic journal
+  gcJournals: number;      // orphaned bank journals deleted (no line references)
   postedLines: number;     // bank lines that landed in a journal
   skippedLines: number;    // TRANSFER_NOT_SUCCESSFUL
   suspenseLines: number;   // parked in 1999
@@ -92,7 +118,8 @@ export async function postBankLinesToGl(
 
   const byCat = new Map<string, { account: string; direction: string; journals: number; lines: number; amount: number; suspense: boolean }>();
   const errors: GlPostResult["errors"] = [];
-  let journals = 0, postedLines = 0, suspenseLines = 0, totalDebit = 0, totalCredit = 0;
+  const fin = getFinanceClient();
+  let journals = 0, reusedJournals = 0, postedLines = 0, suspenseLines = 0, totalDebit = 0, totalCredit = 0;
 
   for (const g of groups.values()) {
     if (g.amount <= 0) continue;
@@ -115,26 +142,76 @@ export async function postBankLinesToGl(
 
     if (!commit) continue;
     try {
-      const desc = `Bank ${g.direction === "CR" ? "receipts" : "payments"} — ${g.category}→${contra} ${g.date} (${g.lineIds.length} line${g.lineIds.length > 1 ? "s" : ""})`;
-      const res = await postJournal({
-        companyId: g.company,
-        txnDate: g.date,
-        description: desc,
-        txnType: "payment",
-        outletId: g.outletId,
-        agent: "bank",
-        agentVersion: "bank-gl-v1",
-        confidence: 1,
-        lines: journalLines,
-      });
+      const key = bankJournalKey(g.company, g.outletId, contra, g.date, g.direction);
+      const { data: existingRows, error: exErr } = await fin
+        .from("fin_transactions")
+        .select("id, amount")
+        .eq("source_doc_id", key)
+        .eq("posted_by_agent", "bank")
+        .eq("status", "posted")
+        .limit(1);
+      if (exErr) throw new Error(exErr.message);
+      const existing = existingRows?.[0];
+
+      let txnId: string;
+      if (!existing) {
+        const desc = `Bank ${g.direction === "CR" ? "receipts" : "payments"} — ${g.category}→${contra} ${g.date} (${g.lineIds.length} line${g.lineIds.length > 1 ? "s" : ""})`;
+        const res = await postJournal({
+          companyId: g.company,
+          txnDate: g.date,
+          description: desc,
+          txnType: "payment",
+          outletId: g.outletId,
+          agent: "bank",
+          agentVersion: "bank-gl-v1",
+          confidence: 1,
+          sourceDocId: key,
+          lines: journalLines,
+        });
+        txnId = res.transactionId;
+      } else {
+        // A journal for this (company, outlet, contra, day, direction) exists.
+        // If lines still reference it, this group is a late arrival for the day
+        // → fold in additively. If none do (the feed rebuild dropped them), the
+        // group IS the day again → the journal amount is replaced.
+        txnId = existing.id as string;
+        const linked = await prisma.bankStatementLine.count({ where: { glTransactionId: txnId } });
+        const newTotal = round2((linked > 0 ? Number(existing.amount) : 0) + g.amount);
+        const { data: jls, error: jlErr } = await fin
+          .from("fin_journal_lines").select("id, debit, credit").eq("transaction_id", txnId);
+        if (jlErr) throw new Error(jlErr.message);
+        if (!jls || jls.length !== 2) throw new Error(`journal ${txnId} has ${jls?.length ?? 0} lines; expected 2`);
+        for (const jl of jls) {
+          const upd = Number(jl.debit) > 0 ? { debit: newTotal } : { credit: newTotal };
+          const { error } = await fin.from("fin_journal_lines").update(upd).eq("id", jl.id);
+          if (error) throw new Error(error.message);
+        }
+        const { error: tErr } = await fin.from("fin_transactions").update({ amount: newTotal }).eq("id", txnId);
+        if (tErr) throw new Error(tErr.message);
+        reusedJournals++;
+      }
       await prisma.bankStatementLine.updateMany({
         where: { id: { in: g.lineIds } },
-        data: { glTransactionId: res.transactionId, glPostedAt: new Date() },
+        data: { glTransactionId: txnId, glPostedAt: new Date() },
       });
     } catch (err) {
       errors.push({ company: g.company, category: g.category, date: g.date, error: err instanceof Error ? err.message : String(err) });
       journals--; postedLines -= g.lineIds.length;
       totalDebit = round2(totalDebit - g.amount); totalCredit = round2(totalCredit - g.amount);
+    }
+  }
+
+  // GC: bank journals no line references are leftovers of feed rebuilds (their
+  // lines were deleted and re-posted under a fresh key). Only safe when this
+  // run drained the whole backlog — a bounded run hasn't re-stamped everything.
+  let gcJournals = 0;
+  const drained = !opts.limit || lines.length < opts.limit;
+  if (commit && drained && lines.length > 0) {
+    try {
+      const since = lines[0].txnDate.toISOString().slice(0, 10);
+      gcJournals = await gcOrphanBankJournals(since);
+    } catch (err) {
+      errors.push({ company: "-", category: "gc", date: "-", error: err instanceof Error ? err.message : String(err) });
     }
   }
 
@@ -145,7 +222,43 @@ export async function postBankLinesToGl(
   return {
     committed: commit,
     scannedLines: lines.length,
-    journals, postedLines, skippedLines, suspenseLines,
+    journals, reusedJournals, gcJournals, postedLines, skippedLines, suspenseLines,
     totalDebit, totalCredit, byCategory, errors,
   };
+}
+
+// Delete posted bank-agent journals that no bank line references. These are
+// derived rows whose source lines were rebuilt away; keeping them is exactly
+// the double-count. Scoped to the given window and to posted_by_agent='bank' —
+// AR/manual journals are never touched.
+async function gcOrphanBankJournals(sinceDate: string): Promise<number> {
+  const fin = getFinanceClient();
+  const { data: txns, error } = await fin
+    .from("fin_transactions")
+    .select("id")
+    .eq("posted_by_agent", "bank")
+    .eq("status", "posted")
+    .gte("txn_date", sinceDate);
+  if (error) throw new Error(error.message);
+  const ids = (txns ?? []).map((t) => t.id as string);
+
+  const orphans: string[] = [];
+  for (let i = 0; i < ids.length; i += 500) {
+    const chunk = ids.slice(i, i + 500);
+    const linked = await prisma.bankStatementLine.groupBy({
+      by: ["glTransactionId"],
+      where: { glTransactionId: { in: chunk } },
+    });
+    const linkedSet = new Set(linked.map((r) => r.glTransactionId));
+    for (const id of chunk) if (!linkedSet.has(id)) orphans.push(id);
+  }
+
+  for (let i = 0; i < orphans.length; i += 200) {
+    const chunk = orphans.slice(i, i + 200);
+    const { error: le } = await fin.from("fin_journal_lines").delete().in("transaction_id", chunk);
+    if (le) throw new Error(le.message);
+    const { error: te } = await fin.from("fin_transactions").delete().in("id", chunk);
+    if (te) throw new Error(te.message);
+  }
+  return orphans.length;
 }


### PR DESCRIPTION
## Critical: the GL was compounding duplicates every 6 hours

The Bukku feed sync rebuilds its whole window (**delete + recreate**) every run, wiping `glTransactionId` on every line. The GL poster then re-posted the window as brand-new journals each cycle. Verified in production: June 2026 bank activity is in the ledger **~2.8×** — `bank-gl-sqlfill` posted it once (381,062 / 380,043, exactly matching the bank), and the cron has since added ~2 more copies (694,298 / 736,712). Every future sync would add another.

### Fix (three layers)
1. **Feed sync carries state across the rebuild** — GL links, AP matches, and human classifications snapshot per `(date, direction, amount, description)` occurrence-queue before the wipe, restored after recreate.
2. **Deterministic journal identity** — `source_doc_id = md5(company|outlet|contra|day|direction)` (reproducible from SQL via `md5(text)::uuid`). If the journal exists: rebuilt lines re-stamp onto it; genuinely-new lines for an already-posted day fold in additively. Never posted twice.
3. **Orphan GC** — bank journals no line references are rebuild leftovers and get deleted (only when the backlog fully drained; AR/manual journals untouched). This also self-cleans the existing duplicate pile.

## Classifier v2 (33% of June outflow value was unclassified)

Diagnosis: Maybank's beneficiary field glues a fixed **20-char sender prefix** straight onto the payee — `CELSIUS COFFEE PUTRAYOW SENG SDN BHD` — so every `\b`-anchored supplier rule missed (`PUTRAYOW` is one word). Rules for Yow Seng, TMM, Collective Project etc. existed and never fired on these.

- Every rule now also matches with those 20 chars stripped.
- Purpose suffixes that run into references classify (`DIVIDENDQ1` → DIVIDEND); new rules: audit → COMPLIANCE, taxation → TAX, Rentokil/CleanHero/Simple Axe → MAINTENANCE, Jijus Cakes/BGS Trading/Milk Ministry/Elite Pac/KL Fried → RAW_MATERIALS.
- **Supplier-registry pass**: an unmatched outflow whose payee is a procurement `Supplier` classifies as RAW_MATERIALS (`vendor_registry`) — onboarding a supplier in procurement is enough; no classifier edit needed.

The next sync re-classifies the whole feed window with these rules automatically. A one-time GL rebuild follows this merge to purge the current duplicates and re-post under deterministic keys.

Tests: 10/10 classifier tests (4 new cases), typecheck clean.