### PR TITLE
Par levels: weekly auto-recalc, statistical reorder points, purchase fallback

### DIFF
--- a/apps/backoffice/src/app/api/cron/par-levels-recalc/route.ts
+++ b/apps/backoffice/src/app/api/cron/par-levels-recalc/route.ts
@@ -1,0 +1,51 @@
+import { NextRequest, NextResponse } from "next/server";
+import { checkCronAuth } from "@celsius/shared";
+import { getSession } from "@/lib/auth";
+import { prisma } from "@/lib/prisma";
+import { recalcOutletParLevels } from "@/lib/inventory/par-calc";
+
+export const dynamic = "force-dynamic";
+export const maxDuration = 120;
+
+// GET /api/cron/par-levels-recalc — weekly par-level refresh, every outlet
+// with a POS-native mapping. Keeps reorder points / pars / max levels tracking
+// the last 30 days of real sales instead of freezing at a one-off calculation
+// (all 336 pars sat at their 2026-04-12 values until this existed). Scheduled
+// Mondays 03:00 MYT in vercel.json; safe to run on demand as OWNER/ADMIN.
+//
+// Pars are engine-managed: each run overwrites the outlet's rows. Outlets with
+// no POS sales in the window are skipped (their stale pars are left alone
+// rather than zeroed).
+export async function GET(req: NextRequest) {
+  const cronAuth = checkCronAuth(req.headers);
+  if (!cronAuth.ok) {
+    const user = await getSession();
+    if (!user || !["OWNER", "ADMIN"].includes(user.role)) {
+      return NextResponse.json({ error: cronAuth.error }, { status: cronAuth.status });
+    }
+  }
+  try {
+    const outlets = await prisma.outlet.findMany({
+      where: { loyaltyOutletId: { not: null } },
+      select: { id: true, name: true },
+    });
+    const results: Array<{ outlet: string; ok: boolean; productsUpdated: number; fallbackProducts: number; error?: string }> = [];
+    for (const o of outlets) {
+      const r = await recalcOutletParLevels(o.id);
+      results.push({
+        outlet: o.name,
+        ok: r.ok,
+        productsUpdated: r.productsUpdated,
+        fallbackProducts: r.fallbackProducts,
+        ...(r.error ? { error: r.error } : {}),
+      });
+      console.log(
+        `[par-recalc] ${o.name}: ok=${r.ok} updated=${r.productsUpdated} fallback=${r.fallbackProducts}${r.error ? ` (${r.error})` : ""}`,
+      );
+    }
+    return NextResponse.json({ ok: true, results });
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : "par-levels-recalc failed";
+    return NextResponse.json({ error: msg }, { status: 500 });
+  }
+}

--- a/apps/backoffice/src/app/api/inventory/par-levels/calculate/route.ts
+++ b/apps/backoffice/src/app/api/inventory/par-levels/calculate/route.ts
@@ -1,231 +1,24 @@
 import { NextResponse, NextRequest } from "next/server";
-import { prisma } from "@/lib/prisma";
 import { requireAuth } from "@/lib/auth";
+import { recalcOutletParLevels } from "@/lib/inventory/par-calc";
 
