### PR TITLE
feat(finance): manual reconciliation — reclassify pass + per-line classify/match on /finance/recon

### DIFF
--- a/apps/backoffice/src/app/(admin)/finance/recon/page.tsx
+++ b/apps/backoffice/src/app/(admin)/finance/recon/page.tsx
@@ -26,9 +26,38 @@ type ReconData = {
 const fmtRM = (n: number) => `RM ${n.toLocaleString("en-MY", { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`;
 const fmtRM0 = (n: number) => `RM ${n.toLocaleString("en-MY", { maximumFractionDigits: 0 })}`;
 
+// Outflow categories a human can assign — mirrors CashCategory (validated
+// server-side against the Prisma enum).
+const MANUAL_CATEGORIES = [
+  "RAW_MATERIALS", "RENT", "UTILITIES", "MAINTENANCE", "EQUIPMENTS", "SOFTWARE",
+  "STAFF_CLAIM", "PARTIMER", "EMPLOYEE_SALARY", "STATUTORY_PAYMENT", "TAX",
+  "COMPLIANCE", "LICENSING_FEE", "BANK_FEE", "MARKETPLACE_FEE", "OTHER_MARKETING",
+  "KOL", "DELIVERY", "PETTY_CASH", "LOAN", "DIVIDEND", "DIRECTORS_ALLOWANCE",
+  "CAPITAL", "INVESTMENTS", "MANAGEMENT_FEE", "CFS_FEE",
+] as const;
+
 export default function ReconPage() {
   const [days, setDays] = useState(90);
-  const { data, isLoading } = useFetch<ReconData>(`/api/finance/ap-match?sinceDays=${days}`);
+  const { data, isLoading, mutate } = useFetch<ReconData>(`/api/finance/ap-match?sinceDays=${days}`);
+  const [reclassifying, setReclassifying] = useState(false);
+  const [reclassNote, setReclassNote] = useState<string | null>(null);
+
+  async function rerunRules() {
+    setReclassifying(true);
+    setReclassNote(null);
+    try {
+      const res = await fetch("/api/finance/reclassify", { method: "POST" });
+      const j = await res.json();
+      setReclassNote(res.ok
+        ? `Re-classified ${j.changed} lines (RM ${Math.round(j.changedValue).toLocaleString("en-MY")}); ${j.unstampedJournals} journals queued for GL re-key.`
+        : `Failed: ${j.error ?? res.status}`);
+      mutate();
+    } catch (e) {
+      setReclassNote(`Failed: ${e instanceof Error ? e.message : String(e)}`);
+    } finally {
+      setReclassifying(false);
+    }
+  }
 
   return (
     <div className="p-3 sm:p-6">
@@ -106,21 +135,29 @@ export default function ReconPage() {
             <MatchTable rows={data.review} showReasons />
           </Section>
 
-          <Section id="recon-unmatched-out" title="Unmatched outflows — unreconciled cash-out" desc="Bank payments with no matching invoice yet. The pile to drive to zero.">
+          <Section id="recon-unmatched-out" title="Unmatched outflows — unreconciled cash-out" desc="Bank payments with no matching invoice yet. Reconcile manually: pick a category (books it to that expense) or match it to its invoice.">
+            <div className="flex items-center gap-2 border-b border-gray-100 px-4 py-2">
+              <button
+                onClick={rerunRules}
+                disabled={reclassifying}
+                className="rounded-md border border-gray-200 bg-white px-2.5 py-1 text-xs font-medium text-gray-700 hover:bg-gray-50 disabled:opacity-50"
+              >
+                {reclassifying ? "Re-running rules…" : "Re-run classifier rules"}
+              </button>
+              <span className="text-[11px] text-gray-400">
+                {reclassNote ?? "Applies the current rules to this pile first — most known payees clear automatically."}
+              </span>
+            </div>
             <div className="overflow-x-auto">
-              <table className="w-full min-w-[640px] text-sm">
+              <table className="w-full min-w-[760px] text-sm">
                 <thead><tr className="border-b bg-gray-50/50 text-left text-gray-500">
                   <th className="px-3 py-2 font-medium">Date</th><th className="px-3 py-2 font-medium">Description</th>
                   <th className="px-3 py-2 font-medium">Category</th><th className="px-3 py-2 text-right font-medium">Amount</th>
+                  <th className="px-3 py-2 font-medium">Reconcile</th>
                 </tr></thead>
                 <tbody className="divide-y">
                   {data.unmatchedOutflows.slice(0, 100).map((o) => (
-                    <tr key={o.bankLineId} className="hover:bg-gray-50">
-                      <td className="px-3 py-2 text-xs text-gray-500 whitespace-nowrap">{o.date}</td>
-                      <td className="px-3 py-2 text-xs text-gray-700">{o.desc}</td>
-                      <td className="px-3 py-2 text-[11px] text-gray-400">{o.category ?? "Unclassified"}</td>
-                      <td className="px-3 py-2 text-right font-mono text-xs text-red-700">−{fmtRM(o.amount)}</td>
-                    </tr>
+                    <OutflowRow key={o.bankLineId} row={o} onDone={() => mutate()} />
                   ))}
                 </tbody>
               </table>
@@ -154,6 +191,129 @@ export default function ReconPage() {
         </>
       )}
     </div>
+  );
+}
+
+type Candidate = {
+  invoiceId: string; invoiceNumber: string | null; payee: string; amount: number;
+  issueDate: string; status: string; linkOnly: boolean;
+  amountExact: boolean; refHit: boolean; nameHit: boolean; score: number;
+};
+
+// One unmatched outflow with its manual-reconcile controls: a category select
+// (books the line to that expense; the GL re-keys on the next loop run) and a
+// Match panel listing candidate invoices to link.
+function OutflowRow({ row, onDone }: { row: { bankLineId: string; desc: string; date: string; amount: number; category: string | null }; onDone: () => void }) {
+  const [busy, setBusy] = useState(false);
+  const [note, setNote] = useState<string | null>(null);
+  const [open, setOpen] = useState(false);
+  const [cands, setCands] = useState<Candidate[] | null>(null);
+
+  async function setCategory(category: string) {
+    if (!category) return;
+    setBusy(true); setNote(null);
+    try {
+      const res = await fetch("/api/finance/bank-lines/classify", {
+        method: "POST", headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ bankLineId: row.bankLineId, category }),
+      });
+      const j = await res.json();
+      if (!res.ok) setNote(j.error ?? `Failed (${res.status})`);
+      else onDone();
+    } catch (e) { setNote(e instanceof Error ? e.message : String(e)); }
+    finally { setBusy(false); }
+  }
+
+  async function openMatch() {
+    setOpen((v) => !v);
+    if (cands || open) return;
+    try {
+      const res = await fetch(`/api/finance/bank-lines/match?bankLineId=${row.bankLineId}`);
+      const j = await res.json();
+      setCands(res.ok ? j.candidates : []);
+      if (!res.ok) setNote(j.error ?? `Failed (${res.status})`);
+    } catch (e) { setCands([]); setNote(e instanceof Error ? e.message : String(e)); }
+  }
+
+  async function applyMatch(invoiceId: string) {
+    setBusy(true); setNote(null);
+    try {
+      const res = await fetch("/api/finance/bank-lines/match", {
+        method: "POST", headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ bankLineId: row.bankLineId, invoiceId }),
+      });
+      const j = await res.json();
+      if (!res.ok) setNote(j.error ?? `Failed (${res.status})`);
+      else onDone();
+    } catch (e) { setNote(e instanceof Error ? e.message : String(e)); }
+    finally { setBusy(false); }
+  }
+
+  return (
+    <>
+      <tr className="hover:bg-gray-50">
+        <td className="px-3 py-2 text-xs text-gray-500 whitespace-nowrap align-top">{row.date}</td>
+        <td className="px-3 py-2 text-xs text-gray-700 align-top">
+          {row.desc}
+          {note && <div className="mt-0.5 text-[10px] text-red-600">{note}</div>}
+        </td>
+        <td className="px-3 py-2 text-[11px] text-gray-400 align-top">{row.category ?? "Unclassified"}</td>
+        <td className="px-3 py-2 text-right font-mono text-xs text-red-700 align-top">−{fmtRM(row.amount)}</td>
+        <td className="px-3 py-2 align-top">
+          <div className="flex items-center gap-1.5">
+            <select
+              defaultValue=""
+              disabled={busy}
+              onChange={(e) => setCategory(e.target.value)}
+              className="h-6 max-w-[130px] rounded border border-gray-200 bg-white px-1 text-[11px] text-gray-700 disabled:opacity-50"
+              title="Book this payment to a category"
+            >
+              <option value="" disabled>Set category…</option>
+              {MANUAL_CATEGORIES.map((c) => <option key={c} value={c}>{c.toLowerCase().replace(/_/g, " ")}</option>)}
+            </select>
+            <button
+              onClick={openMatch}
+              disabled={busy}
+              className={`h-6 rounded border px-1.5 text-[11px] font-medium disabled:opacity-50 ${open ? "border-terracotta text-terracotta" : "border-gray-200 text-gray-600 hover:bg-gray-50"}`}
+            >
+              Match…
+            </button>
+          </div>
+        </td>
+      </tr>
+      {open && (
+        <tr className="bg-gray-50/60">
+          <td colSpan={5} className="px-3 py-2">
+            {!cands ? (
+              <span className="text-[11px] text-gray-400">Looking for candidate invoices…</span>
+            ) : cands.length === 0 ? (
+              <span className="text-[11px] text-gray-400">No candidate invoices near this amount/date. Set a category instead.</span>
+            ) : (
+              <div className="flex flex-col gap-1">
+                {cands.map((c) => (
+                  <div key={c.invoiceId} className="flex flex-wrap items-center gap-2 rounded border border-gray-200 bg-white px-2 py-1">
+                    <span className="text-xs text-gray-700">{c.payee}{c.invoiceNumber ? <span className="text-gray-400"> · {c.invoiceNumber}</span> : ""}</span>
+                    <span className="font-mono text-[11px] text-gray-600">{fmtRM(c.amount)}</span>
+                    <span className="text-[10px] text-gray-400">{c.issueDate}</span>
+                    {c.amountExact && <span className="rounded bg-green-50 px-1 text-[10px] text-green-700">amount exact</span>}
+                    {c.refHit && <span className="rounded bg-green-50 px-1 text-[10px] text-green-700">invoice no in line</span>}
+                    {c.nameHit && <span className="rounded bg-green-50 px-1 text-[10px] text-green-700">name hit</span>}
+                    {c.linkOnly && <span className="rounded bg-amber-50 px-1 text-[10px] text-amber-700">already paid — link only</span>}
+                    <button
+                      onClick={() => applyMatch(c.invoiceId)}
+                      disabled={busy}
+                      className="ml-auto h-6 rounded bg-terracotta px-2 text-[11px] font-medium text-white disabled:opacity-50"
+                    >
+                      Match
+                    </button>
+                  </div>
+                ))}
+              </div>
+            )}
+          </td>
+        </tr>
+      )}
+    </>
   );
 }
 

