### PR TITLE
feat(finance): AP-match v2 kills the OTHER_OUTFLOW double-count; Grab fee from payout recon

### DIFF
--- a/apps/backoffice/src/lib/finance/ap-match-lib.test.ts
+++ b/apps/backoffice/src/lib/finance/ap-match-lib.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from "vitest";
+import { digitRuns, invoiceRefInDesc, subsetSumIdx } from "./ap-match-lib";
+
+describe("ap-match-lib", () => {
+  it("extracts digit runs from bank descriptions", () => {
+    expect(digitRuns("celsius coffee putracountry bread baker* inv-006545, 006577")).toEqual(["6545", "6577"]);
+    expect(digitRuns("yow seng sdn bhd*ysiv-0801")).toEqual(["801"]);
+    expect(digitRuns("no digits here")).toEqual([]);
+  });
+
+  it("matches invoice numbers against description digit runs", () => {
+    const runs = digitRuns("inv 006545, 006577, 006556, 006593");
+    expect(invoiceRefInDesc("INV-006545", runs)).toBe(true);
+    expect(invoiceRefInDesc("006593", runs)).toBe(true);
+    expect(invoiceRefInDesc("INV-999999", runs)).toBe(false);
+    // short/absent numbers never confirm
+    expect(invoiceRefInDesc("12", runs)).toBe(false);
+    expect(invoiceRefInDesc(null, runs)).toBe(false);
+  });
+
+  it("finds the invoice subset summing to a combined payment", () => {
+    // Country Bread case: one transfer paying 4 invoices
+    const cents = [70425, 55010, 88450, 46800, 120000];
+    const target = 70425 + 55010 + 46800;
+    const idx = subsetSumIdx(cents, target);
+    expect(idx).not.toBeNull();
+    expect(idx!.map((i) => cents[i]).reduce((a, b) => a + b, 0)).toBe(target);
+  });
+
+  it("never returns a single-invoice subset and handles no-solution", () => {
+    expect(subsetSumIdx([50000, 30000], 50000)).toBeNull(); // size-1 is the single-match pass's job
+    expect(subsetSumIdx([100, 200, 300], 999)).toBeNull();
+  });
+
+  it("tolerates 1-2 sen rounding drift", () => {
+    const idx = subsetSumIdx([10001, 20001], 30000);
+    expect(idx).not.toBeNull();
+  });
+});

--- a/apps/backoffice/src/lib/finance/ap-match-lib.ts
+++ b/apps/backoffice/src/lib/finance/ap-match-lib.ts
@@ -1,0 +1,40 @@
+// Pure matching helpers for the AP auto-matcher. No DB/IO imports so they are
+// unit-testable and safe to import anywhere (ap-match.ts wires them to Prisma).
+
+// Invoice references in bank descriptions ("YSIV-0801", "INV 006545, 006577").
+// Compare on trailing digit runs: the invoice's number reduced to its digits
+// (leading zeros dropped) found as a digit run in the description.
+export function digitRuns(s: string | null | undefined): string[] {
+  return ((s ?? "").match(/\d{3,}/g) ?? []).map((d) => d.replace(/^0+/, "")).filter((d) => d.length >= 3);
+}
+
+export function invoiceRefInDesc(invoiceNumber: string | null | undefined, descRuns: string[]): boolean {
+  const invDigits = (invoiceNumber ?? "").replace(/\D/g, "").replace(/^0+/, "");
+  if (invDigits.length < 3) return false;
+  return descRuns.some((r) => r === invDigits || r.endsWith(invDigits) || invDigits.endsWith(r));
+}
+
+// Subset of invoice amounts (in cents) summing to the target — suppliers are
+// routinely paid for several invoices in ONE transfer, which single-invoice
+// amount matching can never see. DFS over amounts sorted desc with pruning;
+// bounded so a pathological supplier can't blow the loop up. Returns original
+// indexes, or null. Subsets of size 1 are excluded (that's the single-match
+// pass's job).
+export function subsetSumIdx(cents: number[], target: number, maxSize = 8): number[] | null {
+  const idx = cents.map((c, i) => [c, i] as const).sort((a, b) => b[0] - a[0]);
+  const suffix: number[] = new Array(idx.length + 1).fill(0);
+  for (let i = idx.length - 1; i >= 0; i--) suffix[i] = suffix[i + 1] + idx[i][0];
+  let steps = 0;
+  const pick: number[] = [];
+  const dfs = (i: number, remain: number): number[] | null => {
+    if (Math.abs(remain) <= 2 && pick.length >= 2) return [...pick];
+    if (i >= idx.length || remain < -2 || suffix[i] < remain - 2 || pick.length >= maxSize) return null;
+    if (++steps > 20_000) return null;
+    pick.push(idx[i][1]);
+    const withIt = dfs(i + 1, remain - idx[i][0]);
+    pick.pop();
+    if (withIt) return withIt;
+    return dfs(i + 1, remain);
+  };
+  return dfs(0, target);
+}

