### PR TITLE
feat(finance): WME standing-instruction debits are loan instalments

### DIFF
--- a/apps/backoffice/src/lib/finance/bank-line-classifier.test.ts
+++ b/apps/backoffice/src/lib/finance/bank-line-classifier.test.ts
@@ -60,6 +60,12 @@ describe("bank-line-classifier", () => {
     expect(dr("CELSIUS COFFEE TAMARPILIHAN MEGAH SDN*").category).toBe("RENT");
   });
 
+  it("books WME standing-instruction debits as loan instalments (per owner)", () => {
+    expect(dr("ESI PAYMENT DEBIT CELSIUS COFFEE SDN. WME000001 000046226300").category).toBe("LOAN");
+    expect(dr("0000462263001821 CELSIUS COFFEE SDN.* WME000001").category).toBe("LOAN");
+    expect(dr("0000462263002252 CELSIUS COFFEE SDN.* WME000002").category).toBe("LOAN");
+  });
+
   it("falls back to OTHER_* for genuinely unknown lines", () => {
     expect(dr("TRANSFER FR A/C SOME UNKNOWN VENDOR XYZ").category).toBe("OTHER_OUTFLOW");
     expect(cr("MISC CREDIT NO PATTERN").category).toBe("OTHER_INFLOW");

--- a/apps/backoffice/src/lib/finance/bank-line-classifier.ts
+++ b/apps/backoffice/src/lib/finance/bank-line-classifier.ts
@@ -211,6 +211,11 @@ const OUTFLOW_RULES: Rule[] = [
 
   // Loan repayments
   { name: "loan_payment",   match: /\b(LOAN\s*(PAYMENT|PAYBACK|REPAY(MENT)?|SETTLEMENT)|FINANCING|HIRE\s*PURCHASE)\b/i, direction: "DR", category: "LOAN" as CashCategory },
+  // ESI standing-instruction auto-debits with a WME reference are the two
+  // monthly loan instalments (WME000001 RM2,233 / WME000002 RM2,182, since
+  // Jan 2025) — per owner. Match the reference, not the ESI prefix, since the
+  // description format varies ("ESI PAYMENT DEBIT …" vs the bare mandate no.).
+  { name: "loan_wme_esi",   match: /\bWME\d{4,}\b/i, direction: "DR", category: "LOAN" as CashCategory },
 
   // Bank fees
   { name: "bank_fee",       match: /\b(SERVICE\s*FEE|HANDLING\s*FEE|BANK\s*CHARGE|MAINTENANCE\s*FEE|GIRO\s*FEE)\b/i, direction: "DR", category: "BANK_FEE" as CashCategory },


### PR DESCRIPTION
Owner: the monthly ESI auto-debits referenced **WME000001** (RM2,233) and **WME000002** (RM2,182) are **loan repayments** — 19 instalments each since Jan 2025, RM83,885 total sitting in OTHER_OUTFLOW.

New `loan_wme_esi` rule matches the WME reference (the description varies between `ESI PAYMENT DEBIT …` and the bare mandate number) → LOAN → 3010 Short-term Loans on the GL bridge — a balance-sheet movement, correctly out of opex.

13/13 classifier tests, typecheck clean. Reclassify + GL re-key run after deploy.