### PR TITLE
feat(procurement): cold POs as a PDF document (no reply-prompt)

### DIFF
--- a/apps/backoffice/src/lib/inventory/po-pdf.ts
+++ b/apps/backoffice/src/lib/inventory/po-pdf.ts
@@ -1,0 +1,112 @@
+import { PDFDocument, StandardFonts, rgb } from "pdf-lib";
+
+// Generate a clean A4 purchase-order PDF from an order, so a COLD supplier (24h window closed)
+// can receive the FULL order in one WhatsApp message — attached as the document header of an
+// approved template — instead of a "reply for details" prompt. Uses pdf-lib (already a dep;
+// works in serverless, no headless browser). Kept deliberately simple: one item per line,
+// paginates if a PO is unusually long.
+export interface PoPdfInput {
+  orderNumber: string;
+  outletName: string;
+  outletAddress?: string | null;
+  date: string; // YYYY-MM-DD
+  deliveryDate?: string | null;
+  items: { name: string; quantity: number; uom: string }[];
+}
+
+const A4: [number, number] = [595.28, 841.89];
+const MX = 48; // left/right margin
+
+export async function generatePoPdf(input: PoPdfInput): Promise<Buffer> {
+  const doc = await PDFDocument.create();
+  const font = await doc.embedFont(StandardFonts.Helvetica);
+  const bold = await doc.embedFont(StandardFonts.HelveticaBold);
+  const dark = rgb(0.11, 0.11, 0.11);
+  const gray = rgb(0.42, 0.42, 0.42);
+  const rule = rgb(0.85, 0.85, 0.85);
+
+  let page = doc.addPage(A4);
+  const width = page.getWidth();
+  const qtyX = width - MX - 110;
+  let y = 792;
+
+  const newPageIfNeeded = () => {
+    if (y < 80) {
+      page = doc.addPage(A4);
+      y = 792;
+    }
+  };
+  const text = (s: string, x: number, size: number, f = font, color = dark) =>
+    page.drawText(s, { x, y, size, font: f, color });
+  const hr = (thickness = 1) => {
+    page.drawLine({ start: { x: MX, y }, end: { x: width - MX, y }, thickness, color: rule });
+  };
+
+  // Header
+  text("PURCHASE ORDER", MX, 20, bold);
+  y -= 26;
+  text(input.outletName, MX, 13, bold);
+  y -= 20;
+  text(`PO #: ${input.orderNumber}`, MX, 11, font, gray);
+  y -= 15;
+  text(`Date: ${input.date}`, MX, 11, font, gray);
+  y -= 14;
+  hr();
+  y -= 22;
+
+  // Item header
+  text("Item", MX, 10, bold, gray);
+  text("Qty", qtyX, 10, bold, gray);
+  y -= 17;
+
+  // Items — one per line, long names clipped so the qty column stays aligned.
+  input.items.forEach((it, i) => {
+    newPageIfNeeded();
+    const label = `${i + 1}. ${it.name}`;
+    text(label.length > 58 ? label.slice(0, 57) + "…" : label, MX, 11);
+    text(`${it.quantity} ${it.uom}`, qtyX, 11);
+    y -= 17;
+  });
+
+  y -= 8;
+  newPageIfNeeded();
+  hr(0.5);
+  y -= 22;
+
+  if (input.deliveryDate) {
+    text(`Delivery date: ${input.deliveryDate}`, MX, 11, bold);
+    y -= 18;
+  }
+  if (input.outletAddress) {
+    text("Deliver to:", MX, 11, bold);
+    y -= 15;
+    for (const ln of wrap(input.outletAddress, 78)) {
+      newPageIfNeeded();
+      text(ln, MX, 11, font, gray);
+      y -= 14;
+    }
+  }
+  y -= 12;
+  newPageIfNeeded();
+  text("Thank you.", MX, 12, bold);
+
+  const bytes = await doc.save();
+  return Buffer.from(bytes);
+}
+
+// Greedy word wrap to `max` chars per line (address is short; approximate width is fine).
+function wrap(s: string, max: number): string[] {
+  const words = s.split(/\s+/);
+  const out: string[] = [];
+  let line = "";
+  for (const w of words) {
+    if ((line + " " + w).trim().length > max) {
+      if (line) out.push(line);
+      line = w;
+    } else {
+      line = (line + " " + w).trim();
+    }
+  }
+  if (line) out.push(line);
+  return out;
+}

