### PR TITLE
Add procurement_new_order WhatsApp template to the WABA template set

### DIFF
--- a/apps/backoffice/src/app/api/ops/workspace/templates/route.ts
+++ b/apps/backoffice/src/app/api/ops/workspace/templates/route.ts
@@ -58,6 +58,18 @@ const TEMPLATE_DEFS = [
     sample: "Clock in for your 8:00am shift at Putrajaya — you haven't yet.",
   },
   {
+    // Cold-send PO prompt (procurement). Sent when a PO is created outside the
+    // supplier's 24h window: invites a reply, which reopens the window so the
+    // full PO block follows automatically (sendPendingPurchaseOrders on the
+    // webhook). {{1}} = supplier name, {{2}} = PO number — must match the
+    // sendWhatsAppTemplate call in procurement-po-send.ts. Once APPROVED, set
+    // PROCUREMENT_PO_PROMPT_TEMPLATE=procurement_new_order. Dry, transactional
+    // wording so Meta classifies it UTILITY.
+    name: "procurement_new_order",
+    body: "Hi {{1}}, we have prepared a new purchase order {{2}} for you. Reply to this message and we will send over the full order details. Thank you.",
+    sample: ["Jiju Cakes To Share", "CC-CC002-0215"],
+  },
+  {
     // Multi-line LIST: a headline ({{1}}) + up to four item lines ({{2}}..{{5}}),
     // each on its OWN line — the only way to get real line breaks (a single param
     // can't contain newlines). Generous fixed text wraps the variables: Meta


### PR DESCRIPTION
Follow-up to #685 (cold "Create & prompt" flow). The cold-send PO prompt referenced by `procurement-po-send.ts` (`PROCUREMENT_PO_PROMPT_TEMPLATE`) never existed on the WABA, so POs created outside a supplier's 24h window had no compliant send path.

This adds `procurement_new_order` to `TEMPLATE_DEFS` so it's part of the existing one-click `/api/ops/workspace/templates?action=create` submission flow (same mechanism the ops-pulse templates were created with):

> Hi {{1}}, we have prepared a new purchase order {{2}} for you. Reply to this message and we will send over the full order details. Thank you.

- `{{1}}` = supplier name, `{{2}}` = PO number — matches the two body parameters `sendPurchaseOrder` already sends.
- Transactional wording (no CTA/urgency) so Meta classifies it UTILITY; fixed text before/after the variables per Meta's body rules.
- Re-running `?action=create` is safe — existing names return a surfaced error.

After merge + deploy: an OWNER/ADMIN opens `/api/ops/workspace/templates?action=create` once, waits for Meta approval (usually fast for UTILITY), then sets `PROCUREMENT_PO_PROMPT_TEMPLATE=procurement_new_order` in Vercel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01SrjfLzrbEAQdNUBgawNqE5)_