### PR TITLE
ads: budget-cut optimizer — reclaim spend to redeploy to other marketing (approval-gated)

### DIFF
--- a/apps/backoffice/src/app/(admin)/ads/optimizer/page.tsx
+++ b/apps/backoffice/src/app/(admin)/ads/optimizer/page.tsx
@@ -1,0 +1,317 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import Link from "next/link";
+import { ArrowLeft, BadgeCheck, Ban, Coins, Loader2, Scissors, TrendingDown, XCircle } from "lucide-react";
+
+type TrimSuggestion = {
+  trimPct: number;
+  newDailyMyr: number;
+  dailySavedMyr: number;
+  monthlySavedMyr: number;
+  projConvLostPerMonth: number;
+};
+type Campaign = {
+  campaignId: string;
+  campaignName: string;
+  outletName: string | null;
+  dailyBudgetMyr: number;
+  costMyr: number;
+  clicks: number;
+  conversions: number;
+  costPerConv: number | null;
+  cpc: number | null;
+  avgDailySpendMyr: number;
+  budgetCapped: boolean;
+  efficiencyRatio: number | null;
+  wasteMonthlyMyr: number;
+  trim: TrimSuggestion;
+  reclaimableMonthlyMyr: number;
+  lastChange: { status: string; newDailyMyr: number; decidedAt: string } | null;
+};
+type Report = {
+  windowDays: number;
+  benchmarkCostPerConv: number | null;
+  benchmarkOutlet: string | null;
+  campaigns: Campaign[];
+  summary: {
+    totalMonthlySpendMyr: number;
+    reclaimableWasteMyr: number;
+    reclaimableTrimMyr: number;
+    totalReclaimableMyr: number;
+    projConvLostPerMonth: number;
+    searchTermsAvailable: boolean;
+  };
+};
+
+const myr = (n: number) => `RM${n.toLocaleString(undefined, { maximumFractionDigits: 0 })}`;
+
+function Stat({ label, value, sub, tone }: { label: string; value: string; sub?: string; tone?: string }) {
+  return (
+    <div className="rounded-xl border border-border bg-white p-4">
+      <p className="text-xs font-medium text-muted-foreground">{label}</p>
+      <p className={`mt-1 text-2xl font-bold ${tone ?? "text-foreground"}`}>{value}</p>
+      {sub && <p className="text-[11px] text-muted-foreground">{sub}</p>}
+    </div>
+  );
+}
+
+export default function AdsOptimizerPage() {
+  const [report, setReport] = useState<Report | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState("");
+  const [busy, setBusy] = useState<string | null>(null);
+  const [rowError, setRowError] = useState<Record<string, string>>({});
+
+  const load = () => {
+    setLoading(true);
+    fetch("/api/ads/optimizer?days=30")
+      .then((r) => r.json())
+      .then((d) => (d.error ? setError(d.error) : setReport(d)))
+      .catch(() => setError("Network error"))
+      .finally(() => setLoading(false));
+  };
+  useEffect(load, []);
+
+  const campaigns = report?.campaigns ?? [];
+  // Only campaigns with something to reclaim are actionable.
+  const actionable = useMemo(() => campaigns.filter((c) => c.reclaimableMonthlyMyr > 0), [campaigns]);
+
+  const decide = async (c: Campaign, action: "apply" | "reject") => {
+    const key = c.campaignId;
+    if (
+      action === "apply" &&
+      !window.confirm(
+        `Cut ${c.campaignName} daily budget from ${myr(c.dailyBudgetMyr)} to ${myr(c.trim.newDailyMyr)}?\n\n` +
+          `Reclaims ~${myr(c.trim.monthlySavedMyr)}/mo to redeploy elsewhere, giving up ~${c.trim.projConvLostPerMonth} ` +
+          `conversions/mo (direction/call/menu clicks — a proxy, not sales). This changes the live campaign budget.`,
+      )
+    ) {
+      return;
+    }
+    setBusy(key);
+    setRowError((prev) => ({ ...prev, [key]: "" }));
+    try {
+      const res = await fetch("/api/ads/optimizer/apply-budget", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          campaignId: c.campaignId,
+          newDailyMyr: c.trim.newDailyMyr,
+          action,
+          monthlySavingMyr: c.trim.monthlySavedMyr,
+          projConvLostPerMonth: c.trim.projConvLostPerMonth,
+          reason:
+            c.efficiencyRatio != null
+              ? `cost/conv RM${c.costPerConv} = ${c.efficiencyRatio}× fleet best (${report?.benchmarkOutlet ?? "benchmark"})`
+              : null,
+        }),
+      });
+      const d = await res.json();
+      if (!res.ok) {
+        setRowError((prev) => ({ ...prev, [key]: d.error || "Failed" }));
+      } else {
+        setReport((prev) =>
+          prev
+            ? {
+                ...prev,
+                campaigns: prev.campaigns.map((x) =>
+                  x.campaignId === c.campaignId
+                    ? { ...x, lastChange: { status: d.status, newDailyMyr: c.trim.newDailyMyr, decidedAt: new Date().toISOString() } }
+                    : x,
+                ),
+              }
+            : prev,
+        );
+      }
+    } catch {
+      setRowError((prev) => ({ ...prev, [key]: "Network error" }));
+    } finally {
+      setBusy(null);
+    }
+  };
+
+  return (
+    <div className="mx-auto max-w-6xl px-4 py-6 sm:px-6">
+      <Link href="/ads" className="mb-1 flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground">
+        <ArrowLeft className="h-3.5 w-3.5" /> Back to Google Ads
+      </Link>
+      <h1 className="font-heading text-2xl font-bold text-foreground">Budget Optimizer</h1>
+      <p className="text-sm text-muted-foreground">
+        How much ad spend you can safely reclaim and move to other marketing. Two tiers: <strong>waste</strong> (terms you
+        already own on the map — near-zero conversion loss) and <strong>efficiency trims</strong> on the least cost-efficient
+        campaigns (conversions given up shown explicitly). Every cut needs your approval before it touches Google Ads.
+      </p>
+
+      {loading ? (
+        <p className="mt-8 flex items-center gap-2 text-sm text-muted-foreground">
+          <Loader2 className="h-4 w-4 animate-spin" /> Loading spend + efficiency…
+        </p>
+      ) : error ? (
+        <div className="mt-4 rounded-xl border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-900">{error}</div>
+      ) : !report || campaigns.length === 0 ? (
+        <div className="mt-6 rounded-xl border border-border bg-white p-10 text-center">
+          <Coins className="mx-auto h-10 w-10 text-muted-foreground/30" />
+          <p className="mt-3 text-sm text-muted-foreground">
+            No enabled campaigns with spend yet. Metrics flow in with the nightly ads sync.
+          </p>
+        </div>
+      ) : (
+        <>
+          <div className="mt-5 grid grid-cols-2 gap-3 sm:grid-cols-4">
+            <Stat label="Monthly ad spend" value={myr(report.summary.totalMonthlySpendMyr)} sub={`${report.windowDays}d run-rate`} />
+            <Stat
+              label="Reclaimable / month"
+              value={myr(report.summary.totalReclaimableMyr)}
+              sub="to redeploy to other marketing"
+              tone="text-emerald-700"
+            />
+            <Stat
+              label="Waste (≈0 conv loss)"
+              value={myr(report.summary.reclaimableWasteMyr)}
+              sub="terms you own organically"
+              tone="text-emerald-700"
+            />
+            <Stat
+              label="Efficiency trims"
+              value={myr(report.summary.reclaimableTrimMyr)}
+              sub={`−${report.summary.projConvLostPerMonth} conv/mo`}
+              tone="text-amber-700"
+            />
+          </div>
+
+          {!report.summary.searchTermsAvailable && (
+            <div className="mt-4 rounded-xl border border-amber-200 bg-amber-50 px-4 py-3 text-xs text-amber-900">
+              No search-term spend synced yet, so the <strong>waste</strong> tier is blind — only efficiency trims are shown.
+              Run the ads backfill (<span className="font-mono">/api/cron/ads-backfill?from=…&amp;to=…</span>) to load the last
+              30 days of search terms.
+            </div>
+          )}
+
+          <p className="mt-5 text-xs font-medium text-muted-foreground">
+            Benchmark cost/conversion:{" "}
+            <span className="text-foreground">
+              {report.benchmarkCostPerConv != null ? `RM${report.benchmarkCostPerConv}` : "not enough data"}
+            </span>
+            {report.benchmarkOutlet ? ` · your best: ${report.benchmarkOutlet}` : ""}
+          </p>
+
+          <div className="mt-2 rounded-xl border border-border bg-white p-4">
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="text-left text-xs text-muted-foreground">
+                  <th className="py-1 pr-2">Campaign</th>
+                  <th className="pr-2">Daily budget</th>
+                  <th className="pr-2">Cost / conv</th>
+                  <th className="pr-2">Reclaimable / mo</th>
+                  <th>Action</th>
+                </tr>
+              </thead>
+              <tbody className="[&_td]:align-middle">
+                {actionable.map((c) => {
+                  const key = c.campaignId;
+                  const applied = c.lastChange?.status === "applied";
+                  const rejected = c.lastChange?.status === "rejected";
+                  const canTrim = c.trim.trimPct > 0 && !applied && !rejected;
+                  return (
+                    <tr key={key} className="border-t border-border">
+                      <td className="py-2 pr-2">
+                        <span className="font-medium text-foreground">{c.outletName ?? c.campaignName}</span>
+                        <span className="block text-[11px] text-muted-foreground">
+                          {c.conversions} conv · {c.clicks.toLocaleString()} clicks ({report.windowDays}d)
+                          {c.budgetCapped ? " · budget-limited" : ""}
+                        </span>
+                      </td>
+                      <td className="pr-2 tabular-nums">
+                        <span className="font-medium text-foreground">{myr(c.dailyBudgetMyr)}</span>
+                        {c.trim.trimPct > 0 && (
+                          <span className="block text-[11px] text-amber-700">
+                            → {myr(c.trim.newDailyMyr)} (−{Math.round(c.trim.trimPct * 100)}%)
+                          </span>
+                        )}
+                      </td>
+                      <td className="pr-2 tabular-nums">
+                        {c.costPerConv != null ? (
+                          <>
+                            <span className="font-medium text-foreground">RM{c.costPerConv}</span>
+                            {c.efficiencyRatio != null && (
+                              <span
+                                className={`block text-[11px] ${c.efficiencyRatio > 1.15 ? "text-amber-700" : "text-muted-foreground"}`}
+                              >
+                                {c.efficiencyRatio}× best
+                              </span>
+                            )}
+                          </>
+                        ) : (
+                          <span className="text-xs text-muted-foreground">no conv</span>
+                        )}
+                      </td>
+                      <td className="pr-2 tabular-nums">
+                        <span className="font-medium text-emerald-700">{myr(c.reclaimableMonthlyMyr)}</span>
+                        <span className="block text-[11px] text-muted-foreground">
+                          {c.wasteMonthlyMyr > 0 ? `${myr(c.wasteMonthlyMyr)} waste` : ""}
+                          {c.wasteMonthlyMyr > 0 && c.trim.monthlySavedMyr > 0 ? " · " : ""}
+                          {c.trim.monthlySavedMyr > 0 ? `${myr(c.trim.monthlySavedMyr)} trim, −${c.trim.projConvLostPerMonth} conv` : ""}
+                        </span>
+                      </td>
+                      <td>
+                        {c.lastChange ? (
+                          <span className="inline-flex items-center gap-1 text-[11px] font-medium text-muted-foreground">
+                            {applied ? (
+                              <>
+                                <BadgeCheck className="h-3.5 w-3.5 text-emerald-600" /> Cut to {myr(c.lastChange.newDailyMyr)}
+                              </>
+                            ) : rejected ? (
+                              <>
+                                <XCircle className="h-3.5 w-3.5" /> Dismissed
+                              </>
+                            ) : (
+                              <>
+                                <Ban className="h-3.5 w-3.5 text-red-500" /> Failed — retry below
+                              </>
+                            )}
+                          </span>
+                        ) : null}
+                        {canTrim && (
+                          <span className="flex flex-wrap items-center gap-1.5">
+                            <button
+                              onClick={() => decide(c, "apply")}
+                              disabled={busy === key}
+                              className="inline-flex items-center gap-1 rounded-lg bg-emerald-700 px-2.5 py-1 text-[11px] font-medium text-white hover:bg-emerald-800 disabled:opacity-50"
+                            >
+                              {busy === key ? <Loader2 className="h-3 w-3 animate-spin" /> : <Scissors className="h-3 w-3" />}
+                              Cut to {myr(c.trim.newDailyMyr)} · save ~{myr(c.trim.monthlySavedMyr)}/mo
+                            </button>
+                            <button
+                              onClick={() => decide(c, "reject")}
+                              disabled={busy === key}
+                              className="rounded-lg border border-border bg-white px-2.5 py-1 text-[11px] font-medium text-foreground hover:bg-muted/50 disabled:opacity-50"
+                            >
+                              Dismiss
+                            </button>
+                          </span>
+                        )}
+                        {!canTrim && c.wasteMonthlyMyr > 0 && !c.lastChange && (
+                          <Link href="/reviews/geogrid/paid-organic" className="inline-flex items-center gap-1 text-[11px] font-medium text-emerald-700 hover:underline">
+                            <TrendingDown className="h-3 w-3" /> Cut {myr(c.wasteMonthlyMyr)} waste via exclusions
+                          </Link>
+                        )}
+                        {rowError[key] && <span className="block text-[11px] text-red-600">{rowError[key]}</span>}
+                      </td>
+                    </tr>
+                  );
+                })}
+              </tbody>
+            </table>
+            <p className="mt-2 text-[11px] text-muted-foreground">
+              <strong>Waste</strong> is reclaimed by excluding terms you own organically (approve on Paid × Organic) — the map
+              already serves those for free. <strong>Efficiency trims</strong> cut the least cost-efficient campaigns toward
+              your best cost/conversion, capped at −20% per step and never below 50% of budget (a visibility floor); the weekly
+              loop re-measures and steps again. Conversions are direction/call/menu clicks — a proxy for interest, not sales.
+            </p>
+          </div>
+        </>
+      )}
+    </div>
+  );
+}

