### PR TITLE
feat(finance): P&L reports UX — consolidated drill, tx detail, inline recategorise, per-outlet ads, comparison columns

### DIFF
--- a/apps/backoffice/src/app/(admin)/finance/recon/page.tsx
+++ b/apps/backoffice/src/app/(admin)/finance/recon/page.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from "react";
 import { useFetch } from "@/lib/use-fetch";
-import { CONTRA_ACCOUNT } from "@/lib/finance/gl-posting-map";
+import { OUTFLOW_CATEGORIES, INFLOW_CATEGORIES, categoryLabel } from "@/lib/finance/cash-categories";
 import { Loader2, CheckCircle2, AlertTriangle, HelpCircle, Copy, ArrowDownCircle, Paperclip } from "lucide-react";
 
 type ApMatch = {
@@ -33,45 +33,8 @@ type ReconData = {
 const fmtRM = (n: number) => `RM ${n.toLocaleString("en-MY", { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`;
 const fmtRM0 = (n: number) => `RM ${n.toLocaleString("en-MY", { maximumFractionDigits: 0 })}`;
 
-// Categories a human can assign — mirrors CashCategory (validated server-side
-// against the Prisma enum). Each books to a COA account via CONTRA_ACCOUNT
-// (statutory/salary route through control accounts in resolveContra), shown in
-// the dropdown so the pick IS a chart-of-accounts decision.
-// Inter-company: one entity paid for another's cost (or funded it). Booking
-// both mirror legs to the "Due to/from" control accounts (3600-xx, routed by
-// the counterparty in the narration) offsets them — neither P&L is touched and
-// they eliminate on consolidation. Four flavours keep the balance-sheet nature
-// (general / equipment / stock / salary funding); all post to 3600-xx.
-const INTERCO_CATEGORIES = [
-  "INTERCO_EXPENSES", "INTERCO_INVESTMENTS", "INTERCO_RAW_MATERIAL", "INTERCO_PEOPLE",
-] as const;
-const OUTFLOW_CATEGORIES = [
-  "RAW_MATERIALS", "RENT", "UTILITIES", "MAINTENANCE", "EQUIPMENTS", "SOFTWARE",
-  "STAFF_CLAIM", "PARTIMER", "EMPLOYEE_SALARY", "STATUTORY_PAYMENT", "TAX",
-  "COMPLIANCE", "LICENSING_FEE", "BANK_FEE", "MARKETPLACE_FEE", "OTHER_MARKETING",
-  "KOL", "DELIVERY", "PETTY_CASH", "LOAN", "DIVIDEND", "DIRECTORS_ALLOWANCE",
-  "CAPITAL", "INVESTMENTS", "MANAGEMENT_FEE", "CFS_FEE", "CUSTOMER_REFUND",
-  ...INTERCO_CATEGORIES,
-] as const;
-const INFLOW_CATEGORIES = [
-  "QR", "CARD", "GRAB", "STOREHUB", "FOODPANDA", "REVENUE_MONSTER",
-  "GASTROHUB", "MEETINGS_EVENTS", "REFUND", "LOAN", "CAPITAL",
-  "MANAGEMENT_FEE", "EMPLOYEE_SALARY", "STATUTORY_PAYMENT",
-  ...INTERCO_CATEGORIES,
-] as const;
-// Control-account routes that CONTRA_ACCOUNT doesn't carry (resolveContra does):
-// salary/statutory controls, and the inter-company Due-to/from account (3600-xx
-// by counterparty — the label shows the parent 3600).
-const CONTROL_COA: Record<string, string> = {
-  EMPLOYEE_SALARY: "3008", STATUTORY_PAYMENT: "3004-7",
-  INTERCO_EXPENSES: "3600", INTERCO_INVESTMENTS: "3600", INTERCO_RAW_MATERIAL: "3600", INTERCO_PEOPLE: "3600",
-};
-function categoryLabel(c: string, accountNames: Map<string, string>): string {
-  const code = CONTRA_ACCOUNT[c] ?? CONTROL_COA[c];
-  const name = code ? accountNames.get(code) : undefined;
-  const human = c.toLowerCase().replace(/_/g, " ");
-  return code ? `${human} → ${code}${name ? ` ${name}` : ""}` : human;
-}
+// Category lists + labels live in @/lib/finance/cash-categories (shared with
+// the Reports drill-down so both offer the same recategorization choices).
 
 type ReconTab = "categorise" | "review" | "matched" | "invoices" | "cashin";
 

--- a/apps/backoffice/src/app/(admin)/finance/reports/page.tsx
+++ b/apps/backoffice/src/app/(admin)/finance/reports/page.tsx
@@ -236,6 +236,15 @@ type DrillLine = {
   amount: number;
   debit: number;
   credit: number;
+  meta?: {
+    reference?: string | null;
+    category?: string | null;
+    company?: string | null;
+    account?: string | null;
+    isInterCo?: boolean;
+    classifiedBy?: string | null;
+    ruleName?: string | null;
+  };
 };
 
 // Common-size %: every P&L line expressed against total income — the standard
@@ -388,7 +397,7 @@ function PnlTab() {
             )}
           </SheetHeader>
           {drillCode && data && (
-            <DrillDown code={drillCode} start={data.report.start} end={data.report.end} outletId={outletId || undefined} />
+            <DrillDown code={drillCode} start={data.report.start} end={data.report.end} outletId={outletId || undefined} consolidated={consolidated} />
           )}
         </SheetContent>
       </Sheet>
@@ -396,28 +405,27 @@ function PnlTab() {
   );
 }
 
