### PR TITLE
feat(finance): cash-in reconciliation + COA-labeled categories + utility/rent rules

### DIFF
--- a/apps/backoffice/src/app/(admin)/finance/recon/page.tsx
+++ b/apps/backoffice/src/app/(admin)/finance/recon/page.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from "react";
 import { useFetch } from "@/lib/use-fetch";
+import { CONTRA_ACCOUNT } from "@/lib/finance/gl-posting-map";
 import { Loader2, CheckCircle2, AlertTriangle, HelpCircle, Copy, ArrowDownCircle } from "lucide-react";
 
 type ApMatch = {
@@ -15,30 +16,53 @@ type CashIn = {
   salesByChannel: { channel: string; amount: number }[];
   grab: { gross: number; settled: number; deductionPct: number | null };
 };
+type UnmatchedLine = { bankLineId: string; desc: string; date: string; amount: number; category: string | null };
 type ReconData = {
-  summary: { auto: number; review: number; doublePayments: number; unmatchedInvoices: number; unmatchedOutflows: number; unmatchedOutflowValue: number };
+  summary: {
+    auto: number; review: number; doublePayments: number; unmatchedInvoices: number;
+    unmatchedOutflows: number; unmatchedOutflowValue: number;
+    unmatchedInflows: number; unmatchedInflowValue: number;
+  };
   auto: ApMatch[]; review: ApMatch[]; doublePayments: ApMatch[];
   unmatchedInvoices: { invoiceId: string; invoiceNumber: string | null; payee: string; amount: number; issueDate: string }[];
-  unmatchedOutflows: { bankLineId: string; desc: string; date: string; amount: number; category: string | null }[];
+  unmatchedOutflows: UnmatchedLine[];
+  unmatchedInflows: UnmatchedLine[];
   cashIn: CashIn;
 };
 
 const fmtRM = (n: number) => `RM ${n.toLocaleString("en-MY", { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`;
 const fmtRM0 = (n: number) => `RM ${n.toLocaleString("en-MY", { maximumFractionDigits: 0 })}`;
 
-// Outflow categories a human can assign — mirrors CashCategory (validated
-// server-side against the Prisma enum).
-const MANUAL_CATEGORIES = [
+// Categories a human can assign — mirrors CashCategory (validated server-side
+// against the Prisma enum). Each books to a COA account via CONTRA_ACCOUNT
+// (statutory/salary route through control accounts in resolveContra), shown in
+// the dropdown so the pick IS a chart-of-accounts decision.
+const OUTFLOW_CATEGORIES = [
   "RAW_MATERIALS", "RENT", "UTILITIES", "MAINTENANCE", "EQUIPMENTS", "SOFTWARE",
   "STAFF_CLAIM", "PARTIMER", "EMPLOYEE_SALARY", "STATUTORY_PAYMENT", "TAX",
   "COMPLIANCE", "LICENSING_FEE", "BANK_FEE", "MARKETPLACE_FEE", "OTHER_MARKETING",
   "KOL", "DELIVERY", "PETTY_CASH", "LOAN", "DIVIDEND", "DIRECTORS_ALLOWANCE",
   "CAPITAL", "INVESTMENTS", "MANAGEMENT_FEE", "CFS_FEE",
 ] as const;
+const INFLOW_CATEGORIES = [
+  "QR", "CARD", "GRAB", "STOREHUB", "FOODPANDA", "REVENUE_MONSTER",
+  "GASTROHUB", "MEETINGS_EVENTS", "LOAN", "CAPITAL", "MANAGEMENT_FEE",
+  "EMPLOYEE_SALARY", "STATUTORY_PAYMENT",
+] as const;
+// Control-account routes that CONTRA_ACCOUNT doesn't carry (resolveContra does).
+const CONTROL_COA: Record<string, string> = { EMPLOYEE_SALARY: "3008", STATUTORY_PAYMENT: "3004-7" };
+function categoryLabel(c: string, accountNames: Map<string, string>): string {
+  const code = CONTRA_ACCOUNT[c] ?? CONTROL_COA[c];
+  const name = code ? accountNames.get(code) : undefined;
+  const human = c.toLowerCase().replace(/_/g, " ");
+  return code ? `${human} → ${code}${name ? ` ${name}` : ""}` : human;
+}
 
 export default function ReconPage() {
   const [days, setDays] = useState(90);
   const { data, isLoading, mutate } = useFetch<ReconData>(`/api/finance/ap-match?sinceDays=${days}`);
+  const { data: acctData } = useFetch<{ accounts: { code: string; name: string }[] }>("/api/finance/accounts");
+  const accountNames = new Map((acctData?.accounts ?? []).map((a) => [a.code, a.name]));
   const [reclassifying, setReclassifying] = useState(false);
   const [reclassNote, setReclassNote] = useState<string | null>(null);
 
@@ -65,7 +89,7 @@ export default function ReconPage() {
         <div>
           <h2 className="text-lg sm:text-xl font-semibold text-gray-900">Reconciliation</h2>
           <p className="mt-0.5 text-xs sm:text-sm text-gray-500">
-            Cash-out: bank payments matched to procurement invoices. Read-only preview — the loop auto-applies high-confidence matches; the rest is your queue.
+            Cash out AND cash in: payments matched to invoices, receipts matched to their source. The loop auto-applies high-confidence matches; the rest is your queue — every manual pick books straight to the chart of accounts.
           </p>
         </div>
         <div className="flex rounded-lg border border-gray-200 bg-white p-0.5">
@@ -83,11 +107,12 @@ export default function ReconPage() {
       ) : (
         <>
           {/* Summary tiles — each jumps to its detail section */}
-          <div className="mt-4 grid grid-cols-2 sm:grid-cols-5 gap-2 sm:gap-3">
+          <div className="mt-4 grid grid-cols-2 sm:grid-cols-6 gap-2 sm:gap-3">
             <Tile icon={<CheckCircle2 className="h-4 w-4 text-green-600" />} label="Auto-matched" value={data.summary.auto} tone="green" targetId="recon-auto" />
             <Tile icon={<HelpCircle className="h-4 w-4 text-amber-600" />} label="Needs review" value={data.summary.review} tone="amber" targetId="recon-review" />
             <Tile icon={<Copy className="h-4 w-4 text-red-600" />} label="Double payments" value={data.summary.doublePayments} tone={data.summary.doublePayments ? "red" : "gray"} targetId="recon-double" />
             <Tile icon={<ArrowDownCircle className="h-4 w-4 text-gray-500" />} label="Unmatched out" value={data.summary.unmatchedOutflows} sub={fmtRM0(data.summary.unmatchedOutflowValue)} tone="gray" targetId="recon-unmatched-out" />
+            <Tile icon={<ArrowDownCircle className="h-4 w-4 rotate-180 text-gray-500" />} label="Unmatched in" value={data.summary.unmatchedInflows} sub={fmtRM0(data.summary.unmatchedInflowValue)} tone="gray" targetId="recon-unmatched-in" />
             <Tile icon={<AlertTriangle className="h-4 w-4 text-gray-500" />} label="Open invoices, no payment" value={data.summary.unmatchedInvoices} tone="gray" targetId="recon-open-invoices" />
           </div>
 
@@ -157,11 +182,31 @@ export default function ReconPage() {
                 </tr></thead>
                 <tbody className="divide-y">
                   {data.unmatchedOutflows.slice(0, 100).map((o) => (
-                    <OutflowRow key={o.bankLineId} row={o} onDone={() => mutate()} />
+                    <LineRow key={o.bankLineId} row={o} direction="DR" categories={OUTFLOW_CATEGORIES} accountNames={accountNames} onDone={() => mutate()} />
                   ))}
                 </tbody>
               </table>
               {data.unmatchedOutflows.length > 100 && <p className="px-3 py-2 text-[11px] text-gray-400">Showing top 100 of {data.unmatchedOutflows.length} by amount.</p>}
+            </div>
+          </Section>
+
+          <Section id="recon-unmatched-in" title="Unmatched inflows — unreconciled cash-in" desc="Money that arrived with no recognised source. Pick the category it belongs to — sales settlements clear their debtor; loans/capital book to the balance sheet.">
+            <div className="overflow-x-auto">
+              <table className="w-full min-w-[760px] text-sm">
+                <thead><tr className="border-b bg-gray-50/50 text-left text-gray-500">
+                  <th className="px-3 py-2 font-medium">Date</th><th className="px-3 py-2 font-medium">Description</th>
+                  <th className="px-3 py-2 font-medium">Category</th><th className="px-3 py-2 text-right font-medium">Amount</th>
+                  <th className="px-3 py-2 font-medium">Reconcile</th>
+                </tr></thead>
+                <tbody className="divide-y">
+                  {data.unmatchedInflows.length === 0 ? (
+                    <tr><td colSpan={5} className="px-4 py-4 text-xs text-gray-400">Nothing here.</td></tr>
+                  ) : data.unmatchedInflows.slice(0, 100).map((o) => (
+                    <LineRow key={o.bankLineId} row={o} direction="CR" categories={INFLOW_CATEGORIES} accountNames={accountNames} onDone={() => mutate()} />
+                  ))}
+                </tbody>
+              </table>
+              {data.unmatchedInflows.length > 100 && <p className="px-3 py-2 text-[11px] text-gray-400">Showing top 100 of {data.unmatchedInflows.length} by amount.</p>}
             </div>
           </Section>
 
@@ -200,10 +245,16 @@ type Candidate = {
   amountExact: boolean; refHit: boolean; nameHit: boolean; score: number;
 };
 
-// One unmatched outflow with its manual-reconcile controls: a category select
-// (books the line to that expense; the GL re-keys on the next loop run) and a
-// Match panel listing candidate invoices to link.
-function OutflowRow({ row, onDone }: { row: { bankLineId: string; desc: string; date: string; amount: number; category: string | null }; onDone: () => void }) {
+// One unmatched bank line with its manual-reconcile controls: a category
+// select labeled with the COA account it books to (the GL re-keys on the next
+// loop run), and — for outflows — a Match panel listing candidate invoices.
+function LineRow({ row, direction, categories, accountNames, onDone }: {
+  row: UnmatchedLine;
+  direction: "DR" | "CR";
+  categories: readonly string[];
+  accountNames: Map<string, string>;
+  onDone: () => void;
+}) {
   const [busy, setBusy] = useState(false);
   const [note, setNote] = useState<string | null>(null);
   const [open, setOpen] = useState(false);
@@ -258,26 +309,28 @@ function OutflowRow({ row, onDone }: { row: { bankLineId: string; desc: string; 
           {note && <div className="mt-0.5 text-[10px] text-red-600">{note}</div>}
         </td>
         <td className="px-3 py-2 text-[11px] text-gray-400 align-top">{row.category ?? "Unclassified"}</td>
-        <td className="px-3 py-2 text-right font-mono text-xs text-red-700 align-top">−{fmtRM(row.amount)}</td>
+        <td className={`px-3 py-2 text-right font-mono text-xs align-top ${direction === "DR" ? "text-red-700" : "text-green-700"}`}>{direction === "DR" ? "−" : "+"}{fmtRM(row.amount)}</td>
         <td className="px-3 py-2 align-top">
           <div className="flex items-center gap-1.5">
             <select
               defaultValue=""
               disabled={busy}
               onChange={(e) => setCategory(e.target.value)}
-              className="h-6 max-w-[130px] rounded border border-gray-200 bg-white px-1 text-[11px] text-gray-700 disabled:opacity-50"
-              title="Book this payment to a category"
+              className="h-6 max-w-[220px] rounded border border-gray-200 bg-white px-1 text-[11px] text-gray-700 disabled:opacity-50"
+              title="Book this line to a category — the label shows the COA account it posts to"
             >
               <option value="" disabled>Set category…</option>
-              {MANUAL_CATEGORIES.map((c) => <option key={c} value={c}>{c.toLowerCase().replace(/_/g, " ")}</option>)}
+              {categories.map((c) => <option key={c} value={c}>{categoryLabel(c, accountNames)}</option>)}
             </select>
-            <button
-              onClick={openMatch}
-              disabled={busy}
-              className={`h-6 rounded border px-1.5 text-[11px] font-medium disabled:opacity-50 ${open ? "border-terracotta text-terracotta" : "border-gray-200 text-gray-600 hover:bg-gray-50"}`}
-            >
-              Match…
-            </button>
+            {direction === "DR" && (
+              <button
+                onClick={openMatch}
+                disabled={busy}
+                className={`h-6 rounded border px-1.5 text-[11px] font-medium disabled:opacity-50 ${open ? "border-terracotta text-terracotta" : "border-gray-200 text-gray-600 hover:bg-gray-50"}`}
+              >
+                Match…
+              </button>
+            )}
           </div>
         </td>
       </tr>

--- a/apps/backoffice/src/app/api/finance/ap-match/route.ts
+++ b/apps/backoffice/src/app/api/finance/ap-match/route.ts
@@ -1,8 +1,10 @@
-// GET /api/finance/ap-match?sinceDays=90 — the cash-out reconciliation state
-// for the finance-loop monitor. Read-only (proposes matches; nothing written).
+// GET /api/finance/ap-match?sinceDays=90 — the reconciliation state for the
+// finance-loop monitor: cash-OUT (AP matches + unmatched outflows) AND
+// cash-IN (settlement summary + unmatched inflows). Read-only.
 
 import { NextRequest, NextResponse } from "next/server";
 import { requireRole, AuthError } from "@/lib/auth";
+import { prisma } from "@/lib/prisma";
 import { proposeApMatches } from "@/lib/finance/ap-match";
 import { cashInRecon } from "@/lib/finance/sales-recon";
 
@@ -15,12 +17,32 @@ export async function GET(req: NextRequest) {
     if (e instanceof AuthError) return NextResponse.json({ error: e.message }, { status: e.status });
     return NextResponse.json({ error: "Auth error" }, { status: 500 });
   }
-  const sinceDays = Number(req.nextUrl.searchParams.get("sinceDays") ?? 90);
+  const sinceDaysRaw = Number(req.nextUrl.searchParams.get("sinceDays") ?? 90);
+  const sinceDays = Number.isFinite(sinceDaysRaw) ? sinceDaysRaw : 90;
   try {
-    const [result, cashIn] = await Promise.all([
-      proposeApMatches({ sinceDays: Number.isFinite(sinceDays) ? sinceDays : 90 }),
-      cashInRecon({ sinceDays: Number.isFinite(sinceDays) ? sinceDays : 90 }),
+    const [result, cashIn, inflowLines] = await Promise.all([
+      proposeApMatches({ sinceDays }),
+      cashInRecon({ sinceDays }),
+      // Unreconciled cash-IN: money that arrived with no recognised source —
+      // the mirror of the outflow pile, categorised the same way.
+      prisma.bankStatementLine.findMany({
+        where: {
+          direction: "CR",
+          txnDate: { gte: new Date(Date.now() - sinceDays * 86400_000) },
+          OR: [{ category: null }, { category: "OTHER_INFLOW" }],
+        },
+        select: { id: true, description: true, txnDate: true, amount: true, category: true },
+        orderBy: { amount: "desc" },
+        take: 300,
+      }),
     ]);
+    const unmatchedInflows = inflowLines.map((l) => ({
+      bankLineId: l.id,
+      desc: (l.description ?? "").replace(/\s+/g, " ").slice(0, 60),
+      date: l.txnDate.toISOString().slice(0, 10),
+      amount: Math.round(Number(l.amount) * 100) / 100,
+      category: l.category as string | null,
+    }));
     const summary = {
       auto: result.auto.length,
       review: result.review.length,
@@ -28,8 +50,10 @@ export async function GET(req: NextRequest) {
       unmatchedInvoices: result.unmatchedInvoices.length,
       unmatchedOutflows: result.unmatchedOutflows.length,
       unmatchedOutflowValue: Math.round(result.unmatchedOutflows.reduce((s, o) => s + o.amount, 0)),
+      unmatchedInflows: unmatchedInflows.length,
+      unmatchedInflowValue: Math.round(unmatchedInflows.reduce((s, o) => s + o.amount, 0)),
     };
-    return NextResponse.json({ summary, ...result, cashIn });
+    return NextResponse.json({ summary, ...result, unmatchedInflows, cashIn });
   } catch (err) {
     console.error("[finance/ap-match]", err);
     return NextResponse.json({ error: err instanceof Error ? err.message : "AP match failed" }, { status: 500 });

--- a/apps/backoffice/src/lib/finance/bank-line-classifier.test.ts
+++ b/apps/backoffice/src/lib/finance/bank-line-classifier.test.ts
@@ -50,6 +50,16 @@ describe("bank-line-classifier", () => {
     expect(cr("DR/CARD SALES M/N 2612988 D 5").category).toBe("CARD");
   });
 
+  it("maps utility providers + Pilihan Megah rent (per owner)", () => {
+    expect(dr("TRANSFER FR A/C TIME DOTCOM BHD monthly bill").category).toBe("UTILITIES");
+    expect(dr("PAYMENT TO TT DOTCOM SDN BHD").category).toBe("UTILITIES");
+    expect(dr("CELSIUS COFFEE PUTRATIMEDOTCOM* JUN26").category).toBe("UTILITIES");
+    expect(dr("TRANSFER FR A/C SOMEBODY water bill june").category).toBe("UTILITIES");
+    expect(dr("TRANSFER FR A/C XYZ internet subscription").category).toBe("UTILITIES");
+    expect(dr("TRANSFER FR A/C PILIHAN MEGAH SDN B rental jun").category).toBe("RENT");
+    expect(dr("CELSIUS COFFEE TAMARPILIHAN MEGAH SDN*").category).toBe("RENT");
+  });
+
   it("falls back to OTHER_* for genuinely unknown lines", () => {
     expect(dr("TRANSFER FR A/C SOME UNKNOWN VENDOR XYZ").category).toBe("OTHER_OUTFLOW");
     expect(cr("MISC CREDIT NO PATTERN").category).toBe("OTHER_INFLOW");

--- a/apps/backoffice/src/lib/finance/bank-line-classifier.ts
+++ b/apps/backoffice/src/lib/finance/bank-line-classifier.ts
@@ -160,6 +160,9 @@ const OUTFLOW_RULES: Rule[] = [
   // marketing = Google Ads (ads module) + SMS Niaga only (rules below).
   { name: "purpose_rent",             match: /\bRENT(AL)?\b/i,                        direction: "DR", category: "RENT" as CashCategory },
   { name: "purpose_utility",          match: /\bUTILIT(Y|IES)\b/i,                    direction: "DR", category: "UTILITIES" as CashCategory },
+  // Internet/ISP is a UTILITY (per owner) and must outrank the generic
+  // /SUBSCRIPTION/ software rule ("internet subscription").
+  { name: "util_internet",            match: /TIME\s*DOTCOM|TIMEDOTCOM|TT\s*DOTCOM|TTDOTCOM|TIME\s*FIBRE|\bINTERNET\b/i, direction: "DR", category: "UTILITIES" as CashCategory },
   { name: "purpose_software",         match: /\bSOFTWARE|\bSAAS\b|\bSUBSCRIPTION\b/i, direction: "DR", category: "SOFTWARE" as CashCategory },
   { name: "purpose_petty_cash",       match: /\bPETTY\s*CASH\b/i,                     direction: "DR", category: "PETTY_CASH" as CashCategory },
   { name: "purpose_staff_claim",      match: /\bSTAFF\s*CLAIM|\bCLAIM\b/i,             direction: "DR", category: "STAFF_CLAIM" as CashCategory },
@@ -195,10 +198,11 @@ const OUTFLOW_RULES: Rule[] = [
   { name: "rent_properties_sdn_bhd",  match: /\bPROPERTIES\s*SDN\s*BHD\b/i, direction: "DR", category: "RENT" as CashCategory },
   { name: "rent_holdings_sdn_bhd",    match: /\bHOLDINGS\s*SDN\s*BHD\b/i,   direction: "DR", category: "RENT" as CashCategory },
   { name: "rent_hartanah",            match: /\bHARTANAH\b/i,               direction: "DR", category: "RENT" as CashCategory },
+  { name: "rent_pilihan_megah",       match: /PILIHAN\s*MEGAH/i,            direction: "DR", category: "RENT" as CashCategory },
 
-  // Utilities — TNB / AIR / IWK / TM / MAXIS / DIGI / UNIFI
+  // Utilities — TNB / AIR / IWK / TM / MAXIS / DIGI / UNIFI / TIME / TT Dotcom
   { name: "util_tnb",       match: /\bTNB\b|\bTENAGA NASIONAL\b/i, direction: "DR", category: "UTILITIES" as CashCategory },
-  { name: "util_water",     match: /\b(AIR\s+(SELANGOR|PUTRAJAYA|JOHOR|MELAKA)|INDAH WATER|IWK)\b/i, direction: "DR", category: "UTILITIES" as CashCategory },
+  { name: "util_water",     match: /\b(AIR\s+(SELANGOR|PUTRAJAYA|JOHOR|MELAKA)|INDAH WATER|IWK)\b|\bWATER\b/i, direction: "DR", category: "UTILITIES" as CashCategory },
   { name: "util_telco",     match: /\b(MAXIS|DIGI|UNIFI|TM\s|CELCOM|U MOBILE)\b/i, direction: "DR", category: "UTILITIES" as CashCategory },
 
   // Software / SaaS subscriptions


### PR DESCRIPTION
Owner directives: reconciliation must cover **cash in and out**; a manual match/classify should be a **chart-of-accounts decision**; **water / TIME / internet / TT Dotcom are utilities**; **Pilihan Megah = rental**.

## Cash-in reconciliation
`/api/finance/ap-match` now also returns **unmatched inflows** (CR lines still OTHER_INFLOW/unclassified in the window). The recon page gains an *Unmatched inflows — unreconciled cash-in* section with the same per-row **Set category** control (sales settlements clear their debtor; loans/capital book to the balance sheet), plus a sixth summary tile. The existing classify endpoint already handles CR lines and re-keys posted journals.

## Categorize on the COA
Category dropdowns now read like the chart of accounts — each option shows the account it books to, e.g. `utilities → 6505 Utilities`, `rent → 6504 Rental`, `raw materials → 6000-01…` — sourced from the GL bridge's CONTRA_ACCOUNT map + the accounts API. Salary/statutory show their control-account route (3008 / 3004-7).

## New rules
- `TIME DOTCOM` / `TIMEDOTCOM` / `TT DOTCOM` / `TIME FIBRE` / generic `INTERNET` and `WATER` → **UTILITIES** (internet placed above the generic `/SUBSCRIPTION/` software rule so "internet subscription" books as utilities)
- `PILIHAN MEGAH` → **RENT** (glued-prefix tolerant)

18/18 finance unit tests, typecheck + lint clean. After deploy: run the reclassify pass so existing TIME/TT Dotcom/Pilihan Megah lines re-book.