--- a/apps/backoffice/src/lib/finance/ap-match.ts
+++ b/apps/backoffice/src/lib/finance/ap-match.ts
@@ -48,9 +48,22 @@ export type ApMatch = {
   reasons: string[];
   alreadyPaid: boolean; // invoice was already settled → potential double-payment
 };
+export type ApMultiMatch = {
+  bankLineId: string;
+  bankDesc: string;
+  bankDate: string;
+  amount: number;
+  payee: string;
+  invoiceIds: string[];
+  invoiceNumbers: (string | null)[];
+  refsConfirmed: number; // how many of the invoices' numbers appear in the description
+  tier: MatchTier;
+  reasons: string[];
+};
 export type ApMatchResult = {
   auto: ApMatch[];
   review: ApMatch[];
+  multi: ApMultiMatch[];
   unmatchedInvoices: { invoiceId: string; invoiceNumber: string | null; payee: string; amount: number; issueDate: string }[];
   unmatchedOutflows: { bankLineId: string; desc: string; date: string; amount: number; category: string | null }[];
   doublePayments: ApMatch[];
@@ -75,6 +88,9 @@ function nameInDesc(nameTokens: string[], descLower: string): boolean {
   // A single distinctive token (e.g. "xora", "365eat") or ≥2 tokens is a match.
   return hits >= 2 || (hits === 1 && nameTokens.some((t) => t.length >= 5 && descLower.includes(t)));
 }
+
+import { digitRuns, invoiceRefInDesc, subsetSumIdx } from "./ap-match-lib";
+export { digitRuns, invoiceRefInDesc, subsetSumIdx } from "./ap-match-lib";
 
 export async function proposeApMatches(opts: { sinceDays?: number } = {}): Promise<ApMatchResult> {
   const sinceDays = opts.sinceDays ?? 120;
@@ -152,6 +168,12 @@ export async function proposeApMatches(opts: { sinceDays?: number } = {}): Promi
       else { score += 0.35; reasons.push(`amount ~ (RM${amtDiff.toFixed(2)} off)`); }
       const named = nameInDesc(nm, descLower);
       if (named) { score += 0.4; reasons.push("payee name in description"); }
+      // The invoice's own number quoted in the transfer is the strongest signal
+      // a bank line carries — count it as identity confirmation like a name hit.
+      if (invoiceRefInDesc(inv.invoiceNumber, digitRuns(descLower))) {
+        score += named ? 0.05 : 0.4;
+        reasons.push("invoice no in description");
+      }
       if (dDays <= 14) { score += 0.1; reasons.push("paid ≤14d of issue"); }
       else if (dDays <= 45) { score += 0.05; }
 
@@ -166,14 +188,79 @@ export async function proposeApMatches(opts: { sinceDays?: number } = {}): Promi
     }
 
     if (best && best.score >= 0.55) {
-      // AUTO requires amount-exact AND a name hit (score ≥ 0.85 only achievable that way).
-      best.tier = best.score >= 0.85 && best.reasons.includes("amount exact") && best.reasons.includes("payee name in description") ? "auto" : "review";
+      // AUTO requires amount-exact AND identity confirmation — payee name or
+      // the invoice number quoted in the transfer (score ≥ 0.85 needs one).
+      const confirmed = best.reasons.includes("payee name in description") || best.reasons.includes("invoice no in description");
+      best.tier = best.score >= 0.85 && best.reasons.includes("amount exact") && confirmed ? "auto" : "review";
       usedBankLineIds.add(best.bankLineId);
       matchedInvoiceIds.add(inv.id);
       if (best.alreadyPaid) doublePayments.push(best);
       else (best.tier === "auto" ? auto : review).push(best);
     } else {
       unmatchedInvoices.push({ invoiceId: inv.id, invoiceNumber: inv.invoiceNumber, payee, amount: amt, issueDate: ymd(issue) });
+    }
+  }
+
+  // ── Multi-invoice pass ─────────────────────────────────────────────────────
+  // Suppliers are routinely paid several invoices in ONE transfer (the bank
+  // line even lists the invoice numbers: "INV 006545, 006577, 006556…"), which
+  // single-invoice amount matching can never see. For each still-unmatched
+  // outflow, try each supplier whose name or invoice refs appear in the
+  // description: find the subset of their open invoices summing to the amount.
+  const multi: ApMultiMatch[] = [];
+  {
+    type Inv = (typeof invoices)[number];
+    const bySupplier = new Map<string, { payee: string; toks: string[]; invs: Inv[] }>();
+    for (const inv of invoices) {
+      if (matchedInvoiceIds.has(inv.id)) continue;
+      if (Number(inv.amountPaid ?? 0) >= Number(inv.amount) - 0.01) continue;
+      const payee = inv.supplier?.name ?? inv.vendorName ?? inv.vendorBankAccountName ?? "(unknown payee)";
+      const key = payee.toLowerCase();
+      const g = bySupplier.get(key) ?? { payee, toks: [...new Set([...tokens(inv.supplier?.name), ...tokens(inv.vendorName), ...tokens(inv.vendorBankAccountName)])], invs: [] };
+      g.invs.push(inv);
+      bySupplier.set(key, g);
+    }
+
+    for (const l of lines) {
+      if (usedBankLineIds.has(l.id)) continue;
+      const descLower = (l.description ?? "").toLowerCase();
+      const runs = digitRuns(descLower);
+      const target = Math.round(Number(l.amount) * 100);
+
+      let found: ApMultiMatch | null = null;
+      for (const g of bySupplier.values()) {
+        if (g.invs.length < 2) continue;
+        const refHits = g.invs.filter((i) => invoiceRefInDesc(i.invoiceNumber, runs)).length;
+        const named = nameInDesc(g.toks, descLower);
+        if (!named && refHits === 0) continue;
+
+        const pickIdx = subsetSumIdx(g.invs.map((i) => Math.round(Number(i.amount) * 100)), target);
+        if (!pickIdx) continue;
+        const picked = pickIdx.map((i) => g.invs[i]);
+        const refsConfirmed = picked.filter((i) => invoiceRefInDesc(i.invoiceNumber, runs)).length;
+        // AUTO only when the transfer itself confirms the bundle: every picked
+        // invoice's number quoted, or all-but-one quoted alongside a name hit.
+        const tier: MatchTier =
+          refsConfirmed === picked.length || (named && refsConfirmed >= picked.length - 1 && refsConfirmed >= 1)
+            ? "auto" : "review";
+        const reasons = [
+          `sum of ${picked.length} invoices = amount`,
+          ...(named ? ["payee name in description"] : []),
+          ...(refsConfirmed ? [`${refsConfirmed}/${picked.length} invoice nos in description`] : []),
+        ];
+        found = {
+          bankLineId: l.id, bankDesc: (l.description ?? "").replace(/\s+/g, " ").slice(0, 60),
+          bankDate: ymd(l.txnDate), amount: round2(Number(l.amount)), payee: g.payee,
+          invoiceIds: picked.map((i) => i.id), invoiceNumbers: picked.map((i) => i.invoiceNumber),
+          refsConfirmed, tier, reasons,
+        };
+        if (tier === "auto") break; // best possible for this line
+      }
+      if (found) {
+        usedBankLineIds.add(found.bankLineId);
+        for (const id of found.invoiceIds) matchedInvoiceIds.add(id);
+        multi.push(found);
+      }
     }
   }
 
