### PR TITLE
chore(db): add migration file for CashCategory.REFUND enum value

### DIFF
--- a/packages/db/prisma/migrations/20260703_cashcategory_refund/migration.sql
+++ b/packages/db/prisma/migrations/20260703_cashcategory_refund/migration.sql
@@ -1,0 +1,3 @@
+-- Supplier refunds / return credits land as bank inflows; REFUND posts against 6000-01
+-- (money back reduces COGS). Applied to production 2026-07-02 (supabase migration cashcategory_refund).
+alter type "CashCategory" add value if not exists 'REFUND';


### PR DESCRIPTION
#729 added REFUND to the CashCategory enum in schema.prisma but not the migration file, so migration-guard failed on that PR (it was not a required check and the merge went through). The enum value was already applied to production on 2026-07-02. This commits the SQL record so the repo matches production and the guard is satisfied.