### PR TITLE
docs: Claude Code harness scaffolding — CLAUDE.md, STATE.md, three skills

### DIFF
--- a/.claude/skills/db-migration/SKILL.md
+++ b/.claude/skills/db-migration/SKILL.md
@@ -1,0 +1,48 @@
+---
+name: db-migration
+description: Make a database schema change in celsius-ops. Use whenever a task requires adding/altering tables, columns, or indexes — i.e. any edit to packages/db/prisma/schema.prisma. Enforces the manual-SQL migration workflow; NEVER prisma db push or migrate deploy.
+---
+
+# Database schema change (hybrid workflow)
+
+Canonical policy: `docs/database-migrations.md`. Summary: the Supabase database
+hosts tables Prisma doesn't know about (`auth.*`, `storage.*`, SQL-managed RLS
+tables). `prisma db push` and `prisma migrate deploy` will drop them. **Never
+run either.** Prisma's apply path is bypassed entirely; SQL is applied manually
+and committed for audit.
+
+## Steps
+
+1. **Edit `packages/db/prisma/schema.prisma`** with the new model/column/index.
+2. **Generate the diff SQL for inspection** (this never touches the DB):
+   ```bash
+   cd packages/db
+   npx prisma migrate diff \
+     --from-migrations ./prisma/migrations \
+     --to-schema-datamodel ./prisma/schema.prisma \
+     --script
+   ```
+   Review the output. If it contains `DROP` statements you didn't intend,
+   stop and investigate before going further.
+3. **Get human approval before applying to production.** Show the SQL and wait.
+   Apply via the Supabase MCP `apply_migration` tool or the Supabase SQL editor.
+4. **Save the SQL** as
+   `packages/db/prisma/migrations/YYYYMMDD_HHMMSS_<short_name>/migration.sql`.
+   These files are never executed by tooling — they exist for reproducibility
+   and audit, and CI's `migration-guard` job fails any PR that changes
+   `schema.prisma` without one.
+5. **Regenerate the client:** `cd packages/db && npx prisma generate`.
+6. **Commit both** the schema change and the migration SQL in the same commit.
+7. **Typecheck the apps that consume the changed models** before pushing:
+   `cd apps/<app> && npx tsc --noEmit`.
+
+## Checks
+
+- New tables that end-users reach need an RLS decision — see `docs/rls-strategy.md`.
+- If the change supports a hot POS path, check existing index conventions in
+  `supabase/migrations/` (POS order hot-path indexes live there).
+
+## Lessons
+
+_Append dated entries when this skill misses something. Promote stable ones into
+the steps above._

--- a/.claude/skills/finance-module/SKILL.md
+++ b/.claude/skills/finance-module/SKILL.md
@@ -1,0 +1,63 @@
+---
+name: finance-module
+description: Work on the agentic finance module (apps/backoffice /finance routes, fin_* tables, the 8 finance agents). Use for any change touching finance code, finance migrations, agent prompts/thresholds, or the exception inbox. Encodes the ledger invariants that must never break.
+---
+
+# Finance module — working rules
+
+Canonical spec: `docs/finance-module-spec.md`. The module is the system of
+record for Celsius accounting (replaced Bukku). Agents auto-categorize,
+auto-match, auto-post; humans only touch the exception inbox.
+
+## Invariants — never break these
+
+DB triggers enforce them, but write code as if they didn't:
+
+1. **Set the actor before any `fin_*` mutation.** Every server-side call:
+   `select set_config('app.actor', 'matcher-v1', true)` for agents,
+   `set_config('app.actor', :user_id, true)` for humans. The `'system'`
+   fallback must never be hit in production — treat it appearing in
+   `fin_audit_log` as a bug.
+2. **Posted transactions balance.** `sum(debit) = sum(credit)` at
+   `status='posted'` (`fin_check_balanced` blocks otherwise).
+3. **No posting to closed periods** (`fin_check_period_open`).
+4. **COA codes are stable identifiers.** Agents reference sub-account codes
+   like `5000-04` (Grabfood) directly in prompts and history. Never renumber
+   or reuse a code; deactivate instead.
+5. **Don't break the training signal.** Every agent call writes
+   `fin_agent_decisions`; exception-inbox corrections update the same row
+   (`corrected=true, corrected_to=…`). Any refactor must preserve this
+   write path — it is the eval/retraining dataset.
+
+## Agent thresholds (auto-post vs exception)
+
+Categorizer 0.85 · Matcher 0.90 · AP 0.85 · AR 0.95 · Close and Compliance
+are manual-approve · Anomaly always files an exception. Changing a threshold
+is a product decision — ask, don't tune.
+
+## UI rules
+
+Only 5 routes (`/finance`, `/transactions`, `/inbox`, `/reports`,
+`/compliance`). By design there is **no** invoice form, bill form, COA editor,
+or manual-journal screen (API-only escape hatch with written reason). Don't
+add manual-entry surfaces — the exception inbox is the human path. Every agent
+decision exposes its `reasoning` on hover.
+
+## Month-end close
+
+Close agent runs day 1, **manual approve** — never auto-close a period.
+Close writes the period snapshot and `fin_period_locks`. Reopening a period
+is an exceptional, human-only action.
+
+## Eval loop (the compounding part)
+
+`fin_agent_decisions` rows with `corrected=true` are ground truth the agent
+got wrong. When improving an agent (prompt, context window, threshold):
+replay recent corrected rows against the new version before shipping — the
+correction rate for that vendor/pattern should drop, and previously-correct
+decisions must not flip.
+
+## Lessons
+
+_Append dated entries when this skill misses something. Promote stable ones
+into the sections above._

