### PR TITLE
fix(hr): staff can see payslips again + weekly (part-timer) payslips

### DIFF
--- a/apps/staff/src/app/(ops)/hr/payslips/page.tsx
+++ b/apps/staff/src/app/(ops)/hr/payslips/page.tsx
@@ -15,6 +15,8 @@ type ComputationDetails = {
   source?: string;
   gross_additions?: number;
   briohr_internal_id?: string;
+  basis?: string;
+  hourly_rate?: number;
 };
 
 type Payslip = {
@@ -37,13 +39,23 @@ type Payslip = {
   net_pay: number;
   computation_details: ComputationDetails | null;
   hr_payroll_runs: {
-    period_month: number;
-    period_year: number;
+    cycle_type: string | null;
+    period_month: number | null;
+    period_year: number | null;
+    period_start: string | null;
+    period_end: string | null;
     confirmed_at: string;
   };
 };
 
 const MONTHS = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"];
+
+// "2026-06-30" → "30 Jun 2026" (no Date parsing — avoids TZ drift on date-only strings)
+function fmtDate(iso: string | null | undefined): string {
+  if (!iso) return "";
+  const [y, m, d] = iso.split("-").map(Number);
+  return `${d} ${MONTHS[m - 1]} ${y}`;
+}
 
 export default function PayslipsPage() {
   const { data } = useFetch<{ payslips: Payslip[] }>("/api/hr/payslips");
@@ -74,7 +86,12 @@ export default function PayslipsPage() {
       ) : (
         <div className="space-y-3">
           {payslips.map((slip) => {
-            const period = `${MONTHS[slip.hr_payroll_runs.period_month - 1]} ${slip.hr_payroll_runs.period_year}`;
+            const run = slip.hr_payroll_runs;
+            const isWeekly = run.cycle_type === "weekly" || run.period_month == null;
+            const period = isWeekly
+              ? `Week of ${fmtDate(run.period_start)}`
+              : `${MONTHS[(run.period_month as number) - 1]} ${run.period_year}`;
+            const hourlyRate = Number(slip.computation_details?.hourly_rate || 0);
             const isOpen = expanded === slip.id;
             const totalOT =
               Number(slip.ot_1x_amount || 0) +
@@ -108,7 +125,12 @@ export default function PayslipsPage() {
                   <div className="border-t px-4 pb-4 pt-3 text-sm">
                     {/* Earnings */}
                     <p className="mb-2 font-semibold text-green-700">Earnings</p>
-                    <Row label="Basic Salary" value={fmt(slip.basic_salary)} />
+                    <Row
+                      label={isWeekly
+                        ? `Wages (${slip.total_regular_hours}h${hourlyRate > 0 ? ` × RM${hourlyRate}/h` : ""})`
+                        : "Basic Salary"}
+                      value={fmt(slip.basic_salary)}
+                    />
                     {totalOT > 0 && (
                       <>
                         {Number(slip.ot_1x_amount) > 0 && <Row label="OT 1x" value={fmt(slip.ot_1x_amount)} />}
@@ -147,7 +169,8 @@ export default function PayslipsPage() {
 
                     {/* Hours */}
                     <p className="mt-4 text-xs text-gray-400">
-                      {slip.total_regular_hours}h regular{Number(slip.total_ot_hours) > 0 ? ` + ${slip.total_ot_hours}h OT` : ""}
+                      {slip.total_regular_hours}h {isWeekly ? "clocked" : "regular"}{Number(slip.total_ot_hours) > 0 ? ` + ${slip.total_ot_hours}h OT` : ""}
+                      {isWeekly && " · from staff app clock-in/out"}
                       {isImported && " · imported from BrioHR"}
                     </p>
                   </div>

--- a/apps/staff/src/app/(ops)/hr/payslips/page.tsx
+++ b/apps/staff/src/app/(ops)/hr/payslips/page.tsx
@@ -4,6 +4,7 @@ import { useFetch } from "@/lib/use-fetch";
 import { useState } from "react";
 import Link from "next/link";
 import { Receipt, ChevronDown, ChevronUp, ArrowLeft } from "lucide-react";
+import { PAYROLL_UI_ENABLED } from "@/lib/hr/constants";
 
 type AllowanceItem = { amount: number; base?: number; score?: number };
 type OtherDeductions = {
@@ -58,11 +59,34 @@ function fmtDate(iso: string | null | undefined): string {
 }
 
 export default function PayslipsPage() {
-  const { data } = useFetch<{ payslips: Payslip[] }>("/api/hr/payslips");
+  // Payroll hidden pre-launch: don't fetch (SWR skips null keys) and show a notice.
+  const { data } = useFetch<{ payslips: Payslip[] }>(PAYROLL_UI_ENABLED ? "/api/hr/payslips" : null);
   const [expanded, setExpanded] = useState<string | null>(null);
 
   const payslips = data?.payslips || [];
   const fmt = (n: number) => `RM ${Number(n || 0).toLocaleString("en-MY", { minimumFractionDigits: 2 })}`;
+
+  if (!PAYROLL_UI_ENABLED) {
+    return (
+      <div className="px-4 pt-6">
+        <div className="mb-6 flex items-center gap-3">
+          <Link
+            href="/hr"
+            aria-label="Back"
+            className="flex h-9 w-9 shrink-0 items-center justify-center rounded-full bg-gray-100 text-gray-600 active:scale-95 active:bg-gray-200"
+          >
+            <ArrowLeft className="h-5 w-5" />
+          </Link>
+          <h1 className="text-2xl font-bold">Payslips</h1>
+        </div>
+        <div className="flex flex-col items-center justify-center rounded-2xl border border-gray-200 bg-gray-50 py-16 text-center">
+          <Receipt className="mb-3 h-12 w-12 text-gray-300" />
+          <p className="font-semibold text-gray-500">Payslips coming soon</p>
+          <p className="text-sm text-gray-400">Your payslips will appear here once payroll goes live.</p>
+        </div>
+      </div>
+    );
+  }
 
   return (
     <div className="px-4 pt-6">

--- a/apps/staff/src/app/api/hr/payslips/route.ts
+++ b/apps/staff/src/app/api/hr/payslips/route.ts
@@ -1,26 +1,27 @@
 import { NextResponse } from "next/server";
 import { getSession } from "@/lib/auth";
-import { supabase } from "@/lib/supabase";
+// Service-role client: hr_* tables are RLS deny-all, so the anon client returns
+// nothing (payslips were invisible to ALL staff since the lockdown). We scope to
+// the caller's own user_id below, which is the security boundary here.
+import { supabaseAdmin } from "@/lib/supabase";
 
 export const dynamic = "force-dynamic";
 
-// GET: my payslips
+// GET: my payslips (monthly full-timer runs AND weekly part-timer runs).
 export async function GET() {
   const session = await getSession();
   if (!session) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
 
-  // Get confirmed payroll items for this user. Order by pay period (year then
-  // month) so the newest period is always on top — earlier code used
-  // `created_at` which is the row insert time. Re-confirming an old run could
-  // bump it ahead of newer payslips, confusing staff.
-  const { data: items, error } = await supabase
+  // Confirmed/paid payroll items for THIS user only. Order by confirmed_at so
+  // both cycles interleave correctly — weekly runs have null period_year/month,
+  // so month/year ordering would sink them below every monthly payslip.
+  const { data: items, error } = await supabaseAdmin
     .from("hr_payroll_items")
-    .select("*, hr_payroll_runs!inner(status, period_month, period_year, confirmed_at)")
+    .select("*, hr_payroll_runs!inner(status, cycle_type, period_month, period_year, period_start, period_end, confirmed_at)")
     .eq("user_id", session.id)
     .in("hr_payroll_runs.status", ["confirmed", "paid"])
-    .order("period_year", { ascending: false, foreignTable: "hr_payroll_runs" })
-    .order("period_month", { ascending: false, foreignTable: "hr_payroll_runs" })
-    .limit(12);
+    .order("confirmed_at", { ascending: false, foreignTable: "hr_payroll_runs" })
+    .limit(24);
 
   if (error) return NextResponse.json({ error: error.message }, { status: 500 });
 

--- a/apps/staff/src/lib/hr/constants.ts
+++ b/apps/staff/src/lib/hr/constants.ts
@@ -42,6 +42,11 @@ export const LEAVE_TYPES = {
 
 export type LeaveType = keyof typeof LEAVE_TYPES;
 
+// Feature flag: is Payroll (payslips) exposed to staff yet? OFF pre-launch — the
+// wiring stays, but the Payslips page shows a "coming soon" notice instead of
+// data. Mirror of the backoffice PAYROLL_UI_ENABLED; flip both when payroll goes live.
+export const PAYROLL_UI_ENABLED = false;
+
 // Malaysia time offset
 export const MYT_OFFSET_HOURS = 8;
 


### PR DESCRIPTION
Gives part-timers a payslip they can actually see — and un-breaks payslip visibility for everyone.

## Problem
The staff payslips route used the **anon** Supabase client, which the `hr_*` RLS deny-all lockdown blocks. So the payslips page returned nothing for **all** staff (full-timer monthly too), not just part-timers. On top of that, weekly part-timer runs have null `period_month`/`period_year`, so even if returned they had no label and sorted below every monthly slip.

## Fix
- **Route** → service-role client, scoped to `session.id` (the security boundary — a staffer only ever sees their own). Payslips load again. Now selects `cycle_type` + `period_start/end` and orders by `confirmed_at` so weekly and monthly interleave correctly.
- **Page** labels weekly runs **"Week of <date>"**, shows the part-timer earnings line as **"Wages (Nh × RMx/h)"**, and notes the hours came from the staff-app clock-in/out. Monthly full-timer payslips are unchanged.

Part-timers now see their weekly pay in the staff app once a weekly run is confirmed. Pairs with #689 (which makes the weekly run pay actual clocked hours).

## Verification
- Changed files typecheck + eslint clean. (The 3 `@celsius/db`/`baseQtyByProduct` tsc errors in a local run are a worktree symlink artifact — the export exists on main; CI will confirm.)
- Auth-gated staff page needing a confirmed weekly run to render, so verified via typecheck rather than a live preview.