### PR TITLE
Finance Reports: fix miscategorised or mismatched lines where you found them

### DIFF
--- a/apps/backoffice/src/app/(admin)/finance/reports/page.tsx
+++ b/apps/backoffice/src/app/(admin)/finance/reports/page.tsx
@@ -12,9 +12,9 @@ import {
   SheetHeader,
   SheetTitle,
 } from "@celsius/ui";
-import { Loader2, Download, FileText, AlertTriangle, ChevronRight, ChevronDown } from "lucide-react";
+import { Loader2, Download, FileText, AlertTriangle, ChevronRight, ChevronDown, ListTree, X } from "lucide-react";
 import { DateRangePicker } from "@/components/date-range-picker";
-import { OUTFLOW_CATEGORIES, INFLOW_CATEGORIES, categoryLabel } from "@/lib/finance/cash-categories";
+import { OUTFLOW_CATEGORIES, INFLOW_CATEGORIES, categoryLabel, categoryChipLabel } from "@/lib/finance/cash-categories";
 
 // Accounting format: negatives in parentheses, the convention every
 // accounting package (Xero, QuickBooks, Bukku) uses on statements.
@@ -230,6 +230,8 @@ type PnlReport = {
   txnCount: number;
 };
 
+type MatchedInvoice = { invoiceNumber: string | null; vendor: string | null; amount: number };
+
 type DrillLine = {
   transactionId: string;
   txnDate: string;
@@ -245,6 +247,14 @@ type DrillLine = {
     isInterCo?: boolean;
     classifiedBy?: string | null;
     ruleName?: string | null;
+    // Bank-sourced rows: the line id behind the fix-in-place chips.
+    bankLineId?: string;
+    direction?: "DR" | "CR";
+    apInvoiceId?: string | null;
+    matchedInvoice?: MatchedInvoice | null;
+    // Journal-backed rows: the posting agent ("bank" journals expand into
+    // their source bank lines).
+    glAgent?: string | null;
   };
 };
 
@@ -709,6 +719,160 @@ function PnlTab() {
   );
 }
 
