### PR TITLE
docs: finance eval-replay grounding + verified RLS access map (1 critical finding)

### DIFF
--- a/.claude/skills/finance-module/SKILL.md
+++ b/.claude/skills/finance-module/SKILL.md
@@ -49,6 +49,28 @@ Close agent runs day 1, **manual approve** — never auto-close a period.
 Close writes the period snapshot and `fin_period_locks`. Reopening a period
 is an exceptional, human-only action.
 
+## Code map (verified 2026-07-05)
+
+- Categorizer: `src/lib/finance/agents/categorizer.ts` — `categorize()` at
+  ~L159, `claude-haiku-4-5`, COA system block is prompt-cached; vendor
+  context is **last 5 bills** via `supplierHistory()` (~L55), not the 50 the
+  spec describes. Version tag `categorizer-v1` (L19).
+- Decision logging: `logDecision()` in the same file (~L227) — the ONLY
+  `fin_agent_decisions` inserter. Writes `applied:false`; nothing ever
+  updates `applied` today.
+- Corrections: `recordCorrection()` in `src/lib/finance/inbox.ts` (~L200),
+  called from `resolveException()` on genuine overrides only.
+- Other agents: `src/lib/finance/agents/{ap,ar,close,compliance,sst,
+  ap-verifier}.ts`; matching is rules-based in `lib/finance/ap-match.ts` +
+  LLM verifier; **Anomaly agent is not built yet**; nothing writes
+  `fin_matches`.
+- Inbox API: `src/app/api/finance/exceptions/[id]/resolve/route.ts` →
+  `resolveException()` — only `ap`/`categorization` exceptions are
+  implemented; others noop.
+- Table DDL: `apps/backoffice/supabase/migrations/002_finance_module.sql`
+  (~L238) — `fin_agent_decisions` is SQL-managed, NOT in Prisma; access via
+  `getFinanceClient()` (service-role Supabase), not Prisma.
+
 ## Eval loop (the compounding part)
 
 `fin_agent_decisions` rows with `corrected=true` are ground truth the agent
@@ -56,6 +78,25 @@ got wrong. When improving an agent (prompt, context window, threshold):
 replay recent corrected rows against the new version before shipping — the
 correction rate for that vendor/pattern should drop, and previously-correct
 decisions must not flip.
+
+Concrete replay recipe for the categorizer:
+1. Pull the set: `select * from fin_agent_decisions where agent='categorizer'
+   and corrected order by created_at desc` (partial index exists on
+   `corrected`). `input` jsonb holds supplier_name/id, total, line_items,
+   outlet_hint — enough to re-call `categorize()` (only `contextNotes` is
+   missing).
+2. Re-run each through the candidate agent version; compare
+   `output.account_code` (snake_case) against `corrected_to.accountCode`
+   (camelCase — mind the shape mismatch).
+3. Also replay a sample of `corrected=false` rows — those must NOT flip.
+4. Bump `CATEGORIZER_VERSION` when shipping so cohorts are comparable.
+
+**Data-quality caveats before trusting the replay set** (see STATE.md open
+failures): corrections are attached to the *latest* categorizer decision,
+not the matching one (`inbox.ts` ~L215 — known concurrency mis-attribution);
+`related_id` is never populated; `applied` is always false. Fixing
+attribution (populate `related_id` at decision time, join on it in
+`recordCorrection`) is the highest-leverage prerequisite for the eval loop.
 
 ## Lessons
 

--- a/docs/STATE.md
+++ b/docs/STATE.md
@@ -31,6 +31,13 @@ delete entries that have been promoted into `CLAUDE.md`, a skill, or a doc.
 - 2026-07-04 — Exception-inbox corrections update `fin_agent_decisions`
   (`corrected=true, corrected_to=…`) — this is the finance agents' eval/
   retraining dataset. Preserve the write path in any refactor.
+- 2026-07-05 — Categorizer runs on `claude-haiku-4-5` with a prompt-cached
+  COA block; its vendor context is the last **5** bills, not the 50 the
+  spec describes (spec drift, `categorizer.ts` `supplierHistory()`).
+- 2026-07-05 — The Anomaly agent from the finance spec is **not built**;
+  matching is rules-based (`ap-match.ts`) + an LLM verifier — nothing
+  writes `fin_matches`. Only `ap`/`categorization` exceptions have a
+  resolver; other exception types noop on resolve.
 
 ## General rules
 