--- a/apps/backoffice/src/app/api/finance/bank-lines/classify/route.ts
+++ b/apps/backoffice/src/app/api/finance/bank-lines/classify/route.ts
@@ -1,0 +1,49 @@
+// POST /api/finance/bank-lines/classify — manually classify a bank line.
+// Body: { bankLineId, category }
+//
+// Sets classifiedBy='user' so rule re-runs and feed rebuilds never overwrite
+// it (the sync's carry-over preserves user classifications). If the line was
+// already posted to the GL under the old category, the WHOLE day-aggregate
+// journal is un-stamped so the poster re-keys it — un-stamping only this line
+// would leave the old journal over-stated.
+
+import { NextRequest, NextResponse } from "next/server";
+import { requireAuth } from "@/lib/auth";
+import { prisma } from "@/lib/prisma";
+import { CashCategory } from "@prisma/client";
+
+export const dynamic = "force-dynamic";
+
+export async function POST(req: NextRequest) {
+  const auth = await requireAuth(req);
+  if (auth.error) return auth.error;
+  if (!["OWNER", "ADMIN"].includes(auth.user.role)) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+  let body: { bankLineId?: string; category?: string } = {};
+  try { body = await req.json(); } catch { /* handled below */ }
+  const { bankLineId, category } = body;
+  if (!bankLineId || !category) return NextResponse.json({ error: "bankLineId and category required" }, { status: 400 });
+  if (!(category in CashCategory)) return NextResponse.json({ error: `Unknown category ${category}` }, { status: 400 });
+
+  const line = await prisma.bankStatementLine.findUnique({
+    where: { id: bankLineId },
+    select: { id: true, category: true, glTransactionId: true, apInvoiceId: true },
+  });
+  if (!line) return NextResponse.json({ error: "Bank line not found" }, { status: 404 });
+  if (line.apInvoiceId) return NextResponse.json({ error: "Line is AP-matched — unmatch it first" }, { status: 409 });
+
+  await prisma.$transaction(async (tx) => {
+    await tx.bankStatementLine.update({
+      where: { id: bankLineId },
+      data: { category: category as CashCategory, classifiedBy: "user", ruleName: "manual" },
+    });
+    if (line.glTransactionId) {
+      await tx.bankStatementLine.updateMany({
+        where: { glTransactionId: line.glTransactionId },
+        data: { glTransactionId: null, glPostedAt: null },
+      });
+    }
+  });
+  return NextResponse.json({ ok: true, rekeyed: !!line.glTransactionId });
+}

