### PR TITLE
fix(finance): posting key moves off source_doc_id (FK to fin_documents)

### DIFF
--- a/apps/backoffice/src/lib/finance/gl-posting.ts
+++ b/apps/backoffice/src/lib/finance/gl-posting.ts
@@ -24,7 +24,7 @@
 //      line is never posted again (and the feed sync now carries stamps across
 //      its rebuild).
 //   2. Journal layer — each journal's identity is DETERMINISTIC:
-//      source_doc_id = md5(company|outlet|contra|day|direction). If a journal
+//      posting_key = md5(company|outlet|contra|day|direction). If a journal
 //      for the group already exists, it is REUSED: unlinked (rebuilt) lines are
 //      re-stamped onto it, and genuinely new lines for an already-posted day
 //      fold in by updating the journal amount (additive).
@@ -40,7 +40,7 @@ import type { JournalLineInput } from "./types";
 import { BANK_CASH, companyFromAccountName, resolveContra, round2, SKIP_CATS } from "./gl-posting-map";
 
 // Deterministic journal identity for a (company, outlet, contra, day, direction)
-// aggregate. Formatted as a UUID so it fits fin_transactions.source_doc_id and
+// aggregate. Formatted as a UUID so it fits fin_transactions.posting_key and
 // matches postgres md5(text)::uuid — SQL backfills can reproduce it exactly.
 export function bankJournalKey(company: string, outletId: string | null, contra: string, date: string, direction: string): string {
   const h = createHash("md5").update(`bank-gl|${company}|${outletId ?? ""}|${contra}|${date}|${direction}`).digest("hex");
@@ -146,7 +146,7 @@ export async function postBankLinesToGl(
       const { data: existingRows, error: exErr } = await fin
         .from("fin_transactions")
         .select("id, amount")
-        .eq("source_doc_id", key)
+        .eq("posting_key", key)
         .eq("posted_by_agent", "bank")
         .eq("status", "posted")
         .limit(1);
@@ -165,7 +165,7 @@ export async function postBankLinesToGl(
           agent: "bank",
           agentVersion: "bank-gl-v1",
           confidence: 1,
-          sourceDocId: key,
+          postingKey: key,
           lines: journalLines,
         });
         txnId = res.transactionId;

--- a/apps/backoffice/src/lib/finance/ledger.ts
+++ b/apps/backoffice/src/lib/finance/ledger.ts
@@ -62,6 +62,7 @@ export async function postJournal(input: PostJournalInput): Promise<PostJournalR
     amount: totalDebit,
     currency: "MYR",
     source_doc_id: input.sourceDocId ?? null,
+    posting_key: input.postingKey ?? null,
     txn_type: input.txnType,
     posted_by_agent: input.agent,
     agent_version: input.agentVersion,

--- a/apps/backoffice/src/lib/finance/types.ts
+++ b/apps/backoffice/src/lib/finance/types.ts
@@ -60,6 +60,10 @@ export type PostJournalInput = {
   txnType: TxnType;
   outletId?: string | null;
   sourceDocId?: string | null;
+  // Deterministic identity for DERIVED journals (e.g. bank day-aggregates):
+  // md5-uuid of the aggregation key, unique-indexed so a group can never post
+  // twice. NOT source_doc_id — that is an FK to fin_documents.
+  postingKey?: string | null;
   agent: AgentName;
   agentVersion: string;
   confidence: number;     // 0-1; agents below their threshold should NOT call this — they should write fin_exceptions instead

--- a/supabase/migrations/066_fin_transactions_posting_key.sql
+++ b/supabase/migrations/066_fin_transactions_posting_key.sql
@@ -1,0 +1,8 @@
+-- Deterministic posting identity for DERIVED journals (bank day-aggregates).
+-- The idempotent poster (#694) stored its md5 aggregation key in
+-- source_doc_id, which is an FK to fin_documents — every bank post failed the
+-- constraint. Dedicated column instead, unique so a group can never post twice.
+-- (Already applied to production 2026-07-02; file recorded for reproducibility.)
+alter table fin_transactions add column if not exists posting_key uuid;
+create unique index if not exists uq_fin_transactions_posting_key
+  on fin_transactions(posting_key) where posting_key is not null;


### PR DESCRIPTION
Found live: since #694 deployed, **every bank GL post failed** — the deterministic journal key was stored in `source_doc_id`, which turned out to be a **foreign key to fin_documents**, so each insert violated the constraint. The cron absorbed the failures silently into the result's `errors` array (184 errors per run, `[object Object]` because Supabase error objects throw raw).

## Fix
- Migration 066 (**already applied to production**): `fin_transactions.posting_key uuid` + partial unique index — a group can never post twice.
- `PostJournalInput.postingKey` inserted atomically by `postJournal`; the poster looks up and writes `posting_key` instead of `source_doc_id` (which stays what it is: a document FK).

Typecheck clean; 41 finance tests pass. After deploy the stalled re-key drain resumes (3,490 lines waiting).