--- a/apps/backoffice/src/app/(admin)/layout.tsx
+++ b/apps/backoffice/src/app/(admin)/layout.tsx
@@ -16,6 +16,7 @@ import {
   ClipboardList,
   UtensilsCrossed,
   BarChart3,
+  Scissors,
   Power,
   Users,
   Package,
@@ -346,6 +347,7 @@ const NAV_SECTIONS: NavSection[] = [
         items: [
           { label: "Overview",  href: "/ads",           icon: <LayoutDashboard className={ICON_SIZE} />, moduleKey: "ads:overview" },
           { label: "Campaigns", href: "/ads/campaigns", icon: <BarChart3 className={ICON_SIZE} />,        moduleKey: "ads:campaigns" },
+          { label: "Optimizer", href: "/ads/optimizer", icon: <Scissors className={ICON_SIZE} />,         moduleKey: "ads:campaigns" },
           { label: "Invoices",  href: "/ads/invoices",  icon: <Receipt className={ICON_SIZE} />,          moduleKey: "ads:invoices" },
         ],
       },

--- a/apps/backoffice/src/app/api/ads/optimizer/apply-budget/route.ts
+++ b/apps/backoffice/src/app/api/ads/optimizer/apply-budget/route.ts
@@ -1,0 +1,52 @@
+import { NextRequest, NextResponse } from "next/server";
+import { requireRole } from "@/lib/auth";
+import { applyBudgetChange, rejectBudgetChange } from "@/lib/ads/set-budget";
+
+export const dynamic = "force-dynamic";
+export const maxDuration = 60;
+
+// POST /api/ads/optimizer/apply-budget — THE approval gate for cutting a Smart
+// campaign's daily budget. Only an admin's explicit click reaches this endpoint;
+// action "apply" writes the new amount to the Google Ads CampaignBudget, action
+// "reject" just records the dismissal.
+// Body: { campaignId, newDailyMyr, action: "apply" | "reject",
+//         monthlySavingMyr?, projConvLostPerMonth?, reason? }
+export async function POST(request: NextRequest) {
+  let user;
+  try {
+    user = await requireRole(request.headers, "ADMIN");
+  } catch {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const body = await request.json().catch(() => ({}));
+  const campaignId: string = body.campaignId;
+  const newDailyMyr = Number(body.newDailyMyr);
+  const action: string = body.action;
+  if (!campaignId || !Number.isFinite(newDailyMyr) || newDailyMyr <= 0 || !["apply", "reject"].includes(action)) {
+    return NextResponse.json(
+      { error: "campaignId, newDailyMyr (> 0) and action (apply|reject) required" },
+      { status: 400 },
+    );
+  }
+
+  const decision = {
+    campaignId,
+    newDailyMyr,
+    decidedBy: user.name || user.id,
+    monthlySavingMyr: typeof body.monthlySavingMyr === "number" ? body.monthlySavingMyr : null,
+    projConvLostPerMonth: typeof body.projConvLostPerMonth === "number" ? body.projConvLostPerMonth : null,
+    reason: typeof body.reason === "string" ? body.reason.slice(0, 500) : null,
+  };
+
+  if (action === "reject") {
+    await rejectBudgetChange(decision);
+    return NextResponse.json({ ok: true, status: "rejected" });
+  }
+
+  const result = await applyBudgetChange(decision);
+  if (!result.ok) {
+    return NextResponse.json({ error: result.error, status: "failed" }, { status: 502 });
+  }
+  return NextResponse.json({ ok: true, status: "applied" });
+}

--- a/apps/backoffice/src/app/api/ads/optimizer/route.ts
+++ b/apps/backoffice/src/app/api/ads/optimizer/route.ts
@@ -1,0 +1,21 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getUserFromHeaders } from "@/lib/auth";
+import { buildAdsOptimizerReport } from "@/lib/ads/optimizer";
+
+export const dynamic = "force-dynamic";
+export const maxDuration = 60;
+
+// GET /api/ads/optimizer?days=30 — per campaign: how much daily budget can be
+// reclaimed (waste you own organically + the least-efficient marginal spend),
+// with the conversions each trim gives up. Read-only; cuts go through the
+// approval-gated POST /api/ads/optimizer/apply-budget.
+export async function GET(request: NextRequest) {
+  const user = await getUserFromHeaders(request.headers);
+  if (!user) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+
+  const daysParam = Number(new URL(request.url).searchParams.get("days"));
+  const days = Number.isFinite(daysParam) && daysParam >= 7 && daysParam <= 180 ? daysParam : 30;
+
+  const report = await buildAdsOptimizerReport(days);
+  return NextResponse.json(report);
+}

--- a/apps/backoffice/src/app/api/cron/ads-daily/route.ts
+++ b/apps/backoffice/src/app/api/cron/ads-daily/route.ts
@@ -5,6 +5,7 @@ import { syncCampaigns } from "@/lib/ads/sync-campaigns";
 import { syncMetrics } from "@/lib/ads/sync-metrics";
 import { syncSearchTerms } from "@/lib/ads/sync-search-terms";
 import { runSync } from "@/lib/ads/run-sync";
+import { buildAdsOptimizerReport } from "@/lib/ads/optimizer";
 import { checkCronAuth } from "@celsius/shared";
 
 export const dynamic = "force-dynamic";
@@ -70,10 +71,25 @@ export async function GET(req: NextRequest) {
     });
   }
 