--- a/apps/backoffice/src/app/api/finance/bank-lines/match/route.ts
+++ b/apps/backoffice/src/app/api/finance/bank-lines/match/route.ts
@@ -1,0 +1,122 @@
+// Manual invoice matching for a bank line.
+//
+// GET  ?bankLineId=…       → ranked candidate invoices (amount proximity,
+//                            payee/invoice-no hits, open before paid-unlinked)
+// POST { bankLineId, invoiceId } → apply: link the line (and mark the invoice
+//                            paid unless it was already settled via another
+//                            route — then it's link-only, invoice untouched).
+
+import { NextRequest, NextResponse } from "next/server";
+import { requireAuth } from "@/lib/auth";
+import { prisma } from "@/lib/prisma";
+import { writeApMatch, digitRuns, invoiceRefInDesc, type ApMatch } from "@/lib/finance/ap-match";
+
+export const dynamic = "force-dynamic";
+
+const round2 = (n: number) => Math.round(n * 100) / 100;
+const ymd = (d: Date) => d.toISOString().slice(0, 10);
+
+async function guard(req: NextRequest) {
+  const auth = await requireAuth(req);
+  if (auth.error) return auth.error;
+  if (!["OWNER", "ADMIN"].includes(auth.user.role)) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+  return null;
+}
+
+export async function GET(req: NextRequest) {
+  const err = await guard(req);
+  if (err) return err;
+  const bankLineId = new URL(req.url).searchParams.get("bankLineId");
+  if (!bankLineId) return NextResponse.json({ error: "bankLineId required" }, { status: 400 });
+
+  const line = await prisma.bankStatementLine.findUnique({
+    where: { id: bankLineId },
+    select: { id: true, description: true, amount: true, txnDate: true, apInvoiceId: true },
+  });
+  if (!line) return NextResponse.json({ error: "Bank line not found" }, { status: 404 });
+  if (line.apInvoiceId) return NextResponse.json({ error: "Already matched" }, { status: 409 });
+
+  const amt = Number(line.amount);
+  const descLower = (line.description ?? "").toLowerCase();
+  const runs = digitRuns(descLower);
+  const windowStart = new Date(line.txnDate.getTime() - 120 * 86400_000);
+
+  const [invoices, linkedRows] = await Promise.all([
+    prisma.invoice.findMany({
+      where: {
+        issueDate: { gte: windowStart, lte: new Date(line.txnDate.getTime() + 14 * 86400_000) },
+        amount: { gte: amt * 0.5, lte: amt * 1.5 },
+      },
+      select: {
+        id: true, invoiceNumber: true, amount: true, status: true, issueDate: true,
+        vendorName: true, supplier: { select: { name: true } },
+      },
+      take: 400,
+    }),
+    prisma.bankStatementLine.findMany({ where: { apInvoiceId: { not: null } }, select: { apInvoiceId: true } }),
+  ]);
+  const linked = new Set(linkedRows.map((r) => r.apInvoiceId as string));
+
+  const candidates = invoices
+    .filter((i) => !(i.status === "PAID" && linked.has(i.id))) // settled AND linked = done
+    .map((i) => {
+      const payee = i.supplier?.name ?? i.vendorName ?? "(unknown payee)";
+      const diff = Math.abs(Number(i.amount) - amt);
+      const nameHit = payee.length >= 4 && descLower.includes(payee.toLowerCase().split(" ")[0]);
+      const refHit = invoiceRefInDesc(i.invoiceNumber, runs);
+      const score = (diff <= 0.01 ? 3 : diff <= amt * 0.005 ? 2 : 0) + (refHit ? 3 : 0) + (nameHit ? 1 : 0);
+      return {
+        invoiceId: i.id, invoiceNumber: i.invoiceNumber, payee,
+        amount: round2(Number(i.amount)), issueDate: ymd(i.issueDate),
+        status: i.status, linkOnly: i.status === "PAID",
+        amountExact: diff <= 0.01, refHit, nameHit, score,
+      };
+    })
+    .sort((a, b) => b.score - a.score || Math.abs(a.amount - amt) - Math.abs(b.amount - amt))
+    .slice(0, 12);
+
+  return NextResponse.json({ line: { id: line.id, amount: round2(amt), date: ymd(line.txnDate) }, candidates });
+}
+
+export async function POST(req: NextRequest) {
+  const err = await guard(req);
+  if (err) return err;
+  let body: { bankLineId?: string; invoiceId?: string } = {};
+  try { body = await req.json(); } catch { /* handled below */ }
+  const { bankLineId, invoiceId } = body;
+  if (!bankLineId || !invoiceId) return NextResponse.json({ error: "bankLineId and invoiceId required" }, { status: 400 });
+
+  const [line, inv, alreadyLinked] = await Promise.all([
+    prisma.bankStatementLine.findUnique({ where: { id: bankLineId }, select: { id: true, description: true, amount: true, txnDate: true, apInvoiceId: true, glTransactionId: true, category: true } }),
+    prisma.invoice.findUnique({ where: { id: invoiceId }, select: { id: true, invoiceNumber: true, amount: true, status: true, issueDate: true, outletId: true, vendorName: true, supplier: { select: { name: true } } } }),
+    prisma.bankStatementLine.findFirst({ where: { apInvoiceId: invoiceId }, select: { id: true } }),
+  ]);
+  if (!line) return NextResponse.json({ error: "Bank line not found" }, { status: 404 });
+  if (!inv) return NextResponse.json({ error: "Invoice not found" }, { status: 404 });
+  if (line.apInvoiceId) return NextResponse.json({ error: "Line already matched" }, { status: 409 });
+  if (inv.status === "PAID" && alreadyLinked) {
+    return NextResponse.json({ error: "Invoice already settled by another bank line — matching again would be a double payment" }, { status: 409 });
+  }
+
+  const linkOnly = inv.status === "PAID";
+  const m: ApMatch = {
+    invoiceId: inv.id, invoiceNumber: inv.invoiceNumber,
+    payee: inv.supplier?.name ?? inv.vendorName ?? "(unknown payee)",
+    amount: round2(Number(inv.amount)), issueDate: ymd(inv.issueDate), outletId: inv.outletId,
+    bankLineId: line.id, bankDesc: (line.description ?? "").slice(0, 60), bankDate: ymd(line.txnDate),
+    bankCategory: line.category as string | null,
+    score: 1, tier: "auto", reasons: ["manual match"], alreadyPaid: false, linkOnly,
+  };
+  await writeApMatch(m);
+  // The match re-tags the line's category; if it was posted under the old one,
+  // re-key the whole day-aggregate journal.
+  if (line.glTransactionId) {
+    await prisma.bankStatementLine.updateMany({
+      where: { glTransactionId: line.glTransactionId },
+      data: { glTransactionId: null, glPostedAt: null },
+    });
+  }
+  return NextResponse.json({ ok: true, linkOnly });
+}

