### PR TITLE
feat(finance): consolidated group P&L with inter-company eliminations

### DIFF
--- a/apps/backoffice/src/app/(admin)/finance/reports/page.tsx
+++ b/apps/backoffice/src/app/(admin)/finance/reports/page.tsx
@@ -61,8 +61,8 @@ function rangeForPreset(preset: Preset, customStart: string, customEnd: string):
   }
 }
 
-type Controls = { start: string; end: string; outletId: string };
-const ControlsCtx = createContext<Controls>({ start: "", end: "", outletId: "" });
+type Controls = { start: string; end: string; outletId: string; consolidated: boolean };
+const ControlsCtx = createContext<Controls>({ start: "", end: "", outletId: "", consolidated: false });
 const useControls = () => useContext(ControlsCtx);
 
 const CONTROLS_KEY = "finance:reports:controls";
@@ -72,6 +72,7 @@ function useReportControlsState() {
   const [customStart, setCustomStart] = useState(thisMonthStart());
   const [customEnd, setCustomEnd] = useState(todayMyt());
   const [outletId, setOutletId] = useState("");
+  const [consolidated, setConsolidated] = useState(false);
   const [hydrated, setHydrated] = useState(false);
 
   // Remember the last-used range + filter across reloads.
@@ -79,22 +80,23 @@ function useReportControlsState() {
     try {
       const raw = localStorage.getItem(CONTROLS_KEY);
       if (raw) {
-        const s = JSON.parse(raw) as Partial<{ preset: Preset; customStart: string; customEnd: string; outletId: string }>;
+        const s = JSON.parse(raw) as Partial<{ preset: Preset; customStart: string; customEnd: string; outletId: string; consolidated: boolean }>;
         if (s.preset) setPreset(s.preset);
         if (s.customStart) setCustomStart(s.customStart);
         if (s.customEnd) setCustomEnd(s.customEnd);
         if (s.outletId) setOutletId(s.outletId);
+        if (s.consolidated) setConsolidated(true);
       }
     } catch { /* ignore */ }
     setHydrated(true);
   }, []);
   useEffect(() => {
     if (!hydrated) return;
-    try { localStorage.setItem(CONTROLS_KEY, JSON.stringify({ preset, customStart, customEnd, outletId })); } catch { /* ignore */ }
-  }, [hydrated, preset, customStart, customEnd, outletId]);
+    try { localStorage.setItem(CONTROLS_KEY, JSON.stringify({ preset, customStart, customEnd, outletId, consolidated })); } catch { /* ignore */ }
+  }, [hydrated, preset, customStart, customEnd, outletId, consolidated]);
 
   const { start, end } = rangeForPreset(preset, customStart, customEnd);
-  return { preset, setPreset, customStart, setCustomStart, customEnd, setCustomEnd, outletId, setOutletId, start, end };
+  return { preset, setPreset, customStart, setCustomStart, customEnd, setCustomEnd, outletId, setOutletId, consolidated, setConsolidated, start, end };
 }
 
 type FinCompany = { id: string; name: string; outletIds: string[] };
