### PR TITLE
reviews: unbreak the °C logo (middleware blocked /brand/) + redirect legacy review links

### DIFF
--- a/apps/backoffice/src/middleware.ts
+++ b/apps/backoffice/src/middleware.ts
@@ -24,6 +24,14 @@ export async function middleware(request: NextRequest) {
   // /<outletId> rewrites to /review/<outletId>; API + static pass through so
   // the page's own fetches work; anything else lands on the brand site.
   const host = (request.headers.get("host") ?? "").toLowerCase();
+
+  // Legacy review links (old printed QRs, backoffice…/review/<id>) hop to the
+  // customer domain so every scan lands on review.celsiuscoffee.com. Scoped to
+  // the prod backoffice host so Vercel previews still serve /review directly.
+  if (host === "backoffice.celsiuscoffee.com" && pathname.startsWith("/review/")) {
+    const outletPath = pathname.slice("/review".length); // "/<outletId>"
+    return NextResponse.redirect(`https://${REVIEW_HOST}${outletPath}`, 308);
+  }
   if (host === REVIEW_HOST && !isApi && !pathname.startsWith("/_next") && !pathname.startsWith("/review/")) {
     const isAsset = /\.[a-z0-9]+$/i.test(pathname) || pathname === "/sw.js" || pathname === "/manifest.json";
     if (pathname === "/") {
@@ -102,7 +110,8 @@ export async function middleware(request: NextRequest) {
     pathname === "/sw.js" ||
     pathname === "/manifest.json" ||
     pathname.startsWith("/images/") ||
-    pathname.startsWith("/fonts/")
+    pathname.startsWith("/fonts/") ||
+    pathname.startsWith("/brand/")
   ) {
     return buildResponse(() => NextResponse.next());
   }


### PR DESCRIPTION
## What & why

Two follow-ups from the owner's live phone test of the QR review page (#704):

1. **Broken logo** — the °C mark at `/brand/celsius-degc.png` rendered as a broken image. The middleware's public-path bypass allows `/images/` and `/fonts/` but not `/brand/`, so the image request fell through to the auth gate and got redirected to `/login`. Added `/brand/` to the bypass.

2. **Legacy review links** — `backoffice.celsiuscoffee.com/review/<id>` (old printed QRs, previously shared links) now **308-redirects** to `review.celsiuscoffee.com/<id>`, so every scan lands on the customer domain. Scoped to the prod backoffice host only, so Vercel preview deployments still serve `/review/*` directly for testing. (Nothing in the product still *mints* the old URL — the QR endpoint moved to the new domain in #704; this just migrates links already in the wild.)

One file: `apps/backoffice/src/middleware.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01KAg3qfmYoUCakrJNpQoMZJ)_