### PR TITLE
fix(order): reject sold-out (86'd) items server-side at checkout

### DIFF
--- a/apps/order/src/app/api/checkout/initiate/route.ts
+++ b/apps/order/src/app/api/checkout/initiate/route.ts
@@ -16,6 +16,7 @@ import { getOutletSst } from "@/lib/outlet-sst";
 import { fetchValidTableLabels } from "@/lib/table-layout";
 import { resolveOrderReward } from "@celsius/shared";
 import { reconcileNonStackTier } from "@/lib/loyalty/non-stack-tier";
+import { findUnavailableItems, unavailableItemsMessage } from "@/lib/menu-availability";
 
 function generateOrderNumber(): string {
   return `C-${Date.now().toString(36).slice(-4).toUpperCase()}${Math.floor(Math.random() * 100).toString().padStart(2, '0')}`;
@@ -205,6 +206,21 @@ export async function POST(request: NextRequest) {
 
     if (productsError || !dbProducts || dbProducts.length === 0) {
       return NextResponse.json({ error: "Failed to verify product prices" }, { status: 400 });
+    }
+
+    // ── Server-side availability gate ──────────────────────────────────────
+    // The menu / pairing hide 86'd items client-side, but that's advisory: an
+    // item can reach here if it was added before being 86'd, from a stale
+    // cache, or via a direct product link. Reject sold-out items server-side so
+    // the kitchen never receives an order for something the outlet can't make.
+    {
+      const blocked = await findUnavailableItems(supabase, storeId, productIds);
+      if (blocked.length > 0) {
+        return NextResponse.json(
+          { error: unavailableItemsMessage(blocked), unavailableProductIds: blocked.map((b) => b.id) },
+          { status: 409 },
+        );
+      }
     }
 
     const priceMap = new Map(dbProducts.map((p: { id: string; price: number }) => [p.id, p.price]));

--- a/apps/order/src/app/api/orders/route.ts
+++ b/apps/order/src/app/api/orders/route.ts
@@ -16,6 +16,7 @@ import {
   type CartLine,
 } from "@/lib/loyalty/promotions";
 import { requireCustomerSession } from "@/lib/customer-jwt";
+import { findUnavailableItems, unavailableItemsMessage } from "@/lib/menu-availability";
 import { attributeOrderToCampaign } from "@/lib/push/attribution";
 import { attributeOrderToPoster } from "@/lib/poster/attribution";
 import { getOutletSst } from "@/lib/outlet-sst";
@@ -370,6 +371,21 @@ export async function POST(request: NextRequest) {
     if (pricedErr || !pricedProducts || pricedProducts.length === 0) {
       return NextResponse.json({ error: "Failed to verify product prices" }, { status: 400 });
     }
+
+    // ── Server-side availability gate ──────────────────────────────────────
+    // Mirror of /api/checkout/initiate: reject items that are globally
+    // discontinued or 86'd at this outlet, so a sold-out item can't be ordered
+    // even if it slipped into the cart before the menu hid it.
+    {
+      const blocked = await findUnavailableItems(supabase, storeId, pricingIds);
+      if (blocked.length > 0) {
+        return NextResponse.json(
+          { error: unavailableItemsMessage(blocked), unavailableProductIds: blocked.map((b) => b.id) },
+          { status: 409 },
+        );
+      }
+    }
+
     const pricedMap = new Map(
       (pricedProducts as Array<{ id: string; price: number }>).map((p) => [p.id, p.price]),
     );

--- a/apps/order/src/lib/menu-availability.ts
+++ b/apps/order/src/lib/menu-availability.ts
@@ -1,0 +1,68 @@
+import type { SupabaseClient } from "@supabase/supabase-js";
+
+/**
+ * Server-side "can these items be ordered at this outlet right now?" gate.
+ *
+ * The menu and pairing rails hide 86'd / snoozed items client-side, but that is
+ * advisory only: an item can still reach checkout if it was added to the cart
+ * BEFORE being 86'd, from a stale menu cache, or via a direct product link. This
+ * is the authoritative check both order-creation paths (/api/checkout/initiate
+ * for web-QR, /api/orders for native pickup) run before writing the order, so a
+ * sold-out item can never actually be ordered.
+ *
+ * An item is unavailable when it is either:
+ *   • globally discontinued  — products.is_available = false, or
+ *   • snoozed at THIS outlet  — an outlet_product_availability row with
+ *     is_available = false, keyed by the STORE SLUG (e.g. "shah-alam") — the
+ *     same key the menu availability read, POS register, and pickup app use.
+ *
+ * Returns the blocked items as { id, name } (empty array = everything orderable)
+ * so the caller can name them in the error the customer sees.
+ */
+// Loosely-typed client so either app's admin client is accepted.
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type Db = SupabaseClient<any, any, any>;
+
+export async function findUnavailableItems(
+  supabase: Db,
+  storeId: string,
+  productIds: string[],
+): Promise<{ id: string; name: string }[]> {
+  const ids = Array.from(new Set(productIds.filter(Boolean)));
+  if (ids.length === 0) return [];
+
+  const [{ data: prods }, { data: oosRows }] = await Promise.all([
+    supabase.from("products").select("id, name, is_available").in("id", ids),
+    supabase
+      .from("outlet_product_availability")
+      .select("product_id")
+      .eq("outlet_id", storeId)
+      .eq("is_available", false)
+      .in("product_id", ids),
+  ]);
+
+  const snoozed = new Set(
+    ((oosRows ?? []) as Array<{ product_id: string }>).map((r) => r.product_id),
+  );
+
+  const blocked: { id: string; name: string }[] = [];
+  for (const p of (prods ?? []) as Array<{ id: string; name: string | null; is_available: boolean | null }>) {
+    if (p.is_available === false || snoozed.has(p.id)) {
+      blocked.push({ id: p.id, name: p.name ?? p.id });
+    }
+  }
+  return blocked;
+}
+
+/** Customer-facing "these items are sold out" message for a blocked list. */
+export function unavailableItemsMessage(blocked: { name: string }[]): string {
+  const names = blocked.map((b) => b.name);
+  const list =
+    names.length === 1
+      ? names[0]
+      : names.length === 2
+        ? `${names[0]} and ${names[1]}`
+        : `${names.slice(0, -1).join(", ")}, and ${names[names.length - 1]}`;
+  const verb = names.length === 1 ? "is" : "are";
+  return `${list} ${verb} sold out at this outlet. Please remove ${names.length === 1 ? "it" : "them"} from your order to continue.`;
+}


### PR DESCRIPTION
## Problem

A customer placed a **dine-in QR order** (`#C-428549`, Table 6, Putrajaya) that included **Red Velvet Cake** — an item that was 86'd (out of stock) at that outlet. The item shouldn't have been orderable at all.

This is the deeper half of the snooze-gating issue. PR #629 stopped 86'd items from being *suggested* in pairing rails, but the **menu / pairing hiding is entirely client-side and advisory**. An item still reaches checkout if it was:
- added to the cart **before** being 86'd,
- served from a **stale menu cache**, or
- opened via a **direct product link** (the product page has no availability gate).

Neither order-creation path validated availability, so a sold-out item sailed through checkout and hit the kitchen.

## Fix

Add an **authoritative server-side gate** that both order paths run right after the product/price lookup they already do:

- **`lib/menu-availability.ts`** (new) — `findUnavailableItems()` flags any ordered item that is globally discontinued (`products.is_available = false`) **or** 86'd at this outlet (`outlet_product_availability`, keyed by the store slug — the same key the menu read and POS register use). Plus `unavailableItemsMessage()` for a customer-facing "sold out" string.
- **`/api/checkout/initiate`** (web-QR) and **`/api/orders`** (native pickup) — return **409** with the sold-out item names *before* creating the order.

The checkout client already surfaces `data.error`, so the customer sees a clear "… is sold out at this outlet, please remove it to continue" message instead of placing an unfulfillable order.

## Why server-side

Client hiding can't close the race: 86 can happen after an item is already in the cart, and caches/deep-links bypass the menu filter. The order-creation endpoint is the only place that sees the final cart against live availability, so that's where the gate belongs.

## Testing

- Traced both order-creation paths; confirmed the gate sits after the existing product lookup and uses the same store-slug key as the menu availability read.
- A full typecheck isn't possible in this container (app `node_modules` aren't installed); CI typecheck/lint/build will verify.

### Suggested manual verification
1. Add a product to a dine-in cart, then 86 it at that outlet in the backoffice Availability matrix.
2. Attempt checkout → expect a 409 and a "… is sold out at this outlet" message; no order is created.
3. Confirm a normal (in-stock) cart still checks out unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01H8yhE3f3tZJoa1gk8ZRgQV)_