--- a/apps/backoffice/src/app/api/finance/reclassify/route.ts
+++ b/apps/backoffice/src/app/api/finance/reclassify/route.ts
@@ -1,0 +1,39 @@
+// GET /api/finance/reclassify — dry-run: what the CURRENT rules would change
+// in the OTHER_OUTFLOW/unclassified pile. POST commits (updates categories and
+// un-stamps affected GL journals; the next gl-post run re-keys them).
+
+import { NextRequest, NextResponse } from "next/server";
+import { requireAuth } from "@/lib/auth";
+import { reclassifyBankLines } from "@/lib/finance/reclassify";
+
+export const dynamic = "force-dynamic";
+export const maxDuration = 120;
+
+async function guard(req: NextRequest) {
+  const auth = await requireAuth(req);
+  if (auth.error) return auth.error;
+  if (!["OWNER", "ADMIN"].includes(auth.user.role)) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+  return null;
+}
+
+export async function GET(req: NextRequest) {
+  const err = await guard(req);
+  if (err) return err;
+  try {
+    return NextResponse.json(await reclassifyBankLines({ commit: false }));
+  } catch (e) {
+    return NextResponse.json({ error: e instanceof Error ? e.message : String(e) }, { status: 500 });
+  }
+}
+
+export async function POST(req: NextRequest) {
+  const err = await guard(req);
+  if (err) return err;
+  try {
+    return NextResponse.json(await reclassifyBankLines({ commit: true }));
+  } catch (e) {
+    return NextResponse.json({ error: e instanceof Error ? e.message : String(e) }, { status: 500 });
+  }
+}