--- a/apps/backoffice/src/lib/inventory/procurement-po-send.ts
+++ b/apps/backoffice/src/lib/inventory/procurement-po-send.ts
@@ -18,6 +18,8 @@ import { prisma } from "@/lib/prisma";
 import { sendWhatsAppText, sendWhatsAppTemplate } from "@/lib/whatsapp";
 import { recordOutboundMessage } from "@/lib/whatsapp-store";
 import { formatWhatsAppOrder } from "@celsius/shared";
+import { generatePoPdf } from "@/lib/inventory/po-pdf";
+import { uploadToStorage } from "@/lib/inventory/pdf-splitter";
 
 export const PO_SEND_VERSION = "po-send-v1";
 
@@ -27,6 +29,12 @@ export const PO_SEND_VERSION = "po-send-v1";
 // the env var overrides for testing/renames. The template body must be:
 // {{1}} = supplier name, {{2}} = PO number.
 const PO_PROMPT_TEMPLATE = process.env.PROCUREMENT_PO_PROMPT_TEMPLATE?.trim() || "procurement_new_order";
+
+// PREFERRED cold path: send the full order as a PDF on an approved DOCUMENT template, so a cold
+// supplier gets the whole order in ONE message (no reply-prompt round-trip). Set this to the
+// approved template's name to enable; unset → the prompt flow. The template needs a DOCUMENT
+// header + a body with {{1}} = supplier name, {{2}} = PO number.
+const PO_DOC_TEMPLATE = process.env.PROCUREMENT_PO_DOC_TEMPLATE?.trim();
 
 const digits = (s: string | null | undefined) => (s ?? "").replace(/[^0-9]/g, "");
 
