### PR TITLE
feat(hr): roster attendance view — rostered vs actual, who's late/absent

### DIFF
--- a/apps/backoffice/src/app/(admin)/hr/roster-attendance/page.tsx
+++ b/apps/backoffice/src/app/(admin)/hr/roster-attendance/page.tsx
@@ -2,14 +2,11 @@
 
 import { useEffect, useMemo, useState } from "react";
 import { useFetch } from "@/lib/use-fetch";
-import { CalendarClock, CheckCircle2, Clock, UserX, HelpCircle } from "lucide-react";
+import { CalendarClock, CheckCircle2, Clock, UserX, HelpCircle, ChevronLeft, ChevronRight } from "lucide-react";
 import { HrPageHeader } from "@/components/hr/page-header";
 
-type Row = {
-  user_id: string;
-  name: string | null;
-  nickname: string | null;
-  position: string | null;
+type Status = "on_time" | "late" | "absent" | "no_roster" | "off";
+type Cell = {
   scheduled_start: string | null;
   scheduled_end: string | null;
   clock_in: string | null;
@@ -17,31 +14,50 @@ type Row = {
   total_hours: number | null;
   late_minutes: number;
   open: boolean;
-  status: "on_time" | "late" | "absent" | "no_roster";
+  status: Status;
 };
-
-type Resp = {
-  date: string;
+type Staff = { user_id: string; name: string | null; nickname: string | null; position: string | null };
+type DayRow = Staff & Cell;
+type Summary = { rostered: number; present: number; late: number; absent: number; unrostered: number };
+type DayResp = { mode: "day"; date: string; outlet: { id: string; name: string }; rows: DayRow[]; summary: Summary };
+type WeekResp = {
+  mode: "week";
+  week_start: string;
+  days: string[];
   outlet: { id: string; name: string };
-  rows: Row[];
-  summary: { rostered: number; present: number; late: number; absent: number; unrostered: number };
+  staff: (Staff & { days: Record<string, Cell> })[];
+  summary: Summary;
 };
 
+const DAY_MS = 24 * 3600 * 1000;
 const mytToday = () => new Date(Date.now() + 8 * 3600 * 1000).toISOString().slice(0, 10);
+function mytMonday() {
+  const now = new Date(Date.now() + 8 * 3600 * 1000);
+  const dow = now.getUTCDay(); // 0=Sun..6=Sat (already MYT-shifted)
+  return new Date(now.getTime() + (dow === 0 ? -6 : 1 - dow) * DAY_MS).toISOString().slice(0, 10);
+}
+const shiftDays = (iso: string, n: number) => new Date(Date.parse(iso + "T00:00:00Z") + n * DAY_MS).toISOString().slice(0, 10);
 const fmtTime = (iso: string | null) =>
   iso ? new Date(iso).toLocaleTimeString("en-MY", { hour: "2-digit", minute: "2-digit" }) : "—";
+const fmtDayHead = (d: string) =>
+  new Date(d + "T00:00:00").toLocaleDateString("en-MY", { weekday: "short", day: "2-digit", month: "short" });
+const fmtRange = (start: string) =>
+  `${new Date(start + "T00:00:00").toLocaleDateString("en-MY", { day: "2-digit", month: "short" })} – ${new Date(shiftDays(start, 6) + "T00:00:00").toLocaleDateString("en-MY", { day: "2-digit", month: "short" })}`;
 
-const STATUS: Record<Row["status"], { label: string; cls: string; icon: typeof Clock }> = {
+const STATUS: Record<Status, { label: string; cls: string; icon: typeof Clock }> = {
   on_time: { label: "On time", cls: "text-green-700 bg-green-50 border-green-200", icon: CheckCircle2 },
   late: { label: "Late", cls: "text-amber-700 bg-amber-50 border-amber-200", icon: Clock },
   absent: { label: "Absent", cls: "text-red-700 bg-red-50 border-red-200", icon: UserX },
   no_roster: { label: "Not rostered", cls: "text-gray-600 bg-gray-50 border-gray-200", icon: HelpCircle },
+  off: { label: "Off", cls: "text-gray-400 bg-transparent border-transparent", icon: HelpCircle },
 };
 
 export default function RosterAttendancePage() {
+  const [mode, setMode] = useState<"day" | "week">("week");
   const [outlets, setOutlets] = useState<{ id: string; name: string }[]>([]);
   const [outletId, setOutletId] = useState("");
   const [date, setDate] = useState(mytToday);
+  const [weekStart, setWeekStart] = useState(mytMonday);
 
   const { data: scheduleList } = useFetch<{ outlets: { id: string; name: string }[] }>("/api/hr/schedules");
   useEffect(() => {
@@ -51,11 +67,12 @@ export default function RosterAttendancePage() {
     }
   }, [scheduleList, outlets.length, outletId]);
 
-  const { data, isLoading } = useFetch<Resp>(
-    outletId && date ? `/api/hr/schedules/roster-attendance?outlet_id=${outletId}&date=${date}` : null,
-  );
-
-  const rows = useMemo(() => data?.rows ?? [], [data]);
+  const url = !outletId
+    ? null
+    : mode === "day"
+      ? `/api/hr/schedules/roster-attendance?outlet_id=${outletId}&date=${date}`
+      : `/api/hr/schedules/roster-attendance?outlet_id=${outletId}&week_start=${weekStart}`;
+  const { data, isLoading } = useFetch<DayResp | WeekResp>(url);
   const s = data?.summary;
 
   return (
@@ -65,27 +82,40 @@ export default function RosterAttendancePage() {
         description="Who's rostered vs. who actually showed up — on time, late, or absent"
         action={
           <div className="flex flex-wrap items-center gap-2">
-            <select
-              value={outletId}
-              onChange={(e) => setOutletId(e.target.value)}
-              className="rounded-lg border bg-card px-3 py-1.5 text-sm"
-            >
+            <div className="flex gap-1 rounded-lg border bg-card p-1 text-sm">
+              {(["day", "week"] as const).map((m) => (
+                <button
+                  key={m}
+                  onClick={() => setMode(m)}
+                  className={`rounded-md px-3 py-1.5 font-medium capitalize ${mode === m ? "bg-terracotta text-white" : "text-gray-600 hover:bg-muted"}`}
+                >
+                  {m}
+                </button>
+              ))}
+            </div>
+            <select value={outletId} onChange={(e) => setOutletId(e.target.value)} className="rounded-lg border bg-card px-3 py-1.5 text-sm">
               <option value="">Select outlet…</option>
               {outlets.map((o) => (
                 <option key={o.id} value={o.id}>{o.name}</option>
               ))}
             </select>
-            <input
-              type="date"
-              value={date}
-              onChange={(e) => setDate(e.target.value)}
-              className="rounded-lg border bg-card px-3 py-1.5 text-sm"
-            />
+            {mode === "day" ? (
+              <input type="date" value={date} onChange={(e) => setDate(e.target.value)} className="rounded-lg border bg-card px-3 py-1.5 text-sm" />
+            ) : (
+              <div className="flex items-center gap-1 rounded-lg border bg-card px-1 py-0.5 text-sm">
+                <button onClick={() => setWeekStart((w) => shiftDays(w, -7))} className="rounded p-1 hover:bg-muted" aria-label="Previous week">
+                  <ChevronLeft className="h-4 w-4" />
+                </button>
+                <span className="min-w-[9rem] text-center text-xs font-medium">{fmtRange(weekStart)}</span>
+                <button onClick={() => setWeekStart((w) => shiftDays(w, 7))} className="rounded p-1 hover:bg-muted" aria-label="Next week">
+                  <ChevronRight className="h-4 w-4" />
+                </button>
+              </div>
+            )}
           </div>
         }
       />
 
-      {/* Summary chips */}
       {s && (
         <div className="grid grid-cols-2 gap-3 sm:grid-cols-5">
           <Stat label="Rostered" value={s.rostered} />
@@ -97,66 +127,129 @@ export default function RosterAttendancePage() {
       )}
 
       {!outletId ? (
-        <Empty icon={CalendarClock} title="Pick an outlet" body="Select an outlet and date to see the roster vs. attendance." />
-      ) : isLoading ? (
-        <Empty icon={CalendarClock} title="Loading…" body="" />
-      ) : rows.length === 0 ? (
-        <Empty icon={CalendarClock} title="Nothing here" body="No rostered shifts or attendance for this day." />
+        <Empty title="Pick an outlet" body="Select an outlet to see the roster vs. attendance." />
+      ) : isLoading || !data ? (
+        <Empty title="Loading…" body="" />
+      ) : data.mode === "day" ? (
+        <DayTable rows={data.rows} />
       ) : (
-        <div className="overflow-hidden rounded-xl border bg-card shadow-sm">
-          <table className="w-full text-sm">
-            <thead className="border-b bg-muted/40 text-left text-xs uppercase tracking-wide text-muted-foreground">
-              <tr>
-                <th className="px-4 py-2.5 font-semibold">Staff</th>
-                <th className="px-4 py-2.5 font-semibold">Rostered</th>
-                <th className="px-4 py-2.5 font-semibold">Clock in</th>
-                <th className="px-4 py-2.5 font-semibold">Clock out</th>
-                <th className="px-4 py-2.5 text-right font-semibold">Status</th>
-              </tr>
-            </thead>
-            <tbody className="divide-y">
-              {rows.map((r) => {
-                const st = STATUS[r.status];
-                const Icon = st.icon;
-                return (
-                  <tr key={r.user_id} className="hover:bg-muted/30">
-                    <td className="px-4 py-2.5">
-                      <div className="font-medium">{r.name || r.user_id.slice(0, 8) + "…"}</div>
-                      {r.position && <div className="text-xs text-muted-foreground">{r.position}</div>}
-                    </td>
-                    <td className="px-4 py-2.5 text-muted-foreground">
-                      {r.scheduled_start ? `${r.scheduled_start}–${r.scheduled_end ?? "?"}` : "—"}
-                    </td>
-                    <td className="px-4 py-2.5">
-                      {fmtTime(r.clock_in)}
-                      {r.open && r.clock_in && <span className="ml-1 text-xs text-blue-600">· in</span>}
-                    </td>
-                    <td className="px-4 py-2.5">{fmtTime(r.clock_out)}</td>
-                    <td className="px-4 py-2.5">
-                      <div className="flex items-center justify-end gap-2">
-                        {r.status === "late" && r.late_minutes > 0 && (
-                          <span className="text-xs text-amber-700">{r.late_minutes} min</span>
-                        )}
-                        <span className={`inline-flex items-center gap-1 rounded-full border px-2 py-0.5 text-xs font-medium ${st.cls}`}>
-                          <Icon className="h-3 w-3" />
-                          {st.label}
-                        </span>
-                      </div>
-                    </td>
-                  </tr>
-                );
-              })}
-            </tbody>
-          </table>
-        </div>
+        <WeekGrid data={data} />
       )}
     </div>
   );
 }
 
+function DayTable({ rows }: { rows: DayRow[] }) {
+  if (rows.length === 0) return <Empty title="Nothing here" body="No rostered shifts or attendance for this day." />;
+  return (
+    <div className="overflow-x-auto rounded-xl border bg-card shadow-sm">
+      <table className="w-full text-sm">
+        <thead className="border-b bg-muted/40 text-left text-xs uppercase tracking-wide text-muted-foreground">
+          <tr>
+            <th className="px-4 py-2.5 font-semibold">Staff</th>
+            <th className="px-4 py-2.5 font-semibold">Rostered</th>
+            <th className="px-4 py-2.5 font-semibold">Clock in</th>
+            <th className="px-4 py-2.5 font-semibold">Clock out</th>
+            <th className="px-4 py-2.5 text-right font-semibold">Status</th>
+          </tr>
+        </thead>
+        <tbody className="divide-y">
+          {rows.map((r) => {
+            const st = STATUS[r.status];
+            const Icon = st.icon;
+            return (
+              <tr key={r.user_id} className="hover:bg-muted/30">
+                <td className="px-4 py-2.5">
+                  <div className="font-medium">{r.name || r.user_id.slice(0, 8) + "…"}</div>
+                  {r.position && <div className="text-xs text-muted-foreground">{r.position}</div>}
+                </td>
+                <td className="px-4 py-2.5 text-muted-foreground">{r.scheduled_start ? `${r.scheduled_start}–${r.scheduled_end ?? "?"}` : "—"}</td>
+                <td className="px-4 py-2.5">
+                  {fmtTime(r.clock_in)}
+                  {r.open && r.clock_in && <span className="ml-1 text-xs text-blue-600">· in</span>}
+                </td>
+                <td className="px-4 py-2.5">{fmtTime(r.clock_out)}</td>
+                <td className="px-4 py-2.5">
+                  <div className="flex items-center justify-end gap-2">
+                    {r.status === "late" && r.late_minutes > 0 && <span className="text-xs text-amber-700">{r.late_minutes} min</span>}
+                    <span className={`inline-flex items-center gap-1 rounded-full border px-2 py-0.5 text-xs font-medium ${st.cls}`}>
+                      <Icon className="h-3 w-3" />
+                      {st.label}
+                    </span>
+                  </div>
+                </td>
+              </tr>
+            );
+          })}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+function WeekGrid({ data }: { data: WeekResp }) {
+  if (data.staff.length === 0) return <Empty title="Nothing here" body="No rostered shifts or attendance this week." />;
+  return (
+    <div className="overflow-x-auto rounded-xl border bg-card shadow-sm">
+      <table className="min-w-[760px] w-full border-collapse text-sm">
+        <thead>
+          <tr className="border-b bg-muted/40 text-xs uppercase tracking-wide text-muted-foreground">
+            <th className="sticky left-0 z-10 bg-muted/40 px-4 py-2.5 text-left font-semibold">Staff</th>
+            {data.days.map((d) => (
+              <th key={d} className="px-2 py-2.5 text-center font-semibold">{fmtDayHead(d)}</th>
+            ))}
+          </tr>
+        </thead>
+        <tbody className="divide-y">
+          {data.staff.map((row) => (
+            <tr key={row.user_id} className="hover:bg-muted/20">
+              <td className="sticky left-0 z-10 bg-card px-4 py-2 align-top">
+                <div className="font-medium">{row.name || row.user_id.slice(0, 8) + "…"}</div>
+                {row.position && <div className="text-xs text-muted-foreground">{row.position}</div>}
+              </td>
+              {data.days.map((d) => (
+                <td key={d} className="px-1.5 py-1.5 align-top">
+                  <WeekCell cell={row.days[d]} />
+                </td>
+              ))}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+function WeekCell({ cell }: { cell: Cell }) {
+  if (!cell || cell.status === "off") return <div className="h-11" />;
+  const cls =
+    cell.status === "on_time"
+      ? "bg-green-50 border-green-200"
+      : cell.status === "late"
+        ? "bg-amber-50 border-amber-200"
+        : cell.status === "absent"
+          ? "bg-red-50 border-red-200"
+          : "bg-gray-50 border-gray-200";
+  return (
+    <div className={`rounded-md border px-2 py-1 ${cls}`}>
+      {cell.status === "absent" ? (
+        <div className="text-xs font-semibold text-red-700">Absent</div>
+      ) : (
+        <div className="flex items-baseline justify-between gap-1">
+          <span className="text-sm font-medium tabular-nums">{fmtTime(cell.clock_in)}</span>
+          {cell.status === "late" && cell.late_minutes > 0 && <span className="text-[10px] font-semibold text-amber-700">+{cell.late_minutes}m</span>}
+          {cell.open && <span className="text-[10px] text-blue-600">in</span>}
+        </div>
+      )}
+      <div className="text-[10px] text-muted-foreground">
+        {cell.scheduled_start ? `${cell.scheduled_start}–${cell.scheduled_end ?? "?"}` : "unscheduled"}
+      </div>
+    </div>
+  );
+}
+
 function Stat({ label, value, tone }: { label: string; value: number; tone?: "green" | "amber" | "red" }) {
-  const toneCls =
-    tone === "green" ? "text-green-700" : tone === "amber" ? "text-amber-700" : tone === "red" ? "text-red-700" : "text-foreground";
+  const toneCls = tone === "green" ? "text-green-700" : tone === "amber" ? "text-amber-700" : tone === "red" ? "text-red-700" : "text-foreground";
   return (
     <div className="rounded-xl border bg-card p-3 shadow-sm">
       <div className={`text-2xl font-bold tabular-nums ${toneCls}`}>{value}</div>
@@ -165,10 +258,10 @@ function Stat({ label, value, tone }: { label: string; value: number; tone?: "gr
   );
 }
 
-function Empty({ icon: Icon, title, body }: { icon: typeof CalendarClock; title: string; body: string }) {
+function Empty({ title, body }: { title: string; body: string }) {
   return (
     <div className="flex flex-col items-center justify-center rounded-xl border bg-card py-16 text-center">
-      <Icon className="mb-3 h-12 w-12 text-muted-foreground" />
+      <CalendarClock className="mb-3 h-12 w-12 text-muted-foreground" />
       <p className="text-lg font-semibold">{title}</p>
       {body && <p className="text-sm text-muted-foreground">{body}</p>}
     </div>

--- a/apps/backoffice/src/app/(admin)/hr/roster-attendance/page.tsx
+++ b/apps/backoffice/src/app/(admin)/hr/roster-attendance/page.tsx
@@ -1,0 +1,176 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import { useFetch } from "@/lib/use-fetch";
+import { CalendarClock, CheckCircle2, Clock, UserX, HelpCircle } from "lucide-react";
+import { HrPageHeader } from "@/components/hr/page-header";
+
+type Row = {
+  user_id: string;
+  name: string | null;
+  nickname: string | null;
+  position: string | null;
+  scheduled_start: string | null;
+  scheduled_end: string | null;
+  clock_in: string | null;
+  clock_out: string | null;
+  total_hours: number | null;
+  late_minutes: number;
+  open: boolean;
+  status: "on_time" | "late" | "absent" | "no_roster";
+};
+
+type Resp = {
+  date: string;
+  outlet: { id: string; name: string };
+  rows: Row[];
+  summary: { rostered: number; present: number; late: number; absent: number; unrostered: number };
+};
+
+const mytToday = () => new Date(Date.now() + 8 * 3600 * 1000).toISOString().slice(0, 10);
+const fmtTime = (iso: string | null) =>
+  iso ? new Date(iso).toLocaleTimeString("en-MY", { hour: "2-digit", minute: "2-digit" }) : "—";
+
+const STATUS: Record<Row["status"], { label: string; cls: string; icon: typeof Clock }> = {
+  on_time: { label: "On time", cls: "text-green-700 bg-green-50 border-green-200", icon: CheckCircle2 },
+  late: { label: "Late", cls: "text-amber-700 bg-amber-50 border-amber-200", icon: Clock },
+  absent: { label: "Absent", cls: "text-red-700 bg-red-50 border-red-200", icon: UserX },
+  no_roster: { label: "Not rostered", cls: "text-gray-600 bg-gray-50 border-gray-200", icon: HelpCircle },
+};
+
+export default function RosterAttendancePage() {
+  const [outlets, setOutlets] = useState<{ id: string; name: string }[]>([]);
+  const [outletId, setOutletId] = useState("");
+  const [date, setDate] = useState(mytToday);
+
+  const { data: scheduleList } = useFetch<{ outlets: { id: string; name: string }[] }>("/api/hr/schedules");
+  useEffect(() => {
+    if (scheduleList?.outlets && outlets.length === 0) {
+      setOutlets(scheduleList.outlets);
+      if (scheduleList.outlets.length > 0 && !outletId) setOutletId(scheduleList.outlets[0].id);
+    }
+  }, [scheduleList, outlets.length, outletId]);
+
+  const { data, isLoading } = useFetch<Resp>(
+    outletId && date ? `/api/hr/schedules/roster-attendance?outlet_id=${outletId}&date=${date}` : null,
+  );
+
+  const rows = useMemo(() => data?.rows ?? [], [data]);
+  const s = data?.summary;
+
+  return (
+    <div className="space-y-6 p-4 sm:p-6 lg:p-8">
+      <HrPageHeader
+        title="Roster Attendance"
+        description="Who's rostered vs. who actually showed up — on time, late, or absent"
+        action={
+          <div className="flex flex-wrap items-center gap-2">
+            <select
+              value={outletId}
+              onChange={(e) => setOutletId(e.target.value)}
+              className="rounded-lg border bg-card px-3 py-1.5 text-sm"
+            >
+              <option value="">Select outlet…</option>
+              {outlets.map((o) => (
+                <option key={o.id} value={o.id}>{o.name}</option>
+              ))}
+            </select>
+            <input
+              type="date"
+              value={date}
+              onChange={(e) => setDate(e.target.value)}
+              className="rounded-lg border bg-card px-3 py-1.5 text-sm"
+            />
+          </div>
+        }
+      />
+
+      {/* Summary chips */}
+      {s && (
+        <div className="grid grid-cols-2 gap-3 sm:grid-cols-5">
+          <Stat label="Rostered" value={s.rostered} />
+          <Stat label="Present" value={s.present} tone="green" />
+          <Stat label="Late" value={s.late} tone="amber" />
+          <Stat label="Absent" value={s.absent} tone="red" />
+          <Stat label="Unrostered" value={s.unrostered} />
+        </div>
+      )}
+
+      {!outletId ? (
+        <Empty icon={CalendarClock} title="Pick an outlet" body="Select an outlet and date to see the roster vs. attendance." />
+      ) : isLoading ? (
+        <Empty icon={CalendarClock} title="Loading…" body="" />
+      ) : rows.length === 0 ? (
+        <Empty icon={CalendarClock} title="Nothing here" body="No rostered shifts or attendance for this day." />
+      ) : (
+        <div className="overflow-hidden rounded-xl border bg-card shadow-sm">
+          <table className="w-full text-sm">
+            <thead className="border-b bg-muted/40 text-left text-xs uppercase tracking-wide text-muted-foreground">
+              <tr>
+                <th className="px-4 py-2.5 font-semibold">Staff</th>
+                <th className="px-4 py-2.5 font-semibold">Rostered</th>
+                <th className="px-4 py-2.5 font-semibold">Clock in</th>
+                <th className="px-4 py-2.5 font-semibold">Clock out</th>
+                <th className="px-4 py-2.5 text-right font-semibold">Status</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y">
+              {rows.map((r) => {
+                const st = STATUS[r.status];
+                const Icon = st.icon;
+                return (
+                  <tr key={r.user_id} className="hover:bg-muted/30">
+                    <td className="px-4 py-2.5">
+                      <div className="font-medium">{r.name || r.user_id.slice(0, 8) + "…"}</div>
+                      {r.position && <div className="text-xs text-muted-foreground">{r.position}</div>}
+                    </td>
+                    <td className="px-4 py-2.5 text-muted-foreground">
+                      {r.scheduled_start ? `${r.scheduled_start}–${r.scheduled_end ?? "?"}` : "—"}
+                    </td>
+                    <td className="px-4 py-2.5">
+                      {fmtTime(r.clock_in)}
+                      {r.open && r.clock_in && <span className="ml-1 text-xs text-blue-600">· in</span>}
+                    </td>
+                    <td className="px-4 py-2.5">{fmtTime(r.clock_out)}</td>
+                    <td className="px-4 py-2.5">
+                      <div className="flex items-center justify-end gap-2">
+                        {r.status === "late" && r.late_minutes > 0 && (
+                          <span className="text-xs text-amber-700">{r.late_minutes} min</span>
+                        )}
+                        <span className={`inline-flex items-center gap-1 rounded-full border px-2 py-0.5 text-xs font-medium ${st.cls}`}>
+                          <Icon className="h-3 w-3" />
+                          {st.label}
+                        </span>
+                      </div>
+                    </td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function Stat({ label, value, tone }: { label: string; value: number; tone?: "green" | "amber" | "red" }) {
+  const toneCls =
+    tone === "green" ? "text-green-700" : tone === "amber" ? "text-amber-700" : tone === "red" ? "text-red-700" : "text-foreground";
+  return (
+    <div className="rounded-xl border bg-card p-3 shadow-sm">
+      <div className={`text-2xl font-bold tabular-nums ${toneCls}`}>{value}</div>
+      <div className="text-xs text-muted-foreground">{label}</div>
+    </div>
+  );
+}
+
+function Empty({ icon: Icon, title, body }: { icon: typeof CalendarClock; title: string; body: string }) {
+  return (
+    <div className="flex flex-col items-center justify-center rounded-xl border bg-card py-16 text-center">
+      <Icon className="mb-3 h-12 w-12 text-muted-foreground" />
+      <p className="text-lg font-semibold">{title}</p>
+      {body && <p className="text-sm text-muted-foreground">{body}</p>}
+    </div>
+  );
+}

--- a/apps/backoffice/src/app/api/hr/schedules/roster-attendance/route.ts
+++ b/apps/backoffice/src/app/api/hr/schedules/roster-attendance/route.ts
@@ -1,0 +1,154 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getSession } from "@/lib/auth";
+import { hrSupabaseAdmin } from "@/lib/hr/supabase";
+import { prisma } from "@/lib/prisma";
+import { computeLateMinutes } from "@/lib/hr/hours";
+import { GRACE_PERIOD_MINUTES } from "@/lib/hr/constants";
+import { canAccessOutlet, hasModuleAccess } from "@/lib/hr/scope";
+
+export const dynamic = "force-dynamic";
+
+// GET /api/hr/schedules/roster-attendance?outlet_id=X&date=YYYY-MM-DD
+//
+// Roster-vs-actual for one outlet on one day: every rostered shift with who
+// actually clocked in, who's late, and who's absent — plus anyone who worked
+// without being on the roster. Read-only companion to the Schedules grid.
+export async function GET(req: NextRequest) {
+  const session = await getSession();
+  if (!session || !["OWNER", "ADMIN", "MANAGER"].includes(session.role)) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+  if (!(await hasModuleAccess(session, "hr:schedules"))) {
+    return NextResponse.json({ error: "Forbidden — no access to Schedules" }, { status: 403 });
+  }
+
+  const { searchParams } = new URL(req.url);
+  const outletId = searchParams.get("outlet_id");
+  const date = searchParams.get("date"); // YYYY-MM-DD (MYT calendar day)
+  if (!outletId || !date || !/^\d{4}-\d{2}-\d{2}$/.test(date)) {
+    return NextResponse.json({ error: "outlet_id and a valid date are required" }, { status: 400 });
+  }
+
+  if (session.role === "MANAGER" && !(await canAccessOutlet(session, outletId))) {
+    return NextResponse.json({ error: "Forbidden — managers can only view their assigned outlets" }, { status: 403 });
+  }
+
+  const outlet = await prisma.outlet.findUnique({ where: { id: outletId }, select: { id: true, name: true } });
+  if (!outlet) return NextResponse.json({ error: "Outlet not found" }, { status: 404 });
+
+  // 1. Rostered shifts for this outlet on this date (any status — rosters are
+  //    often kept as draft). Two-step to stay off embed typing.
+  const { data: scheds } = await hrSupabaseAdmin
+    .from("hr_schedules")
+    .select("id")
+    .eq("outlet_id", outletId);
+  const schedIds = (scheds || []).map((s: { id: string }) => s.id);
+
+  let shifts: { user_id: string; start_time: string; end_time: string | null; role_type: string | null }[] = [];
+  if (schedIds.length > 0) {
+    const { data } = await hrSupabaseAdmin
+      .from("hr_schedule_shifts")
+      .select("user_id, start_time, end_time, role_type")
+      .in("schedule_id", schedIds)
+      .eq("shift_date", date);
+    shifts = data || [];
+  }
+  // Keep the earliest-starting shift per user for the day.
+  const shiftByUser = new Map<string, (typeof shifts)[number]>();
+  for (const s of shifts) {
+    const prev = shiftByUser.get(s.user_id);
+    if (!prev || s.start_time < prev.start_time) shiftByUser.set(s.user_id, s);
+  }
+
+  // 2. Attendance logs at this outlet on this MYT calendar day.
+  const startMs = Date.parse(`${date}T00:00:00+08:00`);
+  const dayStart = new Date(startMs).toISOString();
+  const dayEnd = new Date(startMs + 24 * 3600 * 1000).toISOString();
+  const { data: logs } = await hrSupabaseAdmin
+    .from("hr_attendance_logs")
+    .select("user_id, clock_in, clock_out, total_hours")
+    .eq("outlet_id", outletId)
+    .gte("clock_in", dayStart)
+    .lt("clock_in", dayEnd)
+    .order("clock_in", { ascending: true });
+  // Earliest clock-in per user is the shift start.
+  const logByUser = new Map<string, { user_id: string; clock_in: string; clock_out: string | null; total_hours: number | null }>();
+  for (const l of logs || []) {
+    if (!logByUser.has(l.user_id)) logByUser.set(l.user_id, l);
+  }
+
+  // 3. Names + positions for everyone involved.
+  const userIds = Array.from(new Set([...shiftByUser.keys(), ...logByUser.keys()]));
+  const [users, profilesResp] = await Promise.all([
+    userIds.length
+      ? prisma.user.findMany({ where: { id: { in: userIds } }, select: { id: true, name: true, fullName: true } })
+      : Promise.resolve([]),
+    userIds.length
+      ? hrSupabaseAdmin.from("hr_employee_profiles").select("user_id, position").in("user_id", userIds)
+      : Promise.resolve({ data: [] as { user_id: string; position: string | null }[] }),
+  ]);
+  const userMap = new Map(users.map((u) => [u.id, u]));
+  const positionMap = new Map((profilesResp.data || []).map((p: { user_id: string; position: string | null }) => [p.user_id, p.position]));
+
+  type Row = {
+    user_id: string;
+    name: string | null;
+    nickname: string | null;
+    position: string | null;
+    scheduled_start: string | null;
+    scheduled_end: string | null;
+    clock_in: string | null;
+    clock_out: string | null;
+    total_hours: number | null;
+    late_minutes: number;
+    open: boolean;
+    status: "on_time" | "late" | "absent" | "no_roster";
+  };
+
+  const rows: Row[] = userIds.map((uid) => {
+    const shift = shiftByUser.get(uid) || null;
+    const log = logByUser.get(uid) || null;
+    const u = userMap.get(uid);
+    const lateMin = shift && log ? Math.max(0, computeLateMinutes(log.clock_in, shift.start_time, date)) : 0;
+    let status: Row["status"];
+    if (!shift) status = "no_roster";
+    else if (!log) status = "absent";
+    else if (lateMin > GRACE_PERIOD_MINUTES) status = "late";
+    else status = "on_time";
+    return {
+      user_id: uid,
+      name: u?.fullName || u?.name || null,
+      nickname: u?.name || null,
+      position: positionMap.get(uid) || shift?.role_type || null,
+      scheduled_start: shift ? shift.start_time.slice(0, 5) : null,
+      scheduled_end: shift?.end_time ? shift.end_time.slice(0, 5) : null,
+      clock_in: log?.clock_in ?? null,
+      clock_out: log?.clock_out ?? null,
+      total_hours: log?.total_hours ?? null,
+      late_minutes: lateMin,
+      open: !!log && !log.clock_out,
+      status,
+    };
+  });
+
+  // Order: rostered first (by scheduled start), unrostered last; within that,
+  // attention-needing (absent/late) bubble up.
+  const statusRank: Record<Row["status"], number> = { absent: 0, late: 1, on_time: 2, no_roster: 3 };
+  rows.sort((a, b) => {
+    if ((a.status === "no_roster") !== (b.status === "no_roster")) return a.status === "no_roster" ? 1 : -1;
+    if (a.scheduled_start && b.scheduled_start && a.scheduled_start !== b.scheduled_start) {
+      return a.scheduled_start.localeCompare(b.scheduled_start);
+    }
+    return statusRank[a.status] - statusRank[b.status];
+  });
+
+  const summary = {
+    rostered: shiftByUser.size,
+    present: rows.filter((r) => r.status === "on_time" || r.status === "late").length,
+    late: rows.filter((r) => r.status === "late").length,
+    absent: rows.filter((r) => r.status === "absent").length,
+    unrostered: rows.filter((r) => r.status === "no_roster").length,
+  };
+
+  return NextResponse.json({ date, outlet, rows, summary });
+}

--- a/apps/backoffice/src/app/api/hr/schedules/roster-attendance/route.ts
+++ b/apps/backoffice/src/app/api/hr/schedules/roster-attendance/route.ts
@@ -2,17 +2,35 @@ import { NextRequest, NextResponse } from "next/server";
 import { getSession } from "@/lib/auth";
 import { hrSupabaseAdmin } from "@/lib/hr/supabase";
 import { prisma } from "@/lib/prisma";
-import { computeLateMinutes } from "@/lib/hr/hours";
+import { computeLateMinutes, mytDateString } from "@/lib/hr/hours";
 import { GRACE_PERIOD_MINUTES } from "@/lib/hr/constants";
 import { canAccessOutlet, hasModuleAccess } from "@/lib/hr/scope";
 
 export const dynamic = "force-dynamic";
 
+type Cell = {
+  scheduled_start: string | null;
+  scheduled_end: string | null;
+  clock_in: string | null;
+  clock_out: string | null;
+  total_hours: number | null;
+  late_minutes: number;
+  open: boolean;
+  status: "on_time" | "late" | "absent" | "no_roster" | "off";
+};
+
+function cellStatus(hasShift: boolean, hasLog: boolean, lateMin: number): Cell["status"] {
+  if (!hasShift && !hasLog) return "off"; // not scheduled and didn't work
+  if (!hasShift) return "no_roster"; // worked without a roster
+  if (!hasLog) return "absent"; // rostered but no-show
+  return lateMin > GRACE_PERIOD_MINUTES ? "late" : "on_time";
+}
+
 // GET /api/hr/schedules/roster-attendance?outlet_id=X&date=YYYY-MM-DD
+//                                        (or) &week_start=YYYY-MM-DD (Monday)
 //
-// Roster-vs-actual for one outlet on one day: every rostered shift with who
-// actually clocked in, who's late, and who's absent — plus anyone who worked
-// without being on the roster. Read-only companion to the Schedules grid.
+// Roster-vs-actual for one outlet. `date` → a single day's rows; `week_start`
+// → a staff × 7-day matrix. Read-only companion to the Schedules grid.
 export async function GET(req: NextRequest) {
   const session = await getSession();
   if (!session || !["OWNER", "ADMIN", "MANAGER"].includes(session.role)) {
@@ -24,9 +42,11 @@ export async function GET(req: NextRequest) {
 
   const { searchParams } = new URL(req.url);
   const outletId = searchParams.get("outlet_id");
-  const date = searchParams.get("date"); // YYYY-MM-DD (MYT calendar day)
-  if (!outletId || !date || !/^\d{4}-\d{2}-\d{2}$/.test(date)) {
-    return NextResponse.json({ error: "outlet_id and a valid date are required" }, { status: 400 });
+  const date = searchParams.get("date");
+  const weekStart = searchParams.get("week_start");
+  const anchor = weekStart || date;
+  if (!outletId || !anchor || !/^\d{4}-\d{2}-\d{2}$/.test(anchor)) {
+    return NextResponse.json({ error: "outlet_id and a valid date or week_start are required" }, { status: 400 });
   }
 
   if (session.role === "MANAGER" && !(await canAccessOutlet(session, outletId))) {
@@ -36,49 +56,58 @@ export async function GET(req: NextRequest) {
   const outlet = await prisma.outlet.findUnique({ where: { id: outletId }, select: { id: true, name: true } });
   if (!outlet) return NextResponse.json({ error: "Outlet not found" }, { status: 404 });
 
-  // 1. Rostered shifts for this outlet on this date (any status — rosters are
-  //    often kept as draft). Two-step to stay off embed typing.
-  const { data: scheds } = await hrSupabaseAdmin
-    .from("hr_schedules")
-    .select("id")
-    .eq("outlet_id", outletId);
-  const schedIds = (scheds || []).map((s: { id: string }) => s.id);
+  // Days covered by this query (1 for day mode, 7 for week mode).
+  const days: string[] = [];
+  if (weekStart) {
+    const startMs = Date.parse(`${weekStart}T00:00:00+08:00`);
+    for (let i = 0; i < 7; i++) days.push(mytDateString(new Date(startMs + i * 24 * 3600 * 1000)));
+  } else {
+    days.push(anchor);
+  }
 
-  let shifts: { user_id: string; start_time: string; end_time: string | null; role_type: string | null }[] = [];
+  // 1. Rostered shifts across these days (any status — rosters are often draft).
+  const { data: scheds } = await hrSupabaseAdmin.from("hr_schedules").select("id").eq("outlet_id", outletId);
+  const schedIds = (scheds || []).map((s: { id: string }) => s.id);
+  let shifts: { user_id: string; shift_date: string; start_time: string; end_time: string | null; role_type: string | null }[] = [];
   if (schedIds.length > 0) {
     const { data } = await hrSupabaseAdmin
       .from("hr_schedule_shifts")
-      .select("user_id, start_time, end_time, role_type")
+      .select("user_id, shift_date, start_time, end_time, role_type")
       .in("schedule_id", schedIds)
-      .eq("shift_date", date);
+      .in("shift_date", days);
     shifts = data || [];
   }
-  // Keep the earliest-starting shift per user for the day.
-  const shiftByUser = new Map<string, (typeof shifts)[number]>();
-  for (const s of shifts) {
-    const prev = shiftByUser.get(s.user_id);
-    if (!prev || s.start_time < prev.start_time) shiftByUser.set(s.user_id, s);
-  }
 
-  // 2. Attendance logs at this outlet on this MYT calendar day.
-  const startMs = Date.parse(`${date}T00:00:00+08:00`);
-  const dayStart = new Date(startMs).toISOString();
-  const dayEnd = new Date(startMs + 24 * 3600 * 1000).toISOString();
+  // 2. Attendance logs across the window at this outlet.
+  const windowStartMs = Date.parse(`${days[0]}T00:00:00+08:00`);
+  const windowStart = new Date(windowStartMs).toISOString();
+  const windowEnd = new Date(windowStartMs + days.length * 24 * 3600 * 1000).toISOString();
   const { data: logs } = await hrSupabaseAdmin
     .from("hr_attendance_logs")
     .select("user_id, clock_in, clock_out, total_hours")
     .eq("outlet_id", outletId)
-    .gte("clock_in", dayStart)
-    .lt("clock_in", dayEnd)
+    .gte("clock_in", windowStart)
+    .lt("clock_in", windowEnd)
     .order("clock_in", { ascending: true });
-  // Earliest clock-in per user is the shift start.
-  const logByUser = new Map<string, { user_id: string; clock_in: string; clock_out: string | null; total_hours: number | null }>();
+
+  // Index by user+date. Earliest-starting shift / earliest clock-in wins.
+  const key = (u: string, d: string) => `${u}|${d}`;
+  const shiftByKey = new Map<string, (typeof shifts)[number]>();
+  for (const s of shifts) {
+    const k = key(s.user_id, s.shift_date);
+    const prev = shiftByKey.get(k);
+    if (!prev || s.start_time < prev.start_time) shiftByKey.set(k, s);
+  }
+  const logByKey = new Map<string, { clock_in: string; clock_out: string | null; total_hours: number | null }>();
   for (const l of logs || []) {
-    if (!logByUser.has(l.user_id)) logByUser.set(l.user_id, l);
+    const k = key(l.user_id, mytDateString(l.clock_in));
+    if (!logByKey.has(k)) logByKey.set(k, l);
   }
 
   // 3. Names + positions for everyone involved.
-  const userIds = Array.from(new Set([...shiftByUser.keys(), ...logByUser.keys()]));
+  const userIds = Array.from(
+    new Set([...shifts.map((s) => s.user_id), ...(logs || []).map((l) => l.user_id)]),
+  );
   const [users, profilesResp] = await Promise.all([
     userIds.length
       ? prisma.user.findMany({ where: { id: { in: userIds } }, select: { id: true, name: true, fullName: true } })
@@ -88,38 +117,15 @@ export async function GET(req: NextRequest) {
       : Promise.resolve({ data: [] as { user_id: string; position: string | null }[] }),
   ]);
   const userMap = new Map(users.map((u) => [u.id, u]));
-  const positionMap = new Map((profilesResp.data || []).map((p: { user_id: string; position: string | null }) => [p.user_id, p.position]));
+  const positionMap = new Map(
+    (profilesResp.data || []).map((p: { user_id: string; position: string | null }) => [p.user_id, p.position]),
+  );
 
-  type Row = {
-    user_id: string;
-    name: string | null;
-    nickname: string | null;
-    position: string | null;
-    scheduled_start: string | null;
-    scheduled_end: string | null;
-    clock_in: string | null;
-    clock_out: string | null;
-    total_hours: number | null;
-    late_minutes: number;
-    open: boolean;
-    status: "on_time" | "late" | "absent" | "no_roster";
-  };
-
-  const rows: Row[] = userIds.map((uid) => {
-    const shift = shiftByUser.get(uid) || null;
-    const log = logByUser.get(uid) || null;
-    const u = userMap.get(uid);
-    const lateMin = shift && log ? Math.max(0, computeLateMinutes(log.clock_in, shift.start_time, date)) : 0;
-    let status: Row["status"];
-    if (!shift) status = "no_roster";
-    else if (!log) status = "absent";
-    else if (lateMin > GRACE_PERIOD_MINUTES) status = "late";
-    else status = "on_time";
+  const buildCell = (uid: string, d: string): Cell => {
+    const shift = shiftByKey.get(key(uid, d)) || null;
+    const log = logByKey.get(key(uid, d)) || null;
+    const lateMin = shift && log ? Math.max(0, computeLateMinutes(log.clock_in, shift.start_time, d)) : 0;
     return {
-      user_id: uid,
-      name: u?.fullName || u?.name || null,
-      nickname: u?.name || null,
-      position: positionMap.get(uid) || shift?.role_type || null,
       scheduled_start: shift ? shift.start_time.slice(0, 5) : null,
       scheduled_end: shift?.end_time ? shift.end_time.slice(0, 5) : null,
       clock_in: log?.clock_in ?? null,
@@ -127,28 +133,48 @@ export async function GET(req: NextRequest) {
       total_hours: log?.total_hours ?? null,
       late_minutes: lateMin,
       open: !!log && !log.clock_out,
-      status,
+      status: cellStatus(!!shift, !!log, lateMin),
     };
-  });
-
-  // Order: rostered first (by scheduled start), unrostered last; within that,
-  // attention-needing (absent/late) bubble up.
-  const statusRank: Record<Row["status"], number> = { absent: 0, late: 1, on_time: 2, no_roster: 3 };
-  rows.sort((a, b) => {
-    if ((a.status === "no_roster") !== (b.status === "no_roster")) return a.status === "no_roster" ? 1 : -1;
-    if (a.scheduled_start && b.scheduled_start && a.scheduled_start !== b.scheduled_start) {
-      return a.scheduled_start.localeCompare(b.scheduled_start);
-    }
-    return statusRank[a.status] - statusRank[b.status];
-  });
-
-  const summary = {
-    rostered: shiftByUser.size,
-    present: rows.filter((r) => r.status === "on_time" || r.status === "late").length,
-    late: rows.filter((r) => r.status === "late").length,
-    absent: rows.filter((r) => r.status === "absent").length,
-    unrostered: rows.filter((r) => r.status === "no_roster").length,
   };
 
-  return NextResponse.json({ date, outlet, rows, summary });
+  const meta = (uid: string) => {
+    const u = userMap.get(uid);
+    return {
+      user_id: uid,
+      name: u?.fullName || u?.name || null,
+      nickname: u?.name || null,
+      position: positionMap.get(uid) || null,
+    };
+  };
+
+  const countStatuses = (cells: Cell[]) => ({
+    rostered: cells.filter((c) => c.status === "on_time" || c.status === "late" || c.status === "absent").length,
+    present: cells.filter((c) => c.status === "on_time" || c.status === "late").length,
+    late: cells.filter((c) => c.status === "late").length,
+    absent: cells.filter((c) => c.status === "absent").length,
+    unrostered: cells.filter((c) => c.status === "no_roster").length,
+  });
+
+  // ---- WEEK MODE: staff × day matrix ----
+  if (weekStart) {
+    const staff = userIds
+      .map((uid) => ({ ...meta(uid), days: Object.fromEntries(days.map((d) => [d, buildCell(uid, d)])) }))
+      .sort((a, b) => (a.name || "").localeCompare(b.name || ""));
+    const allCells = staff.flatMap((s) => days.map((d) => s.days[d]));
+    return NextResponse.json({ mode: "week", week_start: weekStart, days, outlet, staff, summary: countStatuses(allCells) });
+  }
+
+  // ---- DAY MODE: flat rows ----
+  const d = days[0];
+  const rows = userIds
+    .map((uid) => ({ ...meta(uid), position: positionMap.get(uid) || shiftByKey.get(key(uid, d))?.role_type || null, ...buildCell(uid, d), user_id: uid }))
+    .sort((a, b) => {
+      if ((a.status === "no_roster") !== (b.status === "no_roster")) return a.status === "no_roster" ? 1 : -1;
+      if (a.scheduled_start && b.scheduled_start && a.scheduled_start !== b.scheduled_start) {
+        return a.scheduled_start.localeCompare(b.scheduled_start);
+      }
+      const rank: Record<Cell["status"], number> = { absent: 0, late: 1, on_time: 2, no_roster: 3, off: 4 };
+      return rank[a.status] - rank[b.status];
+    });
+  return NextResponse.json({ mode: "day", date: d, outlet, rows, summary: countStatuses(rows) });
 }

--- a/apps/backoffice/src/components/hr/module-tabs.tsx
+++ b/apps/backoffice/src/components/hr/module-tabs.tsx
@@ -36,6 +36,7 @@ const TAB_GROUPS: { module: string; tabs: { href: string; label: string }[] }[] 
     module: "Time & Attendance",
     tabs: [
       { href: "/hr/attendance", label: "Attendance" },
+      { href: "/hr/roster-attendance", label: "Roster" },
       { href: "/hr/overtime", label: "Overtime" },
       { href: "/hr/shift-swaps", label: "Shift Swaps" },
     ],


### PR DESCRIPTION
## What
A new **Roster** tab under Time & Attendance: pick an **outlet + date** and see every rostered shift next to who actually showed up — **on time / late (with minutes) / absent** — plus anyone who worked **without** being on the roster. This is the "know each schedule, who comes and who's late" view.

## How it works
- **API** `GET /api/hr/schedules/roster-attendance?outlet_id&date` — joins the day's `hr_schedule_shifts` (any status, since rosters are often left draft) with that day's `hr_attendance_logs`, matching per user. Lateness uses the shared cross-midnight-safe `computeLateMinutes` with a 5-min grace (`GRACE_PERIOD_MINUTES`). Same auth as the grid: OWNER/ADMIN/MANAGER, module-gated (`hr:schedules`) and outlet-scoped (`canAccessOutlet`).
- **Page** — outlet + date pickers, summary tiles (rostered / present / late / absent / unrostered), and a per-staff table (rostered time, clock-in, clock-out, status badge; in-progress shifts marked).
- **Statuses:** `absent` (rostered, no clock-in), `late`, `on_time`, `no_roster` (worked but not scheduled). Absent/late bubble to the top.

## Notes
- Read-only; complements the existing Attendance Review (which handles fixing/approving) and the Schedules grid (which builds rosters).
- Surfaces the forgot-to-clock-in / no-show cases per schedule that were previously invisible.

## Testing
`tsc` local shows only the repo's standard env noise (ungenerated Prisma `{}` types, implicit-any on JSX callbacks) — identical to the existing `hr/attendance/page.tsx` and `hr/schedules/page.tsx`, which pass CI. No new real type errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01B7WiKCn4NpWzaka6ZtjB6z)_