--- a/.claude/skills/ota-release/SKILL.md
+++ b/.claude/skills/ota-release/SKILL.md
@@ -1,0 +1,59 @@
+---
+name: ota-release
+description: Ship or verify a release of the native apps (pos-native, pickup-native, staff-native). Use before merging any change under apps/*-native to main, when asked to release/rollback a native app, or when deciding whether a change can go OTA vs needing a new APK build.
+---
+
+# Native app releases (EAS OTA + APK)
+
+A merge to `main` touching `apps/pos-native`, `apps/pickup-native`, or
+`apps/staff-native` **is a production deploy**: the matching
+`.github/workflows/<app>-ota.yml` publishes an EAS Update to the `production`
+channel, and devices (SUNMI tills, KDS tablets, manager phones) pull the new JS
+bundle on next app launch. There is no staging channel between merge and till.
+
+## Decision: OTA or new APK?
+
+OTA works only for **JS/asset-only** changes with unchanged `runtimeVersion`
+(pinned to appVersion, e.g. 1.0.0). A change needs a **fresh APK build** if it
+touches any of:
+
+- native modules (`apps/pos-native/modules/` — customer-display, device-speaker,
+  sunmi-printer)
+- any dependency with native code (check whether `npx expo install` would alter
+  android config); plain JS dep bumps are fine
+- `app.json` / `eas.json` runtime or build config, permissions, appVersion
+
+APK builds: `pos-native-build-apk.yml` and `build-kds-apk.yml`
+(workflow_dispatch or push). OTA-only changes shipped on top of an outdated
+APK silently no-op on devices still running an older runtimeVersion — after a
+native change, rebuild and reinstall before relying on OTA again.
+
+## Pre-merge checklist (pos-native especially — this is the till)
+
+1. `cd apps/<app> && npm ci && npx tsc --noEmit` — for pos-native/pickup-native
+   this typecheck is **the only gate** between a TS error and a broken till;
+   the OTA workflows do no pre-build validation.
+2. Confirm the change is JS-only (see decision above) or plan an APK build.
+3. Human approval before merging pos-native changes (CLAUDE.md hard rule 6).
+
+## Post-merge verification
+
+1. Watch the `<app> OTA` workflow run to completion in GitHub Actions.
+2. Confirm the update landed: `npx eas-cli update:list --branch production`
+   (needs `EXPO_TOKEN`), or relaunch a test device and check behaviour.
+3. Rollback = revert the commit on main; the OTA workflow republishes the old
+   bundle. `workflow_dispatch` on the OTA workflow re-pushes on demand.
+
+## Gotchas (verified)
+
+- `eas update` shells out to `expo export`; its interactive prompts ignore
+  `--non-interactive` — the workflows set `CI=1` to suppress them.
+- pos-native is Android-only; publishing without `--platform android` makes
+  expo export try to bundle web and fail (no react-native-web).
+- Commit messages are passed to `eas update` via env var, not inline — inline
+  multi-line messages get shell-expanded into garbage args.
+
+## Lessons
+
+_Append dated entries when this skill misses something. Promote stable ones into
+the sections above._

--- a/.claude/skills/procurement-e2e/SKILL.md
+++ b/.claude/skills/procurement-e2e/SKILL.md
@@ -1,0 +1,63 @@
+---
+name: procurement-e2e
+description: Exercise or debug the procurement loop end-to-end (inventory-driven PO → WhatsApp supplier-chat agent → POP auto-send). Use when testing procurement changes, investigating supplier-agent misbehaviour, or verifying the loop after deploys.
+---
+
+# Procurement loop — E2E test
+
+Canonical runbook: `docs/design/procurement-e2e-test-runbook.md` (follow it for
+the full test matrix and seed SQL). This skill is the map plus hard-won caveats.
+
+This is a **live** test: it needs the deployed BackOffice, a phone holding the
+test supplier's WhatsApp number, and real WhatsApp Cloud API traffic. There is
+no local simulator.
+
+## Scope — what's automated vs not
+
+- Automated: reorder recommendation (`ai-decisions`), inbound supplier-message
+  handling (`handleSupplierMessage` — auto-edits PO for clear OOS/qty/date,
+  vision-captures invoices, escalates the rest), POP auto-send on invoice PAID.
+- **Not wired:** automated PO-send to the supplier (`purchase_order` /
+  `po_approval` buttons — designed, never shipped). Creating the PO in
+  BackOffice is enough; the agent only needs an open PO (DRAFT counts).
+
+## Phases (details in the runbook)
+
+1. **Prereqs** — env flags (`PROCUREMENT_AGENT_ENABLED`, allowlist by last 8
+   digits, `PROCUREMENT_WHATSAPP_ENABLED`, WhatsApp creds incl.
+   `WHATSAPP_APP_SECRET`), approved `proof_of_payment` Meta template, ACTIVE
+   test supplier, webhook subscribed to `/api/whatsapp/webhook`.
+2. **Force a reorder recommendation** — below-par condition on test
+   outlet+product: supplier price set, par level set, stock ≤ reorderPoint, no
+   surplus at other outlets, no existing open PO. Seed SQL in the runbook —
+   **staging DB only, never production**.
+3. **Create the PO** from AI Decisions; sanity-check On-Order column, price
+   trend %, below-MOQ warning.
+4. **Agent test matrix** — send the runbook's messages (Malay included) one at a
+   time; verify reply, Supplier Chats thread, and PO state after each. Clear
+   intents auto-apply; substitutions/MOQ/payment/ambiguity must ESCALATE with
+   no PO change.
+5. **POP flow** — attach invoice, record payment, mark PAID → `proof_of_payment`
+   auto-sends; check `popSentAt` and the "POP sent" pill.
+
+## Debugging handles
+
+- Agent log line: `[supplier-agent] supplier=… po=… intent=… conf=… action=… escalate=…`
+- POP log: `[invoices/[id]] POP auto-sent …` or `… POP not sent reason=…`
+- No inbound reaching the agent at all → almost always a missing/wrong
+  `WHATSAPP_APP_SECRET` (signature-rejected before the agent runs).
+- POP receipt must be the **last** photo on the invoice and a direct public
+  file URL, not a redirect.
+- POP send is best-effort: a WhatsApp failure won't fail the payment write —
+  absence of an error in the UI proves nothing; check the log line.
+
+## Known gaps (don't chase these as bugs)
+
+- PO-send + `po_approval` buttons: not wired.
+- Stock accuracy is shadow-only (consumption engine off); reorder runs off
+  receipts − wastage/transfers, not sales.
+
+## Lessons
+
+_Append dated entries when this skill misses something. Promote stable ones into
+the sections above._

--- a/.claude/skills/sentry-triage/SKILL.md
+++ b/.claude/skills/sentry-triage/SKILL.md
@@ -1,0 +1,47 @@
+---
+name: sentry-triage
+description: Triage Sentry issues for the Celsius apps. Use when asked to check errors/monitoring, when a Sentry alert comes in, or as the procedure for the scheduled nightly triage routine. Produces STATE.md entries and draft PRs for mechanical fixes.
+---
+
+# Sentry triage
+
+Sentry MCP server is configured in `.mcp.json` (token via env). Monitoring
+context: `docs/monitoring-setup.md` — every app exposes `/api/health`;
+14 Vercel crons fail silently into logs unless heartbeat-monitored, so a
+"quiet" cron is not evidence it's healthy.
+
+## Procedure
+
+1. **Guard:** if Sentry tools are unavailable or unauthenticated, stop —
+   report that and change nothing.
+2. **Sweep:** new + regressed issues since the last triage (default 24h),
+   across all Celsius projects. Note event counts and affected users.
+3. **Prioritise by business impact:** POS/till (`pos-native`) and order flow
+   (`order`, payment/reconcile crons) first — they lose money per minute;
+   backoffice/staff issues can wait for a human.
+4. **Classify each issue:**
+   - **Mechanical + confident** (null guard, missing await, bad import,
+     obvious regression from a recent commit): branch, fix, typecheck the
+     affected app, push, open a **draft** PR referencing the Sentry issue.
+   - **Real but non-trivial:** append to `docs/STATE.md → Open failures`
+     with the Sentry link, first-seen date, and a hypothesis.
+   - **Noise/known:** skip, but if it's recurring noise, propose a Sentry
+     ignore rule or a `beforeSend` filter rather than skipping forever.
+5. **Never** auto-fix anything touching payments, payroll, or `fin_*`
+   posting logic — those always go to Open failures for a human.
+6. **Batch the paperwork:** one branch/PR per triage run, not per issue.
+   If the run produced only notes and no fix, put them in the session
+   summary instead of pushing a notes-only commit.
+
+## Cron-health cross-check
+
+While in Sentry, check Cron Monitors (if wired — see monitoring doc §2) for
+missed check-ins on: `reconcile-pending` (1 min, order),
+`expire-orders` (10 min, order), `attendance-auto-close` (15 min,
+backoffice). A missed `reconcile-pending` window is a payments problem —
+treat as top priority.
+
+## Lessons
+
+_Append dated entries when this skill misses something. Promote stable ones
+into the sections above._

--- a/.claude/workflows/rls-audit.js
+++ b/.claude/workflows/rls-audit.js
@@ -1,0 +1,96 @@
+export const meta = {
+  name: 'rls-audit',
+  description: 'Audit sensitive tables for RLS coverage against docs/rls-strategy.md, verify findings, produce a prioritized report',
+  whenToUse: 'When asked to audit database security/RLS coverage, or before starting Path A of the RLS strategy',
+  phases: [
+    { title: 'Audit', detail: 'one agent per table group — RLS state + access paths' },
+    { title: 'Verify', detail: 'adversarial re-check of every "covered" or "critical" claim' },
+    { title: 'Synthesize', detail: 'single prioritized report' },
+  ],
+}
+
+// Priority groups from docs/rls-strategy.md ("Path A scoping"), highest
+// sensitivity first. Override with: args = { groups: [ ... ] }
+const DEFAULT_GROUPS = [
+  { name: 'customer-pii', tables: ['members', 'member_brands', 'transactions', 'redemptions'] },
+  { name: 'customer-activity', tables: ['push_subscriptions', 'points_history'] },
+  { name: 'employee-pii', tables: ['attendance', 'payroll_runs'] },
+  { name: 'internal-qa', tables: ['audits', 'audit_reports', 'checklists'] },
+  { name: 'financial', tables: ['bank_statements', 'bank_statement_lines'] },
+  { name: 'finance-module', tables: ['fin_transactions', 'fin_journal_lines', 'fin_invoices', 'fin_bills', 'fin_audit_log'] },
+]
+
+const groups = (args && args.groups) || DEFAULT_GROUPS
+
+const FINDING_SCHEMA = {
+  type: 'object',
+  properties: {
+    findings: {
+      type: 'array',
+      items: {
+        type: 'object',
+        properties: {
+          table: { type: 'string' },
+          rls_enabled: { type: 'boolean' },
+          policies_found: { type: 'array', items: { type: 'string' } },
+          evidence: { type: 'string', description: 'file:line references for every claim' },
+          access_paths: { type: 'string', description: 'which apps/routes query this table and with which key' },
+          severity: { enum: ['critical', 'high', 'medium', 'low', 'covered'] },
+          recommendation: { type: 'string' },
+        },
+        required: ['table', 'rls_enabled', 'evidence', 'severity', 'recommendation'],
+      },
+    },
+  },
+  required: ['findings'],
+}
+
+const VERDICT_SCHEMA = {
+  type: 'object',
+  properties: {
+    confirmed: { type: 'boolean' },
+    corrected_severity: { enum: ['critical', 'high', 'medium', 'low', 'covered'] },
+    reason: { type: 'string' },
+  },
+  required: ['confirmed', 'reason'],
+}
+
+const results = await pipeline(
+  groups,
+  g =>
+    agent(
+      `Audit Row-Level Security for these Postgres tables in the celsius-ops repo: ${g.tables.join(', ')}.
+Context: docs/rls-strategy.md says only "orders" and "order_items" have RLS enabled today and everything else is reached via the service-role key (bypasses RLS). Verify whether that is still true for each table:
+1. Grep supabase/migrations/ and packages/db/prisma/migrations/ for ENABLE ROW LEVEL SECURITY / CREATE POLICY statements touching each table (a table may also not exist yet — say so).
+2. Find the access paths: grep apps/ and packages/ for queries against each table (Prisma model name or raw SQL) and note whether they run server-side with the service-role key or client-side with the anon key.
+3. Rate severity per table: "covered" (RLS on with sane policies), or critical/high/medium/low exposure based on data sensitivity (${g.name}) and reachability.
+Cite file:line evidence for every claim. Return via StructuredOutput.`,
+      { label: `audit:${g.name}`, phase: 'Audit', schema: FINDING_SCHEMA }
+    ),
+  (audit, g) =>
+    parallel(
+      (audit?.findings || [])
+        .filter(f => f.severity === 'covered' || f.severity === 'critical')
+        .map(f => () =>
+          agent(
+            `Adversarially verify this RLS audit finding for table "${f.table}" in celsius-ops. Claim: rls_enabled=${f.rls_enabled}, severity=${f.severity}. Evidence given: ${f.evidence}. Re-check the cited files yourself; for "covered" claims also check the policies aren't trivially bypassable (e.g. USING (true)) and that no later migration dropped them. Return confirmed=true/false with a corrected_severity if the rating is wrong.`,
+            { label: `verify:${f.table}`, phase: 'Verify', schema: VERDICT_SCHEMA }
+          ).then(v => ({ ...f, verdict: v }))
+        )
+    ).then(verified => {
+      const byTable = new Map(verified.filter(Boolean).map(f => [f.table, f]))
+      return {
+        group: g.name,
+        findings: (audit?.findings || []).map(f => byTable.get(f.table) || f),
+      }
+    })
+)
+
+phase('Synthesize')
+const flat = results.filter(Boolean)
+const report = await agent(
+  `Combine these RLS audit findings into a single markdown report ordered by severity (critical first). For each table: current state, evidence, and the concrete next step. Where a verifier disagreed with the auditor, use the verifier's corrected severity and note the disagreement. End with a short "Path B quick wins" section (IP allowlist, key rotation — see docs/rls-strategy.md) if any critical findings exist. Findings JSON:\n${JSON.stringify(flat, null, 2)}`,
+  { label: 'report', phase: 'Synthesize' }
+)
+
+return { report, findings: flat }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -80,4 +80,6 @@ and the migration guard. Always typecheck before pushing.
 - `docs/finance-module-spec.md`, `docs/hr-payroll-spec.md` — module specs
 - `docs/design/` — business-loop specs and retrospectives (procurement, ops KPI
   pulse, reviews recovery, SMS/loyalty, GBP)
-- `.claude/skills/` — executable runbooks (db-migration, ota-release, procurement-e2e)
+- `.claude/skills/` — executable runbooks (db-migration, ota-release,
+  procurement-e2e, finance-module, sentry-triage)
+- `.claude/workflows/` — named multi-agent workflows (rls-audit)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,83 @@
+# celsius-ops
+
+Operations monorepo for Celsius Coffee (Malaysian coffee chain). Runs the business
+end-to-end: POS/till, kitchen pickup displays, online ordering, staff/manager apps,
+and a back-office admin (finance, inventory, HR/payroll, marketing loops). Actively
+replacing StoreHub (POS — retired ~2026-06) and Bukku (accounting — replaced by the
+agentic Finance module).
+
+## Session protocol
+
+- **Start of session:** read `docs/STATE.md`. It holds verified facts, open
+  failures, lessons, and a resume pointer from the previous session.
+- **End of session:** update `docs/STATE.md` before finishing — new verified
+  facts, anything that failed and why, and where the next session should pick up.
+- **After a task covered by a skill** in `.claude/skills/`: if you learned
+  something the skill didn't cover, append it to that skill's *Lessons* section.
+
+## Layout
+
+npm workspaces + Turborepo. Workspace members: `apps/{backoffice,order,pickup,staff,staff-native}` and `packages/*`.
+
+| Path | What it is |
+| --- | --- |
+| `apps/backoffice` | Next.js 16 admin console — finance, inventory, HR/payroll, procurement, marketing loops. Dev port 3003. |
+| `apps/order` | Next.js 16 customer online-ordering app. Dev port 3007. |
+| `apps/staff` | Next.js 16 staff web app. Dev port 3006. |
+| `apps/pickup` | Next.js + Capacitor shell for the kitchen/pickup display (KDS). |
+| `apps/pickup-native` | Expo/React Native KDS ("Celsius Coffee"). **Outside the npm workspace** — own `package-lock.json`. |
+| `apps/pos-native` | Expo/React Native POS for SUNMI registers ("Celsius POS"); native modules in `modules/`. **Outside the npm workspace** — own `package-lock.json`. |
+| `apps/staff-native` | Expo/React Native manager app ("Celsius Manager"); the only native app *inside* the workspace. |
+| `packages/db` | Prisma schema — **source of truth** for the database. Migrations are hand-applied SQL (see hard rule 1). |
+| `packages/{auth,shared,ui}` | Shared auth, utilities/types, UI components. |
+| `tools/print-bridge` | LAN HTTP bridge forwarding ESC/POS jobs to thermal printers. |
+
+For `pos-native` / `pickup-native`, run `npm ci` *inside the app directory* —
+the root install does not cover them.
+
+Note: `.claude/launch.json` has stale entries (`inventory`, `loyalty`, `pos` point
+at apps that no longer exist); trust the table above.
+
+## Commands
+
+```bash
+npm test                                # vitest, from root
+cd apps/<app> && npx tsc --noEmit       # typecheck (what CI runs)
+cd apps/<app> && npx eslint .           # lint — order/staff/backoffice only
+cd apps/<app> && npx next build         # production build check
+```
+
+CI (`.github/workflows/ci.yml`) runs: tests, per-app typecheck (including
+`pos-native`/`pickup-native` with their own installs), lint, production builds,
+and the migration guard. Always typecheck before pushing.
+
+## Hard rules
+
+1. **NEVER run `prisma db push` or `prisma migrate deploy`.** The Supabase
+   database hosts non-Prisma tables (`auth.*`, `storage.*`, SQL-managed RLS
+   tables) that Prisma will drop. Schema changes follow the hybrid workflow in
+   the `db-migration` skill / `docs/database-migrations.md`.
+2. **Any edit to `packages/db/prisma/schema.prisma` must ship with a matching
+   SQL file under `packages/db/prisma/migrations/`** — the `migration-guard` CI
+   job fails the PR otherwise.
+3. **`apps/order` runs a Next.js with breaking changes** vs. your training data.
+   Read the relevant guide in `node_modules/next/dist/docs/` before writing code
+   there (see `apps/order/AGENTS.md`).
+4. **Lint `any`-suppression markers are a ratchet** — reduce, never add
+   (grep `"ratchet: reduce, never add"`).
+5. **A merge to `main` touching `apps/pos-native`, `apps/pickup-native`, or
+   `apps/staff-native` is a production deploy** — the OTA workflows push the JS
+   bundle to live tills/KDS screens on the next app launch. See the
+   `ota-release` skill before merging native-app changes.
+6. **Keep a human in the loop** for: applying migrations to the production
+   database, anything touching payroll or payments, and `pos-native` releases.
+   Propose, show the diff/SQL, wait for approval.
+
+## Where things are documented
+
+- `docs/STATE.md` — cross-session state (read first, update last)
+- `docs/database-migrations.md`, `docs/rls-strategy.md`, `docs/monitoring-setup.md` — platform runbooks
+- `docs/finance-module-spec.md`, `docs/hr-payroll-spec.md` — module specs
+- `docs/design/` — business-loop specs and retrospectives (procurement, ops KPI
+  pulse, reviews recovery, SMS/loyalty, GBP)
+- `.claude/skills/` — executable runbooks (db-migration, ota-release, procurement-e2e)

--- a/docs/STATE.md
+++ b/docs/STATE.md
@@ -21,6 +21,16 @@ delete entries that have been promoted into `CLAUDE.md`, a skill, or a doc.
 - 2026-07-04 — Stock accuracy is shadow-only (consumption engine off); reorder
   runs off receipts − wastage/transfers, not sales. Going live needs unit
   normalisation + recipe import (`docs/design/procurement-qa-2026-06-26.md`).
+- 2026-07-04 — RLS: only `orders` and `order_items` have it enabled; everything
+  else goes through the service-role key. Path B (key hardening) chosen for
+  now, Path A (per-table policies) is the destination; all Path B checkboxes in
+  `docs/rls-strategy.md` are still unticked.
+- 2026-07-04 — 14 Vercel crons fail silently into logs (no heartbeat
+  monitoring wired yet). `reconcile-pending` (order, every 1 min) is the
+  payments-critical one. See `docs/monitoring-setup.md`.
+- 2026-07-04 — Exception-inbox corrections update `fin_agent_decisions`
+  (`corrected=true, corrected_to=…`) — this is the finance agents' eval/
+  retraining dataset. Preserve the write path in any refactor.
 
 ## General rules
 
@@ -44,9 +54,12 @@ _None recorded yet. Format:_
 
 ## Resume pointer
 
-- 2026-07-04 — Claude Code harness scaffolding added (this file, root
-  `CLAUDE.md`, `.claude/skills/{db-migration,ota-release,procurement-e2e}`).
-  Next candidates: a skill for the finance close process
-  (`docs/finance-module-spec.md`), a scheduled routine for Sentry triage
-  (Sentry MCP already configured in `.mcp.json`), and an eval loop built from
-  finance exception-inbox resolutions.
+- 2026-07-04 — Harness scaffolding rounds 1+2 done: root `CLAUDE.md`, this
+  file, skills `{db-migration,ota-release,procurement-e2e,finance-module,
+  sentry-triage}`, workflow `.claude/workflows/rls-audit.js`, and a nightly
+  Sentry-triage routine scheduled (05:00 MYT, fresh session per run —
+  manage via the Routines/triggers list).
+  Next candidates: run the `rls-audit` workflow and act on the report;
+  build the finance eval replay (corrected `fin_agent_decisions` rows →
+  regression set per agent, see finance-module skill); wire cron heartbeat
+  monitors (`docs/monitoring-setup.md` §2).

--- a/docs/STATE.md
+++ b/docs/STATE.md
@@ -1,0 +1,52 @@
+# STATE — cross-session memory
+
+Working memory for agent sessions on this repo. Read this at the start of every
+session; update it before ending one. Keep entries dated, terse, and factual —
+delete entries that have been promoted into `CLAUDE.md`, a skill, or a doc.
+
+## Verified facts
+
+- 2026-07-04 — `apps/pos-native` and `apps/pickup-native` sit **outside** the npm
+  workspace (own `package-lock.json` each); root `npm ci` does not install them.
+- 2026-07-04 — Two migration directories exist: `packages/db/prisma/migrations/`
+  (the audit trail CI's migration-guard checks — files are saved, never executed)
+  and `supabase/migrations/` (018–070, applied history). Schema of record is
+  `packages/db/prisma/schema.prisma`.
+- 2026-07-04 — `.claude/launch.json` is partially stale: `inventory`, `loyalty`,
+  and `pos` entries point at `apps/` directories that no longer exist.
+- 2026-07-04 — Procurement loop: automated PO-send to suppliers over WhatsApp
+  (`purchase_order` / `po_approval` buttons) was designed but **never shipped**;
+  sending the order block is still manual. Agent only needs an open PO to exist.
+  (Source: `docs/design/procurement-e2e-test-runbook.md`.)
+- 2026-07-04 — Stock accuracy is shadow-only (consumption engine off); reorder
+  runs off receipts − wastage/transfers, not sales. Going live needs unit
+  normalisation + recipe import (`docs/design/procurement-qa-2026-06-26.md`).
+
+## General rules
+
+- Typecheck before pushing — every time. CI enforces it, but catch it locally.
+- Never test against the production database; the procurement runbook's seed SQL
+  is staging-only.
+- When a fix is confirmed working, record *why it worked* here or in the relevant
+  skill — not just in the chat.
+
+## Open failures
+
+_None recorded yet. Format:_
+- `YYYY-MM-DD — <symptom> — <what was tried> — <current hypothesis> — <blocking?>`
+
+## Lessons learned
+
+- 2026-07-04 — `eas update` shells out to `expo export`, whose interactive
+  prompts ignore `--non-interactive`; set `CI=1` in the environment instead.
+  Pass commit messages via env var, not inline in the shell command (backticks/
+  `*`/newlines get shell-expanded). (Source: `.github/workflows/pos-native-ota.yml`.)
+
+## Resume pointer
+
+- 2026-07-04 — Claude Code harness scaffolding added (this file, root
+  `CLAUDE.md`, `.claude/skills/{db-migration,ota-release,procurement-e2e}`).
+  Next candidates: a skill for the finance close process
+  (`docs/finance-module-spec.md`), a scheduled routine for Sentry triage
+  (Sentry MCP already configured in `.mcp.json`), and an eval loop built from
+  finance exception-inbox resolutions.


### PR DESCRIPTION
## What

Scaffolds the agent-harness foundation (Phases 1–2 of the self-improving-agent setup) so every Claude Code session on this repo starts with its guardrails instead of rediscovering them:

- **`CLAUDE.md`** (root) — repo map (workspace vs. out-of-workspace native apps), CI-mirroring commands, and the hard rules: never `prisma db push`/`migrate deploy`, schema edits require a migration file (migration-guard), the `apps/order` Next.js breaking-changes caveat, the lint `any` ratchet, merges touching `apps/*-native` are production OTA deploys, and human-approval boundaries (prod migrations, payroll/payments, pos-native releases).
- **`docs/STATE.md`** — cross-session memory: verified facts, general rules, open failures, lessons learned, resume pointer. Sessions read it first and update it last.
- **`.claude/skills/db-migration`** — the hybrid manual-SQL migration workflow, distilled from `docs/database-migrations.md`.
- **`.claude/skills/ota-release`** — OTA-vs-new-APK decision, pre-merge checklist (per-app typecheck is the only gate for pos/pickup-native), post-merge verification, and known `eas update` gotchas.
- **`.claude/skills/procurement-e2e`** — a map of the live procurement-loop test with debugging handles, distilled from `docs/design/procurement-e2e-test-runbook.md` (incl. what's deliberately not wired, so it isn't chased as a bug).

Each skill ends with a *Lessons* section that sessions append to after use — the self-updating part.

## Why

The repo has a strong agentic-loop culture in `docs/design/` but had no root `CLAUDE.md`, no state file, and no skills — every session re-learned the same landmines (the `db push` hazard, the OTA-on-merge behaviour, the stale `launch.json`).

## Notes

- Docs/markdown only — no runtime surface, no code changes.
- `npx vitest run`: all 259 tests pass. Six suite files fail to *load* in a fresh container without `npm ci` (missing `jose`/`bcryptjs`/Expo tsconfig) — pre-existing environment behaviour, unrelated to this diff.
- Suggested next steps (tracked in `docs/STATE.md`): a finance-close skill, a scheduled Sentry-triage routine (Sentry MCP is already in `.mcp.json`), and an eval loop fed by finance exception-inbox resolutions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L3K554Hw6n4vaL9yvGbvtJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01L3K554Hw6n4vaL9yvGbvtJ)_