### PR TITLE
fix(finance): reports correctness — aged payables scoping, BS balance, CF ties by construction

### DIFF
--- a/apps/backoffice/src/app/(admin)/finance/reports/page.tsx
+++ b/apps/backoffice/src/app/(admin)/finance/reports/page.tsx
@@ -126,7 +126,7 @@ function useReportControlsState() {
 
 type FinCompany = { id: string; name: string; outletIds: string[] };
 
-function ReportControlsBar({ c }: { c: ReturnType<typeof useReportControlsState> }) {
+function ReportControlsBar({ c, outletApplies }: { c: ReturnType<typeof useReportControlsState>; outletApplies: boolean }) {
   const { data: outlets } = useFetch<{ id: string; name: string }[]>("/api/settings/outlets");
   const { data: co } = useFetch<{ companies: FinCompany[]; activeCompanyId: string }>("/api/finance/companies");
   const [switching, setSwitching] = useState(false);
@@ -198,13 +198,17 @@ function ReportControlsBar({ c }: { c: ReturnType<typeof useReportControlsState>
       )}
       <span className="text-[11px] text-muted-foreground tabular-nums">{c.start} → {c.end}</span>
       <select
-        value={c.outletId}
+        value={outletApplies ? c.outletId : ""}
         onChange={(e) => c.setOutletId(e.target.value)}
-        disabled={c.consolidated}
+        disabled={c.consolidated || !outletApplies}
         className="ml-auto h-8 rounded-md border bg-background px-2 text-sm disabled:opacity-50"
-        title={c.consolidated ? "Consolidated view spans all outlets" : "Filter by outlet (outlets of the active company)"}
+        title={c.consolidated
+          ? "Consolidated view spans all outlets"
+          : !outletApplies
+            ? "Outlet filter applies to the P&L and Aged Payables. Ledger statements are entity-level; expenses are paid from the company account and cannot be split per outlet."
+            : "Filter by outlet (outlets of the active company)"}
       >
-        <option value="">All outlets</option>
+        <option value="">{outletApplies ? "All outlets" : "All outlets (entity-level tab)"}</option>
         {companyOutlets.map((o) => <option key={o.id} value={o.id}>{o.name}</option>)}
       </select>
     </div>
@@ -949,9 +953,11 @@ const AP_COLS: { key: keyof AgedPayables["totals"]; label: string }[] = [
 ];
 
 function ApTab() {
-  const { end: asOf } = useControls();
+  const { end: asOf, outletId } = useControls();
   const [q, setQ] = useState("");
-  const { data, isLoading } = useFetch<{ report: AgedPayables }>(`/api/finance/reports/aged-payables?asOf=${asOf}`);
+  const { data, isLoading } = useFetch<{ report: AgedPayables }>(
+    `/api/finance/reports/aged-payables?asOf=${asOf}${outletId ? `&outletId=${outletId}` : ""}`
+  );
   const rows = (data?.report?.rows ?? []).filter((r) => {
     const t = q.trim().toLowerCase();
     return !t || r.vendor.toLowerCase().includes(t);
@@ -1165,7 +1171,7 @@ export default function FinanceReportsPage() {
         </div>
       </nav>
 
-      {usesControls && <ReportControlsBar c={controls} />}
+      {usesControls && <ReportControlsBar c={controls} outletApplies={tab === "pnl" || tab === "ap"} />}
 
       {(tab === "bs" || tab === "cf") && (
         <div className="rounded-lg border border-amber-500/40 bg-amber-500/5 p-3 text-xs sm:text-sm text-amber-700 dark:text-amber-400">

--- a/apps/backoffice/src/app/api/finance/reports/aged-payables/route.ts
+++ b/apps/backoffice/src/app/api/finance/reports/aged-payables/route.ts
@@ -1,8 +1,10 @@
-// GET /api/finance/reports/aged-payables?asOf=YYYY-MM-DD
+// GET /api/finance/reports/aged-payables?asOf=YYYY-MM-DD[&outletId=…]
+// Scoped to the active company (cookie), optionally narrowed to one outlet.
 
 import { NextRequest, NextResponse } from "next/server";
 import { requireAuth } from "@/lib/auth";
 import { buildAgedPayables } from "@/lib/finance/reports/aging";
+import { getActiveCompanyId } from "@/lib/finance/companies";
 
 export const dynamic = "force-dynamic";
 export const maxDuration = 60;
@@ -11,10 +13,13 @@ export async function GET(req: NextRequest) {
   const auth = await requireAuth(req);
   if (auth.error) return auth.error;
   if (!["OWNER", "ADMIN"].includes(auth.user.role)) return NextResponse.json({ error: "Forbidden" }, { status: 403 });
-  const asOf = new URL(req.url).searchParams.get("asOf");
+  const url = new URL(req.url);
+  const asOf = url.searchParams.get("asOf");
   if (!asOf || !/^\d{4}-\d{2}-\d{2}$/.test(asOf)) return NextResponse.json({ error: "asOf (YYYY-MM-DD) required" }, { status: 400 });
+  const companyId = url.searchParams.get("companyId") ?? (await getActiveCompanyId());
+  const outletId = url.searchParams.get("outletId") ?? undefined;
   try {
-    return NextResponse.json({ report: await buildAgedPayables({ asOf }) });
+    return NextResponse.json({ report: await buildAgedPayables({ asOf, companyId, outletId }) });
   } catch (err) {
     return NextResponse.json({ error: err instanceof Error ? err.message : String(err) }, { status: 500 });
   }

--- a/apps/backoffice/src/lib/finance/reports/aging.ts
+++ b/apps/backoffice/src/lib/finance/reports/aging.ts
@@ -6,6 +6,7 @@
 // customer-invoice ledger to age.
 
 import { prisma } from "@/lib/prisma";
+import { getFinanceClient } from "../supabase";
 
 function round2(n: number): number {
   return Math.round(n * 100) / 100;
@@ -34,10 +35,28 @@ function bucketFor(daysOverdue: number): Bucket {
   return "d90_plus";
 }
 
-export async function buildAgedPayables(input: { asOf: string }): Promise<AgedPayables> {
+export async function buildAgedPayables(input: { asOf: string; companyId: string; outletId?: string }): Promise<AgedPayables> {
   const asOfDate = new Date(`${input.asOf}T23:59:59Z`);
+
+  // Scope to the active company's outlets (every invoice carries an outletId),
+  // narrowed further when a specific outlet is picked — the report was showing
+  // all three companies' bills regardless of the switcher and ignored the
+  // outlet filter entirely.
+  const client = getFinanceClient();
+  const { data: oc } = await client
+    .from("fin_outlet_companies").select("outlet_id").eq("company_id", input.companyId);
+  const companyOutletIds = (oc ?? []).map((r) => r.outlet_id as string);
+  const outletIds = input.outletId && companyOutletIds.includes(input.outletId)
+    ? [input.outletId]
+    : companyOutletIds;
+
   const invoices = await prisma.invoice.findMany({
-    where: { status: { notIn: ["PAID", "DRAFT"] } },
+    where: {
+      status: { notIn: ["PAID", "DRAFT"] },
+      outletId: { in: outletIds },
+      // A bill issued after the report date does not exist at that date.
+      issueDate: { lte: asOfDate },
+    },
     select: {
       amount: true, amountPaid: true, dueDate: true, issueDate: true,
       vendorName: true, supplier: { select: { name: true } },

--- a/apps/backoffice/src/lib/finance/reports/balance-sheet.ts
+++ b/apps/backoffice/src/lib/finance/reports/balance-sheet.ts
@@ -72,7 +72,8 @@ export async function buildBalanceSheet(input: BsInput): Promise<BsReport> {
   const txnDate = new Map((txns ?? []).map((t) => [t.id as string, t.txn_date as string]));
 
   const byCode = new Map<string, number>();
-  let pnlYtd = 0;     // for retained-earnings synthetic line
+  let pnlYtd = 0;     // current fiscal year earnings → synthetic equity line
+  let pnlPrior = 0;   // pre-fiscal-year earnings → retained earnings b/f
 
   if (txnIds.length > 0) {
     const chunkSize = 200;
@@ -93,16 +94,29 @@ export async function buildBalanceSheet(input: BsInput): Promise<BsReport> {
         if (meta.type === "asset" || meta.type === "liability" || meta.type === "equity") {
           const sign = meta.type === "asset" ? debit - credit : credit - debit;
           byCode.set(code, round2((byCode.get(code) ?? 0) + sign));
-        } else if (date >= fiscalYearStart && date <= input.asOf) {
-          // Income/cogs/expense — accrue to YTD P&L for retained earnings.
-          if (meta.type === "income") pnlYtd += credit - debit;
-          else pnlYtd -= debit - credit; // cogs + expense subtract
+        } else {
+          // Income/cogs/expense accrue to earnings. There are no year-end
+          // closing entries in this ledger, so PRIOR-year P&L must roll into
+          // retained earnings brought forward — dropping it left the whole of
+          // last year's net income out of equity and the BS out of balance by
+          // exactly that amount.
+          const contribution = meta.type === "income" ? credit - debit : -(debit - credit);
+          if (date >= fiscalYearStart && date <= input.asOf) pnlYtd += contribution;
+          else pnlPrior += contribution;
         }
       }
     }
   }
 
-  // Inject retained earnings (current period) under equity if non-zero.
+  // Inject earnings under equity: prior years brought forward + current year.
+  if (pnlPrior !== 0) {
+    byCode.set("RE-PRIOR", round2(pnlPrior));
+    accountMeta.set("RE-PRIOR", {
+      name: "Retained earnings (brought forward)",
+      type: "equity",
+      parent: null,
+    });
+  }
   if (pnlYtd !== 0) {
     byCode.set("RE-CURRENT", round2(pnlYtd));
     accountMeta.set("RE-CURRENT", {

--- a/apps/backoffice/src/lib/finance/reports/cash-flow.ts
+++ b/apps/backoffice/src/lib/finance/reports/cash-flow.ts
@@ -1,13 +1,21 @@
-// Cash Flow statement — indirect method.
+// Cash Flow statement — indirect method, built so it TIES BY CONSTRUCTION.
 //
-// Operating activities  = net income
-//                       + non-cash add-backs (depreciation 6512)
-//                       + working-capital changes (∆ AR, ∆ AP, ∆ Inventory, ...)
-// Investing activities  = ∆ PP&E (1500), exclude acc dep
-// Financing activities  = ∆ Loans (3010, 3500, 3400), ∆ Equity (4001)
+// Every posted journal line hits either a cash account (1000-*) or something
+// else; since debits always equal credits, the cash movement of the period is
+// exactly the sum of (credit − debit) over every NON-cash account. So instead
+// of enumerating a fixed list of accounts (the old builder missed Suspense,
+// channel debtors, inter-company and dividends — everything it missed became
+// an unexplained "reconciliation gap"), this walks the ledger once, buckets
+// every non-cash account into a named line, and sweeps the remainder into an
+// explicit "Other movements" line. The gap can then only be rounding.
 //
-// Net change in cash    = ∆ on bank accounts (1000-*)
-// Reconciliation: operating + investing + financing should ≈ net change in cash.
+// Operating  = net income (all 5*/6* accounts, depreciation stays inside)
+//            + working-capital deltas + channel-debtor settlements + Suspense
+// Investing  = ∆ PP&E net (1500*, accumulated depreciation included)
+// Financing  = ∆ loans (3010/3500/3400) + inter-company (3600*)
+//            + owner capital & dividends (4*)
+//
+// Net change in cash = ∆ on 1000-* accounts.
 
 import { getFinanceClient } from "../supabase";
 
@@ -37,130 +45,118 @@ export type CfInput = {
   end: string;
 };
 
-// Compute the closing balance for a code as of a given date (debit-positive
-// for asset/expense/cogs accounts, credit-positive for the rest).
-async function balanceFor(
-  companyId: string,
-  codePrefix: string,
-  asOfDate: string,
-  signMode: "debit" | "credit"
-): Promise<number> {
-  const client = getFinanceClient();
-  const { data: txns } = await client
-    .from("fin_transactions")
-    .select("id")
-    .eq("company_id", companyId)
-    .eq("status", "posted")
-    .lte("txn_date", asOfDate);
-  const txnIds = (txns ?? []).map((t) => t.id as string);
-  if (txnIds.length === 0) return 0;
+// Which named line a non-cash account belongs to. First match wins.
+type BucketKey =
+  | "pnl" | "ar" | "inventory" | "prepay" | "channelDebtors" | "suspense"
+  | "ap" | "sst" | "payroll" | "otherOperating"
+  | "ppe"
+  | "shortLoan" | "longLoan" | "directors" | "interco" | "equity";
 
-  let total = 0;
-  const chunkSize = 200;
-  for (let i = 0; i < txnIds.length; i += chunkSize) {
-    const chunk = txnIds.slice(i, i + chunkSize);
-    const { data: lines } = await client
-      .from("fin_journal_lines")
-      .select("account_code, debit, credit")
-      .in("transaction_id", chunk)
-      .like("account_code", `${codePrefix}%`);
-    for (const l of lines ?? []) {
-      total +=
-        signMode === "debit"
-          ? Number(l.debit) - Number(l.credit)
-          : Number(l.credit) - Number(l.debit);
-    }
-  }
-  return round2(total);
-}
-
-async function rangeMovement(
-  companyId: string,
-  codePrefix: string,
-  start: string,
-  end: string,
-  signMode: "debit" | "credit"
-): Promise<number> {
-  // Movement = balanceFor(end) - balanceFor(start - 1 day)
-  const dayBefore = oneDayBefore(start);
-  const closing = await balanceFor(companyId, codePrefix, end, signMode);
-  const opening = await balanceFor(companyId, codePrefix, dayBefore, signMode);
-  return round2(closing - opening);
+function bucketFor(code: string): BucketKey {
+  if (code.startsWith("5") || code.startsWith("6")) return "pnl";
+  if (code === "1001" || code.startsWith("1001-")) return "ar";
+  if (code === "1002" || code.startsWith("1002-")) return "inventory";
+  if (code === "1003" || code.startsWith("1003-")) return "prepay";
+  if (code === "1005" || code === "1006" || code === "1007" || code.startsWith("1005-") || code.startsWith("1006-") || code.startsWith("1007-")) return "channelDebtors";
+  if (code === "1999") return "suspense";
+  if (code === "3001" || code.startsWith("3001-")) return "ap";
+  if (code === "3002" || code.startsWith("3002-")) return "sst";
+  if (code >= "3004" && code <= "3008") return "payroll";
+  if (code.startsWith("3004") || code.startsWith("3005") || code.startsWith("3006") || code.startsWith("3007") || code.startsWith("3008")) return "payroll";
+  if (code.startsWith("1500")) return "ppe";
+  if (code === "3010" || code.startsWith("3010-")) return "shortLoan";
+  if (code.startsWith("3500")) return "longLoan";
+  if (code.startsWith("3400")) return "directors";
+  if (code.startsWith("3600")) return "interco";
+  if (code.startsWith("4")) return "equity";
+  return "otherOperating"; // any 1xxx/2xxx/3xxx not named above
 }
 
 export async function buildCashFlow(input: CfInput): Promise<CfReport> {
+  const client = getFinanceClient();
   const dayBefore = oneDayBefore(input.start);
 
-  // Net income for the range — re-compute from journals to match P&L exactly.
-  const netIncome = await rangeMovement(input.companyId, "5", input.start, input.end, "credit")
-    - await rangeMovement(input.companyId, "6000", input.start, input.end, "debit")
-    - await rangeMovement(input.companyId, "6001", input.start, input.end, "debit")
-    - await rangeMovement(input.companyId, "6002", input.start, input.end, "debit")
-    - await rangeMovement(input.companyId, "6003", input.start, input.end, "debit")
-    - await rangeMovement(input.companyId, "65", input.start, input.end, "debit")
-    - await rangeMovement(input.companyId, "69", input.start, input.end, "debit");
+  // One ledger walk: every posted txn through the period end.
+  const { data: txns } = await client
+    .from("fin_transactions")
+    .select("id, txn_date")
+    .eq("company_id", input.companyId)
+    .eq("status", "posted")
+    .lte("txn_date", input.end);
+  const txnDate = new Map((txns ?? []).map((t) => [t.id as string, t.txn_date as string]));
+  const txnIds = [...txnDate.keys()];
 
-  // Depreciation add-back
-  const depreciation = await rangeMovement(input.companyId, "6512", input.start, input.end, "debit");
+  let cashAtStart = 0;
+  let cashAtEnd = 0;
+  const flows = new Map<BucketKey, number>(); // (credit − debit) per bucket, in-range only
 
-  // Working capital changes (signs flipped: increase in asset = use of cash;
-  // increase in liability = source of cash)
-  const deltaAr = -await rangeMovement(input.companyId, "1001", input.start, input.end, "debit");
-  const deltaInventory = -await rangeMovement(input.companyId, "1002", input.start, input.end, "debit");
-  const deltaPrepay = -await rangeMovement(input.companyId, "1003", input.start, input.end, "debit");
-  const deltaAp = await rangeMovement(input.companyId, "3001", input.start, input.end, "credit");
-  const deltaSstPayable = await rangeMovement(input.companyId, "3002", input.start, input.end, "credit");
-  const deltaPayrollControls =
-    await rangeMovement(input.companyId, "3004", input.start, input.end, "credit") +
-    await rangeMovement(input.companyId, "3005", input.start, input.end, "credit") +
-    await rangeMovement(input.companyId, "3006", input.start, input.end, "credit") +
-    await rangeMovement(input.companyId, "3007", input.start, input.end, "credit") +
-    await rangeMovement(input.companyId, "3008", input.start, input.end, "credit");
+  for (let i = 0; i < txnIds.length; i += 200) {
+    const chunk = txnIds.slice(i, i + 200);
+    const { data: lines } = await client
+      .from("fin_journal_lines")
+      .select("transaction_id, account_code, debit, credit")
+      .in("transaction_id", chunk);
+    for (const l of lines ?? []) {
+      const date = txnDate.get(l.transaction_id as string) ?? "";
+      const code = l.account_code as string;
+      const debit = Number(l.debit);
+      const credit = Number(l.credit);
+      if (code.startsWith("1000")) {
+        const mov = debit - credit;
+        if (date <= dayBefore) cashAtStart += mov;
+        cashAtEnd += mov;
+        continue;
+      }
+      if (date < input.start || date > input.end) continue;
+      // Cash-flow contribution of a non-cash account: credit = source of
+      // cash (+), debit = use of cash (−) — for every account type.
+      const b = bucketFor(code);
+      flows.set(b, (flows.get(b) ?? 0) + (credit - debit));
+    }
+  }
+
+  const f = (k: BucketKey) => round2(flows.get(k) ?? 0);
+  const netIncome = f("pnl");
 
   const operating: CfSection = {
     title: "Operating",
     lines: [
-      { label: "Net income", amount: round2(netIncome) },
-      { label: "Depreciation", amount: round2(depreciation), code: "6512" },
-      { label: "∆ Accounts receivable", amount: round2(deltaAr), code: "1001" },
-      { label: "∆ Inventory", amount: round2(deltaInventory), code: "1002" },
-      { label: "∆ Deposits & prepayments", amount: round2(deltaPrepay), code: "1003" },
-      { label: "∆ Accounts payable", amount: round2(deltaAp), code: "3001" },
-      { label: "∆ SST payable", amount: round2(deltaSstPayable), code: "3002" },
-      { label: "∆ Payroll controls", amount: round2(deltaPayrollControls) },
-    ],
+      { label: "Net income (depreciation included)", amount: netIncome },
+      { label: "∆ Accounts receivable", amount: f("ar"), code: "1001" },
+      { label: "∆ Inventory", amount: f("inventory"), code: "1002" },
+      { label: "∆ Deposits & prepayments", amount: f("prepay"), code: "1003" },
+      { label: "∆ Channel debtors (card / Grab settlements)", amount: f("channelDebtors"), code: "1005-1007" },
+      { label: "∆ Accounts payable", amount: f("ap"), code: "3001" },
+      { label: "∆ SST payable", amount: f("sst"), code: "3002" },
+      { label: "∆ Payroll controls", amount: f("payroll"), code: "3004-3008" },
+      { label: "Unreconciled inflows (Suspense)", amount: f("suspense"), code: "1999" },
+      { label: "Other movements", amount: f("otherOperating") },
+    ].filter((l) => l.amount !== 0 || l.label.startsWith("Net income")),
     total: 0,
   };
   operating.total = round2(operating.lines.reduce((s, l) => s + l.amount, 0));
 
-  // Investing = ∆ PP&E (capex). Negative = cash spent on PP&E.
-  const deltaPpe = -await rangeMovement(input.companyId, "1500", input.start, input.end, "debit");
   const investing: CfSection = {
     title: "Investing",
-    lines: [{ label: "∆ Property, Plant & Equipment", amount: round2(deltaPpe), code: "1500" }],
-    total: round2(deltaPpe),
+    lines: [{ label: "∆ Property, Plant & Equipment (net)", amount: f("ppe"), code: "1500" }],
+    total: f("ppe"),
   };
-
-  // Financing = ∆ loans + ∆ equity contributions
-  const deltaShortLoan = await rangeMovement(input.companyId, "3010", input.start, input.end, "credit");
-  const deltaLongLoan = await rangeMovement(input.companyId, "3500", input.start, input.end, "credit");
-  const deltaDirectorLoan = await rangeMovement(input.companyId, "3400", input.start, input.end, "credit");
-  const deltaCapital = await rangeMovement(input.companyId, "4001", input.start, input.end, "credit");
 
   const financing: CfSection = {
     title: "Financing",
     lines: [
-      { label: "∆ Short-term loans", amount: round2(deltaShortLoan), code: "3010" },
-      { label: "∆ Long-term loans", amount: round2(deltaLongLoan), code: "3500" },
-      { label: "∆ Due to directors", amount: round2(deltaDirectorLoan), code: "3400" },
-      { label: "∆ Owner capital", amount: round2(deltaCapital), code: "4001" },
-    ],
+      { label: "∆ Short-term loans", amount: f("shortLoan"), code: "3010" },
+      { label: "∆ Long-term loans", amount: f("longLoan"), code: "3500" },
+      { label: "∆ Due to directors", amount: f("directors"), code: "3400" },
+      { label: "∆ Inter-company balances", amount: f("interco"), code: "3600" },
+      { label: "Owner capital & dividends", amount: f("equity"), code: "4xxx" },
+    ].filter((l) => l.amount !== 0),
     total: 0,
   };
   financing.total = round2(financing.lines.reduce((s, l) => s + l.amount, 0));
 
-  const cashAtStart = await balanceFor(input.companyId, "1000", dayBefore, "debit");
-  const cashAtEnd = await balanceFor(input.companyId, "1000", input.end, "debit");
+  cashAtStart = round2(cashAtStart);
+  cashAtEnd = round2(cashAtEnd);
   const netChange = round2(cashAtEnd - cashAtStart);
   const computed = round2(operating.total + investing.total + financing.total);
 
@@ -168,13 +164,13 @@ export async function buildCashFlow(input: CfInput): Promise<CfReport> {
     companyId: input.companyId,
     start: input.start,
     end: input.end,
-    netIncome: round2(netIncome),
+    netIncome,
     operating,
     investing,
     financing,
     netChangeInCash: netChange,
-    cashAtStart: round2(cashAtStart),
-    cashAtEnd: round2(cashAtEnd),
+    cashAtStart,
+    cashAtEnd,
     reconciliationGap: round2(computed - netChange),
   };
 }


### PR DESCRIPTION
Owner: 'aged payables did not follow based on outlet. there are a few
issues aswell'. Audited every reports tab; three real defects found and a
live probe confirmed them (BS out by RM265,513 with a balanced TB; CF gap
RM135,740).

AGED PAYABLES was completely unscoped: it ignored the outlet filter (the
report the owner caught), ignored the ACTIVE COMPANY switcher (all three
entities' bills mixed into every view), and included invoices issued after
the report date. Now scoped company -> fin_outlet_companies outlets ->
optional single outlet, and issueDate <= asOf.

BALANCE SHEET imbalance root cause: the ledger has no year-end closing
entries and journals reach back to Jan 2025, but only CURRENT-fiscal-year
P&L was injected into equity — all prior-year net income simply vanished,
leaving the BS out by exactly that amount while the TB stayed balanced.
New 'Retained earnings (brought forward)' synthetic line carries
pre-fiscal-year P&L.

CASH FLOW rewritten to tie by construction: the old builder enumerated a
fixed account list, so movements in Suspense 1999, channel debtors
(1005-1007), inter-company 3600 and dividends 4000 fell into an
unexplained reconciliation gap. Since debits equal credits, cash movement
is exactly the sum of (credit - debit) over every non-cash account — the
builder now walks the ledger ONCE (instead of ~20 full scans), buckets
every account into a named line, and sweeps the remainder into an explicit
'Other movements' line. Gap can only be rounding now.

Also: the outlet dropdown disables on entity-level tabs (BS/CF/TB/GL) with
an explanation instead of silently no-oping.

55/55 finance tests pass, typecheck + lint clean.
