### PR TITLE
feat(procurement): Resend to WhatsApp for a sent-but-undelivered PO

### DIFF
--- a/apps/backoffice/src/app/api/inventory/orders/[id]/resend-po/route.ts
+++ b/apps/backoffice/src/app/api/inventory/orders/[id]/resend-po/route.ts
@@ -1,0 +1,76 @@
+import { NextRequest, NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+import { getUserFromHeaders } from "@/lib/auth";
+import { sendPurchaseOrder, type PoForSend } from "@/lib/inventory/procurement-po-send";
+
+export const dynamic = "force-dynamic";
+
+// POST /api/inventory/orders/[id]/resend-po
+// Re-fire the WhatsApp PO send for a purchase order that's marked sent but was never
+// delivered (e.g. it was blocked by the old allowlist gate, or a cold-window prompt needs
+// re-sending). Owner/admin only. Re-runs sendPurchaseOrder (which keeps all its own gates:
+// automationMode, 24h window / prompt template, and the poSentFor dedup so an
+// already-delivered PO is a no-op), then reports what actually happened.
+export async function POST(req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  const caller = await getUserFromHeaders(req.headers);
+  if (!caller) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  if (!["OWNER", "ADMIN", "MANAGER"].includes(caller.role)) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+
+  const { id } = await params;
+  const order = await prisma.order.findUnique({
+    where: { id },
+    include: {
+      outlet: true,
+      supplier: true,
+      items: { include: { product: true, productPackage: true } },
+    },
+  });
+  if (!order) return NextResponse.json({ error: "Order not found" }, { status: 404 });
+  if (order.orderType !== "PURCHASE_ORDER") {
+    return NextResponse.json({ error: "Not a purchase order." }, { status: 400 });
+  }
+  if (!["SENT", "CONFIRMED", "AWAITING_DELIVERY"].includes(order.status)) {
+    return NextResponse.json({ error: `PO is ${order.status.toLowerCase()} — not in a sendable state.` }, { status: 400 });
+  }
+
+  await sendPurchaseOrder(order as unknown as PoForSend);
+
+  // Report the outcome by reading the row sendPurchaseOrder just recorded for this PO.
+  const [sent, prompted] = await Promise.all([
+    prisma.whatsAppMessage.findFirst({
+      where: { direction: "outbound", raw: { path: ["poSentFor"], equals: id } },
+      orderBy: { timestamp: "desc" },
+      select: { status: true },
+    }),
+    prisma.whatsAppMessage.findFirst({
+      where: { direction: "outbound", raw: { path: ["poPromptFor"], equals: id } },
+      orderBy: { timestamp: "desc" },
+      select: { status: true, raw: true },
+    }),
+  ]);
+
+  if (sent) {
+    return NextResponse.json({ ok: true, via: "po-block", message: "PO block sent to the supplier." });
+  }
+  if (prompted) {
+    const raw = (prompted.raw ?? {}) as Record<string, unknown>;
+    if (prompted.status === "sent" && raw.ok === true) {
+      return NextResponse.json({
+        ok: true,
+        via: "prompt",
+        message: "Supplier is cold — sent the reply prompt; the PO block follows automatically when they reply.",
+      });
+    }
+    return NextResponse.json({
+      ok: false,
+      via: "prompt",
+      message: `Cold prompt failed — most likely the "procurement_new_order" template isn't approved on Meta yet.${raw.error ? ` (${String(raw.error)})` : ""}`,
+    });
+  }
+  return NextResponse.json({
+    ok: false,
+    message: "Nothing sent — the supplier is on the manual lane (OFF) or PROCUREMENT_AGENT_ENABLED is off.",
+  });
+}

--- a/apps/backoffice/src/components/inventory/EditOrderModal.tsx
+++ b/apps/backoffice/src/components/inventory/EditOrderModal.tsx
@@ -209,6 +209,29 @@ export function EditOrderModal({
     }
   };
 
+  // Re-fire the WhatsApp send for a SENT-but-undelivered PO. Reports what actually happened —
+  // block sent, cold prompt sent, or the template/OFF reason it didn't — so it's not a guess.
+  // Keeps the modal open so the result toast is visible.
+  const resendPo = async () => {
+    if (!order) return;
+    setStatusBusy(true);
+    try {
+      const res = await fetch(`/api/inventory/orders/${order.id}/resend-po`, { method: "POST" });
+      const json = await res.json().catch(() => ({}));
+      if (!res.ok) {
+        toast.error(json?.error || `Resend failed (${res.status})`);
+        return;
+      }
+      if (json.ok) toast.success(json.message ?? "Re-sent to WhatsApp.");
+      else toast.error(json.message ?? "Resend didn't deliver — check the template.");
+      onSaved?.();
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : "Resend failed");
+    } finally {
+      setStatusBusy(false);
+    }
+  };
+
   // Initialize the internal state from `order` (port of openEditDialog).
   // Keyed on order?.id so re-opening with a different order re-inits.
   useEffect(() => {
@@ -973,6 +996,17 @@ export function EditOrderModal({
               >
                 {statusBusy ? <Loader2 className="mr-1.5 h-4 w-4 animate-spin" /> : <Send className="mr-1.5 h-4 w-4" />}
                 Send to supplier
+              </Button>
+            )}
+            {["SENT", "CONFIRMED", "AWAITING_DELIVERY"].includes(order.status) && (
+              <Button
+                onClick={resendPo}
+                disabled={statusBusy || editSaving || uploading}
+                className="border border-gray-300 bg-white text-gray-700 hover:bg-gray-50"
+                title="Re-fire the WhatsApp send for this PO (use if it never reached the supplier)"
+              >
+                {statusBusy ? <Loader2 className="mr-1.5 h-4 w-4 animate-spin" /> : <Send className="mr-1.5 h-4 w-4" />}
+                Resend to WhatsApp
               </Button>
             )}
             {["SENT", "CONFIRMED", "AWAITING_DELIVERY", "PARTIALLY_RECEIVED"].includes(order.status) && (


### PR DESCRIPTION
## Why
A PO already in `SENT` had no way to re-fire its WhatsApp send — the "Send to supplier" button only appears for `APPROVED`. So POs that were marked sent but never actually delivered (blocked by the old allowlist gate, or a cold-window prompt that needs re-sending) were stuck with no recovery path. Directly relevant: NYC Treats' 3 POs created today were allowlist-blocked and never reached them.

## What
- **`POST /api/inventory/orders/[id]/resend-po`** (owner/admin/manager) — re-runs `sendPurchaseOrder`, which keeps all its existing gates (`automationMode`, the 24h-window / prompt-template logic, and the `poSentFor` dedup so an already-delivered PO is a safe no-op). It then **reports the outcome** by reading the row it just recorded:
  - PO block sent, or
  - supplier cold → reply-prompt sent (block follows on reply), or
  - it didn't send → *why* (the `procurement_new_order` template isn't approved yet / supplier is OFF).
- **"Resend to WhatsApp" button** in `EditOrderModal` for `SENT`/`CONFIRMED`/`AWAITING_DELIVERY` POs — surfaces that result as a toast, so it's not a guess.

## Notes
- This is the app-side trigger; the actual delivery still depends on **#713 being deployed** (allowlist gate removed) and, for cold suppliers, the **`procurement_new_order` template being approved**. The endpoint's response makes that explicit when it fails.
- Verify: typecheck + lint clean on the touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)