-// ─── Par Level Calculation ─────────────────────────────────────────────
-//
-// Formula:
-//   reorderPoint = avgDailyUsage × (leadTimeDays + safetyDays)
-//   parLevel     = avgDailyUsage × (leadTimeDays + safetyDays + coverageDays)
-//   maxLevel     = parLevel × 1.5
-//
-// Where:
-//   leadTimeDays  = from the product's cheapest supplier (or default 1)
-//   safetyDays    = buffer for demand spikes (default 1)
-//   coverageDays  = days of stock after reorder arrives (default 3)
-//
-
-const DEFAULT_SAFETY_DAYS = 1;
-const DEFAULT_COVERAGE_DAYS = 3;
-const DEFAULT_LEAD_TIME_DAYS = 1;
-const DEFAULT_LOOKBACK_DAYS = 30;
-const MAX_LEVEL_MULTIPLIER = 1.5;
-
+// POST /api/inventory/par-levels/calculate — recalc one outlet's par levels
+// on demand. The formula + engine-managed semantics live in
+// lib/inventory/par-calc.ts (shared with the weekly cron/par-levels-recalc,
+// which keeps pars from freezing the way they did after 2026-04-12).
 export async function POST(req: NextRequest) {
   const auth = await requireAuth(req);
   if (auth.error) return auth.error;
   const body = await req.json();
-  const {
-    outletId,
-    lookbackDays = DEFAULT_LOOKBACK_DAYS,
-    safetyDays = DEFAULT_SAFETY_DAYS,
-    coverageDays = DEFAULT_COVERAGE_DAYS,
-  } = body;
+  const { outletId, lookbackDays, safetyDays, coverageDays } = body;
 
   if (!outletId) {
     return NextResponse.json({ error: "outletId is required" }, { status: 400 });
   }
 
-  const since = new Date();
-  since.setDate(since.getDate() - lookbackDays);
-
-  // POS-native sales source (StoreHub retired). pos_orders.outlet_id is the
-  // native/loyalty id (e.g. "outlet-con"); the inventory `outletId` here is the
-  // Outlet uuid, so resolve across. The native POS reuses StoreHub product ids,
-  // so pos_order_items.product_id maps to Menu.storehubId — the same join the
-  // old StoreHub sync used to set SalesTransaction.menuId.
-  const outletRow = await prisma.outlet.findUnique({
-    where: { id: outletId },
-    select: { loyaltyOutletId: true },
-  });
-  const loyaltyOutletId = outletRow?.loyaltyOutletId ?? null;
-
-  // ── Parallel data fetches ──────────────────────────────────────────
-  const [salesByMenuRaw, bom, supplierProducts, existingParLevels, productPackages] = await Promise.all([
-    loyaltyOutletId
-      ? prisma.$queryRaw<Array<{ menuId: string; quantity: number }>>`
-          SELECT m.id AS "menuId", COALESCE(SUM(i.quantity), 0)::int AS quantity
-          FROM pos_order_items i
-          JOIN pos_orders o ON o.id = i.order_id
-          JOIN "Menu" m ON m."storehubId" = i.product_id
-          WHERE o.outlet_id = ${loyaltyOutletId}
-            AND o.status = 'completed'
-            AND o.refund_of_order_id IS NULL
-            AND o.created_at >= ${since}
-          GROUP BY m.id
-        `
-      : Promise.resolve([] as Array<{ menuId: string; quantity: number }>),
-    prisma.menuIngredient.findMany({
-      include: { menu: true, product: true },
-    }),
-    // Get lead times from suppliers (cheapest per product)
-    prisma.supplierProduct.findMany({
-      where: { isActive: true },
-      select: {
-        productId: true,
-        price: true,
-        supplier: { select: { leadTimeDays: true } },
-        productPackage: { select: { conversionFactor: true } },
-      },
-    }),
-    // Get existing par levels to preserve manual overrides
-    prisma.parLevel.findMany({
-      where: { outletId },
-      select: { productId: true, parLevel: true, reorderPoint: true, maxLevel: true },
-    }),
-    // Get packages for each product (for rounding to whole packages)
-    // Prefer bulk packages (those with containsPackageId) for purchase rounding
-    prisma.productPackage.findMany({
-      select: { productId: true, conversionFactor: true, isDefault: true, containsPackageId: true },
-      orderBy: { conversionFactor: "desc" },
-    }),
-  ]);
-
-  // Shape native rows like the old SalesTransaction.groupBy result + a units total.
-  const salesByMenu = salesByMenuRaw.map((r) => ({ menuId: r.menuId, _sum: { quantity: Number(r.quantity) } }));
-  const salesCount = salesByMenu.reduce((s, r) => s + (r._sum.quantity ?? 0), 0);
-
-  if (salesCount === 0) {
-    return NextResponse.json(
-      {
-        error: "No sales data found",
-        message: `No POS sales for this outlet in the last ${lookbackDays} days.`,
-      },
-      { status: 422 },
-    );
+  const result = await recalcOutletParLevels(outletId, { lookbackDays, safetyDays, coverageDays });
+  if (!result.ok) {
+    return NextResponse.json({ error: "No sales data found", message: result.error }, { status: 422 });
   }
-
-  // ── Avg daily sales per menu item ──────────────────────────────────
-  const avgDailySalesByMenu: Record<string, number> = {};
-  for (const row of salesByMenu) {
-    if (row.menuId) {
-      avgDailySalesByMenu[row.menuId] = (row._sum.quantity || 0) / lookbackDays;
-    }
-  }
-
-  // ── Build lead time map: productId → shortest lead time ────────────
-  const leadTimeMap: Record<string, number> = {};
-  for (const sp of supplierProducts) {
-    const lt = sp.supplier.leadTimeDays || DEFAULT_LEAD_TIME_DAYS;
-    if (!leadTimeMap[sp.productId] || lt < leadTimeMap[sp.productId]) {
-      leadTimeMap[sp.productId] = lt;
-    }
-  }
-
-  // ── Calculate daily usage per product from BOM × sales ─────────────
-  const usageByProduct: Record<
-    string,
-    { name: string; sku: string; baseUom: string; dailyUsage: number }
-  > = {};
-
-  for (const ingredient of bom) {
-    const avgDailySales = avgDailySalesByMenu[ingredient.menuId];
-    if (!avgDailySales) continue;
-
-    const dailyUsageFromMenu = Number(ingredient.quantityUsed) * avgDailySales;
-
-    if (!usageByProduct[ingredient.productId]) {
-      usageByProduct[ingredient.productId] = {
-        name: ingredient.product.name,
-        sku: ingredient.product.sku,
-        baseUom: ingredient.product.baseUom,
-        dailyUsage: 0,
-      };
-    }
-    usageByProduct[ingredient.productId].dailyUsage += dailyUsageFromMenu;
-  }
-
-  // ── Build package conversion map: productId → conversionFactor ─────
-  // Prefer bulk packages (containsPackageId set) for purchase rounding,
-  // then default package, then largest package
-  const packageMap: Record<string, number> = {};
-  for (const pkg of productPackages) {
-    const cf = Number(pkg.conversionFactor);
-    if (!packageMap[pkg.productId]) {
-      packageMap[pkg.productId] = cf;
-    }
-    // Prefer bulk packages (sorted by conversionFactor desc, so first bulk wins)
-    if (pkg.containsPackageId && cf > 0) {
-      packageMap[pkg.productId] = cf;
-    }
-  }
-
-  /** Round a base-UOM value UP to the nearest whole package */
-  function roundToPackage(baseQty: number, productId: string): number {
-    const cf = packageMap[productId];
-    if (!cf || cf <= 0) return Math.ceil(baseQty);
-    return Math.ceil(baseQty / cf) * cf;
-  }
-
-  // ── Calculate and upsert par levels ────────────────────────────────
-  const results: { productId: string; name: string; dailyUsage: number; leadTime: number; reorderPoint: number; parLevel: number; maxLevel: number }[] = [];
-
-  const upserts = Object.entries(usageByProduct)
-    .map(([productId, data]) => {
-      if (data.dailyUsage <= 0) return null;
-
-      const leadTime = leadTimeMap[productId] || DEFAULT_LEAD_TIME_DAYS;
-      // Calculate raw values in base UOM, then round up to whole packages
-      const rawReorder = data.dailyUsage * (leadTime + safetyDays);
-      const rawPar = data.dailyUsage * (leadTime + safetyDays + coverageDays);
-      const rawMax = rawPar * MAX_LEVEL_MULTIPLIER;
-
-      const reorderPoint = roundToPackage(rawReorder, productId);
-      const parLevel = roundToPackage(rawPar, productId);
-      const maxLevel = roundToPackage(rawMax, productId);
-
-      results.push({
-        productId,
-        name: data.name,
-        dailyUsage: Math.round(data.dailyUsage * 100) / 100,
-        leadTime,
-        reorderPoint,
-        parLevel,
-        maxLevel,
-      });
-
-      return prisma.parLevel.upsert({
-        where: { productId_outletId: { productId, outletId } },
-        create: {
-          productId,
-          outletId,
-          parLevel,
-          reorderPoint,
-          maxLevel,
-          avgDailyUsage: Math.round(data.dailyUsage * 100) / 100,
-          lastCalculated: new Date(),
-        },
-        update: {
-          parLevel,
-          reorderPoint,
-          maxLevel,
-          avgDailyUsage: Math.round(data.dailyUsage * 100) / 100,
-          lastCalculated: new Date(),
-        },
-      });
-    })
-    .filter(Boolean);
-
-  await Promise.all(upserts);
-
-  return NextResponse.json({
-    success: true,
-    salesTransactions: salesCount,
-    menuItemsWithSales: Object.keys(avgDailySalesByMenu).length,
-    productsUpdated: upserts.length,
-    lookbackDays,
-    settings: { safetyDays, coverageDays },
-    // Return details so UI can show the breakdown
-    details: results.sort((a, b) => a.name.localeCompare(b.name)),
-  });
+  return NextResponse.json({ success: true, ...result });
 }

--- a/apps/backoffice/src/lib/inventory/par-calc.ts
+++ b/apps/backoffice/src/lib/inventory/par-calc.ts
@@ -1,0 +1,274 @@
+import { prisma } from "@/lib/prisma";
+
+// ─── Par-level calculation (shared by the manual route + weekly cron) ────
+//
+// Formula (base UOM):
+//   avgDailyUsage = Σ over menus (BOM quantityUsed × that menu's avg daily
+//                   POS-native sales over the lookback)
+//                   — falling back to purchase history (receivings) for
+//                   products with no BOM linkage (packaging, direct-sale items)
+//   reorderPoint  = usage × (leadTimeDays + safetyDays)        — NOT package-rounded
+//   parLevel      = usage × (leadTime + safety + coverageDays) — rounded UP to a package
+//   maxLevel      = max(parLevel × 1.5 rounded to a package, parLevel + one package)
+//
+// Why reorderPoint is left unrounded: rounding it up to a whole bulk package
+// made reorder == par on 220/336 rows (both raws smaller than one carton), so
+// those items read "below reorder" permanently and every PO composer / exec
+// pass nudged another carton. The trigger should be the statistical point;
+// only the AMOUNTS you buy need package rounding.
+//
+// Why maxLevel gets a one-package floor above par: with par == max (same
+// rounding artifact), a suggested top-up of one package always breached the
+// ceiling. Guaranteeing max ≥ par + 1 package keeps the overstock cap
+// meaningful while never blocking the minimal possible order.
+//
+// Pars are ENGINE-MANAGED: every recalc overwrites all values for the outlet.
+// Tune demand via recipes/lead times/safety days, not by hand-editing rows —
+// manual edits do not survive the weekly recalc (documented behaviour).
+
+export const PAR_DEFAULTS = {
+  safetyDays: 1,
+  coverageDays: 3,
+  leadTimeDays: 1,
+  lookbackDays: 30,
+  maxLevelMultiplier: 1.5,
+  // Purchase-fallback usage averages over a longer window — deliveries are
+  // lumpy, so 30d would whipsaw items that arrive fortnightly.
+  purchaseLookbackDays: 60,
+} as const;
+
+export interface ParCalcOptions {
+  lookbackDays?: number;
+  safetyDays?: number;
+  coverageDays?: number;
+}
+
+export interface ParCalcDetail {
+  productId: string;
+  name: string;
+  dailyUsage: number;
+  usageSource: "bom" | "purchases";
+  leadTime: number;
+  reorderPoint: number;
+  parLevel: number;
+  maxLevel: number;
+}
+
+export interface ParCalcResult {
+  ok: boolean;
+  error?: string;
+  salesTransactions: number;
+  menuItemsWithSales: number;
+  productsUpdated: number;
+  fallbackProducts: number;
+  lookbackDays: number;
+  settings: { safetyDays: number; coverageDays: number };
+  details: ParCalcDetail[];
+}
+
+export async function recalcOutletParLevels(outletId: string, opts: ParCalcOptions = {}): Promise<ParCalcResult> {
+  const lookbackDays = opts.lookbackDays ?? PAR_DEFAULTS.lookbackDays;
+  const safetyDays = opts.safetyDays ?? PAR_DEFAULTS.safetyDays;
+  const coverageDays = opts.coverageDays ?? PAR_DEFAULTS.coverageDays;
+
+  const empty: Omit<ParCalcResult, "ok" | "error"> = {
+    salesTransactions: 0,
+    menuItemsWithSales: 0,
+    productsUpdated: 0,
+    fallbackProducts: 0,
+    lookbackDays,
+    settings: { safetyDays, coverageDays },
+    details: [],
+  };
+
+  const since = new Date();
+  since.setDate(since.getDate() - lookbackDays);
+  const purchaseSince = new Date();
+  purchaseSince.setDate(purchaseSince.getDate() - PAR_DEFAULTS.purchaseLookbackDays);
+
+  // POS-native sales source (StoreHub retired). pos_orders.outlet_id is the
+  // native/loyalty id (e.g. "outlet-con"); the inventory `outletId` here is the
+  // Outlet uuid, so resolve across. The native POS reuses StoreHub product ids,
+  // so pos_order_items.product_id maps to Menu.storehubId.
+  const outletRow = await prisma.outlet.findUnique({
+    where: { id: outletId },
+    select: { loyaltyOutletId: true },
+  });
+  const loyaltyOutletId = outletRow?.loyaltyOutletId ?? null;
+
+  const [salesByMenuRaw, bom, supplierProducts, productPackages, receivedLines] = await Promise.all([
+    loyaltyOutletId
+      ? prisma.$queryRaw<Array<{ menuId: string; quantity: number }>>`
+          SELECT m.id AS "menuId", COALESCE(SUM(i.quantity), 0)::int AS quantity
+          FROM pos_order_items i
+          JOIN pos_orders o ON o.id = i.order_id
+          JOIN "Menu" m ON m."storehubId" = i.product_id
+          WHERE o.outlet_id = ${loyaltyOutletId}
+            AND o.status = 'completed'
+            AND o.refund_of_order_id IS NULL
+            AND o.created_at >= ${since}
+          GROUP BY m.id
+        `
+      : Promise.resolve([] as Array<{ menuId: string; quantity: number }>),
+    prisma.menuIngredient.findMany({ include: { menu: true, product: true } }),
+    prisma.supplierProduct.findMany({
+      where: { isActive: true },
+      select: {
+        productId: true,
+        price: true,
+        supplier: { select: { leadTimeDays: true } },
+        productPackage: { select: { conversionFactor: true } },
+      },
+    }),
+    // Packages for rounding to whole purchasable packages — prefer bulk
+    // (containsPackageId set), then default, then largest.
+    prisma.productPackage.findMany({
+      select: { productId: true, conversionFactor: true, isDefault: true, containsPackageId: true },
+      orderBy: { conversionFactor: "desc" },
+    }),
+    // Purchase history for the fallback usage estimate. receivedQty is stored
+    // in the line's PACKAGE units — convert via its own package factor.
+    prisma.receivingItem.findMany({
+      where: { receiving: { outletId, receivedAt: { gte: purchaseSince } } },
+      select: {
+        productId: true,
+        receivedQty: true,
+        productPackage: { select: { conversionFactor: true } },
+        product: { select: { name: true, sku: true, baseUom: true } },
+      },
+    }),
+  ]);
+
+  const salesByMenu = salesByMenuRaw.map((r) => ({ menuId: r.menuId, qty: Number(r.quantity) }));
+  const salesCount = salesByMenu.reduce((s, r) => s + r.qty, 0);
+  if (salesCount === 0) {
+    return { ...empty, ok: false, error: `No POS sales for this outlet in the last ${lookbackDays} days.` };
+  }
+
+  const avgDailySalesByMenu: Record<string, number> = {};
+  for (const row of salesByMenu) {
+    if (row.menuId) avgDailySalesByMenu[row.menuId] = row.qty / lookbackDays;
+  }
+
+  // Shortest lead time per product across its suppliers.
+  const leadTimeMap: Record<string, number> = {};
+  for (const sp of supplierProducts) {
+    const lt = sp.supplier.leadTimeDays || PAR_DEFAULTS.leadTimeDays;
+    if (!leadTimeMap[sp.productId] || lt < leadTimeMap[sp.productId]) leadTimeMap[sp.productId] = lt;
+  }
+  const orderable = new Set(supplierProducts.map((sp) => sp.productId));
+
+  // ── Daily usage: BOM × sales ──
+  const usageByProduct: Record<
+    string,
+    { name: string; dailyUsage: number; source: "bom" | "purchases" }
+  > = {};
+  for (const ingredient of bom) {
+    const avgDailySales = avgDailySalesByMenu[ingredient.menuId];
+    if (!avgDailySales) continue;
+    const add = Number(ingredient.quantityUsed) * avgDailySales;
+    const cur = usageByProduct[ingredient.productId];
+    if (cur) cur.dailyUsage += add;
+    else usageByProduct[ingredient.productId] = { name: ingredient.product.name, dailyUsage: add, source: "bom" };
+  }
+
+  // ── Fallback usage: purchase history, for orderable products the BOM
+  // doesn't reach (packaging, direct-sale cakes, cleaning). Over a long
+  // window, what an outlet buys of a consumable approximates what it uses.
+  let fallbackProducts = 0;
+  const receivedBase: Record<string, { name: string; base: number }> = {};
+  for (const line of receivedLines) {
+    const convRaw = line.productPackage ? Number(line.productPackage.conversionFactor) : 1;
+    const conv = convRaw > 0 ? convRaw : 1;
+    const cur = receivedBase[line.productId];
+    const add = Number(line.receivedQty) * conv;
+    if (cur) cur.base += add;
+    else receivedBase[line.productId] = { name: line.product?.name ?? "?", base: add };
+  }
+  for (const [productId, r] of Object.entries(receivedBase)) {
+    if (usageByProduct[productId]) continue; // BOM wins — it tracks demand, not delivery cadence
+    if (!orderable.has(productId)) continue;
+    const daily = r.base / PAR_DEFAULTS.purchaseLookbackDays;
+    if (daily <= 0) continue;
+    usageByProduct[productId] = { name: r.name, dailyUsage: daily, source: "purchases" };
+    fallbackProducts++;
+  }
+
+  // Package factor per product for rounding (bulk preferred).
+  const packageMap: Record<string, number> = {};
+  for (const pkg of productPackages) {
+    const cf = Number(pkg.conversionFactor);
+    if (!packageMap[pkg.productId]) packageMap[pkg.productId] = cf;
+    if (pkg.containsPackageId && cf > 0) packageMap[pkg.productId] = cf;
+  }
+  const packageSize = (productId: string) => {
+    const cf = packageMap[productId];
+    return cf && cf > 0 ? cf : 1;
+  };
+  const roundToPackage = (baseQty: number, productId: string) => {
+    const cf = packageSize(productId);
+    return Math.ceil(baseQty / cf) * cf;
+  };
+
+  const details: ParCalcDetail[] = [];
+  const upserts = Object.entries(usageByProduct)
+    .map(([productId, data]) => {
+      if (data.dailyUsage <= 0) return null;
+      const leadTime = leadTimeMap[productId] || PAR_DEFAULTS.leadTimeDays;
+
+      const rawReorder = data.dailyUsage * (leadTime + safetyDays);
+      const rawPar = data.dailyUsage * (leadTime + safetyDays + coverageDays);
+      const rawMax = rawPar * PAR_DEFAULTS.maxLevelMultiplier;
+
+      // Trigger stays statistical; amounts get package-rounded; the ceiling
+      // always leaves room for at least one more package above par.
+      const reorderPoint = Math.ceil(rawReorder);
+      const parLevel = roundToPackage(rawPar, productId);
+      const maxLevel = Math.max(roundToPackage(rawMax, productId), parLevel + packageSize(productId));
+
+      details.push({
+        productId,
+        name: data.name,
+        dailyUsage: Math.round(data.dailyUsage * 100) / 100,
+        usageSource: data.source,
+        leadTime,
+        reorderPoint,
+        parLevel,
+        maxLevel,
+      });
+
+      return prisma.parLevel.upsert({
+        where: { productId_outletId: { productId, outletId } },
+        create: {
+          productId,
+          outletId,
+          parLevel,
+          reorderPoint,
+          maxLevel,
+          avgDailyUsage: Math.round(data.dailyUsage * 100) / 100,
+          lastCalculated: new Date(),
+        },
+        update: {
+          parLevel,
+          reorderPoint,
+          maxLevel,
+          avgDailyUsage: Math.round(data.dailyUsage * 100) / 100,
+          lastCalculated: new Date(),
+        },
+      });
+    })
+    .filter(Boolean);
+
+  await Promise.all(upserts);
+
+  return {
+    ok: true,
+    salesTransactions: salesCount,
+    menuItemsWithSales: Object.keys(avgDailySalesByMenu).length,
+    productsUpdated: upserts.length,
+    fallbackProducts,
+    lookbackDays,
+    settings: { safetyDays, coverageDays },
+    details: details.sort((a, b) => a.name.localeCompare(b.name)),
+  };
+}

--- a/apps/backoffice/vercel.json
+++ b/apps/backoffice/vercel.json
@@ -167,6 +167,10 @@
     {
       "path": "/api/cron/procurement-exec",
       "schedule": "0 1 * * *"
+    },
+    {
+      "path": "/api/cron/par-levels-recalc",
+      "schedule": "7 19 * * 0"
     }
   ]
 }


