### PR TITLE
fix(sales): live dashboard counts QR/app orders when paid, not at close-out

### DIFF
--- a/apps/staff/src/app/api/sales/dashboard/route.ts
+++ b/apps/staff/src/app/api/sales/dashboard/route.ts
@@ -226,12 +226,18 @@ export async function GET(req: NextRequest) {
   for (const r of appRows) {
     if (!isAppSale(r.status)) continue;
     const d = getMYTDateStr(r.created_at);
-    // Same as the POS loop: net `total`, and only COMPLETED orders count toward
-    // revenue/series/breakdowns (pickup/app orders sit in paid/preparing/ready
-    // before completion — backoffice waits for completed, so we do too). Phone
-    // capture + growth splits keep the broader isAppSale base.
+    // QR/app orders count as soon as they're PLACED & PAID — the moment the
+    // customer pays (status paid/preparing/ready/collected/completed), not only
+    // after staff close the ticket. QR-table dine-in tickets sit unclosed for a
+    // median ~15–20 min (tail 1–2h), so gating revenue on `completed` made those
+    // sales surface that late on the live dashboard. `isAppSale` already excludes
+    // pending (unpaid) and cancelled/refunded, so every row here is real, paid
+    // revenue. Trade-off: the headline can lead the completed-only finance/EOD
+    // figure by whatever is still open, and they reconcile once tickets close.
+    // Applied symmetrically to cur/prev so the comparison stays like-for-like.
+    // Phone capture + growth splits use this same base.
     const net = r.total || 0;
-    const counts = (r.status || "").toLowerCase() === "completed";
+    const counts = isAppSale(r.status);
     if (inCur(d)) {
       curAppOrd++;
       // Native = the iOS/Android binary (orders.source app_ios|app_android);


### PR DESCRIPTION
## Why

Owner reported "sales data came in late today." Two Putrajaya **Table-QR** orders rang up at **08:28 / 08:29** (RM26.80 + RM46.60) but didn't move the dashboard's **Today** number until **08:49** — the day's early QR tickets sat open and all flipped to `completed` in one batch ~20 min later.

## Root cause

The staff Sales dashboard gated headline revenue / orders / series / channel & round breakdowns / payment split on `status === 'completed'`. But QR-table dine-in tickets are **placed and paid immediately**, then sit in `paid`/`preparing`/`ready` until staff close them out — a **median ~15–20 min lag** (tail 1–2h, measured across the last week). So paid sales surfaced on the live dashboard that late.

## Change

`apps/staff/src/app/api/sales/dashboard/route.ts` — the app-orders loop now counts an order as soon as it's **placed & paid**, using the `isAppSale` base (`paid`/`preparing`/`ready`/`collected`/`completed`) the loop already filters on. `pending` (unpaid) and cancelled/refunded stay excluded. Applied symmetrically to the current and previous period, so the comparison stays like-for-like.

The till (`pos_orders`) is intentionally **unchanged** — it rings as `completed` at the point of sale, so it has no such lag.

## Impact / safety

- **No retroactive change.** Every paid order eventually completes, so past-day and finance/EOD-reconciled totals don't move — verified equal under old vs new rule across the last 4 days (Jul 1–4).
- Only the **intraday live view** changes: sales now appear the moment they're paid instead of ~20 min later at close-out.
- Trade-off (accepted): the live headline can briefly *lead* the completed-only finance/EOD figure by whatever tickets are still open; they reconcile once closed.

## Verification

- Data-level: confirmed the place→complete lag (median 15.8–20.5 min over Jun 29–Jul 4) and that paid-onward vs completed-only totals are identical for every already-closed day.
- Typecheck could not run in this environment (fresh clone, `node_modules` not installed → module-resolution errors across the whole app); the changed line is type-safe (`isAppSale()` returns `boolean`, already imported and used one line above as the loop guard).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_019opbUfipe1ZojvkmTdTRTD)_