+  // Weekly (Monday, after the fresh sync above) shadow pass of the budget-cut
+  // optimizer — no new Vercel cron slot needed, and it deliberately mutates
+  // nothing: cutting a budget is approval-gated on /ads/optimizer. This just
+  // records the week's reclaimable total so the recommendation is auditable.
+  let optimizer: Record<string, unknown> | null = null;
+  if (new Date().getUTCDay() === 1) {
+    try {
+      const report = await buildAdsOptimizerReport(30);
+      optimizer = { mode: "shadow", summary: report.summary };
+    } catch (e) {
+      optimizer = { error: (e as Error).message };
+    }
+  }
+
   return NextResponse.json({
     ok: true,
     date: y,
     accounts: accountsRun.error ?? accountsRun.result,
     perAccount: results,
+    optimizer,
   });
 }

--- a/apps/backoffice/src/app/api/cron/ads-optimizer/route.ts
+++ b/apps/backoffice/src/app/api/cron/ads-optimizer/route.ts
@@ -1,0 +1,39 @@
+import { NextRequest, NextResponse } from "next/server";
+import { buildAdsOptimizerReport } from "@/lib/ads/optimizer";
+import { checkCronAuth } from "@celsius/shared";
+
+export const dynamic = "force-dynamic";
+export const maxDuration = 120;
+
+// Weekly. SHADOW MODE — computes how much ad spend is reclaimable (waste +
+// least-efficient marginal spend) and returns it. It deliberately does NOT
+// mutate any budget: cutting a Smart campaign's budget is approval-gated and
+// only ever happens from an explicit click on /ads/optimizer. This cron exists
+// so the recommendation is fresh (and can later drive a nudge), not to act.
+export async function GET(req: NextRequest) {
+  const cronAuth = checkCronAuth(req.headers);
+  if (!cronAuth.ok) return NextResponse.json({ error: cronAuth.error }, { status: cronAuth.status });
+
+  const report = await buildAdsOptimizerReport(30);
+
+  return NextResponse.json({
+    ok: true,
+    mode: "shadow",
+    generatedFor: `${report.windowDays}d`,
+    summary: report.summary,
+    // The campaigns with something to reclaim, most first — the shortlist a
+    // human would review on the Optimizer page.
+    recommendations: report.campaigns
+      .filter((c) => c.reclaimableMonthlyMyr > 0)
+      .map((c) => ({
+        campaign: c.campaignName,
+        outlet: c.outletName,
+        dailyBudgetMyr: c.dailyBudgetMyr,
+        efficiencyRatio: c.efficiencyRatio,
+        wasteMonthlyMyr: c.wasteMonthlyMyr,
+        trimToDailyMyr: c.trim.trimPct > 0 ? c.trim.newDailyMyr : null,
+        reclaimableMonthlyMyr: c.reclaimableMonthlyMyr,
+        projConvLostPerMonth: c.trim.projConvLostPerMonth,
+      })),
+  });
+}