@@ -82,8 +90,13 @@ export async function sendPurchaseOrder(order: PoForSend): Promise<void> {
     const windowOpen =
       !!lastInbound && Date.now() - +new Date(lastInbound.timestamp) < 24 * 60 * 60 * 1000;
     if (!windowOpen) {
-      // Cold: WhatsApp blocks free text. Ping with the approved prompt template (if
-      // configured) so the supplier replies and opens the window; the full PO block then
+      // Preferred cold path: send the FULL order as a PDF on an approved DOCUMENT template — the
+      // supplier gets the whole order in one message, no "reply for details" round-trip. Returns
+      // true when it handled the send (delivered OR a template failure recorded — don't also
+      // prompt); false to fall back to the prompt (PDF/upload error).
+      if (PO_DOC_TEMPLATE && (await sendPoAsDocument(order, supplier, dest))) return;
+      // Fallback cold path: WhatsApp blocks free text, so ping with the approved prompt template
+      // (if configured) so the supplier replies and opens the window; the full PO block then
       // follows in-window. Deduped via poPromptFor. No template set → skip + log as before.
       if (!PO_PROMPT_TEMPLATE) {
         console.log(`[po-send] po=${order.orderNumber} skipped — 24h window closed, no PROCUREMENT_PO_PROMPT_TEMPLATE`);
@@ -189,6 +202,73 @@ export async function sendPurchaseOrder(order: PoForSend): Promise<void> {
     console.log(`[po-send] po=${order.orderNumber} supplier=${supplier.name} sent=${res.ok}`);
   } catch (err) {
     console.error("[po-send] error:", err instanceof Error ? err.message : err);
+  }
+}
+
+// Cold-send a PO to the supplier as a PDF attached to an approved document template — the full
+// order in ONE message, no reply-prompt. Returns true when the send was handled (delivered OR a
+// template failure recorded — caller should NOT also prompt), false to fall back to the prompt
+// (PDF generation / upload failed). Deduped via poSentFor. Records the real caption + the PDF as
+// mediaUrl so the chat shows the actual message + attachment.
+async function sendPoAsDocument(
+  order: PoForSend,
+  supplier: NonNullable<PoForSend["supplier"]>,
+  dest: string,
+): Promise<boolean> {
+  try {
+    const already = await prisma.whatsAppMessage.findFirst({
+      where: { direction: "outbound", raw: { path: ["poSentFor"], equals: order.id } },
+      select: { id: true },
+    });
+    if (already) return true; // already delivered — don't prompt
+
+    const pdf = await generatePoPdf({
+      orderNumber: order.orderNumber,
+      outletName: order.outlet.name,
+      outletAddress: order.outlet.address,
+      date: new Date().toISOString().slice(0, 10),
+      deliveryDate: order.deliveryDate ? new Date(order.deliveryDate).toISOString().slice(0, 10) : null,
+      items: order.items
+        .filter((it) => it.product)
+        .map((it) => ({
+          name: it.product!.name,
+          quantity: Number(it.quantity),
+          uom: it.productPackage?.packageLabel ?? it.product!.baseUom,
+        })),
+    });
+    const url = await uploadToStorage(pdf, `po/PO-${order.orderNumber}-${Date.now()}.pdf`, "application/pdf");
+
+    const t = await sendWhatsAppTemplate(dest, PO_DOC_TEMPLATE!, "en", [
+      {
+        type: "header",
+        parameters: [{ type: "document", document: { link: url, filename: `PO-${order.orderNumber}.pdf` } }],
+      },
+      {
+        type: "body",
+        parameters: [
+          { type: "text", text: supplier.name },
+          { type: "text", text: order.orderNumber },
+        ],
+      },
+    ]);
+
+    await recordOutboundMessage({
+      waMessageId: t.messageId,
+      fromNumber: "",
+      toNumber: dest,
+      type: "document",
+      // The real caption the supplier sees (the doc-template body) — plus the PDF as mediaUrl.
+      body: `Hi ${supplier.name}, here's purchase order ${order.orderNumber} from Celsius Coffee. The full order details are attached. Please confirm. Thank you.`,
+      mediaUrl: url,
+      supplierId: supplier.id,
+      status: t.ok ? "sent" : "failed",
+      raw: { agent: PO_SEND_VERSION, poSentFor: order.id, poNumber: order.orderNumber, via: "pdf-template", ok: t.ok, error: t.error ?? null },
+    });
+    console.log(`[po-send] po=${order.orderNumber} cold → PDF document template (${PO_DOC_TEMPLATE}) ok=${t.ok}`);
+    return true;
+  } catch (e) {
+    console.warn(`[po-send] po=${order.orderNumber} PDF send failed, falling back to prompt:`, e instanceof Error ? e.message : e);
+    return false;
   }
 }
 


### PR DESCRIPTION
## Why
A cold supplier (24h window closed) couldn't be sent the order as free text (WhatsApp blocks it), so we sent a "reply for details" prompt and waited for a reply before the order followed. This lets a cold supplier get the **full order in one message** — as a PDF attached to an approved document template.

## What
- **`lib/inventory/po-pdf.ts`** — `generatePoPdf()` renders a clean A4 purchase order (header, one item per line with qty, delivery date, deliver-to address) using `pdf-lib` (already a dep — no headless browser, works in serverless).
- **`procurement-po-send.ts` cold path** — when `PROCUREMENT_PO_DOC_TEMPLATE` is set: generate the PDF → upload to storage (`po/…`) → send the document template (header = the PDF, body `{{1}}`=supplier, `{{2}}`=PO number) → record with the real caption + the PDF as `mediaUrl` (so it shows in the chat). Deduped via `poSentFor`.
- **Safe fallback** — if the env is unset, or PDF generation/upload fails, it falls straight through to the existing reply-prompt flow. Nothing breaks; it's opt-in.

## Operator setup (required to enable)
1. In Meta WhatsApp Manager, create a **UTILITY** template, English:
   - **Header:** Document
   - **Body:** `Hi {{1}}, here's purchase order {{2}} from Celsius Coffee. The full order details are attached. Please confirm. Thank you.`
   - Sample: `{{1}}` = NYC Treats, `{{2}}` = CC-CC002-0241
2. Once **approved**, set Vercel env `PROCUREMENT_PO_DOC_TEMPLATE` to that template's name.
3. From then on, cold POs go out as the PDF; warm suppliers still get the in-window text block.

## Verify
Typecheck + lint clean. Not runtime-tested (needs the approved template + a cold supplier). Gated behind the env, with a fallback, so it can't disrupt the current flow until you switch it on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)