### PR TITLE
feat(hr): carry BrioHR H1 YTD into monthly PCB (opening-balance run)

### DIFF
--- a/apps/backoffice/src/lib/hr/agents/payroll-calculator.ts
+++ b/apps/backoffice/src/lib/hr/agents/payroll-calculator.ts
@@ -138,12 +138,15 @@ export async function calculatePayroll(month: number, year: number): Promise<Pay
     attendanceByUser.set(a.user_id, list);
   });
 
-  // 2b. YTD totals — sum confirmed runs earlier in the same year for PCB carryover
+  // 2b. YTD totals — sum confirmed runs earlier in the same year for PCB carryover.
+  // Includes prior MONTHLY runs (period_month < month) AND the H1 "opening_balance"
+  // run (period_month NULL) that carries the BrioHR Jan-Jun YTD, so the cumulative
+  // PCB / EPF / gross continue correctly across the mid-year switch off BrioHR.
   const { data: priorRuns } = await hrSupabaseAdmin
     .from("hr_payroll_runs")
     .select("id")
     .eq("period_year", year)
-    .lt("period_month", month)
+    .or(`period_month.lt.${month},cycle_type.eq.opening_balance`)
     .in("status", ["confirmed", "paid"]);
   const priorRunIds = (priorRuns || []).map((r: { id: string }) => r.id);
   const ytdByUser = new Map<string, { gross: number; pcb: number }>();

--- a/supabase/migrations/070_payroll_opening_balance_cycle.sql
+++ b/supabase/migrations/070_payroll_opening_balance_cycle.sql
@@ -1,0 +1,14 @@
+-- Allow an "opening_balance" payroll run — used to carry a mid-year YTD forward
+-- from a prior payroll system (BrioHR, whose last run was June 2026) so the
+-- in-house monthly PCB stays cumulative and the EA form reconciles.
+--
+-- Same shape as a weekly run (period_start/end, no period_month). Already applied
+-- to prod on 2026-07-03 alongside the BrioHR YTD import (run 38752e06); this file
+-- keeps the repo in sync. See payroll-calculator.ts: the YTD query now unions
+-- prior monthly runs with the opening_balance run.
+alter table hr_payroll_runs drop constraint if exists hr_payroll_runs_cycle_fields;
+alter table hr_payroll_runs add constraint hr_payroll_runs_cycle_fields check (
+  (cycle_type = 'monthly' and period_month is not null and period_year is not null)
+  or (cycle_type = 'weekly' and period_start is not null and period_end is not null)
+  or (cycle_type = 'opening_balance' and period_start is not null and period_end is not null)
+);


### PR DESCRIPTION
Wires the BrioHR Jan–Jun 2026 YTD (loaded 2026-07-03 as an `opening_balance` payroll run) into the monthly PCB calc, so July's first in-house payroll computes **cumulative** tax correctly instead of restarting from zero.

## The gap
`payroll-calculator.ts` builds each employee's YTD (for `calcPCB`'s `ytdGross` / `ytdTaxPaid`) by summing prior **monthly** runs (`period_month < month`). The opening-balance run has `period_month = NULL`, so it was excluded — July would ignore the RM10,121 of PCB already paid in H1 and the EA form wouldn't reconcile.

## Change
- The prior-runs query now unions prior monthly runs **with the `opening_balance` run** for the year (`.or(period_month.lt.${month}, cycle_type.eq.opening_balance)`), still scoped to `period_year` + `status in (confirmed, paid)`.
- Migration **070** records the `hr_payroll_runs` check-constraint change allowing `cycle_type='opening_balance'` (already applied to prod with the YTD import).

## Data cleanup done alongside (prod)
Discovered 6 stale in-house Jan–Jun monthly runs (test/draft computations built while standing up the system — numbers don't match BrioHR, which was the real payer through June). Left in they'd **double-count** against the opening balance. Per decision, they were **voided to `draft`** (excluded from YTD + payslips, kept for reference).

## Verification (live)
Simulated July YTD now reads the opening balance only: **total YTD PCB RM10,121.30**, Ariff RM65,019 gross / RM6,830 PCB — exact BrioHR H1 figures, no double-count. `tsc` + `eslint` clean.