@@ -184,7 +271,11 @@ export async function proposeApMatches(opts: { sinceDays?: number } = {}): Promi
     .map((l) => ({ bankLineId: l.id, desc: (l.description ?? "").replace(/\s+/g, " ").slice(0, 60), date: ymd(l.txnDate), amount: round2(Number(l.amount)), category: l.category as string | null }))
     .sort((a, b) => b.amount - a.amount);
 
-  return { auto, review, unmatchedInvoices, unmatchedOutflows, doublePayments };
+  return {
+    auto, review, multi,
+    unmatchedInvoices: unmatchedInvoices.filter((i) => !matchedInvoiceIds.has(i.invoiceId)),
+    unmatchedOutflows, doublePayments,
+  };
 }
 
 // ── VERIFIER + APPLY ────────────────────────────────────────────────────────
@@ -196,7 +287,9 @@ export async function proposeApMatches(opts: { sinceDays?: number } = {}): Promi
 export function verifyMatch(m: ApMatch): { ok: boolean; reason?: string } {
   if (m.tier !== "auto") return { ok: false, reason: "not auto-tier" };
   if (!m.reasons.includes("amount exact")) return { ok: false, reason: "amount not exact" };
-  if (!m.reasons.includes("payee name in description")) return { ok: false, reason: "payee not confirmed in bank line" };
+  if (!m.reasons.includes("payee name in description") && !m.reasons.includes("invoice no in description")) {
+    return { ok: false, reason: "identity not confirmed in bank line (no payee name or invoice no)" };
+  }
   if (m.alreadyPaid) return { ok: false, reason: "invoice already settled — possible double-pay" };
   return { ok: true };
 }
