### PR TITLE
Remove the temporary template-submission key

### DIFF
--- a/apps/backoffice/src/app/api/ops/workspace/templates/route.ts
+++ b/apps/backoffice/src/app/api/ops/workspace/templates/route.ts
@@ -88,20 +88,12 @@ const TEMPLATE_DEFS = [
   },
 ] as const;
 
-// TEMPORARY access key (same pattern as the original DIAG_KEY, fresh value) so
-// the procurement_new_order template submission can be triggered server-side
-// without a browser session. Scope: list templates + submit TEMPLATE_DEFS (both
-// idempotent; no secrets returned). REMOVE once procurement_new_order is
-// submitted + verified — tracked as an immediate follow-up.
-const DIAG_KEY = "celsius-tpl-52af3e8b59295e477849b38c";
-
 // GET — list the WABA's WhatsApp message templates with their approval status,
 // so an owner can see what's approved before wiring a template into ops-pulse.
 export async function GET(req: NextRequest) {
-  const key = req.nextUrl.searchParams.get("key");
   const session = await getSession();
   const owner = !!session && (session.role === "OWNER" || session.role === "ADMIN");
-  if (!owner && key !== DIAG_KEY) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  if (!owner) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
 
   const waba = process.env.WHATSAPP_WABA_ID;
   const token = process.env.WHATSAPP_ACCESS_TOKEN;


### PR DESCRIPTION
`procurement_new_order` is now submitted to Meta — verified live on the WABA with **status PENDING** — so the temporary diagnostic key added in #698 has served its purpose. The templates route is back to OWNER/ADMIN session auth only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01SrjfLzrbEAQdNUBgawNqE5)_