### PR TITLE
fix(finance): catch truncated 'Divide' references as shareholder dividends

### DIFF
--- a/apps/backoffice/src/lib/finance/bank-line-classifier.test.ts
+++ b/apps/backoffice/src/lib/finance/bank-line-classifier.test.ts
@@ -97,6 +97,11 @@ describe("bank-line-classifier", () => {
 
   it("classifies purpose suffixes that run into references", () => {
     expect(dr("TRANSFER FR A/C ENCIK AZLAND ZULFIZ Q1 DIVIDENDQ1 2 MBB").category).toBe("DIVIDEND");
+    // Maybank truncates the reference mid-word: "Q1 2026 Divide" is a
+    // shareholder dividend (owner confirmed), and a dividend to a name that is
+    // ALSO a supplier stays a dividend (Mikofee went to RAW_MATERIALS once).
+    expect(dr("TRANSFER FR A/C BADRUL AZMI BIN JAM Q1 2026 Divide").category).toBe("DIVIDEND");
+    expect(dr("TRANSFER FR A/C MIKOFEE SDN. BHD. Q4 2025 Dividend MBB CT").category).toBe("DIVIDEND");
     expect(dr("TRANSFER FR A/C AAS TAXATION SDN. B TAX FORMC").category).toBe("TAX");
     expect(dr("CELSIUSCOFFEE SB ASSOCIATES * HALF AUDIT FEE").category).toBe("COMPLIANCE");
     expect(dr("ELECTRONIC REMITTANCE - GIR RENTOKIL INITIAL (M").category).toBe("MAINTENANCE");

--- a/apps/backoffice/src/lib/finance/bank-line-classifier.ts
+++ b/apps/backoffice/src/lib/finance/bank-line-classifier.ts
@@ -179,8 +179,10 @@ const OUTFLOW_RULES: Rule[] = [
   { name: "purpose_renovation",       match: /\bRENOVATION\b|\bRENOVATE\b/i,          direction: "DR", category: "INVESTMENTS" as CashCategory },
   { name: "purpose_legal",            match: /\bLEGAL\s*FEE|\bASHRAF\s*&\s*PARTNERS|\bLAWYER\b/i, direction: "DR", category: "COMPLIANCE" as CashCategory },
   // No trailing boundary: Maybank purpose suffixes run straight into references
-  // ("DIVIDENDQ1 2"), which a \b after the word would reject.
-  { name: "purpose_dividend",         match: /\bDIVIDEN/i,                            direction: "DR", category: "DIVIDEND" as CashCategory },
+  // ("DIVIDENDQ1 2"), which a \b after the word would reject. Maybank ALSO
+  // truncates the reference field mid-word ("Q1 2026 Divide"), so accept the
+  // standalone stem too (owner confirmed: those are shareholder dividends).
+  { name: "purpose_dividend",         match: /\bDIVIDEN|\bDIVIDE\b/i,                 direction: "DR", category: "DIVIDEND" as CashCategory },
   { name: "purpose_cfs_contract",     match: /\bCFS\s*CONTRACT\b|\bCFS\s*FEE\b/i,     direction: "DR", category: "CFS_FEE" as CashCategory },
   { name: "purpose_audit",            match: /\bAUDIT\s*FEE\b|\bAUDIT\b/i,            direction: "DR", category: "COMPLIANCE" as CashCategory },
   { name: "purpose_tax_agent",        match: /\bTAXATION\b|\bTAX\s*(FORM|AGENT|FILING)/i, direction: "DR", category: "TAX" as CashCategory },


### PR DESCRIPTION
Owner confirmed the 'Q1 2026 Divide' transfers are shareholder dividends.
Maybank truncates the reference field mid-word, so \bDIVIDEN (which already
tolerates DIVIDENDQ1 gluing) never saw them and 4 lines sat in
OTHER_OUTFLOW. Rule now also accepts the standalone stem \bDIVIDE\b.

Tests cover the truncated form and the supplier-name collision (Mikofee is
a supplier AND a shareholder; its Q4 2025 dividend had been swept to
RAW_MATERIALS by an old reclass pass; purpose rules outrank vendor rules so
the current classifier books it as dividend).

Data already corrected in production via the manual classify endpoint:
5 lines RM10,992.76 booked to DIVIDEND (4000), GL balanced, orphans GC'd.
15/15 classifier tests pass.