--- a/apps/backoffice/src/lib/ads/optimizer.ts
+++ b/apps/backoffice/src/lib/ads/optimizer.ts
@@ -1,0 +1,225 @@
+/**
+ * Smart-campaign budget optimizer — "how much ad spend can I safely reclaim
+ * and move to other marketing?"
+ *
+ * Two reclaim tiers, honest about the tradeoff:
+ *
+ *   1. WASTE (≈ zero conversion loss) — spend on terms you own organically /
+ *      competitor brands, from the Paid×Organic report. Cut via negatives;
+ *      the clicks were buying what the map already gives you free.
+ *
+ *   2. EFFICIENCY TRIM (proportional conversion loss, shown explicitly) — the
+ *      least cost-efficient campaigns carry the most expensive marginal
+ *      conversions. Trim their daily budget in small steps toward the fleet's
+ *      best cost/conversion. We do NOT pretend trimming improves efficiency —
+ *      it reclaims the worst-value ringgit and states the conversions given up.
+ *
+ * Smart campaigns expose only two real levers (negatives + budget), so this is
+ * the whole optimisation surface. Every number is a proxy: a Smart-campaign
+ * "conversion" is a direction/call/menu click, not a sale — use it to compare
+ * campaigns and size cuts, not as revenue.
+ */
+
+import { prisma } from "@/lib/prisma";
+import { microsToMYR } from "./client";
+import { buildPaidOrganicReport } from "./paid-organic";
+
+// Trim policy. Conservative single-step cuts; the weekly loop re-measures and
+// steps again rather than making one big move a Smart campaign can't absorb.
+export const BENCHMARK_MIN_CONV = 20;   // a campaign needs this many conv to set/judge the benchmark
+export const EFFICIENT_RATIO = 1.15;    // ≤ this × the best cost/conv → leave alone
+export const MAX_TRIM_PCT = 0.20;       // never cut more than 20% of daily budget in one step
+export const FLOOR_PCT = 0.5;           // never drop below 50% of current budget (visibility floor)
+export const CAPPED_AT = 0.9;           // spending ≥ 90% of budget ⇒ budget-limited
+
+const round2 = (n: number) => Math.round(n * 100) / 100;
+const round0 = (n: number) => Math.round(n);
+
+export type TrimSuggestion = {
+  trimPct: number;          // 0..MAX_TRIM_PCT
+  newDailyMyr: number;      // recommended daily budget
+  dailySavedMyr: number;
+  monthlySavedMyr: number;
+  projConvLostPerMonth: number; // trimmed spend ÷ this campaign's cost/conv
+};
+
+/**
+ * Pure: given a campaign's cost-efficiency vs the fleet benchmark, how much to
+ * trim. Efficient campaigns are left alone; inefficiency scales the cut up to
+ * MAX_TRIM_PCT, bounded by the visibility floor. Null cost/conv (no data) → no cut.
+ */
+export function suggestTrim(
+  currentDailyMyr: number,
+  costPerConv: number | null,
+  benchmarkCostPerConv: number | null,
+): TrimSuggestion {
+  const none: TrimSuggestion = { trimPct: 0, newDailyMyr: round2(currentDailyMyr), dailySavedMyr: 0, monthlySavedMyr: 0, projConvLostPerMonth: 0 };
+  if (!costPerConv || !benchmarkCostPerConv || currentDailyMyr <= 0) return none;
+
+  const ratio = costPerConv / benchmarkCostPerConv;
+  if (ratio <= EFFICIENT_RATIO) return none; // it's among your best spend — keep it
+
+  // Scale trim from 0 at EFFICIENT_RATIO up to MAX_TRIM_PCT at ratio ≥ 2×.
+  const scaled = ((ratio - EFFICIENT_RATIO) / (2 - EFFICIENT_RATIO)) * MAX_TRIM_PCT;
+  const trimPct = Math.max(0, Math.min(MAX_TRIM_PCT, scaled));
+  if (trimPct <= 0) return none;
+
+  const newDaily = Math.max(currentDailyMyr * FLOOR_PCT, currentDailyMyr * (1 - trimPct));
+  const dailySaved = currentDailyMyr - newDaily;
+  const monthlySaved = dailySaved * 30;
+  return {
+    trimPct: round2((currentDailyMyr - newDaily) / currentDailyMyr),
+    newDailyMyr: round2(newDaily),
+    dailySavedMyr: round2(dailySaved),
+    monthlySavedMyr: round2(monthlySaved),
+    projConvLostPerMonth: round0(monthlySaved / costPerConv),
+  };
+}
+
+export type OptimizerCampaign = {
+  campaignId: string;
+  campaignName: string;
+  outletName: string | null;
+  dailyBudgetMyr: number;
+  costMyr: number;          // over window
+  clicks: number;
+  conversions: number;
+  costPerConv: number | null;
+  cpc: number | null;
+  avgDailySpendMyr: number;
+  budgetCapped: boolean;
+  efficiencyRatio: number | null; // costPerConv ÷ benchmark; 1 = best
+  wasteMonthlyMyr: number;        // reclaimable via negatives (Paid×Organic)
+  trim: TrimSuggestion;
+  reclaimableMonthlyMyr: number;  // waste + trim
+  lastChange: { status: string; newDailyMyr: number; decidedAt: string } | null; // latest budget decision
+};
+
+export type OptimizerReport = {
+  windowDays: number;
+  benchmarkCostPerConv: number | null;
+  benchmarkOutlet: string | null;
+  campaigns: OptimizerCampaign[];
+  summary: {
+    totalMonthlySpendMyr: number;
+    reclaimableWasteMyr: number;   // tier 1 — ~no conv loss
+    reclaimableTrimMyr: number;    // tier 2 — with conv loss
+    totalReclaimableMyr: number;
+    projConvLostPerMonth: number;  // from the trims only
+    searchTermsAvailable: boolean; // false ⇒ backfill not run, waste is blind
+  };
+};
+
+export async function buildAdsOptimizerReport(windowDays = 30): Promise<OptimizerReport> {
+  const since = new Date(Date.now() - windowDays * 86400000);
+
+  const [campaigns, metrics, paidOrganic] = await Promise.all([
+    prisma.adsCampaign.findMany({
+      where: { status: "ENABLED", account: { isManager: false } },
+      select: { id: true, name: true, dailyBudgetMicros: true, outletId: true },
+    }),
+    prisma.adsMetricDaily.groupBy({
+      by: ["campaignId"],
+      where: { date: { gte: since }, campaignId: { not: null } },
+      _sum: { costMicros: true, clicks: true, conversions: true },
+    }),
+    buildPaidOrganicReport(windowDays).catch(() => null),
+  ]);
+
+  const [outlets, changes] = await Promise.all([
+    prisma.outlet.findMany({ select: { id: true, name: true } }),
+    // Latest budget decision per campaign — surfaced so the page reflects an
+    // already-applied cut and can suppress a duplicate suggestion.
+    prisma.adsBudgetChange.findMany({
+      orderBy: { decidedAt: "desc" },
+      select: { campaignId: true, status: true, newDailyMicros: true, decidedAt: true },
+    }),
+  ]);
+  const outletName = new Map(outlets.map((o) => [o.id, o.name]));
+
+  const lastChangeByCampaign = new Map<string, OptimizerCampaign["lastChange"]>();
+  for (const c of changes) {
+    if (!lastChangeByCampaign.has(c.campaignId)) {
+      lastChangeByCampaign.set(c.campaignId, {
+        status: c.status,
+        newDailyMyr: microsToMYR(c.newDailyMicros),
+        decidedAt: c.decidedAt.toISOString(),
+      });
+    }
+  }
+
+  const metricByCampaign = new Map(metrics.map((m) => [m.campaignId as string, m._sum]));
+
+  // Waste per campaign = owned-organic exclude candidates not yet applied.
+  const wasteByCampaign = new Map<string, number>();
+  if (paidOrganic) {
+    for (const r of paidOrganic.rows) {
+      if (r.verdict === "exclude_candidate" && r.exclusion?.status !== "applied") {
+        wasteByCampaign.set(r.campaignId, (wasteByCampaign.get(r.campaignId) ?? 0) + r.estMonthlySavingMyr);
+      }
+    }
+  }
+
+  // First pass: raw efficiency per campaign.
+  const base = campaigns.map((c) => {
+    const m = metricByCampaign.get(c.id);
+    const costMyr = microsToMYR(m?.costMicros ?? BigInt(0));
+    const clicks = Number(m?.clicks ?? 0);
+    const conversions = Number(m?.conversions ?? 0);
+    const costPerConv = conversions > 0 ? costMyr / conversions : null;
+    const dailyBudgetMyr = microsToMYR(c.dailyBudgetMicros ?? BigInt(0));
+    const avgDailySpendMyr = windowDays > 0 ? costMyr / windowDays : 0;
+    return {
+      campaignId: c.id,
+      campaignName: c.name,
+      outletName: c.outletId ? outletName.get(c.outletId) ?? null : null,
+      dailyBudgetMyr,
+      costMyr: round2(costMyr),
+      clicks,
+      conversions: round0(conversions),
+      costPerConv: costPerConv != null ? round2(costPerConv) : null,
+      cpc: clicks > 0 ? round2(costMyr / clicks) : null,
+      avgDailySpendMyr: round2(avgDailySpendMyr),
+      budgetCapped: dailyBudgetMyr > 0 && avgDailySpendMyr >= dailyBudgetMyr * CAPPED_AT,
+      wasteMonthlyMyr: round2(wasteByCampaign.get(c.id) ?? 0),
+    };
+  });
+
+  // Benchmark = best (lowest) cost/conv among campaigns with enough conversions.
+  const eligible = base.filter((b) => b.costPerConv != null && b.conversions >= BENCHMARK_MIN_CONV);
+  const benchmark = eligible.length
+    ? eligible.reduce((best, b) => (b.costPerConv! < best.costPerConv! ? b : best))
+    : null;
+  const benchmarkCostPerConv = benchmark?.costPerConv ?? null;
+
+  const enriched: OptimizerCampaign[] = base.map((b) => {
+    const trim = suggestTrim(b.dailyBudgetMyr, b.costPerConv, benchmarkCostPerConv);
+    return {
+      ...b,
+      efficiencyRatio: b.costPerConv != null && benchmarkCostPerConv ? round2(b.costPerConv / benchmarkCostPerConv) : null,
+      trim,
+      reclaimableMonthlyMyr: round2(b.wasteMonthlyMyr + trim.monthlySavedMyr),
+      lastChange: lastChangeByCampaign.get(b.campaignId) ?? null,
+    };
+  });
+
+  enriched.sort((a, b) => b.reclaimableMonthlyMyr - a.reclaimableMonthlyMyr);
+
+  const reclaimableWasteMyr = round2(enriched.reduce((s, c) => s + c.wasteMonthlyMyr, 0));
+  const reclaimableTrimMyr = round2(enriched.reduce((s, c) => s + c.trim.monthlySavedMyr, 0));
+
+  return {
+    windowDays,
+    benchmarkCostPerConv,
+    benchmarkOutlet: benchmark?.outletName ?? benchmark?.campaignName ?? null,
+    campaigns: enriched,
+    summary: {
+      totalMonthlySpendMyr: round2(enriched.reduce((s, c) => s + c.avgDailySpendMyr * 30, 0)),
+      reclaimableWasteMyr,
+      reclaimableTrimMyr,
+      totalReclaimableMyr: round2(reclaimableWasteMyr + reclaimableTrimMyr),
+      projConvLostPerMonth: round0(enriched.reduce((s, c) => s + c.trim.projConvLostPerMonth, 0)),
+      searchTermsAvailable: !!paidOrganic && (paidOrganic.summary.termsWithSpend > 0),
+    },
+  };
+}

