### PR TITLE
New PO composer: suggested order quantities per outlet (ASSIST)

### DIFF
--- a/apps/backoffice/src/app/(admin)/inventory/supplier-chats/page.tsx
+++ b/apps/backoffice/src/app/(admin)/inventory/supplier-chats/page.tsx
@@ -58,7 +58,7 @@ type Counts = {
   assist: number;
   off: number;
 };
-type PoProduct = { supplierProductId: string; productId: string; name: string; packageLabel: string; productPackageId: string | null; price: number; moq: number };
+type PoProduct = { supplierProductId: string; productId: string; name: string; packageLabel: string; productPackageId: string | null; price: number; moq: number; suggestedQty?: number };
 type NeedItem = { productId: string; productPackageId: string | null; name: string; qty: number; unitPrice: number; packageLabel: string; onHand: number; reorderPoint: number };
 type NeedGroup = { supplierId: string; supplierName: string; outletId: string; outletName: string; items: NeedItem[]; total: number; itemCount: number };
 
@@ -278,18 +278,36 @@ export default function SupplierChatsPage() {
     setPoError(null);
     setPoQty({});
     try {
-      const [oRaw, pRaw] = await Promise.all([
-        fetch("/api/settings/outlets?status=ACTIVE").then((r) => r.json()),
-        fetch(`/api/inventory/suppliers/${detail.supplierId}/products`).then((r) => r.json()),
-      ]);
+      const oRaw = await fetch("/api/settings/outlets?status=ACTIVE").then((r) => r.json());
       const oList: { id: string; name: string }[] = Array.isArray(oRaw) ? oRaw : (oRaw.outlets ?? []);
       setOutlets(oList.map((o) => ({ id: o.id, name: o.name })));
+      // Products (with per-outlet suggested quantities) load via the effect below
+      // once the outlet is known — and reload when the outlet changes.
       setPoOutlet((prev) => prev || oList[0]?.id || "");
-      setPoProducts(Array.isArray(pRaw) ? pRaw : []);
     } catch {
       setPoError("Couldn't load outlets / products.");
     }
   }
