### PR TITLE
fix(procurement): "Fill suggested" button writes qty under the correct key

### DIFF
--- a/apps/backoffice/src/app/(admin)/inventory/supplier-chats/page.tsx
+++ b/apps/backoffice/src/app/(admin)/inventory/supplier-chats/page.tsx
@@ -1250,7 +1250,7 @@ export default function SupplierChatsPage() {
                                 setPoQty((q) => {
                                   const next = { ...q };
                                   for (const p of poProducts) {
-                                    if ((p.suggestedQty ?? 0) > 0 && !next[p.productId]) next[p.productId] = p.suggestedQty!;
+                                    if ((p.suggestedQty ?? 0) > 0 && !next[p.supplierProductId]) next[p.supplierProductId] = p.suggestedQty!;
                                   }
                                   return next;
                                 })


### PR DESCRIPTION
## Bug
In the New-PO composer, the **"Fill suggested"** button did nothing — clicking it left all quantities at 0.

## Cause
Follow-up to #743. That PR re-keyed the quantity state from `productId` → the unique `supplierProductId` (so same-product/different-package rows don't collide) — but the bulk **"Fill suggested"** handler still wrote `next[p.productId]`. The inputs read `poQty[p.supplierProductId]`, so the suggested values landed under the wrong keys and never rendered → the button looked dead.

## Fix
One line: the Fill-suggested loop now writes `next[p.supplierProductId]`, matching the inputs and the per-row "suggest" button. Swept the file — no other qty key still uses `productId`.

Verify: lint clean; "Fill suggested" now populates each row's quantity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)