### PR TITLE
Finance: rebuild the General Ledger tab into a full working ledger view

### DIFF
--- a/apps/backoffice/src/app/(admin)/finance/reports/page.tsx
+++ b/apps/backoffice/src/app/(admin)/finance/reports/page.tsx
@@ -12,7 +12,7 @@ import {
   SheetHeader,
   SheetTitle,
 } from "@celsius/ui";
-import { Loader2, Download, FileText, AlertTriangle, ChevronRight, ChevronDown, ListTree, X } from "lucide-react";
+import { Loader2, Download, FileText, AlertTriangle, ChevronRight, ChevronDown, Paperclip, X } from "lucide-react";
 import { DateRangePicker } from "@/components/date-range-picker";
 import { OUTFLOW_CATEGORIES, INFLOW_CATEGORIES, categoryLabel, categoryChipLabel } from "@/lib/finance/cash-categories";
 
@@ -887,7 +887,45 @@ type SourceLine = {
   direction: "DR" | "CR"; reference: string | null; category: string | null;
   isInterCo: boolean; classifiedBy: string | null; ruleName: string | null;
   apInvoiceId: string | null; matchedInvoice: MatchedInvoice | null;
+  attachments: number;
 };
+
+// Paperclip indicator on a bank line that has uploaded attachments (invoice,
+// receipt, charge advice). Clicking fetches the signed links lazily.
+function AttachmentBadge({ bankLineId, count }: { bankLineId: string; count: number }) {
+  const [open, setOpen] = useState(false);
+  const { data, isLoading } = useFetch<{ attachments: { id: string; filename: string; url: string | null }[] }>(
+    open ? `/api/finance/bank-lines/attach?bankLineId=${encodeURIComponent(bankLineId)}` : null
+  );
+  return (
+    <span className="relative inline-flex items-center">
+      <button
+        type="button"
+        onClick={(e) => { e.stopPropagation(); setOpen((o) => !o); }}
+        title={`${count} attachment${count > 1 ? "s" : ""}. Click to view.`}
+        className="inline-flex items-center gap-0.5 rounded-full border px-1.5 py-0.5 text-[11px] text-muted-foreground transition hover:text-foreground hover:ring-1 hover:ring-ring"
+      >
+        <Paperclip className="h-3 w-3" /> {count}
+      </button>
+      {open && (
+        <span className="absolute left-0 top-full z-20 mt-1 w-56 rounded-md border bg-card p-2 shadow-lg">
+          {isLoading && <Loader2 className="h-3.5 w-3.5 animate-spin text-muted-foreground" />}
+          {(data?.attachments ?? []).map((a) =>
+            a.url ? (
+              <a key={a.id} href={a.url} target="_blank" rel="noreferrer" onClick={(e) => e.stopPropagation()}
+                 className="block truncate py-0.5 text-[11px] underline-offset-2 hover:underline">
+                {a.filename}
+              </a>
+            ) : (
+              <span key={a.id} className="block truncate py-0.5 text-[11px] text-muted-foreground">{a.filename}</span>
+            )
+          )}
+          {data && data.attachments.length === 0 && <span className="text-[11px] text-muted-foreground">No attachments.</span>}
+        </span>
+      )}
+    </span>
+  );
+}
 
 // The bank statement lines a bank-agent journal was posted from, each with
 // the same fix-in-place chips as the P&L drill. A fix re-keys the journal,
@@ -915,6 +953,7 @@ function GlSourceLines({ transactionId, accountNames, onChanged }: {
           <span className="min-w-0 flex-1 break-words">{l.description}</span>
           <CategoryChip bankLineId={l.id} category={l.category} direction={l.direction} accountNames={accountNames} onSaved={refresh} />
           {l.matchedInvoice && <MatchedChip bankLineId={l.id} invoice={l.matchedInvoice} onSaved={refresh} />}
+          {l.attachments > 0 && <AttachmentBadge bankLineId={l.id} count={l.attachments} />}
           <span className="whitespace-nowrap tabular-nums">{RM(l.amount)} <span className="text-[10px] text-muted-foreground">{l.direction}</span></span>
         </div>
       ))}
@@ -1509,19 +1548,50 @@ function TbTab({ onDrill }: { onDrill: (code: string) => void }) {
 }
 
 // ─── General Ledger tab ─────────────────────────────────────────
-type GlEntry = { transactionId: string; postedByAgent: string | null; date: string; txnType: string; description: string; debit: number; credit: number; balance: number };
-type Gl = { accountCode: string; accountName: string; start: string; end: string; opening: number; entries: GlEntry[]; closing: number; totalDebit: number; totalCredit: number };
+// Bukku-grade ledger view: multiple account sections, opening balance row,
+// Date / Ref / Contact / Description / Debit / Credit / Balance columns,
+// and every row expanding inline into the full journal entry (all legs,
+// posted-by provenance, and the source bank lines with fix-in-place chips).
+
+type GlEntry = {
+  transactionId: string; reference: string; postedByAgent: string | null;
+  actor: string | null; contact: string | null;
+  date: string; txnType: string; description: string; memo: string | null;
+  debit: number; credit: number; balance: number;
+};
+type GlAccountSection = {
+  account: { code: string; name: string; type: string };
+  opening: number; entries: GlEntry[]; closing: number;
+  totalDebit: number; totalCredit: number;
+};
+type GlMulti = { companyId: string; start: string; end: string; accounts: GlAccountSection[] };
+
+// Full journal detail behind one GL row, from /api/finance/transactions/:id.
+type JournalDetail = {
+  transaction: {
+    id: string; txn_date: string; description: string | null; txn_type: string;
+    posted_by_agent: string | null; agent_version: string | null; status: string; amount: number;
+  };
+  lines: { id: string; account_code: string; account_name: string | null; debit: number; credit: number; memo: string | null }[];
+};
+
+function glAgentLine(agent: string | null, agentVersion: string | null): string {
+  if (agent === "manual") return `Manual, ${agentVersion ?? "unknown"}`;
+  if (!agent) return "System";
+  const name = `${agent.charAt(0).toUpperCase()}${agent.slice(1)} agent`;
+  return agentVersion ? `${name}, ${agentVersion}` : name;
+}
 
 type CoaAccount = { code: string; name: string; type: string };
 
 // Searchable COA picker — nobody should have to know "6000-01" by heart.
 // Type a code OR a name fragment ("raw", "rental", "grab") and pick from the
 // chart of accounts, the way Xero's Account Transactions report does it.
