### PR TITLE
feat(finance): recon page rework — tabbed queues, filter + paging, bulk, attachments

### DIFF
--- a/apps/backoffice/src/app/(admin)/finance/recon/page.tsx
+++ b/apps/backoffice/src/app/(admin)/finance/recon/page.tsx
@@ -3,7 +3,7 @@
 import { useState } from "react";
 import { useFetch } from "@/lib/use-fetch";
 import { CONTRA_ACCOUNT } from "@/lib/finance/gl-posting-map";
-import { Loader2, CheckCircle2, AlertTriangle, HelpCircle, Copy, ArrowDownCircle } from "lucide-react";
+import { Loader2, CheckCircle2, AlertTriangle, HelpCircle, Copy, ArrowDownCircle, Paperclip } from "lucide-react";
 
 type ApMatch = {
   invoiceId: string; invoiceNumber: string | null; payee: string; amount: number; issueDate: string;
@@ -58,8 +58,11 @@ function categoryLabel(c: string, accountNames: Map<string, string>): string {
   return code ? `${human} → ${code}${name ? ` ${name}` : ""}` : human;
 }
 
+type ReconTab = "categorise" | "review" | "matched" | "invoices" | "cashin";
+
 export default function ReconPage() {
   const [days, setDays] = useState(90);
+  const [tab, setTab] = useState<ReconTab>("categorise");
   const { data, isLoading, mutate } = useFetch<ReconData>(`/api/finance/ap-match?sinceDays=${days}`);
   const { data: acctData } = useFetch<{ accounts: { code: string; name: string }[] }>("/api/finance/accounts");
   const accountNames = new Map((acctData?.accounts ?? []).map((a) => [a.code, a.name]));
@@ -110,107 +113,110 @@ export default function ReconPage() {
         <div className="mt-6 flex justify-center py-12"><Loader2 className="h-5 w-5 animate-spin text-gray-400" /></div>
       ) : (
         <>
-          {/* Summary tiles — each jumps to its detail section */}
+          {/* Summary tiles — click to jump to that queue */}
           <div className="mt-4 grid grid-cols-2 sm:grid-cols-6 gap-2 sm:gap-3">
-            <Tile icon={<CheckCircle2 className="h-4 w-4 text-green-600" />} label="Auto-matched" value={data.summary.auto} tone="green" targetId="recon-auto" />
-            <Tile icon={<HelpCircle className="h-4 w-4 text-amber-600" />} label="Needs review" value={data.summary.review} tone="amber" targetId="recon-review" />
-            <Tile icon={<Copy className="h-4 w-4 text-red-600" />} label="Double payments" value={data.summary.doublePayments} tone={data.summary.doublePayments ? "red" : "gray"} targetId="recon-double" />
-            <Tile icon={<ArrowDownCircle className="h-4 w-4 text-gray-500" />} label="Unmatched out" value={data.summary.unmatchedOutflows} sub={fmtRM0(data.summary.unmatchedOutflowValue)} tone="gray" targetId="recon-unmatched-out" />
-            <Tile icon={<ArrowDownCircle className="h-4 w-4 rotate-180 text-gray-500" />} label="Unmatched in" value={data.summary.unmatchedInflows} sub={fmtRM0(data.summary.unmatchedInflowValue)} tone="gray" targetId="recon-unmatched-in" />
-            <Tile icon={<AlertTriangle className="h-4 w-4 text-gray-500" />} label="Open invoices, no payment" value={data.summary.unmatchedInvoices} tone="gray" targetId="recon-open-invoices" />
+            <Tile icon={<ArrowDownCircle className="h-4 w-4 text-gray-500" />} label="Unmatched out" value={data.summary.unmatchedOutflows} sub={fmtRM0(data.summary.unmatchedOutflowValue)} tone="gray" onClick={() => setTab("categorise")} active={tab === "categorise"} />
+            <Tile icon={<ArrowDownCircle className="h-4 w-4 rotate-180 text-gray-500" />} label="Unmatched in" value={data.summary.unmatchedInflows} sub={fmtRM0(data.summary.unmatchedInflowValue)} tone="gray" onClick={() => setTab("categorise")} active={tab === "categorise"} />
+            <Tile icon={<HelpCircle className="h-4 w-4 text-amber-600" />} label="Needs review" value={data.summary.review} tone="amber" onClick={() => setTab("review")} active={tab === "review"} />
+            <Tile icon={<Copy className="h-4 w-4 text-red-600" />} label="Double payments" value={data.summary.doublePayments} tone={data.summary.doublePayments ? "red" : "gray"} onClick={() => setTab("review")} active={tab === "review"} />
+            <Tile icon={<CheckCircle2 className="h-4 w-4 text-green-600" />} label="Auto-matched" value={data.summary.auto} tone="green" onClick={() => setTab("review")} active={tab === "review"} />
+            <Tile icon={<AlertTriangle className="h-4 w-4 text-gray-500" />} label="Open invoices" value={data.summary.unmatchedInvoices} tone="gray" onClick={() => setTab("invoices")} active={tab === "invoices"} />
           </div>
 
-          {/* CASH-IN: sales rung up vs settlements received */}
-          <Section title={`Cash-in — sales vs settlements (${data.cashIn.from} → ${data.cashIn.to})`} desc="What the POS rang up vs what landed in the bank. The gap is fees + platform commission + cash-not-banked + settlement timing.">
-            <div className="grid grid-cols-3 gap-3 px-4 py-3">
-              <div><p className="text-[11px] text-gray-500">Sales rung up</p><p className="font-mono text-sm font-semibold text-gray-900">{fmtRM(data.cashIn.salesGross)}</p></div>
-              <div><p className="text-[11px] text-gray-500">Settled to bank</p><p className="font-mono text-sm font-semibold text-gray-900">{fmtRM(data.cashIn.settlementsTotal)}</p></div>
-              <div><p className="text-[11px] text-gray-500">Gap</p><p className={`font-mono text-sm font-semibold ${Math.abs(data.cashIn.gapPct ?? 0) > 12 ? "text-red-600" : "text-amber-600"}`}>{fmtRM(data.cashIn.gap)}{data.cashIn.gapPct != null && <span className="text-[11px] font-normal text-gray-400"> ({data.cashIn.gapPct}%)</span>}</p></div>
-            </div>
-            <div className="overflow-x-auto border-t border-gray-100">
-              <table className="w-full min-w-[480px] text-sm">
-                <thead><tr className="border-b bg-gray-50/50 text-left text-gray-500">
-                  <th className="px-3 py-2 font-medium">Channel</th><th className="px-3 py-2 text-right font-medium">Settled</th><th className="px-3 py-2 text-right font-medium">Txns</th>
-                </tr></thead>
-                <tbody className="divide-y">
-                  {data.cashIn.settlementsByChannel.map((c) => (
-                    <tr key={c.channel} className="hover:bg-gray-50">
-                      <td className="px-3 py-1.5 text-xs text-gray-700">{c.channel}</td>
-                      <td className="px-3 py-1.5 text-right font-mono text-xs text-green-700">+{fmtRM(c.amount)}</td>
-                      <td className="px-3 py-1.5 text-right text-[11px] text-gray-400">{c.n}</td>
-                    </tr>
-                  ))}
-                </tbody>
-              </table>
-            </div>
-            {data.cashIn.grab.deductionPct != null && (
-              <p className={`border-t border-gray-100 px-4 py-2 text-[11px] ${data.cashIn.grab.deductionPct > 45 ? "text-red-600" : "text-gray-500"}`}>
-                Grab: gross {fmtRM(data.cashIn.grab.gross)} vs settled {fmtRM(data.cashIn.grab.settled)} → <strong>{data.cashIn.grab.deductionPct}% deducted</strong> at source (commission + promos + timing){data.cashIn.grab.deductionPct > 45 ? " — high, review" : ""}.
-              </p>
-            )}
-          </Section>
-
-          {data.doublePayments.length > 0 && (
-            <Section id="recon-double" title="⚠ Possible double payments" desc="Invoice already settled but another bank payment matches it.">
-              <MatchTable rows={data.doublePayments} />
-            </Section>
-          )}
-
-          <Section id="recon-auto" title="Auto-matched (high confidence)" desc="Amount-exact + payee name + date. The loop clears these and re-tags the bank line to COGS.">
-            <MatchTable rows={data.auto} />
-          </Section>
-
-          <Section id="recon-review" title="Needs review" desc="Likely matches that aren't certain enough to auto-clear. Confirm applies the match (links the line, marks the invoice paid unless it was settled elsewhere); Reject dismisses it for good.">
-            <MatchTable rows={data.review} showReasons actionable onDone={() => mutate()} />
-          </Section>
-
-          <Section id="recon-matched" title="Matched lines — review applied matches" desc="Everything the matcher (or you) has linked to an invoice, newest first. If one looks wrong, Unmatch reverses it: the link is removed, the invoice's paid status is reverted only if this match is what paid it, and the pair never auto-matches again.">
-            <MatchedTable />
-          </Section>
-
-          <Section id="recon-unmatched-out" title="Unmatched outflows — unreconciled cash-out" desc="Bank payments with no matching invoice yet. Reconcile manually: pick a category (books it to that expense) or match it to its invoice.">
-            <div className="flex items-center gap-2 border-b border-gray-100 px-4 py-2">
-              <button
-                onClick={rerunRules}
-                disabled={reclassifying}
-                className="rounded-md border border-gray-200 bg-white px-2.5 py-1 text-xs font-medium text-gray-700 hover:bg-gray-50 disabled:opacity-50"
-              >
-                {reclassifying ? "Re-running rules…" : "Re-run classifier rules"}
+          {/* Queue switcher — one focused table at a time */}
+          <nav className="mt-4 flex flex-wrap gap-1 border-b border-gray-200">
+            {([
+              ["categorise", "To categorise", data.summary.unmatchedOutflows + data.summary.unmatchedInflows],
+              ["review", "To review", data.summary.review + data.summary.doublePayments],
+              ["matched", "Matched", null],
+              ["invoices", "Open invoices", data.summary.unmatchedInvoices],
+              ["cashin", "Cash-in", null],
+            ] as [ReconTab, string, number | null][]).map(([id, label, count]) => (
+              <button key={id} onClick={() => setTab(id)}
+                className={`-mb-px whitespace-nowrap border-b-2 px-3 py-2 text-sm transition-colors ${tab === id ? "border-terracotta font-medium text-gray-900" : "border-transparent text-gray-500 hover:text-gray-800"}`}>
+                {label}{count != null && count > 0 ? <span className="ml-1.5 rounded-full bg-gray-100 px-1.5 text-[10px] text-gray-500">{count}</span> : null}
               </button>
-              <span className="text-[11px] text-gray-400">
-                {reclassNote ?? "Applies the current rules to this pile first — most known payees clear automatically."}
-              </span>
-            </div>
-            <UnmatchedTable rows={data.unmatchedOutflows} direction="DR" categories={OUTFLOW_CATEGORIES} accountNames={accountNames} onDone={() => mutate()} />
-          </Section>
+            ))}
+          </nav>
 
-          <Section id="recon-unmatched-in" title="Unmatched inflows — unreconciled cash-in" desc="Money that arrived with no recognised source. Pick the category it belongs to — sales settlements clear their debtor; loans/capital book to the balance sheet.">
-            <UnmatchedTable rows={data.unmatchedInflows} direction="CR" categories={INFLOW_CATEGORIES} accountNames={accountNames} onDone={() => mutate()} />
-          </Section>
+          <div className="mt-4">
+            {tab === "categorise" && (
+              <div className="space-y-4">
+                <QueueCard title="Unmatched outflows — cash out" desc="Bank payments with no matching invoice yet. Book a category, match to an invoice, or attach a receipt.">
+                  <div className="flex flex-wrap items-center gap-2 border-b border-gray-100 px-4 py-2">
+                    <button onClick={rerunRules} disabled={reclassifying}
+                      className="rounded-md border border-gray-200 bg-white px-2.5 py-1 text-xs font-medium text-gray-700 hover:bg-gray-50 disabled:opacity-50">
+                      {reclassifying ? "Re-running rules…" : "Re-run classifier rules"}
+                    </button>
+                    <span className="text-[11px] text-gray-400">{reclassNote ?? "Applies current rules first — known payees clear automatically."}</span>
+                  </div>
+                  <UnmatchedTable rows={data.unmatchedOutflows} direction="DR" categories={OUTFLOW_CATEGORIES} accountNames={accountNames} onDone={() => mutate()} />
+                </QueueCard>
+                <QueueCard title="Unmatched inflows — cash in" desc="Money in with no recognised source. Sales settlements clear their debtor; loans/capital book to the balance sheet.">
+                  <UnmatchedTable rows={data.unmatchedInflows} direction="CR" categories={INFLOW_CATEGORIES} accountNames={accountNames} onDone={() => mutate()} />
+                </QueueCard>
+              </div>
+            )}
 
-          <Section id="recon-open-invoices" title="Open invoices — no payment found" desc="Procurement invoices with no matching bank payment yet. Either unpaid, or paid via an outflow we haven't matched.">
-            <div className="overflow-x-auto">
-              <table className="w-full min-w-[560px] text-sm">
-                <thead><tr className="border-b bg-gray-50/50 text-left text-gray-500">
-                  <th className="px-3 py-2 font-medium">Payee</th><th className="px-3 py-2 font-medium">Invoice</th>
-                  <th className="px-3 py-2 font-medium">Issued</th><th className="px-3 py-2 text-right font-medium">Amount</th>
-                </tr></thead>
-                <tbody className="divide-y">
-                  {data.unmatchedInvoices.length === 0 ? (
-                    <tr><td colSpan={4} className="px-4 py-4 text-xs text-gray-400">Nothing here.</td></tr>
-                  ) : data.unmatchedInvoices.slice(0, 100).map((inv) => (
-                    <tr key={inv.invoiceId} className="hover:bg-gray-50">
-                      <td className="px-3 py-2 text-xs text-gray-700">{inv.payee}</td>
-                      <td className="px-3 py-2 text-[11px] text-gray-400">{inv.invoiceNumber ?? "—"}</td>
-                      <td className="px-3 py-2 text-xs text-gray-500 whitespace-nowrap">{inv.issueDate}</td>
-                      <td className="px-3 py-2 text-right font-mono text-xs text-gray-700">{fmtRM(inv.amount)}</td>
-                    </tr>
-                  ))}
-                </tbody>
-              </table>
-              {data.unmatchedInvoices.length > 100 && <p className="px-3 py-2 text-[11px] text-gray-400">Showing top 100 of {data.unmatchedInvoices.length}.</p>}
-            </div>
-          </Section>
+            {tab === "review" && (
+              <div className="space-y-4">
+                {data.doublePayments.length > 0 && (
+                  <QueueCard title="⚠ Possible double payments" desc="Invoice already settled but another bank payment matches it.">
+                    <MatchTable rows={data.doublePayments} />
+                  </QueueCard>
+                )}
+                <QueueCard title="Needs review" desc="Likely matches not certain enough to auto-clear. Confirm links the line and marks the invoice paid (unless settled elsewhere); Reject dismisses it for good. Select rows for bulk.">
+                  <MatchTable rows={data.review} showReasons actionable onDone={() => mutate()} />
+                </QueueCard>
+                <QueueCard title="Auto-matched (high confidence)" desc="Amount-exact + payee name + date. The loop already cleared these and re-tagged the bank line to COGS.">
+                  <MatchTable rows={data.auto} />
+                </QueueCard>
+              </div>
+            )}
+
+            {tab === "matched" && (
+              <QueueCard title="Matched lines" desc="Everything linked to an invoice, newest first. Unmatch reverses it: link removed, invoice paid-status reverted only if this match paid it, and the pair never auto-matches again.">
+                <MatchedTable />
+              </QueueCard>
+            )}
+
+            {tab === "invoices" && (
+              <QueueCard title="Open invoices — no payment found" desc="Procurement invoices with no matching bank payment yet. Either unpaid, or paid via an outflow not matched.">
+                <OpenInvoicesTable rows={data.unmatchedInvoices} />
+              </QueueCard>
+            )}
+
+            {tab === "cashin" && (
+              <QueueCard title={`Cash-in — sales vs settlements (${data.cashIn.from} → ${data.cashIn.to})`} desc="What the POS rang up vs what landed in the bank. The gap is fees + platform commission + cash-not-banked + settlement timing.">
+                <div className="grid grid-cols-3 gap-3 px-4 py-3">
+                  <div><p className="text-[11px] text-gray-500">Sales rung up</p><p className="font-mono text-sm font-semibold text-gray-900">{fmtRM(data.cashIn.salesGross)}</p></div>
+                  <div><p className="text-[11px] text-gray-500">Settled to bank</p><p className="font-mono text-sm font-semibold text-gray-900">{fmtRM(data.cashIn.settlementsTotal)}</p></div>
+                  <div><p className="text-[11px] text-gray-500">Gap</p><p className={`font-mono text-sm font-semibold ${Math.abs(data.cashIn.gapPct ?? 0) > 12 ? "text-red-600" : "text-amber-600"}`}>{fmtRM(data.cashIn.gap)}{data.cashIn.gapPct != null && <span className="text-[11px] font-normal text-gray-400"> ({data.cashIn.gapPct}%)</span>}</p></div>
+                </div>
+                <div className="overflow-x-auto border-t border-gray-100">
+                  <table className="w-full min-w-[480px] text-sm">
+                    <thead><tr className="border-b bg-gray-50/50 text-left text-gray-500">
+                      <th className="px-3 py-2 font-medium">Channel</th><th className="px-3 py-2 text-right font-medium">Settled</th><th className="px-3 py-2 text-right font-medium">Txns</th>
+                    </tr></thead>
+                    <tbody className="divide-y">
+                      {data.cashIn.settlementsByChannel.map((c) => (
+                        <tr key={c.channel} className="hover:bg-gray-50">
+                          <td className="px-3 py-1.5 text-xs text-gray-700">{c.channel}</td>
+                          <td className="px-3 py-1.5 text-right font-mono text-xs text-green-700">+{fmtRM(c.amount)}</td>
+                          <td className="px-3 py-1.5 text-right text-[11px] text-gray-400">{c.n}</td>
+                        </tr>
+                      ))}
+                    </tbody>
+                  </table>
+                </div>
+                {data.cashIn.grab.deductionPct != null && (
+                  <p className={`border-t border-gray-100 px-4 py-2 text-[11px] ${data.cashIn.grab.deductionPct > 45 ? "text-red-600" : "text-gray-500"}`}>
+                    Grab: gross {fmtRM(data.cashIn.grab.gross)} vs settled {fmtRM(data.cashIn.grab.settled)} → <strong>{data.cashIn.grab.deductionPct}% deducted</strong> at source (commission + promos + timing){data.cashIn.grab.deductionPct > 45 ? " — high, review" : ""}.
+                  </p>
+                )}
+              </QueueCard>
+            )}
+          </div>
         </>
       )}
     </div>
@@ -234,6 +240,7 @@ function UnmatchedTable({ rows, direction, categories, accountNames, onDone }: {
   const [busy, setBusy] = useState(false);
   const [note, setNote] = useState<string | null>(null);
   const [q, setQ] = useState("");
+  const [pageSize, setPageSize] = useState<number>(50);
   const t = q.trim().toLowerCase();
   const filtered = t
     ? rows.filter((r) =>
@@ -241,7 +248,7 @@ function UnmatchedTable({ rows, direction, categories, accountNames, onDone }: {
         r.date.includes(t) ||
         String(Math.abs(r.amount)).includes(t.replace(/,/g, "")))
     : rows;
-  const visible = filtered.slice(0, 100);
+  const visible = filtered.slice(0, pageSize);
   // Select-all covers every filtered match, beyond the visible page — the
   // bulk call chunks itself to the endpoint's 200-line cap.
   const allSelected = filtered.length > 0 && filtered.every((r) => sel.has(r.bankLineId));
@@ -288,6 +295,7 @@ function UnmatchedTable({ rows, direction, categories, accountNames, onDone }: {
         <span className="text-[11px] text-gray-400 tabular-nums">
           {t ? `${filtered.length} of ${rows.length} lines` : `${rows.length} lines`}
         </span>
+        <span className="ml-auto"><RowsPerPage value={pageSize} onChange={setPageSize} total={filtered.length} /></span>
       </div>
       {sel.size > 0 && (
         <div className="flex flex-wrap items-center gap-2 border-b border-terracotta/30 bg-terracotta/5 px-4 py-2">
@@ -322,9 +330,9 @@ function UnmatchedTable({ rows, direction, categories, accountNames, onDone }: {
           ))}
         </tbody>
       </table>
-      {filtered.length > 100 && (
+      {filtered.length > pageSize && (
         <p className="px-3 py-2 text-[11px] text-gray-400">
-          Showing top 100 of {filtered.length} by amount. Select-all selects every match, including the ones not shown.
+          Showing {pageSize} of {filtered.length} by amount. Select-all still selects every match, including rows not shown.
         </p>
       )}
     </div>
@@ -353,6 +361,39 @@ function LineRow({ row, direction, categories, accountNames, selected, onToggle,
   const [note, setNote] = useState<string | null>(null);
   const [open, setOpen] = useState(false);
   const [cands, setCands] = useState<Candidate[] | null>(null);
+  const [attachOpen, setAttachOpen] = useState(false);
+  const [attachments, setAttachments] = useState<{ id: string; filename: string; url: string | null }[] | null>(null);
+  const [uploading, setUploading] = useState(false);
+
+  async function loadAttachments() {
+    try {
+      const res = await fetch(`/api/finance/bank-lines/attach?bankLineId=${row.bankLineId}`);
+      const j = await res.json();
+      setAttachments(res.ok ? j.attachments : []);
+    } catch { setAttachments([]); }
+  }
+  function toggleAttach() {
+    const next = !attachOpen;
+    setAttachOpen(next);
+    if (next && attachments === null) loadAttachments();
+  }
+  async function upload(file: File) {
+    setUploading(true); setNote(null);
+    try {
+      const fd = new FormData();
+      fd.append("file", file);
+      fd.append("bankLineId", row.bankLineId);
+      const res = await fetch("/api/finance/bank-lines/attach", { method: "POST", body: fd });
+      const j = await res.json();
+      if (!res.ok) setNote(j.error ?? `Upload failed (${res.status})`);
+      else await loadAttachments();
+    } catch (e) { setNote(e instanceof Error ? e.message : String(e)); }
+    finally { setUploading(false); }
+  }
+  async function removeAttachment(id: string) {
+    await fetch("/api/finance/bank-lines/attach", { method: "DELETE", headers: { "Content-Type": "application/json" }, body: JSON.stringify({ documentId: id }) });
+    loadAttachments();
+  }
 
   async function setCategory(category: string) {
     if (!category) return;
@@ -428,6 +469,14 @@ function LineRow({ row, direction, categories, accountNames, selected, onToggle,
                 Match…
               </button>
             )}
+            <button
+              onClick={toggleAttach}
+              disabled={busy}
+              title="Attach the invoice or receipt behind this line (needed for bank fees & other non-supplier expenses)"
+              className={`flex h-6 items-center gap-0.5 rounded border px-1.5 text-[11px] font-medium disabled:opacity-50 ${attachOpen ? "border-terracotta text-terracotta" : "border-gray-200 text-gray-600 hover:bg-gray-50"}`}
+            >
+              <Paperclip className="h-3 w-3" />{attachments && attachments.length > 0 ? attachments.length : ""}
+            </button>
           </div>
         </td>
       </tr>
@@ -463,27 +512,42 @@ function LineRow({ row, direction, categories, accountNames, selected, onToggle,
           </td>
         </tr>
       )}
+      {attachOpen && (
+        <tr className="bg-gray-50/60">
+          <td colSpan={6} className="px-3 py-2">
+            <div className="flex flex-col gap-1.5">
+              {attachments === null ? (
+                <span className="text-[11px] text-gray-400">Loading attachments…</span>
+              ) : attachments.length === 0 ? (
+                <span className="text-[11px] text-gray-400">No invoice or receipt attached yet.</span>
+              ) : attachments.map((a) => (
+                <div key={a.id} className="flex items-center gap-2 text-xs">
+                  <Paperclip className="h-3 w-3 text-gray-400" />
+                  {a.url ? <a href={a.url} target="_blank" rel="noreferrer" className="text-terracotta underline">{a.filename}</a> : <span className="text-gray-700">{a.filename}</span>}
+                  <button onClick={() => removeAttachment(a.id)} className="text-[10px] text-gray-400 underline hover:text-gray-600">remove</button>
+                </div>
+              ))}
+              <label className="mt-0.5 inline-flex w-fit cursor-pointer items-center gap-1 rounded border border-dashed border-gray-300 px-2 py-1 text-[11px] text-gray-600 hover:bg-white">
+                {uploading ? <Loader2 className="h-3 w-3 animate-spin" /> : <Paperclip className="h-3 w-3" />}
+                {uploading ? "Uploading…" : "Upload invoice / receipt (PDF or image)"}
+                <input type="file" accept="application/pdf,image/*" className="hidden" disabled={uploading}
+                  onChange={(e) => { const f = e.target.files?.[0]; if (f) upload(f); e.target.value = ""; }} />
+              </label>
+            </div>
+          </td>
+        </tr>
+      )}
     </>
   );
 }
 
-function scrollToSection(id: string) {
-  const el = document.getElementById(id);
-  if (!el) return;
-  el.scrollIntoView({ behavior: "smooth", block: "start" });
-  // brief highlight so it's obvious which section the tile jumped to
-  el.classList.add("ring-2", "ring-terracotta");
-  window.setTimeout(() => el.classList.remove("ring-2", "ring-terracotta"), 1400);
-}
-
-function Tile({ icon, label, value, sub, tone, targetId }: { icon: React.ReactNode; label: string; value: number; sub?: string; tone: "green" | "amber" | "red" | "gray"; targetId?: string }) {
+function Tile({ icon, label, value, sub, tone, onClick, active }: { icon: React.ReactNode; label: string; value: number; sub?: string; tone: "green" | "amber" | "red" | "gray"; onClick: () => void; active?: boolean }) {
   const ring = tone === "green" ? "border-green-200" : tone === "amber" ? "border-amber-200" : tone === "red" ? "border-red-200" : "border-gray-200";
   return (
     <button
       type="button"
-      onClick={() => targetId && scrollToSection(targetId)}
-      disabled={!targetId}
-      className={`rounded-lg border ${ring} bg-white px-3 py-2.5 text-left transition-shadow ${targetId ? "cursor-pointer hover:shadow-md hover:border-terracotta/40 focus:outline-none focus:ring-2 focus:ring-terracotta/40" : ""}`}
+      onClick={onClick}
+      className={`rounded-lg border bg-white px-3 py-2.5 text-left transition-shadow cursor-pointer hover:shadow-md focus:outline-none focus:ring-2 focus:ring-terracotta/40 ${active ? "border-terracotta ring-1 ring-terracotta/30" : `${ring} hover:border-terracotta/40`}`}
     >
       <div className="flex items-center gap-1.5 text-xs text-gray-500">{icon}{label}</div>
       <p className="mt-0.5 text-lg font-bold text-gray-900">{value}</p>
@@ -492,14 +556,67 @@ function Tile({ icon, label, value, sub, tone, targetId }: { icon: React.ReactNo
   );
 }
 
-function Section({ id, title, desc, children }: { id?: string; title: string; desc: string; children: React.ReactNode }) {
+function QueueCard({ title, desc, children }: { title: string; desc: string; children: React.ReactNode }) {
   return (
-    <div id={id} className="mt-4 scroll-mt-4 rounded-xl border border-gray-200 bg-white transition-all">
+    <div className="rounded-xl border border-gray-200 bg-white">
       <div className="border-b border-gray-100 px-4 py-2.5">
         <p className="text-xs font-semibold uppercase tracking-wide text-gray-500">{title}</p>
         <p className="mt-0.5 text-[11px] text-gray-400">{desc}</p>
       </div>
       {children}
+    </div>
+  );
+}
+
+// Rows-per-page selector shared by the queues — "cannot increase/decrease" fix.
+const PAGE_SIZES = [25, 50, 100] as const;
+function RowsPerPage({ value, onChange, total }: { value: number; onChange: (n: number) => void; total: number }) {
+  return (
+    <span className="flex items-center gap-1 text-[11px] text-gray-400">
+      Rows
+      <select value={value === Infinity ? "all" : value} onChange={(e) => onChange(e.target.value === "all" ? Infinity : Number(e.target.value))}
+        className="h-6 rounded border border-gray-200 bg-white px-1 text-[11px] text-gray-600">
+        {PAGE_SIZES.map((n) => <option key={n} value={n}>{n}</option>)}
+        <option value="all">All</option>
+      </select>
+      <span className="tabular-nums">of {total}</span>
+    </span>
+  );
+}
+
+// Open invoices with search + rows-per-page.
+function OpenInvoicesTable({ rows }: { rows: { invoiceId: string; invoiceNumber: string | null; payee: string; amount: number; issueDate: string }[] }) {
+  const [q, setQ] = useState("");
+  const [pageSize, setPageSize] = useState<number>(50);
+  const t = q.trim().toLowerCase();
+  const filtered = t ? rows.filter((r) => r.payee.toLowerCase().includes(t) || (r.invoiceNumber ?? "").toLowerCase().includes(t) || String(r.amount).includes(t) || r.issueDate.includes(t)) : rows;
+  const visible = filtered.slice(0, pageSize);
+  return (
+    <div className="overflow-x-auto">
+      <div className="flex flex-wrap items-center gap-2 border-b border-gray-100 px-4 py-2">
+        <input value={q} onChange={(e) => setQ(e.target.value)} placeholder="Search payee, invoice no, amount…" className="h-7 w-64 rounded border border-gray-200 bg-white px-2 text-xs text-gray-700" />
+        <span className="text-[11px] text-gray-400 tabular-nums">{t ? `${filtered.length} of ${rows.length}` : `${rows.length} invoices`}</span>
+        <span className="ml-auto"><RowsPerPage value={pageSize} onChange={setPageSize} total={filtered.length} /></span>
+      </div>
+      <table className="w-full min-w-[560px] text-sm">
+        <thead><tr className="border-b bg-gray-50/50 text-left text-gray-500">
+          <th className="px-3 py-2 font-medium">Payee</th><th className="px-3 py-2 font-medium">Invoice</th>
+          <th className="px-3 py-2 font-medium">Issued</th><th className="px-3 py-2 text-right font-medium">Amount</th>
+        </tr></thead>
+        <tbody className="divide-y">
+          {visible.length === 0 ? (
+            <tr><td colSpan={4} className="px-4 py-4 text-xs text-gray-400">{t ? "No invoices match the search." : "Nothing here."}</td></tr>
+          ) : visible.map((inv) => (
+            <tr key={inv.invoiceId} className="hover:bg-gray-50">
+              <td className="px-3 py-2 text-xs text-gray-700">{inv.payee}</td>
+              <td className="px-3 py-2 text-[11px] text-gray-400">{inv.invoiceNumber ?? "—"}</td>
+              <td className="px-3 py-2 text-xs text-gray-500 whitespace-nowrap">{inv.issueDate}</td>
+              <td className="px-3 py-2 text-right font-mono text-xs text-gray-700">{fmtRM(inv.amount)}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+      {filtered.length > pageSize && <p className="px-3 py-2 text-[11px] text-gray-400">Showing {pageSize} of {filtered.length}. Increase rows above to see more.</p>}
     </div>
   );
 }
@@ -532,13 +649,20 @@ function MatchTable({ rows, showReasons, actionable, onDone }: { rows: ApMatch[]
   const [sel, setSel] = useState<Set<string>>(new Set());
   const [bulkBusy, setBulkBusy] = useState(false);
   const [bulkNote, setBulkNote] = useState<string | null>(null);
+  const [q, setQ] = useState("");
+  const [pageSize, setPageSize] = useState<number>(50);
 
-  const allSelected = rows.length > 0 && rows.every((m) => sel.has(matchKey(m)));
+  const t = q.trim().toLowerCase();
+  const filtered = t
+    ? rows.filter((m) => m.payee.toLowerCase().includes(t) || (m.invoiceNumber ?? "").toLowerCase().includes(t) || m.bankDesc.toLowerCase().includes(t) || String(m.amount).includes(t) || m.bankDate.includes(t))
+    : rows;
+  const visible = filtered.slice(0, pageSize);
+  const allSelected = filtered.length > 0 && filtered.every((m) => sel.has(matchKey(m)));
   function toggle(key: string) {
-    setSel((s) => { const n = new Set(s); n.has(key) ? n.delete(key) : n.add(key); return n; });
+    setSel((s) => { const n = new Set(s); if (n.has(key)) n.delete(key); else n.add(key); return n; });
   }
   function toggleAll() {
-    setSel(allSelected ? new Set() : new Set(rows.map(matchKey)));
+    setSel(allSelected ? new Set() : new Set(filtered.map(matchKey)));
   }
 
   async function act(m: ApMatch, action: "confirm" | "reject") {
@@ -571,6 +695,11 @@ function MatchTable({ rows, showReasons, actionable, onDone }: { rows: ApMatch[]
   if (rows.length === 0) return <p className="px-4 py-4 text-xs text-gray-400">Nothing here.</p>;
   return (
     <div className="overflow-x-auto">
+      <div className="flex flex-wrap items-center gap-2 border-b border-gray-100 px-4 py-2">
+        <input value={q} onChange={(e) => setQ(e.target.value)} placeholder="Search payee, bank line, amount…" className="h-7 w-64 rounded border border-gray-200 bg-white px-2 text-xs text-gray-700" />
+        <span className="text-[11px] text-gray-400 tabular-nums">{t ? `${filtered.length} of ${rows.length}` : `${rows.length} rows`}</span>
+        <span className="ml-auto"><RowsPerPage value={pageSize} onChange={setPageSize} total={filtered.length} /></span>
+      </div>
       {actionable && sel.size > 0 && (
         <div className="flex flex-wrap items-center gap-2 border-b border-terracotta/30 bg-terracotta/5 px-4 py-2">
           <span className="text-xs font-medium text-gray-700">{sel.size} selected</span>
@@ -596,7 +725,7 @@ function MatchTable({ rows, showReasons, actionable, onDone }: { rows: ApMatch[]
           {actionable && <th className="px-3 py-2 font-medium">Decide</th>}
         </tr></thead>
         <tbody className="divide-y">
-          {rows.map((m) => {
+          {visible.map((m) => {
             const key = matchKey(m);
             return (
             <tr key={key} className={`hover:bg-gray-50 ${sel.has(key) ? "bg-terracotta/5" : ""}`}>
@@ -628,6 +757,7 @@ function MatchTable({ rows, showReasons, actionable, onDone }: { rows: ApMatch[]
           );})}
         </tbody>
       </table>
+      {filtered.length > pageSize && <p className="px-3 py-2 text-[11px] text-gray-400">Showing {pageSize} of {filtered.length}. Increase rows above to see more.</p>}
     </div>
   );
 }
@@ -642,8 +772,9 @@ type MatchedRow = {
 
 function MatchedTable() {
   const [q, setQ] = useState("");
+  const [limit, setLimit] = useState<number>(50);
   const { data, mutate } = useFetch<{ total: number; rows: MatchedRow[] }>(
-    `/api/finance/bank-lines/matched?q=${encodeURIComponent(q)}&limit=100`
+    `/api/finance/bank-lines/matched?q=${encodeURIComponent(q)}&limit=${limit === Infinity ? 300 : limit}`
   );
   const [busy, setBusy] = useState<string | null>(null);
   const [note, setNote] = useState<string | null>(null);
@@ -672,6 +803,7 @@ function MatchedTable() {
           className="h-7 w-72 rounded border border-gray-200 bg-white px-2 text-xs text-gray-700" />
         {data && <span className="text-[11px] text-gray-400 tabular-nums">{data.rows.length} shown · {data.total} matched in total</span>}
         {note && <span className="text-[11px] text-gray-500">{note}</span>}
+        <span className="ml-auto"><RowsPerPage value={limit} onChange={setLimit} total={data?.total ?? 0} /></span>
       </div>
       {!data ? <p className="px-4 py-4 text-xs text-gray-400">Loading…</p> : data.rows.length === 0 ? (
         <p className="px-4 py-4 text-xs text-gray-400">{q ? "No matches for the search." : "Nothing matched yet."}</p>

--- a/apps/backoffice/src/app/(admin)/finance/recon/page.tsx
+++ b/apps/backoffice/src/app/(admin)/finance/recon/page.tsx
@@ -504,36 +504,92 @@ function Section({ id, title, desc, children }: { id?: string; title: string; de
   );
 }
 
+const matchKey = (m: ApMatch) => m.invoiceId + m.bankLineId;
+
+async function applyMatchAction(m: ApMatch, action: "confirm" | "reject"): Promise<string | null> {
+  // Returns an error string, or null on success.
+  try {
+    const res = action === "confirm"
+      ? await fetch("/api/finance/bank-lines/match", {
+          method: "POST", headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ bankLineId: m.bankLineId, invoiceId: m.invoiceId }),
+        })
+      : await fetch("/api/finance/bank-lines/reject-match", {
+          method: "POST", headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ bankLineId: m.bankLineId, invoiceId: m.invoiceId }),
+        });
+    if (res.ok) return null;
+    const j = await res.json().catch(() => ({}));
+    return j.error ?? `Failed (${res.status})`;
+  } catch (e) {
+    return e instanceof Error ? e.message : String(e);
+  }
+}
+
 function MatchTable({ rows, showReasons, actionable, onDone }: { rows: ApMatch[]; showReasons?: boolean; actionable?: boolean; onDone?: () => void }) {
   const [busy, setBusy] = useState<string | null>(null); // key of the row being acted on
   const [notes, setNotes] = useState<Record<string, string>>({});
+  const [sel, setSel] = useState<Set<string>>(new Set());
+  const [bulkBusy, setBulkBusy] = useState(false);
+  const [bulkNote, setBulkNote] = useState<string | null>(null);
+
+  const allSelected = rows.length > 0 && rows.every((m) => sel.has(matchKey(m)));
+  function toggle(key: string) {
+    setSel((s) => { const n = new Set(s); n.has(key) ? n.delete(key) : n.add(key); return n; });
+  }
+  function toggleAll() {
+    setSel(allSelected ? new Set() : new Set(rows.map(matchKey)));
+  }
 
   async function act(m: ApMatch, action: "confirm" | "reject") {
-    const key = m.invoiceId + m.bankLineId;
+    const key = matchKey(m);
     setBusy(key);
-    try {
-      const res = action === "confirm"
-        ? await fetch("/api/finance/bank-lines/match", {
-            method: "POST", headers: { "Content-Type": "application/json" },
-            body: JSON.stringify({ bankLineId: m.bankLineId, invoiceId: m.invoiceId }),
-          })
-        : await fetch("/api/finance/bank-lines/reject-match", {
-            method: "POST", headers: { "Content-Type": "application/json" },
-            body: JSON.stringify({ bankLineId: m.bankLineId, invoiceId: m.invoiceId }),
-          });
-      const j = await res.json();
-      if (!res.ok) setNotes((n) => ({ ...n, [key]: j.error ?? `Failed (${res.status})` }));
-      else onDone?.();
-    } catch (e) {
-      setNotes((n) => ({ ...n, [key]: e instanceof Error ? e.message : String(e) }));
-    } finally { setBusy(null); }
+    const err = await applyMatchAction(m, action);
+    if (err) setNotes((n) => ({ ...n, [key]: err }));
+    else onDone?.();
+    setBusy(null);
+  }
+
+  // Bulk: apply the action to every selected row (sequentially, each is its own
+  // idempotent call), then refresh once. Failures are counted, not fatal.
+  async function bulk(action: "confirm" | "reject") {
+    if (sel.size === 0) return;
+    setBulkBusy(true); setBulkNote(null);
+    const targets = rows.filter((m) => sel.has(matchKey(m)));
+    let ok = 0, failed = 0;
+    for (const m of targets) {
+      const err = await applyMatchAction(m, action);
+      if (err) { failed++; setNotes((n) => ({ ...n, [matchKey(m)]: err })); }
+      else ok++;
+    }
+    setBulkNote(`${action === "confirm" ? "Confirmed" : "Rejected"} ${ok}${failed ? `, ${failed} failed` : ""}.`);
+    setSel(new Set());
+    setBulkBusy(false);
+    onDone?.();
   }
 
   if (rows.length === 0) return <p className="px-4 py-4 text-xs text-gray-400">Nothing here.</p>;
   return (
     <div className="overflow-x-auto">
+      {actionable && sel.size > 0 && (
+        <div className="flex flex-wrap items-center gap-2 border-b border-terracotta/30 bg-terracotta/5 px-4 py-2">
+          <span className="text-xs font-medium text-gray-700">{sel.size} selected</span>
+          <button onClick={() => bulk("confirm")} disabled={bulkBusy}
+            className="rounded border border-green-600/30 bg-green-50 px-2.5 py-1 text-xs font-medium text-green-700 hover:bg-green-100 disabled:opacity-50">
+            Confirm selected
+          </button>
+          <button onClick={() => bulk("reject")} disabled={bulkBusy}
+            className="rounded border border-gray-200 bg-white px-2.5 py-1 text-xs text-gray-600 hover:bg-gray-50 disabled:opacity-50">
+            Reject selected
+          </button>
+          <button onClick={() => setSel(new Set())} disabled={bulkBusy} className="text-[11px] text-gray-500 underline">clear</button>
+          {bulkBusy && <Loader2 className="h-3.5 w-3.5 animate-spin text-gray-400" />}
+        </div>
+      )}
+      {bulkNote && <p className="border-b border-gray-100 px-4 py-1.5 text-[11px] text-gray-500">{bulkNote}</p>}
       <table className="w-full min-w-[720px] text-sm">
         <thead><tr className="border-b bg-gray-50/50 text-left text-gray-500">
+          {actionable && <th className="w-8 px-3 py-2"><input type="checkbox" checked={allSelected} onChange={toggleAll} className="h-3.5 w-3.5 accent-terracotta" /></th>}
           <th className="px-3 py-2 font-medium">Invoice payee</th><th className="px-3 py-2 text-right font-medium">Amount</th>
           <th className="px-3 py-2 font-medium">Bank line</th><th className="px-3 py-2 font-medium">Category</th>
           <th className="px-3 py-2 text-right font-medium">Score</th>{showReasons && <th className="px-3 py-2 font-medium">Why</th>}
@@ -541,9 +597,10 @@ function MatchTable({ rows, showReasons, actionable, onDone }: { rows: ApMatch[]
         </tr></thead>
         <tbody className="divide-y">
           {rows.map((m) => {
-            const key = m.invoiceId + m.bankLineId;
+            const key = matchKey(m);
             return (
-            <tr key={key} className="hover:bg-gray-50">
+            <tr key={key} className={`hover:bg-gray-50 ${sel.has(key) ? "bg-terracotta/5" : ""}`}>
+              {actionable && <td className="px-3 py-2"><input type="checkbox" checked={sel.has(key)} onChange={() => toggle(key)} className="h-3.5 w-3.5 accent-terracotta" /></td>}
               <td className="px-3 py-2 text-xs text-gray-700">{m.payee}{m.invoiceNumber ? <span className="text-gray-400"> · {m.invoiceNumber}</span> : ""}<div className="text-[10px] text-gray-400">{m.issueDate}</div></td>
               <td className="px-3 py-2 text-right font-mono text-xs text-gray-700">{fmtRM(m.amount)}</td>
               <td className="px-3 py-2 text-xs text-gray-600">{m.bankDesc}<div className="text-[10px] text-gray-400">{m.bankDate}</div></td>
@@ -554,11 +611,11 @@ function MatchTable({ rows, showReasons, actionable, onDone }: { rows: ApMatch[]
                 <td className="whitespace-nowrap px-3 py-2">
                   {notes[key] ? <span className="text-[10px] text-rose-600">{notes[key]}</span> : (
                     <span className="flex items-center gap-1.5">
-                      <button onClick={() => act(m, "confirm")} disabled={busy === key}
+                      <button onClick={() => act(m, "confirm")} disabled={busy === key || bulkBusy}
                         className="rounded border border-green-600/30 bg-green-50 px-2 py-0.5 text-[11px] font-medium text-green-700 hover:bg-green-100 disabled:opacity-50">
                         Confirm
                       </button>
-                      <button onClick={() => act(m, "reject")} disabled={busy === key}
+                      <button onClick={() => act(m, "reject")} disabled={busy === key || bulkBusy}
                         className="rounded border border-gray-200 bg-white px-2 py-0.5 text-[11px] text-gray-500 hover:bg-gray-50 disabled:opacity-50">
                         Reject
                       </button>

--- a/apps/backoffice/src/app/api/finance/bank-lines/attach/route.ts
+++ b/apps/backoffice/src/app/api/finance/bank-lines/attach/route.ts
@@ -1,0 +1,125 @@
+// Attachments for a bank line — the supporting invoice / receipt / charge
+// advice behind a manual reconciliation. Especially for bank fees and other
+// expenses that have no procurement invoice, this is the audit trail.
+//
+// POST  multipart { file, bankLineId }  → upload to finance-docs, record in
+//       fin_documents (source_ref = bankLineId, doc_type = bank_line_attachment)
+// GET   ?bankLineId=…                    → list attachments with signed view URLs
+// DELETE { documentId }                  → remove an attachment
+
+import { NextRequest, NextResponse } from "next/server";
+import { randomUUID } from "crypto";
+import { requireAuth } from "@/lib/auth";
+import { prisma } from "@/lib/prisma";
+import { getFinanceClient } from "@/lib/finance/supabase";
+
+export const dynamic = "force-dynamic";
+export const maxDuration = 60;
+
+const BUCKET = "finance-docs";
+const DOC_TYPE = "bank_line_attachment";
+const MAX_BYTES = 15 * 1024 * 1024;
+const ALLOWED = ["application/pdf", "image/jpeg", "image/png", "image/webp"] as const;
+
+async function guard(req: NextRequest) {
+  const auth = await requireAuth(req);
+  if (auth.error) return auth.error;
+  if (!["OWNER", "ADMIN"].includes(auth.user.role)) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+  return null;
+}
+
+// Company for a bank line, from its statement account-name suffix (same mapping
+// the GL bridge uses): 2644 = Conezion, 9345 = Tamarind, else the default co.
+async function companyForBankLine(bankLineId: string): Promise<{ companyId: string; outletId: string | null } | null> {
+  const line = await prisma.bankStatementLine.findUnique({
+    where: { id: bankLineId },
+    select: { outletId: true, statement: { select: { accountName: true } } },
+  });
+  if (!line) return null;
+  const acct = line.statement?.accountName ?? "";
+  const companyId = acct.includes("2644") ? "celsiusconezion" : acct.includes("9345") ? "celsiustamarind" : "celsius";
+  return { companyId, outletId: line.outletId ?? null };
+}
+
+export async function POST(req: NextRequest) {
+  const err = await guard(req);
+  if (err) return err;
+
+  const form = await req.formData();
+  const file = form.get("file");
+  const bankLineId = form.get("bankLineId");
+  if (typeof bankLineId !== "string" || !bankLineId) {
+    return NextResponse.json({ error: "bankLineId required" }, { status: 400 });
+  }
+  if (!(file instanceof File)) return NextResponse.json({ error: "Missing file" }, { status: 400 });
+  if (file.size > MAX_BYTES) return NextResponse.json({ error: "File too large (max 15 MB)" }, { status: 413 });
+  const mime = file.type as (typeof ALLOWED)[number];
+  if (!ALLOWED.includes(mime)) {
+    return NextResponse.json({ error: "Use PDF, JPEG, PNG or WEBP" }, { status: 415 });
+  }
+
+  const co = await companyForBankLine(bankLineId);
+  if (!co) return NextResponse.json({ error: "Bank line not found" }, { status: 404 });
+
+  const client = getFinanceClient();
+  const ext = mime === "application/pdf" ? "pdf" : mime.split("/")[1];
+  const path = `bank-line/${bankLineId}/${randomUUID()}.${ext}`;
+  const bytes = Buffer.from(await file.arrayBuffer());
+  const { error: upErr } = await client.storage.from(BUCKET).upload(path, bytes, { contentType: mime, cacheControl: "private" });
+  if (upErr) return NextResponse.json({ error: `Upload failed: ${upErr.message}` }, { status: 500 });
+
+  const { data, error } = await client.from("fin_documents").insert({
+    source: "manual_upload",
+    source_ref: bankLineId,
+    doc_type: DOC_TYPE,
+    outlet_id: co.outletId,
+    company_id: co.companyId,
+    raw_url: path,
+    status: "attached",
+    metadata: { filename: file.name, mime, size: file.size },
+  }).select("id").single();
+  if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+
+  return NextResponse.json({ ok: true, documentId: data.id, filename: file.name });
+}
+
+export async function GET(req: NextRequest) {
+  const err = await guard(req);
+  if (err) return err;
+  const bankLineId = new URL(req.url).searchParams.get("bankLineId");
+  if (!bankLineId) return NextResponse.json({ error: "bankLineId required" }, { status: 400 });
+
+  const client = getFinanceClient();
+  const { data, error } = await client
+    .from("fin_documents")
+    .select("id, raw_url, metadata, created_at")
+    .eq("doc_type", DOC_TYPE)
+    .eq("source_ref", bankLineId)
+    .order("created_at", { ascending: false });
+  if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+
+  // Signed URLs so the private bucket is viewable for a short window.
+  const rows = await Promise.all((data ?? []).map(async (d) => {
+    const { data: signed } = await client.storage.from(BUCKET).createSignedUrl(d.raw_url as string, 3600);
+    const meta = (d.metadata ?? {}) as { filename?: string };
+    return { id: d.id, filename: meta.filename ?? "attachment", url: signed?.signedUrl ?? null, createdAt: d.created_at };
+  }));
+  return NextResponse.json({ attachments: rows });
+}
+
+export async function DELETE(req: NextRequest) {
+  const err = await guard(req);
+  if (err) return err;
+  let body: { documentId?: string } = {};
+  try { body = await req.json(); } catch { /* handled below */ }
+  if (!body.documentId) return NextResponse.json({ error: "documentId required" }, { status: 400 });
+
+  const client = getFinanceClient();
+  const { data: doc } = await client.from("fin_documents").select("raw_url").eq("id", body.documentId).eq("doc_type", DOC_TYPE).maybeSingle();
+  if (doc?.raw_url) await client.storage.from(BUCKET).remove([doc.raw_url as string]);
+  const { error } = await client.from("fin_documents").delete().eq("id", body.documentId).eq("doc_type", DOC_TYPE);
+  if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+  return NextResponse.json({ ok: true });
+}


### PR DESCRIPTION
Reworks /finance/recon per owner feedback ('too many steps and all in one place', 'cannot filter, cannot increase/decrease', 'when matching an outflow need invoice/attachments esp for bank fees').

## Segmented queues
The 8 stacked tables become a single workspace with a tab switcher — **To categorise · To review · Matched · Open invoices · Cash-in** — one focused table at a time. Summary tiles switch tabs.

## Filter + rows-per-page on every table
Search box + a **Rows 25 / 50 / 100 / All** selector, replacing the hard top-100 cap.

## Bulk everywhere
Select-all + bulk categorise (unmatched) and bulk confirm/reject (needs review).

## Attachments
Each line gets a paperclip to upload the invoice/receipt (PDF/image), view (signed URL) or remove — the audit trail for bank fees and other expenses with no procurement invoice. New `/api/finance/bank-lines/attach` (POST/GET/DELETE) → finance-docs bucket + fin_documents (source_ref = bankLineId). No migration.

Typecheck + lint clean.