### PR TITLE
fix(pickup-native): stop unhandled rejection when zustand persist write fails

### DIFF
--- a/apps/pickup-native/lib/store.ts
+++ b/apps/pickup-native/lib/store.ts
@@ -175,6 +175,31 @@ type AppState = {
   signOutReset: () => void;
 };
 
+/** AsyncStorage wrapper whose writes never reject. zustand's persist
+ *  middleware fires setItem on every set() without awaiting or
+ *  catching it, so a failed write (e.g. NSPOSIXErrorDomain 28 "No
+ *  space left on device" — Sentry CELSIUS-PICKUP-NATIVE-5) escapes as
+ *  an unhandled promise rejection. Persistence is best-effort here:
+ *  on a full disk the in-memory store still works for the session,
+ *  the state just won't survive a relaunch. */
+const safeAsyncStorage = {
+  getItem: (name: string) => AsyncStorage.getItem(name),
+  setItem: async (name: string, value: string) => {
+    try {
+      await AsyncStorage.setItem(name, value);
+    } catch (err) {
+      console.warn("persist setItem failed:", err);
+    }
+  },
+  removeItem: async (name: string) => {
+    try {
+      await AsyncStorage.removeItem(name);
+    } catch (err) {
+      console.warn("persist removeItem failed:", err);
+    }
+  },
+};
+
 export const useApp = create<AppState>()(
   persist(
     (set) => ({
@@ -308,7 +333,7 @@ export const useApp = create<AppState>()(
         }
         return persisted as AppState;
       },
-      storage: createJSONStorage(() => AsyncStorage),
+      storage: createJSONStorage(() => safeAsyncStorage),
       partialize: (s) => ({
         outletId: s.outletId,
         outletName: s.outletName,


### PR DESCRIPTION
## Summary

Fixes [CELSIUS-PICKUP-NATIVE-5](https://celsius-coffee-sdn-bhd.sentry.io/issues/CELSIUS-PICKUP-NATIVE-5): `Error: Failed to write value. NSCocoaErrorDomain Code=640 … NSPOSIXErrorDomain Code=28 "No space left on device"`.

## Diagnosis

- The failing file in the Sentry event, `RCTAsyncLocalStorage_V1/7f252b770fd9d0a4613698a21a09c334`, is AsyncStorage's file-backed slot for large values — the filename is `md5(key)`, and `md5("celsius-pickup") = 7f252b770fd9d0a4613698a21a09c334`. That's the zustand persist store in `apps/pickup-native/lib/store.ts`.
- zustand's persist middleware calls `storage.setItem()` on every `set()` and the returned promise is discarded by all callers, so when the customer's iPhone had no free disk space the rejection escaped as an unhandled promise rejection (`mechanism: onunhandledrejection`) and hit Sentry on every state change.
- Every other AsyncStorage write in the app (posters/splash/settings caches, push-token fingerprint, last payment method) already had a `.catch()`; this was the only unguarded write path.

## Change

Wrap the persist storage in a `safeAsyncStorage` whose `setItem`/`removeItem` catch and log failures instead of rejecting. Persistence is best-effort: on a full disk the in-memory store keeps working for the session; state just won't survive a relaunch until the customer frees space.

## Testing

- `npx tsc --noEmit` in `apps/pickup-native` passes.
- Verified zustand 5.0.12's persist middleware fire-and-forgets `setItem` (rejection has no handler upstream), so making the wrapped write never reject removes the unhandled rejection at the source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Dzhy8Kgv9YnYSM7gMKEJyH

---
_Generated by [Claude Code](https://claude.ai/code/session_01Dzhy8Kgv9YnYSM7gMKEJyH)_