-function AccountPicker({ value, onChange }: { value: string; onChange: (code: string) => void }) {
+function AccountPicker({ value, onChange, placeholder, exclude }: { value: string; onChange: (code: string) => void; placeholder?: string; exclude?: string[] }) {
   const { data } = useFetch<{ accounts: CoaAccount[] }>("/api/finance/accounts");
   const [q, setQ] = useState<string | null>(null); // null = not editing, show the selection
   const [open, setOpen] = useState(false);
-  const accounts = data?.accounts ?? [];
+  const accounts = (data?.accounts ?? []).filter((a) => !exclude?.includes(a.code));
   const current = accounts.find((a) => a.code === value);
   const shown = q !== null ? q : current ? `${current.code} · ${current.name}` : value;
   const t = (q ?? "").trim().toLowerCase();
@@ -1536,7 +1606,7 @@ function AccountPicker({ value, onChange }: { value: string; onChange: (code: st
         onFocus={() => { setQ(""); setOpen(true); }}
         onChange={(e) => { setQ(e.target.value); setOpen(true); }}
         onBlur={() => { setOpen(false); setQ(null); }}
-        placeholder="Search account code or name…"
+        placeholder={placeholder ?? "Search account code or name…"}
         className="h-8 w-64 sm:w-80 rounded-md border bg-background px-2 text-sm"
       />
       {open && matches.length > 0 && (
@@ -1560,87 +1630,306 @@ function AccountPicker({ value, onChange }: { value: string; onChange: (code: st
   );
 }
 
-function GlTab({ account, setAccount }: { account: string; setAccount: (c: string) => void }) {
+// The expanded panel behind one GL row: every leg of the journal with the
+// current account's leg highlighted, the provenance line, and (for
+// bank-agent journals) the source bank lines with fix-in-place chips.
+// Detail is fetched lazily on first expand and cached per transactionId in
+// the tab's state; a fix drops the cache so open panels reload fresh.
+function JournalPanel({ transactionId, currentAccount, accountNames, detail, onLoaded, onFixed }: {
+  transactionId: string;
+  currentAccount: string;
+  accountNames: Map<string, string>;
+  detail: JournalDetail | undefined;
+  onLoaded: (id: string, d: JournalDetail) => void;
+  onFixed: () => void;
+}) {
+  const [err, setErr] = useState<string | null>(null);
+  useEffect(() => {
+    if (detail) return;
+    let alive = true;
+    setErr(null);
+    (async () => {
+      try {
+        const res = await fetch(`/api/finance/transactions/${transactionId}`);
+        const j = await res.json();
+        if (!res.ok) throw new Error(j.error ?? `Failed (${res.status})`);
+        if (alive) onLoaded(transactionId, j as JournalDetail);
+      } catch (e) {
+        if (alive) setErr(e instanceof Error ? e.message : String(e));
+      }
+    })();
+    return () => { alive = false; };
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- fetch keyed on id + cache presence only
+  }, [transactionId, detail]);
+
+  if (err) return <div className="px-4 py-2 text-xs text-rose-600">{err}</div>;
+  if (!detail) {
+    return (
+      <div className="flex items-center gap-2 px-4 py-2.5 text-xs text-muted-foreground">
+        <Loader2 className="h-3.5 w-3.5 animate-spin" /> Loading journal…
+      </div>
+    );
+  }
+
+  const t = detail.transaction;
+  return (
+    <div className="space-y-2 px-4 py-3">
+      <div className="flex flex-wrap items-center gap-x-3 gap-y-1 text-[11px] text-muted-foreground">
+        <span className="font-medium text-foreground">Journal {t.id.slice(0, 8).toUpperCase()}</span>
+        <span className="tabular-nums">{t.txn_date}</span>
+        <span>{t.txn_type}</span>
+        <span>Posted by {glAgentLine(t.posted_by_agent, t.agent_version)}</span>
+        {t.status !== "posted" && <span className="uppercase text-amber-600">{t.status}</span>}
+      </div>
+      {t.description && <div className="text-xs">{t.description}</div>}
+      <table className="w-full max-w-3xl text-xs">
+        <thead>
+          <tr className="text-left text-[10px] uppercase tracking-wide text-muted-foreground">
+            <th className="py-1 pr-2 font-medium">Account</th>
+            <th className="py-1 pr-2 font-medium">Memo</th>
+            <th className="w-24 py-1 pr-2 text-right font-medium">Debit</th>
+            <th className="w-24 py-1 text-right font-medium">Credit</th>
+          </tr>
+        </thead>
+        <tbody className="divide-y">
+          {detail.lines.map((l) => {
+            const mine = l.account_code === currentAccount;
+            return (
+              <tr key={l.id} className={mine ? "bg-muted/60 font-medium" : ""}>
+                <td className="whitespace-nowrap py-1 pr-2">
+                  <span className="tabular-nums text-muted-foreground">{l.account_code}</span>{" "}
+                  {l.account_name ?? accountNames.get(l.account_code) ?? ""}
+                  {mine && <span className="ml-1.5 rounded-full border px-1.5 text-[10px] font-normal text-muted-foreground">this account</span>}
+                </td>
+                <td className="py-1 pr-2 text-muted-foreground">{l.memo ?? ""}</td>
+                <td className="whitespace-nowrap py-1 pr-2 text-right tabular-nums">{Number(l.debit) ? RM(Number(l.debit)) : ""}</td>
+                <td className="whitespace-nowrap py-1 text-right tabular-nums">{Number(l.credit) ? RM(Number(l.credit)) : ""}</td>
+              </tr>
+            );
+          })}
+        </tbody>
+      </table>
+      {t.posted_by_agent === "bank" && (
+        <div className="rounded-md border bg-background/60">
+          <GlSourceLines transactionId={transactionId} accountNames={accountNames} onChanged={onFixed} />
+        </div>
+      )}
+    </div>
+  );
+}
+
+// One account section, Bukku style: header with code + name, opening balance
+// row, dated entries with a running balance, closing balance and totals.
+function GlAccountCard({ section, start, openRows, onToggle, detailCache, onDetailLoaded, accountNames, onFixed }: {
+  section: GlAccountSection;
+  start: string;
+  openRows: Set<string>;
+  onToggle: (key: string) => void;
+  detailCache: Record<string, JournalDetail>;
+  onDetailLoaded: (id: string, d: JournalDetail) => void;
+  accountNames: Map<string, string>;
+  onFixed: () => void;
+}) {
+  const a = section.account;
+  return (
+    <section className="rounded-lg border bg-card">
+      <header className="flex flex-wrap items-baseline gap-x-2 gap-y-1 border-b bg-muted/40 px-3 py-2">
+        <span className="text-sm font-semibold tabular-nums">{a.code}</span>
+        <span className="text-sm font-medium">{a.name}</span>
+        <span className="text-[10px] uppercase text-muted-foreground">{a.type}</span>
+        <span className="ml-auto text-xs text-muted-foreground">
+          Opening <span className="font-medium tabular-nums text-foreground">{RM(section.opening)}</span>
+        </span>
+      </header>
+      <div className="max-h-[70vh] overflow-auto">
+        <table className="w-full min-w-[880px] text-sm">
+          <thead className="text-left text-xs uppercase tracking-wide text-muted-foreground">
+            <tr>
+              <th className={`${TH} w-6`} />
+              <th className={`${TH} whitespace-nowrap`}>Date</th>
+              <th className={`${TH} whitespace-nowrap`} title="Journal voucher reference. Expand the row for the full entry.">Ref</th>
+              <th className={TH}>Contact</th>
+              <th className={TH}>Description</th>
+              <th className={`${TH} whitespace-nowrap text-right`}>Debit</th>
+              <th className={`${TH} whitespace-nowrap text-right`}>Credit</th>
+              <th className={`${TH} whitespace-nowrap text-right`}>Balance</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr className="border-t bg-muted/20 text-muted-foreground">
+              <td className="py-1.5" />
+              <td className="whitespace-nowrap px-3 py-1.5 text-xs tabular-nums">{start}</td>
+              <td colSpan={3} className="px-3 py-1.5 text-xs">Opening balance</td>
+              <td colSpan={2} />
+              <td className="whitespace-nowrap px-3 py-1.5 text-right tabular-nums">{RM(section.opening)}</td>
+            </tr>
+            {section.entries.length === 0 && (
+              <tr className="border-t">
+                <td colSpan={8} className="px-3 py-4 text-center text-xs text-muted-foreground">
+                  No movements in this period. Opening equals closing.
+                </td>
+              </tr>
+            )}
+            {section.entries.map((e, i) => {
+              const key = `${a.code}:${e.transactionId}:${i}`;
+              const open = openRows.has(key);
+              return (
+                <Fragment key={key}>
+                  <tr
+                    className={`cursor-pointer border-t align-top transition ${i % 2 === 1 ? "bg-muted/20" : ""} hover:bg-muted/30`}
+                    onClick={() => onToggle(key)}
+                    title="Click to see the full journal entry"
+                  >
+                    <td className="py-1.5 pl-2 text-[10px] text-muted-foreground">{open ? "▾" : "▸"}</td>
+                    <td className="whitespace-nowrap px-3 py-1.5 text-xs tabular-nums text-muted-foreground">{e.date}</td>
+                    <td className="whitespace-nowrap px-3 py-1.5 text-xs tabular-nums text-muted-foreground" title={e.transactionId}>{e.reference}</td>
+                    <td className="max-w-[13rem] truncate px-3 py-1.5 text-xs" title={e.contact ?? undefined}>{e.contact ?? ""}</td>
+                    <td className="px-3 py-1.5 text-xs">
+                      {e.description}
+                      {e.memo && e.memo !== e.description && (
+                        <span className="block text-[11px] leading-snug text-muted-foreground">{e.memo}</span>
+                      )}
+                    </td>
+                    <td className="whitespace-nowrap px-3 py-1.5 text-right tabular-nums">{e.debit ? RM(e.debit) : ""}</td>
+                    <td className="whitespace-nowrap px-3 py-1.5 text-right tabular-nums">{e.credit ? RM(e.credit) : ""}</td>
+                    <td className="whitespace-nowrap px-3 py-1.5 text-right tabular-nums">{RM(e.balance)}</td>
+                  </tr>
+                  {open && (
+                    <tr className="border-t bg-muted/20">
+                      <td colSpan={8} className="p-0" onClick={(ev) => ev.stopPropagation()}>
+                        <JournalPanel
+                          transactionId={e.transactionId}
+                          currentAccount={a.code}
+                          accountNames={accountNames}
+                          detail={detailCache[e.transactionId]}
+                          onLoaded={onDetailLoaded}
+                          onFixed={onFixed}
+                        />
+                      </td>
+                    </tr>
+                  )}
+                </Fragment>
+              );
+            })}
+          </tbody>
+          <tfoot>
+            <tr className="border-t bg-muted/20 text-muted-foreground">
+              <td className="py-1.5" />
+              <td colSpan={4} className="px-3 py-1.5 text-xs">Closing balance</td>
+              <td colSpan={2} />
+              <td className="whitespace-nowrap px-3 py-1.5 text-right tabular-nums">{RM(section.closing)}</td>
+            </tr>
+            <tr className="border-t-2 font-semibold">
+              <td colSpan={5} className="px-3 py-2">Period total · {section.entries.length} entries</td>
+              <td className="whitespace-nowrap px-3 py-2 text-right tabular-nums">{RM(section.totalDebit)}</td>
+              <td className="whitespace-nowrap px-3 py-2 text-right tabular-nums">{RM(section.totalCredit)}</td>
+              <td className="whitespace-nowrap px-3 py-2 text-right tabular-nums">{RM(section.closing)}</td>
+            </tr>
+          </tfoot>
+        </table>
+      </div>
+    </section>
+  );
+}
+
+function GlTab({ accounts, setAccounts }: { accounts: string[]; setAccounts: (codes: string[]) => void }) {
   const { start, end } = useControls();
-  const { data, isLoading, error, mutate } = useFetch<{ report: Gl }>(`/api/finance/reports/general-ledger?account=${encodeURIComponent(account)}&start=${start}&end=${end}`);
-  const { data: acctData } = useFetch<{ accounts: { code: string; name: string }[] }>("/api/finance/accounts");
-  const accountNames = new Map((acctData?.accounts ?? []).map((a) => [a.code, a.name]));
-  // Which entry row is expanded to show the journal's source bank lines.
-  const [openIdx, setOpenIdx] = useState<number | null>(null);
+  const { data: acctData } = useFetch<{ accounts: CoaAccount[] }>("/api/finance/accounts");
+  const accountNames = useMemo(() => new Map((acctData?.accounts ?? []).map((a) => [a.code, a.name])), [acctData]);
+  const url = accounts.length
+    ? `/api/finance/reports/general-ledger?accounts=${encodeURIComponent(accounts.join(","))}&start=${start}&end=${end}`
+    : null;
+  const { data, isLoading, error, mutate } = useFetch<{ report: GlMulti }>(url);
+  const [openRows, setOpenRows] = useState<Set<string>>(new Set());
+  const [detailCache, setDetailCache] = useState<Record<string, JournalDetail>>({});
+
+  const toggleRow = (key: string) =>
+    setOpenRows((prev) => {
+      const next = new Set(prev);
+      if (next.has(key)) next.delete(key); else next.add(key);
+      return next;
+    });
+  const onDetailLoaded = (id: string, d: JournalDetail) => setDetailCache((prev) => ({ ...prev, [id]: d }));
+  // A fix (recategorise, unmatch) re-keys journals: refetch the ledger and
+  // drop cached journal details so any open panel reloads fresh.
+  const onFixed = () => { setDetailCache({}); mutate(); };
+
+  const addAccount = (code: string) => { if (!accounts.includes(code)) setAccounts([...accounts, code]); };
+  const removeAccount = (code: string) => setAccounts(accounts.filter((c) => c !== code));
+
+  const exportCsv = () => {
+    if (!data?.report) return;
+    const r = data.report;
+    const rows: Array<Array<string | number>> = [["Account", "Date", "Ref", "Contact", "Description", "Debit", "Credit", "Balance"]];
+    for (const s of r.accounts) {
+      const label = `${s.account.code} ${s.account.name}`;
+      rows.push([label, "", "", "", "Opening balance", "", "", s.opening]);
+      for (const e of s.entries) rows.push([label, e.date, e.reference, e.contact ?? "", e.description, e.debit || "", e.credit || "", e.balance]);
+      rows.push([label, "", "", "", "Period total / closing", s.totalDebit, s.totalCredit, s.closing]);
+    }
+    downloadCsv(`general-ledger_${r.start}_${r.end}.csv`, rows);
+  };
+
   return (
     <div className="space-y-3">
       <div className="flex flex-wrap items-center gap-2">
-        <label className="flex items-center gap-2 text-xs text-muted-foreground">Account
-          <AccountPicker value={account} onChange={setAccount} />
-        </label>
+        <span className="text-xs text-muted-foreground">Accounts</span>
+        {accounts.map((code) => (
+          <span key={code} className="inline-flex items-center gap-1 rounded-full border bg-muted/30 px-2 py-0.5 text-xs">
+            <span className="tabular-nums text-muted-foreground">{code}</span>
+            <span className="max-w-[14rem] truncate">{accountNames.get(code) ?? ""}</span>
+            <button
+              type="button"
+              onClick={() => removeAccount(code)}
+              title="Remove this account from the view"
+              className="rounded-full text-muted-foreground transition hover:text-foreground"
+            >
+              <X className="h-3 w-3" />
+            </button>
+          </span>
+        ))}
+        <AccountPicker value="" onChange={addAccount} placeholder="Add account…" exclude={accounts} />
         <span className="text-xs text-muted-foreground tabular-nums">{start} → {end}</span>
         {data?.report && (
           <div className="ml-auto">
-            <ExportCsvButton onExport={() => {
-              const r = data.report;
-              const rows: Array<Array<string | number>> = [["Date", "Description", "Debit", "Credit", "Balance"]];
-              rows.push(["", "Opening balance", "", "", r.opening]);
-              for (const e of r.entries) rows.push([e.date, e.description, e.debit || "", e.credit || "", e.balance]);
-              rows.push(["", "Period total / closing", r.totalDebit, r.totalCredit, r.closing]);
-              downloadCsv(`general-ledger_${r.accountCode}_${r.start}_${r.end}.csv`, rows);
-            }} />
+            <ExportCsvButton onExport={exportCsv} />
           </div>
         )}
       </div>
-      {error ? <div className="py-12 text-center text-sm text-muted-foreground">No ledger for this account. Pick another account above.</div>
-      : isLoading || !data?.report ? <div className="py-12 text-center text-sm text-muted-foreground">Loading…</div> : (
-        <div className="overflow-x-auto rounded-lg border">
-          <div className="border-b bg-muted/40 px-3 py-2 text-sm font-medium">{data.report.accountCode} · {data.report.accountName}</div>
-          <table className="w-full min-w-[640px] text-sm">
-            <thead><tr className="border-b text-left text-muted-foreground">
-              <th className="px-3 py-2 font-medium">Date</th><th className="px-3 py-2 font-medium">Description</th>
-              <th className="px-3 py-2 text-right font-medium">Debit</th><th className="px-3 py-2 text-right font-medium">Credit</th><th className="px-3 py-2 text-right font-medium">Balance</th>
-            </tr></thead>
-            <tbody className="divide-y">
-              <tr className="bg-muted/20 text-muted-foreground"><td className="px-3 py-1.5" colSpan={4}>Opening balance</td><td className="px-3 py-1.5 text-right tabular-nums">{RM(data.report.opening)}</td></tr>
-              {data.report.entries.map((e, i) => (
-                <Fragment key={i}>
-                <tr className="hover:bg-muted/40">
-                  <td className="whitespace-nowrap px-3 py-1.5 text-xs text-muted-foreground tabular-nums">{e.date}</td>
-                  <td className="px-3 py-1.5 text-xs">
-                    <span className="flex items-center gap-1.5">
-                      <span className="min-w-0">{e.description}</span>
-                      {e.postedByAgent === "bank" && (
-                        <button
-                          type="button"
-                          onClick={() => setOpenIdx(openIdx === i ? null : i)}
-                          title="Show the source bank lines behind this journal"
-                          className={`shrink-0 rounded p-0.5 text-muted-foreground transition hover:text-foreground ${openIdx === i ? "bg-muted text-foreground" : ""}`}
-                        >
-                          <ListTree className="h-3.5 w-3.5" />
-                        </button>
-                      )}
-                    </span>
-                  </td>
-                  <td className="px-3 py-1.5 text-right tabular-nums">{e.debit ? RM(e.debit) : ""}</td>
-                  <td className="px-3 py-1.5 text-right tabular-nums">{e.credit ? RM(e.credit) : ""}</td>
-                  <td className="px-3 py-1.5 text-right tabular-nums">{RM(e.balance)}</td>
-                </tr>
-                {openIdx === i && e.postedByAgent === "bank" && (
-                  <tr className="bg-muted/20">
-                    <td colSpan={5} className="p-0">
-                      <GlSourceLines transactionId={e.transactionId} accountNames={accountNames} onChanged={() => mutate()} />
-                    </td>
-                  </tr>
-                )}
-                </Fragment>
-              ))}
-              {data.report.entries.length === 0 && <tr><td colSpan={5} className="px-3 py-4 text-center text-xs text-muted-foreground">No movements in this period.</td></tr>}
-            </tbody>
-            <tfoot><tr className="border-t-2 font-semibold">
-              <td className="px-3 py-2" colSpan={2}>Period total / closing</td>
-              <td className="px-3 py-2 text-right tabular-nums">{RM(data.report.totalDebit)}</td>
-              <td className="px-3 py-2 text-right tabular-nums">{RM(data.report.totalCredit)}</td>
-              <td className="px-3 py-2 text-right tabular-nums">{RM(data.report.closing)}</td>
-            </tr></tfoot>
-          </table>
+
+      {accounts.length === 0 && (
+        <div className="rounded-lg border border-dashed p-10 text-center text-sm text-muted-foreground">
+          No accounts selected. Add an account above to see its ledger.
         </div>
       )}
+      {error && accounts.length > 0 && (
+        <div className="rounded-lg border border-destructive/40 bg-destructive/5 p-3 text-sm text-destructive">
+          Failed to load the ledger. Check the account codes and try again.
+        </div>
+      )}
+      {!error && accounts.length > 0 && !data?.report && (
+        <div className="py-12 text-center text-sm text-muted-foreground">Loading…</div>
+      )}
+      {!error && data?.report && (
+        <div className={`space-y-4 ${isLoading ? "opacity-60" : ""}`}>
+          {data.report.accounts.map((section) => (
+            <GlAccountCard
+              key={section.account.code}
+              section={section}
+              start={data.report.start}
+              openRows={openRows}
+              onToggle={toggleRow}
+              detailCache={detailCache}
+              onDetailLoaded={onDetailLoaded}
+              accountNames={accountNames}
+              onFixed={onFixed}
+            />
+          ))}
+        </div>
+      )}
+      <p className="text-[11px] text-muted-foreground">
+        Click any row to open the full journal entry: every leg, who posted it, and the source bank lines with fix-in-place category chips. Contact is best effort, derived from the bank payee, the matched invoice supplier, the sales channel, or the manual actor.
+      </p>
     </div>
   );
 }
@@ -1824,13 +2113,65 @@ function ReconTab() {
   );
 }
 
+const GL_ACCOUNTS_KEY = "finance:reports:gl-accounts";
+
 export default function FinanceReportsPage() {
   const [tab, setTab] = useState<"pnl" | "bs" | "cf" | "tb" | "gl" | "ap" | "recon" | "audit">("pnl");
-  const [glAccount, setGlAccount] = useState("1000-01"); // shared so TB rows can drill into GL
+  const [glAccounts, setGlAccounts] = useState<string[]>(["1000-01"]); // shared so TB rows can drill into GL
+  const [glHydrated, setGlHydrated] = useState(false);
   const controls = useReportControlsState();
   // Tabs driven by the shared date range + outlet filter. Recon has its own
   // matched-period control; Auditor pack works by fiscal year.
   const usesControls = tab !== "recon" && tab !== "audit";
+
+  // Deep link: /finance/reports?tab=gl&accounts=6505,6504&start=...&end=...
+  // URL wins over localStorage; localStorage restores the last GL selection.
+  useEffect(() => {
+    try {
+      const p = new URLSearchParams(window.location.search);
+      const acc = p.get("accounts");
+      const codes = (acc ?? "").split(",").map((s) => s.trim()).filter(Boolean);
+      if (codes.length) {
+        setGlAccounts([...new Set(codes)]);
+        setTab("gl");
+      } else {
+        const saved = localStorage.getItem(GL_ACCOUNTS_KEY);
+        if (saved) {
+          const arr = JSON.parse(saved) as unknown;
+          if (Array.isArray(arr) && arr.length && arr.every((x) => typeof x === "string")) setGlAccounts(arr as string[]);
+        }
+        if (p.get("tab") === "gl") setTab("gl");
+      }
+      const s = p.get("start"), e = p.get("end");
+      if (s && e && /^\d{4}-\d{2}-\d{2}$/.test(s) && /^\d{4}-\d{2}-\d{2}$/.test(e)) {
+        controls.setPreset("custom");
+        controls.setCustomStart(s);
+        controls.setCustomEnd(e);
+      }
+    } catch { /* ignore */ }
+    setGlHydrated(true);
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- one-time URL + localStorage read on mount
+  }, []);
+
+  useEffect(() => {
+    if (!glHydrated) return;
+    try { localStorage.setItem(GL_ACCOUNTS_KEY, JSON.stringify(glAccounts)); } catch { /* ignore */ }
+  }, [glHydrated, glAccounts]);
+
+  // Keep the URL shareable while on the GL tab; strip the params when leaving
+  // so the other tabs' state handling stays untouched.
+  useEffect(() => {
+    if (!glHydrated) return;
+    const u = new URL(window.location.href);
+    for (const k of ["tab", "accounts", "start", "end"]) u.searchParams.delete(k);
+    if (tab === "gl") {
+      u.searchParams.set("tab", "gl");
+      if (glAccounts.length) u.searchParams.set("accounts", glAccounts.join(","));
+      u.searchParams.set("start", controls.start);
+      u.searchParams.set("end", controls.end);
+    }
+    window.history.replaceState(null, "", u.toString());
+  }, [glHydrated, tab, glAccounts, controls.start, controls.end]);
 
   return (
     <div className="space-y-4 p-3 sm:p-6">
@@ -1887,8 +2228,8 @@ export default function FinanceReportsPage() {
         {tab === "pnl" && <PnlTab />}
         {tab === "bs" && <BsTab />}
         {tab === "cf" && <CfTab />}
-        {tab === "tb" && <TbTab onDrill={(code) => { setGlAccount(code); setTab("gl"); }} />}
-        {tab === "gl" && <GlTab account={glAccount} setAccount={setGlAccount} />}
+        {tab === "tb" && <TbTab onDrill={(code) => { setGlAccounts([code]); setTab("gl"); }} />}
+        {tab === "gl" && <GlTab accounts={glAccounts} setAccounts={setGlAccounts} />}
         {tab === "ap" && <ApTab />}
         {tab === "recon" && <ReconTab />}
         {tab === "audit" && <AuditorPack />}

--- a/apps/backoffice/src/app/api/finance/gl-source-lines/route.ts
+++ b/apps/backoffice/src/app/api/finance/gl-source-lines/route.ts
@@ -9,6 +9,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { requireAuth } from "@/lib/auth";
 import { prisma } from "@/lib/prisma";
+import { getFinanceClient } from "@/lib/finance/supabase";
 import { matchedInvoiceSummaries } from "@/lib/finance/reports/pnl-sourced-drill";
 
 export const dynamic = "force-dynamic";
@@ -35,6 +36,23 @@ export async function GET(req: NextRequest) {
     take: 500,
   });
   const invById = await matchedInvoiceSummaries(lines.map((l) => l.apInvoiceId));
+
+  // Attachment count per line (bank_line_attachment docs key source_ref to
+  // the bank line id), one batched query so the UI can show an indicator.
+  const attachCount = new Map<string, number>();
+  if (lines.length > 0) {
+    const fin = getFinanceClient();
+    const { data: docs } = await fin
+      .from("fin_documents")
+      .select("source_ref")
+      .eq("doc_type", "bank_line_attachment")
+      .in("source_ref", lines.map((l) => l.id));
+    for (const d of docs ?? []) {
+      const ref = d.source_ref as string;
+      attachCount.set(ref, (attachCount.get(ref) ?? 0) + 1);
+    }
+  }
+
   return NextResponse.json({
     transactionId,
     lines: lines.map((l) => ({
@@ -50,6 +68,7 @@ export async function GET(req: NextRequest) {
       ruleName: l.ruleName,
       apInvoiceId: l.apInvoiceId,
       matchedInvoice: l.apInvoiceId ? invById.get(l.apInvoiceId) ?? null : null,
+      attachments: attachCount.get(l.id) ?? 0,
     })),
   });
 }

--- a/apps/backoffice/src/app/api/finance/reports/general-ledger/route.ts
+++ b/apps/backoffice/src/app/api/finance/reports/general-ledger/route.ts
@@ -1,12 +1,24 @@
-// GET /api/finance/reports/general-ledger?account=CODE&start=&end=&companyId=...
+// GET /api/finance/reports/general-ledger
+//
+// Two calling conventions:
+//   ?account=CODE&start=&end=            single account, original shape:
+//                                        { report: GeneralLedger }
+//   ?accounts=CODE1,CODE2&start=&end=    multi account (comma separated),
+//                                        grouped per account:
+//                                        { report: { companyId, start, end,
+//                                          accounts: [{ account, opening,
+//                                          entries, closing, totals }] } }
+// companyId defaults to the active-company cookie.
 
 import { NextRequest, NextResponse } from "next/server";
 import { requireAuth } from "@/lib/auth";
-import { buildGeneralLedger } from "@/lib/finance/reports/gl-reports";
+import { buildGeneralLedger, buildGeneralLedgerMulti } from "@/lib/finance/reports/gl-reports";
 import { getActiveCompanyId } from "@/lib/finance/companies";
 
 export const dynamic = "force-dynamic";
 export const maxDuration = 60;
+
+const MAX_ACCOUNTS = 20;
 
 export async function GET(req: NextRequest) {
   const auth = await requireAuth(req);
@@ -14,15 +26,22 @@ export async function GET(req: NextRequest) {
   if (!["OWNER", "ADMIN"].includes(auth.user.role)) return NextResponse.json({ error: "Forbidden" }, { status: 403 });
   const url = new URL(req.url);
   const account = url.searchParams.get("account");
+  const accountsParam = url.searchParams.get("accounts");
   const start = url.searchParams.get("start");
   const end = url.searchParams.get("end");
   const companyId = url.searchParams.get("companyId") ?? (await getActiveCompanyId());
-  if (!account) return NextResponse.json({ error: "account code required" }, { status: 400 });
+  if (!account && !accountsParam) return NextResponse.json({ error: "account code required" }, { status: 400 });
   if (!start || !end || !/^\d{4}-\d{2}-\d{2}$/.test(start) || !/^\d{4}-\d{2}-\d{2}$/.test(end)) {
     return NextResponse.json({ error: "start, end (YYYY-MM-DD) required" }, { status: 400 });
   }
   try {
-    return NextResponse.json({ report: await buildGeneralLedger({ companyId, accountCode: account, start, end }) });
+    if (accountsParam !== null) {
+      const codes = [...new Set(accountsParam.split(",").map((s) => s.trim()).filter(Boolean))];
+      if (codes.length === 0) return NextResponse.json({ error: "accounts must list at least one code" }, { status: 400 });
+      if (codes.length > MAX_ACCOUNTS) return NextResponse.json({ error: `accounts is capped at ${MAX_ACCOUNTS} codes` }, { status: 400 });
+      return NextResponse.json({ report: await buildGeneralLedgerMulti({ companyId, accountCodes: codes, start, end }) });
+    }
+    return NextResponse.json({ report: await buildGeneralLedger({ companyId, accountCode: account!, start, end }) });
   } catch (err) {
     return NextResponse.json({ error: err instanceof Error ? err.message : String(err) }, { status: 500 });
   }

--- a/apps/backoffice/src/lib/finance/reports/gl-reports.ts
+++ b/apps/backoffice/src/lib/finance/reports/gl-reports.ts
@@ -4,10 +4,14 @@
 //
 //   Trial Balance  — every account's net balance on its natural side; total
 //                    debits must equal total credits (the GL's self-proof).
-//   General Ledger — one account's movements over a period with a running
-//                    balance (the drill-down behind any figure).
+//   General Ledger: one or more accounts' movements over a period with a
+//                   running balance, a voucher reference and a best-effort
+//                   contact per entry (the drill-down behind any figure).
 
 import { getFinanceClient } from "../supabase";
+import { prisma } from "@/lib/prisma";
+import { deriveHintPhrase } from "../category-hints";
+import { matchedInvoiceSummaries } from "./pnl-sourced-drill";
 
 function round2(n: number): number {
   return Math.round(n * 100) / 100;
@@ -21,28 +25,63 @@ async function loadAccounts(): Promise<Map<string, AccountMeta>> {
   return new Map((data ?? []).map((a) => [a.code as string, { name: a.name as string, type: a.type as string }]));
 }
 
+type TxnInfo = { date: string; description: string; type: string; agent: string | null; agentVersion: string | null };
+
 // Posted transaction ids for a company up to (and optionally from) a date.
-async function postedTxns(companyId: string, opts: { from?: string; to: string }): Promise<Map<string, { date: string; description: string; type: string; agent: string | null }>> {
+// Paged, because opening-balance scans cover the whole ledger history and
+// Supabase caps unpaged selects at 1000 rows.
+async function postedTxns(companyId: string, opts: { from?: string; to: string }): Promise<Map<string, TxnInfo>> {
   const client = getFinanceClient();
-  let q = client
-    .from("fin_transactions")
-    .select("id, txn_date, description, txn_type, posted_by_agent")
-    .eq("company_id", companyId)
-    .eq("status", "posted")
-    .lte("txn_date", opts.to);
-  if (opts.from) q = q.gte("txn_date", opts.from);
-  const { data } = await q;
-  return new Map((data ?? []).map((t) => [t.id as string, { date: t.txn_date as string, description: (t.description as string) ?? "", type: (t.txn_type as string) ?? "", agent: (t.posted_by_agent as string | null) ?? null }]));
+  const out = new Map<string, TxnInfo>();
+  const PAGE = 1000;
+  for (let offset = 0; ; offset += PAGE) {
+    let q = client
+      .from("fin_transactions")
+      .select("id, txn_date, description, txn_type, posted_by_agent, agent_version")
+      .eq("company_id", companyId)
+      .eq("status", "posted")
+      .lte("txn_date", opts.to)
+      .order("txn_date", { ascending: true })
+      .order("id", { ascending: true })
+      .range(offset, offset + PAGE - 1);
+    if (opts.from) q = q.gte("txn_date", opts.from);
+    const { data } = await q;
+    for (const t of data ?? []) {
+      out.set(t.id as string, {
+        date: t.txn_date as string,
+        description: (t.description as string) ?? "",
+        type: (t.txn_type as string) ?? "",
+        agent: (t.posted_by_agent as string | null) ?? null,
+        agentVersion: (t.agent_version as string | null) ?? null,
+      });
+    }
+    if (!data || data.length < PAGE) break;
+  }
+  return out;
 }
 
-async function* journalLinesFor(txnIds: string[], accountCode?: string) {
+type JournalLineRow = { transaction_id: string; account_code: string; debit: number; credit: number; memo: string | null };
+
+async function* journalLinesFor(txnIds: string[], accountCodes?: string[]) {
   const client = getFinanceClient();
+  const PAGE = 1000;
   for (let i = 0; i < txnIds.length; i += 200) {
     const chunk = txnIds.slice(i, i + 200);
-    let q = client.from("fin_journal_lines").select("transaction_id, account_code, debit, credit, memo").in("transaction_id", chunk);
-    if (accountCode) q = q.eq("account_code", accountCode);
-    const { data } = await q;
-    yield (data ?? []) as { transaction_id: string; account_code: string; debit: number; credit: number; memo: string | null }[];
+    // Page within the chunk too: 200 txns can carry more than 1000 lines
+    // (EOD sales journals post ~10 legs each).
+    for (let offset = 0; ; offset += PAGE) {
+      let q = client
+        .from("fin_journal_lines")
+        .select("transaction_id, account_code, debit, credit, memo")
+        .in("transaction_id", chunk)
+        .order("transaction_id", { ascending: true })
+        .order("line_order", { ascending: true })
+        .range(offset, offset + PAGE - 1);
+      if (accountCodes?.length) q = accountCodes.length === 1 ? q.eq("account_code", accountCodes[0]) : q.in("account_code", accountCodes);
+      const { data } = await q;
+      yield (data ?? []) as JournalLineRow[];
+      if (!data || data.length < PAGE) break;
+    }
   }
 }
 
@@ -79,11 +118,42 @@ export async function buildTrialBalance(input: { companyId: string; asOf: string
   return { companyId: input.companyId, asOf: input.asOf, rows, totalDebit, totalCredit, balanced: Math.abs(totalDebit - totalCredit) < 0.01 };
 }
 
-// ─── General Ledger (one account, with running balance) ─────────────────────
+// ─── General Ledger (multi-account, with running balance) ───────────────────
 
-// transactionId + postedByAgent let the UI expand a bank-agent journal into
-// its source bank statement lines (fix a wrong booking from the report).
-export type GlEntry = { transactionId: string; postedByAgent: string | null; date: string; txnType: string; description: string; memo: string | null; debit: number; credit: number; balance: number };
+// transactionId + postedByAgent let the UI expand any journal into its full
+// legs (and, for bank-agent journals, the source bank statement lines).
+// reference is the short voucher form of the journal id; contact is the
+// best-effort counterparty (see deriveContacts below); actor carries the
+// human name for manual journals (agent_version stores it).
+export type GlEntry = {
+  transactionId: string;
+  reference: string;
+  postedByAgent: string | null;
+  actor: string | null;
+  contact: string | null;
+  date: string;
+  txnType: string;
+  description: string;
+  memo: string | null;
+  debit: number;
+  credit: number;
+  balance: number;
+};
+
+export type GlAccountLedger = {
+  account: { code: string; name: string; type: string };
+  opening: number;
+  entries: GlEntry[];
+  closing: number;
+  totalDebit: number;
+  totalCredit: number;
+};
+
+export type GeneralLedgerMulti = {
+  companyId: string; start: string; end: string;
+  accounts: GlAccountLedger[];
+};
+
 export type GeneralLedger = {
   companyId: string; accountCode: string; accountName: string; type: string;
   start: string; end: string;
@@ -91,39 +161,136 @@ export type GeneralLedger = {
   totalDebit: number; totalCredit: number;
 };
 
-export async function buildGeneralLedger(input: { companyId: string; accountCode: string; start: string; end: string }): Promise<GeneralLedger> {
-  const meta = await loadAccounts();
-  const am = meta.get(input.accountCode);
+// Bank-agent journals: look up their source bank lines ONCE for the whole
+// request, prefer the matched invoice's supplier name, else the payee phrase
+// derived from the bank description (same helper hint-learning uses). Costs
+// two batched queries per request regardless of entry count.
+async function bankContacts(txnIds: string[]): Promise<Map<string, string | null>> {
+  const out = new Map<string, string | null>();
+  if (txnIds.length === 0) return out;
+  const lines = await prisma.bankStatementLine.findMany({
+    where: { glTransactionId: { in: txnIds } },
+    select: { glTransactionId: true, description: true, apInvoiceId: true },
+    orderBy: { txnDate: "asc" },
+  });
+  const invById = await matchedInvoiceSummaries(lines.map((l) => l.apInvoiceId));
+  const namesByTxn = new Map<string, string[]>();
+  for (const l of lines) {
+    if (!l.glTransactionId) continue;
+    const inv = l.apInvoiceId ? invById.get(l.apInvoiceId) : undefined;
+    const name = inv?.vendor ?? deriveHintPhrase(l.description ?? "");
+    if (!name) continue;
+    const arr = namesByTxn.get(l.glTransactionId) ?? [];
+    if (!arr.includes(name)) { arr.push(name); namesByTxn.set(l.glTransactionId, arr); }
+  }
+  for (const id of txnIds) {
+    const names = namesByTxn.get(id) ?? [];
+    out.set(id, names.length === 0 ? null : names.length === 1 ? names[0] : `${names[0]} +${names.length - 1}`);
+  }
+  return out;
+}
 
-  // Opening balance = net of everything strictly before `start` (for B/S accounts
-  // this is the carried balance; for P&L accounts the period-to-date prior).
+// Best-effort contact for one entry. Bank journals use the batched bank-line
+// lookup; ar journals read the sales channel off the leg memo ("GrabFood
+// sales, outlet, date"); manual journals show the person who posted.
+function contactForEntry(txnId: string, t: TxnInfo, memo: string | null, bank: Map<string, string | null>): string | null {
+  if (t.agent === "bank") return bank.get(txnId) ?? null;
+  if (t.agent === "ar") {
+    // Leg memos read "<Channel> sales <separator> <outlet> <date>"; the
+    // separator is a dash variant, matched by escape so none appears here.
+    const head = (memo ?? "").split(/\s+[\u2013\u2014-]\s+/)[0].replace(/\s+(sales|revenue)$/i, "").trim();
+    return head || null;
+  }
+  if (t.agent === "manual") return t.agentVersion;
+  return null;
+}
+
+export async function buildGeneralLedgerMulti(input: { companyId: string; accountCodes: string[]; start: string; end: string }): Promise<GeneralLedgerMulti> {
+  const codes = [...new Set(input.accountCodes)];
+  const meta = await loadAccounts();
+
+  // Opening balances = net of everything strictly before `start` (for B/S
+  // accounts the carried balance; for P&L accounts the period-to-date prior).
+  // One pass over history for ALL requested accounts.
   const before = await postedTxns(input.companyId, { to: dayBefore(input.start) });
-  let opening = 0;
-  for await (const lines of journalLinesFor([...before.keys()], input.accountCode)) {
-    for (const l of lines) opening = round2(opening + Number(l.debit) - Number(l.credit));
+  const opening = new Map<string, number>();
+  for await (const lines of journalLinesFor([...before.keys()], codes)) {
+    for (const l of lines) {
+      opening.set(l.account_code, round2((opening.get(l.account_code) ?? 0) + Number(l.debit) - Number(l.credit)));
+    }
   }
 
   const inPeriod = await postedTxns(input.companyId, { from: input.start, to: input.end });
-  const raw: { transactionId: string; postedByAgent: string | null; date: string; txnType: string; description: string; memo: string | null; debit: number; credit: number }[] = [];
-  for await (const lines of journalLinesFor([...inPeriod.keys()], input.accountCode)) {
+  type RawLine = { transactionId: string; memo: string | null; debit: number; credit: number };
+  const rawByAccount = new Map<string, RawLine[]>(codes.map((c) => [c, []]));
+  const usedTxnIds = new Set<string>();
+  for await (const lines of journalLinesFor([...inPeriod.keys()], codes)) {
     for (const l of lines) {
-      const t = inPeriod.get(l.transaction_id)!;
-      raw.push({ transactionId: l.transaction_id, postedByAgent: t.agent, date: t.date, txnType: t.type, description: t.description, memo: l.memo, debit: round2(Number(l.debit)), credit: round2(Number(l.credit)) });
+      rawByAccount.get(l.account_code)?.push({
+        transactionId: l.transaction_id,
+        memo: l.memo,
+        debit: round2(Number(l.debit)),
+        credit: round2(Number(l.credit)),
+      });
+      usedTxnIds.add(l.transaction_id);
     }
   }
-  raw.sort((a, b) => (a.date < b.date ? -1 : a.date > b.date ? 1 : 0));
 
-  let running = opening, totalDebit = 0, totalCredit = 0;
-  const entries: GlEntry[] = raw.map((r) => {
-    running = round2(running + r.debit - r.credit);
-    totalDebit = round2(totalDebit + r.debit);
-    totalCredit = round2(totalCredit + r.credit);
-    return { ...r, balance: running };
+  // Contact derivation in ONE batched pass for the whole request.
+  const bankTxnIds = [...usedTxnIds].filter((id) => inPeriod.get(id)?.agent === "bank");
+  const bank = await bankContacts(bankTxnIds);
+
+  const accounts: GlAccountLedger[] = codes.map((code) => {
+    const m = meta.get(code);
+    const raw = (rawByAccount.get(code) ?? [])
+      .map((r) => ({ r, t: inPeriod.get(r.transactionId)! }))
+      .sort((a, b) => (a.t.date < b.t.date ? -1 : a.t.date > b.t.date ? 1 : 0));
+    const open = round2(opening.get(code) ?? 0);
+    let running = open, totalDebit = 0, totalCredit = 0;
+    const entries: GlEntry[] = raw.map(({ r, t }) => {
+      running = round2(running + r.debit - r.credit);
+      totalDebit = round2(totalDebit + r.debit);
+      totalCredit = round2(totalCredit + r.credit);
+      return {
+        transactionId: r.transactionId,
+        reference: r.transactionId.slice(0, 8).toUpperCase(),
+        postedByAgent: t.agent,
+        actor: t.agent === "manual" ? t.agentVersion : null,
+        contact: contactForEntry(r.transactionId, t, r.memo, bank),
+        date: t.date,
+        txnType: t.type,
+        description: t.description,
+        memo: r.memo,
+        debit: r.debit,
+        credit: r.credit,
+        balance: running,
+      };
+    });
+    return {
+      account: { code, name: m?.name ?? "(unknown account)", type: m?.type ?? "?" },
+      opening: open,
+      entries,
+      closing: running,
+      totalDebit,
+      totalCredit,
+    };
   });
 
+  return { companyId: input.companyId, start: input.start, end: input.end, accounts };
+}
+
+// Single-account GL, the original shape. Delegates to the multi builder so
+// both paths compute identically; existing consumers keep the same response
+// (entries gain reference/contact/actor as additive fields).
+export async function buildGeneralLedger(input: { companyId: string; accountCode: string; start: string; end: string }): Promise<GeneralLedger> {
+  const multi = await buildGeneralLedgerMulti({ companyId: input.companyId, accountCodes: [input.accountCode], start: input.start, end: input.end });
+  const a = multi.accounts[0];
   return {
-    companyId: input.companyId, accountCode: input.accountCode, accountName: am?.name ?? "(unknown)", type: am?.type ?? "?",
-    start: input.start, end: input.end, opening: round2(opening), entries, closing: running, totalDebit, totalCredit,
+    companyId: input.companyId,
+    accountCode: a.account.code, accountName: a.account.name, type: a.account.type,
+    start: input.start, end: input.end,
+    opening: a.opening, entries: a.entries, closing: a.closing,
+    totalDebit: a.totalDebit, totalCredit: a.totalCredit,
   };
 }
 


### PR DESCRIPTION
## What

The GL tab on /finance/reports is now a Bukku-grade ledger, not a sidebar glance.

- **Multi-account view**: chips plus an add combobox; one section per account with opening balance row, entries and closing balance plus period totals. Trial Balance drill opens the account here.
- **Columns**: Date, Ref (journal voucher), Contact, Description, Debit, Credit, running Balance. Sticky header, zebra rows, tabular numerals, dark mode safe.
- **Every row expands inline** into the full journal entry: all legs with the current account highlighted, memo per leg, a posted-by line (for example "Bank agent, bank-gl-v1" or "Manual, Ammar"), and for bank journals the source bank lines with the existing fix-in-place category chips, matched-invoice chips and new attachment indicators. Detail loads lazily on first expand and is cached per journal; a fix refetches both the panel and the ledger.
- **Deep-linkable**: accounts and period live in the URL (tab=gl&accounts=6505,1000-01&start=...&end=...) and the last selection persists in localStorage.
- **CSV export** gains Account, Ref and Contact columns with per-account grouping.

## API

`/api/finance/reports/general-ledger` now also accepts `accounts=CODE1,CODE2` (comma separated, capped at 20) and returns `{ report: { companyId, start, end, accounts: [{ account, opening, entries, closing, totalDebit, totalCredit }] } }`. The original `account=` call is unchanged; entries gain reference, contact and actor as additive fields.

Contact derivation is one batched pass per request (two extra queries total, regardless of entry count): bank journals prefer the matched invoice supplier, else the payee phrase from the bank description (reusing deriveHintPhrase); ar journals read the sales channel off the leg memo; manual journals show the actor stored in agent_version. First name plus "+N" when a grouped journal has several payees.

`/api/finance/gl-source-lines` adds a per-line attachment count (one batched fin_documents query).

Ledger scans (trial balance and GL) now page past the 1000-row Supabase cap, so opening balances stay exact as ledger history grows.

## Verified locally against real data (read-only)

- Multi-account GL for 6505 + 1000-01 for June: sections, openings and closings match the old single-account output for 6505 exactly.
- Expanded a bank journal: balanced legs (6505 DR / 1000-01 CR), provenance line, source bank line with category chip and payee contact (TENAGA NASIONAL).
- Expanded an ar journal on 1005: balanced legs, channel contact "Grabfood", actor line "Ar agent, storehub-backfill-v1".
- URL round trip: fresh load of the deep link restores accounts and the custom period; leaving the GL tab strips the params.
- Typecheck clean; eslint 0 errors on touched files.