### PR TITLE
feat(finance): salary-control accrual — the credit side of the payroll controls

### DIFF
--- a/apps/backoffice/src/app/api/cron/bukku-feed-sync/route.ts
+++ b/apps/backoffice/src/app/api/cron/bukku-feed-sync/route.ts
@@ -18,6 +18,7 @@ import { applyApMatches } from "@/lib/finance/ap-match";
 import { applyVerifiedReview } from "@/lib/finance/agents/ap-verifier";
 import { createWagePaymentSlips } from "@/lib/finance/payment-slips";
 import { postBankLinesToGl } from "@/lib/finance/gl-posting";
+import { accrueSalaryControls } from "@/lib/finance/salary-accrual";
 import { checkCronAuth } from "@celsius/shared";
 
 export const dynamic = "force-dynamic";
@@ -51,7 +52,14 @@ export async function GET(req: NextRequest) {
   // 4. post the classified bank lines into the GL (bounded; drains over runs)
   await step("glPost", async () => {
     const r = await postBankLinesToGl({ commit: true, limit: GL_LINES_PER_RUN });
-    return { journals: r.journals, postedLines: r.postedLines, suspenseLines: r.suspenseLines, errors: r.errors.length };
+    return { journals: r.journals, reusedJournals: r.reusedJournals, gcJournals: r.gcJournals, postedLines: r.postedLines, suspenseLines: r.suspenseLines, errors: r.errors.length };
+  });
+  // 5. clear the payroll control accounts — cash-basis salary expense for what
+  //    the bank paid (self-reconciling; a no-op once real HR payroll accruals
+  //    credit the controls)
+  await step("salaryAccrual", async () => {
+    const r = await accrueSalaryControls({ commit: true });
+    return { journals: r.journals, totalAccrued: r.totalAccrued, errors: r.errors.length };
   });
 
   return NextResponse.json(out);

--- a/apps/backoffice/src/app/api/finance/salary-accrual/route.ts
+++ b/apps/backoffice/src/app/api/finance/salary-accrual/route.ts
@@ -1,0 +1,35 @@
+// GET /api/finance/salary-accrual — dry-run preview of the salary-control
+// accrual (per company × month deltas it would clear). POST commits.
+
+import { NextRequest, NextResponse } from "next/server";
+import { requireAuth } from "@/lib/auth";
+import { accrueSalaryControls } from "@/lib/finance/salary-accrual";
+
+export const dynamic = "force-dynamic";
+export const maxDuration = 120;
+
+export async function GET(req: NextRequest) {
+  const auth = await requireAuth(req);
+  if (auth.error) return auth.error;
+  if (!["OWNER", "ADMIN"].includes(auth.user.role)) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+  try {
+    return NextResponse.json(await accrueSalaryControls({ commit: false }));
+  } catch (err) {
+    return NextResponse.json({ error: err instanceof Error ? err.message : String(err) }, { status: 500 });
+  }
+}
+
+export async function POST(req: NextRequest) {
+  const auth = await requireAuth(req);
+  if (auth.error) return auth.error;
+  if (!["OWNER", "ADMIN"].includes(auth.user.role)) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+  try {
+    return NextResponse.json(await accrueSalaryControls({ commit: true }));
+  } catch (err) {
+    return NextResponse.json({ error: err instanceof Error ? err.message : String(err) }, { status: 500 });
+  }
+}

--- a/apps/backoffice/src/lib/finance/salary-accrual.ts
+++ b/apps/backoffice/src/lib/finance/salary-accrual.ts
@@ -1,0 +1,144 @@
+// Salary-control accrual — the credit side of the payroll control accounts.
+//
+// The bank→GL bridge books every payroll cash movement as a DEBIT on a control
+// account (3008 net salary, 3004 EPF, 3005 SOCSO, 3006 EIS, 3007 PCB), the way
+// Bukku does — the payment settles a liability the payroll run accrued. But the
+// HR payroll module isn't producing real accruals yet, so the controls carried
+// a growing debit balance (RM1.26M by Jul 2026) and the Balance Sheet misread.
+//
+// Until HR accruals are live, expense is recognised CASH-BASIS in the month
+// paid: per company × month, whatever DEBIT excess sits on a control account is
+// cleared against its expense account —
+//
+//   3008 net salary  →  6500-02 Full timer staff
+//   3007 PCB         →  6500-02 (employee tax withheld = part of gross salary)
+//   3004 EPF         →  6501-01 EPF — Employer's Contribution
+//   3005 SOCSO       →  6501-02 SOCSO — Employer's Contribution
+//   3006 EIS         →  6501-03 EIS — Employer's Contribution
+//
+// (The statutory payments mix employer + employee portions in one transfer, so
+// the salary/statutory split is approximate — total staff cost is exact.)
+//
+// SELF-RECONCILING: each run recomputes delta = debits − credits per control
+// per month, and posts only the positive remainder. Re-runs post nothing; new
+// bank payments create a fresh delta that the next run tops up; and once the HR
+// payroll agent posts real accruals (credits), the delta collapses to zero and
+// this becomes a no-op. Part-timer wages are untouched — they post straight to
+// expense 6500-03 (cash basis by design).
+
+import { getFinanceClient } from "./supabase";
+import { postJournal } from "./ledger";
+import type { JournalLineInput } from "./types";
+
+const round2 = (n: number) => Math.round(n * 100) / 100;
+
+const CONTROL_TO_EXPENSE: Record<string, string> = {
+  "3008": "6500-02",
+  "3007": "6500-02",
+  "3004": "6501-01",
+  "3005": "6501-02",
+  "3006": "6501-03",
+};
+const CONTROL_ACCOUNTS = Object.keys(CONTROL_TO_EXPENSE);
+
+export type SalaryAccrualResult = {
+  committed: boolean;
+  journals: number;
+  totalAccrued: number;
+  months: { company: string; month: string; amount: number; byControl: Record<string, number> }[];
+  errors: { company: string; month: string; error: string }[];
+};
+
+function monthEndYmd(month: string): string {
+  const [y, m] = month.split("-").map(Number);
+  return new Date(Date.UTC(y, m, 0)).toISOString().slice(0, 10);
+}
+
+// Accrue the outstanding control-account deltas. Dry-run by default.
+export async function accrueSalaryControls(opts: { commit?: boolean } = {}): Promise<SalaryAccrualResult> {
+  const commit = opts.commit ?? false;
+  const client = getFinanceClient();
+
+  // All posted movements on the control accounts, keyed company|month|account.
+  type Row = { account_code: string; debit: number; credit: number; fin_transactions: { company_id: string; txn_date: string } };
+  const agg = new Map<string, { d: number; c: number }>();
+  const PAGE = 1000;
+  for (let from = 0; ; from += PAGE) {
+    const { data, error } = await client
+      .from("fin_journal_lines")
+      .select("account_code, debit, credit, fin_transactions!inner(company_id, txn_date, status)")
+      .in("account_code", CONTROL_ACCOUNTS)
+      .eq("fin_transactions.status", "posted")
+      .range(from, from + PAGE - 1);
+    if (error) throw new Error(error.message);
+    for (const r of (data ?? []) as unknown as Row[]) {
+      const month = r.fin_transactions.txn_date.slice(0, 7);
+      const key = `${r.fin_transactions.company_id}|${month}|${r.account_code}`;
+      const cur = agg.get(key) ?? { d: 0, c: 0 };
+      cur.d = round2(cur.d + Number(r.debit));
+      cur.c = round2(cur.c + Number(r.credit));
+      agg.set(key, cur);
+    }
+    if (!data || data.length < PAGE) break;
+  }
+
+  // Positive deltas per company|month.
+  const today = new Date(Date.now() + 8 * 3600_000).toISOString().slice(0, 10); // MYT
+  const currentMonth = today.slice(0, 7);
+  const byMonth = new Map<string, Record<string, number>>();
+  for (const [key, v] of agg) {
+    const delta = round2(v.d - v.c);
+    if (delta <= 0.005) continue;
+    const [company, month, account] = key.split("|");
+    if (month > currentMonth) continue;
+    const mk = `${company}|${month}`;
+    const rec = byMonth.get(mk) ?? {};
+    rec[account] = delta;
+    byMonth.set(mk, rec);
+  }
+
+  const months: SalaryAccrualResult["months"] = [];
+  const errors: SalaryAccrualResult["errors"] = [];
+  let journals = 0;
+  let totalAccrued = 0;
+
+  for (const [mk, byControl] of [...byMonth.entries()].sort()) {
+    const [company, month] = mk.split("|");
+    // Dr per expense account (3008+3007 merge into 6500-02), Cr per control.
+    const drByExpense = new Map<string, number>();
+    const lines: JournalLineInput[] = [];
+    let total = 0;
+    for (const [control, delta] of Object.entries(byControl)) {
+      const exp = CONTROL_TO_EXPENSE[control];
+      drByExpense.set(exp, round2((drByExpense.get(exp) ?? 0) + delta));
+      lines.push({ accountCode: control, credit: delta });
+      total = round2(total + delta);
+    }
+    for (const [exp, amt] of drByExpense) lines.unshift({ accountCode: exp, debit: amt });
+
+    months.push({ company, month, amount: total, byControl });
+    journals++;
+    totalAccrued = round2(totalAccrued + total);
+    if (!commit) continue;
+
+    try {
+      await postJournal({
+        companyId: company,
+        txnDate: month === currentMonth ? today : monthEndYmd(month),
+        description: `Salary accrual (cash-basis catch-up) — staff cost paid in ${month} recognised as expense, clearing the payroll control accounts`,
+        txnType: "journal",
+        agent: "payroll",
+        agentVersion: "salary-accrual-v1",
+        confidence: 1,
+        lines,
+      });
+    } catch (err) {
+      errors.push({ company, month, error: err instanceof Error ? err.message : String(err) });
+      journals--;
+      totalAccrued = round2(totalAccrued - total);
+      months.pop();
+    }
+  }
+
+  return { committed: commit, journals, totalAccrued, months, errors };
+}

--- a/apps/backoffice/src/lib/finance/types.ts
+++ b/apps/backoffice/src/lib/finance/types.ts
@@ -21,6 +21,7 @@ export type AgentName =
   | "ap"
   | "ar"
   | "bank"
+  | "payroll"
   | "close"
   | "compliance"
   | "anomaly"


### PR DESCRIPTION
## Problem

The bank→GL bridge books payroll cash as **debits on control accounts** (3008 net salary, 3004 EPF, 3005 SOCSO, 3006 EIS, 3007 PCB), Bukku-style: the payment settles a liability the payroll run accrued. But the HR payroll module isn't producing real accruals yet (5 runs total, null periods), so the credit side never posts — the controls carry **RM1.26M of debits** and the Balance Sheet misreads by that much. This was gap #3 in the finance-module audit.

## Fix: self-reconciling cash-basis accrual

Per company × month, whatever **debit excess** sits on a control account clears against its expense account:

| Control | Expense |
|---|---|
| 3008 net salary + 3007 PCB | 6500-02 Full timer staff |
| 3004 EPF | 6501-01 EPF — Employer's Contribution |
| 3005 SOCSO | 6501-02 SOCSO — Employer's Contribution |
| 3006 EIS | 6501-03 EIS — Employer's Contribution |

(The statutory transfers mix employer + employee portions, so the salary/statutory split is approximate — **total staff cost is exact**.)

**Self-reconciling:** each run recomputes `delta = debits − credits` and posts only the positive remainder. Re-runs post nothing; new bank payments create a fresh delta the next run tops up; and once the HR payroll agent posts real accruals (credits), the delta collapses to zero and this becomes a no-op — no migration needed when HR goes live. Part-timer wages are untouched (already direct expense 6500-03 by design).

## Wiring
- `lib/finance/salary-accrual.ts` — `accrueSalaryControls` (dry-run by default)
- `GET/POST /api/finance/salary-accrual` — preview / commit (OWNER/ADMIN)
- Cron finance loop step 5 (after gl-post); the glPost step now also reports reused/GC'd journal counts from #694
- `AgentName` gains `payroll`

The first committed run clears the whole historical backlog month by month (P&L for those months then shows the real staff cost instead of it hiding on the BS).
