### PR TITLE
fix(procurement): drop the global allowlist gate from PO-send (automationMode is the control)

### DIFF
--- a/apps/backoffice/src/lib/inventory/procurement-po-send.ts
+++ b/apps/backoffice/src/lib/inventory/procurement-po-send.ts
@@ -4,8 +4,10 @@
  * same message staff send by hand via wa.me today — so suppliers see the format
  * they already know.
  *
- * Gated by PROCUREMENT_AGENT_ENABLED + PROCUREMENT_AGENT_ALLOWLIST (scoped to the
- * test supplier for the first live run). De-duped per PO via the outbound row's
+ * Gated by PROCUREMENT_AGENT_ENABLED (master switch) + the per-supplier Supplier.automationMode
+ * dial: OFF = manual/group lane (skipped + noted here), ASSIST/AUTO = auto-send. (The old global
+ * PROCUREMENT_AGENT_ALLOWLIST gate was removed — it shadowed the dial, so an ASSIST supplier was
+ * still blocked; automationMode is the real control now.) De-duped per PO via the outbound row's
  * raw.poSentFor. Free text inside the 24h customer-service window; OUTSIDE it, when
  * PROCUREMENT_PO_PROMPT_TEMPLATE is set we ping the supplier with that approved UTILITY
  * template to invite a reply (which opens the window so the PO block can follow); else the
@@ -32,18 +34,6 @@ function enabled(): boolean {
   return process.env.PROCUREMENT_AGENT_ENABLED === "true";
 }
 
-function allowed(phone: string | null | undefined): boolean {
-  const raw = process.env.PROCUREMENT_AGENT_ALLOWLIST?.trim();
-  if (!raw) return true;
-  const tail = digits(phone).slice(-8);
-  if (!tail) return false;
-  return raw
-    .split(",")
-    .map((s) => digits(s).slice(-8))
-    .filter(Boolean)
-    .includes(tail);
-}
-
 // What we read off the order the PATCH route already loaded (outlet + supplier +
 // items.product included). Loose shapes so the caller can pass its richer object.
 export interface PoForSend {
@@ -64,10 +54,6 @@ export async function sendPurchaseOrder(order: PoForSend): Promise<void> {
     if (!enabled()) return;
     const supplier = order.supplier;
     if (!supplier?.phone) return;
-    if (!allowed(supplier.phone)) {
-      await recordPoThreadNote(order, "not on PROCUREMENT_AGENT_ALLOWLIST — sent manually");
-      return;
-    }
     // OFF = the manual lane: these suppliers are ordered from by hand on the Smart Order
     // page (incl. WhatsApp GROUPS via the wa.me picker, which the Cloud API can't reach).
     // Don't also fire a Cloud-API send for them, or they'd get a duplicate 1:1 message.


### PR DESCRIPTION
## Why
PO auto-send checked `PROCUREMENT_AGENT_ALLOWLIST` **before** the per-supplier `automationMode` dial. So a supplier set to **ASSIST** (e.g. Jiju Cakes) that isn't on the pilot allowlist was still blocked — the PO got marked sent and logged as an internal *"not on PROCUREMENT_AGENT_ALLOWLIST — sent manually"* note, never actually delivered. That's the "I set it to Assist but it can't send" problem.

The allowlist was a training-wheels gate from before per-supplier modes existed; `automationMode` was meant to replace it.

## Change
Remove the allowlist gate (and the now-unused `allowed()`) from `procurement-po-send.ts`. Gating is now:
- `PROCUREMENT_AGENT_ENABLED` — master switch
- `Supplier.automationMode` — **OFF** = manual/group lane (skipped + noted in-thread), **ASSIST/AUTO** = auto-send

**This is effectively go-live for PO auto-sends to every ASSIST/AUTO supplier.** Cold sends (supplier hasn't messaged in 24h) still need the prompt template (`PROCUREMENT_PO_PROMPT_TEMPLATE`, default `procurement_new_order`) to be **approved** on Meta.

## Scope / caveat
`invoice-requester` and `receiving-requester` also read `PROCUREMENT_AGENT_ALLOWLIST` but have **no** `automationMode` fallback — removing it there would blast all suppliers, so this PR does **not** touch them. **Keep `PROCUREMENT_AGENT_ALLOWLIST` set** (clearing it would un-scope those two). A follow-up can migrate them onto the dial.

## Verify
Lint clean; my change is isolated to `procurement-po-send.ts`. (Two local tsc errors are a stale `@celsius/db` type-resolution artifact in files I didn't touch — CI builds clean, main's typecheck is green.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)