+// Inline "fix it where you found it" chip: the bank line's category. Clicking
+// opens a compact select; booking a new category POSTs classify (the GL
+// re-keys), then refreshes the view it sits in AND the parent report.
+function CategoryChip({ bankLineId, category, direction, accountNames, onSaved }: {
+  bankLineId: string;
+  category: string | null;
+  direction: "DR" | "CR";
+  accountNames: Map<string, string>;
+  onSaved: () => Promise<void> | void;
+}) {
+  const [editing, setEditing] = useState(false);
+  const [busy, setBusy] = useState(false);
+  const [err, setErr] = useState<string | null>(null);
+
+  async function save(next: string) {
+    setEditing(false);
+    if (!next || next === category) return;
+    setBusy(true); setErr(null);
+    try {
+      const res = await fetch("/api/finance/bank-lines/classify", {
+        method: "POST", headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ bankLineId, category: next }),
+      });
+      const j = await res.json();
+      if (!res.ok) setErr(j.error ?? `Failed (${res.status})`);
+      else await onSaved();
+    } catch (e) { setErr(e instanceof Error ? e.message : String(e)); }
+    finally { setBusy(false); }
+  }
+
+  if (editing) {
+    return (
+      <select
+        autoFocus
+        defaultValue={category ?? ""}
+        onChange={(e) => save(e.target.value)}
+        onBlur={() => setEditing(false)}
+        onKeyDown={(e) => { if (e.key === "Escape") setEditing(false); }}
+        onClick={(e) => e.stopPropagation()}
+        className="h-6 max-w-[260px] rounded border bg-background px-1 text-[11px]"
+      >
+        {!category && <option value="" disabled>unclassified…</option>}
+        {(direction === "CR" ? INFLOW_CATEGORIES : OUTFLOW_CATEGORIES).map((c) => (
+          <option key={c} value={c}>{categoryLabel(c, accountNames)}</option>
+        ))}
+      </select>
+    );
+  }
+  return (
+    <span className="inline-flex items-center gap-1">
+      <button
+        type="button"
+        disabled={busy}
+        onClick={(e) => { e.stopPropagation(); setEditing(true); }}
+        title="Category this line is booked to. Click to recategorise."
+        className="inline-flex items-center gap-1 rounded-full border px-2 py-0.5 text-[11px] text-muted-foreground transition hover:text-foreground hover:ring-1 hover:ring-ring disabled:opacity-60"
+      >
+        {busy && <Loader2 className="h-3 w-3 animate-spin" />}
+        {categoryChipLabel(category)}
+      </button>
+      {err && <span className="text-[10px] text-rose-600">{err}</span>}
+    </span>
+  );
+}
+
+// AP-matched lines carry the invoice their match settled. The x unmatches
+// (the invoice reverts to unpaid when this match is what paid it); the
+// category chip can then rebook the freed line.
+function MatchedChip({ bankLineId, invoice, onSaved }: {
+  bankLineId: string;
+  invoice: MatchedInvoice;
+  onSaved: () => Promise<void> | void;
+}) {
+  const [busy, setBusy] = useState(false);
+  const [err, setErr] = useState<string | null>(null);
+  const label = invoice.invoiceNumber ?? "invoice";
+
+  async function unmatch() {
+    if (!window.confirm(`Unmatch this line from ${label}? The invoice reverts to unpaid if this match paid it.`)) return;
+    setBusy(true); setErr(null);
+    try {
+      const res = await fetch("/api/finance/bank-lines/unmatch", {
+        method: "POST", headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ bankLineId }),
+      });
+      const j = await res.json();
+      if (!res.ok) setErr(j.error ?? `Failed (${res.status})`);
+      else await onSaved();
+    } catch (e) { setErr(e instanceof Error ? e.message : String(e)); }
+    finally { setBusy(false); }
+  }
+
+  return (
+    <span className="inline-flex items-center gap-1">
+      <span
+        title={`Matched to ${label}${invoice.vendor ? ` from ${invoice.vendor}` : ""}, ${RM(invoice.amount)}`}
+        className="inline-flex items-center gap-1 rounded-full border border-amber-500/40 bg-amber-500/10 px-2 py-0.5 text-[11px] text-amber-700 dark:text-amber-400"
+      >
+        Matched: {label}{invoice.vendor ? ` (${invoice.vendor})` : ""}
+        <button
+          type="button"
+          disabled={busy}
+          onClick={(e) => { e.stopPropagation(); unmatch(); }}
+          title="Unmatch this line from the invoice"
+          className="rounded-full transition hover:text-amber-900 disabled:opacity-60 dark:hover:text-amber-200"
+        >
+          {busy ? <Loader2 className="h-3 w-3 animate-spin" /> : <X className="h-3 w-3" />}
+        </button>
+      </span>
+      {err && <span className="text-[10px] text-rose-600">{err}</span>}
+    </span>
+  );
+}
+
+type SourceLine = {
+  id: string; txnDate: string; description: string; amount: number;
+  direction: "DR" | "CR"; reference: string | null; category: string | null;
+  isInterCo: boolean; classifiedBy: string | null; ruleName: string | null;
+  apInvoiceId: string | null; matchedInvoice: MatchedInvoice | null;
+};
+
+// The bank statement lines a bank-agent journal was posted from, each with
+// the same fix-in-place chips as the P&L drill. A fix re-keys the journal,
+// so the parent view refetches via onChanged.
+function GlSourceLines({ transactionId, accountNames, onChanged }: {
+  transactionId: string;
+  accountNames: Map<string, string>;
+  onChanged: () => void;
+}) {
+  const { data, isLoading, mutate } = useFetch<{ lines: SourceLine[] }>(
+    `/api/finance/gl-source-lines?transactionId=${encodeURIComponent(transactionId)}`
+  );
+  const refresh = async () => { await mutate(); onChanged(); };
+  if (isLoading) return <div className="px-3 py-2"><Loader2 className="h-4 w-4 animate-spin text-muted-foreground" /></div>;
+  const lines = data?.lines ?? [];
+  if (lines.length === 0) {
+    return <div className="px-3 py-2 text-[11px] text-muted-foreground">No bank lines reference this journal. It may have just been re-keyed; the poster rebuilds it on the next run.</div>;
+  }
+  return (
+    <div className="space-y-1.5 px-3 py-2">
+      <div className="text-[10px] uppercase tracking-wide text-muted-foreground">Source bank lines</div>
+      {lines.map((l) => (
+        <div key={l.id} className="flex flex-wrap items-center gap-x-2 gap-y-1 text-xs">
+          <span className="whitespace-nowrap tabular-nums text-muted-foreground">{l.txnDate}</span>
+          <span className="min-w-0 flex-1 break-words">{l.description}</span>
+          <CategoryChip bankLineId={l.id} category={l.category} direction={l.direction} accountNames={accountNames} onSaved={refresh} />
+          {l.matchedInvoice && <MatchedChip bankLineId={l.id} invoice={l.matchedInvoice} onSaved={refresh} />}
+          <span className="whitespace-nowrap tabular-nums">{RM(l.amount)} <span className="text-[10px] text-muted-foreground">{l.direction}</span></span>
+        </div>
+      ))}
+    </div>
+  );
+}
+
 function DrillDown({ code, start, end, outletId, consolidated, onChanged }: { code: string; start: string; end: string; outletId?: string; consolidated?: boolean; onChanged?: () => void }) {
   const { data, isLoading, mutate } = useFetch<{ lines: DrillLine[] }>(
     `/api/finance/reports/drilldown?accountCode=${encodeURIComponent(code)}&start=${start}&end=${end}${consolidated ? "&companyId=consolidated" : outletId ? `&outletId=${outletId}` : ""}`
@@ -716,26 +880,10 @@ function DrillDown({ code, start, end, outletId, consolidated, onChanged }: { co
   const { data: acctData } = useFetch<{ accounts: { code: string; name: string }[] }>("/api/finance/accounts");
   const accountNames = new Map((acctData?.accounts ?? []).map((a) => [a.code, a.name]));
   const [openRow, setOpenRow] = useState<string | null>(null);
-  const [busyRow, setBusyRow] = useState<string | null>(null);
-  const [rowNote, setRowNote] = useState<Record<string, string>>({});
 
-  // Recategorise a bank line straight from the report — the accounting-software
-  // way. Books it to the new category (GL re-keys), then refreshes the drill and
-  // the P&L behind it.
-  async function recategorise(bankLineId: string, category: string) {
-    if (!category) return;
-    setBusyRow(bankLineId); setRowNote((n) => ({ ...n, [bankLineId]: "" }));
-    try {
-      const res = await fetch("/api/finance/bank-lines/classify", {
-        method: "POST", headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ bankLineId, category }),
-      });
-      const j = await res.json();
-      if (!res.ok) setRowNote((n) => ({ ...n, [bankLineId]: j.error ?? `Failed (${res.status})` }));
-      else { await mutate(); onChanged?.(); }
-    } catch (e) { setRowNote((n) => ({ ...n, [bankLineId]: e instanceof Error ? e.message : String(e) })); }
-    finally { setBusyRow(null); }
-  }
+  // Any fix (recategorise, unmatch) refreshes the drill AND the report behind
+  // it, so the totals move without a page reload.
+  const refresh = async () => { await mutate(); onChanged?.(); };
   if (isLoading) return <div className="p-6"><Loader2 className="h-5 w-5 animate-spin" /></div>;
   if (!data) return null;
   if (data.lines.length === 0) {
@@ -777,18 +925,40 @@ function DrillDown({ code, start, end, outletId, consolidated, onChanged }: { co
           {data.lines.map((l, i) => {
             const [main, metaLine] = splitDesc(l.description);
             const key = `${l.transactionId}-${i}`;
-            const expandable = !!l.meta;
+            // Three flavors of expandable row: bank lines and assets show a
+            // detail panel; bank-agent journals (Balance Sheet drill) expand
+            // into their source bank lines with the same chips.
+            const isBankRow = !!l.meta?.bankLineId;
+            const isBankJournal = !isBankRow && l.meta?.glAgent === "bank";
+            const hasDetail = !!l.meta && !l.meta.glAgent;
+            const expandable = hasDetail || isBankJournal;
             const open = openRow === key;
             return (
               <Fragment key={key}>
               <tr className={`align-top ${expandable ? "cursor-pointer hover:bg-muted/30" : ""}`}
                   onClick={expandable ? () => setOpenRow(open ? null : key) : undefined}
-                  title={expandable ? "Click to see the transaction detail" : undefined}>
+                  title={expandable ? (isBankJournal ? "Click to see the source bank lines" : "Click to see the transaction detail") : undefined}>
                 <td className="whitespace-nowrap py-2 pr-2 text-xs tabular-nums text-muted-foreground">{l.txnDate.slice(5)}</td>
                 <td className="break-words py-2 pr-2">
                   <span className="flex items-start gap-1">
                     {expandable && <span className="mt-0.5 text-[10px] text-muted-foreground">{open ? "▾" : "▸"}</span>}
-                    <span>{main}{metaLine && <span className="block text-[11px] leading-snug text-muted-foreground">{metaLine}</span>}</span>
+                    <span>
+                      {main}{metaLine && <span className="block text-[11px] leading-snug text-muted-foreground">{metaLine}</span>}
+                      {isBankRow && l.meta?.bankLineId && (
+                        <span className="mt-1 flex flex-wrap items-center gap-1">
+                          <CategoryChip
+                            bankLineId={l.meta.bankLineId}
+                            category={l.meta.category ?? null}
+                            direction={l.meta.direction ?? (l.credit > 0 ? "CR" : "DR")}
+                            accountNames={accountNames}
+                            onSaved={refresh}
+                          />
+                          {l.meta.matchedInvoice && (
+                            <MatchedChip bankLineId={l.meta.bankLineId} invoice={l.meta.matchedInvoice} onSaved={refresh} />
+                          )}
+                        </span>
+                      )}
+                    </span>
                   </span>
                 </td>
                 {showCompany && <td className="py-2 pr-2 text-xs text-muted-foreground">{l.meta?.company ?? "—"}</td>}
@@ -799,29 +969,24 @@ function DrillDown({ code, start, end, outletId, consolidated, onChanged }: { co
                       <td className="whitespace-nowrap py-2 text-right tabular-nums">{l.credit ? RM(l.credit) : ""}</td>
                     </>}
               </tr>
-              {open && l.meta && (
+              {open && isBankJournal && (
+                <tr className="bg-muted/20">
+                  <td colSpan={cols} className="p-0" onClick={(e) => e.stopPropagation()}>
+                    <GlSourceLines transactionId={l.transactionId} accountNames={accountNames} onChanged={refresh} />
+                  </td>
+                </tr>
+              )}
+              {open && hasDetail && l.meta && (
                 <tr className="bg-muted/20">
                   <td colSpan={cols} className="px-3 py-2">
                     <dl className="grid grid-cols-[7rem_1fr] gap-x-3 gap-y-1 text-[11px]">
                       {l.meta.account && (<><dt className="text-muted-foreground">Bank account</dt><dd>{l.meta.account}</dd></>)}
                       {l.meta.reference && (<><dt className="text-muted-foreground">Reference</dt><dd className="break-words">{l.meta.reference}</dd></>)}
                       {l.meta.category !== undefined && (<><dt className="text-muted-foreground">Category</dt><dd>{l.meta.category ? l.meta.category.toLowerCase().replace(/_/g, " ") : "unclassified"}</dd></>)}
+                      {l.meta.matchedInvoice && (<><dt className="text-muted-foreground">Matched invoice</dt><dd>{l.meta.matchedInvoice.invoiceNumber ?? "(no number)"}{l.meta.matchedInvoice.vendor ? ` · ${l.meta.matchedInvoice.vendor}` : ""} · {RM(l.meta.matchedInvoice.amount)}</dd></>)}
                       <><dt className="text-muted-foreground">Inter-company</dt><dd>{l.meta.isInterCo ? "yes" : "no"}</dd></>
                       {(l.meta.classifiedBy || l.meta.ruleName) && (<><dt className="text-muted-foreground">Classified</dt><dd>{l.meta.classifiedBy ?? "rule"}{l.meta.ruleName ? ` · ${l.meta.ruleName}` : ""}</dd></>)}
                     </dl>
-                    <div className="mt-2 flex flex-wrap items-center gap-2 border-t pt-2" onClick={(e) => e.stopPropagation()}>
-                      <span className="text-[11px] text-muted-foreground">Recategorise to</span>
-                      <select defaultValue="" disabled={busyRow === l.transactionId}
-                        onChange={(e) => { recategorise(l.transactionId, e.target.value); e.target.value = ""; }}
-                        className="h-7 max-w-[280px] rounded border bg-background px-1 text-[11px] disabled:opacity-50">
-                        <option value="" disabled>Choose a category…</option>
-                        {(l.credit > 0 ? INFLOW_CATEGORIES : OUTFLOW_CATEGORIES).map((c) => (
-                          <option key={c} value={c}>{categoryLabel(c, accountNames)}</option>
-                        ))}
-                      </select>
-                      {busyRow === l.transactionId && <Loader2 className="h-3.5 w-3.5 animate-spin text-muted-foreground" />}
-                      {rowNote[l.transactionId] && <span className="text-[10px] text-rose-600">{rowNote[l.transactionId]}</span>}
-                    </div>
                   </td>
                 </tr>
               )}
@@ -910,7 +1075,7 @@ function BsTab() {
   // Consolidation scope applies to the primary AND the comparison fetch, so a
   // group figure is never compared against a single-entity one.
   const scope = consolidated ? "&companyId=consolidated" : "";
-  const { data, isLoading, error } = useFetch<{ report: BsReport }>(
+  const { data, isLoading, error, mutate } = useFetch<{ report: BsReport }>(
     `/api/finance/reports/balance-sheet?asOf=${asOf}${scope}`
   );
   // A balance sheet compares as-OF dates: the prior period-end (the day before
@@ -996,7 +1161,7 @@ function BsTab() {
             </SheetTitle>
             <p className="text-xs text-muted-foreground tabular-nums">{drillCode} · journal lines through {asOf}</p>
           </SheetHeader>
-          {drillCode && <DrillDown code={drillCode} start="2020-01-01" end={asOf} consolidated={consolidated} />}
+          {drillCode && <DrillDown code={drillCode} start="2020-01-01" end={asOf} consolidated={consolidated} onChanged={() => mutate()} />}
         </SheetContent>
       </Sheet>
     </div>
@@ -1295,7 +1460,7 @@ function TbTab({ onDrill }: { onDrill: (code: string) => void }) {
 }
 
 // ─── General Ledger tab ─────────────────────────────────────────
-type GlEntry = { date: string; txnType: string; description: string; debit: number; credit: number; balance: number };
+type GlEntry = { transactionId: string; postedByAgent: string | null; date: string; txnType: string; description: string; debit: number; credit: number; balance: number };
 type Gl = { accountCode: string; accountName: string; start: string; end: string; opening: number; entries: GlEntry[]; closing: number; totalDebit: number; totalCredit: number };
 
 type CoaAccount = { code: string; name: string; type: string };
@@ -1348,7 +1513,11 @@ function AccountPicker({ value, onChange }: { value: string; onChange: (code: st
 
 function GlTab({ account, setAccount }: { account: string; setAccount: (c: string) => void }) {
   const { start, end } = useControls();
-  const { data, isLoading, error } = useFetch<{ report: Gl }>(`/api/finance/reports/general-ledger?account=${encodeURIComponent(account)}&start=${start}&end=${end}`);
+  const { data, isLoading, error, mutate } = useFetch<{ report: Gl }>(`/api/finance/reports/general-ledger?account=${encodeURIComponent(account)}&start=${start}&end=${end}`);
+  const { data: acctData } = useFetch<{ accounts: { code: string; name: string }[] }>("/api/finance/accounts");
+  const accountNames = new Map((acctData?.accounts ?? []).map((a) => [a.code, a.name]));
+  // Which entry row is expanded to show the journal's source bank lines.
+  const [openIdx, setOpenIdx] = useState<number | null>(null);
   return (
     <div className="space-y-3">
       <div className="flex flex-wrap items-center gap-2">
@@ -1381,13 +1550,36 @@ function GlTab({ account, setAccount }: { account: string; setAccount: (c: strin
             <tbody className="divide-y">
               <tr className="bg-muted/20 text-muted-foreground"><td className="px-3 py-1.5" colSpan={4}>Opening balance</td><td className="px-3 py-1.5 text-right tabular-nums">{RM(data.report.opening)}</td></tr>
               {data.report.entries.map((e, i) => (
-                <tr key={i} className="hover:bg-muted/40">
+                <Fragment key={i}>
+                <tr className="hover:bg-muted/40">
                   <td className="whitespace-nowrap px-3 py-1.5 text-xs text-muted-foreground tabular-nums">{e.date}</td>
-                  <td className="px-3 py-1.5 text-xs">{e.description}</td>
+                  <td className="px-3 py-1.5 text-xs">
+                    <span className="flex items-center gap-1.5">
+                      <span className="min-w-0">{e.description}</span>
+                      {e.postedByAgent === "bank" && (
+                        <button
+                          type="button"
+                          onClick={() => setOpenIdx(openIdx === i ? null : i)}
+                          title="Show the source bank lines behind this journal"
+                          className={`shrink-0 rounded p-0.5 text-muted-foreground transition hover:text-foreground ${openIdx === i ? "bg-muted text-foreground" : ""}`}
+                        >
+                          <ListTree className="h-3.5 w-3.5" />
+                        </button>
+                      )}
+                    </span>
+                  </td>
                   <td className="px-3 py-1.5 text-right tabular-nums">{e.debit ? RM(e.debit) : ""}</td>
                   <td className="px-3 py-1.5 text-right tabular-nums">{e.credit ? RM(e.credit) : ""}</td>
                   <td className="px-3 py-1.5 text-right tabular-nums">{RM(e.balance)}</td>
                 </tr>
+                {openIdx === i && e.postedByAgent === "bank" && (
+                  <tr className="bg-muted/20">
+                    <td colSpan={5} className="p-0">
+                      <GlSourceLines transactionId={e.transactionId} accountNames={accountNames} onChanged={() => mutate()} />
+                    </td>
+                  </tr>
+                )}
+                </Fragment>
               ))}
               {data.report.entries.length === 0 && <tr><td colSpan={5} className="px-3 py-4 text-center text-xs text-muted-foreground">No movements in this period.</td></tr>}
             </tbody>

--- a/apps/backoffice/src/app/api/finance/gl-source-lines/route.ts
+++ b/apps/backoffice/src/app/api/finance/gl-source-lines/route.ts
@@ -1,0 +1,55 @@
+// GET /api/finance/gl-source-lines?transactionId=...
+//
+// The bank statement lines a bank-agent GL journal was posted from, so a
+// wrong booking can be fixed from the report that surfaced it. Each line
+// carries its category (recategorise via /api/finance/bank-lines/classify,
+// which re-keys the journal) and, when AP-matched, the matched invoice
+// summary (unmatch via /api/finance/bank-lines/unmatch).
+
+import { NextRequest, NextResponse } from "next/server";
+import { requireAuth } from "@/lib/auth";
+import { prisma } from "@/lib/prisma";
+import { matchedInvoiceSummaries } from "@/lib/finance/reports/pnl-sourced-drill";
+
+export const dynamic = "force-dynamic";
+
+const round2 = (n: number) => Math.round(n * 100) / 100;
+
+export async function GET(req: NextRequest) {
+  const auth = await requireAuth(req);
+  if (auth.error) return auth.error;
+  if (!["OWNER", "ADMIN"].includes(auth.user.role)) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+  const transactionId = new URL(req.url).searchParams.get("transactionId");
+  if (!transactionId) return NextResponse.json({ error: "transactionId required" }, { status: 400 });
+
+  const lines = await prisma.bankStatementLine.findMany({
+    where: { glTransactionId: transactionId },
+    select: {
+      id: true, txnDate: true, description: true, amount: true, direction: true,
+      reference: true, category: true, isInterCo: true, classifiedBy: true,
+      ruleName: true, apInvoiceId: true,
+    },
+    orderBy: { txnDate: "asc" },
+    take: 500,
+  });
+  const invById = await matchedInvoiceSummaries(lines.map((l) => l.apInvoiceId));
+  return NextResponse.json({
+    transactionId,
+    lines: lines.map((l) => ({
+      id: l.id,
+      txnDate: l.txnDate.toISOString().slice(0, 10),
+      description: l.description ?? "(no description)",
+      amount: round2(Number(l.amount)),
+      direction: l.direction,
+      reference: l.reference,
+      category: l.category,
+      isInterCo: l.isInterCo,
+      classifiedBy: l.classifiedBy,
+      ruleName: l.ruleName,
+      apInvoiceId: l.apInvoiceId,
+      matchedInvoice: l.apInvoiceId ? invById.get(l.apInvoiceId) ?? null : null,
+    })),
+  });
+}

--- a/apps/backoffice/src/lib/finance/cash-categories.ts
+++ b/apps/backoffice/src/lib/finance/cash-categories.ts
@@ -42,3 +42,11 @@ export function categoryLabel(c: string, accountNames: Map<string, string>): str
   const human = c.toLowerCase().replace(/_/g, " ");
   return code ? `${human} → ${code}${name ? ` ${name}` : ""}` : human;
 }
+
+// Compact form for inline chips: category plus COA code, no account name.
+export function categoryChipLabel(c: string | null | undefined): string {
+  if (!c) return "unclassified";
+  const code = CONTRA_ACCOUNT[c] ?? CONTROL_COA[c];
+  const human = c.toLowerCase().replace(/_/g, " ");
+  return code ? `${human} · ${code}` : human;
+}

--- a/apps/backoffice/src/lib/finance/reports/gl-reports.ts
+++ b/apps/backoffice/src/lib/finance/reports/gl-reports.ts
@@ -22,17 +22,17 @@ async function loadAccounts(): Promise<Map<string, AccountMeta>> {
 }
 
 // Posted transaction ids for a company up to (and optionally from) a date.
-async function postedTxns(companyId: string, opts: { from?: string; to: string }): Promise<Map<string, { date: string; description: string; type: string }>> {
+async function postedTxns(companyId: string, opts: { from?: string; to: string }): Promise<Map<string, { date: string; description: string; type: string; agent: string | null }>> {
   const client = getFinanceClient();
   let q = client
     .from("fin_transactions")
-    .select("id, txn_date, description, txn_type")
+    .select("id, txn_date, description, txn_type, posted_by_agent")
     .eq("company_id", companyId)
     .eq("status", "posted")
     .lte("txn_date", opts.to);
   if (opts.from) q = q.gte("txn_date", opts.from);
   const { data } = await q;
-  return new Map((data ?? []).map((t) => [t.id as string, { date: t.txn_date as string, description: (t.description as string) ?? "", type: (t.txn_type as string) ?? "" }]));
+  return new Map((data ?? []).map((t) => [t.id as string, { date: t.txn_date as string, description: (t.description as string) ?? "", type: (t.txn_type as string) ?? "", agent: (t.posted_by_agent as string | null) ?? null }]));
 }
 
 async function* journalLinesFor(txnIds: string[], accountCode?: string) {
@@ -81,7 +81,9 @@ export async function buildTrialBalance(input: { companyId: string; asOf: string
 
 // ─── General Ledger (one account, with running balance) ─────────────────────
 
-export type GlEntry = { date: string; txnType: string; description: string; memo: string | null; debit: number; credit: number; balance: number };
+// transactionId + postedByAgent let the UI expand a bank-agent journal into
+// its source bank statement lines (fix a wrong booking from the report).
+export type GlEntry = { transactionId: string; postedByAgent: string | null; date: string; txnType: string; description: string; memo: string | null; debit: number; credit: number; balance: number };
 export type GeneralLedger = {
   companyId: string; accountCode: string; accountName: string; type: string;
   start: string; end: string;
@@ -102,11 +104,11 @@ export async function buildGeneralLedger(input: { companyId: string; accountCode
   }
 
   const inPeriod = await postedTxns(input.companyId, { from: input.start, to: input.end });
-  const raw: { date: string; txnType: string; description: string; memo: string | null; debit: number; credit: number }[] = [];
+  const raw: { transactionId: string; postedByAgent: string | null; date: string; txnType: string; description: string; memo: string | null; debit: number; credit: number }[] = [];
   for await (const lines of journalLinesFor([...inPeriod.keys()], input.accountCode)) {
     for (const l of lines) {
       const t = inPeriod.get(l.transaction_id)!;
-      raw.push({ date: t.date, txnType: t.type, description: t.description, memo: l.memo, debit: round2(Number(l.debit)), credit: round2(Number(l.credit)) });
+      raw.push({ transactionId: l.transaction_id, postedByAgent: t.agent, date: t.date, txnType: t.type, description: t.description, memo: l.memo, debit: round2(Number(l.debit)), credit: round2(Number(l.credit)) });
     }
   }
   raw.sort((a, b) => (a.date < b.date ? -1 : a.date > b.date ? 1 : 0));

--- a/apps/backoffice/src/lib/finance/reports/pnl-sourced-drill.ts
+++ b/apps/backoffice/src/lib/finance/reports/pnl-sourced-drill.ts
@@ -41,8 +41,35 @@ export type DrillLine = {
     isInterCo?: boolean;
     classifiedBy?: string | null;
     ruleName?: string | null;
+    // Fix-in-place: the bank line id lets the UI recategorise or unmatch the
+    // row straight from the report, QuickBooks style.
+    bankLineId?: string;
+    direction?: "DR" | "CR";
+    apInvoiceId?: string | null;
+    matchedInvoice?: MatchedInvoiceSummary | null;
+    // Journal-backed rows (ledger drill): the agent that posted the journal.
+    // "bank" journals can expand into their source bank lines.
+    glAgent?: string | null;
   };
 };
+
+export type MatchedInvoiceSummary = { invoiceNumber: string | null; vendor: string | null; amount: number };
+
+// One batched Invoice lookup for AP-matched bank lines. BankStatementLine has
+// no prisma relation on apInvoiceId, so the join is manual.
+export async function matchedInvoiceSummaries(invoiceIds: Array<string | null | undefined>): Promise<Map<string, MatchedInvoiceSummary>> {
+  const ids = [...new Set(invoiceIds.filter((x): x is string => !!x))];
+  if (!ids.length) return new Map();
+  const invoices = await prisma.invoice.findMany({
+    where: { id: { in: ids } },
+    select: { id: true, invoiceNumber: true, vendorName: true, amount: true, supplier: { select: { name: true } } },
+  });
+  return new Map(invoices.map((i) => [i.id, {
+    invoiceNumber: i.invoiceNumber ?? null,
+    vendor: i.supplier?.name ?? i.vendorName ?? null,
+    amount: round2(Number(i.amount)),
+  }]));
+}
 
 const CONSOLIDATED = "consolidated";
 
@@ -267,12 +294,13 @@ async function drillBank(cat: string, companyId: string, start: string, end: str
     },
     select: {
       id: true, txnDate: true, description: true, amount: true, reference: true,
-      category: true, isInterCo: true, classifiedBy: true, ruleName: true,
+      category: true, isInterCo: true, classifiedBy: true, ruleName: true, apInvoiceId: true,
       statement: { select: { accountName: true } },
     },
     orderBy: { txnDate: "asc" },
     take: 400,
   });
+  const invById = await matchedInvoiceSummaries(lines.map((l) => l.apInvoiceId));
   return lines.map((l) => ({
     transactionId: l.id,
     txnDate: l.txnDate.toISOString().slice(0, 10),
@@ -288,6 +316,10 @@ async function drillBank(cat: string, companyId: string, start: string, end: str
       isInterCo: l.isInterCo,
       classifiedBy: l.classifiedBy,
       ruleName: l.ruleName,
+      bankLineId: l.id,
+      direction,
+      apInvoiceId: l.apInvoiceId,
+      matchedInvoice: l.apInvoiceId ? invById.get(l.apInvoiceId) ?? null : null,
     },
   }));
 }

--- a/apps/backoffice/src/lib/finance/reports/pnl.ts
+++ b/apps/backoffice/src/lib/finance/reports/pnl.ts
@@ -167,12 +167,15 @@ export async function pnlDrillDown(args: {
     amount: number;
     debit: number;
     credit: number;
+    // Which agent posted the journal; "bank" journals can expand into their
+    // source bank statement lines (the fix-from-report flow).
+    meta?: { glAgent?: string | null };
   }>
 > {
   const client = getFinanceClient();
   const { data: txns } = await client
     .from("fin_transactions")
-    .select("id, txn_date, description, amount")
+    .select("id, txn_date, description, amount, posted_by_agent")
     .eq("company_id", args.companyId)
     .eq("status", "posted")
     .gte("txn_date", args.start)
@@ -188,6 +191,7 @@ export async function pnlDrillDown(args: {
     amount: number;
     debit: number;
     credit: number;
+    meta?: { glAgent?: string | null };
   }> = [];
 
   const chunkSize = 200;
@@ -201,6 +205,7 @@ export async function pnlDrillDown(args: {
     for (const l of lines ?? []) {
       const t = txnMap.get(l.transaction_id as string);
       if (!t) continue;
+      const agent = (t as { posted_by_agent?: string | null }).posted_by_agent ?? null;
       results.push({
         transactionId: l.transaction_id as string,
         txnDate: t.txn_date as string,
@@ -208,6 +213,7 @@ export async function pnlDrillDown(args: {
         amount: Number(t.amount),
         debit: Number(l.debit),
         credit: Number(l.credit),
+        ...(agent ? { meta: { glAgent: agent } } : {}),
       });
     }
   }


### PR DESCRIPTION
QuickBooks-style fix-in-place for the finance Reports page: when a drill or ledger view shows a wrongly categorised or wrongly matched bank line, fix it right there, and the report totals update without a reload.

## What it does

**1. Category chip on every bank-sourced drill row.** Each bank line in a P&L or Balance Sheet drill shows its category as a small chip (category plus COA code, same vocabulary as the Recon page). Click it, pick a new category from the direction-appropriate list (outflow, inflow, interco), and the line is rebooked via the existing classify endpoint. The GL journal re-keys, a spinner shows while saving, then the drill and the parent report refetch. Row expand stays for full detail; fixing no longer requires it. Non-bank rows (sales days, procurement invoices, ads, depreciation) show no chip.

**2. Unmatch from the drill.** AP-matched lines render an amber chip: Matched: INV-123 (Supplier), with an x. Clicking x confirms, then POSTs the existing unmatch endpoint. Per that endpoint's semantics, the invoice reverts to unpaid only when this match is what paid it (paidVia bank-ap-match or bank-ap-match-multi), the pair is recorded as rejected so the auto-matcher never re-applies it, and the journal re-keys. After unmatching, the category chip rebooks the freed line.

**3. Fix from the General Ledger tab.** GL entries posted by the bank agent get a source icon; clicking expands the journal into its source bank statement lines, each with the same category and matched chips. A fix re-keys the journal, so the panel and the GL table refetch.

**Balance Sheet drill integration.** BS drill rows for bank-bridge accounts resolve to fin_transactions journals (not bank lines), so they get the journal source expansion rather than inline chips: rows whose journal was posted by the bank agent expand into their source bank lines with chips. Fixes propagate to the Balance Sheet via a new onChanged hook.

## New API

GET /api/finance/gl-source-lines?transactionId=... (Owner/Admin) returns { transactionId, lines: [{ id, txnDate, description, amount, direction, reference, category, isInterCo, classifiedBy, ruleName, apInvoiceId, matchedInvoice: { invoiceNumber, vendor, amount } | null }] } for all BankStatementLine rows with glTransactionId = the journal id. Matched-invoice summaries come from one batched Invoice lookup (manual join, no prisma relation on apInvoiceId).

## Data plumbing (backward compatible)

- pnl-sourced-drill: bank rows now carry meta.bankLineId, direction, apInvoiceId and matchedInvoice (one batched Invoice lookup per drill); new exported matchedInvoiceSummaries helper reused by the new route.
- pnlDrillDown (ledger drill): selects posted_by_agent and attaches meta.glAgent so the UI knows which journals are bank journals.
- gl-reports GlEntry: adds transactionId and postedByAgent.
- cash-categories: new categoryChipLabel (compact category plus COA code for chips).

## Journal re-key semantics

Classify and unmatch null out glTransactionId on the affected day-aggregate journal's lines; the bank GL poster rebuilds the journal on its next run. Until then a re-keyed journal's source panel reports no referencing lines with a note explaining why.

## Verified (read-only, local dev server against production data)

- GL report for 1000-01 returns entries with transactionId and postedByAgent bank.
- gl-source-lines for a real bank journal returns its 24 source lines; a raw-materials journal returned 18 lines of which 17 carried matchedInvoice summaries.
- Drilldown for BANK:RENT returns meta with bankLineId, direction and category; drilldown for 1000-01 returns journal rows with meta.glAgent bank.
- Reports page renders 200; tsc clean; eslint 0 errors on touched files.

No writes were made to production data.