@@ -42,8 +49,22 @@ delete entries that have been promoted into `CLAUDE.md`, a skill, or a doc.
 
 ## Open failures
 
-_None recorded yet. Format:_
-- `YYYY-MM-DD — <symptom> — <what was tried> — <current hypothesis> — <blocking?>`
+- 2026-07-05 — **Correction mis-attribution in the finance eval dataset** —
+  `recordCorrection()` (`apps/backoffice/src/lib/finance/inbox.ts` ~L215)
+  tags the *most recent* categorizer decision (`order created_at desc,
+  take first`) instead of the one belonging to the corrected exception;
+  `fin_agent_decisions.related_id` is never populated by `logDecision()`
+  (`categorizer.ts` ~L227), so a correct join isn't possible today. Under
+  concurrent AP ingestion, corrections land on the wrong rows — silently
+  corrupting the retraining/eval set. Fix: populate `related_type`/
+  `related_id` at decision time, return the decision id from
+  `categorize()`, and join on it in `recordCorrection`. Not blocking
+  day-to-day finance ops; blocking for the eval-replay loop.
+- 2026-07-05 — `fin_agent_decisions.applied` is written `false` and never
+  updated by any code path — can't distinguish auto-posted decisions from
+  ignored ones when building eval cohorts.
+
+_Format: `YYYY-MM-DD — <symptom> — <evidence> — <hypothesis/fix> — <blocking?>`_
 
 ## Lessons learned
 

--- a/docs/STATE.md
+++ b/docs/STATE.md
@@ -21,10 +21,12 @@ delete entries that have been promoted into `CLAUDE.md`, a skill, or a doc.
 - 2026-07-04 — Stock accuracy is shadow-only (consumption engine off); reorder
   runs off receipts − wastage/transfers, not sales. Going live needs unit
   normalisation + recipe import (`docs/design/procurement-qa-2026-06-26.md`).
-- 2026-07-04 — RLS: only `orders` and `order_items` have it enabled; everything
-  else goes through the service-role key. Path B (key hardening) chosen for
-  now, Path A (per-table policies) is the destination; all Path B checkboxes in
-  `docs/rls-strategy.md` are still unticked.
+- 2026-07-05 — RLS coverage is broader than `docs/rls-strategy.md` claims
+  (three later migration sets added deny-all/policied RLS to HR, bank, ads,
+  and all `fin_*` tables) — but the **loyalty tables' policies are
+  `USING (true)` for all roles, so member PII/points are anon-readable AND
+  writable**. Full verified map + ranked fixes:
+  `docs/rls-access-map-2026-07-05.md`.
 - 2026-07-04 — 14 Vercel crons fail silently into logs (no heartbeat
   monitoring wired yet). `reconcile-pending` (order, every 1 min) is the
   payments-critical one. See `docs/monitoring-setup.md`.
@@ -63,6 +65,13 @@ delete entries that have been promoted into `CLAUDE.md`, a skill, or a doc.
 - 2026-07-05 — `fin_agent_decisions.applied` is written `false` and never
   updated by any code path — can't distinguish auto-posted decisions from
   ignored ones when building eval cohorts.
+- 2026-07-05 — **Loyalty tables anon-writable** (`members`, `member_brands`,
+  `point_transactions`, `redemptions`): RLS policies in
+  `apps/order/supabase/migrations/001_initial_schema.sql:186-195` are
+  `USING (true)` with no `TO service_role`. Blocked on: moving the
+  backoffice pickup page's browser reads (`(admin)/pickup/page.tsx`
+  ~L192-202) behind an API route first, then a policy-fix migration
+  (human approval). Ranked plan in `docs/rls-access-map-2026-07-05.md`.
 
 _Format: `YYYY-MM-DD — <symptom> — <evidence> — <hypothesis/fix> — <blocking?>`_
 
