### PR TITLE
refactor(procurement): retire PROCUREMENT_AGENT_ALLOWLIST — automationMode everywhere

### DIFF
--- a/apps/backoffice/src/lib/inventory/agents/invoice-requester.ts
+++ b/apps/backoffice/src/lib/inventory/agents/invoice-requester.ts
@@ -7,8 +7,9 @@
  * Celsius ops person would ("Hi bos, boleh keluarkan invois untuk order X?").
  *
  * Driven by the /api/cron/request-invoices cron. Same gates as the chat agent:
- * PROCUREMENT_AGENT_ENABLED + PROCUREMENT_AGENT_ALLOWLIST (so the first live run
- * is scoped to the Test supplier). Inside an open 24h window it sends free text;
+ * PROCUREMENT_AGENT_ENABLED (master switch) + the per-supplier automationMode
+ * dial (OFF = hands-off; ASSIST/AUTO = chase) — replaces the retired global
+ * PROCUREMENT_AGENT_ALLOWLIST. Inside an open 24h window it sends free text;
  * otherwise it uses the approved `invoice_request` template (business-initiated).
  * De-duped via the outbound row's raw.invoiceRequestFor so a PO is asked at most
  * once. Never throws.
@@ -37,18 +38,6 @@ function enabled(): boolean {
   return process.env.PROCUREMENT_AGENT_ENABLED === "true";
 }
 