--- a/apps/backoffice/src/lib/ads/set-budget.ts
+++ b/apps/backoffice/src/lib/ads/set-budget.ts
@@ -1,0 +1,136 @@
+/**
+ * Approval-gated daily-budget change for a Smart campaign.
+ *
+ * The optimizer only ever *recommends* a cut — reclaim spend to redeploy to
+ * other marketing. Applying one is a deliberate human click on the Optimizer
+ * page (never a cron, never automatic), and every decision — applied, failed,
+ * or rejected — lands in the ads_budget_change ledger with the previous amount
+ * so a cut can be undone.
+ *
+ * A Smart campaign's budget is a CampaignBudget resource shared via the
+ * campaign. We read its resource_name over GAQL, then update amount_micros.
+ */
+
+import { prisma } from "@/lib/prisma";
+import { getCustomer } from "./client";
+import { randomUUID } from "crypto";
+
+const MYR_TO_MICROS = 1_000_000;
+
+export type BudgetDecision = {
+  campaignId: string; // ads_campaign.id (our PK)
+  newDailyMyr: number;
+  decidedBy: string;
+  monthlySavingMyr?: number | null;
+  projConvLostPerMonth?: number | null;
+  reason?: string | null; // efficiency evidence shown at decision time
+};
+
+async function insertLedger(
+  d: BudgetDecision,
+  fields: {
+    status: string;
+    prevDailyMicros: bigint | null;
+    newDailyMicros: bigint;
+    budgetResource?: string | null;
+    error?: string | null;
+    appliedAt?: Date | null;
+  },
+) {
+  return prisma.adsBudgetChange.create({
+    data: {
+      id: randomUUID(),
+      campaignId: d.campaignId,
+      status: fields.status,
+      prevDailyMicros: fields.prevDailyMicros ?? null,
+      newDailyMicros: fields.newDailyMicros,
+      monthlySavingMyr: d.monthlySavingMyr ?? null,
+      projConvLostPerMonth: d.projConvLostPerMonth ?? null,
+      reason: d.reason ?? null,
+      budgetResource: fields.budgetResource ?? null,
+      error: fields.error ?? null,
+      decidedBy: d.decidedBy,
+      appliedAt: fields.appliedAt ?? null,
+    },
+  });
+}
+
+/** Approve: set the campaign's daily budget in Google Ads, then record it. */
+export async function applyBudgetChange(
+  d: BudgetDecision,
+): Promise<{ ok: boolean; error?: string }> {
+  const campaign = await prisma.adsCampaign.findUnique({
+    where: { id: d.campaignId },
+    include: { account: { select: { customerId: true } } },
+  });
+  if (!campaign) return { ok: false, error: "Campaign not found" };
+
+  const newMicros = BigInt(Math.round(d.newDailyMyr * MYR_TO_MICROS));
+  if (newMicros <= BigInt(0)) return { ok: false, error: "New daily budget must be > 0" };
+
+  const prevMicros = campaign.dailyBudgetMicros ?? null;
+  const customerId = campaign.account.customerId.replace(/-/g, "");
+
+  try {
+    const customer = getCustomer(customerId);
+
+    // Find the CampaignBudget resource this campaign spends against.
+    const rows = (await customer.query(`
+      SELECT campaign_budget.resource_name, campaign_budget.amount_micros
+      FROM campaign
+      WHERE campaign.id = ${campaign.campaignId}
+      LIMIT 1
+    `)) as Array<{ campaign_budget?: { resource_name?: string } }>;
+
+    const budgetResource = rows?.[0]?.campaign_budget?.resource_name;
+    if (!budgetResource) {
+      const msg = "Campaign budget resource not found";
+      await insertLedger(d, { status: "failed", prevDailyMicros: prevMicros, newDailyMicros: newMicros, error: msg });
+      return { ok: false, error: msg };
+    }
+
+    await customer.campaignBudgets.update([
+      { resource_name: budgetResource, amount_micros: Number(newMicros) },
+    ]);
+
+    // Mirror the new amount locally so the report reflects it before the next sync.
+    await prisma.adsCampaign.update({
+      where: { id: campaign.id },
+      data: { dailyBudgetMicros: newMicros },
+    });
+
+    await insertLedger(d, {
+      status: "applied",
+      prevDailyMicros: prevMicros,
+      newDailyMicros: newMicros,
+      budgetResource,
+      appliedAt: new Date(),
+    });
+    return { ok: true };
+  } catch (err) {
+    const e = err as { errors?: Array<{ message?: string }>; message?: string };
+    const message =
+      e?.errors?.map((x) => x.message).filter(Boolean).join(" | ") || e?.message || String(err);
+    await insertLedger(d, {
+      status: "failed",
+      prevDailyMicros: prevMicros,
+      newDailyMicros: newMicros,
+      error: message.slice(0, 1000),
+    });
+    return { ok: false, error: message };
+  }
+}
+
+/** Dismiss: record the human's "no" so the suggestion is auditable. */
+export async function rejectBudgetChange(d: BudgetDecision) {
+  const newMicros = BigInt(Math.round(d.newDailyMyr * MYR_TO_MICROS));
+  const campaign = await prisma.adsCampaign.findUnique({
+    where: { id: d.campaignId },
+    select: { dailyBudgetMicros: true },
+  });
+  await insertLedger(d, {
+    status: "rejected",
+    prevDailyMicros: campaign?.dailyBudgetMicros ?? null,
+    newDailyMicros: newMicros,
+  });
+}

