### PR TITLE
fix(finance): Grab commission rate nets out marketing deductions

### DIFF
--- a/apps/backoffice/src/lib/finance/reports/pnl-sourced-drill.ts
+++ b/apps/backoffice/src/lib/finance/reports/pnl-sourced-drill.ts
@@ -243,8 +243,11 @@ export async function sourcedPnlDrillDown(args: {
     ]);
     const gross = round2(rev.reduce((s, r) => s + r.amount, 0));
     const est = round2(gross * gr.rate);
+    // Grab's payout nets off commission AND marketing (promos, GrabAds); the
+    // marketing part is booked on its own P&L lines, so the commission rate
+    // excludes it — else the marketing spend would double-count.
     const basis = gr.source === "recon"
-      ? `Effective rate ${Math.round(gr.rate * 100)}% from the payout reconciliation: over the trailing window, Grab paid out RM${gr.windowPayouts.toFixed(2)} against RM${gr.windowGross.toFixed(2)} gross Grab sales.`
+      ? `Effective commission ${Math.round(gr.rate * 100)}% from the payout reconciliation: over the trailing window, gross Grab sales RM${gr.windowGross.toFixed(2)} less payouts RM${gr.windowPayouts.toFixed(2)}, merchant promos RM${gr.windowPromos.toFixed(2)} and GrabAds RM${gr.windowAds.toFixed(2)} (both booked as their own marketing lines) leaves the commission portion.`
       : `Fallback rate ${Math.round(gr.rate * 100)}% (payout window too thin to derive the effective rate).`;
     return [{
       transactionId: "grab-comm-estimate",

--- a/apps/backoffice/src/lib/finance/reports/pnl-sourced.ts
+++ b/apps/backoffice/src/lib/finance/reports/pnl-sourced.ts
@@ -54,27 +54,41 @@ const BANK_REVIEW = new Set(["OTHER_OUTFLOW"]);
 // whichever company booked the Grab revenue — independent of which bank
 // account the net payout lands in.
 //
-// The RATE is derived from the reconciliation itself: effective deduction =
-// 1 − (Grab bank payouts ÷ gross Grab sales) over a trailing window, pooled
-// across all companies to smooth weekly payout timing. Payouts land under the
-// GRAB category — plus GRAB_PUTRAJAYA, Conezion's payouts settling into the
-// HQ account. Falls back to the last observed ~43% when the window is too
-// thin to trust, and clamps to a sane band so one weird payout week can't
-// swing the P&L.
-const GRAB_RATE_FALLBACK = 0.43;
+// The RATE is derived from the reconciliation itself. Grab's payout nets off
+// EVERYTHING at source — commission AND the marketing deductions (merchant-
+// funded promos, GrabAds). The promos and ads are already booked as their own
+// P&L lines (MKT-GRAB-PROMO / MKT-GRAB-ADS), so the COMMISSION portion must
+// exclude them or the marketing spend double-counts:
+//
+//   commission(window) = gross − payouts − promos − ads
+//   rate = commission ÷ gross
+//
+// pooled over a trailing window across all companies to smooth weekly payout
+// timing. Payouts land under the GRAB category — plus GRAB_PUTRAJAYA,
+// Conezion's payouts settling into the HQ account. Falls back to ~30% (Grab's
+// nominal commission) when the window is too thin, and clamps to a sane band
+// so one weird payout week can't swing the P&L.
+const GRAB_RATE_FALLBACK = 0.3;
 const GRAB_RATE_WINDOW_DAYS = 120;
 const GRAB_RATE_MIN_GROSS = 20_000; // below this the window is too thin to trust
 
-export type GrabRate = { rate: number; source: "recon" | "fallback"; windowGross: number; windowPayouts: number };
+export type GrabRate = {
+  rate: number;
+  source: "recon" | "fallback";
+  windowGross: number;
+  windowPayouts: number;
+  windowPromos: number;
+  windowAds: number;
+};
 
 export async function effectiveGrabRate(end: string): Promise<GrabRate> {
   const winEnd = dEnd(end);
   const winStart = new Date(winEnd.getTime() - GRAB_RATE_WINDOW_DAYS * 86400_000);
-  const fallback: GrabRate = { rate: GRAB_RATE_FALLBACK, source: "fallback", windowGross: 0, windowPayouts: 0 };
+  const fallback: GrabRate = { rate: GRAB_RATE_FALLBACK, source: "fallback", windowGross: 0, windowPayouts: 0, windowPromos: 0, windowAds: 0 };
   try {
     // Gross Grab sales in the window, pooled: StoreHub archive (pre-cutover
     // grab channel) + POS-native grabfood orders. Totals in RM / sen.
-    const [sh, pn, pay] = await Promise.all([
+    const [sh, pn, pay, promo, ads] = await Promise.all([
       prisma.$queryRaw<{ t: number | null }[]>(Prisma.sql`
         SELECT COALESCE(SUM(total), 0)::float AS t FROM storehub_sales
         WHERE is_cancelled IS NOT TRUE AND channel ~* 'grab'
@@ -93,13 +107,26 @@ export async function effectiveGrabRate(end: string): Promise<GrabRate> {
           txnDate: { gte: winStart, lte: winEnd },
         },
       }),
+      // Marketing deductions Grab nets off the same payouts — booked as their
+      // own P&L lines, so they must NOT be inside the commission rate.
+      prisma.$queryRaw<{ t: number | null }[]>(Prisma.sql`
+        SELECT COALESCE(SUM(grab_merchant_promo), 0)::float / 100 AS t FROM pos_orders
+        WHERE source = 'grabfood' AND status = 'completed'
+          AND created_at >= ${winStart} AND created_at <= ${winEnd}
+      `),
+      prisma.$queryRaw<{ t: number | null }[]>(Prisma.sql`
+        SELECT COALESCE(SUM(amount_sen), 0)::float / 100 AS t FROM grab_ads_spend
+        WHERE period_start >= ${winStart} AND period_start <= ${winEnd}
+      `),
     ]);
     const gross = round2(Number(sh[0]?.t ?? 0) + Number(pn[0]?.t ?? 0));
     const payouts = round2(Number(pay._sum?.amount ?? 0));
+    const promos = round2(Number(promo[0]?.t ?? 0));
+    const adsSpend = round2(Number(ads[0]?.t ?? 0));
     if (gross < GRAB_RATE_MIN_GROSS || payouts <= 0) return fallback;
-    const raw = 1 - payouts / gross;
-    const rate = Math.min(0.55, Math.max(0.25, round2(raw)));
-    return { rate, source: "recon", windowGross: gross, windowPayouts: payouts };
+    const raw = (gross - payouts - promos - adsSpend) / gross;
+    const rate = Math.min(0.5, Math.max(0.15, round2(raw)));
+    return { rate, source: "recon", windowGross: gross, windowPayouts: payouts, windowPromos: promos, windowAds: adsSpend };
   } catch {
     return fallback;
   }


### PR DESCRIPTION
Owner correction on #707: Grab pays out only **after deducting commission AND marketing fees** — the payout gap is not commission alone.

Merchant-funded promos and GrabAds are already booked as their own P&L lines (`MKT-GRAB-PROMO` / `MKT-GRAB-ADS`), so deriving "commission" as `1 − payouts/gross` **double-counted the marketing portion** — which is why the effective rate read 50%.

## Fix

```
commission(window) = gross − payouts − promos − ads
rate = commission ÷ gross
```

- promos = `pos_orders.grab_merchant_promo` over the window; ads = `grab_ads_spend` over the window (both deducted at source by Grab, both already separate P&L lines).
- Clamp tightened to 15–50%; fallback drops to Grab's nominal **30%** commission.
- `GrabRate` exposes `windowPromos` / `windowAds`; the drill-down spells out the full payout math (gross − payouts − promos − ads → commission).

Total Grab cost on the P&L (commission + promos + ads) now ties to the actual payout gap without overlap.

Typecheck + lint clean.
