### PR TITLE
feat(procurement): real PO message + sent-status in the supplier chat

### DIFF
--- a/apps/backoffice/src/app/(admin)/inventory/supplier-chats/page.tsx
+++ b/apps/backoffice/src/app/(admin)/inventory/supplier-chats/page.tsx
@@ -952,7 +952,7 @@ export default function SupplierChatsPage() {
                   <div
                     onDoubleClick={() => setReplyingTo(m)}
                     title="Double-click to reply"
-                    className={`min-w-0 cursor-default select-none rounded-lg px-3 py-2 text-[13px] leading-snug ${
+                    className={`min-w-0 cursor-default select-none whitespace-pre-wrap break-words rounded-lg px-3 py-2 text-[13px] leading-snug ${
                       m.direction === "outbound"
                         ? "bg-primary text-primary-foreground"
                         : "bg-muted text-foreground"

--- a/apps/backoffice/src/app/(admin)/inventory/supplier-chats/page.tsx
+++ b/apps/backoffice/src/app/(admin)/inventory/supplier-chats/page.tsx
@@ -985,9 +985,18 @@ export default function SupplierChatsPage() {
                       )
                     )}
                     <div
-                      className={`mt-1 text-[10px] ${m.direction === "outbound" ? "text-primary-foreground/70" : "text-muted-foreground"}`}
+                      className={`mt-1 flex items-center gap-1 text-[10px] ${m.direction === "outbound" ? "text-primary-foreground/70" : "text-muted-foreground"}`}
                     >
                       {clock(m.timestamp)}
+                      {m.direction === "outbound" && m.status === "sent" && (
+                        <span className="inline-flex items-center gap-0.5">· <Check size={10} /> Sent</span>
+                      )}
+                      {m.direction === "outbound" && m.status === "failed" && (
+                        <span>· Failed</span>
+                      )}
+                      {m.direction === "outbound" && m.status === "note" && (
+                        <span>· Internal note</span>
+                      )}
                     </div>
                   </div>
                   <button

--- a/apps/backoffice/src/lib/inventory/procurement-po-send.ts
+++ b/apps/backoffice/src/lib/inventory/procurement-po-send.ts
@@ -136,7 +136,10 @@ export async function sendPurchaseOrder(order: PoForSend): Promise<void> {
         fromNumber: ourNumber,
         toNumber: dest,
         type: "text",
-        body: `New order ${order.orderNumber} — sent a new-order prompt (cold; supplier to reply for the details).`,
+        // Record the ACTUAL message the supplier received (the procurement_new_order template
+        // body, variables filled) — not an internal status line — so the chat reads like the
+        // real conversation. The "sent" status + raw.via mark it as the cold prompt.
+        body: `Hi ${supplier.name}, we have prepared a new purchase order ${order.orderNumber} for you. Reply to this message and we will send over the full order details. Thank you.`,
         supplierId: supplier.id,
         status: t.ok ? "sent" : "failed",
         raw: {


### PR DESCRIPTION
Two chat-UX fixes on the supplier thread (from a screenshot showing internal status text as the message body):

## 1. Show the real message, not an internal status line
The cold-PO prompt was recording *"New order CC-XXX — sent a new-order prompt (cold; supplier to reply for the details)"* as the message **body**. Now it records the **actual message the supplier received** — the `procurement_new_order` template text with the variables filled ("Hi {supplier}, we have prepared a new purchase order {PO} for you. Reply to this message and we will send over the full order details. Thank you."). The thread now reads like the real conversation.

## 2. WhatsApp-style "sent" status under the bubble
Added a small status line under each outbound bubble — **✓ Sent** / **Failed** / **Internal note** — driven by the message's `status` (which the detail API already returns; the page's `Msg` type already had the field, it just wasn't rendered). So you can tell at a glance what actually delivered vs an internal note.

Verify: typecheck + lint clean on the touched files. (UI not browser-previewed here — the supplier-chats page needs prod auth + data.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)