### PR TITLE
fix(procurement): clarify PO qty — separate order qty from pack unit

### DIFF
--- a/apps/backoffice/src/lib/inventory/po-pdf.ts
+++ b/apps/backoffice/src/lib/inventory/po-pdf.ts
@@ -59,13 +59,19 @@ export async function generatePoPdf(input: PoPdfInput): Promise<Buffer> {
   text("Qty", qtyX, 10, bold, gray);
   y -= 17;
 
-  // Items — one per line, long names clipped so the qty column stays aligned.
+  // Items — item name + the order quantity as a plain number in the Qty column, with the pack
+  // unit on a light sub-line beneath the name. Keeps the qty ("2") from running into a pack
+  // label that itself starts with a number (e.g. "1 Cake (12 slices)" was rendering as a
+  // confusing "2 1 Cake (12 slices)").
   input.items.forEach((it, i) => {
     newPageIfNeeded();
     const label = `${i + 1}. ${it.name}`;
     text(label.length > 58 ? label.slice(0, 57) + "…" : label, MX, 11);
-    text(`${it.quantity} ${it.uom}`, qtyX, 11);
-    y -= 17;
+    text(String(it.quantity), qtyX, 11, bold);
+    y -= 13;
+    const unit = it.uom.replace(/^\s*1\s+/, "").trim(); // drop a redundant leading "1 "
+    if (unit) text(`× ${unit}`, MX + 14, 9, font, gray);
+    y -= 15;
   });
 
   y -= 8;

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -159,7 +159,10 @@ export function formatWhatsAppOrder(params: {
   message += `PO #: ${orderNumber}\n\n`;
 
   items.forEach((item, i) => {
-    message += `${i + 1}. ${item.name} — ${item.quantity} ${item.uom}\n`;
+    // Strip a redundant leading "1 " from the pack label and separate qty with "×" so the order
+    // quantity never runs into a unit that starts with a number (e.g. "2 1 Cake (12 slices)").
+    const unit = item.uom.replace(/^\s*1\s+/, "").trim();
+    message += `${i + 1}. ${item.name} — ${item.quantity} × ${unit}\n`;
   });
 
   if (deliveryDate) {


### PR DESCRIPTION
## Problem
In the PO the **Qty** column glued the order quantity to the pack label (`${qty} ${uom}`). When the pack label *itself* starts with a number — e.g. `1 Cake (12 slices)` — it rendered as a confusing **`2 1 Cake (12 slices)`** (two numbers jammed together, looks like a typo).

## Fix
Both PO renderers now separate the order quantity from the pack unit:

**PDF** (`po-pdf.ts`) — Qty column shows the order quantity as a plain bold number, with the pack unit on a light `× <unit>` sub-line under the item name:
```
1. Chocolate Mudslide                 2
   × Cake (12 slices)
2. Almond Salted Crepe                2
   × Box (12× 1pcs Piece)
```

**WhatsApp text block** (`formatWhatsAppOrder`, warm suppliers) — `<name> — <qty> × <unit>`:
```
1. Chocolate Mudslide — 2 × Cake (12 slices)
2. Almond Salted Crepe — 2 × Box (12× 1pcs Piece)
```

Both strip a **redundant leading `1 `** from the pack label (`1 Cake …` → `Cake …`, since a pack of exactly one adds nothing) while leaving real multi-packs like `6 Bottle` untouched, and use `×` to clearly separate order-qty from unit.

Verified: shared + backoffice typecheck clean; transform checked against the two real labels + edge cases (`6 Bottle` kept, `1pcs Piece` not stripped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)