+
+  // Load the supplier's price-list products for the selected outlet. Each row
+  // carries suggestedQty (below-par shortfall through boundedReorderQty, in
+  // package units) so the composer can assist with amounts, not just items.
+  useEffect(() => {
+    if (!poOpen || !detail?.supplierId || !poOutlet) return;
+    let cancelled = false;
+    fetch(`/api/inventory/suppliers/${detail.supplierId}/products?outletId=${encodeURIComponent(poOutlet)}`)
+      .then((r) => r.json())
+      .then((pRaw) => {
+        if (!cancelled) setPoProducts(Array.isArray(pRaw) ? pRaw : []);
+      })
+      .catch(() => {
+        if (!cancelled) setPoError("Couldn't load products.");
+      });
+    return () => {
+      cancelled = true;
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [poOpen, detail?.supplierId, poOutlet]);
 
   async function createPO(send: boolean) {
     if (!detail?.supplierId || !poOutlet) {
@@ -1210,27 +1228,61 @@ export default function SupplierChatsPage() {
                         first.
                       </p>
                     ) : (
-                      poProducts.map((p) => (
-                        <div key={p.productId} className="flex items-center gap-2 border-b border-border py-1.5">
-                          <div className="min-w-0 flex-1">
-                            <div className="truncate text-[12px]">{p.name}</div>
-                            <div className="text-[10.5px] text-muted-foreground">
-                              {formatRM(p.price)} / {p.packageLabel}
-                              {p.moq ? ` · MOQ ${p.moq}` : ""}
-                            </div>
+                      <>
+                        {poProducts.some((p) => (p.suggestedQty ?? 0) > 0) && (
+                          <div className="flex items-center justify-between border-b border-border py-1.5">
+                            <span className="text-[10.5px] text-muted-foreground">
+                              {poProducts.filter((p) => (p.suggestedQty ?? 0) > 0).length} below par at this outlet
+                            </span>
+                            <button
+                              onClick={() =>
+                                setPoQty((q) => {
+                                  const next = { ...q };
+                                  for (const p of poProducts) {
+                                    if ((p.suggestedQty ?? 0) > 0 && !next[p.productId]) next[p.productId] = p.suggestedQty!;
+                                  }
+                                  return next;
+                                })
+                              }
+                              className="rounded-md border border-amber-300 bg-amber-50 px-2 py-0.5 text-[10.5px] font-medium text-amber-800 hover:bg-amber-100 dark:border-amber-700 dark:bg-amber-950 dark:text-amber-200"
+                            >
+                              Fill suggested
+                            </button>
                           </div>
-                          <input
-                            type="number"
-                            min={0}
-                            value={poQty[p.productId] ?? ""}
-                            onChange={(e) =>
-                              setPoQty((q) => ({ ...q, [p.productId]: Math.max(0, Number(e.target.value) || 0) }))
-                            }
-                            placeholder="0"
-                            className="h-7 w-14 rounded-md border border-border bg-background px-1.5 text-right text-[12px] text-foreground"
-                          />
-                        </div>
-                      ))
+                        )}
+                        {poProducts.map((p) => (
+                          <div key={p.productId} className="flex items-center gap-2 border-b border-border py-1.5">
+                            <div className="min-w-0 flex-1">
+                              <div className="truncate text-[12px]">{p.name}</div>
+                              <div className="flex items-center gap-1.5 text-[10.5px] text-muted-foreground">
+                                <span>
+                                  {formatRM(p.price)} / {p.packageLabel}
+                                  {p.moq ? ` · MOQ ${p.moq}` : ""}
+                                </span>
+                                {(p.suggestedQty ?? 0) > 0 && (
+                                  <button
+                                    onClick={() => setPoQty((q) => ({ ...q, [p.productId]: p.suggestedQty! }))}
+                                    title="Below par at this outlet — tap to use the suggested order quantity (par shortfall, capped by MOQ / max level / shelf life)"
+                                    className="shrink-0 rounded bg-amber-100 px-1.5 py-px font-medium text-amber-800 hover:bg-amber-200 dark:bg-amber-900 dark:text-amber-200"
+                                  >
+                                    suggest {p.suggestedQty}
+                                  </button>
+                                )}
+                              </div>
+                            </div>
+                            <input
+                              type="number"
+                              min={0}
+                              value={poQty[p.productId] ?? ""}
+                              onChange={(e) =>
+                                setPoQty((q) => ({ ...q, [p.productId]: Math.max(0, Number(e.target.value) || 0) }))
+                              }
+                              placeholder="0"
+                              className="h-7 w-14 rounded-md border border-border bg-background px-1.5 text-right text-[12px] text-foreground"
+                            />
+                          </div>
+                        ))}
+                      </>
                     )}
                   </div>
                   <div className="sticky bottom-0 -mx-3 border-t border-border bg-background px-3 pb-1 pt-2">

--- a/apps/backoffice/src/app/api/inventory/suppliers/[id]/products/route.ts
+++ b/apps/backoffice/src/app/api/inventory/suppliers/[id]/products/route.ts
@@ -1,16 +1,36 @@
 import { NextResponse, NextRequest } from "next/server";
+import type { OrderStatus } from "@celsius/db";
 import { prisma } from "@/lib/prisma";
 import { requireAuth } from "@/lib/auth";
 import { recordPriceChange } from "@/lib/inventory/price-history";
+import { boundedReorderQty } from "@/lib/inventory/order-validation";
+
+const OPEN_ORDER_STATUSES: OrderStatus[] = [
+  "DRAFT",
+  "PENDING_APPROVAL",
+  "APPROVED",
+  "SENT",
+  "CONFIRMED",
+  "AWAITING_DELIVERY",
+  "PARTIALLY_RECEIVED",
+];
 
 /**
- * GET /api/inventory/suppliers/[id]/products
+ * GET /api/inventory/suppliers/[id]/products?outletId=…
  * The supplier's active price-list products — for building a PO from the workspace.
+ *
+ * With `outletId`, each row also carries `suggestedQty` (package units): the
+ * below-par shortfall for that outlet run through boundedReorderQty (MOQ floor,
+ * max-level + shelf-life ceilings — the same engine as the exec/reorder
+ * suggestions), 0 when the item is fine or already covered by an open PO. The
+ * composer shows it as a tap-to-apply assist so the buyer isn't guessing amounts.
  */
 export async function GET(req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   const auth = await requireAuth(req);
   if (auth.error) return auth.error;
   const { id: supplierId } = await params;
+  const outletId = req.nextUrl.searchParams.get("outletId");
+
   const rows = await prisma.supplierProduct.findMany({
     where: { supplierId, isActive: true, price: { gt: 0 }, product: { isActive: true } },
     select: {
@@ -18,11 +38,59 @@ export async function GET(req: NextRequest, { params }: { params: Promise<{ id: 
       price: true,
       moq: true,
       productPackageId: true,
-      product: { select: { id: true, name: true } },
-      productPackage: { select: { packageLabel: true } },
+      product: { select: { id: true, name: true, shelfLifeDays: true } },
+      productPackage: { select: { packageLabel: true, conversionFactor: true } },
     },
     orderBy: { product: { name: "asc" } },
   });
+
+  // Per-outlet reorder suggestion per product (base need → this supplier's package units).
+  const suggested = new Map<string, number>();
+  if (outletId && rows.length) {
+    const productIds = rows.map((r) => r.product.id);
+    const [pars, stocks, openLines] = await Promise.all([
+      prisma.parLevel.findMany({
+        where: { outletId, productId: { in: productIds } },
+        select: { productId: true, parLevel: true, reorderPoint: true, maxLevel: true, avgDailyUsage: true },
+      }),
+      prisma.stockBalance.findMany({
+        where: { outletId, productId: { in: productIds } },
+        select: { productId: true, quantity: true },
+      }),
+      prisma.orderItem.findMany({
+        where: {
+          productId: { in: productIds },
+          order: { outletId, orderType: "PURCHASE_ORDER", status: { in: OPEN_ORDER_STATUSES } },
+        },
+        select: { productId: true },
+      }),
+    ]);
+    const stockMap = new Map<string, number>();
+    for (const s of stocks) stockMap.set(s.productId, (stockMap.get(s.productId) ?? 0) + Number(s.quantity));
+    const covered = new Set(openLines.map((l) => l.productId));
+    const parMap = new Map(pars.map((p) => [p.productId, p]));
+
+    for (const r of rows) {
+      const par = parMap.get(r.product.id);
+      if (!par || covered.has(r.product.id)) continue;
+      const stock = stockMap.get(r.product.id) ?? 0;
+      if (stock > Number(par.reorderPoint)) continue;
+      const needed = Math.max(Number(par.parLevel) - stock, 0);
+      if (needed <= 0) continue;
+      const convRaw = r.productPackage ? Number(r.productPackage.conversionFactor) : 1;
+      const avgDaily = par.avgDailyUsage != null ? Number(par.avgDailyUsage) : 0;
+      const { orderQty } = boundedReorderQty({
+        neededBase: needed,
+        conversionFactor: convRaw > 0 ? convRaw : 1,
+        moq: Number(r.moq) || 0,
+        headroomBase: par.maxLevel != null ? Math.max(Number(par.maxLevel) - stock, 0) : null,
+        shelfUsableBase:
+          r.product.shelfLifeDays && avgDaily > 0 ? r.product.shelfLifeDays * avgDaily : null,
+      });
+      if (orderQty > 0) suggested.set(r.product.id, orderQty);
+    }
+  }
+
   return NextResponse.json(
     rows.map((r) => ({
       supplierProductId: r.id,
@@ -32,6 +100,7 @@ export async function GET(req: NextRequest, { params }: { params: Promise<{ id: 
       productPackageId: r.productPackageId,
       price: Number(r.price),
       moq: Number(r.moq) || 0,
+      suggestedQty: suggested.get(r.product.id) ?? 0,
     })),
   );
 }


### PR DESCRIPTION
The **+ New PO** panel listed the supplier's price-list products with blank quantity fields — the buyer had to guess amounts the system already knows.

- `GET /api/inventory/suppliers/[id]/products` now accepts `?outletId` and returns a `suggestedQty` per row: the outlet's below-par shortfall run through `boundedReorderQty` (MOQ floor, max-level + shelf-life ceilings — the same engine as the exec/reorder suggestions), 0 when the item is fine or already covered by an open PO. Suggestions use **this supplier's** package + MOQ (not the cheapest supplier's), since that's who the PO is for.
- Composer: products reload when the outlet changes; below-par rows show an amber **"suggest N"** chip (tap to apply), plus a **"Fill suggested"** bar that populates every empty below-par line at once. Manual entries are never overwritten.

Pairs with the ASSIST dial: the system drafts the amounts, the human reviews and sends.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01SrjfLzrbEAQdNUBgawNqE5)_