### PR TITLE
feat(finance): learning categorizer + Chart of Accounts page

### DIFF
--- a/apps/backoffice/src/app/(admin)/finance/coa/page.tsx
+++ b/apps/backoffice/src/app/(admin)/finance/coa/page.tsx
@@ -1,0 +1,188 @@
+"use client";
+
+// Chart of Accounts — the one place to see and grow the COA (seeded from
+// Bukku, owned in-house since 2026-05). Create an account when a category
+// needs a new home; deactivate what is no longer used. Below it, the learned
+// categorizations: every manual classification on the Reconciliation page
+// teaches the classifier a payee -> category association shown here.
+
+import { useState } from "react";
+import { useFetch } from "@/lib/use-fetch";
+import { Button } from "@celsius/ui";
+import { Loader2, Plus } from "lucide-react";
+
+type Account = {
+  code: string; name: string; type: string; subtype: string | null;
+  parent_code: string | null; outlet_specific: boolean; is_active: boolean;
+};
+type Hint = { phrase: string; category: string; direction: string | null; source: string; hits: number; updated_at: string };
+
+const TYPE_ORDER = ["asset", "liability", "equity", "income", "cogs", "expense"] as const;
+const TYPE_LABEL: Record<string, string> = {
+  asset: "Assets", liability: "Liabilities", equity: "Equity",
+  income: "Income", cogs: "Cost of Sales", expense: "Expenses",
+};
+
+export default function CoaPage() {
+  const { data, mutate } = useFetch<{ accounts: Account[] }>("/api/finance/accounts?all=true");
+  const { data: hintData, mutate: mutateHints } = useFetch<{ hints: Hint[] }>("/api/finance/category-hints");
+  const [q, setQ] = useState("");
+  const [form, setForm] = useState({ code: "", name: "", type: "expense", parentCode: "" });
+  const [busy, setBusy] = useState(false);
+  const [note, setNote] = useState<string | null>(null);
+
+  const accounts = data?.accounts ?? [];
+  const t = q.trim().toLowerCase();
+  const filtered = t
+    ? accounts.filter((a) => a.code.toLowerCase().includes(t) || a.name.toLowerCase().includes(t))
+    : accounts;
+
+  async function createAccount() {
+    setBusy(true); setNote(null);
+    try {
+      const res = await fetch("/api/finance/accounts", {
+        method: "POST", headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ ...form, parentCode: form.parentCode || undefined }),
+      });
+      const j = await res.json();
+      if (!res.ok) setNote(j.error ?? `Failed (${res.status})`);
+      else {
+        setNote(`Created ${form.code} ${form.name}.`);
+        setForm({ code: "", name: "", type: form.type, parentCode: "" });
+        mutate();
+      }
+    } catch (e) { setNote(e instanceof Error ? e.message : String(e)); }
+    finally { setBusy(false); }
+  }
+
+  async function toggleActive(a: Account) {
+    await fetch("/api/finance/accounts", {
+      method: "PATCH", headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ code: a.code, isActive: !a.is_active }),
+    });
+    mutate();
+  }
+
+  async function forgetHint(phrase: string) {
+    await fetch("/api/finance/category-hints", {
+      method: "DELETE", headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ phrase }),
+    });
+    mutateHints();
+  }
+
+  return (
+    <div className="space-y-5 p-3 sm:p-6">
+      <header>
+        <h1 className="text-xl sm:text-2xl font-semibold">Chart of Accounts</h1>
+        <p className="mt-0.5 text-xs sm:text-sm text-gray-500">
+          Seeded from Bukku, owned here. Bank categories book to these accounts; add one when a spend type needs its own line.
+        </p>
+      </header>
+
+      <section className="rounded-lg border bg-white p-3">
+        <div className="flex flex-wrap items-end gap-2">
+          <label className="text-xs text-gray-500">Code
+            <input value={form.code} onChange={(e) => setForm({ ...form, code: e.target.value.trim() })} placeholder="6515-01"
+              className="mt-1 block h-8 w-28 rounded border border-gray-200 px-2 text-sm tabular-nums" />
+          </label>
+          <label className="text-xs text-gray-500">Name
+            <input value={form.name} onChange={(e) => setForm({ ...form, name: e.target.value })} placeholder="Equipment rental"
+              className="mt-1 block h-8 w-56 rounded border border-gray-200 px-2 text-sm" />
+          </label>
+          <label className="text-xs text-gray-500">Type
+            <select value={form.type} onChange={(e) => setForm({ ...form, type: e.target.value })}
+              className="mt-1 block h-8 rounded border border-gray-200 bg-white px-2 text-sm">
+              {TYPE_ORDER.map((x) => <option key={x} value={x}>{TYPE_LABEL[x]}</option>)}
+            </select>
+          </label>
+          <label className="text-xs text-gray-500">Parent (optional)
+            <input value={form.parentCode} onChange={(e) => setForm({ ...form, parentCode: e.target.value.trim() })} placeholder="6515"
+              className="mt-1 block h-8 w-24 rounded border border-gray-200 px-2 text-sm tabular-nums" />
+          </label>
+          <Button size="sm" onClick={createAccount} disabled={busy || !form.code || !form.name}>
+            {busy ? <Loader2 className="h-4 w-4 animate-spin" /> : <Plus className="h-4 w-4" />}
+            Add account
+          </Button>
+        </div>
+        {note && <p className="mt-2 text-[11px] text-gray-500">{note}</p>}
+      </section>
+
+      <div className="flex items-center gap-2">
+        <input value={q} onChange={(e) => setQ(e.target.value)} placeholder="Search code or name…"
+          className="h-8 w-64 rounded border border-gray-200 bg-white px-2 text-sm" />
+        <span className="text-[11px] text-gray-400 tabular-nums">{filtered.length} of {accounts.length} accounts</span>
+      </div>
+
+      {!data ? <div className="py-12 text-center text-sm text-gray-400">Loading…</div> : (
+        <div className="grid gap-4 lg:grid-cols-2">
+          {TYPE_ORDER.map((type) => {
+            const rows = filtered.filter((a) => a.type === type);
+            if (!rows.length) return null;
+            return (
+              <section key={type} className="overflow-hidden rounded-lg border bg-white">
+                <header className="border-b bg-gray-50/60 px-3 py-2 text-xs font-medium uppercase tracking-wide text-gray-500">
+                  {TYPE_LABEL[type]} <span className="font-normal">· {rows.length}</span>
+                </header>
+                <table className="w-full text-sm">
+                  <tbody className="divide-y">
+                    {rows.map((a) => (
+                      <tr key={a.code} className={a.is_active ? "" : "opacity-45"}>
+                        <td className="w-24 whitespace-nowrap px-3 py-1.5 text-xs text-gray-500 tabular-nums"
+                          style={{ paddingLeft: a.parent_code ? 28 : 12 }}>{a.code}</td>
+                        <td className="px-3 py-1.5">{a.name}</td>
+                        <td className="w-24 px-3 py-1.5 text-right">
+                          <button onClick={() => toggleActive(a)} className="text-[11px] text-gray-400 underline hover:text-gray-600">
+                            {a.is_active ? "deactivate" : "reactivate"}
+                          </button>
+                        </td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </section>
+            );
+          })}
+        </div>
+      )}
+
+      <section className="space-y-2">
+        <div className="flex items-baseline justify-between">
+          <h2 className="text-sm font-semibold">Learned categorizations</h2>
+          <span className="text-[11px] text-gray-400">taught by your manual classifications on the Reconciliation page</span>
+        </div>
+        {!hintData ? <div className="py-6 text-center text-sm text-gray-400">Loading…</div>
+        : hintData.hints.length === 0 ? (
+          <p className="rounded-lg border bg-white px-4 py-3 text-xs text-gray-400">
+            Nothing learned yet. Classify a line on the Reconciliation page and its payee shows up here; future payments to that payee classify themselves.
+          </p>
+        ) : (
+          <div className="overflow-x-auto rounded-lg border bg-white">
+            <table className="w-full min-w-[560px] text-sm">
+              <thead><tr className="border-b bg-gray-50/60 text-left text-xs text-gray-500">
+                <th className="px-3 py-2 font-medium">Payee phrase</th>
+                <th className="px-3 py-2 font-medium">Books to</th>
+                <th className="px-3 py-2 font-medium">Direction</th>
+                <th className="px-3 py-2 font-medium">Learned</th>
+                <th className="px-3 py-2" />
+              </tr></thead>
+              <tbody className="divide-y">
+                {hintData.hints.map((h) => (
+                  <tr key={h.phrase}>
+                    <td className="px-3 py-1.5 font-medium">{h.phrase}</td>
+                    <td className="px-3 py-1.5 text-xs text-gray-600">{h.category.toLowerCase().replace(/_/g, " ")}</td>
+                    <td className="px-3 py-1.5 text-xs text-gray-500">{h.direction === "DR" ? "cash out" : h.direction === "CR" ? "cash in" : "both"}</td>
+                    <td className="px-3 py-1.5 text-xs text-gray-400 tabular-nums">{h.updated_at.slice(0, 10)}</td>
+                    <td className="px-3 py-1.5 text-right">
+                      <button onClick={() => forgetHint(h.phrase)} className="text-[11px] text-gray-400 underline hover:text-gray-600">forget</button>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </section>
+    </div>
+  );
+}

--- a/apps/backoffice/src/app/(admin)/finance/recon/page.tsx
+++ b/apps/backoffice/src/app/(admin)/finance/recon/page.tsx
@@ -70,7 +70,11 @@ export default function ReconPage() {
     setReclassifying(true);
     setReclassNote(null);
     try {
-      const res = await fetch("/api/finance/reclassify", { method: "POST" });
+      // full sweep: learned corrections must also fix lines a generic rule
+      // already (mis)classified, not just the OTHER_* pile.
+      const res = await fetch("/api/finance/reclassify", {
+        method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify({ full: true }),
+      });
       const j = await res.json();
       setReclassNote(res.ok
         ? `Re-classified ${j.changed} lines (RM ${Math.round(j.changedValue).toLocaleString("en-MY")}); ${j.unstampedJournals} journals queued for GL re-key.`

--- a/apps/backoffice/src/app/(admin)/layout.tsx
+++ b/apps/backoffice/src/app/(admin)/layout.tsx
@@ -368,6 +368,7 @@ const NAV_SECTIONS: NavSection[] = [
       { label: "Ledger", href: "/finance/transactions", icon: <FileText className={ICON_SIZE} />, moduleKey: "finance:transactions" },
       { label: "Reports", href: "/finance/reports", icon: <TrendingUp className={ICON_SIZE} />, moduleKey: "finance:reports" },
       { label: "Reconciliation", href: "/finance/recon", icon: <Scale className={ICON_SIZE} />, moduleKey: "finance:reports" },
+      { label: "Chart of Accounts", href: "/finance/coa", icon: <BookOpen className={ICON_SIZE} />, moduleKey: "finance:reports" },
       // Legacy (pre-agentic) views — kept until the new module reaches parity.
       { label: "Cashflow", href: "/finance/cashflow", icon: <LineChart className={ICON_SIZE} />, moduleKey: "finance:cashflow" },
       { label: "Cash Tracking", href: "/finance/cash-tracking", icon: <TableProperties className={ICON_SIZE} />, moduleKey: "finance:cash-tracking" },

--- a/apps/backoffice/src/app/api/finance/accounts/route.ts
+++ b/apps/backoffice/src/app/api/finance/accounts/route.ts
@@ -1,6 +1,7 @@
-// GET /api/finance/accounts
-// Lists active accounts in the COA. Used by the inbox "correct" dropdown
-// and by future report drill-downs.
+// GET /api/finance/accounts — lists accounts in the COA (active only by
+// default; ?all=true includes deactivated). Used by report drill-downs, the
+// recon category labels and the /finance/coa page.
+// POST — create an account. PATCH — rename / activate / deactivate.
 
 import { NextRequest, NextResponse } from "next/server";
 import { requireAuth } from "@/lib/auth";
@@ -8,25 +9,84 @@ import { getFinanceClient } from "@/lib/finance/supabase";
 
 export const dynamic = "force-dynamic";
 
-export async function GET(req: NextRequest) {
+const ACCOUNT_TYPES = ["asset", "liability", "equity", "income", "cogs", "expense"] as const;
+
+async function guard(req: NextRequest) {
   const auth = await requireAuth(req);
-  if (auth.error) return auth.error;
+  if (auth.error) return { error: auth.error };
   if (!["OWNER", "ADMIN"].includes(auth.user.role)) {
-    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+    return { error: NextResponse.json({ error: "Forbidden" }, { status: 403 }) };
   }
+  return { user: auth.user };
+}
+
+export async function GET(req: NextRequest) {
+  const g = await guard(req);
+  if (g.error) return g.error;
 
   const url = new URL(req.url);
   const types = url.searchParams.get("types")?.split(",").filter(Boolean);
+  const includeInactive = url.searchParams.get("all") === "true";
 
   const client = getFinanceClient();
   let q = client
     .from("fin_accounts")
     .select("code, name, type, subtype, parent_code, outlet_specific, is_active")
-    .eq("is_active", true)
     .order("code");
+  if (!includeInactive) q = q.eq("is_active", true);
   if (types && types.length) q = q.in("type", types);
 
   const { data, error } = await q;
   if (error) return NextResponse.json({ error: error.message }, { status: 500 });
   return NextResponse.json({ accounts: data ?? [] });
+}
+
+export async function POST(req: NextRequest) {
+  const g = await guard(req);
+  if (g.error) return g.error;
+
+  let body: { code?: string; name?: string; type?: string; parentCode?: string } = {};
+  try { body = await req.json(); } catch { /* handled below */ }
+  const code = body.code?.trim() ?? "";
+  const name = body.name?.trim() ?? "";
+  const type = body.type?.trim() ?? "";
+  if (!/^\d[\d-]{2,9}$/.test(code)) {
+    return NextResponse.json({ error: "Code must be digits and dashes, like 6504 or 6000-01" }, { status: 400 });
+  }
+  if (name.length < 3) return NextResponse.json({ error: "Name too short" }, { status: 400 });
+  if (!ACCOUNT_TYPES.includes(type as (typeof ACCOUNT_TYPES)[number])) {
+    return NextResponse.json({ error: `Type must be one of ${ACCOUNT_TYPES.join(", ")}` }, { status: 400 });
+  }
+
+  const client = getFinanceClient();
+  const { data: existing } = await client.from("fin_accounts").select("code").eq("code", code).maybeSingle();
+  if (existing) return NextResponse.json({ error: `Account ${code} already exists` }, { status: 409 });
+  if (body.parentCode) {
+    const { data: parent } = await client.from("fin_accounts").select("code").eq("code", body.parentCode).maybeSingle();
+    if (!parent) return NextResponse.json({ error: `Parent ${body.parentCode} not found` }, { status: 400 });
+  }
+
+  const { error } = await client.from("fin_accounts").insert({
+    code, name, type, parent_code: body.parentCode ?? null, is_active: true,
+  });
+  if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+  return NextResponse.json({ ok: true, code });
+}
+
+export async function PATCH(req: NextRequest) {
+  const g = await guard(req);
+  if (g.error) return g.error;
+
+  let body: { code?: string; name?: string; isActive?: boolean } = {};
+  try { body = await req.json(); } catch { /* handled below */ }
+  if (!body.code) return NextResponse.json({ error: "code required" }, { status: 400 });
+  const patch: Record<string, unknown> = {};
+  if (typeof body.name === "string" && body.name.trim().length >= 3) patch.name = body.name.trim();
+  if (typeof body.isActive === "boolean") patch.is_active = body.isActive;
+  if (!Object.keys(patch).length) return NextResponse.json({ error: "Nothing to update" }, { status: 400 });
+
+  const client = getFinanceClient();
+  const { error } = await client.from("fin_accounts").update(patch).eq("code", body.code);
+  if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+  return NextResponse.json({ ok: true });
 }

--- a/apps/backoffice/src/app/api/finance/bank-lines/classify/route.ts
+++ b/apps/backoffice/src/app/api/finance/bank-lines/classify/route.ts
@@ -11,6 +11,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { requireAuth } from "@/lib/auth";
 import { prisma } from "@/lib/prisma";
 import { CashCategory } from "@prisma/client";
+import { learnHintsFromLines } from "@/lib/finance/category-hints";
 
 export const dynamic = "force-dynamic";
 export const maxDuration = 60;
@@ -31,7 +32,7 @@ export async function POST(req: NextRequest) {
 
   const lines = await prisma.bankStatementLine.findMany({
     where: { id: { in: ids } },
-    select: { id: true, glTransactionId: true, apInvoiceId: true },
+    select: { id: true, glTransactionId: true, apInvoiceId: true, description: true, direction: true },
   });
   if (!lines.length) return NextResponse.json({ error: "Bank lines not found" }, { status: 404 });
   const matched = lines.filter((l) => l.apInvoiceId).length;
@@ -50,10 +51,19 @@ export async function POST(req: NextRequest) {
       });
     }
   });
+  // Teach the categorizer: this correction becomes a counterparty hint the
+  // classifier consults before its keyword rules, so the same payee never
+  // needs correcting twice. Failure to learn must not fail the classify.
+  let learned = 0;
+  try {
+    learned = await learnHintsFromLines(writable, category as CashCategory);
+  } catch { /* hint learning is best-effort */ }
+
   return NextResponse.json({
     ok: true,
     classified: writable.length,
     rekeyedJournals: journalIds.length,
     skippedMatched: matched, // AP-matched lines are settlement records — unmatch first
+    learnedHints: learned,
   });
 }

--- a/apps/backoffice/src/app/api/finance/category-hints/route.ts
+++ b/apps/backoffice/src/app/api/finance/category-hints/route.ts
@@ -1,0 +1,42 @@
+// GET /api/finance/category-hints — what the categorizer has learned from
+// manual classifications (payee phrase -> category). DELETE removes a hint
+// that was learned wrong; the next full reclassify stops applying it.
+
+import { NextRequest, NextResponse } from "next/server";
+import { requireAuth } from "@/lib/auth";
+import { getFinanceClient } from "@/lib/finance/supabase";
+
+export const dynamic = "force-dynamic";
+
+async function guard(req: NextRequest) {
+  const auth = await requireAuth(req);
+  if (auth.error) return auth.error;
+  if (!["OWNER", "ADMIN"].includes(auth.user.role)) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+  return null;
+}
+
+export async function GET(req: NextRequest) {
+  const err = await guard(req);
+  if (err) return err;
+  const client = getFinanceClient();
+  const { data, error } = await client
+    .from("fin_category_hints")
+    .select("phrase, category, direction, source, hits, updated_at")
+    .order("updated_at", { ascending: false });
+  if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+  return NextResponse.json({ hints: data ?? [] });
+}
+
+export async function DELETE(req: NextRequest) {
+  const err = await guard(req);
+  if (err) return err;
+  let body: { phrase?: string } = {};
+  try { body = await req.json(); } catch { /* handled below */ }
+  if (!body.phrase) return NextResponse.json({ error: "phrase required" }, { status: 400 });
+  const client = getFinanceClient();
+  const { error } = await client.from("fin_category_hints").delete().eq("phrase", body.phrase);
+  if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+  return NextResponse.json({ ok: true });
+}

--- a/apps/backoffice/src/app/api/finance/reclassify/route.ts
+++ b/apps/backoffice/src/app/api/finance/reclassify/route.ts
@@ -22,7 +22,8 @@ export async function GET(req: NextRequest) {
   const err = await guard(req);
   if (err) return err;
   try {
-    return NextResponse.json(await reclassifyBankLines({ commit: false }));
+    const full = new URL(req.url).searchParams.get("full") === "true";
+    return NextResponse.json(await reclassifyBankLines({ commit: false, full }));
   } catch (e) {
     return NextResponse.json({ error: e instanceof Error ? e.message : String(e) }, { status: 500 });
   }
@@ -32,7 +33,9 @@ export async function POST(req: NextRequest) {
   const err = await guard(req);
   if (err) return err;
   try {
-    return NextResponse.json(await reclassifyBankLines({ commit: true }));
+    let body: { full?: boolean } = {};
+    try { body = await req.json(); } catch { /* optional body */ }
+    return NextResponse.json(await reclassifyBankLines({ commit: true, full: body.full ?? false }));
   } catch (e) {
     return NextResponse.json({ error: e instanceof Error ? e.message : String(e) }, { status: 500 });
   }

--- a/apps/backoffice/src/lib/finance/bank-line-classifier.test.ts
+++ b/apps/backoffice/src/lib/finance/bank-line-classifier.test.ts
@@ -120,3 +120,22 @@ describe("bank-line-classifier", () => {
     expect(classifyBankLine({ description: "SOME ACME BEANS ROASTERY CREDIT", amount: 100, direction: "CR", vendorHints: hints }).category).toBe("OTHER_INFLOW");
   });
 });
+
+describe("learned category hints", () => {
+  const hints = [{ phrase: "GET RENTAL", category: "EQUIPMENTS" as const, direction: "DR" as const }];
+
+  it("outranks generic keyword rules — a corrected payee never regresses", () => {
+    // \bRENTAL\b alone would read this as RENT; the learned correction wins.
+    const res = classifyBankLine({ description: "I2606-0155 GET RENTAL SDN. BHD* I2606-0155", amount: 399, direction: "DR", learnedHints: hints });
+    expect(res.category).toBe("EQUIPMENTS");
+    expect(res.ruleName).toBe("learned_hint");
+  });
+
+  it("sees through the glued 20-char sender prefix", () => {
+    expect(classifyBankLine({ description: "CELSIUS COFFEE PUTRAGET RENTAL SDN. BHD*X", amount: 399, direction: "DR", learnedHints: hints }).category).toBe("EQUIPMENTS");
+  });
+
+  it("respects the hint direction and falls through otherwise", () => {
+    expect(classifyBankLine({ description: "GET RENTAL SDN BHD REFUND", amount: 399, direction: "CR", learnedHints: hints }).category).toBe("REFUND");
+  });
+});

--- a/apps/backoffice/src/lib/finance/bank-line-classifier.ts
+++ b/apps/backoffice/src/lib/finance/bank-line-classifier.ts
@@ -27,6 +27,11 @@ export type ClassifyInput = {
   // one of these classifies as RAW_MATERIALS — so onboarding a supplier in
   // procurement is enough for their payments to classify, no rule edit needed.
   vendorHints?: string[];
+  // Learned counterparty -> category associations from manual classifications
+  // (fin_category_hints). Checked BEFORE the keyword rules: a user correction
+  // on a specific payee outranks a generic keyword — "GET RENTAL SDN BHD" is
+  // an equipment vendor even though \bRENTAL\b reads as rent.
+  learnedHints?: { phrase: string; category: CashCategory; direction: Direction | null }[];
 };
 
 export type ClassifyResult = {
@@ -351,6 +356,23 @@ export function classifyBankLine(input: ClassifyInput): ClassifyResult {
   if (/^CELSIUS\s?COFFEE/.test(rawUpper) && rawUpper.length > 20) {
     const stripped = rawUpper.slice(20).replace(/\s+/g, " ").trim();
     if (stripped) candidates.push(stripped);
+  }
+
+  // Learned hints first: a manual classification on this counterparty is the
+  // strongest signal we have — it must beat generic keyword rules or the same
+  // misclassification would just come back on the next line from that payee.
+  if (input.learnedHints?.length) {
+    for (const hint of input.learnedHints) {
+      if (hint.direction && hint.direction !== input.direction) continue;
+      if (candidates.some((c) => c.includes(hint.phrase))) {
+        return {
+          category: hint.category,
+          outletCode: inferOutlet(desc),
+          isInterCo: intercoCounterparty,
+          ruleName: "learned_hint",
+        };
+      }
+    }
   }
 
   const rules = input.direction === "CR" ? INFLOW_RULES : OUTFLOW_RULES;

--- a/apps/backoffice/src/lib/finance/bukku-feed-sync.ts
+++ b/apps/backoffice/src/lib/finance/bukku-feed-sync.ts
@@ -12,6 +12,7 @@
 
 import { prisma } from "@/lib/prisma";
 import { classifyBankLine } from "./bank-line-classifier";
+import { fetchLearnedHints } from "./category-hints";
 import {
   listBankFeeds,
   fetchRawFeedLines,
@@ -149,8 +150,12 @@ async function syncAccount(
     const outlets = await prisma.outlet.findMany({ select: { id: true, code: true } });
     const codeToId = new Map(outlets.map((o) => [o.code, o.id]));
     const vendorHints = await supplierVendorHints();
+    // Learned corrections (fin_category_hints) outrank keyword rules; a payee
+    // the owner corrected once classifies right on every future feed rebuild.
+    let learnedHints: Awaited<ReturnType<typeof fetchLearnedHints>> = [];
+    try { learnedHints = await fetchLearnedHints(); } catch { /* additive */ }
     const classify = (l: BukkuBankLineDraft) => {
-      const cls = classifyBankLine({ description: l.description, reference: l.reference, amount: l.amount, direction: l.direction, accountKey: accountName, vendorHints });
+      const cls = classifyBankLine({ description: l.description, reference: l.reference, amount: l.amount, direction: l.direction, accountKey: accountName, vendorHints, learnedHints });
       return {
         category: cls.category,
         outletId: cls.outletCode ? codeToId.get(cls.outletCode) ?? null : null,

--- a/apps/backoffice/src/lib/finance/category-hints.test.ts
+++ b/apps/backoffice/src/lib/finance/category-hints.test.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect } from "vitest";
+import { deriveHintPhrase } from "./category-hints";
+
+describe("deriveHintPhrase", () => {
+  it("extracts the payee from a remittance with reference noise", () => {
+    expect(deriveHintPhrase("I2606-0155 GET RENTAL SDN. BHD* I2606-0155")).toBe("GET RENTAL");
+  });
+
+  it("strips transfer boilerplate and stops at reference tokens", () => {
+    expect(deriveHintPhrase("TRANSFER FR A/C BADRUL AZMI BIN JAM Q1 2026 Divide")).toBe("BADRUL AZMI BIN JAM");
+  });
+
+  it("strips the glued 20-char CELSIUS sender prefix", () => {
+    expect(deriveHintPhrase("CELSIUS COFFEE PUTRAYOW SENG SDN BHD*INV-1")).toBe("YOW SENG");
+  });
+
+  it("drops entity suffixes so punctuation variants converge", () => {
+    expect(deriveHintPhrase("GET RENTAL SDN BHD")).toBe("GET RENTAL");
+    expect(deriveHintPhrase("GET RENTAL SDN. BHD.")).toBe("GET RENTAL");
+  });
+
+  it("refuses generic or inter-company phrases", () => {
+    expect(deriveHintPhrase("TRANSFER TO A/C 123456")).toBeNull();
+    expect(deriveHintPhrase("TRANSFER FR A/C CELSIUS COFFEE SDN")).toBeNull();
+  });
+});

--- a/apps/backoffice/src/lib/finance/category-hints.ts
+++ b/apps/backoffice/src/lib/finance/category-hints.ts
@@ -1,0 +1,106 @@
+// Learned categorization memory — the "understands more and more" half of the
+// classifier. Every manual classification on /finance/recon teaches a
+// counterparty -> category association (fin_category_hints); the classifier
+// consults these BEFORE its keyword rules, so a correction like "GET RENTAL
+// SDN BHD is equipment, not rent" sticks for every future payment to that
+// payee without a code change. Keyword rules stay as the generic fallback.
+
+import { getFinanceClient } from "./supabase";
+import type { CashCategory } from "@celsius/db";
+
+export type LearnedHint = {
+  phrase: string;
+  category: CashCategory;
+  direction: "DR" | "CR" | null;
+};
+
+// Boilerplate the bank prepends before the counterparty — strip so the
+// derived phrase is the payee, not the transfer mechanics.
+const PREFIXES = [
+  /^TRANSFER (TO|FR) A\/C\s*/,
+  /^ELECTRONIC REMITTANCE\s*-?\s*(GIR\w*)?\s*/,
+  /^TT (CREDIT|DEBIT)( WITHOUT FLOAT)?\s*/,
+  /^(IBG|GIRO|DUITNOW|FPX|JOMPAY)\s*(QR)?-?\s*/,
+  /^PAYMENT (TO|FROM)\s*/,
+  /^CASH DEPOSIT\s*/,
+];
+
+// Words that make a phrase too generic to be a counterparty signature.
+const STOPLIST = new Set(["CELSIUS", "COFFEE", "TRANSFER", "PAYMENT", "REMITTANCE", "DEPOSIT", "CREDIT", "DEBIT"]);
+
+// Extract the counterparty signature from a bank description: strip the glued
+// 20-char sender prefix and transfer boilerplate, then take the longest run of
+// consecutive alphabetic tokens (references and amounts contain digits, so the
+// run naturally stops at them). Returns null when nothing distinctive remains.
+export function deriveHintPhrase(description: string): string | null {
+  let s = (description ?? "").toUpperCase().trim();
+  if (!s) return null;
+  // Maybank glues a fixed-width 20-char sender name onto the payee.
+  if (/^CELSIUS\s?COFFEE/.test(s) && s.length > 20) s = s.slice(20);
+  s = s.replace(/\s+/g, " ").trim();
+  for (const p of PREFIXES) s = s.replace(p, "");
+  s = s.replace(/[.*]/g, "").replace(/\s+/g, " ").trim();
+
+  const tokens = s.split(" ");
+  let best: string[] = [];
+  let run: string[] = [];
+  for (const t of tokens) {
+    if (/^[A-Z&'\-]+$/.test(t)) run.push(t);
+    else {
+      if (run.length > best.length) best = run;
+      run = [];
+    }
+  }
+  if (run.length > best.length) best = run;
+
+  // Trim entity suffixes off the end so "GET RENTAL SDN BHD" and
+  // "GET RENTAL SDN. BHD." derive the same phrase.
+  while (best.length && /^(SDN|BHD|SB|ENTERPRISE|ENTERP|TRADING|RESOURCES)$/.test(best[best.length - 1])) best.pop();
+
+  const phrase = best.join(" ").trim();
+  if (phrase.length < 6 || best.length < 2) return null;
+  if (best.every((w) => STOPLIST.has(w))) return null;
+  if (phrase.includes("CELSIUS")) return null; // inter-company, never a vendor signature
+  return phrase;
+}
+
+export async function fetchLearnedHints(): Promise<LearnedHint[]> {
+  const client = getFinanceClient();
+  const { data, error } = await client
+    .from("fin_category_hints")
+    .select("phrase, category, direction");
+  if (error) throw new Error(`fin_category_hints read failed: ${error.message}`);
+  return (data ?? []) as LearnedHint[];
+}
+
+// Called after a user classification: teach the phrase -> category
+// association. Last correction wins on conflict (the user just told us).
+export async function learnHintsFromLines(
+  lines: Array<{ description: string | null; direction: string }>,
+  category: CashCategory,
+): Promise<number> {
+  const client = getFinanceClient();
+  const seen = new Map<string, { phrase: string; direction: string }>();
+  for (const l of lines) {
+    const phrase = deriveHintPhrase(l.description ?? "");
+    if (!phrase) continue;
+    const prev = seen.get(phrase);
+    // Mixed directions for the same phrase -> hint applies to both (null).
+    seen.set(phrase, { phrase, direction: prev && prev.direction !== l.direction ? "" : l.direction });
+  }
+  let learned = 0;
+  for (const { phrase, direction } of seen.values()) {
+    const { error } = await client.from("fin_category_hints").upsert(
+      {
+        phrase,
+        category,
+        direction: direction || null,
+        source: "user_correction",
+        updated_at: new Date().toISOString(),
+      },
+      { onConflict: "phrase" },
+    );
+    if (!error) learned += 1;
+  }
+  return learned;
+}

--- a/apps/backoffice/src/lib/finance/reclassify.ts
+++ b/apps/backoffice/src/lib/finance/reclassify.ts
@@ -13,6 +13,7 @@
 import { prisma } from "@/lib/prisma";
 import { classifyBankLine } from "./bank-line-classifier";
 import { supplierVendorHints } from "./bukku-feed-sync";
+import { fetchLearnedHints } from "./category-hints";
 
 const round2 = (n: number) => Math.round(n * 100) / 100;
 
@@ -25,13 +26,22 @@ export type ReclassifyResult = {
   byRule: { ruleName: string; category: string; n: number; amount: number }[];
 };
 
-export async function reclassifyBankLines(opts: { commit?: boolean } = {}): Promise<ReclassifyResult> {
+export async function reclassifyBankLines(opts: { commit?: boolean; full?: boolean } = {}): Promise<ReclassifyResult> {
   const commit = opts.commit ?? false;
+  // full=true widens the sweep to EVERY rule-classified line, not just the
+  // OTHER_* pile — needed when a correction changes a category that a generic
+  // rule got wrong (GET RENTAL sat in RENT, Mikofee's dividend in
+  // RAW_MATERIALS; neither is in the catch-all pile). Still never touches
+  // user classifications or AP-matched lines, and a line only changes when
+  // the classifier gives a SPECIFIC answer (fallback never downgrades).
+  const full = opts.full ?? false;
   const vendorHints = await supplierVendorHints();
+  let learnedHints: Awaited<ReturnType<typeof fetchLearnedHints>> = [];
+  try { learnedHints = await fetchLearnedHints(); } catch { /* hints are additive */ }
 
   const lines = await prisma.bankStatementLine.findMany({
     where: {
-      OR: [{ category: null }, { category: { in: ["OTHER_OUTFLOW", "OTHER_INFLOW"] } }],
+      ...(full ? {} : { OR: [{ category: null }, { category: { in: ["OTHER_OUTFLOW", "OTHER_INFLOW"] } }] }),
       AND: [{ OR: [{ classifiedBy: null }, { classifiedBy: "rule" }] }],
       apInvoiceId: null,
     },
@@ -51,6 +61,7 @@ export async function reclassifyBankLines(opts: { commit?: boolean } = {}): Prom
       direction: l.direction as "CR" | "DR",
       accountKey: l.statement.accountName ?? undefined,
       vendorHints,
+      learnedHints,
     });
     if (!res.category || res.category === l.category) continue;
     if (res.category === "OTHER_OUTFLOW" || res.category === "OTHER_INFLOW") continue;

--- a/supabase/migrations/067_fin_category_hints.sql
+++ b/supabase/migrations/067_fin_category_hints.sql
@@ -1,0 +1,16 @@
+-- Learned categorization memory: every manual (user) classification teaches
+-- the classifier a payee->category association, consulted before keyword
+-- rules on future lines. The "understands more and more" agent, v1.
+-- Applied to production 2026-07-03 (supabase migration fin_category_hints).
+create table if not exists fin_category_hints (
+  id uuid primary key default gen_random_uuid(),
+  phrase text not null unique,          -- normalized counterparty phrase, uppercase single-spaced
+  category "CashCategory" not null,
+  direction text,                       -- 'DR' | 'CR' | null = both
+  source text not null default 'user_correction',
+  hits int not null default 1,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+alter table fin_category_hints enable row level security;
+-- service-role access only (finance client); no anon policies.


### PR DESCRIPTION
Owner: 'create an AI agent that can understand the categorisation more and
more as we do this' + 'where can we create the COA' + 'GET RENTAL is
equipment'.

LEARNING CATEGORIZER (fin_category_hints, migration 067 applied to prod):
every manual classification teaches a normalized payee phrase -> category
association. deriveHintPhrase strips the glued 20-char sender prefix,
transfer boilerplate and reference tokens, and trims entity suffixes so
'GET RENTAL SDN. BHD*' and 'GET RENTAL SDN BHD' converge. The classifier
consults learned hints BEFORE its keyword rules — a user correction on a
payee outranks a generic keyword (\bRENTAL\b read GET RENTAL as rent) —
then keyword rules, then the supplier registry. Hints flow into the 6h
feed-sync rebuild and the reclassify pass, so one correction propagates
everywhere and never regresses.

- reclassify gains full mode (POST {full:true} / GET ?full=true): sweeps
  ALL rule-classified lines, not just the OTHER_* pile, so corrections fix
  lines a generic rule got wrong; fallback never downgrades a specific
  category; user + AP-matched lines untouched. Recon button now full-sweeps.
- classify endpoint learns hints on every user classification (best-effort)
  and reports learnedHints in its response.

CHART OF ACCOUNTS page (/finance/coa, nav under Finance): grouped COA with
search, add-account form (code/name/type/parent, validated, duplicate-safe),
deactivate/reactivate; plus a 'Learned categorizations' section showing
every taught payee->category hint with a forget action.
/api/finance/accounts gains POST + PATCH; ?all=true includes inactive.

55/55 finance tests pass, typecheck + lint clean.
