### PR TITLE
Finance: bank reconciliation tick and categorisation audit trail

### DIFF
--- a/apps/backoffice/src/app/(admin)/finance/recon/page.tsx
+++ b/apps/backoffice/src/app/(admin)/finance/recon/page.tsx
@@ -3,7 +3,7 @@
 import { useState } from "react";
 import { useFetch } from "@/lib/use-fetch";
 import { OUTFLOW_CATEGORIES, INFLOW_CATEGORIES, categoryLabel } from "@/lib/finance/cash-categories";
-import { Loader2, CheckCircle2, AlertTriangle, HelpCircle, Copy, ArrowDownCircle, Paperclip } from "lucide-react";
+import { Loader2, CheckCircle2, AlertTriangle, HelpCircle, Copy, ArrowDownCircle, Paperclip, History } from "lucide-react";
 
 type ApMatch = {
   invoiceId: string; invoiceNumber: string | null; payee: string; amount: number; issueDate: string;
@@ -36,7 +36,7 @@ const fmtRM0 = (n: number) => `RM ${n.toLocaleString("en-MY", { maximumFractionD
 // Category lists + labels live in @/lib/finance/cash-categories (shared with
 // the Reports drill-down so both offer the same recategorization choices).
 
-type ReconTab = "categorise" | "review" | "matched" | "invoices" | "cashin";
+type ReconTab = "categorise" | "review" | "matched" | "invoices" | "cashin" | "bankrecon";
 
 export default function ReconPage() {
   const [days, setDays] = useState(90);
@@ -109,6 +109,7 @@ export default function ReconPage() {
               ["matched", "Matched", null],
               ["invoices", "Open invoices", data.summary.unmatchedInvoices],
               ["cashin", "Cash-in", null],
+              ["bankrecon", "Bank recon", null],
             ] as [ReconTab, string, number | null][]).map(([id, label, count]) => (
               <button key={id} onClick={() => setTab(id)}
                 className={`-mb-px whitespace-nowrap border-b-2 px-3 py-2 text-sm transition-colors ${tab === id ? "border-terracotta font-medium text-gray-900" : "border-transparent text-gray-500 hover:text-gray-800"}`}>
@@ -194,9 +195,141 @@ export default function ReconPage() {
                 )}
               </QueueCard>
             )}
+
+            {tab === "bankrecon" && <BankReconPanel />}
           </div>
         </>
       )}
+    </div>
+  );
+}
+
+// Bank reconciliation tick.
+// The owner's monthly checklist: per account, does opening balance + the
+// month's ledger lines land exactly on the statement closing balance?
+// Zero delta earns a green check and can be signed off; anything else means
+// lines are missing or duplicated, or the statement balance is wrong.
+
+type ReconMonth = {
+  month: string;
+  opening: number | null;
+  linesTotal: number;
+  computedClose: number | null;
+  statedClose: number | null;
+  delta: number | null;
+  unclassified: number;
+  hasStatement: boolean;
+  signedOffBy: string | null;
+  signedOffAt: string | null;
+};
+type BankReconData = { accounts: { account: string; months: ReconMonth[] }[] };
+
+const fmtMonth = (m: string) =>
+  new Date(`${m}T00:00:00.000Z`).toLocaleDateString("en-MY", { month: "short", year: "numeric", timeZone: "UTC" });
+const fmtDay = (iso: string) =>
+  new Date(iso).toLocaleDateString("en-MY", { day: "numeric", month: "short", year: "numeric" });
+
+function BankReconPanel() {
+  const { data, isLoading, mutate } = useFetch<BankReconData>("/api/finance/bank-recon");
+  const [busy, setBusy] = useState<string | null>(null);
+  const [note, setNote] = useState<string | null>(null);
+
+  async function signOff(account: string, month: string, undo: boolean) {
+    setBusy(account + month); setNote(null);
+    try {
+      const res = await fetch("/api/finance/bank-recon", {
+        method: undo ? "DELETE" : "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ account, month }),
+      });
+      const j = await res.json();
+      if (!res.ok) setNote(j.error ?? `Failed (${res.status})`);
+      else mutate();
+    } catch (e) { setNote(e instanceof Error ? e.message : String(e)); }
+    finally { setBusy(null); }
+  }
+
+  if (isLoading || !data) return <div className="flex justify-center py-12"><Loader2 className="h-5 w-5 animate-spin text-gray-400" /></div>;
+  if (data.accounts.length === 0) return <p className="px-4 py-4 text-xs text-gray-400">No bank statements uploaded yet.</p>;
+
+  return (
+    <div className="space-y-4">
+      {note && <p className="rounded-lg border border-rose-200 bg-rose-50 px-3 py-2 text-[11px] text-rose-700">{note}</p>}
+      {data.accounts.map(({ account, months }) => (
+        <QueueCard key={account} title={`Bank recon: ${account}`} desc="Opening balance plus the month's ledger lines must equal the statement close. Sign off each month once the delta is zero.">
+          <div className="overflow-x-auto">
+            <table className="w-full min-w-[860px] text-sm">
+              <thead><tr className="border-b bg-gray-50/50 text-left text-gray-500">
+                <th className="px-3 py-2 font-medium">Month</th>
+                <th className="px-3 py-2 text-right font-medium">Opening</th>
+                <th className="px-3 py-2 text-right font-medium">Lines total</th>
+                <th className="px-3 py-2 text-right font-medium">Computed close</th>
+                <th className="px-3 py-2 text-right font-medium">Statement close</th>
+                <th className="px-3 py-2 text-right font-medium">Delta</th>
+                <th className="px-3 py-2 font-medium">Status</th>
+              </tr></thead>
+              <tbody className="divide-y">
+                {months.map((m) => {
+                  const key = account + m.month;
+                  if (!m.hasStatement) {
+                    return (
+                      <tr key={key} className="hover:bg-gray-50">
+                        <td className="px-3 py-2 text-xs text-gray-500 whitespace-nowrap">{fmtMonth(m.month)}</td>
+                        <td colSpan={6} className="px-3 py-2 text-[11px] text-gray-400">no statement</td>
+                      </tr>
+                    );
+                  }
+                  const reconciled = m.delta != null && Math.abs(m.delta) <= 0.01;
+                  return (
+                    <tr key={key} className="hover:bg-gray-50">
+                      <td className="px-3 py-2 text-xs text-gray-700 whitespace-nowrap">{fmtMonth(m.month)}</td>
+                      <td className="px-3 py-2 text-right font-mono text-xs text-gray-600">{m.opening == null ? <span className="text-gray-400">no prior statement</span> : fmtRM(m.opening)}</td>
+                      <td className="px-3 py-2 text-right font-mono text-xs text-gray-600">
+                        {fmtRM(m.linesTotal)}
+                        {m.unclassified > 0 && <div className="text-[10px] font-sans text-amber-600">{m.unclassified} unclassified</div>}
+                      </td>
+                      <td className="px-3 py-2 text-right font-mono text-xs text-gray-700">{m.computedClose == null ? "" : fmtRM(m.computedClose)}</td>
+                      <td className="px-3 py-2 text-right font-mono text-xs text-gray-700">{m.statedClose == null ? "" : fmtRM(m.statedClose)}</td>
+                      <td className="px-3 py-2 text-right">
+                        {m.delta == null ? (
+                          <span className="text-[11px] text-gray-400">n/a</span>
+                        ) : reconciled ? (
+                          <CheckCircle2 className="ml-auto h-4 w-4 text-green-600" />
+                        ) : (
+                          <span className="font-mono text-xs text-rose-600" title="lines missing or duplicated, or statement balance wrong">
+                            {fmtRM(m.delta)}
+                            <div className="text-[10px] font-sans text-rose-400">lines missing or duplicated, or statement balance wrong</div>
+                          </span>
+                        )}
+                      </td>
+                      <td className="whitespace-nowrap px-3 py-2">
+                        {m.signedOffBy ? (
+                          <span className="inline-flex items-center gap-1.5">
+                            <span className="rounded bg-green-50 px-1.5 py-0.5 text-[11px] font-medium text-green-700">
+                              Reconciled by {m.signedOffBy}{m.signedOffAt ? ` on ${fmtDay(m.signedOffAt)}` : ""}
+                            </span>
+                            <button onClick={() => signOff(account, m.month, true)} disabled={busy === key}
+                              className="text-[10px] text-gray-400 underline hover:text-gray-600 disabled:opacity-50">
+                              undo
+                            </button>
+                          </span>
+                        ) : reconciled ? (
+                          <button onClick={() => signOff(account, m.month, false)} disabled={busy === key}
+                            className="rounded border border-green-600/30 bg-green-50 px-2 py-0.5 text-[11px] font-medium text-green-700 hover:bg-green-100 disabled:opacity-50">
+                            {busy === key ? "Signing off" : "Sign off"}
+                          </button>
+                        ) : (
+                          <span className="text-[11px] text-gray-400">fix delta first</span>
+                        )}
+                      </td>
+                    </tr>
+                  );
+                })}
+              </tbody>
+            </table>
+          </div>
+        </QueueCard>
+      ))}
     </div>
   );
 }
@@ -342,6 +475,18 @@ function LineRow({ row, direction, categories, accountNames, selected, onToggle,
   const [attachOpen, setAttachOpen] = useState(false);
   const [attachments, setAttachments] = useState<{ id: string; filename: string; url: string | null }[] | null>(null);
   const [uploading, setUploading] = useState(false);
+  const [historyOpen, setHistoryOpen] = useState(false);
+  const [events, setEvents] = useState<LineEvent[] | null>(null);
+
+  function toggleHistory() {
+    const next = !historyOpen;
+    setHistoryOpen(next);
+    if (next && events === null) {
+      fetch(`/api/finance/bank-lines/events?lineId=${row.bankLineId}`)
+        .then((res) => res.json().then((j) => setEvents(res.ok ? j.events : [])))
+        .catch(() => setEvents([]));
+    }
+  }
 
   async function loadAttachments() {
     try {
@@ -455,6 +600,14 @@ function LineRow({ row, direction, categories, accountNames, selected, onToggle,
             >
               <Paperclip className="h-3 w-3" />{attachments && attachments.length > 0 ? attachments.length : ""}
             </button>
+            <button
+              onClick={toggleHistory}
+              disabled={busy}
+              title="Who changed this line's category or match, and when"
+              className={`flex h-6 items-center rounded border px-1.5 text-[11px] font-medium disabled:opacity-50 ${historyOpen ? "border-terracotta text-terracotta" : "border-gray-200 text-gray-600 hover:bg-gray-50"}`}
+            >
+              <History className="h-3 w-3" />
+            </button>
           </div>
         </td>
       </tr>
@@ -515,8 +668,52 @@ function LineRow({ row, direction, categories, accountNames, selected, onToggle,
           </td>
         </tr>
       )}
+      {historyOpen && (
+        <tr className="bg-gray-50/60">
+          <td colSpan={6} className="px-3 py-2">
+            {events === null ? (
+              <span className="text-[11px] text-gray-400">Loading history...</span>
+            ) : events.length === 0 ? (
+              <span className="text-[11px] text-gray-400">No manual changes recorded for this line yet.</span>
+            ) : (
+              <ul className="flex flex-col gap-0.5">
+                {events.map((e) => (
+                  <li key={e.id} className="flex items-center gap-1.5 text-[11px] text-gray-600">
+                    <History className="h-3 w-3 shrink-0 text-gray-400" />
+                    <span>{fmtEventDay(e.created_at)}, {eventLabel(e)} by {e.actor ?? "system"}</span>
+                  </li>
+                ))}
+              </ul>
+            )}
+          </td>
+        </tr>
+      )}
     </>
   );
+}
+
+// Per-line audit trail (fin_bank_line_events), rendered as compact sentences
+// like "31 May, categorised RENT to EQUIPMENTS by Ammar".
+type LineEventValue = { category?: string | null; invoiceId?: string; invoiceNumber?: string | null; payee?: string | null; linkOnly?: boolean } | null;
+type LineEvent = { id: string; event: string; old_value: LineEventValue; new_value: LineEventValue; actor: string | null; created_at: string };
+
+const fmtEventDay = (iso: string) =>
+  new Date(iso).toLocaleDateString("en-MY", { day: "numeric", month: "short" });
+
+function eventLabel(e: LineEvent): string {
+  const invoiceRef = (v: LineEventValue) => v?.invoiceNumber ?? (v?.payee ? `from ${v.payee}` : v?.invoiceId ?? "unknown");
+  switch (e.event) {
+    case "classify":
+      return `categorised ${e.old_value?.category ?? "unclassified"} to ${e.new_value?.category ?? "unclassified"}`;
+    case "match":
+      return `matched to invoice ${invoiceRef(e.new_value)}${e.new_value?.linkOnly ? " (link only)" : ""}`;
+    case "unmatch":
+      return `unmatched from invoice ${invoiceRef(e.old_value)}`;
+    case "reject_match":
+      return `rejected proposed match with invoice ${invoiceRef(e.new_value)}`;
+    default:
+      return e.event.replace(/_/g, " ");
+  }
 }
 
 function Tile({ icon, label, value, sub, tone, onClick, active }: { icon: React.ReactNode; label: string; value: number; sub?: string; tone: "green" | "amber" | "red" | "gray"; onClick: () => void; active?: boolean }) {

--- a/apps/backoffice/src/app/api/finance/bank-lines/classify/route.ts
+++ b/apps/backoffice/src/app/api/finance/bank-lines/classify/route.ts
@@ -12,6 +12,7 @@ import { requireAuth } from "@/lib/auth";
 import { prisma } from "@/lib/prisma";
 import { CashCategory } from "@prisma/client";
 import { learnHintsFromLines } from "@/lib/finance/category-hints";
+import { logBankLineEvents } from "@/lib/finance/bank-line-events";
 
 export const dynamic = "force-dynamic";
 export const maxDuration = 60;
@@ -32,7 +33,7 @@ export async function POST(req: NextRequest) {
 
   const lines = await prisma.bankStatementLine.findMany({
     where: { id: { in: ids } },
-    select: { id: true, glTransactionId: true, apInvoiceId: true, description: true, direction: true },
+    select: { id: true, glTransactionId: true, apInvoiceId: true, description: true, direction: true, category: true },
   });
   if (!lines.length) return NextResponse.json({ error: "Bank lines not found" }, { status: 404 });
   const matched = lines.filter((l) => l.apInvoiceId).length;
@@ -57,6 +58,18 @@ export async function POST(req: NextRequest) {
       });
     }
   });
+  // Audit trail: one event per line, inserted in one batch. Best-effort, the
+  // helper never throws.
+  await logBankLineEvents(
+    writable.map((l) => ({
+      lineId: l.id,
+      event: "classify" as const,
+      oldValue: { category: l.category ?? null },
+      newValue: { category },
+    })),
+    auth.user.name,
+  );
+
   // Teach the categorizer: this correction becomes a counterparty hint the
   // classifier consults before its keyword rules, so the same payee never
   // needs correcting twice. Failure to learn must not fail the classify.

--- a/apps/backoffice/src/app/api/finance/bank-lines/events/route.ts
+++ b/apps/backoffice/src/app/api/finance/bank-lines/events/route.ts
@@ -1,0 +1,34 @@
+// GET /api/finance/bank-lines/events?lineId=... - the audit trail for one
+// bank line, newest first. Written best-effort by the classify / match /
+// unmatch / reject-match routes (fin_bank_line_events, migration 071).
+
+import { NextRequest, NextResponse } from "next/server";
+import { requireAuth } from "@/lib/auth";
+import { getFinanceClient } from "@/lib/finance/supabase";
+
+export const dynamic = "force-dynamic";
+
+export async function GET(req: NextRequest) {
+  const auth = await requireAuth(req);
+  if (auth.error) return auth.error;
+  if (!["OWNER", "ADMIN"].includes(auth.user.role)) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+  const lineId = new URL(req.url).searchParams.get("lineId");
+  if (!lineId) return NextResponse.json({ error: "lineId required" }, { status: 400 });
+
+  const client = getFinanceClient();
+  const { data, error } = await client
+    .from("fin_bank_line_events")
+    .select("id, event, old_value, new_value, actor, created_at")
+    .eq("line_id", lineId)
+    .order("created_at", { ascending: false })
+    .limit(100);
+  if (error) {
+    // 42P01 = table missing (migration 071 not applied yet): empty history,
+    // not an error, so the UI stays usable.
+    if (error.code === "42P01") return NextResponse.json({ events: [] });
+    return NextResponse.json({ error: error.message }, { status: 500 });
+  }
+  return NextResponse.json({ events: data ?? [] });
+}

--- a/apps/backoffice/src/app/api/finance/bank-lines/match/route.ts
+++ b/apps/backoffice/src/app/api/finance/bank-lines/match/route.ts
@@ -7,26 +7,27 @@
 //                            route — then it's link-only, invoice untouched).
 
 import { NextRequest, NextResponse } from "next/server";
-import { requireAuth } from "@/lib/auth";
+import { requireAuth, type SessionUser } from "@/lib/auth";
 import { prisma } from "@/lib/prisma";
 import { writeApMatch, digitRuns, invoiceRefInDesc, type ApMatch } from "@/lib/finance/ap-match";
+import { logBankLineEvents } from "@/lib/finance/bank-line-events";
 
 export const dynamic = "force-dynamic";
 
 const round2 = (n: number) => Math.round(n * 100) / 100;
 const ymd = (d: Date) => d.toISOString().slice(0, 10);
 
-async function guard(req: NextRequest) {
+async function guard(req: NextRequest): Promise<{ error: NextResponse | null; user: SessionUser | null }> {
   const auth = await requireAuth(req);
-  if (auth.error) return auth.error;
+  if (auth.error) return { error: auth.error, user: null };
   if (!["OWNER", "ADMIN"].includes(auth.user.role)) {
-    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+    return { error: NextResponse.json({ error: "Forbidden" }, { status: 403 }), user: null };
   }
-  return null;
+  return { error: null, user: auth.user };
 }
 
 export async function GET(req: NextRequest) {
-  const err = await guard(req);
+  const { error: err } = await guard(req);
   if (err) return err;
   const bankLineId = new URL(req.url).searchParams.get("bankLineId");
   if (!bankLineId) return NextResponse.json({ error: "bankLineId required" }, { status: 400 });
@@ -81,7 +82,7 @@ export async function GET(req: NextRequest) {
 }
 
 export async function POST(req: NextRequest) {
-  const err = await guard(req);
+  const { error: err, user } = await guard(req);
   if (err) return err;
   let body: { bankLineId?: string; invoiceId?: string } = {};
   try { body = await req.json(); } catch { /* handled below */ }
@@ -118,5 +119,15 @@ export async function POST(req: NextRequest) {
       data: { glTransactionId: null, glPostedAt: null },
     });
   }
+  // Audit trail: who linked this line to which invoice. Best-effort.
+  await logBankLineEvents(
+    [{
+      lineId: line.id,
+      event: "match",
+      oldValue: null,
+      newValue: { invoiceId: inv.id, invoiceNumber: inv.invoiceNumber, payee: m.payee, linkOnly },
+    }],
+    user?.name,
+  );
   return NextResponse.json({ ok: true, linkOnly });
 }

--- a/apps/backoffice/src/app/api/finance/bank-lines/reject-match/route.ts
+++ b/apps/backoffice/src/app/api/finance/bank-lines/reject-match/route.ts
@@ -5,6 +5,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { requireAuth } from "@/lib/auth";
 import { getFinanceClient } from "@/lib/finance/supabase";
+import { logBankLineEvents } from "@/lib/finance/bank-line-events";
 
 export const dynamic = "force-dynamic";
 
@@ -25,5 +26,16 @@ export async function POST(req: NextRequest) {
     { onConflict: "bank_line_id,invoice_id" },
   );
   if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+
+  // Audit trail: who rejected this proposed pair. Best-effort.
+  await logBankLineEvents(
+    [{
+      lineId: body.bankLineId,
+      event: "reject_match",
+      oldValue: null,
+      newValue: { invoiceId: body.invoiceId },
+    }],
+    auth.user.name,
+  );
   return NextResponse.json({ ok: true });
 }

--- a/apps/backoffice/src/app/api/finance/bank-lines/unmatch/route.ts
+++ b/apps/backoffice/src/app/api/finance/bank-lines/unmatch/route.ts
@@ -11,6 +11,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { requireAuth } from "@/lib/auth";
 import { prisma } from "@/lib/prisma";
 import { getFinanceClient } from "@/lib/finance/supabase";
+import { logBankLineEvents } from "@/lib/finance/bank-line-events";
 
 export const dynamic = "force-dynamic";
 
@@ -69,6 +70,20 @@ export async function POST(req: NextRequest) {
   await client.from("fin_ap_match_rejections").upsert(
     { bank_line_id: line.id, invoice_id: invoiceId, reason: "unmatched" },
     { onConflict: "bank_line_id,invoice_id" },
+  );
+
+  // Audit trail: who unlinked this line from which invoice. Best-effort.
+  const inv = await prisma.invoice
+    .findUnique({ where: { id: invoiceId }, select: { invoiceNumber: true } })
+    .catch(() => null);
+  await logBankLineEvents(
+    [{
+      lineId: line.id,
+      event: "unmatch",
+      oldValue: { invoiceId, invoiceNumber: inv?.invoiceNumber ?? null },
+      newValue: null,
+    }],
+    auth.user.name,
   );
 
   return NextResponse.json({

--- a/apps/backoffice/src/app/api/finance/bank-recon/route.ts
+++ b/apps/backoffice/src/app/api/finance/bank-recon/route.ts
@@ -180,7 +180,8 @@ export async function GET(req: NextRequest) {
 
 export async function POST(req: NextRequest) {
   const { error, user } = await guard(req);
-  if (error || !user) return error;
+  if (error) return error;
+  if (!user) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   let body: { account?: string; month?: string } = {};
   try { body = await req.json(); } catch { /* handled below */ }
   const month = normalizeMonth(body.month);
@@ -222,7 +223,8 @@ export async function POST(req: NextRequest) {
 
 export async function DELETE(req: NextRequest) {
   const { error, user } = await guard(req);
-  if (error || !user) return error;
+  if (error) return error;
+  if (!user) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   let body: { account?: string; month?: string } = {};
   try { body = await req.json(); } catch { /* handled below */ }
   const month = normalizeMonth(body.month);

--- a/apps/backoffice/src/app/api/finance/bank-recon/route.ts
+++ b/apps/backoffice/src/app/api/finance/bank-recon/route.ts
@@ -1,0 +1,240 @@
+// Bank reconciliation tick: assert per bank account per month that
+// (opening balance + signed sum of the month's ledger lines) equals the
+// statement closing balance, and let the owner sign it off.
+//
+// GET    -> per account, the last 12 months with opening / lines total /
+//           computed close / statement close / delta / sign-off state.
+// POST   { account, month }  -> sign off (Owner/Admin). Recomputes server
+//           side and refuses with 409 unless the delta is zero (within 0.01).
+// DELETE { account, month }  -> undo a sign-off (Owner/Admin), for corrections.
+//
+// Statement-to-month join: a statement "covers" a month when its period end
+// (periodEnd, falling back to statementDate, which the Maybank parser sets to
+// the statement end date) lands inside that month. Opening is the closing
+// balance of the latest statement ending before the month.
+
+import { NextRequest, NextResponse } from "next/server";
+import { requireAuth, type SessionUser } from "@/lib/auth";
+import { prisma } from "@/lib/prisma";
+import { getFinanceClient } from "@/lib/finance/supabase";
+
+export const dynamic = "force-dynamic";
+export const maxDuration = 60;
+
+const MONTHS_BACK = 12;
+const TOLERANCE = 0.01;
+
+const round2 = (n: number) => Math.round(n * 100) / 100;
+
+type MonthRow = {
+  month: string; // YYYY-MM-01
+  opening: number | null;
+  linesTotal: number;
+  computedClose: number | null;
+  statedClose: number | null;
+  delta: number | null;
+  unclassified: number;
+  hasStatement: boolean;
+  signedOffBy: string | null;
+  signedOffAt: string | null;
+};
+
+type AccountRecon = { account: string; months: MonthRow[] };
+
+async function guard(req: NextRequest): Promise<{ error: NextResponse | null; user: SessionUser | null }> {
+  const auth = await requireAuth(req);
+  if (auth.error) return { error: auth.error, user: null };
+  if (!["OWNER", "ADMIN"].includes(auth.user.role)) {
+    return { error: NextResponse.json({ error: "Forbidden" }, { status: 403 }), user: null };
+  }
+  return { error: null, user: auth.user };
+}
+
+// "2026-06" or "2026-06-15" -> "2026-06-01"; null if unparseable.
+function normalizeMonth(input: unknown): string | null {
+  if (typeof input !== "string") return null;
+  const m = input.match(/^(\d{4})-(\d{2})/);
+  if (!m) return null;
+  const mo = parseInt(m[2], 10);
+  if (mo < 1 || mo > 12) return null;
+  return `${m[1]}-${m[2]}-01`;
+}
+
+function monthStartUTC(offsetBack: number): Date {
+  const now = new Date();
+  return new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth() - offsetBack, 1));
+}
+
+const ymd = (d: Date) => d.toISOString().slice(0, 10);
+
+// Compute the recon grid for every account with statements, newest month first.
+async function computeRecon(): Promise<AccountRecon[]> {
+  const windowStart = monthStartUTC(MONTHS_BACK - 1);
+  const months: string[] = [];
+  for (let i = 0; i < MONTHS_BACK; i++) months.push(ymd(monthStartUTC(i)));
+
+  const statements = await prisma.bankStatement.findMany({
+    select: { id: true, accountName: true, statementDate: true, closingBalance: true, periodEnd: true },
+    orderBy: { statementDate: "asc" },
+  });
+
+  type Stmt = { id: string; effectiveEnd: Date; closing: number };
+  const byAccount = new Map<string, Stmt[]>();
+  const stmtToAccount = new Map<string, string>();
+  for (const s of statements) {
+    const account = s.accountName ?? "(no account)";
+    const effectiveEnd = s.periodEnd ?? s.statementDate;
+    const list = byAccount.get(account) ?? [];
+    list.push({ id: s.id, effectiveEnd, closing: Number(s.closingBalance) });
+    byAccount.set(account, list);
+    stmtToAccount.set(s.id, account);
+  }
+
+  // Signed sums + unclassified counts per (account, month) over the window.
+  const lines = await prisma.bankStatementLine.findMany({
+    where: { txnDate: { gte: windowStart } },
+    select: { statementId: true, txnDate: true, amount: true, direction: true, category: true },
+  });
+  const sums = new Map<string, { total: number; unclassified: number }>();
+  for (const l of lines) {
+    const account = stmtToAccount.get(l.statementId);
+    if (!account) continue;
+    const key = `${account}|${ymd(l.txnDate).slice(0, 7)}-01`;
+    const agg = sums.get(key) ?? { total: 0, unclassified: 0 };
+    agg.total += (l.direction === "CR" ? 1 : -1) * Number(l.amount);
+    if (!l.category) agg.unclassified += 1;
+    sums.set(key, agg);
+  }
+
+  // Sign-offs. Tolerate the table not existing yet (migration 071 pending).
+  const signoffs = new Map<string, { by: string | null; at: string | null }>();
+  try {
+    const client = getFinanceClient();
+    const { data, error } = await client
+      .from("fin_bank_recons")
+      .select("account, month, signed_off_by, signed_off_at")
+      .gte("month", ymd(windowStart));
+    if (!error && data) {
+      for (const r of data) {
+        signoffs.set(`${r.account}|${String(r.month).slice(0, 10)}`, {
+          by: r.signed_off_by ?? null,
+          at: r.signed_off_at ?? null,
+        });
+      }
+    }
+  } catch { /* sign-off info is optional; the grid still renders */ }
+
+  const accounts: AccountRecon[] = [];
+  for (const [account, stmts] of [...byAccount.entries()].sort((a, b) => a[0].localeCompare(b[0]))) {
+    const rows: MonthRow[] = months.map((month) => {
+      const start = new Date(`${month}T00:00:00.000Z`);
+      const next = new Date(Date.UTC(start.getUTCFullYear(), start.getUTCMonth() + 1, 1));
+
+      // Statement covering this month = the one with the latest period end inside it.
+      let covering: Stmt | null = null;
+      for (const s of stmts) {
+        if (s.effectiveEnd >= start && s.effectiveEnd < next) {
+          if (!covering || s.effectiveEnd > covering.effectiveEnd) covering = s;
+        }
+      }
+      // Opening = closing balance of the latest statement ending before the month.
+      let openingStmt: Stmt | null = null;
+      for (const s of stmts) {
+        if (s.effectiveEnd < start) {
+          if (!openingStmt || s.effectiveEnd > openingStmt.effectiveEnd) openingStmt = s;
+        }
+      }
+
+      const agg = sums.get(`${account}|${month}`);
+      const linesTotal = round2(agg?.total ?? 0);
+      const opening = openingStmt ? round2(openingStmt.closing) : null;
+      const statedClose = covering ? round2(covering.closing) : null;
+      const computedClose = opening == null ? null : round2(opening + linesTotal);
+      const delta = computedClose == null || statedClose == null ? null : round2(computedClose - statedClose);
+      const signoff = signoffs.get(`${account}|${month}`);
+
+      return {
+        month,
+        opening,
+        linesTotal,
+        computedClose,
+        statedClose,
+        delta,
+        unclassified: agg?.unclassified ?? 0,
+        hasStatement: !!covering,
+        signedOffBy: signoff?.by ?? null,
+        signedOffAt: signoff?.at ?? null,
+      };
+    });
+    accounts.push({ account, months: rows });
+  }
+  return accounts;
+}
+
+export async function GET(req: NextRequest) {
+  const { error } = await guard(req);
+  if (error) return error;
+  const accounts = await computeRecon();
+  return NextResponse.json({ accounts });
+}
+
+export async function POST(req: NextRequest) {
+  const { error, user } = await guard(req);
+  if (error || !user) return error;
+  let body: { account?: string; month?: string } = {};
+  try { body = await req.json(); } catch { /* handled below */ }
+  const month = normalizeMonth(body.month);
+  if (!body.account || !month) {
+    return NextResponse.json({ error: "account and month required" }, { status: 400 });
+  }
+
+  // Never trust the client's numbers: recompute server-side and only accept
+  // a sign-off when the month actually reconciles.
+  const accounts = await computeRecon();
+  const row = accounts.find((a) => a.account === body.account)?.months.find((m) => m.month === month);
+  if (!row) return NextResponse.json({ error: "Unknown account or month outside the 12-month window" }, { status: 404 });
+  if (row.statedClose == null) {
+    return NextResponse.json({ error: "No statement covers this month yet" }, { status: 409 });
+  }
+  if (row.delta == null || Math.abs(row.delta) > TOLERANCE) {
+    return NextResponse.json(
+      { error: `Delta is not zero (${row.delta ?? "unknown"}). Fix missing or duplicated lines, or the statement balance, before signing off.` },
+      { status: 409 },
+    );
+  }
+
+  const client = getFinanceClient();
+  const { error: dbError } = await client.from("fin_bank_recons").upsert(
+    {
+      account: body.account,
+      month,
+      stated_close: row.statedClose,
+      computed_close: row.computedClose,
+      delta: row.delta,
+      signed_off_by: user.name || user.id,
+      signed_off_at: new Date().toISOString(),
+    },
+    { onConflict: "account,month" },
+  );
+  if (dbError) return NextResponse.json({ error: dbError.message }, { status: 500 });
+  return NextResponse.json({ ok: true, account: body.account, month, delta: row.delta });
+}
+
+export async function DELETE(req: NextRequest) {
+  const { error, user } = await guard(req);
+  if (error || !user) return error;
+  let body: { account?: string; month?: string } = {};
+  try { body = await req.json(); } catch { /* handled below */ }
+  const month = normalizeMonth(body.month);
+  if (!body.account || !month) {
+    return NextResponse.json({ error: "account and month required" }, { status: 400 });
+  }
+  const client = getFinanceClient();
+  const { error: dbError } = await client
+    .from("fin_bank_recons")
+    .delete()
+    .eq("account", body.account)
+    .eq("month", month);
+  if (dbError) return NextResponse.json({ error: dbError.message }, { status: 500 });
+  return NextResponse.json({ ok: true });
+}

--- a/apps/backoffice/src/lib/finance/bank-line-events.ts
+++ b/apps/backoffice/src/lib/finance/bank-line-events.ts
@@ -1,0 +1,36 @@
+// Best-effort audit trail for manual bank line changes (fin_bank_line_events).
+// Every classify / match / unmatch / reject-match records who did what with
+// the old and new values, so the recon page can show a per-line history.
+// Writing the trail must never break the main operation: this helper swallows
+// and logs failures (including the table not existing before migration 071
+// is applied).
+
+import { getFinanceClient } from "./supabase";
+
+export type BankLineEventInput = {
+  lineId: string;
+  event: "classify" | "match" | "unmatch" | "reject_match";
+  oldValue?: Record<string, unknown> | null;
+  newValue?: Record<string, unknown> | null;
+};
+
+export async function logBankLineEvents(
+  events: BankLineEventInput[],
+  actor: string | null | undefined,
+): Promise<void> {
+  if (!events.length) return;
+  try {
+    const client = getFinanceClient();
+    const rows = events.map((e) => ({
+      line_id: e.lineId,
+      event: e.event,
+      old_value: e.oldValue ?? null,
+      new_value: e.newValue ?? null,
+      actor: actor || "system",
+    }));
+    const { error } = await client.from("fin_bank_line_events").insert(rows);
+    if (error) console.error("[bank-line-events] insert failed:", error.message);
+  } catch (e) {
+    console.error("[bank-line-events] insert failed:", e instanceof Error ? e.message : e);
+  }
+}

--- a/supabase/migrations/071_bank_recon_and_line_events.sql
+++ b/supabase/migrations/071_bank_recon_and_line_events.sql
@@ -1,0 +1,41 @@
+-- Bank reconciliation sign-off + bank line audit trail.
+--
+-- fin_bank_recons: one row per (account, month) the owner has signed off.
+-- The QuickBooks-style reconcile tick: opening balance + signed sum of the
+-- month's ledger lines must equal the statement closing balance (within
+-- 0.01) before the sign-off endpoint accepts it. Read/written by
+-- /api/finance/bank-recon and shown on the recon page's Bank recon tab.
+--
+-- fin_bank_line_events: append-only audit trail of every manual change to a
+-- bank line's category or invoice match. Written best-effort by the
+-- classify / match / unmatch / reject-match routes, read by
+-- /api/finance/bank-lines/events for the per-line history view.
+
+create table if not exists fin_bank_recons (
+  id uuid primary key default gen_random_uuid(),
+  account text not null,             -- BankStatement.accountName label
+  month date not null,               -- first day of the month
+  stated_close numeric,              -- statement closing balance
+  computed_close numeric,            -- opening + signed sum of the month's lines
+  delta numeric,                     -- computed_close - stated_close
+  signed_off_by text,
+  signed_off_at timestamptz,
+  created_at timestamptz not null default now(),
+  unique (account, month)
+);
+alter table fin_bank_recons enable row level security;
+-- service-role access only (finance client); no anon policies.
+
+create table if not exists fin_bank_line_events (
+  id uuid primary key default gen_random_uuid(),
+  line_id uuid not null,             -- BankStatementLine.id
+  event text not null,               -- 'classify' | 'match' | 'unmatch' | 'reject_match'
+  old_value jsonb,
+  new_value jsonb,
+  actor text,
+  created_at timestamptz not null default now()
+);
+create index if not exists fin_bank_line_events_line_id_idx
+  on fin_bank_line_events (line_id);
+alter table fin_bank_line_events enable row level security;
+-- service-role access only (finance client); no anon policies.


### PR DESCRIPTION
## What

Two finance features, one migration (not applied to any database).

### 1. Bank reconciliation tick
- New Bank recon tab on /finance/recon: per bank account, a 12-month table with Opening, Lines total, Computed close, Statement close, Delta and Status.
- Computed close = closing balance of the latest statement ending before the month, plus the signed sum of that account's bank lines dated in the month. Statement close = the statement whose period end (falling back to statementDate) lands in the month.
- Zero delta (within 0.01) shows a green check and a Sign off button (Owner/Admin). Nonzero shows the amount in rose with a hint: lines missing or duplicated, or statement balance wrong. Months with no statement show a muted row. Unclassified line counts surface next to the lines total.
- POST /api/finance/bank-recon recomputes server-side and refuses with 409 unless the delta is zero and a statement exists; DELETE un-signs for corrections. Sign-offs land in fin_bank_recons with actor and timestamp, unique per (account, month).

### 2. Categorisation audit trail
- classify (including bulk, one event per line in one batch insert), match, unmatch and reject-match now write fin_bank_line_events with old value, new value, actor and timestamp. Best-effort: a trail failure never breaks the main operation.
- GET /api/finance/bank-lines/events?lineId=... returns the history newest first.
- Each line row on the recon page gets a clock icon; opening it fetches and shows entries like "31 May, categorised RENT to EQUIPMENTS by Ammar".

## Migration
- supabase/migrations/071_bank_recon_and_line_events.sql creates fin_bank_recons and fin_bank_line_events with RLS enabled and service-role-only access, same pattern as 067/068. 069 and 070 were taken. Not applied anywhere yet; apply manually before relying on sign-offs or history (both endpoints degrade gracefully until then).
- fin_ tables are managed outside Prisma, so schema.prisma is untouched.

## Notes
- Actor comes from the backoffice session (SessionUser.name), falling back to system.
- Typecheck clean: npx tsc --noEmit -p apps/backoffice/tsconfig.json.