### PR TITLE
feat(loyalty): grant-time loop engineering for the rewards module

### DIFF
--- a/apps/backoffice/src/lib/loyalty/loop-engine.ts
+++ b/apps/backoffice/src/lib/loyalty/loop-engine.ts
@@ -677,10 +677,15 @@ export async function measureRound(roundId: string) {
   // none. Sibling loops share the audience, so a holdout here can be TREATED by
   // another loop inside this round's window (measured at ~17% for winback) —
   // that biases the baseline up and understates lift. Exclude them from stats.
+  // GRANT rounds skip this: their 'holdout' is a control that RECEIVED the
+  // status-quo reward (not "no message"), and sibling-loop SMS lands on
+  // control and treatment symmetrically (randomised at grant time) — so
+  // excluding only contaminated controls would bias the baseline down.
+  const isGrantRound = (round.meta as { kind?: string } | null)?.kind === "grant";
   const holdoutPhones = ((rows ?? []) as Array<{ arm: string; phone: string }>)
     .filter((r) => r.arm === "holdout").map((r) => r.phone);
   const contaminated = new Set<string>();
-  if (holdoutPhones.length && round.sent_at) {
+  if (holdoutPhones.length && round.sent_at && !isGrantRound) {
     const winStart = round.sent_at as string;
     const winEnd = new Date(new Date(winStart).getTime() + windowMs).toISOString();
     for (let i = 0; i < holdoutPhones.length; i += 200) {
@@ -826,7 +831,7 @@ export const OFFER_CANDIDATES: OfferCandidate[] = [
 // ── Loop registry: each campaign objective is a loop. Same machinery
 // (holdout → optimise offers → auto-issue voucher → measure lift), different
 // audience + candidate subset. Add a loop here and it inherits the whole engine.
-export type LoopKey = "winback" | "welcome" | "birthday" | "round_gap" | "reward_expiring" | "beans_idle";
+export type LoopKey = "winback" | "welcome" | "birthday" | "round_gap" | "reward_expiring" | "beans_idle" | "mission_reward";
 export type LoopDef = {
   key: LoopKey;
   label: string;
@@ -849,6 +854,13 @@ export type LoopDef = {
    *  existing expiring voucher (carried on the segment row) instead. Arms are
    *  message-only; candidateKeys is empty (no offer to optimise). */
   noIssue?: boolean;
+  /** GRANT loop: assignments happen in the ORDER app at the moment a reward
+   *  is handed out (see @celsius/shared grant-loop) — nothing is sent, and
+   *  the 'holdout' arm is a CONTROL that receives the status-quo reward, not
+   *  nothing. Rounds roll: status 'open' accumulates assignments, then closes
+   *  to 'sent' (here or in the order app) and measures like any other round.
+   *  prepareRound/sendRound never run for these; the segment is a stub. */
+  grant?: boolean;
   segment: (o: SegmentOpts) => Promise<{ rows: SegmentRow[]; label: string }>;
 };
 
@@ -873,6 +885,10 @@ export const LOOPS: Record<LoopKey, LoopDef> = {
   // idle Points the moment they go quiet (~5d). Mints nothing — the value
   // already exists. Push-first (free) + SMS fallback, 10% holdout measures lift.
   beans_idle: { key: "beans_idle", label: "Points sitting unused", objective: "Bring back members with idle Points", defaultHoldoutPct: 20, defaultWindowDays: 7, candidateKeys: [], noIssue: true, messageTemplate: "Hi {name}! You have {beans} points at Celsius - enough for {redeem}. Redeem this week before they slip away. Show your number.", trigger: { holdoutPct: 10, cooldownDays: 30, segmentOpts: { minBeans: 100, idleMinDays: 5, idleMaxDays: 9 } }, segment: beansIdleSegment },
+  // Grant loop (no SMS): which mission-completion reward best drives the next
+  // visit. Assignments are made by the order app as missions complete
+  // (@celsius/shared MISSION_REWARD_LOOP); control = the mission's own reward.
+  mission_reward: { key: "mission_reward", label: "Mission reward", objective: "Find the completion reward that best drives the next visit", defaultHoldoutPct: 50, defaultWindowDays: 14, candidateKeys: [], grant: true, messageTemplate: "", segment: async () => ({ rows: [], label: "Mission completers (grant-time)" }) },
 };
 
 // Curated SMS per (loop × offer): slot the offer phrase into the loop's
@@ -1233,6 +1249,21 @@ export async function runTriggeredLoops(opts?: { force?: boolean }): Promise<Arr
 // elapsed (triggered rounds have no operator to click "Measure"). Idempotent —
 // measureRound flips status to 'measured' so it's picked once.
 export async function autoMeasureDueRounds(): Promise<{ measured: number }> {
+  // Grant rounds (status 'open') accumulate assignments in the order app for
+  // meta.round_days, then close to 'sent' so the measure flow below picks
+  // them up. The order app also closes them lazily on the next grant; this is
+  // the backstop for loops whose grant traffic went quiet mid-round.
+  const { data: openRounds } = await supabaseAdmin
+    .from("loop_rounds").select("id, prepared_at, meta").eq("status", "open");
+  for (const r of (openRounds ?? []) as Array<{ id: string; prepared_at: string | null; meta: { round_days?: number } | null }>) {
+    if (!r.prepared_at) continue;
+    const days = Number(r.meta?.round_days ?? 7);
+    if (Date.now() < new Date(r.prepared_at).getTime() + days * 86400000) continue;
+    await supabaseAdmin.from("loop_rounds")
+      .update({ status: "sent", sent_at: new Date().toISOString() })
+      .eq("id", r.id).eq("status", "open");
+  }
+
   const { data: rounds } = await supabaseAdmin
     .from("loop_rounds").select("id, sent_at, attribution_window_days").eq("status", "sent");
   let measured = 0;
@@ -1428,7 +1459,9 @@ export async function getEvaluation(opts?: { sinceDays?: number }): Promise<Eval
     // Conservative: bills every send as SMS. Push sends are free, so this is an
     // UPPER bound on cost (→ ROI is understated, never overstated). Make it
     // channel-accurate via loop_assignments.channel once push volume is material.
-    const sms = +(a.sent * SMS_COST_RM).toFixed(2);
+    // Grant loops send nothing at all — their delivery cost is genuinely zero
+    // (the reward COGS shows up in margin, not here).
+    const sms = LOOPS[loop_key as LoopKey]?.grant ? 0 : +(a.sent * SMS_COST_RM).toFixed(2);
     return {
       loop_key, label: LOOPS[loop_key as LoopKey]?.label ?? loop_key,
       rounds: a.rounds, sent: a.sent, redemptions: a.redemptions,
@@ -1447,6 +1480,10 @@ export async function getEvaluation(opts?: { sinceDays?: number }): Promise<Eval
   for (const a of byLoop.values()) { tAcc.rounds += a.rounds; tAcc.sent += a.sent; tAcc.redemptions += a.redemptions; tAcc.liftW += a.liftW; tAcc.incrOrders += a.incrOrders; tAcc.incrMargin += a.incrMargin; tAcc.holdoutN += a.holdoutN; }
   const { loop_key: _k, label: _l, ...totals } = toEval("__totals__", tAcc);
   void _k; void _l;
+  // Re-derive total cost from the per-loop rows — toEval("__totals__") can't
+  // know which loops are grant (zero-cost), so it would bill their sends.
+  totals.sms_cost_rm = +per_loop.reduce((s, l) => s + l.sms_cost_rm, 0).toFixed(2);
+  totals.roi = totals.sms_cost_rm > 0 ? +(totals.incremental_margin_rm / totals.sms_cost_rm).toFixed(1) : 0;
 
   // ── LIVE activity (server-side aggregate via RPC; UNCAPPED) ──────────────────
   // Available immediately (not gated on the attribution window). The old JS path

--- a/apps/order/src/lib/loyalty/v2.ts
+++ b/apps/order/src/lib/loyalty/v2.ts
@@ -9,6 +9,7 @@
 import { getSupabaseAdmin } from "@/lib/supabase/server";
 import { awardBonusBeans } from "@/lib/loyalty/points";
 import { notifyMissionCompleted, notifyReferralRewarded } from "@/lib/push/templates";
+import { assignGrantArm, recordGrantIssue, MISSION_REWARD_LOOP } from "@celsius/shared";
 
 const BRAND_ID = (process.env.LOYALTY_BRAND_ID ?? "brand-celsius").trim();
 
@@ -638,15 +639,52 @@ async function fulfilCompletedAssignment(args: {
 }): Promise<void> {
   const supabase = getSupabaseAdmin();
 
+  // Grant-loop experiment (mission_reward): does a different completion
+  // reward drive the next visit better than the mission's own? Control
+  // ('holdout' arm) keeps the mission's configured voucher(s); a treatment
+  // arm swaps in its variant. assignGrantArm fails open to control, so the
+  // member always gets a reward even if the experiment plumbing errors.
+  // Missions with no voucher configured stay out of the experiment — there's
+  // no status-quo reward to compare against, and enrolling would mint value
+  // for treatment members that control never gets.
+  const grant = args.voucherTemplateIds.length > 0
+    ? await assignGrantArm({ supabase, loop: MISSION_REWARD_LOOP, memberId: args.memberId })
+    : { arm: "holdout", overrideTemplateId: null, assignmentId: null };
+  const templateIds = grant.overrideTemplateId ? [grant.overrideTemplateId] : args.voucherTemplateIds;
+
   let issuedCount = 0;
-  for (const tplId of args.voucherTemplateIds) {
+  for (const tplId of templateIds) {
     const v = await issueVoucher({
       memberId: args.memberId,
       templateId: tplId,
       sourceType: "mission",
       sourceRefId: args.assignmentId,
     });
-    if (v) issuedCount++;
+    if (v) {
+      issuedCount++;
+      if (grant.assignmentId) await recordGrantIssue(supabase, grant.assignmentId, v.id);
+    }
+  }
+  // A treatment arm whose template failed to issue (deactivated mid-round)
+  // must not leave the member empty-handed — fall back to the mission's own,
+  // and re-file the assignment as control so the arm's stats only ever
+  // contain members who actually received the arm's reward.
+  if (issuedCount === 0 && grant.overrideTemplateId) {
+    if (grant.assignmentId) {
+      await supabase.from("loop_assignments").update({ arm: "holdout" }).eq("id", grant.assignmentId);
+    }
+    for (const tplId of args.voucherTemplateIds) {
+      const v = await issueVoucher({
+        memberId: args.memberId,
+        templateId: tplId,
+        sourceType: "mission",
+        sourceRefId: args.assignmentId,
+      });
+      if (v) {
+        issuedCount++;
+        if (grant.assignmentId) await recordGrantIssue(supabase, grant.assignmentId, v.id);
+      }
+    }
   }
 
   try {

--- a/docs/design/rewards-grant-loops.md
+++ b/docs/design/rewards-grant-loops.md
@@ -1,0 +1,27 @@
+# Grant-time loop engineering (rewards module)
+
+_Scoped + built 2026-07-02. Extends docs/design/sms-loop-engineering.md to rewards the app HANDS OUT._
+
+## Problem
+The SMS loop engine measures every outbound campaign (holdout + arms + honest attribution), but the rewards module itself — mission completions, mystery drops, milestones — hands out fixed, hand-picked rewards with zero measurement. Nobody knows whether "Free Pastry" vs "Beans Boost" on a completed mission changes return-visit rate at all.
+
+## Design
+**Grant loops** reuse the SMS engine's tables + measurement wholesale; only the assignment moment differs.
+
+- **Assignment at grant time, not blast time.** `@celsius/shared` `assignGrantArm()` (packages/shared/src/loyalty/grant-loop.ts) is called by the order app the moment a reward is about to be issued. It enrols the member in the loop's current round, logs a `loop_assignments` row (`channel='grant'`, no SMS), and says which voucher template to issue.
+- **Rolling rounds.** A round (status `'open'`) accumulates assignments for `roundDays`, then closes to `'sent'` — lazily on the next grant, or by `autoMeasureDueRounds` as a backstop. From there the existing measure flow (`measureRound`, pooled baselines, leaderboard, evaluation) runs unchanged.
+- **Control ≠ no reward.** You can't hold an earned reward out of a mission completion. The control arm is stored under the engine's `'holdout'` key but receives the **status-quo reward** (the mission's own configured voucher). Lift reads "treatment reward vs what we hand out today" — the honest baseline for a grant. `measureRound` skips holdout-contamination exclusion for grant rounds (sibling SMS lands on control and treatment symmetrically).
+- **Fail-open.** Any error in the experiment plumbing (no phone, race, settings typo) falls back to the status-quo reward with no assignment logged. Experiments must never break fulfilment. A treatment template that fails to issue falls back to the mission default and re-files the assignment as control, so arm stats only contain members who actually got the arm's reward.
+
+## Loop #1: mission_reward
+- Hook: `fulfilCompletedAssignment` in apps/order/src/lib/loyalty/v2.ts.
+- Split: 50% control (mission's own voucher) / 50% challenger.
+- Default challenger: **Free Coffee** (`206b5fbf-…`) — the same low-COGS, visit-driving lure the birthday loop uses.
+- Arms are owner-tunable without a deploy via `app_settings.mission_reward_loop_arms` (JSON `[{key,label,voucher_template_id}]`); arms freeze onto each round at creation.
+- Window: 7-day rounds, 14-day attribution. Metric: conversion (any order) + redemption + revenue per recipient vs control, in the existing campaigns scorecard.
+- Missions with no configured voucher are excluded (no status quo to compare).
+
+## Known gaps (accepted for the wedge)
+- The live (pre-measure) rollup RPC counts `sms_status='sent'` rows, so grant loops show 0 "sent" until measured; the measured scorecard is the real read.
+- `loop_assignments.issued_reward_id` is single-column: a control grant that issues several vouchers attributes redemption of the first.
+- Next candidates on the same rails: mystery-pool variants (arm = pool), welcome/milestone reward choice.

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -105,6 +105,10 @@ export type {
 // (wallet voucher OR catalog) — used by every server redemption route.
 export { resolveOrderReward } from "./loyalty/order-reward";
 export type { ResolvedOrderReward } from "./loyalty/order-reward";
+// Grant-time loop engineering — holdout/arms/attribution for rewards the app
+// hands out (mission completions etc.), sharing the SMS loop engine's tables.
+export { assignGrantArm, recordGrantIssue, pickGrantArm, MISSION_REWARD_LOOP } from "./loyalty/grant-loop";
+export type { GrantArm, GrantLoopDef, GrantAssignment } from "./loyalty/grant-loop";
 
 // Order number format: CC-{OUTLET_CODE}-{SEQUENCE}
 export function generateOrderNumber(outletCode: string, sequence: number): string {

--- a/packages/shared/src/loyalty/__tests__/grant-loop.test.ts
+++ b/packages/shared/src/loyalty/__tests__/grant-loop.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from "vitest";
+import { pickGrantArm, type GrantArm } from "../grant-loop";
+
+const arms: GrantArm[] = [
+  { key: "free_coffee", label: "Free Coffee", voucher_template_id: "t-coffee" },
+  { key: "b1f1", label: "Buy 1 Free 1", voucher_template_id: "t-b1f1" },
+];
+
+describe("pickGrantArm", () => {
+  it("assigns control below the control share and arms above it", () => {
+    expect(pickGrantArm(50, arms, 0)).toBe("control");
+    expect(pickGrantArm(50, arms, 0.4999)).toBe("control");
+    expect(pickGrantArm(50, arms, 0.5)).toEqual(arms[0]);
+    expect(pickGrantArm(50, arms, 0.74)).toEqual(arms[0]);
+    expect(pickGrantArm(50, arms, 0.75)).toEqual(arms[1]);
+    expect(pickGrantArm(50, arms, 0.9999)).toEqual(arms[1]);
+  });
+
+  it("splits the treatment share uniformly across arms", () => {
+    // controlPct 40 → arms occupy [0.4, 1.0), boundary near 0.7 (exact edge is
+    // FP-dependent, so probe either side of it)
+    expect(pickGrantArm(40, arms, 0.69)).toEqual(arms[0]);
+    expect(pickGrantArm(40, arms, 0.71)).toEqual(arms[1]);
+  });
+
+  it("always returns control when there are no arms", () => {
+    expect(pickGrantArm(50, [], 0.99)).toBe("control");
+    expect(pickGrantArm(0, [], 0.5)).toBe("control");
+  });
+
+  it("controlPct 0 never assigns control; 100 always does", () => {
+    expect(pickGrantArm(0, arms, 0)).toEqual(arms[0]);
+    expect(pickGrantArm(0, arms, 0.999)).toEqual(arms[1]);
+    expect(pickGrantArm(100, arms, 0.999)).toBe("control");
+  });
+
+  it("clamps out-of-range controlPct instead of misassigning", () => {
+    expect(pickGrantArm(-10, arms, 0.001)).toEqual(arms[0]);
+    expect(pickGrantArm(150, arms, 0.999)).toBe("control");
+  });
+
+  it("never returns an out-of-bounds arm at the top edge", () => {
+    // rand asymptotically close to 1 must clamp to the last arm
+    expect(pickGrantArm(50, arms, 0.9999999999)).toEqual(arms[1]);
+  });
+});

--- a/packages/shared/src/loyalty/grant-loop.ts
+++ b/packages/shared/src/loyalty/grant-loop.ts
@@ -1,0 +1,243 @@
+// Grant-time loop engineering — the SMS loop engine's holdout + arms +
+// attribution applied to rewards the app HANDS OUT (mission completions,
+// mystery drops, milestones), where there is no message to send and no one
+// can be held out of a promised reward.
+//
+// Model (shares the SMS engine's tables + measurement wholesale):
+//   • A rolling `loop_rounds` row (status 'open') accumulates assignments for
+//     `roundDays`, then closes to 'sent' — from there the backoffice engine's
+//     autoMeasureDueRounds → measureRound machinery measures it unchanged.
+//   • The CONTROL arm is stored under the engine's 'holdout' key, but it is
+//     not "no reward" — it receives the mechanic's status-quo reward (e.g.
+//     the mission's own configured voucher). Lift therefore reads "treatment
+//     reward vs the reward we hand out today", which is the honest baseline
+//     for a grant: withholding the earned reward would break the promise.
+//   • Treatment arms swap in their own voucher_template_id. Attribution keys
+//     off loop_assignments.issued_reward_id + orders-by-phone, exactly like
+//     the SMS loops (see apps/backoffice/src/lib/loyalty/loop-engine.ts).
+//
+// Every entry point here FAILS OPEN: if anything errors (no phone, race,
+// settings typo), the caller gets the status-quo reward and no assignment is
+// logged. Experiment plumbing must never break reward fulfilment.
+
+import type { SupabaseClient } from "@supabase/supabase-js";
+
+const DEFAULT_BRAND_ID = "brand-celsius";
+
+export type GrantArm = {
+  key: string;
+  label: string;
+  voucher_template_id: string;
+};
+
+export type GrantLoopDef = {
+  /** loop_rounds.loop_key — also needs a LOOPS entry in the backoffice
+   *  engine so dashboards label it and the cron closes/measures rounds. */
+  loopKey: string;
+  /** How long one round accumulates assignments before it closes. */
+  roundDays: number;
+  /** Attribution window measured after the round closes. */
+  windowDays: number;
+  /** % of members kept on the status-quo reward (the control arm). */
+  controlPct: number;
+  /** app_settings key holding a JSON GrantArm[] override — lets the owner
+   *  swap challengers without a deploy. Falls back to defaultArms. */
+  settingsKey?: string;
+  defaultArms: GrantArm[];
+};
+
+/** Mission-completion reward experiment: control keeps the mission's own
+ *  configured voucher(s); the challenger swaps in Free Coffee (the same
+ *  low-COGS, visit-driving lure the birthday loop uses). 50/50 split so the
+ *  control baseline accrues as fast as the treatment evidence. */
+export const MISSION_REWARD_LOOP: GrantLoopDef = {
+  loopKey: "mission_reward",
+  roundDays: 7,
+  windowDays: 14,
+  controlPct: 50,
+  settingsKey: "mission_reward_loop_arms",
+  defaultArms: [
+    { key: "free_coffee", label: "Free Coffee", voucher_template_id: "206b5fbf-c12a-44e5-ad30-85a9e8a81439" },
+  ],
+};
+
+/** Pure arm pick — rand ∈ [0,1). Below controlPct → control ('holdout' in
+ *  engine terms); the remainder splits uniformly across the arms. */
+export function pickGrantArm(controlPct: number, arms: GrantArm[], rand: number): GrantArm | "control" {
+  const c = Math.min(100, Math.max(0, controlPct)) / 100;
+  if (arms.length === 0 || rand < c) return "control";
+  const span = 1 - c;
+  const idx = span > 0 ? Math.floor(((rand - c) / span) * arms.length) : 0;
+  return arms[Math.min(idx, arms.length - 1)];
+}
+
+function rid(prefix: string): string {
+  return `${prefix}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+}
+
+async function resolveArms(supabase: SupabaseClient, loop: GrantLoopDef): Promise<GrantArm[]> {
+  if (loop.settingsKey) {
+    try {
+      const { data } = await supabase
+        .from("app_settings").select("value").eq("key", loop.settingsKey).maybeSingle();
+      if (data?.value) {
+        const parsed: unknown = JSON.parse(String(data.value));
+        if (Array.isArray(parsed)) {
+          const arms = parsed
+            .filter((a): a is Record<string, unknown> => !!a && typeof a === "object")
+            .filter((a) => typeof a.key === "string" && typeof a.voucher_template_id === "string")
+            .map((a) => ({ key: String(a.key), label: String(a.label ?? a.key), voucher_template_id: String(a.voucher_template_id) }));
+          if (arms.length) return arms;
+        }
+      }
+    } catch { /* malformed override → code defaults */ }
+  }
+  return loop.defaultArms;
+}
+
+type OpenRound = { id: string; arms: GrantArm[] };
+
+/** Find the loop's current open round, closing an expired one and starting
+ *  the next as needed. Arms are frozen onto the round at creation so a
+ *  settings change mid-round can't skew a round's split. */
+async function currentOpenRound(supabase: SupabaseClient, loop: GrantLoopDef, brandId: string): Promise<OpenRound> {
+  const { data: open } = await supabase
+    .from("loop_rounds")
+    .select("id, prepared_at, arms")
+    .eq("loop_key", loop.loopKey)
+    .eq("status", "open")
+    .order("prepared_at", { ascending: false })
+    .limit(1)
+    .maybeSingle();
+
+  if (open) {
+    const expiresMs = new Date(open.prepared_at as string).getTime() + loop.roundDays * 86400000;
+    if (Date.now() < expiresMs) {
+      return { id: open.id as string, arms: (open.arms ?? []) as GrantArm[] };
+    }
+    // Round's open window elapsed — close it ('sent' hands it to the existing
+    // autoMeasureDueRounds → measureRound flow). Status-guarded so a
+    // concurrent closer or the backoffice cron can't double-close.
+    await supabase
+      .from("loop_rounds")
+      .update({ status: "sent", sent_at: new Date().toISOString() })
+      .eq("id", open.id).eq("status", "open");
+  }
+
+  const arms = await resolveArms(supabase, loop);
+  const { data: last } = await supabase
+    .from("loop_rounds")
+    .select("round_no")
+    .eq("loop_key", loop.loopKey)
+    .order("round_no", { ascending: false })
+    .limit(1)
+    .maybeSingle();
+
+  const roundId = rid("lr");
+  const { error } = await supabase.from("loop_rounds").insert({
+    id: roundId,
+    brand_id: brandId,
+    loop_key: loop.loopKey,
+    round_no: ((last?.round_no as number) ?? 0) + 1,
+    segment_label: `Grant-time (rolling ${loop.roundDays}d, ${loop.controlPct}% control)`,
+    holdout_pct: loop.controlPct,
+    // message is unused (nothing is sent) but kept for shape-compatibility
+    // with the SMS rounds the dashboards render.
+    arms: arms.map((a) => ({ ...a, message: "" })),
+    attribution_window_days: loop.windowDays,
+    status: "open",
+    meta: { kind: "grant", round_days: loop.roundDays },
+    created_by: `grant:${loop.loopKey}`,
+  });
+  if (error) throw new Error(`grant round insert: ${error.message}`);
+  return { id: roundId, arms };
+}
+
+export type GrantAssignment = {
+  /** 'holdout' = control (status-quo reward) */
+  arm: string;
+  /** Treatment template to issue INSTEAD of the default; null → issue the
+   *  caller's status-quo reward (control, unknown arm, or fail-open). */
+  overrideTemplateId: string | null;
+  /** loop_assignments.id to attach the issued voucher to — null when the
+   *  member couldn't be enrolled (no phone / error). */
+  assignmentId: string | null;
+};
+
+const CONTROL: GrantAssignment = { arm: "holdout", overrideTemplateId: null, assignmentId: null };
+
+/** Enrol a member in a grant loop at the moment a reward is about to be
+ *  handed out, and say which voucher template to issue. One arm per member
+ *  per round (a second grant in the same round reuses the first arm). */
+export async function assignGrantArm(args: {
+  supabase: SupabaseClient;
+  loop: GrantLoopDef;
+  memberId: string;
+  brandId?: string;
+}): Promise<GrantAssignment> {
+  const { supabase, loop, memberId } = args;
+  try {
+    // Attribution joins orders by phone (like every loop) — a phone-less
+    // member can't be measured, so don't enrol them.
+    const { data: member } = await supabase
+      .from("members").select("phone").eq("id", memberId).maybeSingle();
+    const phone = (member?.phone ?? "").trim();
+    if (!phone) return CONTROL;
+
+    const round = await currentOpenRound(supabase, loop, args.brandId ?? DEFAULT_BRAND_ID);
+
+    const templateFor = (armKey: string): string | null =>
+      armKey === "holdout" ? null : (round.arms.find((a) => a.key === armKey)?.voucher_template_id ?? null);
+
+    // UNIQUE(round_id, member_id): if this member was already assigned this
+    // round, stay on that arm — consistency beats re-rolling.
+    const { data: existing } = await supabase
+      .from("loop_assignments")
+      .select("id, arm")
+      .eq("round_id", round.id).eq("member_id", memberId)
+      .maybeSingle();
+    if (existing) {
+      return { arm: existing.arm as string, overrideTemplateId: templateFor(existing.arm as string), assignmentId: existing.id as string };
+    }
+
+    const picked = pickGrantArm(loop.controlPct, round.arms, Math.random());
+    const armKey = picked === "control" ? "holdout" : picked.key;
+    const assignmentId = rid("la");
+    const { error } = await supabase.from("loop_assignments").insert({
+      id: assignmentId,
+      round_id: round.id,
+      member_id: memberId,
+      phone,
+      arm: armKey,
+      channel: "grant",
+    });
+    if (error) {
+      // Unique-violation race (same member, concurrent grants) → reuse the row
+      // that won. Anything else → fail open to control.
+      const { data: raced } = await supabase
+        .from("loop_assignments")
+        .select("id, arm")
+        .eq("round_id", round.id).eq("member_id", memberId)
+        .maybeSingle();
+      if (!raced) return CONTROL;
+      return { arm: raced.arm as string, overrideTemplateId: templateFor(raced.arm as string), assignmentId: raced.id as string };
+    }
+    return { arm: armKey, overrideTemplateId: templateFor(armKey), assignmentId };
+  } catch {
+    return CONTROL;
+  }
+}
+
+/** Attach the voucher that was actually issued to the assignment so
+ *  measureRound can read its redemption. Keeps the FIRST voucher when a
+ *  control grant issues several (single-column attribution; the redemption
+ *  signal stays comparable since treatments issue exactly one). */
+export async function recordGrantIssue(supabase: SupabaseClient, assignmentId: string, issuedRewardId: string): Promise<void> {
+  try {
+    await supabase
+      .from("loop_assignments")
+      .update({ issued_reward_id: issuedRewardId })
+      .eq("id", assignmentId)
+      .is("issued_reward_id", null);
+  } catch { /* attribution-only — never block fulfilment */ }
+}


### PR DESCRIPTION
## What

Extends the SMS loop engine's loop-engineering discipline (control + arms + honest attribution) to rewards the app **hands out**, starting with mission-completion rewards — no second engine, same `loop_rounds`/`loop_assignments` tables, same measurement/leaderboard/scorecard.

**Loop #1: `mission_reward`** — does a different completion reward drive the next visit better than the mission's own?
- 50% control (the mission's configured voucher, filed under the engine's `holdout` key) vs 50% challenger (default: Free Coffee, the birthday loop's low-COGS lure).
- 7-day rolling rounds, 14-day attribution window.
- Arms owner-tunable without a deploy via `app_settings.mission_reward_loop_arms` (JSON `[{key,label,voucher_template_id}]`); arms freeze onto each round at creation.

## How

- **`packages/shared/src/loyalty/grant-loop.ts`** (new): `assignGrantArm()` enrols a member at the moment a reward is issued — finds/rolls the loop's current `open` round, logs a `loop_assignments` row (`channel='grant'`, no SMS), returns the template to issue. `recordGrantIssue()` ties the issued voucher to the assignment for redemption attribution. **Fails open everywhere**: any error → member gets the status-quo reward, no row logged.
- **`apps/order` `fulfilCompletedAssignment`**: resolves the reward through the loop. A treatment template that fails to issue falls back to the mission default **and re-files the assignment as control**, so arm stats only contain members who actually received the arm's reward. Missions with no configured voucher are excluded (no status quo to compare).
- **`apps/backoffice` loop-engine**:
  - `mission_reward` added to `LoopKey`/`LOOPS` (`grant: true`, stub segment — `prepareRound`/`sendRound` never run for it).
  - `autoMeasureDueRounds` closes due `open` grant rounds (backstop for the lazy close at grant time), then measures as usual.
  - `measureRound` skips holdout-contamination exclusion for grant rounds — the control *received* a reward, and sibling-loop SMS lands on both groups symmetrically.
  - `getEvaluation` bills grant loops RM0 delivery cost (nothing is sent); programme totals re-derived from per-loop rows.

## Why control ≠ holdout

You can't withhold an earned mission reward, so the baseline is the **status-quo reward**, not "nothing". Lift reads "challenger vs what we hand out today" — the honest comparison for a grant mechanic. Reusing the `holdout` arm key means the pooled-baseline, leaderboard, and scorecard machinery all work unchanged with that interpretation.

## Known gaps (accepted for the wedge)

- The live (pre-measure) rollup RPC counts `sms_status='sent'` rows, so grant loops show 0 "sent" until rounds measure; the measured scorecard is the real read.
- `loop_assignments.issued_reward_id` is single-column: a control grant issuing several vouchers attributes redemption of the first.
- Next candidates on the same rails: mystery-pool variants, welcome/milestone reward choice.

## Testing

- New unit tests for the pure arm-split (`pickGrantArm`): 6 passing; full `packages/shared` suite 100/100, root + order suites 154/154.
- Typecheck clean for `packages/shared` and `apps/order`; `apps/backoffice` typecheck errors are the pre-existing Prisma-client-generation baseline (identical count, 900, with and without this diff — none in touched files).
- No migration needed: `loop_rounds.meta` (043) and `loop_assignments.channel` (052) already exist; `status` is unconstrained text.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y6KJiezJiHHBwsMFDvtAYw

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y6KJiezJiHHBwsMFDvtAYw)_