### PR TITLE
feat(finance): reports company switcher + missing income lines + real Grab rate

### DIFF
--- a/apps/backoffice/src/app/(admin)/finance/reports/page.tsx
+++ b/apps/backoffice/src/app/(admin)/finance/reports/page.tsx
@@ -97,10 +97,54 @@ function useReportControlsState() {
   return { preset, setPreset, customStart, setCustomStart, customEnd, setCustomEnd, outletId, setOutletId, start, end };
 }
 
+type FinCompany = { id: string; name: string; outletIds: string[] };
+
 function ReportControlsBar({ c }: { c: ReturnType<typeof useReportControlsState> }) {
   const { data: outlets } = useFetch<{ id: string; name: string }[]>("/api/settings/outlets");
+  const { data: co } = useFetch<{ companies: FinCompany[]; activeCompanyId: string }>("/api/finance/companies");
+  const [switching, setSwitching] = useState(false);
+
+  // Every report is scoped to the ACTIVE COMPANY (a server-side cookie) — show
+  // it and let it be switched here, and only offer that company's outlets.
+  // Without this, picking an outlet of another company silently no-ops (the
+  // API falls back to all company outlets) and the numbers mislead.
+  const active = co?.companies.find((x) => x.id === co.activeCompanyId);
+  const companyOutlets = active
+    ? (outlets ?? []).filter((o) => active.outletIds.includes(o.id))
+    : (outlets ?? []);
+
+  useEffect(() => {
+    if (active && c.outletId && !active.outletIds.includes(c.outletId)) c.setOutletId("");
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- clear a stale outlet filter when the company changes
+  }, [active?.id, c.outletId]);
+
+  async function switchCompany(companyId: string) {
+    setSwitching(true);
+    try {
+      await fetch("/api/finance/companies/switch", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ companyId }),
+      });
+      // The cookie drives every server-side report — hard reload so all tabs refetch.
+      window.location.reload();
+    } catch {
+      setSwitching(false);
+    }
+  }
+
   return (
     <div className="flex flex-wrap items-center gap-2 rounded-lg border bg-card p-2">
+      <select
+        value={co?.activeCompanyId ?? ""}
+        onChange={(e) => switchCompany(e.target.value)}
+        disabled={!co || switching}
+        className="h-8 rounded-md border bg-background px-2 text-sm font-semibold"
+        title="Active company — every report is scoped to this legal entity"
+      >
+        {!co && <option value="">Company…</option>}
+        {(co?.companies ?? []).map((x) => <option key={x.id} value={x.id}>{x.name}</option>)}
+      </select>
       <select
         value={c.preset}
         onChange={(e) => c.setPreset(e.target.value as Preset)}
@@ -121,10 +165,10 @@ function ReportControlsBar({ c }: { c: ReturnType<typeof useReportControlsState>
         value={c.outletId}
         onChange={(e) => c.setOutletId(e.target.value)}
         className="ml-auto h-8 rounded-md border bg-background px-2 text-sm"
-        title="Filter by outlet"
+        title="Filter by outlet (outlets of the active company)"
       >
         <option value="">All outlets</option>
-        {(outlets ?? []).map((o) => <option key={o.id} value={o.id}>{o.name}</option>)}
+        {companyOutlets.map((o) => <option key={o.id} value={o.id}>{o.name}</option>)}
       </select>
     </div>
   );

--- a/apps/backoffice/src/app/api/finance/companies/route.ts
+++ b/apps/backoffice/src/app/api/finance/companies/route.ts
@@ -1,8 +1,10 @@
-// GET /api/finance/companies — list active companies for the switcher
+// GET /api/finance/companies — list active companies for the switcher,
+// each with its outlet ids so UIs can scope outlet filters to the company.
 
 import { NextRequest, NextResponse } from "next/server";
 import { requireAuth } from "@/lib/auth";
 import { listCompanies, getActiveCompanyId } from "@/lib/finance/companies";
+import { getFinanceClient } from "@/lib/finance/supabase";
 
 export const dynamic = "force-dynamic";
 
@@ -12,6 +14,20 @@ export async function GET(req: NextRequest) {
   if (!["OWNER", "ADMIN"].includes(auth.user.role)) {
     return NextResponse.json({ error: "Forbidden" }, { status: 403 });
   }
-  const [companies, activeId] = await Promise.all([listCompanies(), getActiveCompanyId()]);
-  return NextResponse.json({ companies, activeCompanyId: activeId });
+  const client = getFinanceClient();
+  const [companies, activeId, oc] = await Promise.all([
+    listCompanies(),
+    getActiveCompanyId(),
+    client.from("fin_outlet_companies").select("outlet_id, company_id"),
+  ]);
+  const outletsByCompany = new Map<string, string[]>();
+  for (const r of oc.data ?? []) {
+    const arr = outletsByCompany.get(r.company_id as string) ?? [];
+    arr.push(r.outlet_id as string);
+    outletsByCompany.set(r.company_id as string, arr);
+  }
+  return NextResponse.json({
+    companies: companies.map((c) => ({ ...c, outletIds: outletsByCompany.get(c.id) ?? [] })),
+    activeCompanyId: activeId,
+  });
 }

--- a/apps/backoffice/src/lib/finance/reports/pnl-sourced-drill.ts
+++ b/apps/backoffice/src/lib/finance/reports/pnl-sourced-drill.ts
@@ -188,16 +188,17 @@ async function drillGrabAds(companyId: string, start: string, end: string, outle
   }));
 }
 
