### PR TITLE
feat(finance): manual commit on /api/finance/gl-post (POST)

### DIFF
--- a/apps/backoffice/src/app/api/finance/gl-post/route.ts
+++ b/apps/backoffice/src/app/api/finance/gl-post/route.ts
@@ -7,7 +7,7 @@ import { requireAuth } from "@/lib/auth";
 import { postBankLinesToGl } from "@/lib/finance/gl-posting";
 
 export const dynamic = "force-dynamic";
-export const maxDuration = 60;
+export const maxDuration = 300;
 
 export async function GET(req: NextRequest) {
   const auth = await requireAuth(req);
@@ -18,6 +18,27 @@ export async function GET(req: NextRequest) {
   try {
     const preview = await postBankLinesToGl({ commit: false });
     return NextResponse.json(preview);
+  } catch (err) {
+    return NextResponse.json({ error: err instanceof Error ? err.message : String(err) }, { status: 500 });
+  }
+}
+
+// Manual commit — the header comment always promised this but only the cron
+// had it. Body: { limit?: number } to bound a run; call repeatedly to drain.
+export async function POST(req: NextRequest) {
+  const auth = await requireAuth(req);
+  if (auth.error) return auth.error;
+  if (!["OWNER", "ADMIN"].includes(auth.user.role)) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+  let limit: number | undefined;
+  try {
+    const body = (await req.json()) as { limit?: number };
+    if (typeof body?.limit === "number" && body.limit > 0) limit = Math.floor(body.limit);
+  } catch { /* empty body — no limit */ }
+  try {
+    const result = await postBankLinesToGl({ commit: true, limit });
+    return NextResponse.json(result);
   } catch (err) {
     return NextResponse.json({ error: err instanceof Error ? err.message : String(err) }, { status: 500 });
   }


### PR DESCRIPTION
The route's header comment always said **POST commits**, but only GET (dry-run) was implemented — the commit path lived solely in the 6h cron chain. This adds the POST handler: commits with an optional `{ limit }` bound (call repeatedly to drain), OWNER/ADMIN session auth, `maxDuration` 300 to match the cron's budget.

Needed right now to drive the GL re-key after the classifier-v2 reclassification (move the old OTHER_OUTFLOW Suspense journals to the corrected contra accounts) without waiting multiple cron cycles. Also generally useful as the manual lever the dry-run GET always implied.

Typecheck clean.