### PR TITLE
chore(hr): Payroll UI is Owner/Admin only (hidden from managers)

### DIFF
--- a/apps/backoffice/src/app/(admin)/hr/page.tsx
+++ b/apps/backoffice/src/app/(admin)/hr/page.tsx
@@ -121,6 +121,9 @@ type DashboardData = {
 
 export default function HRDashboardPage() {
   const { data, mutate } = useFetch<DashboardData>("/api/hr/dashboard");
+  // Payroll is Owner/Admin only — hide the Payroll card + stat from managers.
+  const { data: me } = useFetch<{ role: string }>("/api/auth/me");
+  const canSeePayroll = me?.role === "OWNER" || me?.role === "ADMIN";
   const [processing, setProcessing] = useState(false);
 
   const runProcessor = async () => {
@@ -187,7 +190,7 @@ export default function HRDashboardPage() {
 
       {/* Status Cards */}
       <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
-        {cards.map((card) => {
+        {cards.filter((card) => canSeePayroll || card.label !== "Payroll").map((card) => {
           const Icon = card.icon;
           return (
             <Link
@@ -211,7 +214,7 @@ export default function HRDashboardPage() {
       {/* Module hub — BrioHR-style: one card per module, sub-pages as inline
           links (same groups as the sidebar + in-module tab strips). */}
       <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
-        {MODULES.map((m) => {
+        {MODULES.filter((m) => canSeePayroll || m.label !== "Payroll").map((m) => {
           const Icon = m.icon;
           return (
             <div key={m.label} className="rounded-xl border bg-card p-4 shadow-sm transition hover:shadow-md">

--- a/apps/backoffice/src/app/(admin)/layout.tsx
+++ b/apps/backoffice/src/app/(admin)/layout.tsx
@@ -563,6 +563,12 @@ function canAccess(user: UserProfile | undefined, moduleKey?: string): boolean {
   if (moduleKey?.startsWith("finance:")) {
     return user.role === "ADMIN" || user.role === "OWNER";
   }
+  // Payroll (runs / allowances / statutory) is Owner/Admin only — managers never
+  // see it in the nav even if the moduleAccess checkbox is set (payroll routes are
+  // OWNER/ADMIN-gated too). Keeps pay off managers' screens.
+  if (moduleKey === "hr:payroll" || moduleKey === "hr:allowances") {
+    return user.role === "ADMIN" || user.role === "OWNER";
+  }
   if (user.role === "ADMIN" || user.role === "OWNER") return true;
   if (!moduleKey) return true;
   if (!user.moduleAccess) return false;

--- a/apps/backoffice/src/components/hr/module-tabs.tsx
+++ b/apps/backoffice/src/components/hr/module-tabs.tsx
@@ -2,6 +2,7 @@
 
 import Link from "next/link";
 import { usePathname } from "next/navigation";
+import { useFetch } from "@/lib/use-fetch";
 
 // BrioHR-style in-module tab strip. The sidebar picks the module; this strip
 // switches between the module's sibling pages without going back through the
@@ -67,13 +68,19 @@ const TAB_GROUPS: { module: string; tabs: { href: string; label: string }[] }[] 
 
 export function HrModuleTabs() {
   const pathname = usePathname();
+  // Payroll is Owner/Admin only — managers never get the Payroll tab group.
+  // (Hook must run before the settings early-return below.)
+  const { data: me } = useFetch<{ role: string }>("/api/auth/me");
+  const canSeePayroll = me?.role === "OWNER" || me?.role === "ADMIN";
+
   // Settings pages keep their own SettingsNav as the primary strip — only the
   // Leave group cross-links into settings, and there the SettingsNav already
   // gives Balances/Policies/Holidays switching, so suppress ours to avoid a
   // double tab row.
   if (pathname.startsWith("/hr/settings")) return null;
 
-  const group = TAB_GROUPS.find((g) => g.tabs.some((t) => t.href === pathname));
+  const groups = canSeePayroll ? TAB_GROUPS : TAB_GROUPS.filter((g) => g.module !== "Payroll");
+  const group = groups.find((g) => g.tabs.some((t) => t.href === pathname));
   if (!group) return null;
 
   return (


### PR DESCRIPTION
Payroll is an owner/admin function, so hide every backoffice Payroll entry point from **managers** while **owner/admin keep full access**. (Revised from the earlier hide-from-everyone flag per request: admin/owner can see it.)

## What changed
- **`canAccess()`** treats `hr:payroll` + `hr:allowances` as **Owner/Admin only** — same carve-out as `finance:*` — so the HR sidebar **Payroll** subgroup (Payroll Runs, Allowances, Statutory Calendar) never renders for a manager, even if the moduleAccess checkbox is set. Consistent with the payroll API routes, which are already OWNER/ADMIN-gated.
- **HR landing page** hides the Payroll module card + the Payroll status stat unless the role is OWNER/ADMIN.
- **In-module tab strip** drops the Payroll tab group for non-owner/admin.

Role is read from `/api/auth/me` (SWR-deduped with the sidebar's existing fetch). No global flag; no wiring touched.

## Result
- **Owner / Admin:** see and use Payroll (Runs, Weekly, Allowances, Statutory) as normal.
- **Managers (and other roles):** no Payroll anywhere in the backoffice.
- Staff-app Payslips remain hidden pre-launch via the separate staff flag ([#706](https://github.com/celsiuscoffee/celsius-ops/pull/706)).

## Verification
Changed files typecheck + eslint clean (only pre-existing warnings; the `@celsius/db` tsc error in a local run is a worktree symlink artifact — CI confirms).