### PR TITLE
feat(finance): actionable Needs Review + matched-lines recon with unmatch

### DIFF
--- a/apps/backoffice/src/app/(admin)/finance/recon/page.tsx
+++ b/apps/backoffice/src/app/(admin)/finance/recon/page.tsx
@@ -160,8 +160,12 @@ export default function ReconPage() {
             <MatchTable rows={data.auto} />
           </Section>
 
-          <Section id="recon-review" title="Needs review" desc="Likely matches that aren't certain enough to auto-clear — confirm or reject.">
-            <MatchTable rows={data.review} showReasons />
+          <Section id="recon-review" title="Needs review" desc="Likely matches that aren't certain enough to auto-clear. Confirm applies the match (links the line, marks the invoice paid unless it was settled elsewhere); Reject dismisses it for good.">
+            <MatchTable rows={data.review} showReasons actionable onDone={() => mutate()} />
+          </Section>
+
+          <Section id="recon-matched" title="Matched lines — review applied matches" desc="Everything the matcher (or you) has linked to an invoice, newest first. If one looks wrong, Unmatch reverses it: the link is removed, the invoice's paid status is reverted only if this match is what paid it, and the pair never auto-matches again.">
+            <MatchedTable />
           </Section>
 
           <Section id="recon-unmatched-out" title="Unmatched outflows — unreconciled cash-out" desc="Bank payments with no matching invoice yet. Reconcile manually: pick a category (books it to that expense) or match it to its invoice.">
@@ -500,7 +504,31 @@ function Section({ id, title, desc, children }: { id?: string; title: string; de
   );
 }
 
-function MatchTable({ rows, showReasons }: { rows: ApMatch[]; showReasons?: boolean }) {
+function MatchTable({ rows, showReasons, actionable, onDone }: { rows: ApMatch[]; showReasons?: boolean; actionable?: boolean; onDone?: () => void }) {
+  const [busy, setBusy] = useState<string | null>(null); // key of the row being acted on
+  const [notes, setNotes] = useState<Record<string, string>>({});
+
+  async function act(m: ApMatch, action: "confirm" | "reject") {
+    const key = m.invoiceId + m.bankLineId;
+    setBusy(key);
+    try {
+      const res = action === "confirm"
+        ? await fetch("/api/finance/bank-lines/match", {
+            method: "POST", headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ bankLineId: m.bankLineId, invoiceId: m.invoiceId }),
+          })
+        : await fetch("/api/finance/bank-lines/reject-match", {
+            method: "POST", headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ bankLineId: m.bankLineId, invoiceId: m.invoiceId }),
+          });
+      const j = await res.json();
+      if (!res.ok) setNotes((n) => ({ ...n, [key]: j.error ?? `Failed (${res.status})` }));
+      else onDone?.();
+    } catch (e) {
+      setNotes((n) => ({ ...n, [key]: e instanceof Error ? e.message : String(e) }));
+    } finally { setBusy(null); }
+  }
+
   if (rows.length === 0) return <p className="px-4 py-4 text-xs text-gray-400">Nothing here.</p>;
   return (
     <div className="overflow-x-auto">
@@ -509,20 +537,116 @@ function MatchTable({ rows, showReasons }: { rows: ApMatch[]; showReasons?: bool
           <th className="px-3 py-2 font-medium">Invoice payee</th><th className="px-3 py-2 text-right font-medium">Amount</th>
           <th className="px-3 py-2 font-medium">Bank line</th><th className="px-3 py-2 font-medium">Category</th>
           <th className="px-3 py-2 text-right font-medium">Score</th>{showReasons && <th className="px-3 py-2 font-medium">Why</th>}
+          {actionable && <th className="px-3 py-2 font-medium">Decide</th>}
         </tr></thead>
         <tbody className="divide-y">
-          {rows.map((m) => (
-            <tr key={m.invoiceId + m.bankLineId} className="hover:bg-gray-50">
+          {rows.map((m) => {
+            const key = m.invoiceId + m.bankLineId;
+            return (
+            <tr key={key} className="hover:bg-gray-50">
               <td className="px-3 py-2 text-xs text-gray-700">{m.payee}{m.invoiceNumber ? <span className="text-gray-400"> · {m.invoiceNumber}</span> : ""}<div className="text-[10px] text-gray-400">{m.issueDate}</div></td>
               <td className="px-3 py-2 text-right font-mono text-xs text-gray-700">{fmtRM(m.amount)}</td>
               <td className="px-3 py-2 text-xs text-gray-600">{m.bankDesc}<div className="text-[10px] text-gray-400">{m.bankDate}</div></td>
               <td className="px-3 py-2 text-[11px] text-gray-400">{m.bankCategory ?? "—"}</td>
               <td className="px-3 py-2 text-right font-mono text-xs"><span className={m.score >= 0.85 ? "text-green-700" : "text-amber-700"}>{m.score.toFixed(2)}</span></td>
               {showReasons && <td className="px-3 py-2 text-[10px] text-gray-400">{m.reasons.join(", ")}</td>}
+              {actionable && (
+                <td className="whitespace-nowrap px-3 py-2">
+                  {notes[key] ? <span className="text-[10px] text-rose-600">{notes[key]}</span> : (
+                    <span className="flex items-center gap-1.5">
+                      <button onClick={() => act(m, "confirm")} disabled={busy === key}
+                        className="rounded border border-green-600/30 bg-green-50 px-2 py-0.5 text-[11px] font-medium text-green-700 hover:bg-green-100 disabled:opacity-50">
+                        Confirm
+                      </button>
+                      <button onClick={() => act(m, "reject")} disabled={busy === key}
+                        className="rounded border border-gray-200 bg-white px-2 py-0.5 text-[11px] text-gray-500 hover:bg-gray-50 disabled:opacity-50">
+                        Reject
+                      </button>
+                      {busy === key && <Loader2 className="h-3 w-3 animate-spin text-gray-400" />}
+                    </span>
+                  )}
+                </td>
+              )}
             </tr>
-          ))}
+          );})}
         </tbody>
       </table>
+    </div>
+  );
+}
+
+// The applied-matches review: everything linked to an invoice, searchable,
+// with Unmatch to reverse a wrong one.
+type MatchedRow = {
+  bankLineId: string; date: string; desc: string; amount: number; category: string | null;
+  matchedAt: string | null; invoiceId: string | null; invoiceNumber: string | null;
+  payee: string; invoiceAmount: number | null; paidByMatch: boolean;
+};
+
+function MatchedTable() {
+  const [q, setQ] = useState("");
+  const { data, mutate } = useFetch<{ total: number; rows: MatchedRow[] }>(
+    `/api/finance/bank-lines/matched?q=${encodeURIComponent(q)}&limit=100`
+  );
+  const [busy, setBusy] = useState<string | null>(null);
+  const [note, setNote] = useState<string | null>(null);
+
+  async function unmatch(r: MatchedRow) {
+    setBusy(r.bankLineId); setNote(null);
+    try {
+      const res = await fetch("/api/finance/bank-lines/unmatch", {
+        method: "POST", headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ bankLineId: r.bankLineId }),
+      });
+      const j = await res.json();
+      if (!res.ok) setNote(j.error ?? `Failed (${res.status})`);
+      else {
+        setNote(`Unmatched ${r.payee}${j.invoicesReverted ? ` — invoice reverted to pending` : ` — invoice untouched (paid via another route)`}.`);
+        mutate();
+      }
+    } catch (e) { setNote(e instanceof Error ? e.message : String(e)); }
+    finally { setBusy(null); }
+  }
+
+  return (
+    <div className="overflow-x-auto">
+      <div className="flex flex-wrap items-center gap-2 border-b border-gray-100 px-4 py-2">
+        <input value={q} onChange={(e) => setQ(e.target.value)} placeholder="Search payee, invoice no, description or amount…"
+          className="h-7 w-72 rounded border border-gray-200 bg-white px-2 text-xs text-gray-700" />
+        {data && <span className="text-[11px] text-gray-400 tabular-nums">{data.rows.length} shown · {data.total} matched in total</span>}
+        {note && <span className="text-[11px] text-gray-500">{note}</span>}
+      </div>
+      {!data ? <p className="px-4 py-4 text-xs text-gray-400">Loading…</p> : data.rows.length === 0 ? (
+        <p className="px-4 py-4 text-xs text-gray-400">{q ? "No matches for the search." : "Nothing matched yet."}</p>
+      ) : (
+        <table className="w-full min-w-[760px] text-sm">
+          <thead><tr className="border-b bg-gray-50/50 text-left text-gray-500">
+            <th className="px-3 py-2 font-medium">Bank line</th>
+            <th className="px-3 py-2 text-right font-medium">Amount</th>
+            <th className="px-3 py-2 font-medium">Matched invoice</th>
+            <th className="px-3 py-2 font-medium">Category</th>
+            <th className="px-3 py-2 font-medium">How</th>
+            <th className="px-3 py-2" />
+          </tr></thead>
+          <tbody className="divide-y">
+            {data.rows.map((r) => (
+              <tr key={r.bankLineId} className="hover:bg-gray-50">
+                <td className="px-3 py-2 text-xs text-gray-600">{r.desc}<div className="text-[10px] text-gray-400">{r.date}</div></td>
+                <td className="px-3 py-2 text-right font-mono text-xs text-gray-700">{fmtRM(r.amount)}</td>
+                <td className="px-3 py-2 text-xs text-gray-700">{r.payee}{r.invoiceNumber ? <span className="text-gray-400"> · {r.invoiceNumber}</span> : ""}{r.invoiceAmount !== null && Math.abs(r.invoiceAmount - r.amount) > 0.01 && <span className="ml-1 text-[10px] text-amber-600">(invoice {fmtRM(r.invoiceAmount)})</span>}</td>
+                <td className="px-3 py-2 text-[11px] text-gray-400">{r.category ?? "—"}</td>
+                <td className="px-3 py-2 text-[10px] text-gray-400">{r.paidByMatch ? "match paid the invoice" : "link-only (paid elsewhere)"}{r.matchedAt ? ` · ${r.matchedAt}` : ""}</td>
+                <td className="whitespace-nowrap px-3 py-2 text-right">
+                  <button onClick={() => unmatch(r)} disabled={busy === r.bankLineId}
+                    className="rounded border border-gray-200 bg-white px-2 py-0.5 text-[11px] text-gray-500 hover:bg-gray-50 disabled:opacity-50">
+                    {busy === r.bankLineId ? "Unmatching…" : "Unmatch"}
+                  </button>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      )}
     </div>
   );
 }

--- a/apps/backoffice/src/app/api/finance/bank-lines/matched/route.ts
+++ b/apps/backoffice/src/app/api/finance/bank-lines/matched/route.ts
@@ -1,0 +1,74 @@
+// GET /api/finance/bank-lines/matched — the applied AP matches, newest first,
+// so a wrong auto-match can be found and undone. ?q= searches the bank
+// description and the invoice payee/number.
+
+import { NextRequest, NextResponse } from "next/server";
+import { requireAuth } from "@/lib/auth";
+import { prisma } from "@/lib/prisma";
+
+export const dynamic = "force-dynamic";
+
+const round2 = (n: number) => Math.round(n * 100) / 100;
+const ymd = (d: Date) => d.toISOString().slice(0, 10);
+
+export async function GET(req: NextRequest) {
+  const auth = await requireAuth(req);
+  if (auth.error) return auth.error;
+  if (!["OWNER", "ADMIN"].includes(auth.user.role)) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+
+  const url = new URL(req.url);
+  const q = (url.searchParams.get("q") ?? "").trim().toLowerCase();
+  const limit = Math.min(Number(url.searchParams.get("limit") ?? 100), 300);
+
+  // apInvoiceId is a plain column (no Prisma relation) — fetch the invoices
+  // separately and join in memory. The matched pile is a few thousand rows at
+  // most, and q must search invoice fields too.
+  const lines = await prisma.bankStatementLine.findMany({
+    where: { apInvoiceId: { not: null } },
+    orderBy: { apMatchedAt: "desc" },
+    take: 3000,
+    select: {
+      id: true, txnDate: true, description: true, amount: true, category: true,
+      apMatchedAt: true, apInvoiceId: true,
+    },
+  });
+  const invoices = await prisma.invoice.findMany({
+    where: { id: { in: [...new Set(lines.map((l) => l.apInvoiceId as string))] } },
+    select: {
+      id: true, invoiceNumber: true, amount: true, status: true, paidVia: true,
+      vendorName: true, supplier: { select: { name: true } },
+    },
+  });
+  const invById = new Map(invoices.map((i) => [i.id, i]));
+
+  const rows = lines
+    .map((l) => {
+      const inv = invById.get(l.apInvoiceId as string);
+      const payee = inv?.supplier?.name ?? inv?.vendorName ?? "(unknown payee)";
+      return {
+        bankLineId: l.id,
+        date: ymd(l.txnDate),
+        desc: (l.description ?? "").replace(/\s+/g, " ").slice(0, 70),
+        amount: round2(Number(l.amount)),
+        category: l.category as string | null,
+        matchedAt: l.apMatchedAt ? ymd(l.apMatchedAt) : null,
+        invoiceId: l.apInvoiceId,
+        invoiceNumber: inv?.invoiceNumber ?? null,
+        payee,
+        invoiceAmount: inv ? round2(Number(inv.amount)) : null,
+        // paid by this match vs already settled elsewhere (link-only)
+        paidByMatch: inv?.paidVia === "bank-ap-match" || inv?.paidVia === `bank-ap-match-multi:${l.id}`,
+      };
+    })
+    .filter((r) => !q ||
+      r.desc.toLowerCase().includes(q) ||
+      r.payee.toLowerCase().includes(q) ||
+      (r.invoiceNumber ?? "").toLowerCase().includes(q) ||
+      r.date.includes(q) ||
+      String(r.amount).includes(q))
+    .slice(0, limit);
+
+  return NextResponse.json({ total: lines.length, rows });
+}

--- a/apps/backoffice/src/app/api/finance/bank-lines/reject-match/route.ts
+++ b/apps/backoffice/src/app/api/finance/bank-lines/reject-match/route.ts
@@ -1,0 +1,29 @@
+// POST /api/finance/bank-lines/reject-match — record a human "no" on a match
+// proposal. The pair disappears from Needs Review and the auto-apply cron
+// skips it permanently (proposeApMatches filters rejected pairs).
+
+import { NextRequest, NextResponse } from "next/server";
+import { requireAuth } from "@/lib/auth";
+import { getFinanceClient } from "@/lib/finance/supabase";
+
+export const dynamic = "force-dynamic";
+
+export async function POST(req: NextRequest) {
+  const auth = await requireAuth(req);
+  if (auth.error) return auth.error;
+  if (!["OWNER", "ADMIN"].includes(auth.user.role)) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+  let body: { bankLineId?: string; invoiceId?: string } = {};
+  try { body = await req.json(); } catch { /* handled below */ }
+  if (!body.bankLineId || !body.invoiceId) {
+    return NextResponse.json({ error: "bankLineId and invoiceId required" }, { status: 400 });
+  }
+  const client = getFinanceClient();
+  const { error } = await client.from("fin_ap_match_rejections").upsert(
+    { bank_line_id: body.bankLineId, invoice_id: body.invoiceId, reason: "rejected" },
+    { onConflict: "bank_line_id,invoice_id" },
+  );
+  if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+  return NextResponse.json({ ok: true });
+}

--- a/apps/backoffice/src/app/api/finance/bank-lines/unmatch/route.ts
+++ b/apps/backoffice/src/app/api/finance/bank-lines/unmatch/route.ts
@@ -1,0 +1,79 @@
+// POST /api/finance/bank-lines/unmatch — undo a wrong AP match.
+//
+// Reverses exactly what the match wrote: the line loses its invoice link (and
+// re-keys its GL journal); the invoice's payment state is reverted ONLY when
+// this match is what marked it paid (paidVia stamps 'bank-ap-match' /
+// 'bank-ap-match-multi:<lineId>') — a link-only match against an invoice paid
+// via POP/migration leaves that invoice untouched. The pair is recorded as
+// rejected so the auto-matcher never re-applies it.
+
+import { NextRequest, NextResponse } from "next/server";
+import { requireAuth } from "@/lib/auth";
+import { prisma } from "@/lib/prisma";
+import { getFinanceClient } from "@/lib/finance/supabase";
+
+export const dynamic = "force-dynamic";
+
+export async function POST(req: NextRequest) {
+  const auth = await requireAuth(req);
+  if (auth.error) return auth.error;
+  if (!["OWNER", "ADMIN"].includes(auth.user.role)) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+  let body: { bankLineId?: string } = {};
+  try { body = await req.json(); } catch { /* handled below */ }
+  if (!body.bankLineId) return NextResponse.json({ error: "bankLineId required" }, { status: 400 });
+
+  const line = await prisma.bankStatementLine.findUnique({
+    where: { id: body.bankLineId },
+    select: { id: true, apInvoiceId: true, glTransactionId: true },
+  });
+  if (!line) return NextResponse.json({ error: "Bank line not found" }, { status: 404 });
+  if (!line.apInvoiceId) return NextResponse.json({ error: "Line is not matched" }, { status: 409 });
+  const invoiceId = line.apInvoiceId;
+
+  // Every invoice this line's match paid: the direct link plus any bundle
+  // members stamped with this line id by a multi-match.
+  const paidByThisMatch = await prisma.invoice.findMany({
+    where: {
+      OR: [
+        { id: invoiceId, paidVia: "bank-ap-match" },
+        { paidVia: `bank-ap-match-multi:${line.id}` },
+      ],
+    },
+    select: { id: true },
+  });
+
+  await prisma.$transaction(async (tx) => {
+    await tx.bankStatementLine.update({
+      where: { id: line.id },
+      data: { apInvoiceId: null, apMatchedAt: null, classifiedBy: "rule", ruleName: "unmatched" },
+    });
+    if (paidByThisMatch.length) {
+      await tx.invoice.updateMany({
+        where: { id: { in: paidByThisMatch.map((i) => i.id) } },
+        data: { status: "PENDING", amountPaid: 0, paidAt: null, paidVia: null },
+      });
+    }
+    // Re-key the whole day-aggregate journal the line posted under.
+    if (line.glTransactionId) {
+      await tx.bankStatementLine.updateMany({
+        where: { glTransactionId: line.glTransactionId },
+        data: { glTransactionId: null, glPostedAt: null },
+      });
+    }
+  });
+
+  // Human verdict is final — the matcher must not redo this pair.
+  const client = getFinanceClient();
+  await client.from("fin_ap_match_rejections").upsert(
+    { bank_line_id: line.id, invoice_id: invoiceId, reason: "unmatched" },
+    { onConflict: "bank_line_id,invoice_id" },
+  );
+
+  return NextResponse.json({
+    ok: true,
+    invoicesReverted: paidByThisMatch.length, // 0 = link-only; invoice untouched
+    rekeyedJournal: !!line.glTransactionId,
+  });
+}

--- a/apps/backoffice/src/lib/finance/ap-match.ts
+++ b/apps/backoffice/src/lib/finance/ap-match.ts
@@ -18,6 +18,7 @@
 //   tiers: AUTO ≥ 0.85 (needs amount-exact AND name) · REVIEW ≥ 0.55 · else none
 
 import { prisma } from "@/lib/prisma";
+import { getFinanceClient } from "./supabase";
 import type { CashCategory } from "@celsius/db";
 
 // Categories that can never be the settlement of a SUPPLIER invoice — wages
@@ -300,11 +301,33 @@ export async function proposeApMatches(opts: { sinceDays?: number } = {}): Promi
     .map((l) => ({ bankLineId: l.id, desc: (l.description ?? "").replace(/\s+/g, " ").slice(0, 60), date: ymd(l.txnDate), amount: round2(Number(l.amount)), category: l.category as string | null }))
     .sort((a, b) => b.amount - a.amount);
 
+  // Human verdicts are final: a pair the owner rejected (or unmatched) never
+  // re-surfaces in review and never auto-applies — without this, every propose
+  // run would resurrect the same wrong suggestion.
+  const rejected = await fetchMatchRejections();
+  const keep = (m: ApMatch) => !rejected.has(`${m.bankLineId}|${m.invoiceId}`);
+  const keepMulti = (m: ApMultiMatch) => m.invoiceIds.every((inv) => !rejected.has(`${m.bankLineId}|${inv}`));
+
   return {
-    auto, review, multi,
+    auto: auto.filter(keep),
+    review: review.filter(keep),
+    multi: multi.filter(keepMulti),
     unmatchedInvoices: unmatchedInvoices.filter((i) => !matchedInvoiceIds.has(i.invoiceId)),
     unmatchedOutflows, doublePayments,
   };
+}
+
+// Rejected (bank line, invoice) pairs as "lineId|invoiceId" keys. Failure to
+// read must not take the matcher down — degrade to no filtering.
+async function fetchMatchRejections(): Promise<Set<string>> {
+  try {
+    const client = getFinanceClient();
+    const { data, error } = await client.from("fin_ap_match_rejections").select("bank_line_id, invoice_id");
+    if (error) return new Set();
+    return new Set((data ?? []).map((r) => `${r.bank_line_id}|${r.invoice_id}`));
+  } catch {
+    return new Set();
+  }
 }
 
 // ── VERIFIER + APPLY ────────────────────────────────────────────────────────

--- a/supabase/migrations/068_fin_ap_match_rejections.sql
+++ b/supabase/migrations/068_fin_ap_match_rejections.sql
@@ -1,0 +1,14 @@
+-- Human verdicts on AP match proposals. A rejected (bank line, invoice) pair
+-- never re-surfaces in Needs Review and the auto-apply cron never applies it;
+-- unmatching a wrong match records the same verdict so it stays undone.
+-- Applied to production 2026-07-03 (supabase migration fin_ap_match_rejections).
+create table if not exists fin_ap_match_rejections (
+  id uuid primary key default gen_random_uuid(),
+  bank_line_id text not null,
+  invoice_id text not null,
+  reason text not null default 'rejected',   -- 'rejected' | 'unmatched'
+  created_at timestamptz not null default now(),
+  unique (bank_line_id, invoice_id)
+);
+alter table fin_ap_match_rejections enable row level security;
+-- service-role access only (finance client); no anon policies.


### PR DESCRIPTION
Owner: 'needs review is blind. cannot review manually. also need a place to
recon other matched that could be wrong.'

NEEDS REVIEW gets Confirm / Reject per row:
- Confirm applies the match through the existing manual-match endpoint
  (links the line, marks the invoice paid unless it settled via another
  route, re-keys the GL journal).
- Reject records the verdict in fin_ap_match_rejections (migration 068,
  applied to prod). proposeApMatches filters rejected pairs — single AND
  multi-invoice bundles — so a rejected suggestion never re-surfaces and
  the auto-apply cron never applies it. Verdict read is fail-open.

MATCHED LINES section (new, on /finance/recon): every applied match newest
first, searchable by payee / invoice no / description / amount, showing
whether the match paid the invoice or was link-only. Unmatch reverses a
wrong one: link cleared, whole GL journal re-keyed, invoice payment state
reverted ONLY when this match is what paid it (paidVia stamps
bank-ap-match / bank-ap-match-multi:<lineId>, covering bundles) — POP or
migration-paid invoices stay untouched — and the pair is recorded as
rejected so the matcher never redoes it.

- GET /api/finance/bank-lines/matched (search + limit, in-memory invoice
  join: apInvoiceId has no Prisma relation)
- POST /api/finance/bank-lines/reject-match, /unmatch

55/55 finance tests pass, typecheck + lint clean.
