### PR TITLE
feat(finance): payee aliases in AP matching — TMM = Milk Ministry, Ad-hoc = Ariff Izham

### DIFF
--- a/apps/backoffice/src/lib/finance/ap-match-lib.test.ts
+++ b/apps/backoffice/src/lib/finance/ap-match-lib.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { digitRuns, invoiceRefInDesc, subsetSumIdx } from "./ap-match-lib";
+import { digitRuns, invoiceRefInDesc, subsetSumIdx, aliasPhrasesFor, aliasInDesc } from "./ap-match-lib";
 
 describe("ap-match-lib", () => {
   it("extracts digit runs from bank descriptions", () => {
@@ -35,5 +35,20 @@ describe("ap-match-lib", () => {
   it("tolerates 1-2 sen rounding drift", () => {
     const idx = subsetSumIdx([10001, 20001], 30000);
     expect(idx).not.toBeNull();
+  });
+
+  it("bridges payee aliases: TMM = The Milk Ministry, Ad-hoc Purchase = Ariff Izham", () => {
+    // Invoice says The Milk Ministry; bank transfer says TMM (Resources)
+    const milk = aliasPhrasesFor(["The Milk Ministry", null, null]);
+    expect(aliasInDesc(milk, "celsius coffee putratmm resources *1-260601")).toBe(true);
+    // Bank says Milk Ministry; supplier record says TMM Resources
+    const tmm = aliasPhrasesFor(["TMM Resources", null, null]);
+    expect(aliasInDesc(tmm, "transfer fr a/c the milk ministry #1-14819")).toBe(true);
+    // Ad-hoc purchases are reimbursed to Ariff Izham
+    const adhoc = aliasPhrasesFor([null, "Ad-hoc Purchase", null]);
+    expect(aliasInDesc(adhoc, "transfer fr a/c ariff izham bin abd 2026/0021 celsiuscoffee")).toBe(true);
+    // No alias, no hit
+    expect(aliasPhrasesFor(["Yow Seng Sdn Bhd"])).toEqual([]);
+    expect(aliasInDesc(adhoc, "transfer fr a/c somebody else entirely")).toBe(false);
   });
 });

--- a/apps/backoffice/src/lib/finance/ap-match-lib.ts
+++ b/apps/backoffice/src/lib/finance/ap-match-lib.ts
@@ -1,6 +1,35 @@
 // Pure matching helpers for the AP auto-matcher. No DB/IO imports so they are
 // unit-testable and safe to import anywhere (ap-match.ts wires them to Prisma).
 
+// Payee aliases (per owner): the name on the BANK transfer isn't always the
+// supplier name on the INVOICE. Keys are matched by containment against the
+// invoice's payee names (supplier / vendorName / bank-account name, lowered);
+// values are PHRASES searched directly in the bank description — a phrase hit
+// counts as full name confirmation, same weight as a payee-name token match.
+export const PAYEE_ALIASES: Record<string, string[]> = {
+  // "TMM Resources" on the bank side IS The Milk Ministry.
+  "milk ministry": ["tmm"],
+  "tmm": ["milk ministry"],
+  // Ad-hoc purchases are staff-fronted and reimbursed to Ariff Izham.
+  "ad-hoc purchase": ["ariff izham"],
+  "adhoc purchase": ["ariff izham"],
+};
+
+// Alias phrases for an invoice's payee names — every alias whose key appears
+// in any of the names.
+export function aliasPhrasesFor(names: (string | null | undefined)[]): string[] {
+  const joined = names.filter(Boolean).map((n) => (n as string).toLowerCase());
+  const out = new Set<string>();
+  for (const [key, phrases] of Object.entries(PAYEE_ALIASES)) {
+    if (joined.some((n) => n.includes(key))) for (const p of phrases) out.add(p);
+  }
+  return [...out];
+}
+
+export function aliasInDesc(phrases: string[], descLower: string): boolean {
+  return phrases.some((p) => descLower.includes(p));
+}
+
 // Invoice references in bank descriptions ("YSIV-0801", "INV 006545, 006577").
 // Compare on trailing digit runs: the invoice's number reduced to its digits
 // (leading zeros dropped) found as a digit run in the description.

--- a/apps/backoffice/src/lib/finance/ap-match.ts
+++ b/apps/backoffice/src/lib/finance/ap-match.ts
@@ -90,7 +90,7 @@ function nameInDesc(nameTokens: string[], descLower: string): boolean {
   return hits >= 2 || (hits === 1 && nameTokens.some((t) => t.length >= 5 && descLower.includes(t)));
 }
 
-import { digitRuns, invoiceRefInDesc, subsetSumIdx } from "./ap-match-lib";
+import { digitRuns, invoiceRefInDesc, subsetSumIdx, aliasPhrasesFor, aliasInDesc } from "./ap-match-lib";
 export { digitRuns, invoiceRefInDesc, subsetSumIdx } from "./ap-match-lib";
 
 export async function proposeApMatches(opts: { sinceDays?: number } = {}): Promise<ApMatchResult> {
@@ -159,6 +159,7 @@ export async function proposeApMatches(opts: { sinceDays?: number } = {}): Promi
     const amt = round2(Number(inv.amount));
     const payee = inv.supplier?.name ?? inv.vendorName ?? inv.vendorBankAccountName ?? "(unknown payee)";
     const nm = [...new Set([...tokens(inv.supplier?.name), ...tokens(inv.vendorName), ...tokens(inv.vendorBankAccountName)])];
+    const aliases = aliasPhrasesFor([inv.supplier?.name, inv.vendorName, inv.vendorBankAccountName]);
     const issue = inv.issueDate;
     const linkOnly = inv.status === "PAID"; // paid via another route, line unlinked
     const alreadyPaid = !linkOnly && Number(inv.amountPaid ?? 0) >= amt - 0.01;
@@ -184,7 +185,7 @@ export async function proposeApMatches(opts: { sinceDays?: number } = {}): Promi
       let score = 0;
       if (amtDiff <= 0.01) { score += 0.55; reasons.push("amount exact"); }
       else { score += 0.35; reasons.push(`amount ~ (RM${amtDiff.toFixed(2)} off)`); }
-      const named = nameInDesc(nm, descLower);
+      const named = nameInDesc(nm, descLower) || aliasInDesc(aliases, descLower);
       if (named) { score += 0.4; reasons.push("payee name in description"); }
       // The invoice's own number quoted in the transfer is the strongest signal
       // a bank line carries — count it as identity confirmation like a name hit.
@@ -231,7 +232,7 @@ export async function proposeApMatches(opts: { sinceDays?: number } = {}): Promi
   const multi: ApMultiMatch[] = [];
   {
     type Inv = (typeof invoices)[number];
-    const bySupplier = new Map<string, { payee: string; toks: string[]; invs: Inv[] }>();
+    const bySupplier = new Map<string, { payee: string; toks: string[]; aliases: string[]; invs: Inv[] }>();
     for (const inv of invoices) {
       if (matchedInvoiceIds.has(inv.id)) continue;
       // Paid-but-unlinked invoices stay in the bundle pool (link-only members);
@@ -239,7 +240,12 @@ export async function proposeApMatches(opts: { sinceDays?: number } = {}): Promi
       if (inv.status !== "PAID" && Number(inv.amountPaid ?? 0) >= Number(inv.amount) - 0.01) continue;
       const payee = inv.supplier?.name ?? inv.vendorName ?? inv.vendorBankAccountName ?? "(unknown payee)";
       const key = payee.toLowerCase();
-      const g = bySupplier.get(key) ?? { payee, toks: [...new Set([...tokens(inv.supplier?.name), ...tokens(inv.vendorName), ...tokens(inv.vendorBankAccountName)])], invs: [] };
+      const g = bySupplier.get(key) ?? {
+        payee,
+        toks: [...new Set([...tokens(inv.supplier?.name), ...tokens(inv.vendorName), ...tokens(inv.vendorBankAccountName)])],
+        aliases: aliasPhrasesFor([inv.supplier?.name, inv.vendorName, inv.vendorBankAccountName]),
+        invs: [],
+      };
       g.invs.push(inv);
       bySupplier.set(key, g);
     }
@@ -254,7 +260,7 @@ export async function proposeApMatches(opts: { sinceDays?: number } = {}): Promi
       for (const g of bySupplier.values()) {
         if (g.invs.length < 2) continue;
         const refHits = g.invs.filter((i) => invoiceRefInDesc(i.invoiceNumber, runs)).length;
-        const named = nameInDesc(g.toks, descLower);
+        const named = nameInDesc(g.toks, descLower) || aliasInDesc(g.aliases, descLower);
         if (!named && refHits === 0) continue;
 
         const pickIdx = subsetSumIdx(g.invs.map((i) => Math.round(Number(i.amount) * 100)), target);


### PR DESCRIPTION
Owner directive: the name on the bank transfer isn't always the supplier name on the invoice —

- **TMM Resources** on the bank side **is The Milk Ministry** in procurement (both directions aliased);
- **Ad-hoc Purchase** invoices are staff-fronted and reimbursed via transfers to **Ariff Izham**.

Token comparison could never bridge those, so their payments sat unmatched. New `PAYEE_ALIASES` phrase map: keys matched by containment against the invoice's payee names, values searched directly in the bank description — a hit counts as full name confirmation (so amount-exact + alias auto-applies, same gate as a real name hit). Wired into both the single-invoice pass and the multi-invoice bundle pass (several ad-hoc invoices reimbursed in one Ariff transfer bundle-match).

6/6 matcher unit tests (new alias cases), typecheck clean.