### PR TITLE
fix(grab): payment rows use 'completed' status (was 'paid') + backfill 488

### DIFF
--- a/apps/backoffice/src/lib/grab-ingest.ts
+++ b/apps/backoffice/src/lib/grab-ingest.ts
@@ -325,7 +325,10 @@ export async function ingestGrabOrder(
     order_id: order.id,
     payment_method: payload.paymentType === "CASH" ? "cash" : "grabpay",
     amount: total,
-    status: "paid",
+    // Must be one of the pos_order_payments_status_check values
+    // (pending|completed|failed|refunded); "paid" was rejected (23514), silently
+    // orphaning every Grab payment row. "completed" == card/qr's paid state.
+    status: "completed",
     provider: "grabfood",
     provider_ref: orderID,
     refund_amount: 0,

--- a/supabase/migrations/069_backfill_grab_payments.sql
+++ b/supabase/migrations/069_backfill_grab_payments.sql
@@ -1,0 +1,21 @@
+-- Backfill the orphaned GrabFood payment rows.
+--
+-- grab-ingest.ts inserted pos_order_payments with status='paid', but the
+-- pos_order_payments_status_check constraint only allows
+-- pending|completed|failed|refunded. Every Grab payment insert was rejected
+-- (23514) and swallowed (console.error, not thrown), so the ORDER landed but its
+-- payment/tender row did not — ~488 GrabFood orders (RM18.7k) since 2026-06-17
+-- with no payment row. The code is fixed to write 'completed' going forward
+-- (grab-ingest.ts); this repairs the history.
+--
+-- Method defaults to 'grabpay': GrabFood MY is prepaid, the order does not store
+-- the paymentType, and there are no cash-on-delivery Grab orders in the data.
+-- Only completed/ready orders are affected (no cancelled/rejected), so a
+-- 'completed' payment is correct for all. amount = order gross (integer cents),
+-- matching the live insert. Applied via Supabase MCP 2026-07-03.
+
+INSERT INTO pos_order_payments (order_id, payment_method, provider, amount, provider_ref, status, refund_amount, created_at)
+SELECT o.id, 'grabpay', 'grabfood', o.total, o.external_id, 'completed', 0, o.created_at
+FROM pos_orders o
+LEFT JOIN pos_order_payments p ON p.order_id = o.id
+WHERE o.source = 'grabfood' AND p.order_id IS NULL;


### PR DESCRIPTION
## Bug
`grab-ingest.ts` inserted `pos_order_payments` with `status: "paid"`, but the `pos_order_payments_status_check` constraint only allows `pending | completed | failed | refunded`. Postgres rejected **every** Grab payment insert (error 23514), and the error was logged not thrown — so the order landed while its payment/tender row was silently dropped.

**Blast radius:** 488 GrabFood orders (~RM18.7k gross) since 2026-06-17 with no payment row. Revenue still counted (sales read `pos_orders`), but payment-method breakdowns, QR/tender reconciliation, and Grab payout reconciliation all missed Grab.

## Fix
- **Code:** `status: "paid"` → `"completed"` (one word — the value card/qr already use for a paid tender).
- **Migration 069 (applied to prod via MCP):** backfilled the 488 orphaned rows from `pos_orders` — method `grabpay`, status `completed`, gross amount, provider_ref = external_id. Only completed/ready orders existed (no cancelled/rejected), so a completed payment is correct for all. Method defaults to `grabpay` (GrabFood MY is prepaid; the order doesn't store paymentType; no cash-on-delivery in the data).

## Verified
- tsc clean.
- Post-backfill: **0 orphaned Grab orders, 0 orders with duplicate payments, 488 grab payment rows** now present.