-// BANK:<CAT> — the classified bank lines behind the opex line.
-async function drillBank(cat: string, companyId: string, start: string, end: string, outletId?: string | null): Promise<DrillLine[]> {
+// BANK:<CAT> — the classified bank lines behind the opex line. Also serves the
+// bank-sourced income lines (GastroHub, Meetings & Events) on the CR side.
+async function drillBank(cat: string, companyId: string, start: string, end: string, outletId?: string | null, direction: "DR" | "CR" = "DR"): Promise<DrillLine[]> {
   const suffix = BANK_ACCOUNT_SUFFIX[companyId];
   if (!suffix) return [];
   const lines = await prisma.bankStatementLine.findMany({
     where: {
-      direction: "DR",
+      direction,
       txnDate: { gte: dStart(start), lte: dEnd(end) },
       statement: { accountName: { contains: suffix } },
-      apInvoiceId: null,
+      ...(direction === "DR" ? { apInvoiceId: null } : {}),
       category: cat === "NULL" ? null : (cat as CashCategory),
       ...(outletId ? { outletId } : {}),
     },
@@ -210,8 +211,8 @@ async function drillBank(cat: string, companyId: string, start: string, end: str
     txnDate: l.txnDate.toISOString().slice(0, 10),
     description: l.description ?? "(no description)",
     amount: round2(Number(l.amount)),
-    debit: round2(Number(l.amount)),
-    credit: 0,
+    debit: direction === "DR" ? round2(Number(l.amount)) : 0,
+    credit: direction === "CR" ? round2(Number(l.amount)) : 0,
   }));
 }
 
@@ -223,6 +224,10 @@ export async function sourcedPnlDrillDown(args: {
   outletId?: string | null;
 }): Promise<DrillLine[]> {
   const { companyId, code, start, end, outletId } = args;
+  // Bank-settled income channels drill into their bank inflow lines (they have
+  // no POS orders behind them) — must route before the generic REV-* branch.
+  if (code === "REV-GASTRO") return drillBank("GASTROHUB", companyId, start, end, outletId, "CR");
+  if (code === "REV-EVENTS") return drillBank("MEETINGS_EVENTS", companyId, start, end, outletId, "CR");
   if (code.startsWith("REV-")) return drillRevenue(code, companyId, start, end, outletId);
   if (code === "PROC") return drillPurchases(companyId, start, end, outletId);
   if (code === "MKT-ADS") return drillAds(start, end);
@@ -233,11 +238,11 @@ export async function sourcedPnlDrillDown(args: {
     // Estimate, not transactions: recompute the base so the drawer explains it.
     const rev = await drillRevenue("REV-GRAB", companyId, start, end, outletId);
     const gross = round2(rev.reduce((s, r) => s + r.amount, 0));
-    const est = round2(gross * 0.30);
+    const est = round2(gross * 0.43);
     return [{
       transactionId: "grab-comm-estimate",
       txnDate: end,
-      description: `Estimated commission: 30% of RM${gross.toFixed(2)} gross GrabFood sales in this period. Exact per-order commission lives in the Grab settlement report.`,
+      description: `Estimated commission: 43% of RM${gross.toFixed(2)} gross GrabFood sales in this period (observed effective all-in Grab deduction). Exact per-order commission lives in the Grab settlement report.`,
       amount: est,
       debit: est,
       credit: 0,

--- a/apps/backoffice/src/lib/finance/reports/pnl-sourced.ts
+++ b/apps/backoffice/src/lib/finance/reports/pnl-sourced.ts
@@ -55,7 +55,9 @@ const BANK_REVIEW = new Set(["OTHER_OUTFLOW"]);
 // from the API and replace this estimate). Commission is the selling company's
 // cost, so it attributes to whichever company booked the Grab revenue —
 // independent of which bank account the net payout lands in.
-const GRAB_COMMISSION_RATE = 0.30;
+// ~43% observed effective all-in deduction (commission + platform fees) from
+// reconciling gross Grab sales vs bank payouts — the old 0.30 understated it.
+const GRAB_COMMISSION_RATE = 0.43;
 
 function humanCat(c: string | null): string {
   if (!c) return "Unclassified";
@@ -186,7 +188,36 @@ export async function buildSourcedPnl(input: {
     { code: "REV-GRAB", name: "Sales — GrabFood (gross)", amount: round2(rev.grab), parentCode: null },
     { code: "REV-PANDA", name: "Sales — FoodPanda", amount: round2(rev.foodpanda), parentCode: null },
   ].filter((l) => l.amount !== 0);
-  const totalIncome = round2(rev.instore + rev.online + rev.grab + rev.foodpanda);
+  let totalIncome = round2(rev.instore + rev.online + rev.grab + rev.foodpanda);
+
+  // Non-POS revenue the sales sources can't see: GastroHub (Nilai's cloud-kitchen
+  // channel) and Meetings/Events (IOI Mall) settle straight into the bank with no
+  // POS order behind them, so income was understated by their whole amount.
+  // Sourced from the classified bank inflows for this company's account.
+  const incomeSuffix = BANK_ACCOUNT_SUFFIX[companyId];
+  if (incomeSuffix) {
+    const bankIncome = await prisma.bankStatementLine.groupBy({
+      by: ["category"],
+      where: {
+        direction: "CR",
+        txnDate: { gte: dStart(start), lte: dEnd(end) },
+        statement: { accountName: { contains: incomeSuffix } },
+        category: { in: ["GASTROHUB", "MEETINGS_EVENTS"] },
+        ...(outletId ? { outletId } : {}),
+      },
+      _sum: { amount: true },
+    });
+    for (const g of bankIncome) {
+      const amt = round2(Number(g._sum?.amount ?? 0));
+      if (!amt) continue;
+      incomeLines.push(
+        g.category === "GASTROHUB"
+          ? { code: "REV-GASTRO", name: "Sales — GastroHub (Nilai)", amount: amt, parentCode: null }
+          : { code: "REV-EVENTS", name: "Sales — Meetings & Events", amount: amt, parentCode: null },
+      );
+      totalIncome = round2(totalIncome + amt);
+    }
+  }
 
   // ─── COGS: Opening inventory + Purchases − Closing inventory ──────────────
   const invDate = { gte: dStart(start), lte: dEnd(end) };


### PR DESCRIPTION
Three accuracy fixes for /finance/reports, all found auditing the live page:

## 1. Show + switch the active company (and scope outlets to it)
Every report is scoped to the active-company cookie, but the page never showed which company. The outlet filter listed ALL outlets, and picking one belonging to another company **silently no-oped** (the API falls back to all of the active company's outlets). Verified live: the filter said *Putrajaya* while the data on screen was *Tamarind's*.

The control bar now leads with the **active company**, switchable in place (`POST /api/finance/companies/switch` + reload since the cookie drives every server-side report), and the outlet dropdown only offers that company's outlets (`GET /api/finance/companies` now returns `outletIds` per company). A stale persisted outlet filter clears on mismatch.

## 2. Missing income: GastroHub + Meetings & Events
GastroHub (Nilai cloud kitchen, ~RM12k/mo) and Meetings & Events (IOI Mall) settle straight into the bank with no POS order behind them, so the sourced P&L understated income by their whole amount. Added as `REV-GASTRO` / `REV-EVENTS` income lines from the classified bank inflows; both are clickable and drill into their bank lines.

## 3. Grab commission 30% → 43%
The estimate understated the marketplace fee by a third; ~43% is the observed effective all-in Grab deduction (gross Grab sales vs bank payouts). Still an estimate until the Grab settlement API is sourced; the drill-down explains the basis.

Typecheck clean, lint clean (0 errors).