@@ -216,13 +309,18 @@ export type ApplyResult = {
 // LLM-verified review-tier apply.
 export async function writeApMatch(m: ApMatch): Promise<void> {
   await prisma.$transaction(async (tx) => {
-    const line = await tx.bankStatementLine.findUnique({ where: { id: m.bankLineId }, select: { apInvoiceId: true } });
+    const line = await tx.bankStatementLine.findUnique({ where: { id: m.bankLineId }, select: { apInvoiceId: true, category: true } });
     if (line?.apInvoiceId) return; // already matched — idempotent
     const inv = await tx.invoice.findUnique({ where: { id: m.invoiceId }, select: { status: true, amount: true } });
     if (!inv || inv.status === "PAID") return;
     await tx.bankStatementLine.update({
       where: { id: m.bankLineId },
-      data: { apInvoiceId: m.invoiceId, apMatchedAt: new Date(), classifiedBy: "ap-match" },
+      data: {
+        apInvoiceId: m.invoiceId, apMatchedAt: new Date(), classifiedBy: "ap-match",
+        // A matched line settles a procurement invoice — pull it out of the
+        // catch-all so the GL posts it as COGS, not Suspense.
+        ...(line?.category === null || line?.category === "OTHER_OUTFLOW" ? { category: "RAW_MATERIALS" as CashCategory } : {}),
+      },
     });
     await tx.invoice.update({
       where: { id: m.invoiceId },
@@ -231,15 +329,45 @@ export async function writeApMatch(m: ApMatch): Promise<void> {
   });
 }
 
+// One transfer settling several invoices: link the line to the first invoice
+// (the FK is single) and mark every invoice in the bundle paid, stamped with
+// the bank line id so the trail survives the single-column link.
+export async function writeMultiMatch(m: ApMultiMatch): Promise<void> {
+  await prisma.$transaction(async (tx) => {
+    const line = await tx.bankStatementLine.findUnique({ where: { id: m.bankLineId }, select: { apInvoiceId: true, category: true } });
+    if (line?.apInvoiceId) return; // already matched — idempotent
+    const invs = await tx.invoice.findMany({ where: { id: { in: m.invoiceIds } }, select: { id: true, status: true, amount: true } });
+    if (invs.length !== m.invoiceIds.length || invs.some((i) => i.status === "PAID")) return;
+    await tx.bankStatementLine.update({
+      where: { id: m.bankLineId },
+      data: {
+        apInvoiceId: m.invoiceIds[0], apMatchedAt: new Date(), classifiedBy: "ap-match",
+        ...(line?.category === null || line?.category === "OTHER_OUTFLOW" ? { category: "RAW_MATERIALS" as CashCategory } : {}),
+      },
+    });
+    for (const inv of invs) {
+      await tx.invoice.update({
+        where: { id: inv.id },
+        data: { amountPaid: inv.amount, status: "PAID", paidAt: new Date(m.bankDate + "T00:00:00Z"), paidVia: `bank-ap-match-multi:${m.bankLineId}` },
+      });
+    }
+  });
+}
+
 export async function applyApMatches(opts: { commit?: boolean; sinceDays?: number } = {}): Promise<ApplyResult> {
   const commit = opts.commit ?? false;
-  const { auto } = await proposeApMatches({ sinceDays: opts.sinceDays });
+  const { auto, multi } = await proposeApMatches({ sinceDays: opts.sinceDays });
   const skipped: ApplyResult["skipped"] = [];
   let applied = 0;
   for (const m of auto) {
     const v = verifyMatch(m);
     if (!v.ok) { skipped.push({ payee: m.payee, amount: m.amount, reason: v.reason! }); continue; }
     if (commit) await writeApMatch(m);
+    applied++;
+  }
+  for (const m of multi) {
+    if (m.tier !== "auto") { skipped.push({ payee: m.payee, amount: m.amount, reason: "multi-invoice bundle not ref-confirmed" }); continue; }
+    if (commit) await writeMultiMatch(m);
     applied++;
   }
   return { committed: commit, applied, skipped };

--- a/apps/backoffice/src/lib/finance/reports/pnl-sourced-drill.ts
+++ b/apps/backoffice/src/lib/finance/reports/pnl-sourced-drill.ts
@@ -16,6 +16,7 @@
 import { prisma } from "@/lib/prisma";
 import { Prisma, type CashCategory } from "@prisma/client";
 import { getFinanceClient } from "../supabase";
+import { effectiveGrabRate } from "./pnl-sourced";
 import { getUnifiedSalesForOutlet } from "@/app/api/sales/_lib/unified-sales";
 
 const round2 = (n: number) => Math.round(n * 100) / 100;
@@ -235,14 +236,20 @@ export async function sourcedPnlDrillDown(args: {
   if (code === "MKT-GRAB-ADS") return drillGrabAds(companyId, start, end, outletId);
   if (code.startsWith("BANK:")) return drillBank(code.slice(5), companyId, start, end, outletId);
   if (code === "MKT-GRAB-COMM") {
-    // Estimate, not transactions: recompute the base so the drawer explains it.
-    const rev = await drillRevenue("REV-GRAB", companyId, start, end, outletId);
+    // A derived line, not transactions — the drawer explains the calculation.
+    const [rev, gr] = await Promise.all([
+      drillRevenue("REV-GRAB", companyId, start, end, outletId),
+      effectiveGrabRate(end),
+    ]);
     const gross = round2(rev.reduce((s, r) => s + r.amount, 0));
-    const est = round2(gross * 0.43);
+    const est = round2(gross * gr.rate);
+    const basis = gr.source === "recon"
+      ? `Effective rate ${Math.round(gr.rate * 100)}% from the payout reconciliation: over the trailing window, Grab paid out RM${gr.windowPayouts.toFixed(2)} against RM${gr.windowGross.toFixed(2)} gross Grab sales.`
+      : `Fallback rate ${Math.round(gr.rate * 100)}% (payout window too thin to derive the effective rate).`;
     return [{
       transactionId: "grab-comm-estimate",
       txnDate: end,
-      description: `Estimated commission: 43% of RM${gross.toFixed(2)} gross GrabFood sales in this period (observed effective all-in Grab deduction). Exact per-order commission lives in the Grab settlement report.`,
+      description: `Commission on RM${gross.toFixed(2)} gross GrabFood sales this period. ${basis} Exact per-order commission lives in the Grab settlement report.`,
       amount: est,
       debit: est,
       credit: 0,

--- a/apps/backoffice/src/lib/finance/reports/pnl-sourced.ts
+++ b/apps/backoffice/src/lib/finance/reports/pnl-sourced.ts
@@ -50,14 +50,60 @@ const BANK_REVIEW = new Set(["OTHER_OUTFLOW"]);
 // GrabFood revenue is booked GROSS in income, but Grab deducts a commission
 // (marketplace fee) at source before paying out — so it never appears in the
 // bank feed and must be recognised as a cost here, else Grab margin is wildly
-// overstated. This is an ESTIMATE at a flat rate; the exact per-order
-// commission lives in the GrabFood Partner settlement report (TODO: source it
-// from the API and replace this estimate). Commission is the selling company's
-// cost, so it attributes to whichever company booked the Grab revenue —
-// independent of which bank account the net payout lands in.
-// ~43% observed effective all-in deduction (commission + platform fees) from
-// reconciling gross Grab sales vs bank payouts — the old 0.30 understated it.
-const GRAB_COMMISSION_RATE = 0.43;
+// overstated. Commission is the selling company's cost, so it attributes to
+// whichever company booked the Grab revenue — independent of which bank
+// account the net payout lands in.
+//
+// The RATE is derived from the reconciliation itself: effective deduction =
+// 1 − (Grab bank payouts ÷ gross Grab sales) over a trailing window, pooled
+// across all companies to smooth weekly payout timing. Payouts land under the
+// GRAB category — plus GRAB_PUTRAJAYA, Conezion's payouts settling into the
+// HQ account. Falls back to the last observed ~43% when the window is too
+// thin to trust, and clamps to a sane band so one weird payout week can't
+// swing the P&L.
+const GRAB_RATE_FALLBACK = 0.43;
+const GRAB_RATE_WINDOW_DAYS = 120;
+const GRAB_RATE_MIN_GROSS = 20_000; // below this the window is too thin to trust
+
+export type GrabRate = { rate: number; source: "recon" | "fallback"; windowGross: number; windowPayouts: number };
+
+export async function effectiveGrabRate(end: string): Promise<GrabRate> {
+  const winEnd = dEnd(end);
+  const winStart = new Date(winEnd.getTime() - GRAB_RATE_WINDOW_DAYS * 86400_000);
+  const fallback: GrabRate = { rate: GRAB_RATE_FALLBACK, source: "fallback", windowGross: 0, windowPayouts: 0 };
+  try {
+    // Gross Grab sales in the window, pooled: StoreHub archive (pre-cutover
+    // grab channel) + POS-native grabfood orders. Totals in RM / sen.
+    const [sh, pn, pay] = await Promise.all([
+      prisma.$queryRaw<{ t: number | null }[]>(Prisma.sql`
+        SELECT COALESCE(SUM(total), 0)::float AS t FROM storehub_sales
+        WHERE is_cancelled IS NOT TRUE AND channel ~* 'grab'
+          AND transaction_time >= ${winStart} AND transaction_time <= ${winEnd}
+      `),
+      prisma.$queryRaw<{ t: number | null }[]>(Prisma.sql`
+        SELECT COALESCE(SUM(total), 0)::float / 100 AS t FROM pos_orders
+        WHERE source = 'grabfood' AND status = 'completed'
+          AND created_at >= ${winStart} AND created_at <= ${winEnd}
+      `),
+      prisma.bankStatementLine.aggregate({
+        _sum: { amount: true },
+        where: {
+          direction: "CR",
+          category: { in: ["GRAB", "GRAB_PUTRAJAYA"] },
+          txnDate: { gte: winStart, lte: winEnd },
+        },
+      }),
+    ]);
+    const gross = round2(Number(sh[0]?.t ?? 0) + Number(pn[0]?.t ?? 0));
+    const payouts = round2(Number(pay._sum?.amount ?? 0));
+    if (gross < GRAB_RATE_MIN_GROSS || payouts <= 0) return fallback;
+    const raw = 1 - payouts / gross;
+    const rate = Math.min(0.55, Math.max(0.25, round2(raw)));
+    return { rate, source: "recon", windowGross: gross, windowPayouts: payouts };
+  } catch {
+    return fallback;
+  }
+}
 
 function humanCat(c: string | null): string {
   if (!c) return "Unclassified";
@@ -313,14 +359,16 @@ export async function buildSourcedPnl(input: {
     }
   }
 
-  // GrabFood commission (marketplace fee) — estimated on the gross Grab
-  // revenue booked above, since Grab nets it out before payout (never in the
-  // bank feed). Find the Grab income code(s) and apply the rate.
+  // GrabFood commission (marketplace fee) — applied to the gross Grab revenue
+  // booked above, since Grab nets it out before payout (never in the bank
+  // feed). The rate comes from the payout reconciliation, not a hardcoded
+  // guess — see effectiveGrabRate.
   if (grabGrossRevenue > 0) {
-    const grabComm = round2(grabGrossRevenue * GRAB_COMMISSION_RATE);
+    const gr = await effectiveGrabRate(end);
+    const grabComm = round2(grabGrossRevenue * gr.rate);
     expenseLines.push({
       code: "MKT-GRAB-COMM",
-      name: `Marketplace fee — GrabFood commission (est. ${Math.round(GRAB_COMMISSION_RATE * 100)}%)`,
+      name: `Marketplace fee — GrabFood commission (${Math.round(gr.rate * 100)}% ${gr.source === "recon" ? "effective, from payout recon" : "est."})`,
       amount: grabComm,
       parentCode: null,
     });


### PR DESCRIPTION
Owner directives: (1) `BANK:OTHER_OUTFLOW` double-counts in the P&L — those payments settle procurement invoices already counted as COGS, so they must be **matched**; (2) the GrabFood fee should be **calculated from the recon between revenue and cash in**, not hardcoded.

## 1. AP-match v2 — why the pile never cleared, and the fix

The matcher required an exact **single-invoice** amount plus a payee-name hit. Real transfers routinely pay **several invoices at once** (the bank line even lists them: `INV 006545, 006577, 006556, 006593`), so the amount never matched anything.

- **Invoice-ref matching**: the invoice's number found as a digit run in the description now confirms identity like a name hit.
- **Multi-invoice bundles**: per supplier whose name/refs appear in the description, a bounded subset-sum finds the open invoices summing to the transfer amount. AUTO only when the transfer itself confirms the bundle (every ref quoted, or all-but-one plus a name hit); otherwise review tier.
- **AUTO gate + verifier**: amount-exact + (payee name OR invoice ref).
- **Re-tag on apply**: a matched null/OTHER_OUTFLOW line becomes RAW_MATERIALS, so the GL posts it as COGS instead of Suspense. Multi-apply marks every invoice in the bundle PAID (`paidVia bank-ap-match-multi:<lineId>`).

Matched lines are excluded from P&L opex (existing `apInvoiceId: null` filter), so every match directly removes double-counted expense. Runs in the existing 6h cron.

## 2. Grab fee from the payout reconciliation

`effectiveGrabRate(end)` = `1 − (GRAB + GRAB_PUTRAJAYA bank payouts ÷ gross Grab sales)` over a trailing 120-day window, pooled across companies to smooth weekly payout timing (GRAB_PUTRAJAYA is Conezion's payouts landing in the HQ account). Clamped to 25–55%, falls back to 43% when the window is too thin to trust. The P&L line and its drill-down state the computed rate and the exact payout/gross basis.

Tests: 5 new unit tests on the matching primitives; typecheck + lint clean.