-function DrillDown({ code, start, end, outletId }: { code: string; start: string; end: string; outletId?: string }) {
+function DrillDown({ code, start, end, outletId, consolidated }: { code: string; start: string; end: string; outletId?: string; consolidated?: boolean }) {
   const { data, isLoading } = useFetch<{ lines: DrillLine[] }>(
-    `/api/finance/reports/drilldown?accountCode=${encodeURIComponent(code)}&start=${start}&end=${end}${outletId ? `&outletId=${outletId}` : ""}`
+    `/api/finance/reports/drilldown?accountCode=${encodeURIComponent(code)}&start=${start}&end=${end}${consolidated ? "&companyId=consolidated" : outletId ? `&outletId=${outletId}` : ""}`
   );
+  const [openRow, setOpenRow] = useState<string | null>(null);
   if (isLoading) return <div className="p-6"><Loader2 className="h-5 w-5 animate-spin" /></div>;
   if (!data) return null;
   if (data.lines.length === 0) {
     return <div className="p-6 text-sm text-muted-foreground">No entries in this period.</div>;
   }
 
-  // Source drills are one-sided (all debits or all credits) — show a single
-  // Amount column so nothing gets pushed off-screen. Debit/Credit columns only
-  // when the entries genuinely mix both sides (ledger drills).
   const hasDebit = data.lines.some((l) => l.debit > 0);
   const hasCredit = data.lines.some((l) => l.credit > 0);
   const oneSided = !(hasDebit && hasCredit);
   const amountOf = (l: DrillLine) => (l.debit > 0 ? l.debit : l.credit > 0 ? l.credit : l.amount);
   const totalDebit = data.lines.reduce((s, l) => s + l.debit, 0);
   const totalCredit = data.lines.reduce((s, l) => s + l.credit, 0);
+  // Multi-company drill (consolidated) → show which entity each line belongs to.
+  const showCompany = consolidated && data.lines.some((l) => l.meta?.company);
+  const cols = 2 + (showCompany ? 1 : 0) + (oneSided ? 1 : 2);
 
-  // "Vendor · INV-123 · Outlet" reads as one noisy wrapping line — keep the
-  // first segment as the entry title and demote the rest to a muted meta line.
   const splitDesc = (d: string): [string, string | null] => {
     const parts = d.split(" · ");
     return parts.length > 1 ? [parts[0], parts.slice(1).join(" · ")] : [d, null];
@@ -425,31 +433,39 @@ function DrillDown({ code, start, end, outletId }: { code: string; start: string
 
   return (
     <div className="min-h-0 flex-1 overflow-y-auto p-4 sm:p-6">
-      <table className="w-full table-fixed text-sm">
+      <table className="w-full text-sm">
         <thead className="sticky top-0 bg-background text-left text-xs uppercase tracking-wide text-muted-foreground">
           <tr className="border-b">
-            <th className="w-20 py-2 pr-2 font-medium">Date</th>
+            <th className="w-16 py-2 pr-2 font-medium">Date</th>
             <th className="py-2 pr-2 font-medium">Description</th>
+            {showCompany && <th className="w-36 py-2 pr-2 font-medium">Company</th>}
             {oneSided
               ? <th className="w-28 py-2 text-right font-medium">Amount</th>
               : <>
-                  <th className="w-28 py-2 text-right font-medium">Debit</th>
-                  <th className="w-28 py-2 text-right font-medium">Credit</th>
+                  <th className="w-24 py-2 text-right font-medium">Debit</th>
+                  <th className="w-24 py-2 text-right font-medium">Credit</th>
                 </>}
           </tr>
         </thead>
         <tbody className="divide-y">
           {data.lines.map((l, i) => {
-            const [main, meta] = splitDesc(l.description);
+            const [main, metaLine] = splitDesc(l.description);
+            const key = `${l.transactionId}-${i}`;
+            const expandable = !!l.meta;
+            const open = openRow === key;
             return (
-              <tr key={`${l.transactionId}-${i}`} className="align-top">
-                <td className="whitespace-nowrap py-2 pr-2 text-xs tabular-nums text-muted-foreground">
-                  {l.txnDate.slice(5)}
-                </td>
+              <Fragment key={key}>
+              <tr className={`align-top ${expandable ? "cursor-pointer hover:bg-muted/30" : ""}`}
+                  onClick={expandable ? () => setOpenRow(open ? null : key) : undefined}
+                  title={expandable ? "Click to see the transaction detail" : undefined}>
+                <td className="whitespace-nowrap py-2 pr-2 text-xs tabular-nums text-muted-foreground">{l.txnDate.slice(5)}</td>
                 <td className="break-words py-2 pr-2">
-                  {main}
-                  {meta && <div className="text-[11px] leading-snug text-muted-foreground">{meta}</div>}
+                  <span className="flex items-start gap-1">
+                    {expandable && <span className="mt-0.5 text-[10px] text-muted-foreground">{open ? "▾" : "▸"}</span>}
+                    <span>{main}{metaLine && <span className="block text-[11px] leading-snug text-muted-foreground">{metaLine}</span>}</span>
+                  </span>
                 </td>
+                {showCompany && <td className="py-2 pr-2 text-xs text-muted-foreground">{l.meta?.company ?? "—"}</td>}
                 {oneSided
                   ? <td className="whitespace-nowrap py-2 text-right tabular-nums">{RM(amountOf(l))}</td>
                   : <>
@@ -457,12 +473,26 @@ function DrillDown({ code, start, end, outletId }: { code: string; start: string
                       <td className="whitespace-nowrap py-2 text-right tabular-nums">{l.credit ? RM(l.credit) : ""}</td>
                     </>}
               </tr>
+              {open && l.meta && (
+                <tr className="bg-muted/20">
+                  <td colSpan={cols} className="px-3 py-2">
+                    <dl className="grid grid-cols-[7rem_1fr] gap-x-3 gap-y-1 text-[11px]">
+                      {l.meta.account && (<><dt className="text-muted-foreground">Bank account</dt><dd>{l.meta.account}</dd></>)}
+                      {l.meta.reference && (<><dt className="text-muted-foreground">Reference</dt><dd className="break-words">{l.meta.reference}</dd></>)}
+                      {l.meta.category !== undefined && (<><dt className="text-muted-foreground">Category</dt><dd>{l.meta.category ? l.meta.category.toLowerCase().replace(/_/g, " ") : "unclassified"}</dd></>)}
+                      <><dt className="text-muted-foreground">Inter-company</dt><dd>{l.meta.isInterCo ? "yes" : "no"}</dd></>
+                      {(l.meta.classifiedBy || l.meta.ruleName) && (<><dt className="text-muted-foreground">Classified</dt><dd>{l.meta.classifiedBy ?? "rule"}{l.meta.ruleName ? ` · ${l.meta.ruleName}` : ""}</dd></>)}
+                    </dl>
+                  </td>
+                </tr>
+              )}
+              </Fragment>
             );
           })}
         </tbody>
         <tfoot>
           <tr className="border-t-2 font-semibold">
-            <td className="py-2 pr-2" colSpan={2}>Total · {data.lines.length} entries</td>
+            <td className="py-2 pr-2" colSpan={showCompany ? 3 : 2}>Total · {data.lines.length} entries</td>
             {oneSided
               ? <td className="whitespace-nowrap py-2 text-right tabular-nums">{RM(totalDebit + totalCredit)}</td>
               : <>

--- a/apps/backoffice/src/app/(admin)/finance/reports/page.tsx
+++ b/apps/backoffice/src/app/(admin)/finance/reports/page.tsx
@@ -255,10 +255,25 @@ function pctOfIncome(amount: number, totalIncome: number): string {
   return `${((amount / totalIncome) * 100).toFixed(1)}%`;
 }
 
+// Period-over-period change vs the comparison column. Blank when there's
+// nothing to compare against; "new" when this period has a value and the
+// comparison was zero.
+function pctChange(cur: number, prev: number | null | undefined): string {
+  if (prev == null) return "";
+  if (prev === 0) return cur === 0 ? "" : "new";
+  const p = ((cur - prev) / Math.abs(prev)) * 100;
+  return `${p >= 0 ? "+" : ""}${p.toFixed(0)}%`;
+}
+
+// Compare-period date helpers (plain YYYY-MM-DD, no TZ shift).
+const addDaysStr = (s: string, n: number) => { const d = new Date(`${s}T00:00:00.000Z`); d.setUTCDate(d.getUTCDate() + n); return d.toISOString().slice(0, 10); };
+const addYearsStr = (s: string, n: number) => { const [y, m, d] = s.split("-"); return `${Number(y) + n}-${m}-${d}`; };
+const daysBetween = (a: string, b: string) => Math.round((Date.parse(`${b}T00:00:00Z`) - Date.parse(`${a}T00:00:00Z`)) / 86_400_000);
+
 // Row components live at module scope (not inside PnlTab) so their
 // identity is stable across renders; ReportRow takes the drill-down
 // callback as a prop instead of closing over PnlTab state.
-function ReportRow({ line, totalIncome, onDrill }: { line: PnlLine; totalIncome: number; onDrill: (code: string) => void }) {
+function ReportRow({ line, totalIncome, onDrill, compareAmount, showCompare }: { line: PnlLine; totalIncome: number; onDrill: (code: string) => void; compareAmount?: number | null; showCompare?: boolean }) {
   return (
     <tr
       className="cursor-pointer border-t transition hover:bg-muted/30"
@@ -272,46 +287,65 @@ function ReportRow({ line, totalIncome, onDrill }: { line: PnlLine; totalIncome:
       </td>
       <td className="px-3 py-1.5">{line.name}</td>
       <td className="whitespace-nowrap px-3 py-1.5 text-right tabular-nums">{RM(line.amount)}</td>
+      {showCompare && <td className="whitespace-nowrap px-3 py-1.5 text-right tabular-nums text-muted-foreground">{compareAmount == null ? "—" : RM(compareAmount)}</td>}
+      {showCompare && <td className="whitespace-nowrap px-3 py-1.5 text-right text-xs tabular-nums text-muted-foreground">{pctChange(line.amount, compareAmount)}</td>}
       <td className="whitespace-nowrap px-3 py-1.5 text-right text-xs tabular-nums text-muted-foreground">{pctOfIncome(line.amount, totalIncome)}</td>
     </tr>
   );
 }
 
-function TotalRow({ label, amount, totalIncome, bold = true }: { label: string; amount: number; totalIncome: number; bold?: boolean }) {
+function TotalRow({ label, amount, totalIncome, bold = true, compareAmount, showCompare }: { label: string; amount: number; totalIncome: number; bold?: boolean; compareAmount?: number | null; showCompare?: boolean }) {
+  const f = bold ? "font-semibold" : "";
   return (
     <tr className="border-t bg-muted/30">
-      <td colSpan={2} className={`px-3 py-2 ${bold ? "font-semibold" : ""}`}>
+      <td colSpan={2} className={`px-3 py-2 ${f}`}>{label}</td>
+      <td className={`whitespace-nowrap px-3 py-2 text-right tabular-nums ${f}`}>{RM(amount)}</td>
+      {showCompare && <td className={`whitespace-nowrap px-3 py-2 text-right tabular-nums text-muted-foreground ${f}`}>{compareAmount == null ? "—" : RM(compareAmount)}</td>}
+      {showCompare && <td className={`whitespace-nowrap px-3 py-2 text-right text-xs tabular-nums text-muted-foreground ${f}`}>{pctChange(amount, compareAmount)}</td>}
+      <td className={`whitespace-nowrap px-3 py-2 text-right text-xs tabular-nums text-muted-foreground ${f}`}>{pctOfIncome(amount, totalIncome)}</td>
+    </tr>
+  );
+}
+
+function SectionHeader({ label, cols }: { label: string; cols: number }) {
+  return (
+    <tr>
+      <td colSpan={cols} className="bg-muted/50 px-3 py-1.5 text-xs uppercase tracking-wide text-muted-foreground">
         {label}
-      </td>
-      <td className={`whitespace-nowrap px-3 py-2 text-right tabular-nums ${bold ? "font-semibold" : ""}`}>
-        {RM(amount)}
-      </td>
-      <td className={`whitespace-nowrap px-3 py-2 text-right text-xs tabular-nums text-muted-foreground ${bold ? "font-semibold" : ""}`}>
-        {pctOfIncome(amount, totalIncome)}
       </td>
     </tr>
   );
 }
 
-function SectionHeader({ label }: { label: string }) {
-  return (
-    <tr>
-      <td colSpan={4} className="bg-muted/50 px-3 py-1.5 text-xs uppercase tracking-wide text-muted-foreground">
-        {label}
-      </td>
-    </tr>
-  );
-}
+type CompareMode = "none" | "prev" | "year";
 
 function PnlTab() {
   const { start, end, outletId, consolidated } = useControls();
-  const qs = useMemo(
-    () => `start=${start}&end=${end}${consolidated ? "&companyId=consolidated" : outletId ? `&outletId=${outletId}` : ""}`,
-    [start, end, outletId, consolidated],
-  );
+  const [compare, setCompare] = useState<CompareMode>("none");
+  const scope = consolidated ? "&companyId=consolidated" : outletId ? `&outletId=${outletId}` : "";
+  const qs = useMemo(() => `start=${start}&end=${end}${scope}`, [start, end, scope]);
   const { data, error, isLoading, mutate } = useFetch<{ report: PnlReport }>(
     `/api/finance/reports/pnl?${qs}`
   );
+  // Comparison period: the immediately-preceding equal-length window, or the
+  // same dates a year earlier. Fetched only when a comparison is selected.
+  const cmpRange = useMemo(() => {
+    if (compare === "prev") { const cEnd = addDaysStr(start, -1); return { s: addDaysStr(cEnd, -daysBetween(start, end)), e: cEnd }; }
+    if (compare === "year") return { s: addYearsStr(start, -1), e: addYearsStr(end, -1) };
+    return null;
+  }, [compare, start, end]);
+  const { data: cmpData } = useFetch<{ report: PnlReport }>(
+    cmpRange ? `/api/finance/reports/pnl?start=${cmpRange.s}&end=${cmpRange.e}${scope}` : null
+  );
+  const showCompare = compare !== "none" && !!cmpData;
+  const cmpByCode = useMemo(() => {
+    const m = new Map<string, number>();
+    const r = cmpData?.report;
+    if (r) for (const l of [...r.income.lines, ...r.cogs.lines, ...r.expenses.lines]) m.set(l.code, l.amount);
+    return m;
+  }, [cmpData]);
+  const cmp = cmpData?.report;
+  const cols = 4 + (showCompare ? 2 : 0);
   const [drillCode, setDrillCode] = useState<string | null>(null);
 
   return (
@@ -336,19 +370,31 @@ function PnlTab() {
 
       {data && (
         <>
-        <div className="flex justify-end">
+        <div className="flex flex-wrap items-center justify-end gap-2">
+          <label className="flex items-center gap-1 text-[11px] text-muted-foreground">Compare
+            <select value={compare} onChange={(e) => setCompare(e.target.value as CompareMode)}
+              className="h-7 rounded-md border bg-background px-1.5 text-xs">
+              <option value="none">off</option>
+              <option value="prev">previous period</option>
+              <option value="year">previous year</option>
+            </select>
+          </label>
+          {showCompare && cmpRange && <span className="text-[10px] text-muted-foreground tabular-nums">vs {cmpRange.s} → {cmpRange.e}</span>}
           <ExportCsvButton onExport={() => {
             const r = data.report;
-            const rows: Array<Array<string | number>> = [["Section", "Code", "Account", "Amount", "% of income"]];
-            const push = (section: string, lines: PnlLine[], total: number, totalLabel: string) => {
-              for (const l of lines) rows.push([section, l.code, l.name, l.amount, pctOfIncome(l.amount, r.income.total)]);
-              rows.push([section, "", totalLabel, total, pctOfIncome(total, r.income.total)]);
+            const head = ["Section", "Code", "Account", "Amount", ...(showCompare ? ["Compare", "Change %"] : []), "% of income"];
+            const rows: Array<Array<string | number>> = [head];
+            const cell = (l: PnlLine) => [l.code, l.name, l.amount, ...(showCompare ? [cmpByCode.get(l.code) ?? "", pctChange(l.amount, cmpByCode.get(l.code))] : []), pctOfIncome(l.amount, r.income.total)];
+            const tot = (label: string, amt: number, cAmt?: number | null) => ["", "", label, amt, ...(showCompare ? [cAmt ?? "", pctChange(amt, cAmt)] : []), pctOfIncome(amt, r.income.total)];
+            const push = (section: string, lines: PnlLine[], total: number, totalLabel: string, cTotal?: number | null) => {
+              for (const l of lines) rows.push([section, ...cell(l)]);
+              rows.push([section, ...tot(totalLabel, total, cTotal).slice(2)]);
             };
-            push("Income", r.income.lines, r.income.total, "Total Income");
-            push("Cost of Sales", r.cogs.lines, r.cogs.total, "Total COGS");
-            rows.push(["", "", "Gross Profit", r.grossProfit, pctOfIncome(r.grossProfit, r.income.total)]);
-            push("Expenses", r.expenses.lines, r.expenses.total, "Total Expenses");
-            rows.push(["", "", "Net Income", r.netIncome, pctOfIncome(r.netIncome, r.income.total)]);
+            push("Income", r.income.lines, r.income.total, "Total Income", cmp?.income.total);
+            push("Cost of Sales", r.cogs.lines, r.cogs.total, "Total COGS", cmp?.cogs.total);
+            rows.push(tot("Gross Profit", r.grossProfit, cmp?.grossProfit));
+            push("Expenses", r.expenses.lines, r.expenses.total, "Total Expenses", cmp?.expenses.total);
+            rows.push(tot("Net Income", r.netIncome, cmp?.netIncome));
             downloadCsv(`pnl_${r.start}_${r.end}.csv`, rows);
           }} />
         </div>
@@ -359,24 +405,26 @@ function PnlTab() {
                 <th className="whitespace-nowrap px-3 py-2">Code</th>
                 <th className="px-3 py-2">Account</th>
                 <th className="whitespace-nowrap px-3 py-2 text-right">Amount</th>
+                {showCompare && <th className="whitespace-nowrap px-3 py-2 text-right">{compare === "year" ? "Prev year" : "Prev period"}</th>}
+                {showCompare && <th className="whitespace-nowrap px-3 py-2 text-right" title="Change vs comparison period">Δ</th>}
                 <th className="whitespace-nowrap px-3 py-2 text-right" title="Share of total income">% of income</th>
               </tr>
             </thead>
             <tbody>
-              <SectionHeader label="Income" />
-              {data.report.income.lines.map((l) => <ReportRow key={l.code} line={l} totalIncome={data.report.income.total} onDrill={setDrillCode} />)}
-              <TotalRow label="Total Income" amount={data.report.income.total} totalIncome={data.report.income.total} />
+              <SectionHeader label="Income" cols={cols} />
+              {data.report.income.lines.map((l) => <ReportRow key={l.code} line={l} totalIncome={data.report.income.total} onDrill={setDrillCode} compareAmount={cmpByCode.get(l.code) ?? null} showCompare={showCompare} />)}
+              <TotalRow label="Total Income" amount={data.report.income.total} totalIncome={data.report.income.total} compareAmount={cmp?.income.total} showCompare={showCompare} />
 
-              <SectionHeader label="Cost of Sales" />
-              {data.report.cogs.lines.map((l) => <ReportRow key={l.code} line={l} totalIncome={data.report.income.total} onDrill={setDrillCode} />)}
-              <TotalRow label="Total COGS" amount={data.report.cogs.total} totalIncome={data.report.income.total} />
-              <TotalRow label="Gross Profit" amount={data.report.grossProfit} totalIncome={data.report.income.total} />
+              <SectionHeader label="Cost of Sales" cols={cols} />
+              {data.report.cogs.lines.map((l) => <ReportRow key={l.code} line={l} totalIncome={data.report.income.total} onDrill={setDrillCode} compareAmount={cmpByCode.get(l.code) ?? null} showCompare={showCompare} />)}
+              <TotalRow label="Total COGS" amount={data.report.cogs.total} totalIncome={data.report.income.total} compareAmount={cmp?.cogs.total} showCompare={showCompare} />
+              <TotalRow label="Gross Profit" amount={data.report.grossProfit} totalIncome={data.report.income.total} compareAmount={cmp?.grossProfit} showCompare={showCompare} />
 
-              <SectionHeader label="Expenses" />
-              {data.report.expenses.lines.map((l) => <ReportRow key={l.code} line={l} totalIncome={data.report.income.total} onDrill={setDrillCode} />)}
-              <TotalRow label="Total Expenses" amount={data.report.expenses.total} totalIncome={data.report.income.total} />
+              <SectionHeader label="Expenses" cols={cols} />
+              {data.report.expenses.lines.map((l) => <ReportRow key={l.code} line={l} totalIncome={data.report.income.total} onDrill={setDrillCode} compareAmount={cmpByCode.get(l.code) ?? null} showCompare={showCompare} />)}
+              <TotalRow label="Total Expenses" amount={data.report.expenses.total} totalIncome={data.report.income.total} compareAmount={cmp?.expenses.total} showCompare={showCompare} />
 
-              <TotalRow label="Net Income" amount={data.report.netIncome} totalIncome={data.report.income.total} />
+              <TotalRow label="Net Income" amount={data.report.netIncome} totalIncome={data.report.income.total} compareAmount={cmp?.netIncome} showCompare={showCompare} />
             </tbody>
           </table>
         </div>

--- a/apps/backoffice/src/app/(admin)/finance/reports/page.tsx
+++ b/apps/backoffice/src/app/(admin)/finance/reports/page.tsx
@@ -14,6 +14,7 @@ import {
 } from "@celsius/ui";
 import { Loader2, Download, FileText, AlertTriangle } from "lucide-react";
 import { DateRangePicker } from "@/components/date-range-picker";
+import { OUTFLOW_CATEGORIES, INFLOW_CATEGORIES, categoryLabel } from "@/lib/finance/cash-categories";
 
 // Accounting format: negatives in parentheses, the convention every
 // accounting package (Xero, QuickBooks, Bukku) uses on statements.
@@ -308,7 +309,7 @@ function PnlTab() {
     () => `start=${start}&end=${end}${consolidated ? "&companyId=consolidated" : outletId ? `&outletId=${outletId}` : ""}`,
     [start, end, outletId, consolidated],
   );
-  const { data, error, isLoading } = useFetch<{ report: PnlReport }>(
+  const { data, error, isLoading, mutate } = useFetch<{ report: PnlReport }>(
     `/api/finance/reports/pnl?${qs}`
   );
   const [drillCode, setDrillCode] = useState<string | null>(null);
@@ -397,7 +398,7 @@ function PnlTab() {
             )}
           </SheetHeader>
           {drillCode && data && (
-            <DrillDown code={drillCode} start={data.report.start} end={data.report.end} outletId={outletId || undefined} consolidated={consolidated} />
+            <DrillDown code={drillCode} start={data.report.start} end={data.report.end} outletId={outletId || undefined} consolidated={consolidated} onChanged={() => mutate()} />
           )}
         </SheetContent>
       </Sheet>
@@ -405,11 +406,33 @@ function PnlTab() {
   );
 }
 
-function DrillDown({ code, start, end, outletId, consolidated }: { code: string; start: string; end: string; outletId?: string; consolidated?: boolean }) {
-  const { data, isLoading } = useFetch<{ lines: DrillLine[] }>(
+function DrillDown({ code, start, end, outletId, consolidated, onChanged }: { code: string; start: string; end: string; outletId?: string; consolidated?: boolean; onChanged?: () => void }) {
+  const { data, isLoading, mutate } = useFetch<{ lines: DrillLine[] }>(
     `/api/finance/reports/drilldown?accountCode=${encodeURIComponent(code)}&start=${start}&end=${end}${consolidated ? "&companyId=consolidated" : outletId ? `&outletId=${outletId}` : ""}`
   );
+  const { data: acctData } = useFetch<{ accounts: { code: string; name: string }[] }>("/api/finance/accounts");
+  const accountNames = new Map((acctData?.accounts ?? []).map((a) => [a.code, a.name]));
   const [openRow, setOpenRow] = useState<string | null>(null);
+  const [busyRow, setBusyRow] = useState<string | null>(null);
+  const [rowNote, setRowNote] = useState<Record<string, string>>({});
+
+  // Recategorise a bank line straight from the report — the accounting-software
+  // way. Books it to the new category (GL re-keys), then refreshes the drill and
+  // the P&L behind it.
+  async function recategorise(bankLineId: string, category: string) {
+    if (!category) return;
+    setBusyRow(bankLineId); setRowNote((n) => ({ ...n, [bankLineId]: "" }));
+    try {
+      const res = await fetch("/api/finance/bank-lines/classify", {
+        method: "POST", headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ bankLineId, category }),
+      });
+      const j = await res.json();
+      if (!res.ok) setRowNote((n) => ({ ...n, [bankLineId]: j.error ?? `Failed (${res.status})` }));
+      else { await mutate(); onChanged?.(); }
+    } catch (e) { setRowNote((n) => ({ ...n, [bankLineId]: e instanceof Error ? e.message : String(e) })); }
+    finally { setBusyRow(null); }
+  }
   if (isLoading) return <div className="p-6"><Loader2 className="h-5 w-5 animate-spin" /></div>;
   if (!data) return null;
   if (data.lines.length === 0) {
@@ -483,6 +506,19 @@ function DrillDown({ code, start, end, outletId, consolidated }: { code: string;
                       <><dt className="text-muted-foreground">Inter-company</dt><dd>{l.meta.isInterCo ? "yes" : "no"}</dd></>
                       {(l.meta.classifiedBy || l.meta.ruleName) && (<><dt className="text-muted-foreground">Classified</dt><dd>{l.meta.classifiedBy ?? "rule"}{l.meta.ruleName ? ` · ${l.meta.ruleName}` : ""}</dd></>)}
                     </dl>
+                    <div className="mt-2 flex flex-wrap items-center gap-2 border-t pt-2" onClick={(e) => e.stopPropagation()}>
+                      <span className="text-[11px] text-muted-foreground">Recategorise to</span>
+                      <select defaultValue="" disabled={busyRow === l.transactionId}
+                        onChange={(e) => { recategorise(l.transactionId, e.target.value); e.target.value = ""; }}
+                        className="h-7 max-w-[280px] rounded border bg-background px-1 text-[11px] disabled:opacity-50">
+                        <option value="" disabled>Choose a category…</option>
+                        {(l.credit > 0 ? INFLOW_CATEGORIES : OUTFLOW_CATEGORIES).map((c) => (
+                          <option key={c} value={c}>{categoryLabel(c, accountNames)}</option>
+                        ))}
+                      </select>
+                      {busyRow === l.transactionId && <Loader2 className="h-3.5 w-3.5 animate-spin text-muted-foreground" />}
+                      {rowNote[l.transactionId] && <span className="text-[10px] text-rose-600">{rowNote[l.transactionId]}</span>}
+                    </div>
                   </td>
                 </tr>
               )}

--- a/apps/backoffice/src/lib/finance/cash-categories.ts
+++ b/apps/backoffice/src/lib/finance/cash-categories.ts
@@ -1,0 +1,44 @@
+// The human-assignable bank categories + their COA labels — one source of truth
+// shared by the Reconciliation page and the Reports drill-down (so a category
+// added in one place shows in the other). Mirrors the CashCategory enum;
+// validated server-side by the classify endpoint.
+
+import { CONTRA_ACCOUNT } from "./gl-posting-map";
+
+// Inter-company: one entity paid for / funded another's cost. Booking both
+// mirror legs to the "Due to/from" control accounts (3600-xx, routed by
+// counterparty) offsets them — P&L untouched, eliminated on consolidation.
+export const INTERCO_CATEGORIES = [
+  "INTERCO_EXPENSES", "INTERCO_INVESTMENTS", "INTERCO_RAW_MATERIAL", "INTERCO_PEOPLE",
+] as const;
+
+export const OUTFLOW_CATEGORIES = [
+  "RAW_MATERIALS", "RENT", "UTILITIES", "MAINTENANCE", "EQUIPMENTS", "SOFTWARE",
+  "STAFF_CLAIM", "PARTIMER", "EMPLOYEE_SALARY", "STATUTORY_PAYMENT", "TAX",
+  "COMPLIANCE", "LICENSING_FEE", "BANK_FEE", "MARKETPLACE_FEE", "OTHER_MARKETING",
+  "KOL", "DELIVERY", "PETTY_CASH", "LOAN", "DIVIDEND", "DIRECTORS_ALLOWANCE",
+  "CAPITAL", "INVESTMENTS", "MANAGEMENT_FEE", "CFS_FEE", "CUSTOMER_REFUND",
+  ...INTERCO_CATEGORIES,
+] as const;
+
+export const INFLOW_CATEGORIES = [
+  "QR", "CARD", "GRAB", "STOREHUB", "FOODPANDA", "REVENUE_MONSTER",
+  "GASTROHUB", "MEETINGS_EVENTS", "REFUND", "LOAN", "CAPITAL",
+  "MANAGEMENT_FEE", "EMPLOYEE_SALARY", "STATUTORY_PAYMENT",
+  ...INTERCO_CATEGORIES,
+] as const;
+
+// Control-account routes that CONTRA_ACCOUNT doesn't carry (resolveContra does):
+// salary/statutory controls, and the inter-company Due-to/from account (3600-xx
+// by counterparty — the label shows the parent 3600).
+export const CONTROL_COA: Record<string, string> = {
+  EMPLOYEE_SALARY: "3008", STATUTORY_PAYMENT: "3004-7",
+  INTERCO_EXPENSES: "3600", INTERCO_INVESTMENTS: "3600", INTERCO_RAW_MATERIAL: "3600", INTERCO_PEOPLE: "3600",
+};
+
+export function categoryLabel(c: string, accountNames: Map<string, string>): string {
+  const code = CONTRA_ACCOUNT[c] ?? CONTROL_COA[c];
+  const name = code ? accountNames.get(code) : undefined;
+  const human = c.toLowerCase().replace(/_/g, " ");
+  return code ? `${human} → ${code}${name ? ` ${name}` : ""}` : human;
+}

--- a/apps/backoffice/src/lib/finance/reports/pnl-sourced-drill.ts
+++ b/apps/backoffice/src/lib/finance/reports/pnl-sourced-drill.ts
@@ -30,7 +30,19 @@ export type DrillLine = {
   amount: number;
   debit: number;
   credit: number;
+  // Extra detail shown when a bank-line row is expanded ("see the tx behind it").
+  meta?: {
+    reference?: string | null;
+    category?: string | null;
+    company?: string | null;
+    account?: string | null;
+    isInterCo?: boolean;
+    classifiedBy?: string | null;
+    ruleName?: string | null;
+  };
 };
+
+const CONSOLIDATED = "consolidated";
 
 // Mirrors BANK_ACCOUNT_SUFFIX in pnl-sourced.ts.
 const BANK_ACCOUNT_SUFFIX: Record<string, string> = {
@@ -39,13 +51,31 @@ const BANK_ACCOUNT_SUFFIX: Record<string, string> = {
   celsiustamarind: "9345",
 };
 
+// Company that owns a Maybank account, from the 4-digit suffix in the name.
+function companyForAccount(accountName: string | null): string {
+  const a = (accountName ?? "").toUpperCase();
+  if (a.includes("2644") || a.includes("CONEZION")) return "Celsius Coffee Conezion";
+  if (a.includes("9345") || a.includes("TAMARIND")) return "Celsius Coffee Tamarind";
+  if (a.includes("4384") || a.includes("CELSIUS COFFEE SDN")) return "Celsius Coffee SB";
+  return accountName ?? "—";
+}
+function addMonths(s: string, n: number): string {
+  const [y, m, d] = s.split("-").map(Number);
+  const t = new Date(Date.UTC(y, m - 1 + n, 1));
+  const lastDay = new Date(Date.UTC(t.getUTCFullYear(), t.getUTCMonth() + 1, 0)).getUTCDate();
+  return `${t.getUTCFullYear()}-${String(t.getUTCMonth() + 1).padStart(2, "0")}-${String(Math.min(d, lastDay)).padStart(2, "0")}`;
+}
+
 export function isSourcedPnlCode(code: string): boolean {
   return /^(REV-|PROC$|INV-|MKT-|BANK:)/.test(code);
 }
 
 async function companyOutlets(companyId: string, outletId?: string | null): Promise<string[]> {
   const client = getFinanceClient();
-  const { data } = await client.from("fin_outlet_companies").select("outlet_id").eq("company_id", companyId);
+  // Consolidated → every company's outlets, so the drill spans all entities.
+  let q = client.from("fin_outlet_companies").select("outlet_id");
+  if (companyId !== CONSOLIDATED) q = q.eq("company_id", companyId);
+  const { data } = await q;
   const all = (data ?? []).map((r) => r.outlet_id as string);
   return outletId && all.includes(outletId) ? [outletId] : all;
 }
@@ -192,18 +222,26 @@ async function drillGrabAds(companyId: string, start: string, end: string, outle
 // BANK:<CAT> — the classified bank lines behind the opex line. Also serves the
 // bank-sourced income lines (GastroHub, Meetings & Events) on the CR side.
 async function drillBank(cat: string, companyId: string, start: string, end: string, outletId?: string | null, direction: "DR" | "CR" = "DR"): Promise<DrillLine[]> {
+  const consolidated = companyId === CONSOLIDATED;
   const suffix = BANK_ACCOUNT_SUFFIX[companyId];
-  if (!suffix) return [];
+  if (!consolidated && !suffix) return [];
   const lines = await prisma.bankStatementLine.findMany({
     where: {
       direction,
       txnDate: { gte: dStart(start), lte: dEnd(end) },
-      statement: { accountName: { contains: suffix } },
+      // Per-company: filter to that account. Consolidated: all accounts, but
+      // drop inter-company legs (they eliminate on consolidation) so the drill
+      // ties to the consolidated line.
+      ...(consolidated ? { isInterCo: false } : { statement: { accountName: { contains: suffix } } }),
       ...(direction === "DR" ? { apInvoiceId: null } : {}),
       category: cat === "NULL" ? null : (cat as CashCategory),
       ...(outletId ? { outletId } : {}),
     },
-    select: { id: true, txnDate: true, description: true, amount: true },
+    select: {
+      id: true, txnDate: true, description: true, amount: true, reference: true,
+      category: true, isInterCo: true, classifiedBy: true, ruleName: true,
+      statement: { select: { accountName: true } },
+    },
     orderBy: { txnDate: "asc" },
     take: 400,
   });
@@ -214,6 +252,15 @@ async function drillBank(cat: string, companyId: string, start: string, end: str
     amount: round2(Number(l.amount)),
     debit: direction === "DR" ? round2(Number(l.amount)) : 0,
     credit: direction === "CR" ? round2(Number(l.amount)) : 0,
+    meta: {
+      reference: l.reference,
+      category: l.category as string | null,
+      company: companyForAccount(l.statement?.accountName ?? null),
+      account: l.statement?.accountName ?? null,
+      isInterCo: l.isInterCo,
+      classifiedBy: l.classifiedBy,
+      ruleName: l.ruleName,
+    },
   }));
 }
 
@@ -234,6 +281,10 @@ export async function sourcedPnlDrillDown(args: {
   if (code === "MKT-ADS") return drillAds(start, end);
   if (code === "MKT-GRAB-PROMO") return drillGrabPromo(companyId, start, end, outletId);
   if (code === "MKT-GRAB-ADS") return drillGrabAds(companyId, start, end, outletId);
+  // Management fee is recognised on accrual (paid a month in arrears), so its
+  // drill uses the same shifted window as the P&L line — payments in the
+  // following month, which are this period's fee.
+  if (code === "BANK:MANAGEMENT_FEE") return drillBank("MANAGEMENT_FEE", companyId, addMonths(start, 1), addMonths(end, 1), outletId);
   if (code.startsWith("BANK:")) return drillBank(code.slice(5), companyId, start, end, outletId);
   if (code === "MKT-GRAB-COMM") {
     // A derived line, not transactions — the drawer explains the calculation.

--- a/apps/backoffice/src/lib/finance/reports/pnl-sourced-drill.ts
+++ b/apps/backoffice/src/lib/finance/reports/pnl-sourced-drill.ts
@@ -16,6 +16,7 @@
 import { prisma } from "@/lib/prisma";
 import { Prisma, type CashCategory } from "@prisma/client";
 import { getFinanceClient } from "../supabase";
+import { getDefaultCompanyId } from "../companies";
 import { effectiveGrabRate } from "./pnl-sourced";
 import { getUnifiedSalesForOutlet } from "@/app/api/sales/_lib/unified-sales";
 
@@ -145,25 +146,31 @@ async function drillPurchases(companyId: string, start: string, end: string, out
   }));
 }
 
-// MKT-ADS: Google Ads spend per day.
-async function drillAds(start: string, end: string): Promise<DrillLine[]> {
-  const rows = await prisma.adsMetricDaily.groupBy({
-    by: ["date"],
-    where: { date: { gte: dStart(start), lte: dEnd(end) } },
-    _sum: { costMicros: true },
-    orderBy: { date: "asc" },
-  });
-  return rows
-    .map((r) => ({ day: r.date.toISOString().slice(0, 10), amt: round2(Number(r._sum.costMicros ?? 0) / 1_000_000) }))
+// MKT-ADS: Google Ads spend per day, attributed to the company/outlet via the
+// campaign's outletId — mirrors the P&L so the drill ties to the line.
+async function drillAds(companyId: string, start: string, end: string, outletId?: string | null): Promise<DrillLine[]> {
+  const outletIds = await companyOutlets(companyId, outletId);
+  const defaultCompany = await getDefaultCompanyId();
+  const includeUntagged = !outletId && (companyId === CONSOLIDATED || companyId === defaultCompany);
+  const outletSet = new Set(outletIds);
+  const rows = await prisma.$queryRaw<{ date: Date; outlet_id: string | null; spend: number }[]>(Prisma.sql`
+    SELECT m.date, c.outlet_id, COALESCE(SUM(m.cost_micros), 0)::float / 1e6 AS spend
+    FROM ads_metric_daily m LEFT JOIN ads_campaign c ON c.id = m.campaign_id
+    WHERE m.date >= ${dStart(start)} AND m.date <= ${dEnd(end)}
+    GROUP BY m.date, c.outlet_id ORDER BY m.date ASC
+  `);
+  const byDay = new Map<string, number>();
+  for (const r of rows) {
+    const keep = (r.outlet_id && outletSet.has(r.outlet_id)) || (!r.outlet_id && includeUntagged);
+    if (!keep) continue;
+    const day = r.date.toISOString().slice(0, 10);
+    byDay.set(day, (byDay.get(day) ?? 0) + Number(r.spend));
+  }
+  return [...byDay.entries()]
+    .map(([day, amt]) => ({ day, amt: round2(amt) }))
     .filter((r) => r.amt !== 0)
-    .map((r) => ({
-      transactionId: `ads-${r.day}`,
-      txnDate: r.day,
-      description: "Google Ads spend",
-      amount: r.amt,
-      debit: r.amt,
-      credit: 0,
-    }));
+    .sort((a, b) => (a.day < b.day ? -1 : 1))
+    .map((r) => ({ transactionId: `ads-${r.day}`, txnDate: r.day, description: "Google Ads spend", amount: r.amt, debit: r.amt, credit: 0 }));
 }
 
 // Bridge Outlet UUIDs → loyalty ids (pos_orders / grab_ads_spend key).
@@ -278,7 +285,7 @@ export async function sourcedPnlDrillDown(args: {
   if (code === "REV-EVENTS") return drillBank("MEETINGS_EVENTS", companyId, start, end, outletId, "CR");
   if (code.startsWith("REV-")) return drillRevenue(code, companyId, start, end, outletId);
   if (code === "PROC") return drillPurchases(companyId, start, end, outletId);
-  if (code === "MKT-ADS") return drillAds(start, end);
+  if (code === "MKT-ADS") return drillAds(companyId, start, end, outletId);
   if (code === "MKT-GRAB-PROMO") return drillGrabPromo(companyId, start, end, outletId);
   if (code === "MKT-GRAB-ADS") return drillGrabAds(companyId, start, end, outletId);
   // Management fee is recognised on accrual (paid a month in arrears), so its

--- a/apps/backoffice/src/lib/finance/reports/pnl-sourced.ts
+++ b/apps/backoffice/src/lib/finance/reports/pnl-sourced.ts
@@ -339,14 +339,26 @@ export async function buildSourcedPnl(input: {
   const expenseLines: PnlLine[] = [];
   let totalExpenses = 0;
 
-  // Marketing — digital ads are brand-level (ad accounts carry no outlet), so
-  // attribute them to the default company only to avoid splitting/duplication.
-  if (companyId === defaultCompany) {
-    const adsAgg = await prisma.adsMetricDaily.aggregate({
-      _sum: { costMicros: true },
-      where: { date: { gte: dStart(start), lte: dEnd(end) } },
-    });
-    const adsSpend = round2(Number(adsAgg._sum.costMicros ?? 0) / 1_000_000);
+  // Marketing — Google Ads attributed PER OUTLET via the campaign's outletId
+  // (set in the ads module). A campaign tagged to an outlet lands in that
+  // outlet's / company's P&L; untagged brand-level campaigns stay with the
+  // default company. Per-outlet view shows only that outlet's tagged spend.
+  {
+    const adsByOutlet = await prisma.$queryRaw<{ outlet_id: string | null; spend: number }[]>(Prisma.sql`
+      SELECT c.outlet_id, COALESCE(SUM(m.cost_micros), 0)::float / 1e6 AS spend
+      FROM ads_metric_daily m
+      LEFT JOIN ads_campaign c ON c.id = m.campaign_id
+      WHERE m.date >= ${dStart(start)} AND m.date <= ${dEnd(end)}
+      GROUP BY c.outlet_id
+    `);
+    let adsSpend = 0;
+    for (const r of adsByOutlet) {
+      const oid = r.outlet_id;
+      if (oid && outletIds.includes(oid)) adsSpend += Number(r.spend);
+      // Untagged brand-level spend → default company, company-level view only.
+      else if (!oid && !outletId && companyId === defaultCompany) adsSpend += Number(r.spend);
+    }
+    adsSpend = round2(adsSpend);
     if (adsSpend) {
       expenseLines.push({ code: "MKT-ADS", name: "Marketing — Digital ads (Google)", amount: adsSpend, parentCode: null });
       totalExpenses += adsSpend;


### PR DESCRIPTION
Owner: on a consolidated (all-companies) P&L, the drill-down showed only
the active company's transactions, and rows weren't clickable.

- Consolidated drill: pass companyId=consolidated through to the drill; when
  set, span ALL companies' bank accounts (drop inter-company legs, matching
  the consolidated P&L) instead of the one active entity. companyOutlets also
  returns every company's outlets in that mode. A Company column appears so
  you see which entity each line is from.
- Click a bank-line row to expand its detail: bank account, reference,
  category, inter-company flag, and how it was classified (user/rule).
- Management fee drill uses the same accrual-shifted window as its P&L line
  (paid a month in arrears), so the drill total ties to the figure.

Typecheck + lint clean.
