### PR TITLE
feat(finance): fixed assets register with straight-line depreciation

### DIFF
--- a/apps/backoffice/src/app/(admin)/finance/fixed-assets/page.tsx
+++ b/apps/backoffice/src/app/(admin)/finance/fixed-assets/page.tsx
@@ -1,0 +1,599 @@
+"use client";
+
+// Fixed assets register: straight-line depreciation over useful life.
+// One math everywhere (lib/finance/fixed-assets.ts): the register columns
+// below, the sourced P&L "Depreciation" line and the monthly GL posting all
+// share it, so the numbers always tie.
+//
+// Three flows on this page:
+//   1. Add asset (manual, or one click "Capitalize" on an EQUIPMENTS bank line)
+//   2. Run depreciation for a month: per-company preview, then post ONE
+//      idempotent journal per company (Dr 6512, Cr 1550-xx)
+//   3. Dispose: stops depreciation from the disposal month onward (v1 posts
+//      no gain or loss journal)
+
+import { useMemo, useState } from "react";
+import { useFetch } from "@/lib/use-fetch";
+import {
+  Badge,
+  Button,
+  Input,
+  Sheet,
+  SheetContent,
+  SheetHeader,
+  SheetTitle,
+  useConfirm,
+  usePrompt,
+} from "@celsius/ui";
+import { Calculator, Landmark, Loader2, Pencil, Plus } from "lucide-react";
+
+// Accounting format: negatives in parentheses, same as the Reports page.
+const RM = (n: number | null | undefined) => {
+  if (n === null || n === undefined) return "0.00";
+  const f = new Intl.NumberFormat("en-MY", { style: "currency", currency: "MYR" }).format(Math.abs(n));
+  return n < 0 ? `(${f})` : f;
+};
+
+// The 1500-xx PP&E accounts seeded in 003_finance_coa_seed.sql. The API
+// validates the code against fin_accounts on every write.
+const PPE_ACCOUNTS: [string, string][] = [
+  ["1500-00", "Coffee machines"],
+  ["1500-01", "Furniture and fittings"],
+  ["1500-02", "Kitchen equipment"],
+  ["1500-03", "Office equipment"],
+  ["1500-04", "Renovation"],
+  ["1500-05", "Signboard"],
+];
+
+type Asset = {
+  id: string;
+  companyId: string | null;
+  outletId: string | null;
+  outletName: string | null;
+  name: string;
+  accountCode: string;
+  cost: number;
+  residual: number;
+  acquiredDate: string;
+  usefulLifeMonths: number;
+  status: string;
+  disposedDate: string | null;
+  sourceBankLineId: string | null;
+  notes: string | null;
+  monthlyDep: number;
+  accumulated: number;
+  nbv: number;
+};
+
+type Company = { id: string; name: string };
+type Outlet = { id: string; name: string };
+
+type CapLine = {
+  id: string;
+  date: string;
+  description: string;
+  amount: number;
+  companyId: string;
+  outletId: string | null;
+  outletName: string | null;
+};
+
+type RunCompany = {
+  companyId: string;
+  total: number;
+  byAsset: { id: string; name: string; accountCode: string; amount: number }[];
+  alreadyPosted: boolean;
+  transactionId: string | null;
+};
+type RunResult = { yearMonth: string; committed: boolean; companies: RunCompany[] };
+
+type FormState = {
+  id?: string;            // set = edit
+  bankLineId?: string;    // set = capitalizing a bank line
+  name: string;
+  companyId: string;
+  outletId: string;
+  accountCode: string;
+  cost: string;
+  residual: string;
+  acquiredDate: string;
+  usefulLifeMonths: string;
+  notes: string;
+};
+
+function todayMyt(): string {
+  return new Date(Date.now() + 8 * 60 * 60 * 1000).toISOString().slice(0, 10);
+}
+function previousMonthMyt(): string {
+  const t = todayMyt();
+  const [y, m] = t.split("-").map(Number);
+  const i = y * 12 + (m - 1) - 1;
+  return `${Math.floor(i / 12)}-${String((i % 12) + 1).padStart(2, "0")}`;
+}
+
+const emptyForm = (): FormState => ({
+  name: "",
+  companyId: "",
+  outletId: "",
+  accountCode: "1500-02",
+  cost: "",
+  residual: "0",
+  acquiredDate: todayMyt(),
+  usefulLifeMonths: "60",
+  notes: "",
+});
+
+export default function FixedAssetsPage() {
+  const { data, isLoading, mutate } = useFetch<{ assets: Asset[] }>("/api/finance/fixed-assets");
+  const { data: capData, mutate: mutateCap } = useFetch<{ lines: CapLine[] }>("/api/finance/fixed-assets/capitalizable");
+  const { data: companiesData } = useFetch<{ companies: Company[] }>("/api/finance/companies");
+  const { data: outlets } = useFetch<Outlet[]>("/api/settings/outlets");
+  const { confirm, ConfirmDialog } = useConfirm();
+  const { prompt, PromptDialog } = usePrompt();
+
+  const [form, setForm] = useState<FormState | null>(null);
+  const [saving, setSaving] = useState(false);
+  const [formError, setFormError] = useState("");
+
+  const [runYm, setRunYm] = useState(previousMonthMyt());
+  const [runPreview, setRunPreview] = useState<RunResult | null>(null);
+  const [runLoading, setRunLoading] = useState(false);
+  const [runError, setRunError] = useState("");
+
+  const assets = useMemo(() => data?.assets ?? [], [data]);
+  const capLines = capData?.lines ?? [];
+  const companies = useMemo(() => companiesData?.companies ?? [], [companiesData]);
+  const companyName = useMemo(() => new Map(companies.map((c) => [c.id, c.name])), [companies]);
+  const accountName = useMemo(() => new Map(PPE_ACCOUNTS), []);
+
+  const totals = useMemo(
+    () =>
+      assets.reduce(
+        (t, a) => ({
+          cost: t.cost + a.cost,
+          monthly: t.monthly + a.monthlyDep,
+          accumulated: t.accumulated + a.accumulated,
+          nbv: t.nbv + a.nbv,
+        }),
+        { cost: 0, monthly: 0, accumulated: 0, nbv: 0 }
+      ),
+    [assets]
+  );
+
+  const openAdd = () => { setForm({ ...emptyForm(), companyId: companies[0]?.id ?? "" }); setFormError(""); };
+  const openEdit = (a: Asset) => {
+    setForm({
+      id: a.id,
+      name: a.name,
+      companyId: a.companyId ?? "",
+      outletId: a.outletId ?? "",
+      accountCode: a.accountCode,
+      cost: String(a.cost),
+      residual: String(a.residual),
+      acquiredDate: a.acquiredDate,
+      usefulLifeMonths: String(a.usefulLifeMonths),
+      notes: a.notes ?? "",
+    });
+    setFormError("");
+  };
+  const openCapitalize = (l: CapLine) => {
+    setForm({
+      bankLineId: l.id,
+      name: l.description,
+      companyId: l.companyId,
+      outletId: l.outletId ?? "",
+      accountCode: "1500-02",
+      cost: l.amount.toFixed(2),
+      residual: "0",
+      acquiredDate: l.date,
+      usefulLifeMonths: "60",
+      notes: "",
+    });
+    setFormError("");
+  };
+
+  const save = async () => {
+    if (!form) return;
+    setSaving(true);
+    setFormError("");
+    const isEdit = !!form.id;
+    const res = await fetch(isEdit ? `/api/finance/fixed-assets/${form.id}` : "/api/finance/fixed-assets", {
+      method: isEdit ? "PATCH" : "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(
+        isEdit
+          ? {
+              name: form.name,
+              usefulLifeMonths: Number(form.usefulLifeMonths),
+              residual: Number(form.residual || 0),
+              accountCode: form.accountCode,
+              outletId: form.outletId || null,
+              notes: form.notes || null,
+            }
+          : {
+              bankLineId: form.bankLineId,
+              name: form.name,
+              companyId: form.companyId,
+              outletId: form.outletId || null,
+              accountCode: form.accountCode,
+              cost: Number(form.cost),
+              residual: Number(form.residual || 0),
+              acquiredDate: form.acquiredDate,
+              usefulLifeMonths: Number(form.usefulLifeMonths),
+              notes: form.notes || null,
+            }
+      ),
+    });
+    setSaving(false);
+    if (!res.ok) {
+      const body = await res.json().catch(() => null);
+      setFormError(body?.error || "Save failed");
+      return;
+    }
+    setForm(null);
+    mutate();
+    mutateCap();
+    setRunPreview(null);
+  };
+
+  const dispose = async (a: Asset) => {
+    const date = await prompt({
+      title: `Dispose ${a.name}`,
+      description:
+        "Disposal date (YYYY-MM-DD). Depreciation stops from the disposal month onward. No gain or loss journal is posted in v1; the cost stays on the books until a disposal journal is added.",
+      defaultValue: todayMyt(),
+      required: true,
+      validate: (v) => (/^\d{4}-\d{2}-\d{2}$/.test(v.trim()) ? null : "Use YYYY-MM-DD"),
+      confirmLabel: "Dispose",
+    });
+    if (!date) return;
+    const res = await fetch("/api/finance/fixed-assets/dispose", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ id: a.id, disposedOn: date.trim() }),
+    });
+    if (!res.ok) {
+      const body = await res.json().catch(() => null);
+      alert(body?.error || "Dispose failed");
+      return;
+    }
+    mutate();
+    setRunPreview(null);
+  };
+
+  const previewRun = async () => {
+    if (!/^\d{4}-\d{2}$/.test(runYm)) { setRunError("Pick a month"); return; }
+    setRunLoading(true);
+    setRunError("");
+    const res = await fetch(`/api/finance/fixed-assets/run-depreciation?yearMonth=${runYm}`);
+    const body = await res.json().catch(() => null);
+    setRunLoading(false);
+    if (!res.ok) { setRunError(body?.error || "Preview failed"); return; }
+    setRunPreview(body as RunResult);
+  };
+
+  const postRun = async () => {
+    if (!runPreview) return;
+    const toPost = runPreview.companies.filter((c) => !c.alreadyPosted);
+    if (!toPost.length) return;
+    const ok = await confirm({
+      title: `Post depreciation for ${runYm}?`,
+      description: `Posts ${toPost.length} journal${toPost.length > 1 ? "s" : ""} (one per company, Dr 6512 Depreciation, Cr 1550-xx Accumulated depreciation), total ${RM(toPost.reduce((s, c) => s + c.total, 0))}, dated on the month's last day. Re-running the same month never double posts.`,
+      confirmLabel: "Post journals",
+    });
+    if (!ok) return;
+    setRunLoading(true);
+    setRunError("");
+    const res = await fetch("/api/finance/fixed-assets/run-depreciation", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ yearMonth: runYm }),
+    });
+    const body = await res.json().catch(() => null);
+    setRunLoading(false);
+    if (!res.ok) { setRunError(body?.error || "Posting failed"); return; }
+    setRunPreview(body as RunResult);
+  };
+
+  const statusBadge = (a: Asset) => {
+    if (a.status === "disposed") {
+      return <Badge className="bg-gray-500/10 text-gray-500 text-[10px]">Disposed{a.disposedDate ? ` ${a.disposedDate}` : ""}</Badge>;
+    }
+    if (a.nbv <= a.residual) {
+      return <Badge className="bg-blue-500/10 text-blue-600 dark:text-blue-400 text-[10px]">Fully depreciated</Badge>;
+    }
+    return <Badge className="bg-green-500/10 text-green-700 dark:text-green-400 text-[10px]">Active</Badge>;
+  };
+
+  return (
+    <div className="p-3 sm:p-6 space-y-6">
+      <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+        <div>
+          <h2 className="text-lg sm:text-xl font-semibold">Fixed Assets</h2>
+          <p className="mt-0.5 text-xs sm:text-sm text-muted-foreground">
+            Straight-line register. Depreciation starts the first full month after acquisition and feeds the
+            sourced P&amp;L and the monthly GL journal from the same math.
+          </p>
+        </div>
+        <Button onClick={openAdd} className="w-full sm:w-auto">
+          <Plus className="mr-1.5 h-4 w-4" /> Add asset
+        </Button>
+      </div>
+
+      {/* Register */}
+      {isLoading ? (
+        <div className="flex justify-center py-12"><Loader2 className="h-5 w-5 animate-spin text-muted-foreground" /></div>
+      ) : assets.length === 0 ? (
+        <div className="rounded-xl border border-dashed p-12 text-center">
+          <p className="text-sm text-muted-foreground">No fixed assets yet.</p>
+          <p className="mt-1 text-xs text-muted-foreground">Add one manually or capitalize an EQUIPMENTS bank line below.</p>
+        </div>
+      ) : (
+        <div className="overflow-hidden rounded-md border bg-card">
+          <div className="overflow-x-auto">
+            <table className="w-full min-w-[960px] text-sm">
+              <thead>
+                <tr className="border-b bg-muted/30 text-left text-xs uppercase tracking-wide text-muted-foreground">
+                  <th className="px-3 py-2 font-medium">Name</th>
+                  <th className="px-3 py-2 font-medium">Company</th>
+                  <th className="px-3 py-2 font-medium">Outlet</th>
+                  <th className="px-3 py-2 font-medium">Acquired</th>
+                  <th className="px-3 py-2 text-right font-medium">Cost</th>
+                  <th className="px-3 py-2 text-right font-medium">Life (mo)</th>
+                  <th className="px-3 py-2 text-right font-medium">Monthly dep</th>
+                  <th className="px-3 py-2 text-right font-medium">Accumulated</th>
+                  <th className="px-3 py-2 text-right font-medium">NBV</th>
+                  <th className="px-3 py-2 font-medium">Status</th>
+                  <th className="px-3 py-2 text-right font-medium">Actions</th>
+                </tr>
+              </thead>
+              <tbody>
+                {assets.map((a) => (
+                  <tr key={a.id} className={`border-t hover:bg-muted/30 ${a.status === "disposed" ? "opacity-60" : ""}`}>
+                    <td className="px-3 py-2">
+                      <span className="font-medium">{a.name}</span>
+                      <p className="text-[11px] text-muted-foreground">
+                        {a.accountCode} {accountName.get(a.accountCode) ?? ""}
+                        {a.sourceBankLineId ? " · from bank line" : ""}
+                        {a.notes ? ` · ${a.notes}` : ""}
+                      </p>
+                    </td>
+                    <td className="px-3 py-2 text-xs">{a.companyId ? (companyName.get(a.companyId) ?? a.companyId) : "?"}</td>
+                    <td className="px-3 py-2 text-xs">{a.outletName ?? <span className="text-muted-foreground">HQ</span>}</td>
+                    <td className="px-3 py-2 text-xs tabular-nums">{a.acquiredDate}</td>
+                    <td className="px-3 py-2 text-right tabular-nums">{RM(a.cost)}</td>
+                    <td className="px-3 py-2 text-right tabular-nums">{a.usefulLifeMonths}</td>
+                    <td className="px-3 py-2 text-right tabular-nums">{RM(a.monthlyDep)}</td>
+                    <td className="px-3 py-2 text-right tabular-nums">{RM(a.accumulated)}</td>
+                    <td className="px-3 py-2 text-right tabular-nums font-medium">{RM(a.nbv)}</td>
+                    <td className="px-3 py-2">{statusBadge(a)}</td>
+                    <td className="px-3 py-2">
+                      <div className="flex justify-end gap-1">
+                        <button onClick={() => openEdit(a)} className="rounded-md p-1 text-muted-foreground hover:bg-muted hover:text-foreground" title="Edit">
+                          <Pencil className="h-3.5 w-3.5" />
+                        </button>
+                        {a.status !== "disposed" && (
+                          <Button size="xs" variant="outline" onClick={() => dispose(a)}>Dispose</Button>
+                        )}
+                      </div>
+                    </td>
+                  </tr>
+                ))}
+                <tr className="border-t bg-muted/30 font-semibold">
+                  <td colSpan={4} className="px-3 py-2">Total ({assets.length} asset{assets.length > 1 ? "s" : ""})</td>
+                  <td className="px-3 py-2 text-right tabular-nums">{RM(totals.cost)}</td>
+                  <td className="px-3 py-2" />
+                  <td className="px-3 py-2 text-right tabular-nums">{RM(totals.monthly)}</td>
+                  <td className="px-3 py-2 text-right tabular-nums">{RM(totals.accumulated)}</td>
+                  <td className="px-3 py-2 text-right tabular-nums">{RM(totals.nbv)}</td>
+                  <td colSpan={2} className="px-3 py-2" />
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </div>
+      )}
+
+      <div className="grid gap-4 lg:grid-cols-2">
+        {/* Capitalize from bank */}
+        <section className="overflow-hidden rounded-md border bg-card">
+          <header className="flex items-center gap-2 border-b bg-muted/30 px-3 py-2 text-xs uppercase tracking-wide text-muted-foreground">
+            <Landmark className="h-3.5 w-3.5" /> Capitalize from bank (EQUIPMENTS lines)
+          </header>
+          {capLines.length === 0 ? (
+            <p className="p-4 text-sm text-muted-foreground">
+              No uncapitalized EQUIPMENTS bank lines. Classified equipment outflows appear here for one-click capitalization.
+            </p>
+          ) : (
+            <div className="max-h-80 overflow-y-auto">
+              <table className="w-full text-sm">
+                <tbody>
+                  {capLines.map((l) => (
+                    <tr key={l.id} className="border-t first:border-t-0 hover:bg-muted/30">
+                      <td className="px-3 py-2 text-xs tabular-nums whitespace-nowrap">{l.date}</td>
+                      <td className="px-3 py-2">
+                        <span className="line-clamp-1">{l.description}</span>
+                        <p className="text-[11px] text-muted-foreground">
+                          {companyName.get(l.companyId) ?? l.companyId}{l.outletName ? ` · ${l.outletName}` : ""}
+                        </p>
+                      </td>
+                      <td className="px-3 py-2 text-right tabular-nums whitespace-nowrap">{RM(l.amount)}</td>
+                      <td className="px-3 py-2 text-right">
+                        <Button size="xs" variant="outline" onClick={() => openCapitalize(l)}>Capitalize</Button>
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          )}
+        </section>
+
+        {/* Run depreciation */}
+        <section className="overflow-hidden rounded-md border bg-card">
+          <header className="flex items-center gap-2 border-b bg-muted/30 px-3 py-2 text-xs uppercase tracking-wide text-muted-foreground">
+            <Calculator className="h-3.5 w-3.5" /> Run depreciation
+          </header>
+          <div className="space-y-3 p-3">
+            <div className="flex flex-wrap items-center gap-2">
+              <input
+                type="month"
+                value={runYm}
+                onChange={(e) => { setRunYm(e.target.value); setRunPreview(null); }}
+                className="rounded-md border bg-background px-3 py-1.5 text-sm"
+              />
+              <Button size="xs" variant="outline" onClick={previewRun} disabled={runLoading}>
+                {runLoading ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : "Preview"}
+              </Button>
+              {runPreview && runPreview.companies.some((c) => !c.alreadyPosted) && !runPreview.committed && (
+                <Button size="xs" onClick={postRun} disabled={runLoading}>Post journals</Button>
+              )}
+            </div>
+            <p className="text-[11px] text-muted-foreground">
+              One journal per company, dated on the month&apos;s last day: Dr 6512 Depreciation of PP&amp;E,
+              Cr 1550-xx Accumulated depreciation. Idempotent, so re-running a month never double posts.
+            </p>
+            {runError && <p className="text-xs text-destructive">{runError}</p>}
+            {runPreview && (
+              runPreview.companies.length === 0 ? (
+                <p className="text-sm text-muted-foreground">No depreciation charges for {runPreview.yearMonth}.</p>
+              ) : (
+                <div className="overflow-hidden rounded-md border">
+                  <table className="w-full text-sm">
+                    <tbody>
+                      {runPreview.companies.map((c) => (
+                        <tr key={c.companyId} className="border-t first:border-t-0">
+                          <td className="px-3 py-2">
+                            <span className="font-medium">{companyName.get(c.companyId) ?? c.companyId}</span>
+                            <p className="text-[11px] text-muted-foreground">
+                              {c.byAsset.length} asset{c.byAsset.length > 1 ? "s" : ""}: {c.byAsset.map((a) => `${a.name} ${RM(a.amount)}`).join(", ")}
+                            </p>
+                          </td>
+                          <td className="px-3 py-2 text-right tabular-nums whitespace-nowrap">{RM(c.total)}</td>
+                          <td className="px-3 py-2 text-right">
+                            {c.alreadyPosted ? (
+                              <Badge className="bg-gray-500/10 text-gray-500 text-[10px]">Already posted</Badge>
+                            ) : c.transactionId ? (
+                              <Badge className="bg-green-500/10 text-green-700 dark:text-green-400 text-[10px]">Posted</Badge>
+                            ) : (
+                              <Badge className="bg-amber-500/10 text-amber-600 dark:text-amber-400 text-[10px]">Preview</Badge>
+                            )}
+                          </td>
+                        </tr>
+                      ))}
+                    </tbody>
+                  </table>
+                </div>
+              )
+            )}
+          </div>
+        </section>
+      </div>
+
+      {/* Add / Edit / Capitalize drawer */}
+      <Sheet open={!!form} onOpenChange={(o) => !o && setForm(null)}>
+        <SheetContent side="right" className="w-full sm:max-w-md overflow-y-auto">
+          <SheetHeader>
+            <SheetTitle>
+              {form?.id ? "Edit asset" : form?.bankLineId ? "Capitalize bank line" : "Add asset"}
+            </SheetTitle>
+          </SheetHeader>
+          {form && (
+            <div className="mt-4 space-y-3">
+              {form.bankLineId && (
+                <p className="rounded-md border border-amber-500/40 bg-amber-500/5 p-2 text-xs">
+                  Linked to the selected EQUIPMENTS bank line; that line can never be capitalized twice.
+                  EQUIPMENTS outflows are already excluded from the P&amp;L, so this only starts depreciation.
+                </p>
+              )}
+              <div>
+                <label className="mb-1 block text-xs font-medium text-muted-foreground">Name</label>
+                <Input value={form.name} onChange={(e) => setForm({ ...form, name: e.target.value })} placeholder="e.g. La Marzocco Linea PB" />
+              </div>
+              <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+                <div>
+                  <label className="mb-1 block text-xs font-medium text-muted-foreground">Company</label>
+                  <select
+                    className="w-full rounded-md border bg-background px-3 py-2 text-sm disabled:opacity-60"
+                    value={form.companyId}
+                    disabled={!!form.id}
+                    onChange={(e) => setForm({ ...form, companyId: e.target.value })}
+                  >
+                    <option value="">Select company</option>
+                    {companies.map((c) => <option key={c.id} value={c.id}>{c.name}</option>)}
+                  </select>
+                </div>
+                <div>
+                  <label className="mb-1 block text-xs font-medium text-muted-foreground">Outlet (optional)</label>
+                  <select
+                    className="w-full rounded-md border bg-background px-3 py-2 text-sm"
+                    value={form.outletId}
+                    onChange={(e) => setForm({ ...form, outletId: e.target.value })}
+                  >
+                    <option value="">HQ (no outlet)</option>
+                    {(outlets ?? []).map((o) => <option key={o.id} value={o.id}>{o.name}</option>)}
+                  </select>
+                </div>
+              </div>
+              <div>
+                <label className="mb-1 block text-xs font-medium text-muted-foreground">PP&amp;E account</label>
+                <select
+                  className="w-full rounded-md border bg-background px-3 py-2 text-sm"
+                  value={form.accountCode}
+                  onChange={(e) => setForm({ ...form, accountCode: e.target.value })}
+                >
+                  {PPE_ACCOUNTS.map(([code, label]) => <option key={code} value={code}>{code} {label}</option>)}
+                </select>
+              </div>
+              <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+                <div>
+                  <label className="mb-1 block text-xs font-medium text-muted-foreground">Cost (RM)</label>
+                  <Input type="number" step="0.01" value={form.cost} disabled={!!form.id} onChange={(e) => setForm({ ...form, cost: e.target.value })} />
+                </div>
+                <div>
+                  <label className="mb-1 block text-xs font-medium text-muted-foreground">Residual value (RM)</label>
+                  <Input type="number" step="0.01" value={form.residual} onChange={(e) => setForm({ ...form, residual: e.target.value })} />
+                </div>
+              </div>
+              <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+                <div>
+                  <label className="mb-1 block text-xs font-medium text-muted-foreground">Acquired on</label>
+                  <input
+                    type="date"
+                    value={form.acquiredDate}
+                    disabled={!!form.id}
+                    onChange={(e) => setForm({ ...form, acquiredDate: e.target.value })}
+                    className="w-full rounded-md border bg-background px-3 py-2 text-sm disabled:opacity-60"
+                  />
+                </div>
+                <div>
+                  <label className="mb-1 block text-xs font-medium text-muted-foreground">Useful life (months)</label>
+                  <Input type="number" step="1" min="1" value={form.usefulLifeMonths} onChange={(e) => setForm({ ...form, usefulLifeMonths: e.target.value })} />
+                </div>
+              </div>
+              <div>
+                <label className="mb-1 block text-xs font-medium text-muted-foreground">Notes</label>
+                <Input value={form.notes} onChange={(e) => setForm({ ...form, notes: e.target.value })} placeholder="Optional" />
+              </div>
+              <p className="text-[11px] text-muted-foreground">
+                First charge lands the month AFTER acquisition (no partial months). Monthly charge =
+                (cost minus residual) / life, and the final month absorbs rounding so lifetime
+                depreciation sums exactly.
+              </p>
+              {formError && <p className="text-xs text-destructive">{formError}</p>}
+              <div className="flex gap-2 pt-1">
+                <Button variant="outline" className="flex-1" onClick={() => setForm(null)}>Cancel</Button>
+                <Button className="flex-1" onClick={save} disabled={saving}>
+                  {saving ? <Loader2 className="mx-auto h-4 w-4 animate-spin" /> : form.id ? "Save changes" : form.bankLineId ? "Capitalize" : "Add asset"}
+                </Button>
+              </div>
+            </div>
+          )}
+        </SheetContent>
+      </Sheet>
+
+      <ConfirmDialog />
+      <PromptDialog />
+    </div>
+  );
+}

--- a/apps/backoffice/src/app/(admin)/layout.tsx
+++ b/apps/backoffice/src/app/(admin)/layout.tsx
@@ -77,6 +77,7 @@ import {
   CreditCard,
   QrCode,
   Printer,
+  Landmark,
 } from "lucide-react";
 import { Avatar, AvatarFallback } from "@/components/ui/avatar";
 import {
@@ -371,6 +372,7 @@ const NAV_SECTIONS: NavSection[] = [
       { label: "Reports", href: "/finance/reports", icon: <TrendingUp className={ICON_SIZE} />, moduleKey: "finance:reports" },
       { label: "Reconciliation", href: "/finance/recon", icon: <Scale className={ICON_SIZE} />, moduleKey: "finance:reports" },
       { label: "Chart of Accounts", href: "/finance/coa", icon: <BookOpen className={ICON_SIZE} />, moduleKey: "finance:reports" },
+      { label: "Fixed Assets", href: "/finance/fixed-assets", icon: <Landmark className={ICON_SIZE} />, moduleKey: "finance:reports" },
       // Legacy (pre-agentic) views — kept until the new module reaches parity.
       { label: "Cashflow", href: "/finance/cashflow", icon: <LineChart className={ICON_SIZE} />, moduleKey: "finance:cashflow" },
       { label: "Cash Tracking", href: "/finance/cash-tracking", icon: <TableProperties className={ICON_SIZE} />, moduleKey: "finance:cash-tracking" },

--- a/apps/backoffice/src/app/api/finance/fixed-assets/[id]/route.ts
+++ b/apps/backoffice/src/app/api/finance/fixed-assets/[id]/route.ts
@@ -1,0 +1,60 @@
+// PATCH /api/finance/fixed-assets/[id]: edit name, useful life, residual,
+// PP&E account, outlet or notes. Owner/Admin only. No recompute step needed:
+// depreciation is derived from the row on every read, so edits take effect
+// everywhere immediately (register, P&L line, auditor pack). Already-posted
+// depreciation journals are NOT rewritten; repost via run-depreciation only
+// after reversing, which is a manual ledger operation by design.
+
+import { NextRequest, NextResponse } from "next/server";
+import { requireAuth } from "@/lib/auth";
+import { getFinanceClient } from "@/lib/finance/supabase";
+
+export const dynamic = "force-dynamic";
+
+export async function PATCH(req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  const auth = await requireAuth(req);
+  if (auth.error) return auth.error;
+  if (!["OWNER", "ADMIN"].includes(auth.user.role)) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+  const { id } = await params;
+  let body: Record<string, unknown> = {};
+  try { body = ((await req.json()) ?? {}) as Record<string, unknown>; } catch { /* validated below */ }
+
+  const patch: Record<string, unknown> = {};
+  if (typeof body.name === "string" && body.name.trim()) patch.description = (body.name as string).trim();
+  if (body.usefulLifeMonths != null) {
+    const v = Number(body.usefulLifeMonths);
+    if (!Number.isInteger(v) || v <= 0) return NextResponse.json({ error: "usefulLifeMonths must be a positive integer" }, { status: 400 });
+    patch.useful_life_months = v;
+  }
+  if (body.residual != null) {
+    const v = Number(body.residual);
+    if (!Number.isFinite(v) || v < 0) return NextResponse.json({ error: "residual must be >= 0" }, { status: 400 });
+    patch.residual = v;
+  }
+  if (typeof body.accountCode === "string") {
+    if (!/^1500-\d{2}$/.test(body.accountCode)) {
+      return NextResponse.json({ error: "accountCode must be a 1500-xx PP&E account" }, { status: 400 });
+    }
+    patch.account_code = body.accountCode;
+  }
+  if (body.outletId === null || typeof body.outletId === "string") patch.outlet_id = (body.outletId as string | null) || null;
+  if (body.notes === null || typeof body.notes === "string") patch.notes = (body.notes as string | null) || null;
+  if (!Object.keys(patch).length) return NextResponse.json({ error: "Nothing to update" }, { status: 400 });
+  patch.updated_at = new Date().toISOString();
+
+  const client = getFinanceClient();
+  // residual cannot exceed cost, check against the stored cost.
+  if (patch.residual != null) {
+    const { data: row } = await client.from("fin_fixed_assets").select("cost").eq("id", id).maybeSingle();
+    if (!row) return NextResponse.json({ error: "Asset not found" }, { status: 404 });
+    if (Number(patch.residual) >= Number(row.cost)) {
+      return NextResponse.json({ error: "residual must be below cost" }, { status: 400 });
+    }
+  }
+  await client.rpc("fin_set_actor", { p_actor: auth.user.id }).then(() => undefined, () => undefined);
+  const { error } = await client.from("fin_fixed_assets").update(patch).eq("id", id);
+  if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+  return NextResponse.json({ ok: true });
+}

--- a/apps/backoffice/src/app/api/finance/fixed-assets/capitalizable/route.ts
+++ b/apps/backoffice/src/app/api/finance/fixed-assets/capitalizable/route.ts
@@ -1,0 +1,51 @@
+// GET /api/finance/fixed-assets/capitalizable: classified EQUIPMENTS bank
+// outflows not yet linked to a fixed asset, so the register UI can offer
+// one-click capitalization. EQUIPMENTS lines are already EXCLUDED from the
+// sourced P&L (BANK_NONOPEX in pnl-sourced.ts), so capitalizing one never
+// moves the P&L; it only starts the asset depreciating.
+
+import { NextRequest, NextResponse } from "next/server";
+import { requireAuth } from "@/lib/auth";
+import { prisma } from "@/lib/prisma";
+import { getFinanceClient } from "@/lib/finance/supabase";
+import { companyFromAccountName } from "@/lib/finance/gl-posting-map";
+
+export const dynamic = "force-dynamic";
+
+export async function GET(req: NextRequest) {
+  const auth = await requireAuth(req);
+  if (auth.error) return auth.error;
+  if (!["OWNER", "ADMIN"].includes(auth.user.role)) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+
+  const client = getFinanceClient();
+  const [{ data: linked }, lines] = await Promise.all([
+    client.from("fin_fixed_assets").select("source_bank_line_id").not("source_bank_line_id", "is", null),
+    prisma.bankStatementLine.findMany({
+      where: { direction: "DR", category: "EQUIPMENTS" },
+      select: {
+        id: true, txnDate: true, description: true, amount: true, outletId: true,
+        outlet: { select: { name: true } },
+        statement: { select: { accountName: true } },
+      },
+      orderBy: { txnDate: "desc" },
+      take: 300,
+    }),
+  ]);
+  const linkedIds = new Set((linked ?? []).map((r) => r.source_bank_line_id as string));
+
+  return NextResponse.json({
+    lines: lines
+      .filter((l) => !linkedIds.has(l.id))
+      .map((l) => ({
+        id: l.id,
+        date: l.txnDate.toISOString().slice(0, 10),
+        description: l.description,
+        amount: Math.round(Number(l.amount) * 100) / 100,
+        companyId: companyFromAccountName(l.statement.accountName),
+        outletId: l.outletId,
+        outletName: l.outlet?.name ?? null,
+      })),
+  });
+}

--- a/apps/backoffice/src/app/api/finance/fixed-assets/dispose/route.ts
+++ b/apps/backoffice/src/app/api/finance/fixed-assets/dispose/route.ts
@@ -1,0 +1,43 @@
+// POST /api/finance/fixed-assets/dispose: { id, disposedOn }
+// Marks the asset disposed and stops future depreciation (the disposal month
+// and every later month take no charge; see the convention in
+// lib/finance/fixed-assets.ts). v1 keeps disposal simple: NO gain or loss
+// journal is posted and the asset cost stays on the books until a proper
+// disposal journal is added. Owner/Admin only.
+
+import { NextRequest, NextResponse } from "next/server";
+import { requireAuth } from "@/lib/auth";
+import { getFinanceClient } from "@/lib/finance/supabase";
+
+export const dynamic = "force-dynamic";
+
+export async function POST(req: NextRequest) {
+  const auth = await requireAuth(req);
+  if (auth.error) return auth.error;
+  if (!["OWNER", "ADMIN"].includes(auth.user.role)) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+  let body: { id?: string; disposedOn?: string } = {};
+  try { body = (await req.json()) ?? {}; } catch { /* validated below */ }
+  if (!body.id) return NextResponse.json({ error: "id is required" }, { status: 400 });
+  if (!body.disposedOn || !/^\d{4}-\d{2}-\d{2}$/.test(body.disposedOn)) {
+    return NextResponse.json({ error: "disposedOn must be YYYY-MM-DD" }, { status: 400 });
+  }
+
+  const client = getFinanceClient();
+  const { data: row } = await client
+    .from("fin_fixed_assets").select("id, status, acquired_date").eq("id", body.id).maybeSingle();
+  if (!row) return NextResponse.json({ error: "Asset not found" }, { status: 404 });
+  if (row.status === "disposed") return NextResponse.json({ error: "Asset already disposed" }, { status: 409 });
+  if (body.disposedOn < (row.acquired_date as string)) {
+    return NextResponse.json({ error: "disposedOn cannot be before the acquisition date" }, { status: 400 });
+  }
+
+  await client.rpc("fin_set_actor", { p_actor: auth.user.id }).then(() => undefined, () => undefined);
+  const { error } = await client
+    .from("fin_fixed_assets")
+    .update({ status: "disposed", disposed_date: body.disposedOn, updated_at: new Date().toISOString() })
+    .eq("id", body.id);
+  if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+  return NextResponse.json({ ok: true });
+}

--- a/apps/backoffice/src/app/api/finance/fixed-assets/route.ts
+++ b/apps/backoffice/src/app/api/finance/fixed-assets/route.ts
@@ -1,0 +1,152 @@
+// GET  /api/finance/fixed-assets: the register with computed columns
+//      (monthly depreciation, accumulated to date, net book value).
+// POST /api/finance/fixed-assets: create an asset. Manual entry, or pass
+//      bankLineId to capitalize a classified EQUIPMENTS bank line: cost,
+//      acquisition date, company and outlet prefill from the line and the
+//      asset links source_bank_line_id so the line can never capitalize twice.
+//
+// Owner/Admin only, like every finance mutation.
+
+import { NextRequest, NextResponse } from "next/server";
+import { randomUUID } from "crypto";
+import { requireAuth } from "@/lib/auth";
+import { prisma } from "@/lib/prisma";
+import { getFinanceClient } from "@/lib/finance/supabase";
+import { companyFromAccountName } from "@/lib/finance/gl-posting-map";
+import {
+  accumulatedDepreciation,
+  listFixedAssets,
+  monthlyDepreciation,
+  netBookValue,
+  ymOfDate,
+} from "@/lib/finance/fixed-assets";
+
+export const dynamic = "force-dynamic";
+
+async function guard(req: NextRequest) {
+  const auth = await requireAuth(req);
+  if (auth.error) return { error: auth.error };
+  if (!["OWNER", "ADMIN"].includes(auth.user.role)) {
+    return { error: NextResponse.json({ error: "Forbidden" }, { status: 403 }) };
+  }
+  return { user: auth.user };
+}
+
+export async function GET(req: NextRequest) {
+  const g = await guard(req);
+  if (g.error) return g.error;
+
+  const url = new URL(req.url);
+  const companyId = url.searchParams.get("companyId");
+  const today = new Date(Date.now() + 8 * 3600_000).toISOString().slice(0, 10); // MYT
+
+  const assets = await listFixedAssets(companyId);
+  const outletIds = [...new Set(assets.map((a) => a.outletId).filter((v): v is string => !!v))];
+  const outlets = outletIds.length
+    ? await prisma.outlet.findMany({ where: { id: { in: outletIds } }, select: { id: true, name: true } })
+    : [];
+  const outletName = new Map(outlets.map((o) => [o.id, o.name]));
+
+  return NextResponse.json({
+    assets: assets.map((a) => {
+      const accumulated = accumulatedDepreciation(a, today);
+      return {
+        ...a,
+        outletName: a.outletId ? (outletName.get(a.outletId) ?? null) : null,
+        monthlyDep: monthlyDepreciation(a, ymOfDate(today)),
+        accumulated,
+        nbv: netBookValue(a, today),
+      };
+    }),
+  });
+}
+
+export async function POST(req: NextRequest) {
+  const g = await guard(req);
+  if (g.error) return g.error;
+
+  let body: {
+    bankLineId?: string;
+    name?: string;
+    companyId?: string;
+    outletId?: string | null;
+    accountCode?: string;
+    cost?: number;
+    residual?: number;
+    acquiredDate?: string;
+    usefulLifeMonths?: number;
+    notes?: string | null;
+  } = {};
+  try { body = (await req.json()) ?? {}; } catch { /* fall through to validation */ }
+
+  const client = getFinanceClient();
+
+  // Capitalize from a classified bank line: the line supplies cost, date,
+  // company (from the owning bank account) and outlet.
+  let sourceBankLineId: string | null = null;
+  if (body.bankLineId) {
+    const line = await prisma.bankStatementLine.findUnique({
+      where: { id: body.bankLineId },
+      select: { id: true, amount: true, txnDate: true, description: true, direction: true, outletId: true, statement: { select: { accountName: true } } },
+    });
+    if (!line) return NextResponse.json({ error: "Bank line not found" }, { status: 404 });
+    if (line.direction !== "DR") return NextResponse.json({ error: "Only outflow lines can be capitalized" }, { status: 400 });
+    const { data: linked } = await client
+      .from("fin_fixed_assets").select("id").eq("source_bank_line_id", line.id).limit(1);
+    if (linked && linked.length) {
+      return NextResponse.json({ error: "This bank line is already capitalized" }, { status: 409 });
+    }
+    sourceBankLineId = line.id;
+    body.cost = body.cost ?? Number(line.amount);
+    body.acquiredDate = body.acquiredDate ?? line.txnDate.toISOString().slice(0, 10);
+    body.companyId = body.companyId ?? companyFromAccountName(line.statement.accountName);
+    body.outletId = body.outletId ?? line.outletId;
+    body.name = body.name || line.description;
+  }
+
+  const name = (body.name ?? "").trim();
+  const cost = Number(body.cost);
+  const residual = Number(body.residual ?? 0);
+  const usefulLifeMonths = Number(body.usefulLifeMonths ?? 60);
+  const accountCode = body.accountCode ?? "1500-02"; // Kitchen equipment default
+  if (!name) return NextResponse.json({ error: "name is required" }, { status: 400 });
+  if (!body.companyId) return NextResponse.json({ error: "companyId is required" }, { status: 400 });
+  if (!Number.isFinite(cost) || cost <= 0) return NextResponse.json({ error: "cost must be > 0" }, { status: 400 });
+  if (!Number.isFinite(residual) || residual < 0 || residual >= cost) {
+    return NextResponse.json({ error: "residual must be >= 0 and below cost" }, { status: 400 });
+  }
+  if (!Number.isInteger(usefulLifeMonths) || usefulLifeMonths <= 0) {
+    return NextResponse.json({ error: "usefulLifeMonths must be a positive integer" }, { status: 400 });
+  }
+  if (!body.acquiredDate || !/^\d{4}-\d{2}-\d{2}$/.test(body.acquiredDate)) {
+    return NextResponse.json({ error: "acquiredDate must be YYYY-MM-DD" }, { status: 400 });
+  }
+  // account_code must be a 1500-xx PP&E account so the 1550-xx accumulated
+  // depreciation counterpart derives cleanly.
+  if (!/^1500-\d{2}$/.test(accountCode)) {
+    return NextResponse.json({ error: "accountCode must be a 1500-xx PP&E account" }, { status: 400 });
+  }
+  const { data: acct } = await client.from("fin_accounts").select("code").eq("code", accountCode).maybeSingle();
+  if (!acct) return NextResponse.json({ error: `Unknown account ${accountCode}` }, { status: 400 });
+
+  await client.rpc("fin_set_actor", { p_actor: g.user.id }).then(() => undefined, () => undefined);
+  const id = randomUUID();
+  const { error } = await client.from("fin_fixed_assets").insert({
+    id,
+    company_id: body.companyId,
+    outlet_id: body.outletId || null,
+    description: name,
+    account_code: accountCode,
+    cost,
+    residual,
+    acquired_date: body.acquiredDate,
+    useful_life_months: usefulLifeMonths,
+    method: "straight_line",
+    status: "active",
+    source_bank_line_id: sourceBankLineId,
+    notes: body.notes || null,
+    created_by: g.user.id,
+  });
+  if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+  return NextResponse.json({ id }, { status: 201 });
+}

--- a/apps/backoffice/src/app/api/finance/fixed-assets/run-depreciation/route.ts
+++ b/apps/backoffice/src/app/api/finance/fixed-assets/run-depreciation/route.ts
@@ -1,0 +1,57 @@
+// Depreciation run for one month, across all companies with assets.
+//
+// GET  ?yearMonth=YYYY-MM         is a dry-run preview: per-company totals
+//                                   and per-asset amounts, nothing posted.
+// POST { yearMonth, preview? }      posts ONE journal per company via the
+//                                   ledger engine (Dr 6512, Cr 1550-xx),
+//                                   unless preview=true (same as GET).
+//
+// Idempotent: each company-month has a deterministic posting_key, so
+// re-running a month never double posts (the run reports alreadyPosted
+// instead). Owner/Admin only.
+
+import { NextRequest, NextResponse } from "next/server";
+import { requireAuth } from "@/lib/auth";
+import { getFinanceClient } from "@/lib/finance/supabase";
+import { runDepreciation } from "@/lib/finance/fixed-assets";
+
+export const dynamic = "force-dynamic";
+export const maxDuration = 60;
+
+async function guard(req: NextRequest) {
+  const auth = await requireAuth(req);
+  if (auth.error) return { error: auth.error };
+  if (!["OWNER", "ADMIN"].includes(auth.user.role)) {
+    return { error: NextResponse.json({ error: "Forbidden" }, { status: 403 }) };
+  }
+  return { user: auth.user };
+}
+
+export async function GET(req: NextRequest) {
+  const g = await guard(req);
+  if (g.error) return g.error;
+  const yearMonth = new URL(req.url).searchParams.get("yearMonth") ?? "";
+  try {
+    const result = await runDepreciation({ yearMonth, commit: false });
+    return NextResponse.json(result);
+  } catch (err) {
+    return NextResponse.json({ error: err instanceof Error ? err.message : String(err) }, { status: 400 });
+  }
+}
+
+export async function POST(req: NextRequest) {
+  const g = await guard(req);
+  if (g.error) return g.error;
+  let body: { yearMonth?: string; preview?: boolean } = {};
+  try { body = (await req.json()) ?? {}; } catch { /* validated below */ }
+  try {
+    if (!body.preview) {
+      const client = getFinanceClient();
+      await client.rpc("fin_set_actor", { p_actor: g.user.id }).then(() => undefined, () => undefined);
+    }
+    const result = await runDepreciation({ yearMonth: body.yearMonth ?? "", commit: !body.preview });
+    return NextResponse.json(result);
+  } catch (err) {
+    return NextResponse.json({ error: err instanceof Error ? err.message : String(err) }, { status: 400 });
+  }
+}

--- a/apps/backoffice/src/lib/finance/fixed-assets.ts
+++ b/apps/backoffice/src/lib/finance/fixed-assets.ts
@@ -1,0 +1,305 @@
+// Fixed assets register + straight-line depreciation engine.
+//
+// ONE depreciation math, used everywhere: the register's computed columns, the
+// sourced P&L "Depreciation" line, its drill-down, the auditor pack CSV and
+// the monthly GL posting all call the same functions here, so the numbers can
+// never disagree.
+//
+// MONTH CONVENTION (the single documented convention):
+//   - An asset starts depreciating in the FIRST FULL MONTH AFTER acquired_date.
+//     An asset bought 2026-03-15 (or 2026-03-01) takes its first charge in
+//     April 2026. No partial-month charges.
+//   - Each monthly charge is recognized on the LAST calendar day of its month
+//     (matching how the close agent dates depreciation journals). A reporting
+//     window [start, end] therefore includes a month's charge exactly when that
+//     month's last day falls inside the window.
+//   - Monthly charge = round2((cost - residual) / useful_life_months); the
+//     FINAL life month takes the remainder so lifetime depreciation sums to
+//     exactly cost - residual with no rounding drift.
+//   - Disposal stops depreciation from the disposal month onward: the month of
+//     disposed_date and every later month take no charge (mirror of the start
+//     convention: only full months of ownership depreciate).
+//
+// Data model: fin_fixed_assets (002_finance_module.sql + 072 register v2).
+// account_code is the 1500-xx PP&E account; its 1550-xx accumulated
+// depreciation counterpart is derived by suffix; the expense side is always
+// 6512 Depreciation of property, plant and equipment.
+
+import { createHash } from "crypto";
+import { getFinanceClient } from "./supabase";
+import { postJournal } from "./ledger";
+import type { JournalLineInput } from "./types";
+
+export const FIXED_ASSETS_AGENT_VERSION = "fixed-assets-v1";
+export const DEP_EXPENSE_ACCOUNT = "6512";
+
+const round2 = (n: number) => Math.round(n * 100) / 100;
+
+export type FixedAsset = {
+  id: string;
+  companyId: string | null;
+  outletId: string | null;
+  name: string;               // fin_fixed_assets.description
+  accountCode: string;        // 1500-xx PP&E account
+  cost: number;
+  residual: number;
+  acquiredDate: string;       // YYYY-MM-DD
+  usefulLifeMonths: number;
+  method: string;             // straight_line (only method)
+  status: string;             // active | disposed | fully_depreciated
+  disposedDate: string | null;
+  sourceBankLineId: string | null;
+  notes: string | null;
+  createdBy: string | null;
+  createdAt: string | null;
+};
+
+// 1500-xx maps to its 1550-xx accumulated depreciation counterpart by suffix
+// (1500-02 Kitchen equipment -> 1550-02). Same rule the close agent uses.
+export function accumulatedDepCode(assetCode: string): string {
+  if (!assetCode.startsWith("1500-")) {
+    throw new Error(`Cannot derive accumulated-dep code from ${assetCode}`);
+  }
+  return `1550-${assetCode.slice("1500-".length)}`;
+}
+
+// ── month arithmetic (yearMonth strings "YYYY-MM" <-> linear month index) ────
+export function ymIndex(ym: string): number {
+  const [y, m] = ym.split("-").map(Number);
+  return y * 12 + (m - 1);
+}
+export function ymFromIndex(i: number): string {
+  const y = Math.floor(i / 12);
+  const m = (i % 12) + 1;
+  return `${y}-${String(m).padStart(2, "0")}`;
+}
+export function ymOfDate(dateStr: string): string {
+  return dateStr.slice(0, 7);
+}
+// Last calendar day of a yearMonth, as YYYY-MM-DD.
+export function monthEnd(ym: string): string {
+  const [y, m] = ym.split("-").map(Number);
+  const last = new Date(Date.UTC(y, m, 0)).getUTCDate();
+  return `${ym}-${String(last).padStart(2, "0")}`;
+}
+
+// The depreciation charge this asset takes in the given yearMonth, under the
+// convention documented at the top of this file. 0 outside the asset's life.
+export function monthlyDepreciation(asset: FixedAsset, ym: string): number {
+  const life = asset.usefulLifeMonths;
+  if (life <= 0) return 0;
+  const base = round2(asset.cost - asset.residual);
+  if (base <= 0) return 0;
+
+  const startIdx = ymIndex(ymOfDate(asset.acquiredDate)) + 1; // first full month after acquisition
+  const i = ymIndex(ym) - startIdx;                            // 0-based month of life
+  if (i < 0 || i >= life) return 0;
+
+  // Disposal month and later take no charge.
+  if (asset.disposedDate && ymIndex(ym) >= ymIndex(ymOfDate(asset.disposedDate))) return 0;
+
+  const monthly = round2(base / life);
+  if (i === life - 1) return round2(Math.max(base - monthly * (life - 1), 0)); // remainder month
+  return monthly;
+}
+
+// Total charge over an inclusive yearMonth range.
+export function depreciationForYmRange(asset: FixedAsset, fromYm: string, toYm: string): number {
+  let total = 0;
+  for (let i = ymIndex(fromYm); i <= ymIndex(toYm); i++) {
+    total += monthlyDepreciation(asset, ymFromIndex(i));
+  }
+  return round2(total);
+}
+
+// Total charge for a date window [start, end] (YYYY-MM-DD): sums the months
+// whose LAST day falls inside the window (charges are dated on month end).
+export function depreciationForWindow(asset: FixedAsset, start: string, end: string): number {
+  let total = 0;
+  for (let i = ymIndex(ymOfDate(start)); i <= ymIndex(ymOfDate(end)); i++) {
+    const ym = ymFromIndex(i);
+    const me = monthEnd(ym);
+    if (me >= start && me <= end) total += monthlyDepreciation(asset, ym);
+  }
+  return round2(total);
+}
+
+// Accumulated depreciation through the end of the month containing asOf.
+export function accumulatedDepreciation(asset: FixedAsset, asOf: string): number {
+  const startYm = ymFromIndex(ymIndex(ymOfDate(asset.acquiredDate)) + 1);
+  const asOfYm = ymOfDate(asOf);
+  if (ymIndex(asOfYm) < ymIndex(startYm)) return 0;
+  return depreciationForYmRange(asset, startYm, asOfYm);
+}
+
+export function netBookValue(asset: FixedAsset, asOf: string): number {
+  return round2(asset.cost - accumulatedDepreciation(asset, asOf));
+}
+
+// ── register access ──────────────────────────────────────────────────────────
+type AssetRow = {
+  id: string; company_id: string | null; outlet_id: string | null; description: string;
+  account_code: string; cost: number | string; residual: number | string | null;
+  acquired_date: string; useful_life_months: number; method: string; status: string;
+  disposed_date: string | null; source_bank_line_id: string | null; notes: string | null;
+  created_by: string | null; created_at: string | null;
+};
+
+export function mapAssetRow(r: AssetRow): FixedAsset {
+  return {
+    id: r.id,
+    companyId: r.company_id,
+    outletId: r.outlet_id,
+    name: r.description,
+    accountCode: r.account_code,
+    cost: round2(Number(r.cost)),
+    residual: round2(Number(r.residual ?? 0)),
+    acquiredDate: r.acquired_date,
+    usefulLifeMonths: r.useful_life_months,
+    method: r.method,
+    status: r.status,
+    disposedDate: r.disposed_date,
+    sourceBankLineId: r.source_bank_line_id,
+    notes: r.notes,
+    createdBy: r.created_by,
+    createdAt: r.created_at,
+  };
+}
+
+const ASSET_COLUMNS =
+  "id, company_id, outlet_id, description, account_code, cost, residual, acquired_date, useful_life_months, method, status, disposed_date, source_bank_line_id, notes, created_by, created_at";
+
+export async function listFixedAssets(companyId?: string | null): Promise<FixedAsset[]> {
+  const client = getFinanceClient();
+  let q = client.from("fin_fixed_assets").select(ASSET_COLUMNS).order("acquired_date", { ascending: false });
+  if (companyId) q = q.eq("company_id", companyId);
+  const { data, error } = await q;
+  if (error) throw new Error(error.message);
+  return ((data ?? []) as AssetRow[]).map(mapAssetRow);
+}
+
+// Per-asset depreciation totals for a reporting window. The P&L line, its
+// drill and the run-depreciation preview all read from this.
+export async function depreciationByAsset(input: {
+  companyId?: string | null;
+  start: string; // YYYY-MM-DD
+  end: string;   // YYYY-MM-DD
+  outletId?: string | null;
+}): Promise<{ asset: FixedAsset; amount: number }[]> {
+  const assets = await listFixedAssets(input.companyId);
+  const out: { asset: FixedAsset; amount: number }[] = [];
+  for (const a of assets) {
+    if (input.outletId && a.outletId !== input.outletId) continue;
+    const amount = depreciationForWindow(a, input.start, input.end);
+    if (amount > 0) out.push({ asset: a, amount });
+  }
+  return out;
+}
+
+export async function depreciationTotal(input: {
+  companyId?: string | null;
+  start: string;
+  end: string;
+  outletId?: string | null;
+}): Promise<number> {
+  const rows = await depreciationByAsset(input);
+  return round2(rows.reduce((s, r) => s + r.amount, 0));
+}
+
+// ── GL posting ───────────────────────────────────────────────────────────────
+// Deterministic identity for a company-month depreciation journal, formatted
+// as a uuid to fit fin_transactions.posting_key (same trick as bankJournalKey
+// in gl-posting.ts). The unique index on posting_key makes re-posting a month
+// physically impossible.
+export function depreciationPostingKey(companyId: string, yearMonth: string): string {
+  const h = createHash("md5").update(`fixed-asset-dep|${companyId}|${yearMonth}`).digest("hex");
+  return `${h.slice(0, 8)}-${h.slice(8, 12)}-${h.slice(12, 16)}-${h.slice(16, 20)}-${h.slice(20)}`;
+}
+
+export type DepreciationRunCompany = {
+  companyId: string;
+  total: number;
+  byAsset: { id: string; name: string; accountCode: string; amount: number }[];
+  alreadyPosted: boolean;
+  transactionId: string | null; // set when posted (new or pre-existing)
+};
+
+// Post ONE balanced journal per company for the month's depreciation:
+//   Dr 6512 Depreciation expense (total)
+//   Cr 1550-xx Accumulated depreciation (one line per PP&E account)
+// dated on the month's last day, agent 'close' (the AgentName the ledger types
+// allow for period work), txn_type 'depreciation'. Idempotent via posting_key:
+// re-running a month finds the existing journal and does nothing.
+export async function runDepreciation(input: {
+  yearMonth: string;                 // "YYYY-MM"
+  commit: boolean;                   // false = dry-run preview
+  companyIds?: string[];             // default: every company with assets
+}): Promise<{ yearMonth: string; committed: boolean; companies: DepreciationRunCompany[] }> {
+  if (!/^\d{4}-\d{2}$/.test(input.yearMonth)) {
+    throw new Error(`yearMonth must be YYYY-MM, got ${input.yearMonth}`);
+  }
+  const client = getFinanceClient();
+  const assets = await listFixedAssets(null);
+
+  // Group the month's charges per company.
+  const perCompany = new Map<string, { total: number; byAsset: DepreciationRunCompany["byAsset"]; byAccount: Map<string, number> }>();
+  for (const a of assets) {
+    if (!a.companyId) continue;
+    if (input.companyIds && !input.companyIds.includes(a.companyId)) continue;
+    const charge = monthlyDepreciation(a, input.yearMonth);
+    if (charge <= 0) continue;
+    const g = perCompany.get(a.companyId) ?? { total: 0, byAsset: [], byAccount: new Map<string, number>() };
+    g.total = round2(g.total + charge);
+    g.byAsset.push({ id: a.id, name: a.name, accountCode: a.accountCode, amount: charge });
+    const acc = accumulatedDepCode(a.accountCode);
+    g.byAccount.set(acc, round2((g.byAccount.get(acc) ?? 0) + charge));
+    perCompany.set(a.companyId, g);
+  }
+
+  const txnDate = monthEnd(input.yearMonth);
+  const companies: DepreciationRunCompany[] = [];
+
+  for (const [companyId, g] of perCompany) {
+    const postingKey = depreciationPostingKey(companyId, input.yearMonth);
+    const { data: existingRows, error: exErr } = await client
+      .from("fin_transactions")
+      .select("id")
+      .eq("posting_key", postingKey)
+      .eq("status", "posted")
+      .limit(1);
+    if (exErr) throw new Error(exErr.message);
+    const existing = existingRows?.[0];
+
+    if (existing) {
+      companies.push({ companyId, total: g.total, byAsset: g.byAsset, alreadyPosted: true, transactionId: existing.id as string });
+      continue;
+    }
+    if (!input.commit) {
+      companies.push({ companyId, total: g.total, byAsset: g.byAsset, alreadyPosted: false, transactionId: null });
+      continue;
+    }
+
+    const lines: JournalLineInput[] = [
+      { accountCode: DEP_EXPENSE_ACCOUNT, debit: g.total, memo: `Depreciation ${input.yearMonth} (${g.byAsset.length} asset${g.byAsset.length > 1 ? "s" : ""})` },
+      ...[...g.byAccount.entries()].map(([acc, amt]) => ({
+        accountCode: acc,
+        credit: amt,
+        memo: `Accumulated depreciation ${input.yearMonth}`,
+      })),
+    ];
+    const res = await postJournal({
+      companyId,
+      txnDate,
+      description: `Depreciation ${input.yearMonth}, straight-line, ${g.byAsset.length} asset${g.byAsset.length > 1 ? "s" : ""}`,
+      txnType: "depreciation",
+      agent: "close",
+      agentVersion: FIXED_ASSETS_AGENT_VERSION,
+      confidence: 1,
+      postingKey,
+      lines,
+    });
+    companies.push({ companyId, total: g.total, byAsset: g.byAsset, alreadyPosted: false, transactionId: res.transactionId });
+  }
+
+  return { yearMonth: input.yearMonth, committed: input.commit, companies: companies.sort((a, b) => a.companyId.localeCompare(b.companyId)) };
+}

--- a/apps/backoffice/src/lib/finance/reports/auditor-pack.ts
+++ b/apps/backoffice/src/lib/finance/reports/auditor-pack.ts
@@ -14,6 +14,7 @@
 // proper ZIP packaging is a follow-up using a streaming archiver.
 
 import { getFinanceClient } from "../supabase";
+import { accumulatedDepreciation, listFixedAssets, netBookValue } from "../fixed-assets";
 import { buildPnl } from "./pnl";
 import { buildBalanceSheet } from "./balance-sheet";
 
@@ -216,30 +217,29 @@ async function apListingCsv(
 }
 
 async function fixedAssetCsv(companyId: string): Promise<AuditorPackFile> {
-  const client = getFinanceClient();
-  const { data } = await client
-    .from("fin_fixed_assets")
-    .select("id, account_code, outlet_id, description, acquired_date, cost, useful_life_months, accumulated_dep, status, disposed_date, disposed_amount")
-    .eq("company_id", companyId)
-    .order("acquired_date");
-  const rows = ["asset_id,account_code,outlet_id,description,acquired_date,cost,useful_life_months,accumulated_dep,nbv,status,disposed_date,disposed_amount"];
-  for (const r of data ?? []) {
-    const cost = Number(r.cost);
-    const acc = Number(r.accumulated_dep);
+  // Real register export. Accumulated depreciation and NBV are DERIVED from
+  // the same straight-line engine the P&L and GL posting use (one month
+  // convention everywhere), computed as of today.
+  const assets = await listFixedAssets(companyId);
+  const today = new Date().toISOString().slice(0, 10);
+  const rows = ["asset_id,name,company,account_code,outlet_id,acquired_date,cost,residual,useful_life_months,accumulated_dep,nbv,status,disposed_date"];
+  for (const a of assets) {
+    const acc = accumulatedDepreciation(a, today);
     rows.push(
       [
-        r.id,
-        r.account_code,
-        r.outlet_id ?? "",
-        `"${csvEscape((r.description as string) ?? "")}"`,
-        r.acquired_date,
-        cost.toFixed(2),
-        r.useful_life_months,
+        a.id,
+        `"${csvEscape(a.name)}"`,
+        a.companyId ?? "",
+        a.accountCode,
+        a.outletId ?? "",
+        a.acquiredDate,
+        a.cost.toFixed(2),
+        a.residual.toFixed(2),
+        a.usefulLifeMonths,
         acc.toFixed(2),
-        (cost - acc).toFixed(2),
-        r.status,
-        r.disposed_date ?? "",
-        r.disposed_amount ?? "",
+        netBookValue(a, today).toFixed(2),
+        a.status,
+        a.disposedDate ?? "",
       ].join(",")
     );
   }

--- a/apps/backoffice/src/lib/finance/reports/pnl-sourced-drill.ts
+++ b/apps/backoffice/src/lib/finance/reports/pnl-sourced-drill.ts
@@ -17,6 +17,7 @@ import { prisma } from "@/lib/prisma";
 import { Prisma, type CashCategory } from "@prisma/client";
 import { getFinanceClient } from "../supabase";
 import { getDefaultCompanyId } from "../companies";
+import { depreciationByAsset } from "../fixed-assets";
 import { effectiveGrabRate } from "./pnl-sourced";
 import { getUnifiedSalesForOutlet } from "@/app/api/sales/_lib/unified-sales";
 
@@ -68,7 +69,7 @@ function addMonths(s: string, n: number): string {
 }
 
 export function isSourcedPnlCode(code: string): boolean {
-  return /^(REV-|PROC$|INV-|MKT-|BANK:)/.test(code);
+  return /^(REV-|PROC$|INV-|MKT-|BANK:|DEP$)/.test(code);
 }
 
 async function companyOutlets(companyId: string, outletId?: string | null): Promise<string[]> {
@@ -226,6 +227,26 @@ async function drillGrabAds(companyId: string, start: string, end: string, outle
   }));
 }
 
+// DEP: per-asset depreciation for the period, from the SAME math as the P&L
+// line (lib/finance/fixed-assets.ts), so the drill total ties to the line.
+async function drillDepreciation(companyId: string, start: string, end: string, outletId?: string | null): Promise<DrillLine[]> {
+  const rows = await depreciationByAsset({
+    companyId: companyId === CONSOLIDATED ? null : companyId,
+    start,
+    end,
+    outletId,
+  });
+  return rows.map(({ asset, amount }) => ({
+    transactionId: asset.id,
+    txnDate: asset.acquiredDate,
+    description: `${asset.name}: cost RM${asset.cost.toFixed(2)}, life ${asset.usefulLifeMonths} months (${asset.accountCode})`,
+    amount,
+    debit: amount,
+    credit: 0,
+    meta: { company: asset.companyId, account: asset.accountCode },
+  }));
+}
+
 // BANK:<CAT> — the classified bank lines behind the opex line. Also serves the
 // bank-sourced income lines (GastroHub, Meetings & Events) on the CR side.
 async function drillBank(cat: string, companyId: string, start: string, end: string, outletId?: string | null, direction: "DR" | "CR" = "DR"): Promise<DrillLine[]> {
@@ -288,6 +309,7 @@ export async function sourcedPnlDrillDown(args: {
   if (code === "MKT-ADS") return drillAds(companyId, start, end, outletId);
   if (code === "MKT-GRAB-PROMO") return drillGrabPromo(companyId, start, end, outletId);
   if (code === "MKT-GRAB-ADS") return drillGrabAds(companyId, start, end, outletId);
+  if (code === "DEP") return drillDepreciation(companyId, start, end, outletId);
   // Management fee is recognised on accrual (paid a month in arrears), so its
   // drill uses the same shifted window as the P&L line — payments in the
   // following month, which are this period's fee.

--- a/apps/backoffice/src/lib/finance/reports/pnl-sourced.ts
+++ b/apps/backoffice/src/lib/finance/reports/pnl-sourced.ts
@@ -19,6 +19,7 @@ import { getFinanceClient } from "../supabase";
 import { prisma } from "@/lib/prisma";
 import { Prisma } from "@prisma/client";
 import { getDefaultCompanyId } from "../companies";
+import { depreciationTotal } from "../fixed-assets";
 import type { PnlReport, PnlLine } from "./pnl";
 import { getUnifiedSalesForOutlet } from "@/app/api/sales/_lib/unified-sales";
 
@@ -486,6 +487,23 @@ export async function buildSourcedPnl(input: {
     if (mfAmt) {
       expenseLines.push({ code: "BANK:MANAGEMENT_FEE", name: "Management Fee (accrued — paid next month)", amount: mfAmt, parentCode: null });
       totalExpenses += mfAmt;
+    }
+  }
+
+  // Depreciation: straight-line from the fixed-asset register (source-driven,
+  // no journal dependency). Equipment purchases NEVER hit this P&L as an
+  // expense (EQUIPMENTS sits in BANK_NONOPEX above), so recognising the
+  // depreciation charge here is the whole cost story, with no double count
+  // whether or not a purchase line has been capitalized into an asset yet.
+  // Month convention (documented in lib/finance/fixed-assets.ts): charges
+  // start the first full month after acquisition, are dated on each month's
+  // last day (so a window includes a month iff its last day is inside), and
+  // stop from the disposal month onward.
+  {
+    const dep = await depreciationTotal({ companyId, start, end, outletId });
+    if (dep) {
+      expenseLines.push({ code: "DEP", name: "Depreciation (fixed assets, straight-line)", amount: dep, parentCode: null });
+      totalExpenses += dep;
     }
   }
   totalExpenses = round2(totalExpenses);

--- a/supabase/migrations/072_fixed_assets_register.sql
+++ b/supabase/migrations/072_fixed_assets_register.sql
@@ -1,0 +1,39 @@
+-- Fixed assets register v2: wires the dormant fin_fixed_assets table (created
+-- in apps/backoffice/supabase/migrations/002_finance_module.sql, company_id
+-- added in 004_finance_multi_company.sql) to the new register UI, straight-line
+-- depreciation engine and one-click capitalization of EQUIPMENTS bank lines.
+--
+-- The COA already carries everything depreciation needs (seeded in
+-- 003_finance_coa_seed.sql): 1500-00..05 PP&E asset accounts, their 1550-xx
+-- accumulated depreciation counterparts, and 6512 Depreciation of property,
+-- plant and equipment. No new accounts are inserted here.
+--
+-- RLS: fin_fixed_assets already has row level security enabled with the shared
+-- fin_read select policy for authenticated fin_user_roles holders (002); all
+-- writes go through the service-role finance client. Re-asserted below for
+-- safety, no new policies needed.
+
+-- Depreciable base = cost - residual (salvage) value.
+alter table fin_fixed_assets
+  add column if not exists residual numeric(14,2) not null default 0;
+
+-- The classified EQUIPMENTS bank line this asset was capitalized from, so the
+-- capitalizable list can exclude already-linked lines and a line can never be
+-- capitalized twice. Plain text (BankStatementLine.id is a text uuid managed
+-- by Prisma) and deliberately NOT a hard FK: some feeds rebuild their lines
+-- (delete + recreate) and a constraint would break those rebuilds.
+alter table fin_fixed_assets
+  add column if not exists source_bank_line_id text;
+create unique index if not exists uq_fin_fixed_assets_source_line
+  on fin_fixed_assets(source_bank_line_id) where source_bank_line_id is not null;
+
+-- Who created the asset row (user id), for the audit trail.
+alter table fin_fixed_assets
+  add column if not exists created_by text;
+
+-- 002 defined id as text primary key with no default; give it one so inserts
+-- that omit id still work.
+alter table fin_fixed_assets
+  alter column id set default (gen_random_uuid())::text;
+
+alter table fin_fixed_assets enable row level security;


### PR DESCRIPTION
## What

Fixed assets register at /finance/fixed-assets (nav under Finance), backed by the dormant fin_fixed_assets table, with one straight-line engine shared by the register, the sourced P&L, its drill, the auditor pack CSV and the monthly GL posting.

## Month convention (single, documented in lib/finance/fixed-assets.ts)

- First charge in the first FULL month after acquired_date; no partial months.
- Each charge is dated on the month's LAST day, so a reporting window includes a month exactly when that month's last day falls inside it.
- Monthly charge = round2((cost - residual) / useful_life_months); the final life month takes the remainder so lifetime depreciation sums exactly.
- Disposal month and later take no charge.

## COA accounts

No new accounts. Reuses the seed (003_finance_coa_seed.sql): 1500-00..05 PP&E asset accounts, 1550-xx accumulated depreciation counterparts (derived by suffix), and 6512 Depreciation of property, plant and equipment.

## Pieces

- Migration supabase/migrations/072_fixed_assets_register.sql (072 because #768 claims 071): adds residual, source_bank_line_id (unique partial index, no hard FK), created_by, and an id default to fin_fixed_assets. RLS already enabled per 002; re-asserted. NOT applied to any database.
- APIs under /api/finance/fixed-assets (Owner/Admin): register GET with monthly dep / accumulated / NBV, POST create (manual or bankLineId capitalization), PATCH edit, POST dispose, GET capitalizable (EQUIPMENTS DR lines not yet linked), GET/POST run-depreciation with dry-run preview and idempotent posting_key journals, one per company (Dr 6512, Cr 1550-xx) via postJournal.
- Sourced P&L gets a DEP expense line and a per-asset drill. No double counting: EQUIPMENTS bank lines are already excluded from opex (BANK_NONOPEX), so the depreciation charge is the only P&L cost whether or not a purchase line has been capitalized.
- UI: register table with totals, add/edit drawer, capitalize-from-bank list (default life 60 months, editable), run-depreciation month picker with per-company preview and confirm-gated post, dispose with date prompt.
- Auditor pack fixedAssetCsv exports the real derived register.

## Out of scope for v1

Disposal gain/loss journals: dispose only stops depreciation; cost stays on the books until a proper disposal journal is added.