--- a/apps/backoffice/src/lib/finance/bukku-feed-sync.ts
+++ b/apps/backoffice/src/lib/finance/bukku-feed-sync.ts
@@ -56,7 +56,7 @@ function monthEnd(m: string): Date {
 // RAW_MATERIALS — no classifier rule edit needed. Names are uppercased,
 // single-spaced, stripped of "THE " and a trailing SDN BHD; short results are
 // dropped (too collision-prone against bank references).
-async function supplierVendorHints(): Promise<string[]> {
+export async function supplierVendorHints(): Promise<string[]> {
   const suppliers = await prisma.supplier.findMany({
     where: { supplierCode: { not: "ADHOC" } },
     select: { name: true },

--- a/apps/backoffice/src/lib/finance/reclassify.ts
+++ b/apps/backoffice/src/lib/finance/reclassify.ts
@@ -1,0 +1,111 @@
+// One-shot re-classification of catch-all bank lines with the CURRENT rules.
+//
+// The feed sync re-classifies its own window on every rebuild, but PDF-era
+// lines (before the feed anchor) keep whatever category they got at ingest —
+// so rules added later (suppliers, dividends, Rentokil, card MDR…) never
+// touch them and they sit in OTHER_OUTFLOW forever. This re-runs the
+// classifier over the catch-all pile, updates what now classifies, and
+// un-stamps the affected GL journals so the poster re-keys them under the
+// corrected contra accounts on the next run.
+//
+// Human classifications (classifiedBy != 'rule') are never overwritten.
+
+import { prisma } from "@/lib/prisma";
+import { classifyBankLine } from "./bank-line-classifier";
+import { supplierVendorHints } from "./bukku-feed-sync";
+
+const round2 = (n: number) => Math.round(n * 100) / 100;
+
+export type ReclassifyResult = {
+  committed: boolean;
+  scanned: number;
+  changed: number;
+  changedValue: number;
+  unstampedJournals: number;
+  byRule: { ruleName: string; category: string; n: number; amount: number }[];
+};
+
+export async function reclassifyBankLines(opts: { commit?: boolean } = {}): Promise<ReclassifyResult> {
+  const commit = opts.commit ?? false;
+  const vendorHints = await supplierVendorHints();
+
+  const lines = await prisma.bankStatementLine.findMany({
+    where: {
+      OR: [{ category: null }, { category: { in: ["OTHER_OUTFLOW", "OTHER_INFLOW"] } }],
+      AND: [{ OR: [{ classifiedBy: null }, { classifiedBy: "rule" }] }],
+      apInvoiceId: null,
+    },
+    select: {
+      id: true, description: true, amount: true, direction: true, category: true,
+      glTransactionId: true,
+      statement: { select: { accountName: true } },
+    },
+  });
+
+  type Change = { id: string; category: string; ruleName: string; isInterCo: boolean; amount: number; glTransactionId: string | null };
+  const changes: Change[] = [];
+  for (const l of lines) {
+    const res = classifyBankLine({
+      description: l.description ?? "",
+      amount: Number(l.amount),
+      direction: l.direction as "CR" | "DR",
+      accountKey: l.statement.accountName ?? undefined,
+      vendorHints,
+    });
+    if (!res.category || res.category === l.category) continue;
+    if (res.category === "OTHER_OUTFLOW" || res.category === "OTHER_INFLOW") continue;
+    changes.push({ id: l.id, category: res.category, ruleName: res.ruleName, isInterCo: res.isInterCo, amount: Number(l.amount), glTransactionId: l.glTransactionId });
+  }
+
+  const byRuleMap = new Map<string, { ruleName: string; category: string; n: number; amount: number }>();
+  for (const c of changes) {
+    const k = `${c.ruleName}|${c.category}`;
+    const cur = byRuleMap.get(k) ?? { ruleName: c.ruleName, category: c.category, n: 0, amount: 0 };
+    cur.n++; cur.amount = round2(cur.amount + c.amount);
+    byRuleMap.set(k, cur);
+  }
+
+  // A changed line whose day-aggregate journal is posted re-keys under a new
+  // contra — the WHOLE journal must rebuild (un-stamping only the changed line
+  // would leave the old journal over-stated).
+  const journalIds = [...new Set(changes.map((c) => c.glTransactionId).filter((x): x is string => !!x))];
+
+  let unstampedJournals = 0;
+  if (commit && changes.length) {
+    // Batch category updates per (category, ruleName, isInterCo) triple.
+    const batches = new Map<string, { data: { category: string; ruleName: string; isInterCo: boolean }; ids: string[] }>();
+    for (const c of changes) {
+      const k = `${c.category}|${c.ruleName}|${c.isInterCo}`;
+      const b = batches.get(k);
+      if (b) b.ids.push(c.id);
+      else batches.set(k, { data: { category: c.category, ruleName: c.ruleName, isInterCo: c.isInterCo }, ids: [c.id] });
+    }
+    for (const b of batches.values()) {
+      for (let i = 0; i < b.ids.length; i += 500) {
+        await prisma.bankStatementLine.updateMany({
+          where: { id: { in: b.ids.slice(i, i + 500) } },
+          data: { category: b.data.category as never, ruleName: b.data.ruleName, isInterCo: b.data.isInterCo, classifiedBy: "rule" },
+        });
+      }
+    }
+    for (let i = 0; i < journalIds.length; i += 200) {
+      const chunk = journalIds.slice(i, i + 200);
+      await prisma.bankStatementLine.updateMany({
+        where: { glTransactionId: { in: chunk } },
+        data: { glTransactionId: null, glPostedAt: null },
+      });
+    }
+    unstampedJournals = journalIds.length;
+  } else {
+    unstampedJournals = journalIds.length;
+  }
+
+  return {
+    committed: commit,
+    scanned: lines.length,
+    changed: changes.length,
+    changedValue: round2(changes.reduce((s, c) => s + c.amount, 0)),
+    unstampedJournals,
+    byRule: [...byRuleMap.values()].sort((a, b) => b.amount - a.amount),
+  };
+}


### PR DESCRIPTION
Owner asked **how to reconcile manually**. Answer: mostly you shouldn't have to — most of the visible pile is PDF-era lines that predate the current rules — so this ships two layers:

## 1. Re-run classifier rules (one click)
PDF-era lines never re-classify (only the feed window rebuilds each sync), so rules added later (dividends, loan payback, taxation, Rentokil, CleanHero, Simple Axe, card MDR, the supplier registry) never reached them. `reclassifyBankLines()` re-runs the classifier over the OTHER_* pile — rule/null-classified only, AP-matched and human-classified lines untouched — updates what now classifies, and un-stamps the **whole** affected day-aggregate journals so the GL re-keys them on the next loop run. Exposed as `GET` (dry-run) / `POST` at `/api/finance/reclassify` and a button on the recon page.

## 2. Manual controls on every Unmatched Outflow row
- **Set category…** — books the payment to an expense category. `classifiedBy='user'` so feed rebuilds never overwrite it (the sync carry-over preserves it); if the line was already GL-posted the whole journal re-keys.
- **Match…** — expands ranked candidate invoices (amount proximity, invoice-number digits quoted in the line, payee name; open invoices before paid-unlinked). Applying links the line and marks the invoice paid — or **link-only** when the invoice was already settled via another route (badge shows "already paid — link only"). A genuine double-pay (invoice already settled by another bank line) is blocked with a clear error.

Typecheck + lint clean.