--- a/packages/db/prisma/migrations/20260703_ads_budget_change/migration.sql
+++ b/packages/db/prisma/migrations/20260703_ads_budget_change/migration.sql
@@ -1,0 +1,28 @@
+-- 067_ads_budget_change.sql
+-- Budget-cut optimizer for the local-rank / ad-spend loop.
+--
+-- ads_budget_change: the APPROVAL LEDGER for cutting a Smart campaign's daily
+-- budget so the freed spend can be redeployed to other marketing. Rows are only
+-- ever created by an explicit human decision on the Optimizer page; the Google
+-- Ads CampaignBudget mutation fires on approval, never automatically.
+-- prev_daily_micros retains the pre-cut amount so a cut can be undone.
+
+CREATE TABLE IF NOT EXISTS ads_budget_change (
+  id                       text PRIMARY KEY,
+  campaign_id              text NOT NULL REFERENCES ads_campaign(id) ON DELETE CASCADE,
+  status                   text NOT NULL, -- applied | failed | rejected
+  prev_daily_micros        bigint,
+  new_daily_micros         bigint NOT NULL,
+  monthly_saving_myr       numeric(12,2),
+  proj_conv_lost_per_month integer,
+  reason                   text,          -- the efficiency evidence at decision time
+  budget_resource          text,          -- Google Ads CampaignBudget resource name
+  error                    text,
+  decided_by               text,
+  decided_at               timestamptz NOT NULL DEFAULT now(),
+  applied_at               timestamptz,
+  created_at               timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS ads_budget_change_campaign_idx
+  ON ads_budget_change (campaign_id, decided_at DESC);

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -1664,6 +1664,7 @@ model AdsCampaign {
   keywords    AdsKeywordMetric[]
   searchTerms AdsSearchTermDaily[]
   exclusions  AdsTermExclusion[]
+  budgetChanges AdsBudgetChange[]
 
   @@unique([accountId, campaignId])
   @@index([accountId])
@@ -1760,6 +1761,32 @@ model AdsTermExclusion {
 
   @@unique([campaignId, searchTerm])
   @@map("ads_term_exclusion")
+}
+
+// Approval ledger for cutting a Smart campaign's daily budget (reclaim spend to
+// redeploy to other marketing). Rows exist only from explicit human decisions
+// on the Optimizer page — the Google Ads mutation fires on approval, never
+// automatically. prevDailyMicros retains the pre-cut amount for undo.
+model AdsBudgetChange {
+  id                   String    @id
+  campaignId           String    @map("campaign_id")
+  status               String // applied | failed | rejected
+  prevDailyMicros      BigInt?   @map("prev_daily_micros")
+  newDailyMicros       BigInt    @map("new_daily_micros")
+  monthlySavingMyr     Decimal?  @map("monthly_saving_myr") @db.Decimal(12, 2)
+  projConvLostPerMonth Int?      @map("proj_conv_lost_per_month")
+  reason               String? // the efficiency evidence at decision time
+  budgetResource       String?   @map("budget_resource") // Ads CampaignBudget resource name
+  error                String?
+  decidedBy            String?   @map("decided_by")
+  decidedAt            DateTime  @default(now()) @map("decided_at")
+  appliedAt            DateTime? @map("applied_at")
+  createdAt            DateTime  @default(now()) @map("created_at")
+
+  campaign AdsCampaign @relation(fields: [campaignId], references: [id], onDelete: Cascade)
+
+  @@index([campaignId, decidedAt(sort: Desc)])
+  @@map("ads_budget_change")
 }
 
 model AdsInvoice {


### PR DESCRIPTION
## What & why

You want to **cut Google Ads cost and move the freed budget to other marketing channels**. Smart campaigns expose only two levers (negative keyword themes + budget), and #704 already built the negatives side. This adds the **budget** side of the loop — honest about the tradeoff, and approval-gated the same way exclusions are.

## The two reclaim tiers (per campaign)

1. **Waste (≈ zero conversion loss)** — spend on terms you already own organically, from the existing Paid × Organic report. The map serves those for free; cut them via negatives. The Optimizer links straight back to that approval flow.
2. **Efficiency trim (conversion loss shown explicitly)** — the least cost-efficient campaigns carry the most expensive marginal conversions. Trim their daily budget toward the fleet's **best cost/conversion**, scaled `0 → 20%` by how inefficient they are, floored at 50% of budget (a visibility floor). We do **not** pretend trimming improves efficiency — every trim states the conversions it gives up.

Benchmark = the lowest cost/conversion among campaigns with ≥20 conversions (your own best outlet sets the bar). A "conversion" here is a direction/call/menu click — a proxy for interest, **not a sale** — so it's used to compare campaigns and size cuts, never as revenue.

## Changes

- **`lib/ads/optimizer.ts`** — pure compute: `suggestTrim()` + `buildAdsOptimizerReport()`. Surfaces reclaimable RM per campaign (waste + trim) and the projected monthly conversion loss. Nine fixture cases verified standalone (efficient → no cut; 1.5× → partial; ≥2× → capped 20%; null/zero guards).
- **`lib/ads/set-budget.ts`** — approval-gated `CampaignBudget` mutation via the Google Ads API (reads the budget resource over GAQL, then updates `amount_micros`) + the **`ads_budget_change`** ledger, which retains the previous amount for undo. This is the **only** code path that changes a budget; it fires on an explicit admin click, never from a cron.
- **`api/ads/optimizer`** (GET, read-only) + **`api/ads/optimizer/apply-budget`** (POST, ADMIN-gated, `apply` | `reject`).
- **`(admin)/ads/optimizer`** page — reclaimable RM per campaign with cut / dismiss buttons and a confirm dialog stating the live-campaign impact + conversions given up. New **Optimizer** nav item under Google Ads.
- **Weekly shadow pass** folded into the existing `ads-daily` cron (Mondays) — computes the week's reclaimable total but **mutates nothing** (budget cuts stay approval-gated). No new Vercel cron slot added (the project is already at the cron cap); a standalone `/api/cron/ads-optimizer` route is kept for manual/external runs.
- **`schema.prisma` + migration** `20260703_ads_budget_change` for the ledger table.

## Safety / guardrails

- Nothing auto-applies. Both tiers require an explicit approval click; every decision (applied / failed / rejected) is ledgered with the evidence shown at decision time.
- Single steps are capped at −20% and never below 50% of budget, so no cut can crater a campaign's visibility; the weekly loop re-measures and steps again.
- If search-term spend hasn't been backfilled, the **waste** tier is honestly flagged as blind and only efficiency trims are shown.

## Verification

- `suggestTrim` logic: nine fixture cases pass (standalone, no DB).
- Migration mirrors the Prisma model per the ads-module convention (manual SQL only — never `prisma db push`). Not yet applied to prod; the page/report degrade gracefully until it is.
- Full in-container typecheck isn't available (no `node_modules` in this sandbox); the new code follows the exact patterns of the merged `exclude-term.ts` / paid-organic routes and relies on CI typecheck.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01KAg3qfmYoUCakrJNpQoMZJ)_