### PR DESCRIPTION
All 336 par levels froze at their **2026-04-12** values because the calculation was manual-only — every reorder suggestion has been April-shaped since. The calc already reads POS-native sales (live: ~5.3k completed orders/30d across 3 outlets); it just never re-ran.

- **Shared lib** `lib/inventory/par-calc.ts`, used by the on-demand route and a new **weekly cron** `/api/cron/par-levels-recalc` (Mondays 03:07 MYT) covering every outlet with a POS-native mapping. Outlets with no sales in the window are skipped, not zeroed.
- **Reorder point is no longer package-rounded**: rounding it up to a bulk carton made reorder == par (== often max) on **220/336 rows** — those items read "below reorder" permanently. The trigger stays statistical; par (the fill-to amount) keeps package rounding; `maxLevel` floors at par + one package so a minimal top-up never breaches the ceiling.
- **Purchase-history fallback usage**: orderable products the BOM doesn't reach (packaging, direct-sale items) get `avgDailyUsage` from 60 days of receivings (converted per line's package factor) — napkins/cups/cakes gain pars + suggestions instead of being invisible to the loop.
- Drop the dead "preserve manual overrides" fetch — pars are engine-managed; each recalc overwrites (tune via recipes/lead times/safety days).

After deploy: open `/api/cron/par-levels-recalc` once as OWNER/ADMIN to refresh pars immediately (otherwise the first automatic run is Monday).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01SrjfLzrbEAQdNUBgawNqE5)_