### PR TITLE
feat(finance): consolidated group Balance Sheet and Cash Flow

### DIFF
--- a/apps/backoffice/src/app/(admin)/finance/reports/page.tsx
+++ b/apps/backoffice/src/app/(admin)/finance/reports/page.tsx
@@ -852,7 +852,7 @@ function CfTab() {
     <div className="space-y-4">
       {consolidated && (
         <p className="text-[11px] text-muted-foreground">
-          Consolidated group cash flow: all companies summed, inter-company transfer legs cancel so only external movements show. Cash at start and end is the group's total bank position.
+          Consolidated group cash flow: all companies summed, inter-company transfer legs cancel so only external movements show. Cash at start and end is the group&apos;s total bank position.
         </p>
       )}
       {isLoading && <Loader2 className="h-5 w-5 animate-spin text-muted-foreground" />}

--- a/apps/backoffice/src/app/(admin)/finance/reports/page.tsx
+++ b/apps/backoffice/src/app/(admin)/finance/reports/page.tsx
@@ -177,7 +177,7 @@ function ReportControlsBar({ c, outletApplies }: { c: ReturnType<typeof useRepor
         onChange={(e) => switchCompany(e.target.value)}
         disabled={!co || switching}
         className="h-8 rounded-md border bg-background px-2 text-sm font-semibold"
-        title="Active company — every report is scoped to this legal entity. Consolidated = all companies with inter-company legs eliminated (P&L only)."
+        title="Active company. Every report is scoped to this legal entity. Consolidated = all companies with inter-company legs eliminated (P&L, Balance Sheet and Cash Flow)."
       >
         {!co && <option value="">Company…</option>}
         {(co?.companies ?? []).map((x) => <option key={x.id} value={x.id}>{x.name}</option>)}
@@ -603,6 +603,7 @@ type BsReport = {
   equity: BsSection;
   totalLiabilitiesAndEquity: number;
   imbalance: number;
+  intercoResidual?: number;
 };
 
 function BsSectionTable({ title, total, lines, onDrill, cmpByCode, cmpTotal, showCompare }: { title: string; total: number; lines: BsLine[]; onDrill: (code: string) => void; cmpByCode?: Map<string, number>; cmpTotal?: number | null; showCompare?: boolean }) {
@@ -644,16 +645,19 @@ function BsSectionTable({ title, total, lines, onDrill, cmpByCode, cmpTotal, sho
 }
 
 function BsTab() {
-  const { start, end: asOf } = useControls();
+  const { start, end: asOf, consolidated } = useControls();
   const [compare, setCompare] = useState<CompareMode>("none");
+  // Consolidation scope applies to the primary AND the comparison fetch, so a
+  // group figure is never compared against a single-entity one.
+  const scope = consolidated ? "&companyId=consolidated" : "";
   const { data, isLoading, error } = useFetch<{ report: BsReport }>(
-    `/api/finance/reports/balance-sheet?asOf=${asOf}`
+    `/api/finance/reports/balance-sheet?asOf=${asOf}${scope}`
   );
   // A balance sheet compares as-OF dates: the prior period-end (the day before
   // the current period starts) or the same date a year earlier.
   const cmpAsOf = compare === "prev" ? addDaysStr(start, -1) : compare === "year" ? addYearsStr(asOf, -1) : null;
   const { data: cmpData } = useFetch<{ report: BsReport }>(
-    cmpAsOf ? `/api/finance/reports/balance-sheet?asOf=${cmpAsOf}` : null
+    cmpAsOf ? `/api/finance/reports/balance-sheet?asOf=${cmpAsOf}${scope}` : null
   );
   const showCompare = compare !== "none" && !!cmpData;
   const cmp = cmpData?.report;
@@ -666,6 +670,11 @@ function BsTab() {
 
   return (
     <div className="space-y-4">
+      {consolidated && (
+        <p className="text-[11px] text-muted-foreground">
+          Consolidated group balance sheet: all companies summed, inter-company (3600) balances netted to one line.
+        </p>
+      )}
       <div className="flex flex-wrap items-center gap-2">
         <p className="text-xs text-muted-foreground">Balance as of <span className="tabular-nums">{asOf}</span> (the period end). Click any line to see its journal entries.</p>
         <label className="ml-auto flex items-center gap-1 text-[11px] text-muted-foreground">Compare
@@ -690,6 +699,14 @@ function BsTab() {
               <AlertTriangle className="h-4 w-4 shrink-0 mt-0.5 text-amber-600 dark:text-amber-400" />
               <span>
                 Imbalance of {RM(data.report.imbalance)} — likely an unposted period or malformed manual journal.
+              </span>
+            </div>
+          )}
+          {data.report.intercoResidual != null && Math.abs(data.report.intercoResidual) > 0.01 && (
+            <div className="flex items-start gap-2 rounded-md border border-amber-500/40 bg-amber-500/5 p-3 text-sm">
+              <AlertTriangle className="h-4 w-4 shrink-0 mt-0.5 text-amber-600 dark:text-amber-400" />
+              <span>
+                Inter-company balances do not fully offset: {RM(data.report.intercoResidual)} net remains. One entity is missing (or misbooking) its due-to or due-from leg.
               </span>
             </div>
           )}
@@ -718,7 +735,7 @@ function BsTab() {
             </SheetTitle>
             <p className="text-xs text-muted-foreground tabular-nums">{drillCode} · journal lines through {asOf}</p>
           </SheetHeader>
-          {drillCode && <DrillDown code={drillCode} start="2020-01-01" end={asOf} />}
+          {drillCode && <DrillDown code={drillCode} start="2020-01-01" end={asOf} consolidated={consolidated} />}
         </SheetContent>
       </Sheet>
     </div>
@@ -811,10 +828,12 @@ function CfSummaryCard({ label, amount, prev, showCompare, negative }: { label: 
 }
 
 function CfTab() {
-  const { start, end } = useControls();
+  const { start, end, consolidated } = useControls();
   const [compare, setCompare] = useState<CompareMode>("none");
+  // Consolidation scope applies to the primary AND the comparison fetch.
+  const scope = consolidated ? "&companyId=consolidated" : "";
   const { data, isLoading, error } = useFetch<{ report: CfReport }>(
-    `/api/finance/reports/cash-flow?start=${start}&end=${end}`
+    `/api/finance/reports/cash-flow?start=${start}&end=${end}${scope}`
   );
   // Same compare windows as the P&L: the immediately-preceding equal-length
   // period, or the same dates a year back.
@@ -824,13 +843,18 @@ function CfTab() {
     return null;
   }, [compare, start, end]);
   const { data: cmpData } = useFetch<{ report: CfReport }>(
-    cmpRange ? `/api/finance/reports/cash-flow?start=${cmpRange.s}&end=${cmpRange.e}` : null
+    cmpRange ? `/api/finance/reports/cash-flow?start=${cmpRange.s}&end=${cmpRange.e}${scope}` : null
   );
   const showCompare = compare !== "none" && !!cmpData;
   const cmp = cmpData?.report;
 
   return (
     <div className="space-y-4">
+      {consolidated && (
+        <p className="text-[11px] text-muted-foreground">
+          Consolidated group cash flow: all companies summed, inter-company transfer legs cancel so only external movements show. Cash at start and end is the group's total bank position.
+        </p>
+      )}
       {isLoading && <Loader2 className="h-5 w-5 animate-spin text-muted-foreground" />}
       {error && (
         <div className="rounded-lg border border-destructive/40 bg-destructive/5 p-3 text-sm text-destructive">

--- a/apps/backoffice/src/app/api/finance/reports/balance-sheet/route.ts
+++ b/apps/backoffice/src/app/api/finance/reports/balance-sheet/route.ts
@@ -21,6 +21,8 @@ export async function GET(req: NextRequest) {
     return NextResponse.json({ error: "asOf (YYYY-MM-DD) required" }, { status: 400 });
   }
   try {
+    // companyId=consolidated (same param as the pnl route) → the GROUP balance
+    // sheet: all active companies summed, 3600-xx inter-company balances netted.
     const report = await buildBalanceSheet({ companyId, asOf });
     return NextResponse.json({ report });
   } catch (err) {

--- a/apps/backoffice/src/app/api/finance/reports/cash-flow/route.ts
+++ b/apps/backoffice/src/app/api/finance/reports/cash-flow/route.ts
@@ -22,6 +22,8 @@ export async function GET(req: NextRequest) {
     return NextResponse.json({ error: "start, end (YYYY-MM-DD) required" }, { status: 400 });
   }
   try {
+    // companyId=consolidated (same param as the pnl route) → the GROUP cash
+    // flow: all active companies summed, inter-company transfer legs cancel.
     const report = await buildCashFlow({ companyId, start, end });
     return NextResponse.json({ report });
   } catch (err) {

--- a/apps/backoffice/src/lib/finance/reports/balance-sheet.ts
+++ b/apps/backoffice/src/lib/finance/reports/balance-sheet.ts
@@ -9,7 +9,22 @@
 // surfaced as a synthetic "Retained earnings (current period)" line so the
 // equation A = L + E balances even before the close agent sweeps to 4000.
 
+// Consolidated mode (companyId = "consolidated"): every account balance is
+// summed across all active companies. The 3600 family (inter-company due-to
+// and due-from current accounts) is the exception: each entity's balance is a
+// mirror of another entity's, so the group figure must NET them. They collapse
+// into one "Inter-company balances (net)" line; a net beyond 0.01 is surfaced
+// via intercoResidual so the UI can warn that the group books do not fully
+// offset. Payroll and statutory controls (3008, 3004 to 3007) sum normally:
+// gl-posting-map routes both the accrual and the clearing payment to the same
+// account inside the paying company, and cross-company salary funding is
+// booked to 3600 (INTERCO_PEOPLE), so they are not cross-company mirrors.
+
 import { getFinanceClient } from "../supabase";
+
+export const CONSOLIDATED_COMPANY_ID = "consolidated";
+
+const isIntercoCode = (code: string) => code === "3600" || code.startsWith("3600-");
 
 export type BsLine = {
   code: string;
@@ -35,6 +50,10 @@ export type BsReport = {
   // Difference should be zero. Any non-zero amount indicates an imbalance the
   // UI flags loudly (likely an unclosed period or a malformed manual journal).
   imbalance: number;
+  // Consolidated only: net of all 3600-xx inter-company balances across the
+  // group. Should be ~0 (due-to in one entity mirrors due-from in another);
+  // a residual beyond 0.01 means a leg is missing or misclassified.
+  intercoResidual?: number;
 };
 
 export type BsInput = {
@@ -44,6 +63,7 @@ export type BsInput = {
 
 export async function buildBalanceSheet(input: BsInput): Promise<BsReport> {
   const client = getFinanceClient();
+  const consolidated = input.companyId === CONSOLIDATED_COMPANY_ID;
   const fiscalYearStart = `${input.asOf.slice(0, 4)}-01-01`;
 
   const { data: accounts } = await client
@@ -61,19 +81,33 @@ export async function buildBalanceSheet(input: BsInput): Promise<BsReport> {
     ])
   );
 
-  // Posted txns through asOf
-  const { data: txns } = await client
+  // Posted txns through asOf. Consolidated = every active company's ledger;
+  // summing all their journal lines per account IS the group balance.
+  let txnQuery = client
     .from("fin_transactions")
     .select("id, txn_date")
-    .eq("company_id", input.companyId)
     .eq("status", "posted")
     .lte("txn_date", input.asOf);
+  if (consolidated) {
+    const { data: cos } = await client
+      .from("fin_companies")
+      .select("id")
+      .eq("is_active", true);
+    txnQuery = txnQuery.in("company_id", (cos ?? []).map((c) => c.id as string));
+  } else {
+    txnQuery = txnQuery.eq("company_id", input.companyId);
+  }
+  const { data: txns } = await txnQuery;
   const txnIds = (txns ?? []).map((t) => t.id as string);
   const txnDate = new Map((txns ?? []).map((t) => [t.id as string, t.txn_date as string]));
 
   const byCode = new Map<string, number>();
   let pnlYtd = 0;     // current fiscal year earnings → synthetic equity line
   let pnlPrior = 0;   // pre-fiscal-year earnings → retained earnings b/f
+  // Consolidated: 3600-xx accumulated in raw credit-minus-debit terms (not the
+  // per-type display sign), so a due-from booked in one entity offsets the
+  // mirrored due-to in another regardless of how each account is typed.
+  let intercoNet = 0;
 
   if (txnIds.length > 0) {
     const chunkSize = 200;
@@ -91,7 +125,9 @@ export async function buildBalanceSheet(input: BsInput): Promise<BsReport> {
         const credit = Number(l.credit);
         const date = txnDate.get(l.transaction_id as string) ?? "";
 
-        if (meta.type === "asset" || meta.type === "liability" || meta.type === "equity") {
+        if (consolidated && isIntercoCode(code)) {
+          intercoNet += credit - debit;
+        } else if (meta.type === "asset" || meta.type === "liability" || meta.type === "equity") {
           const sign = meta.type === "asset" ? debit - credit : credit - debit;
           byCode.set(code, round2((byCode.get(code) ?? 0) + sign));
         } else {
@@ -105,6 +141,24 @@ export async function buildBalanceSheet(input: BsInput): Promise<BsReport> {
           else pnlPrior += contribution;
         }
       }
+    }
+  }
+
+  // Consolidated: the 3600-xx due-to/due-from lines collapse to ONE net line.
+  // A clean group nets to zero and the line disappears; a residual stays
+  // visible (as a liability line, credit-positive) and is flagged so the UI
+  // can warn instead of silently absorbing it.
+  let intercoResidual: number | undefined;
+  if (consolidated) {
+    intercoNet = round2(intercoNet);
+    intercoResidual = Math.abs(intercoNet) > 0.01 ? intercoNet : 0;
+    if (intercoNet !== 0) {
+      byCode.set("IC-NET", intercoNet);
+      accountMeta.set("IC-NET", {
+        name: "Inter-company balances (net)",
+        type: "liability",
+        parent: null,
+      });
     }
   }
 
@@ -164,6 +218,7 @@ export async function buildBalanceSheet(input: BsInput): Promise<BsReport> {
     equity,
     totalLiabilitiesAndEquity: totalLE,
     imbalance: round2(assets.total - totalLE),
+    ...(consolidated ? { intercoResidual } : {}),
   };
 }
 

--- a/apps/backoffice/src/lib/finance/reports/cash-flow.ts
+++ b/apps/backoffice/src/lib/finance/reports/cash-flow.ts
@@ -16,8 +16,17 @@
 //            + owner capital & dividends (4*)
 //
 // Net change in cash = ∆ on 1000-* accounts.
+//
+// Consolidated mode (companyId = "consolidated"): every active company's
+// ledger is walked and summed, so opening and closing cash are the group's
+// total bank position. Inter-company transfer legs (3600-xx) appear once as a
+// negative in the sender and once as a positive in the receiver, so summed
+// they cancel; the group statement therefore shows only external movements.
+// Any residual (one leg missing or misclassified) stays visible as a single
+// net Financing line so the statement still ties to the bank delta.
 
 import { getFinanceClient } from "../supabase";
+import { CONSOLIDATED_COMPANY_ID } from "./balance-sheet";
 
 export type CfSection = {
   title: string;
@@ -74,15 +83,26 @@ function bucketFor(code: string): BucketKey {
 
 export async function buildCashFlow(input: CfInput): Promise<CfReport> {
   const client = getFinanceClient();
+  const consolidated = input.companyId === CONSOLIDATED_COMPANY_ID;
   const dayBefore = oneDayBefore(input.start);
 
-  // One ledger walk: every posted txn through the period end.
-  const { data: txns } = await client
+  // One ledger walk: every posted txn through the period end. Consolidated
+  // spans all active companies, so cash and every bucket sum across the group.
+  let txnQuery = client
     .from("fin_transactions")
     .select("id, txn_date")
-    .eq("company_id", input.companyId)
     .eq("status", "posted")
     .lte("txn_date", input.end);
+  if (consolidated) {
+    const { data: cos } = await client
+      .from("fin_companies")
+      .select("id")
+      .eq("is_active", true);
+    txnQuery = txnQuery.in("company_id", (cos ?? []).map((c) => c.id as string));
+  } else {
+    txnQuery = txnQuery.eq("company_id", input.companyId);
+  }
+  const { data: txns } = await txnQuery;
   const txnDate = new Map((txns ?? []).map((t) => [t.id as string, t.txn_date as string]));
   const txnIds = [...txnDate.keys()];
 
@@ -142,13 +162,22 @@ export async function buildCashFlow(input: CfInput): Promise<CfReport> {
     total: f("ppe"),
   };
 
+  // Consolidated: the 3600-xx legs of group-internal transfers cancel when the
+  // companies are summed, so a clean group shows no inter-company line at all.
+  // A residual beyond rounding is kept visible (net) so ops + inv + fin still
+  // equals the group bank delta and the gap check stays honest.
+  const intercoFlow = f("interco");
+  const intercoLine = consolidated
+    ? { label: "Inter-company transfers (net residual, legs should cancel)", amount: Math.abs(intercoFlow) > 0.01 ? intercoFlow : 0, code: "3600" }
+    : { label: "∆ Inter-company balances", amount: intercoFlow, code: "3600" };
+
   const financing: CfSection = {
     title: "Financing",
     lines: [
       { label: "∆ Short-term loans", amount: f("shortLoan"), code: "3010" },
       { label: "∆ Long-term loans", amount: f("longLoan"), code: "3500" },
       { label: "∆ Due to directors", amount: f("directors"), code: "3400" },
-      { label: "∆ Inter-company balances", amount: f("interco"), code: "3600" },
+      intercoLine,
       { label: "Owner capital & dividends", amount: f("equity"), code: "4xxx" },
     ].filter((l) => l.amount !== 0),
     total: 0,


### PR DESCRIPTION
## What

Extends the Consolidated company view (already live on the P&L) to the Balance Sheet and Cash Flow tabs, so the switcher option "Consolidated, all companies" now covers all three statements.

Contains #766 and #767 as its base, merge those two first and this diff shrinks to the consolidation work.

## Balance Sheet (balance-sheet.ts)

- `companyId=consolidated` sums every account balance across all active fin_companies in one ledger walk.
- The 3600 family (inter-company due-to and due-from current accounts) is netted, not summed per line: each entity's 3600-xx is a mirror of another entity's, so the group figure collapses them into ONE line, "Inter-company balances (net)". The net is accumulated in raw credit-minus-debit terms so it is sign-correct regardless of how each 3600 account is typed.
- If the net exceeds 0.01 the line stays visible with the residual and the payload carries `intercoResidual`; the UI shows an amber warning that one entity is missing or misbooking its leg. A clean group nets to zero and the line disappears.

### Decision on 3008 and 3004 to 3007

They sum normally, WITHOUT the net-and-warn treatment. Reading gl-posting-map.ts: EMPLOYEE_SALARY and STATUTORY_PAYMENT bank lines route to 3008 / 3004-3007 inside whichever company owns the paying bank account, and the payroll accrual clears the same account in the same company. The cross-company leg (salary funding transfers between entities) is categorised INTERCO_PEOPLE and routes to 3600-xx, not to the control accounts. So 3008 / 3004-3007 are within-entity accrual-vs-payment controls, not cross-company mirrors; a plain sum is the correct group balance and any nonzero simply means unpaid accruals, which is real.

### Does the group BS net to zero in principle?

Yes, when both legs of every transfer are classified INTERCO_* (both route to 3600-xx with mirrored amounts). In practice a residual is expected wherever classification is asymmetric, e.g. GRAB_PUTRAJAYA settles into the HQ bank but parks in 1999 suspense rather than 3600, and any one-sided categorisation leaves its amount in the residual. That is exactly what the warning surfaces.

## Cash Flow (cash-flow.ts)

- `companyId=consolidated` walks all active companies; opening and closing cash are the sum of every 1000-* account across the group.
- Inter-company transfer legs (3600 bucket) appear once negative in the sender and once positive in the receiver, so summed they cancel and the group statement shows only external movements, mirroring how the consolidated P&L drops isInterCo lines.
- A residual beyond 0.01 is kept as one net Financing line ("Inter-company transfers (net residual, legs should cancel)") so operating + investing + financing still equals the group bank delta and the reconciliation gap check keeps working on the summed figures.

## API

Both routes accept `companyId=consolidated` with the same param name and validation as /api/finance/reports/pnl; the builders detect it internally.

## UI (reports page)

- BsTab and CfTab append `companyId=consolidated` to BOTH the primary and the comparison fetches (prev period / prev year), so a group figure is never compared against a single-entity one.
- Each tab shows a short muted note in consolidated mode, matching the P&L's.
- BsTab shows the amber interco-residual warning when flagged, and its line drill now opens the multi-company journal view.
- Company switcher tooltip updated to say consolidation covers P&L, Balance Sheet and Cash Flow.

## Notes

- No schema changes, no migrations.
- Typecheck clean: `npx tsc --noEmit -p apps/backoffice/tsconfig.json`.