### PR TITLE
fix(hr/schedules): stop the editor silently destroying shifts + delete-audit

### DIFF
--- a/apps/backoffice/src/app/(admin)/hr/schedules/page.tsx
+++ b/apps/backoffice/src/app/(admin)/hr/schedules/page.tsx
@@ -357,7 +357,7 @@ export default function SchedulesPage() {
 
     setSaving(true);
     try {
-      await fetch("/api/hr/schedules/cell", {
+      const res = await fetch("/api/hr/schedules/cell", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
@@ -368,6 +368,13 @@ export default function SchedulesPage() {
           template_id: templateId,
         }),
       });
+      // Never silently swallow a failed save — that let managers believe a
+      // roster was saved when it wasn't. Surface it and keep the picker open.
+      if (!res.ok) {
+        const err = await res.json().catch(() => ({}));
+        alert(`Couldn't save this shift: ${err.error || res.status}. Nothing was changed — please try again.`);
+        return;
+      }
       mutate();
       setPickerOpen(null);
       setPendingCheck(null);
@@ -381,7 +388,7 @@ export default function SchedulesPage() {
     if (!selectedOutlet) return;
     setSaving(true);
     try {
-      await fetch("/api/hr/schedules/cell", {
+      const res = await fetch("/api/hr/schedules/cell", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
@@ -398,6 +405,11 @@ export default function SchedulesPage() {
           },
         }),
       });
+      if (!res.ok) {
+        const err = await res.json().catch(() => ({}));
+        alert(`Couldn't save this shift: ${err.error || res.status}. Nothing was changed — please try again.`);
+        return;
+      }
       mutate();
       setPickerOpen(null);
     } finally {

--- a/apps/backoffice/src/app/api/hr/schedules/cell/route.ts
+++ b/apps/backoffice/src/app/api/hr/schedules/cell/route.ts
@@ -73,99 +73,100 @@ export async function POST(req: NextRequest) {
     schedule = newSched;
   }
 
-  // Delete any existing cell for this (user, date)
-  await hrSupabaseAdmin
+  // Clear = an intentional removal of this cell.
+  if (!template_id) {
+    const { error } = await hrSupabaseAdmin
+      .from("hr_schedule_shifts")
+      .delete()
+      .eq("schedule_id", schedule.id)
+      .eq("user_id", user_id)
+      .eq("shift_date", shift_date);
+    if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+    return NextResponse.json({ success: true, cleared: true });
+  }
+
+  // Build the replacement shift row (rest-day marker or template-based).
+  type NewShift = {
+    schedule_id: string; user_id: string; shift_date: string;
+    start_time: string; end_time: string; role_type: string;
+    break_minutes: number; is_ai_assigned: boolean; notes: string;
+  };
+  let newShift: NewShift;
+
+  if (template_id === REST_DAY_ID) {
+    // Rest day = a marker shift: start=end=00:00, role "Rest Day".
+    newShift = {
+      schedule_id: schedule.id, user_id, shift_date,
+      start_time: "00:00", end_time: "00:00", role_type: "Rest Day",
+      break_minutes: 0, is_ai_assigned: false, notes: "rest_day",
+    };
+  } else {
+    let start_time: string;
+    let end_time: string;
+    let break_minutes: number;
+    let role_type: string;
+
+    if (template_id === "custom" && custom) {
+      start_time = custom.start_time;
+      end_time = custom.end_time;
+      break_minutes = custom.break_minutes ?? 30;
+      role_type = custom.label || "Custom";
+    } else {
+      // Try DB template first (UUID), then hardcoded template (string id)
+      let dbTemplate = null;
+      if (template_id.includes("-")) {
+        const { data } = await hrSupabaseAdmin
+          .from("hr_shift_templates")
+          .select("label, start_time, end_time, break_minutes")
+          .eq("id", template_id)
+          .maybeSingle();
+        dbTemplate = data;
+      }
+      if (dbTemplate) {
+        start_time = dbTemplate.start_time.slice(0, 5);
+        end_time = dbTemplate.end_time.slice(0, 5);
+        break_minutes = dbTemplate.break_minutes;
+        role_type = dbTemplate.label;
+      } else {
+        const template = getTemplate(template_id);
+        if (!template) {
+          return NextResponse.json({ error: `Unknown template_id: ${template_id}` }, { status: 400 });
+        }
+        start_time = template.start_time;
+        end_time = template.end_time;
+        break_minutes = template.break_minutes;
+        role_type = template.label;
+      }
+    }
+    newShift = {
+      schedule_id: schedule.id, user_id, shift_date,
+      start_time, end_time, role_type, break_minutes,
+      is_ai_assigned: false, notes: template_id,
+    };
+  }
+
+  // NON-DESTRUCTIVE REPLACE. Insert the new shift FIRST so the existing one
+  // survives if the insert fails — a failed edit must never destroy the old
+  // value, which was the root cause of vanishing rosters (delete-then-insert
+  // with a swallowed error left the cell empty). Only after the new row is
+  // safely stored do we remove any prior shift for this same cell.
+  const { data: inserted, error: insErr } = await hrSupabaseAdmin
+    .from("hr_schedule_shifts")
+    .insert(newShift)
+    .select()
+    .single();
+  if (insErr) return NextResponse.json({ error: insErr.message }, { status: 500 });
+
+  const { error: delErr } = await hrSupabaseAdmin
     .from("hr_schedule_shifts")
     .delete()
     .eq("schedule_id", schedule.id)
     .eq("user_id", user_id)
-    .eq("shift_date", shift_date);
+    .eq("shift_date", shift_date)
+    .neq("id", inserted.id);
+  // A failed cleanup leaves a harmless duplicate (grid keys by user:date), never
+  // data loss — so it isn't fatal, but surface it so it doesn't hide.
+  if (delErr) console.error("[schedules/cell] replace-cleanup failed:", delErr.message);
 
-  // Clear = just delete, done
-  if (!template_id) {
-    return NextResponse.json({ success: true, cleared: true });
-  }
-
-  // Rest day = mark with special notes (no shift times stored — we just leave cell empty with rest flag)
-  if (template_id === REST_DAY_ID) {
-    // We represent rest day by inserting a shift with a distinctive notes marker,
-    // start=end=00:00 and role_type="Rest Day"
-    const { data, error } = await hrSupabaseAdmin
-      .from("hr_schedule_shifts")
-      .insert({
-        schedule_id: schedule.id,
-        user_id,
-        shift_date,
-        start_time: "00:00",
-        end_time: "00:00",
-        role_type: "Rest Day",
-        break_minutes: 0,
-        is_ai_assigned: false,
-        notes: "rest_day",
-      })
-      .select()
-      .single();
-    if (error) return NextResponse.json({ error: error.message }, { status: 500 });
-    return NextResponse.json({ shift: data });
-  }
-
-  // Template-based shift
-  let start_time: string;
-  let end_time: string;
-  let break_minutes: number;
-  let role_type: string;
-
-  if (template_id === "custom" && custom) {
-    start_time = custom.start_time;
-    end_time = custom.end_time;
-    break_minutes = custom.break_minutes ?? 30;
-    role_type = custom.label || "Custom";
-  } else {
-    // Try DB template first (UUID), then hardcoded template (string id)
-    let dbTemplate = null;
-    if (template_id.includes("-")) {
-      // Looks like a UUID
-      const { data } = await hrSupabaseAdmin
-        .from("hr_shift_templates")
-        .select("label, start_time, end_time, break_minutes")
-        .eq("id", template_id)
-        .maybeSingle();
-      dbTemplate = data;
-    }
-
-    if (dbTemplate) {
-      start_time = dbTemplate.start_time.slice(0, 5);
-      end_time = dbTemplate.end_time.slice(0, 5);
-      break_minutes = dbTemplate.break_minutes;
-      role_type = dbTemplate.label;
-    } else {
-      const template = getTemplate(template_id);
-      if (!template) {
-        return NextResponse.json({ error: `Unknown template_id: ${template_id}` }, { status: 400 });
-      }
-      start_time = template.start_time;
-      end_time = template.end_time;
-      break_minutes = template.break_minutes;
-      role_type = template.label;
-    }
-  }
-
-  const { data, error } = await hrSupabaseAdmin
-    .from("hr_schedule_shifts")
-    .insert({
-      schedule_id: schedule.id,
-      user_id,
-      shift_date,
-      start_time,
-      end_time,
-      role_type,
-      break_minutes,
-      is_ai_assigned: false,
-      notes: template_id,
-    })
-    .select()
-    .single();
-
-  if (error) return NextResponse.json({ error: error.message }, { status: 500 });
-  return NextResponse.json({ shift: data, schedule });
+  return NextResponse.json({ shift: inserted, schedule });
 }

--- a/supabase/migrations/070_hr_schedule_shift_delete_audit.sql
+++ b/supabase/migrations/070_hr_schedule_shift_delete_audit.sql
@@ -1,0 +1,48 @@
+-- Delete-audit for hr_schedule_shifts.
+--
+-- A manager's Shah Alam roster "vanished" and static analysis could not pin the
+-- exact deleter (deleted rows leave no trace on survivors). This records EVERY
+-- shift deletion with the DB role + client application_name + the full old row,
+-- so the next occurrence is traceable instead of a mystery. Append-only.
+--
+-- SECURITY DEFINER so the audit INSERT always succeeds regardless of which role
+-- issued the delete (never blocks a legitimate delete). Applied via Supabase MCP
+-- 2026-07-03.
+
+CREATE TABLE IF NOT EXISTS hr_schedule_shift_audit (
+  id           bigserial PRIMARY KEY,
+  deleted_at   timestamptz NOT NULL DEFAULT now(),
+  shift_id     uuid,
+  schedule_id  uuid,
+  user_id      text,
+  shift_date   date,
+  start_time   time,
+  end_time     time,
+  role_type    text,
+  db_role      text,
+  app_name     text,
+  old_row      jsonb
+);
+
+ALTER TABLE hr_schedule_shift_audit ENABLE ROW LEVEL SECURITY;
+
+CREATE OR REPLACE FUNCTION audit_hr_schedule_shift_delete()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+BEGIN
+  INSERT INTO hr_schedule_shift_audit
+    (shift_id, schedule_id, user_id, shift_date, start_time, end_time, role_type, db_role, app_name, old_row)
+  VALUES
+    (OLD.id, OLD.schedule_id, OLD.user_id, OLD.shift_date, OLD.start_time, OLD.end_time, OLD.role_type,
+     current_user, current_setting('application_name', true), to_jsonb(OLD));
+  RETURN OLD;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS trg_hr_schedule_shift_delete_audit ON hr_schedule_shifts;
+CREATE TRIGGER trg_hr_schedule_shift_delete_audit
+AFTER DELETE ON hr_schedule_shifts
+FOR EACH ROW EXECUTE FUNCTION audit_hr_schedule_shift_delete();


### PR DESCRIPTION
## The bug (manager: "roster was complete, suddenly gone" — recurring)
Two defects combined into silent roster data loss:

1. **Destructive, non-transactional save.** The cell route deleted the existing shift for a (user, date) cell **before** inserting the replacement. A failed insert (transient error, bad value) left the cell empty — **a failed edit destroyed the old shift**, with nothing to replace it.
2. **Silent frontend.** Every cell save was `await fetch(...)` with **no `response.ok` check** — `fetch` doesn't throw on HTTP errors, so a 500/error was swallowed and the UI carried on as if it saved. Managers believed a roster was saved when it wasn't.

Together: shifts erode/vanish during editing and no one is told. Forensics confirmed the surviving Shah Alam row was untouched since creation and no bulk-delete/cron/AI-fill fired — consistent with saves that never landed or edits that destroyed prior values.

## Fix
- **Cell route → non-destructive replace:** insert the new shift **first**, then remove the prior one only after the new row is safely stored. A failed insert now leaves the existing shift intact. Clear stays an intentional delete.
- **Frontend → surface failures:** check `response.ok`, alert on failure, keep the picker open (no phantom saves).
- **Migration 070 (applied):** `AFTER DELETE` audit trigger on `hr_schedule_shifts` → `hr_schedule_shift_audit` records every deletion with `db_role`, client `app_name`, and the full old row. Any future/unknown delete vector is now traceable.

## Verified
- tsc clean; audit migration applied to prod.
- Honest caveat: the already-lost Shah Alam shifts are not recoverable (they left no trace). This prevents recurrence and makes the next occurrence diagnosable.