### PR TITLE
fix(hr): block accidental immediate clock-out (0-hour logs)

### DIFF
--- a/apps/staff/src/app/api/hr/clock/route.ts
+++ b/apps/staff/src/app/api/hr/clock/route.ts
@@ -274,6 +274,20 @@ export async function POST(req: NextRequest) {
       return NextResponse.json({ error: "Not clocked in" }, { status: 400 });
     }
 
+    // Guard against an ACCIDENTAL immediate clock-out. The clock button flips
+    // straight from "Clock In" to "Clock Out" the moment you clock in, so a
+    // reflexive double-tap was closing shifts seconds later at 0h — and since
+    // the staffer then had no open log, they lost the shift entirely. Reject a
+    // clock-out in the first couple of minutes and keep them clocked in.
+    const MIN_SHIFT_MINUTES = 2;
+    const minutesClockedIn = (Date.now() - new Date(activeLog.clock_in).getTime()) / 60000;
+    if (minutesClockedIn < MIN_SHIFT_MINUTES) {
+      return NextResponse.json({
+        error: "You just clocked in — you're all set. (Tap Clock Out at the end of your shift.)",
+        justClockedIn: true,
+      }, { status: 400 });
+    }
+
     // Geofence check against the OUTLET THEY CLOCKED INTO (not their session outletId — rotating staff may differ)
     let clockOutWithinGeofence = false;
     let clockOutDistance: number | null = null;


### PR DESCRIPTION
## The 0-hour issue
The `07:44 → 07:44` (0h) logs are **not** auto-close — they're **accidental immediate clock-outs**. Live data (Jul 1–2): 7 logs with `clock_in == clock_out`, 1–20 seconds apart, `clock_out_method = app`. The clock button flips straight from **Clock In** → **Clock Out** the instant you clock in (no confirmation, no min-duration), so a reflexive double-tap closes the shift at 0h — and since the staffer then has **no open log, they lose the whole shift** (6 of 7 didn't re-clock-in).

## Fix
Server-side guard: reject a clock-out within the first **2 minutes** of clock-in and keep them clocked in, with a friendly message (`"You just clocked in — you're all set."`). Server-side so it covers **both** the PWA and native app in one place.

## Follow-ups (not in this PR)
- **The 7 existing 0h logs** need handling — those staff may be working with no open log. Options: reopen (restore clocked-in state, auto-close tonight pays the shift) vs. manager Fix-times per person. Flagging for a decision rather than guessing pay.
- Optional UX: a confirmation tap on clock-out + brief cooldown on the button after clock-in.

## Testing
`tsc` on the changed file is clean apart from the env's uninstalled-deps noise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01B7WiKCn4NpWzaka6ZtjB6z)_