### PR TITLE
fix(security): close unauthenticated route + storage-write findings (C1, C2, C4, H4)

### DIFF
--- a/apps/backoffice/src/app/api/inventory/pay-and-claim/route.ts
+++ b/apps/backoffice/src/app/api/inventory/pay-and-claim/route.ts
@@ -4,6 +4,9 @@ import { getUserFromHeaders } from "@/lib/auth";
 import { adjustStockBalance } from "@/lib/stock";
 
 export async function GET(req: NextRequest) {
+  const caller = await getUserFromHeaders(req.headers);
+  if (!caller) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+
   const tab = req.nextUrl.searchParams.get("tab") || "pending";
   const search = req.nextUrl.searchParams.get("search") || "";
 

--- a/apps/backoffice/src/app/api/loyalty/promotions/route.ts
+++ b/apps/backoffice/src/app/api/loyalty/promotions/route.ts
@@ -5,6 +5,9 @@ import { requireAuth } from '@/lib/auth';
 // GET /api/loyalty/promotions?brand_id=brand-celsius
 export async function GET(request: NextRequest) {
   try {
+    const auth = await requireAuth(request);
+    if (auth.error) return auth.error;
+
     const { searchParams } = new URL(request.url);
     const brandId = searchParams.get('brand_id') || 'brand-celsius';
 

--- a/apps/backoffice/src/app/api/ops/audit-templates/route.ts
+++ b/apps/backoffice/src/app/api/ops/audit-templates/route.ts
@@ -4,6 +4,9 @@ import { getSession } from "@celsius/auth";
 
 // GET — list all audit templates
 export async function GET() {
+  const session = await getSession();
+  if (!session) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+
   const templates = await prisma.auditTemplate.findMany({
     include: {
       createdBy: { select: { id: true, name: true } },

--- a/apps/backoffice/src/app/api/pos/auth/pin/route.ts
+++ b/apps/backoffice/src/app/api/pos/auth/pin/route.ts
@@ -290,6 +290,10 @@ export async function POST(req: NextRequest) {
       outletName,
       shiftEnd,    // ISO string when rostered (drives till auto-logout), else null
       overrideBy,  // manager name when login was a not-scheduled override, else null
+      // Same JWT as the httpOnly cookie below. The web register uses the cookie;
+      // the native till can't read an httpOnly cookie, so it captures this and
+      // replays it as `Authorization: Bearer <token>` on POS API calls.
+      token,
     });
 
     response.cookies.set(COOKIE_NAME, token, {

--- a/apps/backoffice/src/app/api/pos/loyalty/claim/route.ts
+++ b/apps/backoffice/src/app/api/pos/loyalty/claim/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { createClient } from "@supabase/supabase-js";
+import { requirePosApiAuth } from "@/lib/pos-auth";
 
 /**
  * POST /api/loyalty/claim
@@ -129,6 +130,9 @@ async function creditBonusBeans(
 }
 
 export async function POST(req: NextRequest) {
+  const { block } = await requirePosApiAuth(req, "pos/loyalty/claim");
+  if (block) return block;
+
   try {
     const { member_id, claimable_id } = await req.json();
     if (!member_id || !claimable_id) {

--- a/apps/backoffice/src/app/api/pos/loyalty/complete/route.ts
+++ b/apps/backoffice/src/app/api/pos/loyalty/complete/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { createClient } from "@supabase/supabase-js";
 import { markVoucherUsed } from "@celsius/shared";
+import { requirePosApiAuth } from "@/lib/pos-auth";
 
 /**
  * POST /api/pos/loyalty/complete
@@ -218,6 +219,9 @@ async function spawnMysteryDrop(
 }
 
 export async function POST(req: NextRequest) {
+  const { block } = await requirePosApiAuth(req, "pos/loyalty/complete");
+  if (block) return block;
+
   try {
     const { member_id, order_id } = await req.json();
     if (!member_id || !order_id) {

--- a/apps/backoffice/src/app/api/pos/loyalty/lookup/route.ts
+++ b/apps/backoffice/src/app/api/pos/loyalty/lookup/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { createClient } from "@supabase/supabase-js";
+import { requirePosApiAuth } from "@/lib/pos-auth";
 
 /**
  * GET /api/loyalty/lookup?phone=+60xxx
@@ -37,6 +38,9 @@ function phoneVariants(raw: string): string[] {
 }
 
 export async function GET(req: NextRequest) {
+  const { block } = await requirePosApiAuth(req, "pos/loyalty/lookup");
+  if (block) return block;
+
   const phone = req.nextUrl.searchParams.get("phone");
   if (!phone) {
     return NextResponse.json({ error: "phone required" }, { status: 400 });

--- a/apps/backoffice/src/app/api/pos/loyalty/redeem/route.ts
+++ b/apps/backoffice/src/app/api/pos/loyalty/redeem/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { createClient, type SupabaseClient } from "@supabase/supabase-js";
+import { requirePosApiAuth } from "@/lib/pos-auth";
 import {
   markVoucherUsed,
   rowToDiscountSpec,
@@ -49,6 +50,9 @@ function generateCode(): string {
  * consolidation) — the same spec native + QR-table resolve from.
  */
 export async function POST(req: NextRequest) {
+  const { block } = await requirePosApiAuth(req, "pos/loyalty/redeem");
+  if (block) return block;
+
   const supabase = getSupabase();
   try {
     const { member_id, reward_id, outlet_id, issued_reward_id, preview } = await req.json();

--- a/apps/backoffice/src/app/api/pos/loyalty/rewards/route.ts
+++ b/apps/backoffice/src/app/api/pos/loyalty/rewards/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { createClient, type SupabaseClient } from "@supabase/supabase-js";
+import { requirePosApiAuth } from "@/lib/pos-auth";
 import {
   fetchActiveVouchersForMember,
   fetchAffordableCatalogForMember,
@@ -44,6 +45,9 @@ const BRAND_ID = "brand-celsius";
  * endpoint too) so POS + Pickup never drift on filter logic or shape.
  */
 export async function GET(req: NextRequest) {
+  const { block } = await requirePosApiAuth(req, "pos/loyalty/rewards");
+  if (block) return block;
+
   const supabase = getSupabase();
   try {
     const memberId = req.nextUrl.searchParams.get("member_id");

--- a/apps/backoffice/src/app/api/pos/loyalty/snapshot/route.ts
+++ b/apps/backoffice/src/app/api/pos/loyalty/snapshot/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { fetchLoyaltySnapshot } from "@/lib/loyalty-snapshot";
+import { requirePosApiAuth } from "@/lib/pos-auth";
 
 /**
  * GET /api/loyalty/snapshot?phone=+60xxx
@@ -12,6 +13,9 @@ import { fetchLoyaltySnapshot } from "@/lib/loyalty-snapshot";
  * 404 when no member matches.
  */
 export async function GET(req: NextRequest) {
+  const { block } = await requirePosApiAuth(req, "pos/loyalty/snapshot");
+  if (block) return block;
+
   const phone = req.nextUrl.searchParams.get("phone");
   const memberId = req.nextUrl.searchParams.get("member_id");
   if (!phone && !memberId) {

--- a/apps/backoffice/src/app/api/settings/approval-rules/route.ts
+++ b/apps/backoffice/src/app/api/settings/approval-rules/route.ts
@@ -2,7 +2,10 @@ import { NextResponse, NextRequest } from "next/server";
 import { prisma } from "@/lib/prisma";
 import { getUserFromHeaders } from "@/lib/auth";
 
-export async function GET() {
+export async function GET(req: NextRequest) {
+  const caller = await getUserFromHeaders(req.headers);
+  if (!caller) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+
   const rules = await prisma.approvalRule.findMany({
     orderBy: { createdAt: "desc" },
   });

--- a/apps/backoffice/src/lib/pos-auth.ts
+++ b/apps/backoffice/src/lib/pos-auth.ts
@@ -214,3 +214,61 @@ export async function requireAuth(
   }
   return { user, error: null };
 }
+
+// ─── POS API request auth (Bearer for native till, cookie for web register) ──
+//
+// The PIN login (/api/pos/auth/pin) already mints a 12h JWT via createToken and
+// sets it as the httpOnly celsius-pos-session cookie. The web register replays
+// that cookie automatically; the native till (apps/pos-native) can't read an
+// httpOnly cookie, so it captures the token from the login response body and
+// replays it as `Authorization: Bearer <token>`. Both resolve here.
+
+/** True when POS API auth is enforced. During the rollout window this stays
+ *  unset, so an unauthenticated POS call is allowed-but-logged while the native
+ *  tills ship the Bearer token — flip POS_AUTH_ENFORCE=1 once every till sends
+ *  it (watch the [pos-auth] warnings drop to zero first). */
+export function posAuthEnforced(): boolean {
+  const v = process.env.POS_AUTH_ENFORCE;
+  return v === "1" || v === "true";
+}
+
+/** Resolve the POS staff session from a Bearer header (native till) or the
+ *  celsius-pos-session cookie (web register). */
+export async function getPosUser(
+  request: NextRequest,
+): Promise<SessionUser | null> {
+  const bearer = (request.headers.get("authorization") ?? "").match(
+    /^Bearer\s+(.+)$/i,
+  );
+  if (bearer) {
+    const u = await verifyToken(bearer[1]);
+    if (u) return u;
+  }
+  const cookieTok = request.cookies.get(COOKIE_NAME)?.value;
+  if (cookieTok) {
+    const u = await verifyToken(cookieTok);
+    if (u) return u;
+  }
+  return null;
+}
+
+/** Guard a POS API route. When `block` is non-null the route must return it (a
+ *  401). Unauthenticated calls pass through (block=null) during the rollout
+ *  grace period unless POS_AUTH_ENFORCE is set — see posAuthEnforced. */
+export async function requirePosApiAuth(
+  request: NextRequest,
+  label: string,
+): Promise<{ user: SessionUser | null; block: NextResponse | null }> {
+  const user = await getPosUser(request);
+  if (user) return { user, block: null };
+  if (posAuthEnforced()) {
+    return {
+      user: null,
+      block: NextResponse.json({ error: "Unauthorized" }, { status: 401 }),
+    };
+  }
+  console.warn(
+    `[pos-auth] unauthenticated ${label} (grace period — set POS_AUTH_ENFORCE=1 to reject)`,
+  );
+  return { user: null, block: null };
+}

--- a/apps/order/src/app/api/orders/[orderId]/status/route.ts
+++ b/apps/order/src/app/api/orders/[orderId]/status/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { after } from "next/server";
 import webpush from "web-push";
 import { getSupabaseAdmin } from "@/lib/supabase/server";
+import { requireStaffSession } from "@/lib/staff-token";
 import type { OrderRow, OrderStatus } from "@/lib/supabase/types";
 import {
   notifyOrderPreparing,
@@ -96,6 +97,22 @@ export async function PATCH(
         { error: `Cannot transition from ${order.status} to ${newStatus}` },
         { status: 422 }
       );
+    }
+
+    // Authorization. ready→completed is the customer "swipe to collect", driven
+    // by the pickup-native app with no staff session, so it stays open. Every
+    // other transition — pending/paid→preparing (starts the brew), preparing→
+    // ready, the ready→preparing staff undo, and cancels to failed — is a staff
+    // action and requires a KDS/staff token. Without this guard anyone could
+    // create a pending order and PATCH it to preparing (a free, unpaid drink on
+    // the line). Enforcement is gated by STAFF_AUTH_ENFORCE (see staff-token).
+    const isCustomerCollect = order.status === "ready" && newStatus === "completed";
+    if (!isCustomerCollect) {
+      const { error: authError } = requireStaffSession(
+        request,
+        `orders/status ${order.status}->${newStatus}`,
+      );
+      if (authError) return authError;
     }
 
     // Serving-time instrumentation: stamp the kitchen-bump moments so the Area

--- a/apps/order/src/app/api/staff/auth/route.ts
+++ b/apps/order/src/app/api/staff/auth/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { getSupabaseAdmin } from "@/lib/supabase/server";
 import { verifyPin, hashPin } from "@celsius/auth";
+import { signStaffToken } from "@/lib/staff-token";
 
 const attempts = new Map<string, { count: number; resetAt: number }>();
 
@@ -104,6 +105,7 @@ export async function POST(request: NextRequest) {
                 staffName: user.name,
                 staffId:   user.id,
                 source:    "backoffice",
+                token:     signStaffToken({ storeId, staffId: user.id, staffName: user.name }),
               });
             }
           }
@@ -133,6 +135,7 @@ export async function POST(request: NextRequest) {
         staffName: member.name,
         staffId:   member.id,
         source:    "legacy",
+        token:     signStaffToken({ storeId, staffId: member.id, staffName: member.name }),
       });
     }
 
@@ -162,6 +165,7 @@ export async function POST(request: NextRequest) {
       staffName: null,
       staffId:   null,
       source:    "outlet_pin",
+      token:     signStaffToken({ storeId, staffId: null, staffName: null }),
     });
   } catch (err) {
     console.error("Staff auth error:", err);

--- a/apps/order/src/app/api/staff/availability/route.ts
+++ b/apps/order/src/app/api/staff/availability/route.ts
@@ -1,8 +1,12 @@
 import { NextRequest, NextResponse } from "next/server";
 import { getSupabaseAdmin } from "@/lib/supabase/server";
+import { requireStaffSession } from "@/lib/staff-token";
 
 // GET /api/staff/availability?store=shah-alam
 export async function GET(request: NextRequest) {
+  const { error: authError } = requireStaffSession(request, "staff/availability GET");
+  if (authError) return authError;
+
   const storeId = request.nextUrl.searchParams.get("store");
   if (!storeId) return NextResponse.json({ error: "Missing store" }, { status: 400 });
 
@@ -17,6 +21,9 @@ export async function GET(request: NextRequest) {
 
 // PUT /api/staff/availability  { productId, storeId, isAvailable }
 export async function PUT(request: NextRequest) {
+  const { error: authError } = requireStaffSession(request, "staff/availability PUT");
+  if (authError) return authError;
+
   const { productId, storeId, isAvailable } = await request.json() as {
     productId:   string;
     storeId:     string;

--- a/apps/order/src/app/api/staff/orders/feed/route.ts
+++ b/apps/order/src/app/api/staff/orders/feed/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { getSupabaseAdmin } from "@/lib/supabase/server";
+import { requireStaffSession } from "@/lib/staff-token";
 
 /**
  * Staff KDS feed — returns full orders + order_items for a given store
@@ -13,6 +14,9 @@ import { getSupabaseAdmin } from "@/lib/supabase/server";
  *   GET /api/staff/orders/feed?store=X&statuses=completed&from=ISO&dir=desc
  */
 export async function GET(request: NextRequest) {
+  const { error: authError } = requireStaffSession(request, "staff/orders/feed");
+  if (authError) return authError;
+
   const sp = request.nextUrl.searchParams;
   const storeId = sp.get("store");
   if (!storeId) {

--- a/apps/order/src/app/api/staff/orders/overdue-count/route.ts
+++ b/apps/order/src/app/api/staff/orders/overdue-count/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { getSupabaseAdmin } from "@/lib/supabase/server";
+import { requireStaffSession } from "@/lib/staff-token";
 
 /**
  * Returns the count of "preparing" orders at a store that are older than
@@ -9,6 +10,9 @@ import { getSupabaseAdmin } from "@/lib/supabase/server";
  *   GET /api/staff/orders/overdue-count?store=X&before=ISO
  */
 export async function GET(request: NextRequest) {
+  const { error: authError } = requireStaffSession(request, "staff/orders/overdue-count");
+  if (authError) return authError;
+
   const sp = request.nextUrl.searchParams;
   const storeId = sp.get("store");
   const before  = sp.get("before");

--- a/apps/order/src/app/api/staff/orders/route.ts
+++ b/apps/order/src/app/api/staff/orders/route.ts
@@ -1,8 +1,12 @@
 import { NextRequest, NextResponse } from "next/server";
 import { getSupabaseAdmin } from "@/lib/supabase/server";
+import { requireStaffSession } from "@/lib/staff-token";
 
 // GET /api/staff/orders?store=shah-alam&from=2024-01-01T00:00:00.000Z
 export async function GET(request: NextRequest) {
+  const { error: authError } = requireStaffSession(request, "staff/orders");
+  if (authError) return authError;
+
   const storeId = request.nextUrl.searchParams.get("store");
   const from    = request.nextUrl.searchParams.get("from");
 

--- a/apps/order/src/app/api/staff/products/route.ts
+++ b/apps/order/src/app/api/staff/products/route.ts
@@ -1,7 +1,11 @@
-import { NextResponse } from "next/server";
+import { NextRequest, NextResponse } from "next/server";
 import { getSupabaseAdmin } from "@/lib/supabase/server";
+import { requireStaffSession } from "@/lib/staff-token";
 
-export async function GET() {
+export async function GET(request: NextRequest) {
+  const { error: authError } = requireStaffSession(request, "staff/products");
+  if (authError) return authError;
+
   const supabase = getSupabaseAdmin();
   const { data, error } = await supabase
     .from("products")

--- a/apps/order/src/app/staff/availability/page.tsx
+++ b/apps/order/src/app/staff/availability/page.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useState, useCallback } from "react";
 import { useRouter } from "next/navigation";
 import { Loader2, Search, ToggleLeft, ToggleRight, RotateCcw } from "lucide-react";
-import { getSession } from "@/lib/staff-auth";
+import { getSession, staffAuthHeaders } from "@/lib/staff-auth";
 import { StaffNav } from "@/components/staff-nav";
 
 interface Product {
@@ -36,8 +36,8 @@ export default function StaffAvailabilityPage() {
   const load = useCallback(async (storeIdArg: string) => {
     setLoading(true);
     const [prodRes, ovRes] = await Promise.all([
-      fetch("/api/staff/products"),
-      fetch(`/api/staff/availability?store=${storeIdArg}`),
+      fetch("/api/staff/products", { headers: staffAuthHeaders() }),
+      fetch(`/api/staff/availability?store=${storeIdArg}`, { headers: staffAuthHeaders() }),
     ]);
     const prods = (await prodRes.json() as { id: string; name: string; category: string; price: number }[]).map((p) => ({ ...p, is_available: true }));
     const ovs   = await ovRes.json()  as { product_id: string; is_available: boolean }[];
@@ -62,7 +62,7 @@ export default function StaffAvailabilityPage() {
     try {
       await fetch("/api/staff/availability", {
         method:  "PUT",
-        headers: { "Content-Type": "application/json" },
+        headers: { "Content-Type": "application/json", ...staffAuthHeaders() },
         body:    JSON.stringify({ productId, storeId: session.storeId, isAvailable: !current }),
       });
     } catch {
@@ -87,7 +87,7 @@ export default function StaffAvailabilityPage() {
         unavailable.map((p) =>
           fetch("/api/staff/availability", {
             method:  "PUT",
-            headers: { "Content-Type": "application/json" },
+            headers: { "Content-Type": "application/json", ...staffAuthHeaders() },
             body:    JSON.stringify({ productId: p.id, storeId: session.storeId, isAvailable: true }),
           }),
         ),

--- a/apps/order/src/app/staff/login/page.tsx
+++ b/apps/order/src/app/staff/login/page.tsx
@@ -72,11 +72,11 @@ export default function StaffLoginPage() {
         headers: { "Content-Type": "application/json" },
         body:    JSON.stringify({ storeId, pin: enteredPin }),
       });
-      const data = await res.json() as { ok?: boolean; error?: string; storeName?: string; staffName?: string | null; staffId?: string | null };
+      const data = await res.json() as { ok?: boolean; error?: string; storeName?: string; staffName?: string | null; staffId?: string | null; token?: string | null };
       if (data.ok) {
         const store = stores.find((s) => s.id === storeId) ?? { name: storeId };
         const resolvedStoreName = data.storeName ?? store.name;
-        saveSession(storeId, resolvedStoreName, data.staffName ?? null, data.staffId ?? null);
+        saveSession(storeId, resolvedStoreName, data.staffName ?? null, data.staffId ?? null, data.token ?? null);
         router.replace("/staff/availability");
       } else {
         setError(data.error ?? "Incorrect PIN");

--- a/apps/order/src/app/staff/reports/page.tsx
+++ b/apps/order/src/app/staff/reports/page.tsx
@@ -5,7 +5,7 @@ import { formatRM } from "@celsius/shared";
 import { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
 import { Loader2, ShoppingBag, TrendingUp, Clock, CheckCircle, XCircle } from "lucide-react";
-import { getSession } from "@/lib/staff-auth";
+import { getSession, staffAuthHeaders } from "@/lib/staff-auth";
 import { StaffNav } from "@/components/staff-nav";
 
 interface DayStats {
@@ -38,7 +38,7 @@ export default function StaffReportsPage() {
     const today = new Date();
     today.setHours(0, 0, 0, 0);
 
-    fetch(`/api/staff/orders?store=${session.storeId}&from=${today.toISOString()}`)
+    fetch(`/api/staff/orders?store=${session.storeId}&from=${today.toISOString()}`, { headers: staffAuthHeaders() })
       .then((r) => r.json())
       .then((orders: {
         status: string;

--- a/apps/order/src/lib/staff-auth.ts
+++ b/apps/order/src/lib/staff-auth.ts
@@ -8,6 +8,10 @@ export interface StaffSession {
   storeName:  string;
   staffName:  string | null;
   staffId:    string | null;
+  /** KDS/staff JWT from /api/staff/auth, sent as `Authorization: Bearer` on the
+   *  staff-only routes (order status transitions + /api/staff/* feeds). Optional
+   *  so sessions saved before this field existed still parse. */
+  token?:     string | null;
   loggedInAt: number;
   expiresAt:  number;
 }
@@ -36,12 +40,14 @@ export function saveSession(
   storeName: string,
   staffName: string | null = null,
   staffId:   string | null = null,
+  token:     string | null = null,
 ) {
   const session: StaffSession = {
     storeId,
     storeName,
     staffName,
     staffId,
+    token,
     loggedInAt: Date.now(),
     expiresAt:  Date.now() + TTL,
   };
@@ -51,4 +57,12 @@ export function saveSession(
 
 export function clearSession() {
   localStorage.removeItem(KEY);
+}
+
+/** Authorization headers for staff-only API calls — the Bearer token minted at
+ *  login. Returns {} when there's no session/token (pre-token sessions), so the
+ *  call still goes out and the server's grace period handles it. */
+export function staffAuthHeaders(): Record<string, string> {
+  const token = getSession()?.token;
+  return token ? { Authorization: `Bearer ${token}` } : {};
 }

--- a/apps/order/src/lib/staff-token.ts
+++ b/apps/order/src/lib/staff-token.ts
@@ -1,0 +1,128 @@
+import { createHmac, timingSafeEqual } from "node:crypto";
+import type { NextRequest } from "next/server";
+
+// Hand-rolled HS256 KDS/staff token — mirrors customer-jwt.ts (the order app
+// deliberately avoids a `jose` dependency). Minted by /api/staff/auth after a
+// PIN check and replayed as a Bearer on the staff-only surfaces: the order
+// status transitions (except the customer-driven ready→completed collect) and
+// the /api/staff/* feeds. A distinct `aud` keeps it from being swapped with the
+// customer session token.
+//
+// Payload shape:
+//   { aud: "order-staff", storeId, staffId, staffName, iat, exp }
+
+const SECRET = process.env.STAFF_JWT_SECRET ?? process.env.JWT_SECRET ?? "";
+const DEFAULT_TTL_SEC = 60 * 60 * 24 * 30; // 30 days — matches the KDS localStorage session
+const AUD = "order-staff";
+
+export type StaffSessionToken = {
+  aud:       string;
+  storeId:   string;
+  staffId:   string | null;
+  staffName: string | null;
+  iat:       number;
+  exp:       number;
+};
+
+function b64url(input: Buffer | string): string {
+  const buf = typeof input === "string" ? Buffer.from(input, "utf8") : input;
+  return buf
+    .toString("base64")
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+    .replace(/=+$/, "");
+}
+
+function fromB64url(s: string): Buffer {
+  const pad = "=".repeat((4 - (s.length % 4)) % 4);
+  return Buffer.from(s.replace(/-/g, "+").replace(/_/g, "/") + pad, "base64");
+}
+
+function hmac(payload: string): string {
+  if (!SECRET) throw new Error("STAFF_JWT_SECRET / JWT_SECRET not set");
+  return b64url(createHmac("sha256", SECRET).update(payload).digest());
+}
+
+/** Sign a KDS/staff session token. Returns null only when the secret is missing
+ *  — callers treat null as "auth disabled" rather than failing the login. */
+export function signStaffToken(args: {
+  storeId:   string;
+  staffId:   string | null;
+  staffName: string | null;
+  ttlSec?:   number;
+}): string | null {
+  if (!SECRET) return null;
+  const now = Math.floor(Date.now() / 1000);
+  const payload: StaffSessionToken = {
+    aud:       AUD,
+    storeId:   args.storeId,
+    staffId:   args.staffId,
+    staffName: args.staffName,
+    iat:       now,
+    exp:       now + (args.ttlSec ?? DEFAULT_TTL_SEC),
+  };
+  const head = b64url(JSON.stringify({ alg: "HS256", typ: "JWT" }));
+  const body = b64url(JSON.stringify(payload));
+  const sig  = hmac(`${head}.${body}`);
+  return `${head}.${body}.${sig}`;
+}
+
+/** Verify and parse. Returns null on any failure (bad shape, wrong audience,
+ *  bad signature, expired, missing secret). Does NOT throw. */
+export function verifyStaffToken(token: string | null | undefined): StaffSessionToken | null {
+  if (!token || !SECRET) return null;
+  const parts = token.split(".");
+  if (parts.length !== 3) return null;
+  const [head, body, sig] = parts;
+  const expected = hmac(`${head}.${body}`);
+  // Constant-time compare; length check first because timingSafeEqual throws on
+  // a length mismatch and we want a silent reject.
+  const a = Buffer.from(sig, "utf8");
+  const b = Buffer.from(expected, "utf8");
+  if (a.length !== b.length || !timingSafeEqual(a, b)) return null;
+  let parsed: StaffSessionToken;
+  try {
+    parsed = JSON.parse(fromB64url(body).toString("utf8")) as StaffSessionToken;
+  } catch {
+    return null;
+  }
+  if (parsed.aud !== AUD) return null;
+  if (typeof parsed.exp !== "number" || parsed.exp < Math.floor(Date.now() / 1000)) {
+    return null;
+  }
+  return parsed;
+}
+
+/** Pull and verify the Bearer token off a request. Null when absent/invalid. */
+export function readStaffToken(req: NextRequest): StaffSessionToken | null {
+  const auth = req.headers.get("authorization");
+  if (!auth || !auth.toLowerCase().startsWith("bearer ")) return null;
+  return verifyStaffToken(auth.slice(7).trim());
+}
+
+/** Enforcement flag — set STAFF_AUTH_ENFORCE=1 (or true) in the order app's env
+ *  once every KDS client sends a Bearer token. While unset, the guard logs
+ *  unauthenticated calls but lets them through, so a deploy doesn't 401 tills
+ *  still running the pre-token build. Mirrors STRICT_CUSTOMER_AUTH. */
+export const STRICT_STAFF_AUTH =
+  ["1", "true"].includes((process.env.STAFF_AUTH_ENFORCE ?? "").toLowerCase());
+
+/** Guard a staff-only route. When enforcement is on, returns a 401 `error` if
+ *  no valid Bearer is present; when off, returns `{ session: null, error: null }`
+ *  (allow) after logging, so token adoption can be watched before flipping the
+ *  flag. */
+export function requireStaffSession(
+  req: NextRequest,
+  label: string,
+):
+  | { session: StaffSessionToken; error: null }
+  | { session: null; error: Response | null }
+{
+  const session = readStaffToken(req);
+  if (session) return { session, error: null };
+  if (STRICT_STAFF_AUTH) {
+    return { session: null, error: Response.json({ error: "Unauthorized" }, { status: 401 }) };
+  }
+  console.warn(`[staff-auth] unauthenticated ${label} (grace period — set STAFF_AUTH_ENFORCE=1 to reject)`);
+  return { session: null, error: null };
+}

--- a/apps/pos-native/app/index.tsx
+++ b/apps/pos-native/app/index.tsx
@@ -63,13 +63,15 @@ export default function Login() {
         ? { pin: override!.staffPin, outletId, overridePin: fullPin }
         : { pin: fullPin, outletId };
       try {
-        const u = await apiPost<{ id: string; name: string; role: string; shiftEnd?: string | null }>(
+        const u = await apiPost<{ id: string; name: string; role: string; shiftEnd?: string | null; token?: string }>(
           "/api/pos/auth/pin", payload,
         );
         // Rostered login → auto-logout at the scheduled shift end; otherwise null
         // (manager / override / no roster) falls back to the till's 2h TTL.
         const shiftEndsAt = u.shiftEnd ? Date.parse(u.shiftEnd) : null;
-        setStaff({ staffId: u.id, staffName: u.name, role: u.role }, shiftEndsAt);
+        // Keep the POS session JWT so apiPost/apiGet can replay it as a Bearer
+        // (the httpOnly cookie the endpoint also sets is unreachable to native).
+        setStaff({ staffId: u.id, staffName: u.name, role: u.role, token: u.token ?? null }, shiftEndsAt);
         setOverride(null);
         Haptics.notificationAsync(Haptics.NotificationFeedbackType.Success);
         router.replace("/register");

--- a/apps/pos-native/components/lock-screen.tsx
+++ b/apps/pos-native/components/lock-screen.tsx
@@ -59,12 +59,13 @@ export default function LockScreen() {
         ? { pin: override!.staffPin, outletId, overridePin: fullPin }
         : { pin: fullPin, outletId };
       try {
-        const u = await apiPost<{ id: string; name: string; role: string; shiftEnd?: string | null }>(
+        const u = await apiPost<{ id: string; name: string; role: string; shiftEnd?: string | null; token?: string }>(
           "/api/pos/auth/pin", payload,
         );
         const shiftEndsAt = u.shiftEnd ? Date.parse(u.shiftEnd) : null;
         // setStaff stamps a fresh session AND clears `locked` → this unmounts.
-        setStaff({ staffId: u.id, staffName: u.name, role: u.role }, shiftEndsAt);
+        // Refresh the Bearer token too (unlock is a full re-auth).
+        setStaff({ staffId: u.id, staffName: u.name, role: u.role, token: u.token ?? null }, shiftEndsAt);
         setOverride(null);
         Haptics.notificationAsync(Haptics.NotificationFeedbackType.Success);
       } catch (e: any) {

--- a/apps/pos-native/lib/api.ts
+++ b/apps/pos-native/lib/api.ts
@@ -1,5 +1,6 @@
 import Constants from "expo-constants";
 import { markOnline, markOffline } from "./connectivity";
+import { usePos } from "./store";
 
 /**
  * Thin client for the POS Next.js API (auth/pin, loyalty, order
@@ -12,12 +13,18 @@ import { markOnline, markOffline } from "./connectivity";
 const API_BASE = process.env.EXPO_PUBLIC_API_BASE ?? "https://backoffice.celsiuscoffee.com";
 
 function headers(extra?: Record<string, string>): Record<string, string> {
+  // Replay the POS session JWT (captured at PIN login) as a Bearer. The web
+  // register authenticates via its httpOnly cookie; the native till can't read
+  // that cookie, so it carries the token in the store and sends it here. Absent
+  // before sign-in (e.g. the /api/pos/auth/pin call itself), which is fine.
+  const token = usePos.getState().staff?.token;
   return {
     "Content-Type": "application/json",
     Origin: API_BASE,
     Referer: API_BASE + "/",
     "X-App-Version": Constants.expoConfig?.version ?? "1.0.0",
     "X-App-Platform": "android-pos",
+    ...(token ? { Authorization: `Bearer ${token}` } : {}),
     ...(extra ?? {}),
   };
 }

--- a/apps/pos-native/lib/store.ts
+++ b/apps/pos-native/lib/store.ts
@@ -14,6 +14,11 @@ export type StaffSession = {
   staffId: string;
   staffName: string;
   role: string;
+  /** POS session JWT from /api/pos/auth/pin, replayed as `Authorization:
+   *  Bearer <token>` on POS API calls. The till can't use the httpOnly
+   *  celsius-pos-session cookie the same endpoint sets, so it carries the
+   *  token here. Null for sessions minted before this field existed. */
+  token: string | null;
 };
 
 /** Staff sessions auto-expire 2 hours after sign-in — the till re-prompts for

--- a/apps/staff/src/app/api/dashboard/route.ts
+++ b/apps/staff/src/app/api/dashboard/route.ts
@@ -1,7 +1,11 @@
 import { NextResponse, NextRequest } from "next/server";
 import { prisma } from "@/lib/prisma";
+import { getSession } from "@/lib/auth";
 
 export async function GET(req: NextRequest) {
+  const session = await getSession();
+  if (!session) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+
   const outletId = new URL(req.url).searchParams.get("outletId") || undefined;
   const outletFilter = outletId ? { outletId } : undefined;
   const now = new Date();

--- a/apps/staff/src/app/api/products/options/route.ts
+++ b/apps/staff/src/app/api/products/options/route.ts
@@ -1,11 +1,15 @@
 import { NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
+import { getSession } from "@/lib/auth";
 
 /**
  * GET /api/products/options
  * Products with fields needed by stock check, receiving, wastage, transfer pages.
  */
 export async function GET() {
+  const session = await getSession();
+  if (!session) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+
   const products = await prisma.product.findMany({
     where: { isActive: true },
     select: {

--- a/apps/staff/src/app/api/settings/stock-count/route.ts
+++ b/apps/staff/src/app/api/settings/stock-count/route.ts
@@ -1,10 +1,14 @@
 import { NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
+import { getSession } from "@/lib/auth";
 
 const KEY = "stock_count_schedule";
 const DEFAULT_SCHEDULE = { weeklyDays: [0, 2, 4], endOfMonthDays: [28, 29, 30, 31] };
 
 export async function GET() {
+  const session = await getSession();
+  if (!session) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+
   const config = await prisma.appConfig.findUnique({ where: { key: KEY } });
   return NextResponse.json(config?.value ?? DEFAULT_SCHEDULE);
 }

--- a/supabase/migrations/066_invoices_bucket_lock_writes.sql
+++ b/supabase/migrations/066_invoices_bucket_lock_writes.sql
@@ -1,0 +1,27 @@
+-- C4 — Revoke anonymous WRITE access to the `invoices` and `product-images`
+-- storage buckets.
+--
+-- Migration 20260502_storage_public_read_policies (prisma tree) created
+-- `TO public` SELECT **and INSERT/UPDATE** policies on storage.objects for
+-- both buckets, gated only on bucket_id. The anon key ships in every client
+-- bundle, so any caller could not only READ supplier invoices / proof-of-
+-- payment photos (vendor bank details) but UPLOAD arbitrary objects and —
+-- worst — OVERWRITE existing invoice evidence. This drops the write policies.
+--
+-- Why this is safe with NO app change and no broken-image window:
+--   • Uploads go through the server (apps/backoffice /api/inventory/upload,
+--     behind requireAuth) using the SERVICE_ROLE key, which bypasses RLS
+--     entirely — dropping the public INSERT/UPDATE policies does not touch it.
+--   • The public SELECT policies are intentionally KEPT: the app displays
+--     invoices/product images via public object URLs, so revoking read would
+--     404 the current UI. Locking read down properly requires switching those
+--     read sites to signed URLs first (mirror 063_hr_photos_private.sql +
+--     lib/hr/photos.ts). Tracked as a follow-up — see the C4 note in
+--     docs/codebase-review-2026-07-01.md.
+--
+-- IF EXISTS guards keep this idempotent and safe to re-run.
+
+DROP POLICY IF EXISTS "invoices_public_insert" ON storage.objects;
+DROP POLICY IF EXISTS "invoices_public_update" ON storage.objects;
+DROP POLICY IF EXISTS "product_images_public_insert" ON storage.objects;
+DROP POLICY IF EXISTS "product_images_public_update" ON storage.objects;


### PR DESCRIPTION
## Summary

Fixes the exploitable-without-credentials findings from the codebase review (`docs/codebase-review-2026-07-01.md`, PR #691). Split out of the review PR so the doc can merge independently.

Ordered by how they roll out — the GET guards and the storage migration are safe to deploy immediately; the C1/C2 token work is backward-compatible and gated behind enforcement flags so it does not 401 field clients still on the pre-token build.

## Changes

### H4 — auth guards on leaking GET endpoints (`0062bff`) — deploy-safe now
Callers already send the `celsius-session` cookie (web) / Bearer (native); the server just wasn't checking. Same-deploy, no client change.
- Backoffice: `inventory/pay-and-claim`, `settings/approval-rules`, `loyalty/promotions`, `ops/audit-templates` GETs — using each file's existing auth helper.
- Staff: `dashboard`, `products/options`, `settings/stock-count` GETs via `getSession`.
- **`/api/outlets` deliberately left public** — the login page's store picker calls it pre-authentication; guarding it would break login. Follow-up: trim its response to id + name only.

### C4 — revoke anon write to `invoices` / `product-images` buckets (`b0222b3`) — deploy-safe now
`supabase/migrations/066_invoices_bucket_lock_writes.sql` drops the `TO public` INSERT/UPDATE policies that let anyone upload or **overwrite invoice evidence** with the client anon key. Uploads run server-side under the service-role key (RLS-exempt), so nothing legitimate breaks. Public SELECT is kept intentionally (the UI reads via public object URLs); locking read down needs a signed-URL migration mirroring `063_hr_photos_private` — tracked as a follow-up.

### C1 / C2 — authenticate POS-loyalty and order/staff routes (`9f4957a`, `2f4aa18`) — needs staged rollout
Both surfaces had no server-verifiable credential (the POS till sends only Origin/Referer; the order app's "staff session" was localStorage-only). Rather than 401 every live register/KDS, the server mints + accepts tokens now but only **rejects** once an enforcement flag is set.
- **C1 (POS loyalty):** PIN login also returns its JWT in the body (the native till can't read the httpOnly cookie); pos-native stores it and sends `Authorization: Bearer` on every POS API call; all six `/api/pos/loyalty/*` routes verify it, gated by `POS_AUTH_ENFORCE`.
- **C2 (order status + staff feeds):** new signed `order-staff` token (`lib/staff-token.ts`); status transitions and `/api/staff/*` feeds require it, gated by `STAFF_AUTH_ENFORCE`. Closes the free-drink hole (create order → PATCH `preparing`). The customer-driven `ready→completed` "swipe to collect" stays open (nuisance-only; real fix is binding it to the customer session once `STRICT_CUSTOMER_AUTH` ships).

## Rollout
1. Merge + deploy (server accepts tokens; clients unaffected).
2. Push the pos-native / KDS builds so field clients send tokens.
3. Watch the `[pos-auth]` / `[staff-auth]` grace-period warnings drop to zero.
4. Set `POS_AUTH_ENFORCE=1` and `STAFF_AUTH_ENFORCE=1` to start rejecting.

## Test plan
- CI (typecheck all web + native, lint, vitest) must pass.
- Manual: with enforcement off, verify existing clients still work and warnings log; with a token, verify guarded routes accept; without, verify they reject once the flag is on.
- C4: confirm invoice upload (server) still works and anon INSERT/UPDATE to the bucket is denied.

## Not included (separate follow-ups)
C3 (card-terminal stub), C5 (Bukku GL re-posting), C6 (payroll race), and the C4 read-side signed-URL migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AVhg8aDKAV38geJYxQ9hwW

---
_Generated by [Claude Code](https://claude.ai/code/session_01AVhg8aDKAV38geJYxQ9hwW)_