-function allowed(phone: string | null | undefined): boolean {
-  const raw = process.env.PROCUREMENT_AGENT_ALLOWLIST?.trim();
-  if (!raw) return true;
-  const tail = digits(phone).slice(-8);
-  if (!tail) return false;
-  return raw
-    .split(",")
-    .map((s) => digits(s).slice(-8))
-    .filter(Boolean)
-    .includes(tail);
-}
-
 const firstName = (name: string) => (name || "bos").trim().split(/\s+/)[0];
 
 export interface InvoiceRequestSummary {
@@ -66,7 +55,8 @@ export async function runInvoiceRequests(): Promise<InvoiceRequestSummary> {
       orderType: "PURCHASE_ORDER",
       status: { in: INVOICE_DUE_STATUSES },
       invoices: { none: {} },
-      supplier: { phone: { not: null }, status: "ACTIVE" },
+      // Per-supplier dial: OFF = the agent never contacts this supplier.
+      supplier: { phone: { not: null }, status: "ACTIVE", automationMode: { not: "OFF" } },
     },
     orderBy: { createdAt: "asc" },
     take: 100,
@@ -81,7 +71,7 @@ export async function runInvoiceRequests(): Promise<InvoiceRequestSummary> {
   let skipped = 0;
   for (const o of orders) {
     const sup = o.supplier;
-    if (!sup?.phone || !allowed(sup.phone)) {
+    if (!sup?.phone) {
       skipped++;
       continue;
     }

--- a/apps/backoffice/src/lib/inventory/agents/receiving-requester.ts
+++ b/apps/backoffice/src/lib/inventory/agents/receiving-requester.ts
@@ -6,9 +6,10 @@
  * in the app — so a delivered order doesn't sit un-received and silently break
  * stock + invoice matching.
  *
- * Cron /api/cron/request-receivings. Gated by PROCUREMENT_AGENT_ENABLED, scoped to
- * allow-listed SUPPLIERS (PROCUREMENT_AGENT_ALLOWLIST) during rollout. Messages the
- * PO creator; set PROCUREMENT_RECEIVING_CHASE_TO to route all chases to one number
+ * Cron /api/cron/request-receivings. Gated by PROCUREMENT_AGENT_ENABLED (master
+ * switch) + the per-supplier automationMode dial (OFF = hands-off for that
+ * supplier's POs) — replaces the retired global PROCUREMENT_AGENT_ALLOWLIST.
+ * Messages the PO creator; set PROCUREMENT_RECEIVING_CHASE_TO to route all chases to one number
  * for testing. Free text inside the 24h window; outside it skipped + logged (a
  * staff-reminder template is the production path). De-duped per PO via
  * raw.receivingChaseFor. Never throws.
@@ -30,18 +31,6 @@ function enabled(): boolean {
   return process.env.PROCUREMENT_AGENT_ENABLED === "true";
 }
 
-function allowedSupplier(phone: string | null | undefined): boolean {
-  const raw = process.env.PROCUREMENT_AGENT_ALLOWLIST?.trim();
-  if (!raw) return true;
-  const tail = digits(phone).slice(-8);
-  if (!tail) return false;
-  return raw
-    .split(",")
-    .map((s) => digits(s).slice(-8))
-    .filter(Boolean)
-    .includes(tail);
-}
-
 const firstName = (name: string | null | undefined) => (name || "team").trim().split(/\s+/)[0];
 
 export interface ReceivingRequestSummary {
@@ -61,7 +50,8 @@ export async function runReceivingRequests(): Promise<ReceivingRequestSummary> {
       orderType: "PURCHASE_ORDER",
       status: { in: DUE_STATUSES },
       receivings: { none: {} },
-      supplier: { phone: { not: null }, status: "ACTIVE" },
+      // Per-supplier dial: OFF = the agent stays hands-off for this supplier's POs.
+      supplier: { phone: { not: null }, status: "ACTIVE", automationMode: { not: "OFF" } },
       OR: [
         { deliveryDate: { lt: now } },
         { deliveryDate: null, sentAt: { lt: staleSentBefore } },
@@ -82,7 +72,7 @@ export async function runReceivingRequests(): Promise<ReceivingRequestSummary> {
   let requested = 0;
   let skipped = 0;
   for (const o of orders) {
-    if (!o.supplier?.phone || !allowedSupplier(o.supplier.phone)) {
+    if (!o.supplier?.phone) {
       skipped++;
       continue;
     }

--- a/apps/backoffice/src/lib/inventory/agents/supplier-chat-agent.ts
+++ b/apps/backoffice/src/lib/inventory/agents/supplier-chat-agent.ts
@@ -12,8 +12,8 @@
  *
  * Guardrails are enforced in CODE, not left to the model:
  *   - Off unless PROCUREMENT_AGENT_ENABLED=true.
- *   - Only acts for suppliers on PROCUREMENT_AGENT_ALLOWLIST (last-8 phone digits)
- *     when set — so the first live run is scoped to the Test supplier.
+ *   - Scope is the per-supplier automationMode dial (OFF | ASSIST | AUTO) — the
+ *     retired global PROCUREMENT_AGENT_ALLOWLIST no longer gates anything.
  *   - substitutions, full cancellations, payment/PoP/reconciliation, complaints,
  *     and ANY low-confidence call ESCALATE: a safe holding reply, no PO change.
  *   - every decision is stamped on the outbound message's `raw` for audit, and


### PR DESCRIPTION
## What
The invoice-requester and receiving-requester crons were the **last two readers** of the global `PROCUREMENT_AGENT_ALLOWLIST` (phone-tail allowlist, a rollout training wheel). Both now gate on the per-supplier **`automationMode` dial** directly in the Prisma query — `OFF` = the agent never touches that supplier's POs; `ASSIST`/`AUTO` = chase — matching procurement-po-send (#713) and the chat agent.

## Behavior change
- Chasers act on the **8 ASSIST** suppliers, skip the **45 OFF** (current DB distribution).
- `PROCUREMENT_AGENT_ENABLED` remains the master kill switch; per-PO dedupe (ask once, ever) unchanged.
- Also fixed the stale allowlist mention in supplier-chat-agent's header comment.

## Cleanup unlocked
`PROCUREMENT_AGENT_ALLOWLIST` now has **zero code readers** — safe to delete from Vercel env after this deploys.

Verified: backoffice typecheck + eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)