### PR TITLE
feat(ops): unpublished-roster guardrail + kill the dual published truth

### DIFF
--- a/apps/backoffice/src/app/api/cron/ops-nudge-roster/route.ts
+++ b/apps/backoffice/src/app/api/cron/ops-nudge-roster/route.ts
@@ -1,0 +1,34 @@
+import { NextRequest, NextResponse } from "next/server";
+import { checkCronAuth } from "@celsius/shared";
+import { runRosterPublishNudges } from "@/lib/ops-nudges";
+
+export const dynamic = "force-dynamic";
+export const maxDuration = 60;
+
+/**
+ * GET /api/cron/ops-nudge-roster — unpublished-roster guardrail.
+ *
+ * Every active outlet must have a PUBLISHED schedule covering the current week:
+ * without one, staff can't be assigned checklists, the lateness nudge has
+ * nothing to measure against, and the on-shift team resolves empty. This pages
+ * the managers (ops leads) for any outlet missing one, distinguishing "built
+ * but not published" (one click) from "no roster created" (real work). Born
+ * from the Shah Alam week of 2026-06-29: a built roster whose publish never
+ * landed ran silent for 5 days and cost ~43% of that week's checklist misses.
+ * Daily 09:30 MYT; the ledger dedupes per (outlet, week) so one gap pings once.
+ * OPS_NUDGES_MODE (off|shadow|armed), default armed.
+ * Design: docs/design/ops-performance-loop.md.
+ */
+export async function GET(req: NextRequest) {
+  const cronAuth = checkCronAuth(req.headers);
+  if (!cronAuth.ok) return NextResponse.json({ error: cronAuth.error }, { status: cronAuth.status });
+  try {
+    const result = await runRosterPublishNudges();
+    console.log(`[cron/ops-nudge-roster] mode=${result.mode} items=${result.items} mgr=${result.managerSent}`);
+    return NextResponse.json({ ok: true, ...result });
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : "ops-nudge-roster failed";
+    console.error("[cron/ops-nudge-roster]", msg);
+    return NextResponse.json({ error: msg }, { status: 500 });
+  }
+}

--- a/apps/backoffice/src/lib/ops-nudges/index.ts
+++ b/apps/backoffice/src/lib/ops-nudges/index.ts
@@ -652,3 +652,83 @@ export async function runStoreStatusNudges(now = new Date()): Promise<NudgeRunRe
   const managerSent = await sendManagerDigestToOps(headline, managerLines, mode);
   return { mode, ranAt, items: managerLines.length, staffSent, managerSent };
 }
+
+// ── 7. Roster not published → managers ────────────────────────────────────────
+// The guardrail for the silent roster gap (Shah Alam, week of 2026-06-29: the
+// roster was BUILT at 00:26 but the publish never landed; the ops loops treated
+// the whole outlet as unrostered for 5 days and nobody was told). Every active
+// outlet must have a PUBLISHED schedule covering the current week: without one,
+// staff can't be assigned checklists, the lateness nudge has nothing to measure
+// against, and the on-shift team resolves empty. Distinguishes "built but not
+// published" (one click) from "no roster created" (real work). Managers only.
+// Deduped per (outlet, week) so it fires once per gap, not daily.
+export async function runRosterPublishNudges(now = new Date()): Promise<NudgeRunResult> {
+  const mode = nudgesMode();
+  const ranAt = now.toISOString();
+  if (mode === "off") return { mode, ranAt, items: 0, staffSent: 0, managerSent: 0 };
+
+  const ymd = mytYmd(now);
+  // Monday of the current MYT week — the dedupe anchor for outlets with no
+  // schedule row at all (rows with a draft dedupe on the draft's own week_start).
+  const myt = new Date(now.getTime() + 8 * 3_600_000);
+  const monday = new Date(
+    Date.UTC(myt.getUTCFullYear(), myt.getUTCMonth(), myt.getUTCDate() - ((myt.getUTCDay() + 6) % 7)),
+  )
+    .toISOString()
+    .slice(0, 10);
+  const outlets = await prisma.outlet.findMany({
+    where: { status: "ACTIVE", type: "OUTLET" },
+    select: { id: true, name: true },
+  });
+  if (outlets.length === 0) return { mode, ranAt, items: 0, staffSent: 0, managerSent: 0 };
+
+  // Schedules covering today, any status. status juggling ends at the trigger
+  // (migration 068): status='published' <=> published_at set, so gate on status.
+  const rows = await prisma.$queryRaw<
+    Array<{ outlet_id: string; status: string; week_start: string; shifts: bigint }>
+  >`
+    SELECT sc.outlet_id, sc.status, sc.week_start::text AS week_start,
+           (SELECT count(*) FROM hr_schedule_shifts s WHERE s.schedule_id = sc.id) AS shifts
+    FROM hr_schedules sc
+    WHERE sc.week_start <= ${ymd}::date AND sc.week_end >= ${ymd}::date
+  `;
+  const byOutlet = new Map<string, { status: string; week_start: string; shifts: number }[]>();
+  for (const r of rows) {
+    (byOutlet.get(r.outlet_id) ?? byOutlet.set(r.outlet_id, []).get(r.outlet_id)!).push({
+      status: r.status,
+      week_start: r.week_start,
+      shifts: Number(r.shifts),
+    });
+  }
+
+  const managerLines: string[] = [];
+  for (const o of outlets) {
+    const scheds = byOutlet.get(o.id) ?? [];
+    if (scheds.some((s) => s.status === "published")) continue; // covered
+    const draft = scheds.find((s) => s.status !== "published");
+    const line = draft
+      ? `${o.name}: this week's roster is built (${draft.shifts} shifts) but NOT published. One click in HR, Schedules.`
+      : `${o.name}: no roster created for this week. Staff get no checklists or lateness tracking until one is published.`;
+    const b: Breach = {
+      signal: "ROSTER_MISSING",
+      outletId: o.id,
+      outletName: o.name,
+      severity: "HIGH",
+      routeKey: "operations",
+      // Key on the outlet + the week so one gap pings once, not every morning.
+      dedupeKey: `ROSTER_MISSING:${o.id}:${draft?.week_start ?? monday}`,
+      summary: line,
+      detail: { weekOf: ymd, built: !!draft, shifts: draft?.shifts ?? 0 },
+    };
+    if (mode === "armed") {
+      const { isNew } = await recordBreach(b, null);
+      if (!isNew) continue;
+    }
+    managerLines.push(line);
+  }
+  if (managerLines.length === 0) return { mode, ranAt, items: 0, staffSent: 0, managerSent: 0 };
+
+  const headline = `${managerLines.length} outlet roster${managerLines.length === 1 ? "" : "s"} not published for this week`;
+  const managerSent = await sendManagerDigestToOps(headline, managerLines, mode);
+  return { mode, ranAt, items: managerLines.length, staffSent: 0, managerSent };
+}

