### PR TITLE
feat(finance): classify CARD SALES debits as bank charges (terminal MDR)

### DIFF
--- a/apps/backoffice/src/lib/finance/bank-line-classifier.test.ts
+++ b/apps/backoffice/src/lib/finance/bank-line-classifier.test.ts
@@ -44,6 +44,12 @@ describe("bank-line-classifier", () => {
     expect(dr("TRANSFER FR A/C TUJUAN GEMILANG rent").category).toBe("RENT");
   });
 
+  it("books CARD SALES debits as bank charges (terminal MDR), credits as CARD", () => {
+    expect(dr("DR/CARD SALES M/N 2612988 D 5").category).toBe("BANK_FEE");
+    expect(dr("CR/CARD SALES M/N 2612988 DATED 010626 D").category).toBe("BANK_FEE");
+    expect(cr("DR/CARD SALES M/N 2612988 D 5").category).toBe("CARD");
+  });
+
   it("falls back to OTHER_* for genuinely unknown lines", () => {
     expect(dr("TRANSFER FR A/C SOME UNKNOWN VENDOR XYZ").category).toBe("OTHER_OUTFLOW");
     expect(cr("MISC CREDIT NO PATTERN").category).toBe("OTHER_INFLOW");

--- a/apps/backoffice/src/lib/finance/bank-line-classifier.ts
+++ b/apps/backoffice/src/lib/finance/bank-line-classifier.ts
@@ -210,6 +210,10 @@ const OUTFLOW_RULES: Rule[] = [
 
   // Bank fees
   { name: "bank_fee",       match: /\b(SERVICE\s*FEE|HANDLING\s*FEE|BANK\s*CHARGE|MAINTENANCE\s*FEE|GIRO\s*FEE)\b/i, direction: "DR", category: "BANK_FEE" as CashCategory },
+  // "DR/CARD SALES" on the DEBIT side is the terminal MDR charge the bank
+  // nets off each card settlement (the CR twin is the settlement itself,
+  // matched by card_terminal above). Per the owner: book as a bank charge.
+  { name: "bank_fee_card_mdr", match: /\b(?:DR|CR)\/?CARD\s*SALES?\b/i, direction: "DR", category: "BANK_FEE" as CashCategory },
 
   // Marketing — for now ONLY Google Ads + SMS Niaga (per owner). Google Ads is
   // also pulled from the ads module, so DIGITAL_ADS is DEDUPED out of the bank


### PR DESCRIPTION
Owner directive: `DR/CARD SALES` debit lines are the per-settlement MDR charge the bank nets off card sales — auto-classify as bank charges.

~895 such lines (small per-transaction amounts, ~RM1.7k total) were sitting in OTHER_OUTFLOW. New `bank_fee_card_mdr` rule books the DR side as BANK_FEE (→ 6514 Bank Charges via the GL bridge); the CR twin stays a CARD settlement. Existing lines get reclassified by SQL now and stay correct on future feed re-syncs.

11/11 classifier tests, typecheck clean.