### PR TITLE
feat(finance): single-calendar date range picker (no more choosing twice)

### DIFF
--- a/apps/backoffice/src/app/(admin)/finance/payouts/page.tsx
+++ b/apps/backoffice/src/app/(admin)/finance/payouts/page.tsx
@@ -7,6 +7,7 @@
 // server-windowed date range, client-side filter/sort, row-click detail drawer.
 
 import { useState, useMemo, useEffect } from "react";
+import { DateRangePicker } from "@/components/date-range-picker";
 import { useFetch } from "@/lib/use-fetch";
 import { Sheet, SheetContent, SheetHeader, SheetTitle, Badge, Button } from "@celsius/ui";
 import { Loader2, Search, X, ArrowUp, ArrowDown, ChevronsUpDown, Building2, Download, CheckCircle2, AlertTriangle } from "lucide-react";
@@ -211,12 +212,7 @@ export default function FinancePayoutsPage() {
               <option value="custom">Custom range…</option>
             </select>
           </label>
-          <label className="flex items-center gap-1">From
-            <input type="date" value={dateFrom} onChange={(e) => { setDateFrom(e.target.value); setPeriodSel("custom"); }} className="h-8 rounded-md border bg-background px-2 text-xs" />
-          </label>
-          <label className="flex items-center gap-1">To
-            <input type="date" value={dateTo} onChange={(e) => { setDateTo(e.target.value); setPeriodSel("custom"); }} className="h-8 rounded-md border bg-background px-2 text-xs" />
-          </label>
+          <DateRangePicker size="xs" start={dateFrom} end={dateTo} onChange={(s, e) => { setDateFrom(s); setDateTo(e); setPeriodSel("custom"); }} />
           <Button variant="outline" size="sm" className="h-8" onClick={exportCsv} disabled={filtered.length === 0} title="Export the filtered payouts to CSV">
             <Download className="mr-1 h-3 w-3" /> Export
           </Button>

--- a/apps/backoffice/src/app/(admin)/finance/reports/page.tsx
+++ b/apps/backoffice/src/app/(admin)/finance/reports/page.tsx
@@ -13,6 +13,7 @@ import {
   SheetTitle,
 } from "@celsius/ui";
 import { Loader2, Download, FileText, AlertTriangle } from "lucide-react";
+import { DateRangePicker } from "@/components/date-range-picker";
 
 // Accounting format: negatives in parentheses, the convention every
 // accounting package (Xero, QuickBooks, Bukku) uses on statements.
@@ -190,11 +191,7 @@ function ReportControlsBar({ c, outletApplies }: { c: ReturnType<typeof useRepor
         {PRESETS.map((p) => <option key={p.id} value={p.id}>{p.label}</option>)}
       </select>
       {c.preset === "custom" && (
-        <div className="flex items-center gap-1.5">
-          <input type="date" value={c.customStart} max={c.customEnd} onChange={(e) => c.setCustomStart(e.target.value)} className="h-8 rounded-md border bg-background px-2 text-sm" />
-          <span className="text-xs text-muted-foreground">to</span>
-          <input type="date" value={c.customEnd} min={c.customStart} onChange={(e) => c.setCustomEnd(e.target.value)} className="h-8 rounded-md border bg-background px-2 text-sm" />
-        </div>
+        <DateRangePicker start={c.customStart} end={c.customEnd} onChange={(s, e) => { c.setCustomStart(s); c.setCustomEnd(e); }} />
       )}
       <span className="text-[11px] text-muted-foreground tabular-nums">{c.start} → {c.end}</span>
       <select
@@ -1032,13 +1029,9 @@ function ReconTab() {
   const { data, isLoading } = useFetch<{ report: Recon }>(`/api/finance/reports/reconciliation?start=${start}&end=${end}`);
   return (
     <div className="space-y-3">
-      <div className="flex flex-wrap items-end gap-2">
-        <label className="text-xs text-muted-foreground">From
-          <input type="date" value={start} onChange={(e) => setStart(e.target.value)} className="ml-2 rounded border px-2 py-1 text-sm" />
-        </label>
-        <label className="text-xs text-muted-foreground">To
-          <input type="date" value={end} onChange={(e) => setEnd(e.target.value)} className="ml-2 rounded border px-2 py-1 text-sm" />
-        </label>
+      <div className="flex flex-wrap items-center gap-2">
+        <span className="text-xs text-muted-foreground">Period</span>
+        <DateRangePicker start={start} end={end} onChange={(s, e) => { setStart(s); setEnd(e); }} />
       </div>
       {isLoading || !data?.report ? <div className="py-12 text-center text-sm text-muted-foreground">Loading…</div> : (
         <div className="overflow-x-auto rounded-lg border">

--- a/apps/backoffice/src/app/(admin)/finance/transactions/page.tsx
+++ b/apps/backoffice/src/app/(admin)/finance/transactions/page.tsx
@@ -7,6 +7,7 @@
 // client-side for instant feel. Row click opens a detail drawer.
 
 import { useState, useMemo } from "react";
+import { DateRangePicker } from "@/components/date-range-picker";
 import { useFetch } from "@/lib/use-fetch";
 import { Sheet, SheetContent, SheetHeader, SheetTitle, Badge, Button } from "@celsius/ui";
 import { Loader2, Search, X, ArrowUp, ArrowDown, ChevronsUpDown, Building2, Download } from "lucide-react";
@@ -344,12 +345,7 @@ export default function FinanceLedgerPage() {
               <option value="custom">Custom range…</option>
             </select>
           </label>
-          <label className="flex items-center gap-1">From
-            <input type="date" value={dateFrom} onChange={(e) => { setDateFrom(e.target.value); setPeriodSel("custom"); }} className="h-8 rounded-md border bg-background px-2 text-xs" />
-          </label>
-          <label className="flex items-center gap-1">To
-            <input type="date" value={dateTo} onChange={(e) => { setDateTo(e.target.value); setPeriodSel("custom"); }} className="h-8 rounded-md border bg-background px-2 text-xs" />
-          </label>
+          <DateRangePicker size="xs" start={dateFrom} end={dateTo} onChange={(s, e) => { setDateFrom(s); setDateTo(e); setPeriodSel("custom"); }} />
           <label className="flex items-center gap-1">Min RM
             <input type="number" inputMode="decimal" value={amountMin} onChange={(e) => setAmountMin(e.target.value)} className="h-8 w-24 rounded-md border bg-background px-2 text-xs tabular-nums" />
           </label>

--- a/apps/backoffice/src/components/date-range-picker.tsx
+++ b/apps/backoffice/src/components/date-range-picker.tsx
@@ -1,0 +1,118 @@
+"use client";
+
+// Single-calendar date-range picker. Click the start day then the end day in
+// ONE calendar — no two separate date inputs, no choosing the date twice.
+// Dates are plain "YYYY-MM-DD" strings (calendar dates, timezone-agnostic).
+// Reuse this for EVERY custom date range across the app.
+
+import { useEffect, useRef, useState } from "react";
+import { Calendar as CalendarIcon, ChevronLeft, ChevronRight } from "lucide-react";
+
+const MONTHS = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"];
+const DOW = ["M", "T", "W", "T", "F", "S", "S"];
+
+function parse(s: string): { y: number; m: number; d: number } | null {
+  const m = /^(\d{4})-(\d{2})-(\d{2})$/.exec(s || "");
+  return m ? { y: +m[1], m: +m[2] - 1, d: +m[3] } : null;
+}
+const fmt = (y: number, m: number, d: number) => `${y}-${String(m + 1).padStart(2, "0")}-${String(d).padStart(2, "0")}`;
+function label(s: string): string {
+  const p = parse(s);
+  return p ? `${p.d} ${MONTHS[p.m]} ${p.y}` : "";
+}
+function todayStr(): string {
+  const t = new Date(Date.now() + 8 * 3600_000); // MYT
+  return t.toISOString().slice(0, 10);
+}
+
+export function DateRangePicker({
+  start, end, onChange, className, size = "sm",
+}: {
+  start: string;
+  end: string;
+  onChange: (start: string, end: string) => void;
+  className?: string;
+  size?: "sm" | "xs";
+}) {
+  const [open, setOpen] = useState(false);
+  const [pending, setPending] = useState<string | null>(null); // start of an in-progress selection
+  const [hover, setHover] = useState<string | null>(null);
+  const init = parse(start) ?? parse(todayStr())!;
+  const [view, setView] = useState<{ y: number; m: number }>({ y: init.y, m: init.m });
+  const ref = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    function onDoc(e: MouseEvent) {
+      if (open && ref.current && !ref.current.contains(e.target as Node)) { setOpen(false); setPending(null); }
+    }
+    document.addEventListener("mousedown", onDoc);
+    return () => document.removeEventListener("mousedown", onDoc);
+  }, [open]);
+
+  // Range currently shown as selected/preview.
+  const lo = pending ? (hover && hover < pending ? hover : pending) : start;
+  const hi = pending ? (hover && hover > pending ? hover : pending) : end;
+
+  function pickDay(ds: string) {
+    if (!pending) { setPending(ds); setHover(ds); return; }
+    if (ds >= pending) { onChange(pending, ds); setPending(null); setHover(null); setOpen(false); }
+    else { setPending(ds); setHover(ds); } // clicked earlier than start → restart from there
+  }
+
+  // Build the visible month grid (Mon-first), with leading blanks.
+  const first = new Date(Date.UTC(view.y, view.m, 1));
+  const lead = (first.getUTCDay() + 6) % 7; // Mon=0
+  const daysInMonth = new Date(Date.UTC(view.y, view.m + 1, 0)).getUTCDate();
+  const cells: (number | null)[] = [...Array(lead).fill(null), ...Array.from({ length: daysInMonth }, (_, i) => i + 1)];
+  const today = todayStr();
+
+  const h = size === "xs" ? "h-7 text-xs" : "h-8 text-sm";
+  return (
+    <div ref={ref} className={`relative ${className ?? ""}`}>
+      <button type="button" onClick={() => setOpen((v) => !v)}
+        className={`flex ${h} items-center gap-1.5 rounded-md border bg-background px-2 text-foreground hover:bg-muted/40`}>
+        <CalendarIcon className="h-3.5 w-3.5 text-muted-foreground" />
+        {start && end ? <span className="tabular-nums">{label(start)} → {label(end)}</span> : <span className="text-muted-foreground">Select dates</span>}
+      </button>
+      {open && (
+        <div className="absolute left-0 z-30 mt-1 w-64 rounded-lg border bg-card p-3 shadow-lg">
+          <div className="mb-2 flex items-center justify-between">
+            <button type="button" onClick={() => setView((v) => v.m === 0 ? { y: v.y - 1, m: 11 } : { y: v.y, m: v.m - 1 })}
+              className="rounded p-1 hover:bg-muted/50"><ChevronLeft className="h-4 w-4" /></button>
+            <span className="text-sm font-medium">{MONTHS[view.m]} {view.y}</span>
+            <button type="button" onClick={() => setView((v) => v.m === 11 ? { y: v.y + 1, m: 0 } : { y: v.y, m: v.m + 1 })}
+              className="rounded p-1 hover:bg-muted/50"><ChevronRight className="h-4 w-4" /></button>
+          </div>
+          <div className="grid grid-cols-7 gap-0.5 text-center">
+            {DOW.map((d, i) => <div key={i} className="py-1 text-[10px] font-medium text-muted-foreground">{d}</div>)}
+            {cells.map((day, i) => {
+              if (day === null) return <div key={i} />;
+              const ds = fmt(view.y, view.m, day);
+              const inRange = lo && hi && ds >= lo && ds <= hi;
+              const isEdge = ds === lo || ds === hi;
+              const isToday = ds === today;
+              return (
+                <button key={i} type="button"
+                  onClick={() => pickDay(ds)}
+                  onMouseEnter={() => pending && setHover(ds)}
+                  className={`py-1 text-xs tabular-nums rounded transition-colors ${
+                    isEdge ? "bg-terracotta text-white font-semibold"
+                    : inRange ? "bg-terracotta/15 text-foreground"
+                    : "hover:bg-muted/60"} ${isToday && !isEdge ? "ring-1 ring-terracotta/40" : ""}`}>
+                  {day}
+                </button>
+              );
+            })}
+          </div>
+          <div className="mt-2 flex items-center justify-between border-t pt-2 text-[11px]">
+            <button type="button" onClick={() => { const t = today; onChange(t, t); setPending(null); setOpen(false); }}
+              className="text-terracotta hover:underline">Today</button>
+            {pending
+              ? <span className="text-muted-foreground">Pick the end date…</span>
+              : <span className="text-muted-foreground tabular-nums">{start && end ? `${label(start)} → ${label(end)}` : ""}</span>}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
Owner: custom date ranges force picking start and end in two separate date
inputs / two calendars. Want ONE calendar — click start then end — used
everywhere. Saved as a standing preference.

- New reusable <DateRangePicker>: one month calendar, click the start day
  then the end day and it's set. Prev/next month, in-range highlight, Today
  shortcut, click-outside to close. Plain YYYY-MM-DD strings, no dependency.
- Swapped it in for every custom start+end pair in the finance module:
  Reports control bar + Reconciliation tab, Ledger (transactions), Payouts.

Rolls out to the rest of the app's date ranges next; the component is the
one to reuse. Typecheck clean.
