### PR TITLE
feat(finance): manually offset inter-company transfers on recon

### DIFF
--- a/apps/backoffice/src/app/(admin)/finance/recon/page.tsx
+++ b/apps/backoffice/src/app/(admin)/finance/recon/page.tsx
@@ -37,20 +37,35 @@ const fmtRM0 = (n: number) => `RM ${n.toLocaleString("en-MY", { maximumFractionD
 // against the Prisma enum). Each books to a COA account via CONTRA_ACCOUNT
 // (statutory/salary route through control accounts in resolveContra), shown in
 // the dropdown so the pick IS a chart-of-accounts decision.
+// Inter-company: one entity paid for another's cost (or funded it). Booking
+// both mirror legs to the "Due to/from" control accounts (3600-xx, routed by
+// the counterparty in the narration) offsets them — neither P&L is touched and
+// they eliminate on consolidation. Four flavours keep the balance-sheet nature
+// (general / equipment / stock / salary funding); all post to 3600-xx.
+const INTERCO_CATEGORIES = [
+  "INTERCO_EXPENSES", "INTERCO_INVESTMENTS", "INTERCO_RAW_MATERIAL", "INTERCO_PEOPLE",
+] as const;
 const OUTFLOW_CATEGORIES = [
   "RAW_MATERIALS", "RENT", "UTILITIES", "MAINTENANCE", "EQUIPMENTS", "SOFTWARE",
   "STAFF_CLAIM", "PARTIMER", "EMPLOYEE_SALARY", "STATUTORY_PAYMENT", "TAX",
   "COMPLIANCE", "LICENSING_FEE", "BANK_FEE", "MARKETPLACE_FEE", "OTHER_MARKETING",
   "KOL", "DELIVERY", "PETTY_CASH", "LOAN", "DIVIDEND", "DIRECTORS_ALLOWANCE",
   "CAPITAL", "INVESTMENTS", "MANAGEMENT_FEE", "CFS_FEE", "CUSTOMER_REFUND",
+  ...INTERCO_CATEGORIES,
 ] as const;
 const INFLOW_CATEGORIES = [
   "QR", "CARD", "GRAB", "STOREHUB", "FOODPANDA", "REVENUE_MONSTER",
   "GASTROHUB", "MEETINGS_EVENTS", "REFUND", "LOAN", "CAPITAL",
   "MANAGEMENT_FEE", "EMPLOYEE_SALARY", "STATUTORY_PAYMENT",
+  ...INTERCO_CATEGORIES,
 ] as const;
-// Control-account routes that CONTRA_ACCOUNT doesn't carry (resolveContra does).
-const CONTROL_COA: Record<string, string> = { EMPLOYEE_SALARY: "3008", STATUTORY_PAYMENT: "3004-7" };
+// Control-account routes that CONTRA_ACCOUNT doesn't carry (resolveContra does):
+// salary/statutory controls, and the inter-company Due-to/from account (3600-xx
+// by counterparty — the label shows the parent 3600).
+const CONTROL_COA: Record<string, string> = {
+  EMPLOYEE_SALARY: "3008", STATUTORY_PAYMENT: "3004-7",
+  INTERCO_EXPENSES: "3600", INTERCO_INVESTMENTS: "3600", INTERCO_RAW_MATERIAL: "3600", INTERCO_PEOPLE: "3600",
+};
 function categoryLabel(c: string, accountNames: Map<string, string>): string {
   const code = CONTRA_ACCOUNT[c] ?? CONTROL_COA[c];
   const name = code ? accountNames.get(code) : undefined;

--- a/apps/backoffice/src/app/api/finance/bank-lines/classify/route.ts
+++ b/apps/backoffice/src/app/api/finance/bank-lines/classify/route.ts
@@ -39,10 +39,16 @@ export async function POST(req: NextRequest) {
   const writable = lines.filter((l) => !l.apInvoiceId);
   const journalIds = [...new Set(writable.map((l) => l.glTransactionId).filter((x): x is string => !!x))];
 
+  // Inter-company categories also flip the isInterCo flag, so the line is
+  // excluded from the Ledger's operating view and eliminated in the
+  // consolidated P&L (which filter on the flag), consistent with the GL
+  // booking it to a 3600 Due-to/from account.
+  const isInterco = category.startsWith("INTERCO_");
+
   await prisma.$transaction(async (tx) => {
     await tx.bankStatementLine.updateMany({
       where: { id: { in: writable.map((l) => l.id) } },
-      data: { category: category as CashCategory, classifiedBy: "user", ruleName: "manual" },
+      data: { category: category as CashCategory, classifiedBy: "user", ruleName: "manual", ...(isInterco ? { isInterCo: true } : {}) },
     });
     if (journalIds.length) {
       await tx.bankStatementLine.updateMany({
@@ -56,7 +62,9 @@ export async function POST(req: NextRequest) {
   // needs correcting twice. Failure to learn must not fail the classify.
   let learned = 0;
   try {
-    learned = await learnHintsFromLines(writable, category as CashCategory);
+    // Inter-company is a one-off routing decision, not a stable payee rule —
+    // don't teach a hint that could mislabel future transactions.
+    if (!isInterco) learned = await learnHintsFromLines(writable, category as CashCategory);
   } catch { /* hint learning is best-effort */ }
 
   return NextResponse.json({


### PR DESCRIPTION
Owner: an entity paid for another's cost (Conezion fronted an aircond for
Celsius Coffee SB, then SB transferred the money back). Both legs need to
offset via the Due-to/from control accounts, but the auto-detector only
catches clean 'TRANSFER TO/FR A/C CELSIUS COFFEE …' narrations, and there
was no way to mark a line inter-company by hand.

- Adds inter-company categories to both recon dropdowns (Due-to/from,
  routed to 3600-xx by the counterparty in the narration via resolveContra).
  Four flavours keep the balance-sheet nature: general / equipment /
  stock / salary funding. Labelled '→ 3600 Due to/from Related Companies'.
- Classifying a line INTERCO_* also flips isInterCo=true, so it drops out of
  the Ledger operating view and eliminates in the consolidated P&L (both
  filter on the flag), consistent with the GL posting it to 3600.
- No hint learned for inter-company (a one-off routing, not a payee rule).

Both mirror legs booked to Due-to/from net to zero across the entities and
never touch either P&L. Typecheck + lint clean.