@@ -119,8 +121,16 @@ function ReportControlsBar({ c }: { c: ReturnType<typeof useReportControlsState>
   }, [active?.id, c.outletId]);
 
   async function switchCompany(companyId: string) {
+    // "Consolidated" is a view, not a legal entity — a client-side flag the
+    // P&L understands, with no cookie switch.
+    if (companyId === "__consolidated__") {
+      c.setConsolidated(true);
+      c.setOutletId("");
+      return;
+    }
     setSwitching(true);
     try {
+      if (c.consolidated) c.setConsolidated(false);
       await fetch("/api/finance/companies/switch", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
@@ -136,14 +146,15 @@ function ReportControlsBar({ c }: { c: ReturnType<typeof useReportControlsState>
   return (
     <div className="flex flex-wrap items-center gap-2 rounded-lg border bg-card p-2">
       <select
-        value={co?.activeCompanyId ?? ""}
+        value={c.consolidated ? "__consolidated__" : (co?.activeCompanyId ?? "")}
         onChange={(e) => switchCompany(e.target.value)}
         disabled={!co || switching}
         className="h-8 rounded-md border bg-background px-2 text-sm font-semibold"
-        title="Active company — every report is scoped to this legal entity"
+        title="Active company — every report is scoped to this legal entity. Consolidated = all companies with inter-company legs eliminated (P&L only)."
       >
         {!co && <option value="">Company…</option>}
         {(co?.companies ?? []).map((x) => <option key={x.id} value={x.id}>{x.name}</option>)}
+        <option value="__consolidated__">Consolidated — all companies</option>
       </select>
       <select
         value={c.preset}
@@ -164,8 +175,9 @@ function ReportControlsBar({ c }: { c: ReturnType<typeof useReportControlsState>
       <select
         value={c.outletId}
         onChange={(e) => c.setOutletId(e.target.value)}
-        className="ml-auto h-8 rounded-md border bg-background px-2 text-sm"
-        title="Filter by outlet (outlets of the active company)"
+        disabled={c.consolidated}
+        className="ml-auto h-8 rounded-md border bg-background px-2 text-sm disabled:opacity-50"
+        title={c.consolidated ? "Consolidated view spans all outlets" : "Filter by outlet (outlets of the active company)"}
       >
         <option value="">All outlets</option>
         {companyOutlets.map((o) => <option key={o.id} value={o.id}>{o.name}</option>)}
@@ -256,8 +268,11 @@ function SectionHeader({ label }: { label: string }) {
 }
 
 function PnlTab() {
-  const { start, end, outletId } = useControls();
-  const qs = useMemo(() => `start=${start}&end=${end}${outletId ? `&outletId=${outletId}` : ""}`, [start, end, outletId]);
+  const { start, end, outletId, consolidated } = useControls();
+  const qs = useMemo(
+    () => `start=${start}&end=${end}${consolidated ? "&companyId=consolidated" : outletId ? `&outletId=${outletId}` : ""}`,
+    [start, end, outletId, consolidated],
+  );
   const { data, error, isLoading } = useFetch<{ report: PnlReport }>(
     `/api/finance/reports/pnl?${qs}`
   );
@@ -265,7 +280,12 @@ function PnlTab() {
 
   return (
     <div className="space-y-4">
-      {outletId && (
+      {consolidated && (
+        <p className="text-[11px] text-muted-foreground">
+          Consolidated group P&amp;L: all companies summed with inter-company legs eliminated — HQ-paid salary, Google Ads and management fees count once as group cost. Other tabs stay per-company; switch to a company to drill into a line.
+        </p>
+      )}
+      {!consolidated && outletId && (
         <p className="text-[11px] text-amber-600">
           Per-outlet view: revenue + COGS + outlet-tagged costs only (contribution margin). Shared/HQ opex is paid from the entity account and can&apos;t be split per outlet.
         </p>
@@ -1030,7 +1050,7 @@ export default function FinanceReportsPage() {
         </div>
       )}
 
-      <ControlsCtx.Provider value={{ start: controls.start, end: controls.end, outletId: controls.outletId }}>
+      <ControlsCtx.Provider value={{ start: controls.start, end: controls.end, outletId: controls.outletId, consolidated: controls.consolidated }}>
         {tab === "pnl" && <PnlTab />}
         {tab === "bs" && <BsTab />}
         {tab === "cf" && <CfTab />}

--- a/apps/backoffice/src/app/api/finance/reports/pnl/route.ts
+++ b/apps/backoffice/src/app/api/finance/reports/pnl/route.ts
@@ -2,7 +2,7 @@
 
 import { NextRequest, NextResponse } from "next/server";
 import { requireAuth } from "@/lib/auth";
-import { buildSourcedPnl } from "@/lib/finance/reports/pnl-sourced";
+import { buildSourcedPnl, buildConsolidatedPnl, CONSOLIDATED_COMPANY_ID } from "@/lib/finance/reports/pnl-sourced";
 import { getActiveCompanyId } from "@/lib/finance/companies";
 
 export const dynamic = "force-dynamic";
@@ -23,7 +23,11 @@ export async function GET(req: NextRequest) {
     return NextResponse.json({ error: "start, end (YYYY-MM-DD) required" }, { status: 400 });
   }
   try {
-    const report = await buildSourcedPnl({ companyId, start, end, outletId });
+    // companyId=consolidated → the GROUP statement: all companies summed with
+    // inter-company legs eliminated (outlet filter doesn't apply).
+    const report = companyId === CONSOLIDATED_COMPANY_ID
+      ? await buildConsolidatedPnl({ start, end })
+      : await buildSourcedPnl({ companyId, start, end, outletId });
     return NextResponse.json({ report });
   } catch (err) {
     return NextResponse.json(

--- a/apps/backoffice/src/lib/finance/reports/pnl-sourced.ts
+++ b/apps/backoffice/src/lib/finance/reports/pnl-sourced.ts
@@ -211,8 +211,12 @@ export async function buildSourcedPnl(input: {
                      // outlet-TAGGED bank costs only. Shared/HQ opex (paid from
                      // the entity account, untagged) can't be split per outlet,
                      // so a per-outlet view is a contribution margin, not net.
+  excludeInterCo?: boolean; // consolidated mode: drop inter-company legs so
+                            // group-internal transfers (salary funding, mgmt
+                            // fees, stock transfers) eliminate instead of
+                            // stacking as expense in every entity they pass.
 }): Promise<PnlReport> {
-  const { companyId, start, end, outletId } = input;
+  const { companyId, start, end, outletId, excludeInterCo } = input;
   const client = getFinanceClient();
   const defaultCompany = await getDefaultCompanyId();
 
@@ -277,6 +281,7 @@ export async function buildSourcedPnl(input: {
         statement: { accountName: { contains: incomeSuffix } },
         category: { in: ["GASTROHUB", "MEETINGS_EVENTS"] },
         ...(outletId ? { outletId } : {}),
+        ...(excludeInterCo ? { isInterCo: false } : {}),
       },
       _sum: { amount: true },
     });
@@ -413,6 +418,7 @@ export async function buildSourcedPnl(input: {
         statement: { accountName: { contains: suffix } },
         apInvoiceId: null, // AP-matched lines settle a procurement invoice (COGS) — not opex
         ...(outletId ? { outletId } : {}), // per-outlet: only outlet-tagged costs
+        ...(excludeInterCo ? { isInterCo: false } : {}),
       },
       _sum: { amount: true },
     });
@@ -448,5 +454,55 @@ export async function buildSourcedPnl(input: {
     expenses: { type: "expense", total: totalExpenses, lines: expenseLines },
     netIncome,
     txnCount: saleCount,
+  };
+}
+
+// ─── Consolidated P&L — the GROUP statement ─────────────────────────────────
+// Per-company P&Ls distort where the group pays centrally: HQ carries all
+// Google Ads and most payroll, management fees sit as cost in one entity, and
+// inter-company transfers (salary funding, stock, fees) stack as expense in
+// every entity they pass through. Consolidation runs each company with
+// inter-company legs EXCLUDED (they eliminate on consolidation by definition)
+// and sums line-by-line — HQ-paid ads and payroll then appear exactly once,
+// as the group's cost.
+export const CONSOLIDATED_COMPANY_ID = "consolidated";
+
+export async function buildConsolidatedPnl(input: { start: string; end: string }): Promise<PnlReport> {
+  const { start, end } = input;
+  const companies = Object.keys(BANK_ACCOUNT_SUFFIX);
+  const reports = await Promise.all(
+    companies.map((companyId) => buildSourcedPnl({ companyId, start, end, excludeInterCo: true })),
+  );
+
+  const mergeLines = (sections: PnlLine[][]): PnlLine[] => {
+    const byCode = new Map<string, PnlLine>();
+    for (const lines of sections) {
+      for (const l of lines) {
+        const cur = byCode.get(l.code);
+        if (cur) cur.amount = round2(cur.amount + l.amount);
+        else byCode.set(l.code, { ...l });
+      }
+    }
+    return [...byCode.values()].sort((a, b) => b.amount - a.amount);
+  };
+
+  const income = mergeLines(reports.map((r) => r.income.lines));
+  const cogs = mergeLines(reports.map((r) => r.cogs.lines));
+  const expenses = mergeLines(reports.map((r) => r.expenses.lines));
+  const totalIncome = round2(reports.reduce((s, r) => s + r.income.total, 0));
+  const cogsTotal = round2(reports.reduce((s, r) => s + r.cogs.total, 0));
+  const totalExpenses = round2(reports.reduce((s, r) => s + r.expenses.total, 0));
+  const grossProfit = round2(totalIncome - cogsTotal);
+
+  return {
+    companyId: CONSOLIDATED_COMPANY_ID,
+    start,
+    end,
+    income: { type: "income", total: totalIncome, lines: income },
+    cogs: { type: "cogs", total: cogsTotal, lines: cogs },
+    grossProfit,
+    expenses: { type: "expense", total: totalExpenses, lines: expenses },
+    netIncome: round2(grossProfit - totalExpenses),
+    txnCount: reports.reduce((s, r) => s + r.txnCount, 0),
   };
 }


### PR DESCRIPTION
Owner directive: **employee salary, marketing ads in HQ, and MANAGEMENT_FEE should be consolidated between the companies.**

Per-company P&Ls distort where the group pays centrally — HQ carries all Google Ads and most payroll, and inter-company transfers (salary funding, stock, fees) stack as expense in every entity they pass through.

## Consolidated view
`buildConsolidatedPnl` runs each company's sourced P&L with **inter-company legs excluded** (they eliminate on consolidation by definition) and sums line-by-line:

- **HQ-paid Google Ads** — already attributed only to the default company, so it appears exactly once as group cost;
- **Employee salary** — each entity's inter-company salary funding leg drops out; only the actual payroll payouts count, once;
- **Management fees** — the group-internal fee legs eliminate;
- Everything else (sales, COGS from procurement, Grab commission via the pooled recon rate, GastroHub/Events income) sums naturally.

## UI
The Reports company switcher gains **"Consolidated — all companies"** — a persisted client-side view (no cookie switch). Outlet filter is disabled in that mode; a note explains the eliminations and that drilling stays per-company. The common-size % column works on the consolidated statement too.

Typecheck + lint clean.