--- a/apps/backoffice/src/lib/ops-pulse/types.ts
+++ b/apps/backoffice/src/lib/ops-pulse/types.ts
@@ -15,7 +15,8 @@ export type OpsSignal =
   | "MENU_SNOOZED"
   | "NO_CLOCK_IN"
   | "POS_NOT_OPEN"
-  | "RESTOCK_NEEDED";
+  | "RESTOCK_NEEDED"
+  | "ROSTER_MISSING";
 
 export type Severity = "LOW" | "MED" | "HIGH";
 

--- a/apps/backoffice/vercel.json
+++ b/apps/backoffice/vercel.json
@@ -141,6 +141,10 @@
       "schedule": "*/15 * * * *"
     },
     {
+      "path": "/api/cron/ops-nudge-roster",
+      "schedule": "30 1 * * *"
+    },
+    {
       "path": "/api/cron/geogrid-keywords",
       "schedule": "0 6 1 * *"
     },

--- a/supabase/migrations/068_hr_schedules_published_sync.sql
+++ b/supabase/migrations/068_hr_schedules_published_sync.sql
@@ -1,0 +1,39 @@
+-- Kill the dual source of truth for "published" on hr_schedules.
+--
+-- The UI + staff app gate on status='published'; the ops loops (checklist
+-- owner, on-shift team, lateness nudge) gate on published_at IS NOT NULL.
+-- The BrioHR import (April 2026) wrote status='published' with published_at
+-- NULL, so those weeks looked published everywhere except the ops loops —
+-- the "published but suddenly incomplete" ghost. This trigger makes the two
+-- fields inseparable no matter which writer misbehaves next.
+--
+-- Captured for reproducibility per docs/database-migrations.md (never
+-- auto-run; applied via Supabase MCP 2026-07-03).
+
+-- One-time repair: the 7 divergent import rows (status published, no
+-- timestamp). Past weeks, so operationally inert, but divergence breeds bugs.
+UPDATE hr_schedules
+SET published_at = created_at
+WHERE status = 'published' AND published_at IS NULL;
+
+-- Keep them in lockstep forever:
+--   status -> 'published'  and no timestamp => stamp now()
+--   status -> anything else                 => clear the timestamp
+CREATE OR REPLACE FUNCTION sync_hr_schedule_published()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+BEGIN
+  IF NEW.status = 'published' AND NEW.published_at IS NULL THEN
+    NEW.published_at := now();
+  ELSIF NEW.status IS DISTINCT FROM 'published' THEN
+    NEW.published_at := NULL;
+  END IF;
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS trg_hr_schedules_published_sync ON hr_schedules;
+CREATE TRIGGER trg_hr_schedules_published_sync
+BEFORE INSERT OR UPDATE ON hr_schedules
+FOR EACH ROW EXECUTE FUNCTION sync_hr_schedule_published();


### PR DESCRIPTION
## The bug (user report: "published before but suddenly incomplete, happened before")
Two findings:

1. **Dual source of truth.** UI + staff app decide "published" from `status='published'`; every ops loop gates on `published_at IS NOT NULL`. The BrioHR import (April) set status without the timestamp → 7 weeks that looked published everywhere except the ops loops. That divergence is the recurring ghost.
2. **This week was a human miss with no guardrail.** Shah Alam's roster was built Jun 29 00:26 but the publish never landed (`published_by` null = never published, not unpublished — Adam published Putrajaya 00:24 and Tamarind 00:35 around it). Nilai has no schedule at all since April. Silent for 5 days; ~43% of the week's checklist misses trace to it.

## Fix
- **Migration 068** (applied to prod via MCP): backfill the 7 divergent rows; `BEFORE INSERT OR UPDATE` trigger keeps `status`/`published_at` in lockstep permanently. Verified: 0 divergent rows in either direction post-apply.
- **`runRosterPublishNudges` + `/api/cron/ops-nudge-roster`** (daily 09:30 MYT): any active outlet without a published schedule covering the current week → manager digest, distinguishing "built but not published (N shifts), one click" from "no roster created". Ledger-deduped per (outlet, week) — one gap pings once, not daily. Armed-gated recordBreach (shadow never writes), per the pulse-review convention.
- `ROSTER_MISSING` added to `OpsSignal`.

## Verified
- tsc clean; trigger + backfill verified live (0 divergent rows).
- First run after deploy will ping for Shah Alam ("built, 21 shifts, not published") and Nilai ("no roster created") — that's the guardrail working, and it stops once they publish.