@@ -84,3 +93,10 @@ _Format: `YYYY-MM-DD — <symptom> — <evidence> — <hypothesis/fix> — <bloc
   build the finance eval replay (corrected `fin_agent_decisions` rows →
   regression set per agent, see finance-module skill); wire cron heartbeat
   monitors (`docs/monitoring-setup.md` §2).
+- 2026-07-05 — Both exploration passes done and documented (finance code
+  map → finance-module skill; RLS access map →
+  `docs/rls-access-map-2026-07-05.md`). Highest-priority next work, in
+  order: (1) pickup-page loyalty reads behind an API route, (2) loyalty
+  RLS policy-fix migration [approval], (3) `related_id` attribution fix in
+  the finance decisions log, (4) `hr_payroll_runs` deny-all migration
+  [approval].

--- a/docs/rls-access-map-2026-07-05.md
+++ b/docs/rls-access-map-2026-07-05.md
@@ -1,0 +1,88 @@
+# RLS access-path map — 2026-07-05
+
+Verified map of who touches the sensitive tables from `docs/rls-strategy.md`,
+and what RLS actually covers today. Supersedes that doc's "where we stand"
+section, which is stale (see corrections below). Evidence gathered by
+code/migration sweep on this date.
+
+## Corrections to `rls-strategy.md`
+
+1. **"Only `orders`/`order_items` have RLS" is outdated.** Three later
+   migration sets already enable RLS more widely:
+   - `packages/db/prisma/migrations/20260502_rls_sensitive_tables/migration.sql`
+     — deny-all RLS on 27 tables (BankStatement/Line, hr_attendance_pings,
+     hr_payroll_cycles, hr_payslips, salary/overtime, ads_*).
+   - `supabase/migrations/064_rls_hr_attendance_logs.sql` — deny-all on
+     `hr_attendance_logs`.
+   - `apps/backoffice/supabase/migrations/002_finance_module.sql:515-553` —
+     RLS on all `fin_*` tables with a proper `fin_read` policy
+     (`to authenticated`, gated on `fin_user_roles`).
+2. **Several doc table names don't exist.** Real names: `point_transactions`
+   (not `transactions`/`points_history`), `hr_attendance_logs`/`hr_payroll_runs`
+   (not `attendance`/`payroll_runs`), Prisma PascalCase `AuditReport`,
+   `Checklist`, `BankStatement`, `BankStatementLine`.
+
+## Ranked exposures
+
+### 1. CRITICAL — loyalty tables are effectively public despite RLS "on"
+
+`apps/order/supabase/migrations/001_initial_schema.sql:168-195` enables RLS
+on `members`, `member_brands`, `point_transactions`, `redemptions`, but the
+"Service full access" policies (lines ~186-195) are
+`FOR ALL USING (true) WITH CHECK (true)` **without `TO service_role`** —
+they apply to every role, including `anon`. Anyone holding the published
+anon key can read **and write** full member PII and points balances. No
+later migration tightens these.
+
+**Fix:** recreate those four policies scoped `TO service_role` (or drop
+them — service_role bypasses RLS anyway) and add explicit narrow policies
+if any client-side read is still needed. One SQL migration; needs human
+approval + coordination with exposure 2 (which this fix will break).
+
+### 2. HIGH — backoffice pickup page queries loyalty tables from the browser
+
+`apps/backoffice/src/app/(admin)/pickup/page.tsx` (a `"use client"`
+component) queries `member_brands` (lines ~192-202) and `redemptions`
+(~195) directly with the anon key via `lib/pickup/supabase.ts`. It works
+*only because of exposure 1*, and will break the moment the policies are
+fixed. **Fix first:** move these reads behind a backoffice API route
+(service-role, server-side), then apply the policy fix.
+
+### 3. MEDIUM — `hr_payroll_runs` has no RLS
+
+Sibling HR tables got deny-all RLS in `20260502_rls_sensitive_tables`, but
+`hr_payroll_runs` (salary data) was missed — anon-reachable via PostgREST.
+No app code reads it with the anon key, so exposure is latent, not active.
+Fix: add to the deny-all set (one-line migration; payroll — human approval).
+
+### 4. LOW — Prisma ops tables without RLS
+
+`AuditReport`, `Checklist` (+ related PascalCase tables): no RLS, latent
+anon-reachability via PostgREST; all code access is Prisma server-side.
+Fold into the next deny-all batch.
+
+## Access-path map (compact)
+
+| Table(s) | Server-side access | Client-side access | RLS state |
+| --- | --- | --- | --- |
+| `members`, `member_brands`, `redemptions`, `point_transactions` | order + backoffice API routes, loop-engine, reviews recovery (service-role) | **backoffice pickup page (browser, anon)** | ON but `USING (true)` all roles → ineffective |
+| `push_subscriptions` | order push routes (service-role) | none | ON, deny-all ✓ |
+| `hr_attendance_logs`, `hr_attendance_pings` | staff + backoffice HR routes, HR agents (service-role) | none | ON, deny-all ✓ |
+| `hr_payroll_runs` | backoffice payroll routes + payroll-calculator agents | none | **NONE** |
+| `AuditReport`, `Checklist` | staff + backoffice ops routes (Prisma) | none | none (latent) |
+| `BankStatement`, `BankStatementLine` | backoffice finance routes (Prisma) | none | ON, deny-all ✓ |
+| `fin_*` (all) | backoffice finance client (service-role) | none | ON with scoped `fin_read` ✓ — best in repo |
+
+Native apps (`pos-native`, `pickup-native`, `staff-native`) touch none of
+these tables — their anon clients read POS/catalog tables only.
+
+## Proposed order of work
+
+1. New backoffice API route for the pickup page's loyalty reads; switch the
+   page to it. (Code-only, no approval gate.)
+2. Migration: scope the four loyalty policies to `service_role`.
+   (**Human approval — production DB.**)
+3. Migration: deny-all on `hr_payroll_runs` + the PascalCase ops tables.
+   (**Human approval — payroll table.**)
+4. Rewrite `docs/rls-strategy.md` against real table names and current
+   coverage; then re-run this sweep (or the `rls-audit` workflow) to verify.

--- a/docs/rls-strategy.md
+++ b/docs/rls-strategy.md
@@ -1,5 +1,10 @@
 # Row-Level Security strategy
 
+> **⚠️ Stale (2026-07-05):** the coverage claims below are outdated and some
+> table names in "Path A scoping" don't exist under those names. See
+> `docs/rls-access-map-2026-07-05.md` for the verified current map, real
+> table names, and the ranked fix list (including one critical finding).
+
 ## Where we stand today
 
 - Supabase Postgres holds 95+ tables


### PR DESCRIPTION
## What

Follow-up to #772 — grounds the harness docs in verified code instead of the spec's claims. Two commits:

### 1. Finance eval-replay grounding

- **`.claude/skills/finance-module`**: verified code map (categorizer runs `claude-haiku-4-5` with a prompt-cached COA block; `logDecision()` is the only `fin_agent_decisions` inserter; only `ap`/`categorization` exceptions have a resolver; the table is SQL-managed, not in Prisma) and a concrete 4-step categorizer replay recipe, including the `output.account_code` (snake_case) vs `corrected_to.accountCode` (camelCase) shape mismatch.
- **`docs/STATE.md`** open failures: `recordCorrection()` attaches human corrections to the *most recent* categorizer decision rather than the matching one (`related_id` never populated) — silently corrupting the retraining/eval dataset under concurrent ingestion; and `fin_agent_decisions.applied` is never updated.

### 2. RLS access map — `docs/rls-access-map-2026-07-05.md`

Code+migration sweep of every sensitive table in `docs/rls-strategy.md`. Ranked findings:

1. **CRITICAL — loyalty tables are effectively public.** `members`, `member_brands`, `point_transactions`, `redemptions` have RLS enabled but the policies are `FOR ALL USING (true)` with no `TO service_role` (`apps/order/supabase/migrations/001_initial_schema.sql:186-195`) — the published anon key can read **and write** member PII and points.
2. **HIGH** — `apps/backoffice/.../(admin)/pickup/page.tsx` reads `member_brands`/`redemptions` from the browser with the anon key; it depends on finding 1 and must move behind an API route before the policy fix.
3. **MEDIUM** — `hr_payroll_runs` missed the 2026-05-02 deny-all RLS batch.
4. `docs/rls-strategy.md` was stale (coverage claims + nonexistent table names) — now carries a stale-notice pointing at the new map.

## Notes

- Docs/markdown only; **no code or policy changes** — the loyalty policy fix and `hr_payroll_runs` migration touch the production DB/payroll and are gated on approval per CLAUDE.md hard rule 6. Proposed order of work is in the access map doc.
- The `related_id` attribution fix is similarly deliberately not included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L3K554Hw6n4vaL9yvGbvtJ