### PR TITLE
security(loyalty)+finance: server-side pickup stats, decision attribution fix, payments-cron heartbeat

### DIFF
--- a/apps/backoffice/src/app/(admin)/pickup/page.tsx
+++ b/apps/backoffice/src/app/(admin)/pickup/page.tsx
@@ -157,28 +157,10 @@ export default function PickupDashboard() {
   const loadInventory = useCallback(async () => {
     if (invLoaded) return;
     setInvLoading(true);
-    const supabase = getSupabaseClient();
-    const [ingR, lvlR, parR] = await Promise.all([
-      supabase.from("ingredients").select("id,name,unit").eq("is_active", true),
-      supabase.from("stock_levels").select("ingredient_id,quantity"),
-      supabase.from("ingredient_outlet_settings").select("ingredient_id,par_level"),
-    ]);
-    const ingredients = ingR.data  as Array<{ id: string; name: string; unit: string }>       | null;
-    const stockLevels = lvlR.data  as Array<{ ingredient_id: string; quantity: number }>      | null;
-    const parSettings = parR.data  as Array<{ ingredient_id: string; par_level: number }>     | null;
-    const ing    = ingredients ?? [];
-    const lvlMap = Object.fromEntries((stockLevels ?? []).map((l) => [l.ingredient_id, l.quantity as number]));
-    const parMap = Object.fromEntries((parSettings ?? []).map((s) => [s.ingredient_id, s.par_level as number]));
-    const lowItems = ing
-      .filter((i) => { const qty = lvlMap[i.id] ?? 0; const par = parMap[i.id] ?? 0; return qty > 0 && par > 0 && qty < par; })
-      .map((i) => ({ name: i.name as string, qty: lvlMap[i.id] ?? 0, unit: i.unit as string }))
-      .slice(0, 5);
-    setInvStats({
-      total:    ing.length,
-      lowStock: lowItems.length,
-      outStock: ing.filter((i) => (lvlMap[i.id] ?? 0) === 0).length,
-      lowItems,
-    });
+    const stats = await fetch("/api/pickup/dashboard-stats?section=inventory", { cache: "no-store" })
+      .then((r) => (r.ok ? r.json() : null))
+      .catch(() => null);
+    if (stats) setInvStats(stats);
     setInvLoading(false);
     setInvLoaded(true);
   }, [invLoaded]);
@@ -186,43 +168,10 @@ export default function PickupDashboard() {
   const loadLoyalty = useCallback(async () => {
     if (loyaltyLoaded) return;
     setLoyaltyLoading(true);
-    const supabase   = getSupabaseClient();
-    const monthStart = new Date(); monthStart.setDate(1); monthStart.setHours(0, 0, 0, 0);
-    const [mbRes, rdmRes, { count }] = await Promise.all([
-      supabase.from("member_brands")
-        .select("points_balance, total_points_earned, last_visit_at, members(name, phone, created_at)")
-        .eq("brand_id", "brand-celsius").order("last_visit_at", { ascending: false }).limit(5),
-      supabase.from("redemptions").select("id", { count: "exact", head: true }).eq("brand_id", "brand-celsius"),
-      supabase.from("member_brands").select("*", { count: "exact", head: true }).eq("brand_id", "brand-celsius"),
-    ]);
-    const { count: activeCount } = await supabase.from("member_brands")
-      .select("*", { count: "exact", head: true })
-      .eq("brand_id", "brand-celsius")
-      .gte("last_visit_at", monthStart.toISOString());
-    const pointsRaw   = await supabase.from("member_brands")
-      .select("total_points_earned").eq("brand_id", "brand-celsius");
-    const pointsData  = pointsRaw.data as Array<{ total_points_earned: number }> | null;
-    const pointsIssued = (pointsData ?? []).reduce((s, m) => s + (m.total_points_earned ?? 0), 0);
-
-    type MbRow = {
-      points_balance: number;
-      total_points_earned: number;
-      last_visit_at: string | null;
-      members: { name: string | null; phone: string; created_at: string } | null;
-    };
-
-    setLoyaltyStats({
-      totalMembers:  count ?? 0,
-      activeMonth:   activeCount ?? 0,
-      pointsIssued,
-      redemptions:   rdmRes.count ?? 0,
-      recentMembers: ((mbRes.data ?? []) as unknown as MbRow[]).map((m) => ({
-        name:   m.members?.name ?? null,
-        phone:  m.members?.phone ?? "",
-        joined: m.members?.created_at ?? "",
-        points: m.points_balance,
-      })),
-    });
+    const stats = await fetch("/api/pickup/dashboard-stats?section=loyalty", { cache: "no-store" })
+      .then((r) => (r.ok ? r.json() : null))
+      .catch(() => null);
+    if (stats) setLoyaltyStats(stats);
     setLoyaltyLoading(false);
     setLoyaltyLoaded(true);
   }, [loyaltyLoaded]);

--- a/apps/backoffice/src/app/api/pickup/dashboard-stats/route.ts
+++ b/apps/backoffice/src/app/api/pickup/dashboard-stats/route.ts
@@ -1,0 +1,88 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getSupabaseAdmin } from "@/lib/pickup/supabase";
+import { requireAuth } from "@/lib/auth";
+
+// GET /api/pickup/dashboard-stats?section=loyalty|inventory
+//
+// Server-side aggregates for the pickup dashboard's lazy-loaded tabs.
+// These reads previously ran in the browser with the anon key and only
+// worked because the loyalty tables' RLS policies were USING (true) for
+// every role (see docs/rls-access-map-2026-07-05.md, exposure 2). Keeping
+// them behind the service-role client lets those policies be tightened
+// without breaking the page.
+export async function GET(request: NextRequest) {
+  const auth = await requireAuth(request);
+  if (auth.error) return auth.error;
+  const section = request.nextUrl.searchParams.get("section");
+  const supabase = getSupabaseAdmin();
+  try {
+    if (section === "loyalty") {
+      const monthStart = new Date();
+      monthStart.setDate(1);
+      monthStart.setHours(0, 0, 0, 0);
+      const [mbRes, rdmRes, totalRes, activeRes, pointsRes] = await Promise.all([
+        supabase.from("member_brands")
+          .select("points_balance, total_points_earned, last_visit_at, members(name, phone, created_at)")
+          .eq("brand_id", "brand-celsius").order("last_visit_at", { ascending: false }).limit(5),
+        supabase.from("redemptions").select("id", { count: "exact", head: true }).eq("brand_id", "brand-celsius"),
+        supabase.from("member_brands").select("*", { count: "exact", head: true }).eq("brand_id", "brand-celsius"),
+        supabase.from("member_brands").select("*", { count: "exact", head: true })
+          .eq("brand_id", "brand-celsius").gte("last_visit_at", monthStart.toISOString()),
+        supabase.from("member_brands").select("total_points_earned").eq("brand_id", "brand-celsius"),
+      ]);
+      type MbRow = {
+        points_balance: number;
+        total_points_earned: number;
+        last_visit_at: string | null;
+        members: { name: string | null; phone: string; created_at: string } | null;
+      };
+      const pointsData = pointsRes.data as Array<{ total_points_earned: number }> | null;
+      return NextResponse.json({
+        totalMembers: totalRes.count ?? 0,
+        activeMonth: activeRes.count ?? 0,
+        pointsIssued: (pointsData ?? []).reduce((s, m) => s + (m.total_points_earned ?? 0), 0),
+        redemptions: rdmRes.count ?? 0,
+        recentMembers: ((mbRes.data ?? []) as unknown as MbRow[]).map((m) => ({
+          name: m.members?.name ?? null,
+          phone: m.members?.phone ?? "",
+          joined: m.members?.created_at ?? "",
+          points: m.points_balance,
+        })),
+      });
+    }
+
+    if (section === "inventory") {
+      const [ingR, lvlR, parR] = await Promise.all([
+        supabase.from("ingredients").select("id,name,unit").eq("is_active", true),
+        supabase.from("stock_levels").select("ingredient_id,quantity"),
+        supabase.from("ingredient_outlet_settings").select("ingredient_id,par_level"),
+      ]);
+      const ing = (ingR.data ?? []) as Array<{ id: string; name: string; unit: string }>;
+      const lvlMap = Object.fromEntries(
+        ((lvlR.data ?? []) as Array<{ ingredient_id: string; quantity: number }>).map((l) => [l.ingredient_id, l.quantity]),
+      );
+      const parMap = Object.fromEntries(
+        ((parR.data ?? []) as Array<{ ingredient_id: string; par_level: number }>).map((s) => [s.ingredient_id, s.par_level]),
+      );
+      const lowItems = ing
+        .filter((i) => {
+          const qty = lvlMap[i.id] ?? 0;
+          const par = parMap[i.id] ?? 0;
+          return qty > 0 && par > 0 && qty < par;
+        })
+        .map((i) => ({ name: i.name, qty: lvlMap[i.id] ?? 0, unit: i.unit }))
+        .slice(0, 5);
+      return NextResponse.json({
+        total: ing.length,
+        lowStock: lowItems.length,
+        outStock: ing.filter((i) => (lvlMap[i.id] ?? 0) === 0).length,
+        lowItems,
+      });
+    }
+
+    return NextResponse.json({ error: "section must be loyalty or inventory" }, { status: 400 });
+  } catch (e) {
+    console.error("[pickup/dashboard-stats]", e);
+    return NextResponse.json({ error: "failed to load stats" }, { status: 500 });
+  }
+}

--- a/apps/backoffice/src/lib/finance/agents/ap.ts
+++ b/apps/backoffice/src/lib/finance/agents/ap.ts
@@ -21,7 +21,7 @@ import { randomUUID } from "crypto";
 import { prisma } from "@/lib/prisma";
 import { getFinanceClient } from "../supabase";
 import { postJournal } from "../ledger";
-import { categorize } from "./categorizer";
+import { categorize, markDecisionApplied } from "./categorizer";
 import { parseSupplierDoc, type ParsedBill } from "../parsers/supplier-doc";
 import { resolveCompanyFromOutlet, getDefaultCompanyId } from "../companies";
 import type { JournalLineInput } from "../types";
@@ -168,6 +168,7 @@ export async function ingestSupplierDoc(input: ApIngestInput): Promise<ApIngestR
       ? await resolveOutletNameById(outletId)
       : null,
     contextNotes: parsed.notes ?? undefined,
+    related: { type: "document", id: docId },
   });
 
   // 8. Decision: auto-post or exception
@@ -263,6 +264,8 @@ export async function ingestSupplierDoc(input: ApIngestInput): Promise<ApIngestR
   });
 
   await client.from("fin_documents").update({ status: "processed", ingested_at: new Date().toISOString() }).eq("id", docId);
+
+  if (cat.decisionId) await markDecisionApplied(cat.decisionId);
 
   return { kind: "posted", transactionId: journal.transactionId, billId, total: parsed.total };
 }

--- a/apps/backoffice/src/lib/finance/agents/categorizer.ts
+++ b/apps/backoffice/src/lib/finance/agents/categorizer.ts
@@ -25,6 +25,10 @@ export type CategorizationInput = {
   total: number;
   outletHint?: { id: string; name: string } | null;
   contextNotes?: string;
+  // Source artefact this categorization belongs to (e.g. the fin_documents
+  // row). Written to fin_agent_decisions.related_type/related_id so inbox
+  // corrections can be attributed to THIS decision instead of "the latest".
+  related?: { type: "document"; id: string } | null;
 };
 
 export type CategorizationResult = {
@@ -32,6 +36,7 @@ export type CategorizationResult = {
   confidence: number;
   reasoning: string;
   alternativeCodes: string[];   // top 3 alternatives the human can pick from in the inbox
+  decisionId?: string | null;   // fin_agent_decisions row logged for this call
 };
 
 // Pulls the categorize-able accounts (expenses + cogs + selected current
@@ -219,18 +224,19 @@ export async function categorize(input: CategorizationInput): Promise<Categoriza
   };
 
   // Log every decision for audit + retraining
-  await logDecision(input, result);
+  const decisionId = await logDecision(input, result);
 
-  return result;
+  return { ...result, decisionId };
 }
 
 async function logDecision(
   input: CategorizationInput,
   result: CategorizationResult
-): Promise<void> {
+): Promise<string> {
   const client = getFinanceClient();
+  const id = randomUUID();
   await client.from("fin_agent_decisions").insert({
-    id: randomUUID(),
+    id,
     agent: "categorizer",
     agent_version: CATEGORIZER_VERSION,
     input: {
@@ -246,6 +252,20 @@ async function logDecision(
       alternatives: result.alternativeCodes,
     },
     confidence: result.confidence,
-    applied: false,  // set by AP agent / inbox resolver when actually used
+    related_type: input.related?.type ?? null,
+    related_id: input.related?.id ?? null,
+    applied: false,  // set true by markDecisionApplied when the proposal is used as-is
   });
+  return id;
+}
+
+// Called when a decision's proposal is actually used unchanged — the AP
+// agent's auto-post path or an inbox "approve". Corrections don't set
+// applied; corrected=true covers them (see recordCorrection in inbox.ts).
+export async function markDecisionApplied(decisionId: string): Promise<void> {
+  const client = getFinanceClient();
+  await client
+    .from("fin_agent_decisions")
+    .update({ applied: true })
+    .eq("id", decisionId);
 }

--- a/apps/backoffice/src/lib/finance/inbox.ts
+++ b/apps/backoffice/src/lib/finance/inbox.ts
@@ -63,7 +63,12 @@ export async function resolveException(
     supplierId?: string;
     supplierName?: string;
     outletId?: string | null;
-    categorize?: { accountCode: string | null; confidence: number; reasoning: string };
+    categorize?: {
+      accountCode: string | null;
+      confidence: number;
+      reasoning: string;
+      decisionId?: string | null;
+    };
     bill?: {
       supplierName: string | null;
       billNumber: string | null;
@@ -187,34 +192,64 @@ export async function resolveException(
   // correction so the next run learns from it.
   if (action.kind === "correct" && proposal.categorize?.accountCode !== accountCode) {
     await recordCorrection({
+      decisionId: proposal.categorize?.decisionId ?? null,
+      relatedId: (exc.related_id as string) ?? null,
       supplierId: proposal.supplierId,
       originalCode: proposal.categorize?.accountCode ?? null,
       correctedTo: { accountCode, outletId, reasoning: "human override" },
       correctedBy: userId,
     });
+  } else if (action.kind === "approve" && proposal.categorize?.decisionId) {
+    // The proposal was used as-is — the decision counts as applied.
+    await client
+      .from("fin_agent_decisions")
+      .update({ applied: true })
+      .eq("id", proposal.categorize.decisionId);
   }
 
   return { kind: "posted", transactionId: result.transactionId, amount: total };
 }
 
 async function recordCorrection(args: {
+  decisionId: string | null;
+  relatedId: string | null;
   supplierId: string;
   originalCode: string | null;
   correctedTo: { accountCode: string; outletId: string | null; reasoning: string };
   correctedBy: string;
 }): Promise<void> {
   const client = getFinanceClient();
-  // Find the most recent categorizer decision for this supplier.
-  const { data } = await client
-    .from("fin_agent_decisions")
-    .select("id")
-    .eq("agent", "categorizer")
-    .order("created_at", { ascending: false })
-    .limit(20);
-  if (!data || data.length === 0) return;
-  // Heuristic: tag the most recent decision. A future iteration can join on
-  // input.supplier_id when we add a pg index.
-  const target = data[0];
+
+  // Resolve the decision this correction belongs to, most exact first:
+  // 1. The decision id carried in the exception's proposal (new rows).
+  // 2. The decision logged against the same source document.
+  // 3. The latest decision for the same supplier (legacy rows from before
+  //    related_id was populated — better than "latest overall", which
+  //    mis-attributed corrections under concurrent ingestion).
+  let targetId = args.decisionId;
+  if (!targetId && args.relatedId) {
+    const { data } = await client
+      .from("fin_agent_decisions")
+      .select("id")
+      .eq("agent", "categorizer")
+      .eq("related_type", "document")
+      .eq("related_id", args.relatedId)
+      .order("created_at", { ascending: false })
+      .limit(1);
+    targetId = data?.[0]?.id ?? null;
+  }
+  if (!targetId) {
+    const { data } = await client
+      .from("fin_agent_decisions")
+      .select("id")
+      .eq("agent", "categorizer")
+      .eq("input->>supplier_id", args.supplierId)
+      .order("created_at", { ascending: false })
+      .limit(1);
+    targetId = data?.[0]?.id ?? null;
+  }
+  if (!targetId) return;
+
   await client
     .from("fin_agent_decisions")
     .update({
@@ -223,7 +258,7 @@ async function recordCorrection(args: {
       corrected_by: args.correctedBy,
       corrected_at: new Date().toISOString(),
     })
-    .eq("id", target.id);
+    .eq("id", targetId);
 }
 
 function round2(n: number): number {

--- a/apps/order/src/app/api/cron/reconcile-pending/route.ts
+++ b/apps/order/src/app/api/cron/reconcile-pending/route.ts
@@ -1,6 +1,7 @@
 export const dynamic = "force-dynamic";
 
 import { NextRequest, NextResponse } from "next/server";
+import * as Sentry from "@sentry/nextjs";
 import Stripe from "stripe";
 import { getSupabaseAdmin } from "@/lib/supabase/server";
 import { earnLoyaltyPoints, deductLoyaltyPoints } from "@/lib/loyalty/points";
@@ -40,9 +41,30 @@ export async function GET(request: NextRequest) {
   const cronAuth = checkCronAuth(request.headers);
   if (!cronAuth.ok) return NextResponse.json({ error: cronAuth.error }, { status: cronAuth.status });
 
+  // Heartbeat: this cron settles payments and fails silently into logs
+  // otherwise (docs/monitoring-setup.md). withMonitor upserts the Sentry
+  // Cron Monitor on first check-in and alerts on missed windows or thrown
+  // errors — config errors below throw (instead of returning 500 directly)
+  // so they register as failed runs, not healthy ones.
+  try {
+    return await Sentry.withMonitor("reconcile-pending", () => runReconcile(), {
+      schedule: { type: "crontab", value: "* * * * *" },
+      checkinMargin: 5,
+      maxRuntime: 10,
+      timezone: "Etc/UTC",
+    });
+  } catch (err) {
+    return NextResponse.json(
+      { error: err instanceof Error ? err.message : "reconcile-pending failed" },
+      { status: 500 },
+    );
+  }
+}
+
+async function runReconcile(): Promise<NextResponse> {
   const stripe = getStripe();
   if (!stripe) {
-    return NextResponse.json({ error: "Stripe not configured" }, { status: 500 });
+    throw new Error("Stripe not configured");
   }
 
   const supabase = getSupabaseAdmin();
@@ -64,7 +86,7 @@ export async function GET(request: NextRequest) {
     .gt("created_at", youngerThan);
 
   if (error) {
-    return NextResponse.json({ error: error.message }, { status: 500 });
+    throw new Error(error.message);
   }
 
   const orders = (pending ?? []) as OrderLite[];

--- a/docs/STATE.md
+++ b/docs/STATE.md
@@ -51,27 +51,22 @@ delete entries that have been promoted into `CLAUDE.md`, a skill, or a doc.
 
 ## Open failures
 
-- 2026-07-05 — **Correction mis-attribution in the finance eval dataset** —
-  `recordCorrection()` (`apps/backoffice/src/lib/finance/inbox.ts` ~L215)
-  tags the *most recent* categorizer decision (`order created_at desc,
-  take first`) instead of the one belonging to the corrected exception;
-  `fin_agent_decisions.related_id` is never populated by `logDecision()`
-  (`categorizer.ts` ~L227), so a correct join isn't possible today. Under
-  concurrent AP ingestion, corrections land on the wrong rows — silently
-  corrupting the retraining/eval set. Fix: populate `related_type`/
-  `related_id` at decision time, return the decision id from
-  `categorize()`, and join on it in `recordCorrection`. Not blocking
-  day-to-day finance ops; blocking for the eval-replay loop.
-- 2026-07-05 — `fin_agent_decisions.applied` is written `false` and never
-  updated by any code path — can't distinguish auto-posted decisions from
-  ignored ones when building eval cohorts.
-- 2026-07-05 — **Loyalty tables anon-writable** (`members`, `member_brands`,
-  `point_transactions`, `redemptions`): RLS policies in
-  `apps/order/supabase/migrations/001_initial_schema.sql:186-195` are
-  `USING (true)` with no `TO service_role`. Blocked on: moving the
-  backoffice pickup page's browser reads (`(admin)/pickup/page.tsx`
-  ~L192-202) behind an API route first, then a policy-fix migration
-  (human approval). Ranked plan in `docs/rls-access-map-2026-07-05.md`.
+- 2026-07-05 — **Loyalty tables anon-writable** — and wider than the access
+  map first said: the `USING (true)` "Service full access" policies in
+  `apps/order/supabase/migrations/001_initial_schema.sql:186-195` also
+  cover `staff_users` and `otp_codes`, and make the four public-read
+  tables anon-WRITABLE too. Code prerequisite is DONE (pickup page reads
+  moved behind `/api/pickup/dashboard-stats`); remaining step is applying
+  `docs/proposals/2026-07-05-loyalty-rls-policy-fix.sql` (human approval,
+  loyalty Supabase project) after that deploys. Checklist:
+  `docs/ops-hardening-checklist.md` §5.
+- 2026-07-05 — 13 of 14 Vercel crons still have no heartbeat monitoring
+  (`reconcile-pending` wired 2026-07-05; the rest fail silently).
+
+_Fixed 2026-07-05 (see Lessons): categorizer correction mis-attribution +
+never-set `applied` flag — `related_id` now populated at decision time,
+corrections join decisionId → document → supplier, `applied` set on
+auto-post and inbox approve._
 
 _Format: `YYYY-MM-DD — <symptom> — <evidence> — <hypothesis/fix> — <blocking?>`_
 
@@ -93,10 +88,13 @@ _Format: `YYYY-MM-DD — <symptom> — <evidence> — <hypothesis/fix> — <bloc
   build the finance eval replay (corrected `fin_agent_decisions` rows →
   regression set per agent, see finance-module skill); wire cron heartbeat
   monitors (`docs/monitoring-setup.md` §2).
-- 2026-07-05 — Both exploration passes done and documented (finance code
-  map → finance-module skill; RLS access map →
-  `docs/rls-access-map-2026-07-05.md`). Highest-priority next work, in
-  order: (1) pickup-page loyalty reads behind an API route, (2) loyalty
-  RLS policy-fix migration [approval], (3) `related_id` attribution fix in
-  the finance decisions log, (4) `hr_payroll_runs` deny-all migration
-  [approval].
+- 2026-07-05 — Hardening batch shipped: pickup-page reads moved server-side,
+  `related_id`/`applied` fixes, `reconcile-pending` Sentry heartbeat,
+  `docs/ops-hardening-checklist.md` (human dashboard items + quarterly
+  key-rotation calendar reminder on barista@, next 2026-10-01), and the
+  loyalty policy-fix proposal in `docs/proposals/`. **Waiting on human:**
+  apply the proposal SQL after deploy (checklist §5), `hr_payroll_runs`
+  RLS one-liner (§6), IP allowlist (§1), BetterUptime + Vercel→Slack (§3),
+  PITR decision (§4). SMS attribution holdout (loop #1) still needs the
+  two owner decisions: exact reward + success bar
+  (`docs/design/sms-loop-engineering.md`).

--- a/docs/ops-hardening-checklist.md
+++ b/docs/ops-hardening-checklist.md
@@ -1,0 +1,74 @@
+# Ops hardening checklist — 2026-07-05
+
+Human-action items batched from `docs/rls-strategy.md` (Path B, open since
+the April audit), `docs/monitoring-setup.md` ("set up TODAY", never done),
+and the 2026-07-05 RLS access map. Everything here is dashboard work no
+agent can do; each item says how to verify it's done. Tick and date as you
+go.
+
+## 1. Supabase IP allowlist (~30 min) — biggest single win
+
+Do this on **both** Supabase projects (main + loyalty `kqdcdhpnyuwrxqhbuyfl`).
+
+- [ ] Collect Vercel egress IPs: https://vercel.com/docs/edge-network/regions
+      (published ranges) — or log `x-forwarded-for` from one request per app.
+- [ ] Supabase → Settings → Database → Network Restrictions → enable, paste
+      the ranges, and add your office/home IPs for direct SQL access.
+- [ ] Verify: from a phone hotspot (non-allowlisted IP), a direct Postgres
+      connection with the service-role key must FAIL; the apps must still work.
+
+Effect: a leaked service-role key becomes unusable from anywhere but Vercel.
+
+## 2. Service-role key rotation (~15 min, quarterly)
+
+- [ ] Supabase → Project → API → "Roll" the service-role key (both projects).
+- [ ] Update `SUPABASE_SERVICE_ROLE_KEY` / `LOYALTY_SUPABASE_SERVICE_ROLE_KEY`
+      in each Vercel project's env vars; redeploy each app.
+- [ ] Also update any `.env.local` on dev machines.
+
+A quarterly calendar reminder (1st of Jan/Apr/Jul/Oct, created 2026-07-05)
+points back at this section. Next one due: **2026-10-01**.
+
+## 3. Uptime monitoring (~15 min, free)
+
+- [ ] BetterUptime (betterstack.com/uptime) free tier: one monitor per
+      `/api/health` URL in `docs/monitoring-setup.md` §health-endpoints.
+      1-min interval for order + backoffice; 5-min for the rest. Email alert
+      to yourself (add the ops WhatsApp/Slack later).
+- [ ] Vercel → each project → Integrations → Slack: failed-deploy
+      notifications to an #ops channel.
+- [ ] Verify: temporarily point one monitor at a bogus path and confirm the
+      alert arrives, then fix it.
+
+Note: the `reconcile-pending` payments cron now carries a Sentry Cron
+Monitor heartbeat in code (auto-creates on first production run — check
+Sentry → Crons and set the alert rule to notify you). The other 13 crons
+remain unmonitored; wire them the same way if one bites.
+
+## 4. Point-in-Time Recovery decision (~5 min to decide)
+
+- [ ] Supabase → Settings → Add-ons → check whether PITR is enabled on the
+      main project.
+- Decision guide: without PITR you have daily snapshots (7-day retention) —
+  a bad deletion can lose up to a day, and the DB is now the book of record
+  for accounting + payroll. PITR (~USD 100/mo ≈ RM430) restores to any
+  second in a 7-day window. Recommendation: **enable on the main project**
+  once Bukku parallel-run data is the only copy; the loyalty project can
+  stay on snapshots.
+- [ ] Record the decision (either way) in `docs/STATE.md`.
+
+## 5. Loyalty RLS policy fix (after this PR deploys)
+
+- [ ] Confirm the pickup dashboard-stats API route is live in production.
+- [ ] Review + apply `docs/proposals/2026-07-05-loyalty-rls-policy-fix.sql`
+      (pre-apply verification steps are in the file header).
+- [ ] Smoke test: order checkout, OTP login, pickup dashboard loyalty tab,
+      POS loyalty lookup.
+- [ ] Move the SQL under the loyalty migrations dir + update the access map.
+
+## 6. hr_payroll_runs deny-all RLS (quick follow-up migration)
+
+- [ ] One-liner migration on the main project:
+      `ALTER TABLE hr_payroll_runs ENABLE ROW LEVEL SECURITY;`
+      (matches the 20260502 batch; no policies = service-role only).
+      Payroll table — review before applying per hard rule 6.

--- a/docs/proposals/2026-07-05-loyalty-rls-policy-fix.sql
+++ b/docs/proposals/2026-07-05-loyalty-rls-policy-fix.sql
@@ -1,0 +1,47 @@
+-- PROPOSAL — NOT APPLIED. Requires human approval (CLAUDE.md hard rule 6)
+-- and must ship AFTER the pickup dashboard-stats API route is deployed
+-- (the page's browser reads move server-side in the same PR as this file).
+--
+-- Target: the LOYALTY Supabase project (kqdcdhpnyuwrxqhbuyfl) — the one
+-- apps/order and lib/pickup point at. Not the main project.
+--
+-- Problem (docs/rls-access-map-2026-07-05.md, exposure 1 — and wider than
+-- the map first said): apps/order/supabase/migrations/001_initial_schema.sql
+-- creates "Service full access <table>" policies as
+--   FOR ALL USING (true) WITH CHECK (true)
+-- with no TO clause, so they apply to EVERY role including anon. That
+-- makes members, member_brands, point_transactions, redemptions — and
+-- also staff_users and otp_codes (staff credentials + login codes) —
+-- readable AND writable with the published anon key.
+--
+-- Fix: drop the ten policies outright. service_role bypasses RLS, so the
+-- API routes lose nothing; anon/authenticated fall back to deny (RLS is
+-- already enabled on every one of these tables). The four intentional
+-- "Public read" SELECT policies (brands, outlets, rewards, campaigns)
+-- are kept — those tables stay anon-READABLE but stop being anon-writable.
+--
+-- Pre-apply verification (human):
+--   1. Confirm the dashboard-stats route is live in production backoffice.
+--   2. Supabase Dashboard → Logs → PostgREST: confirm no anon-role
+--      requests to these tables in the last 7 days other than the pickup
+--      page (which the route replaces).
+--   3. Apply in the SQL editor or via Supabase MCP apply_migration.
+--   4. Smoke test: order app checkout + OTP login + pickup dashboard
+--      loyalty tab + POS loyalty lookup.
+-- After applying: save this file under the loyalty project's migrations
+-- dir per the db-migration skill, and update the access map + STATE.md.
+
+DROP POLICY IF EXISTS "Service full access brands" ON brands;
+DROP POLICY IF EXISTS "Service full access outlets" ON outlets;
+DROP POLICY IF EXISTS "Service full access members" ON members;
+DROP POLICY IF EXISTS "Service full access member_brands" ON member_brands;
+DROP POLICY IF EXISTS "Service full access point_transactions" ON point_transactions;
+DROP POLICY IF EXISTS "Service full access rewards" ON rewards;
+DROP POLICY IF EXISTS "Service full access redemptions" ON redemptions;
+DROP POLICY IF EXISTS "Service full access campaigns" ON campaigns;
+DROP POLICY IF EXISTS "Service full access staff_users" ON staff_users;
+DROP POLICY IF EXISTS "Service full access otp_codes" ON otp_codes;
+
+-- ROLLBACK (restores the previous — insecure — behaviour):
+-- CREATE POLICY "Service full access members" ON members FOR ALL USING (true) WITH CHECK (true);
+-- ...and likewise for the other nine tables.


### PR DESCRIPTION
## What

Acts on the findings merged in #776 (RLS access map + finance code map). Four changes:

### 1. Pickup dashboard reads move server-side (prereq for the loyalty RLS fix)

New `/api/pickup/dashboard-stats?section=loyalty|inventory` route (service-role + `requireAuth`), serving the aggregates `(admin)/pickup/page.tsx` previously queried **from the browser with the anon key**. The page's two lazy loaders now `fetch` it; its realtime `orders` subscription is unchanged. This unblocks tightening the loyalty policies without breaking the page.

### 2. Loyalty RLS policy fix — proposal only, NOT applied

`docs/proposals/2026-07-05-loyalty-rls-policy-fix.sql` drops the ten `FOR ALL USING (true)` "Service full access" policies. Scope grew while drafting: beyond the four tables in the access map, **`staff_users` and `otp_codes` are also anon-writable**, and the four public-read tables (brands/outlets/rewards/campaigns) are unintentionally anon-*writable*. The file header carries pre-apply verification steps + rollback. Gated on human approval per CLAUDE.md hard rule 6; apply only after this PR deploys.

### 3. Finance decision attribution + `applied` flag (the eval-dataset fix)

- `logDecision()` now records `related_type`/`related_id` (the source `fin_documents` row) and returns the decision id; `categorize()` surfaces it as `decisionId`, which rides into the exception's `proposed_action`.
- `recordCorrection()` resolves its target decision **exact-first**: proposal `decisionId` → same source document → same supplier (legacy fallback) — replacing the "tag the most recent decision overall" heuristic that mis-attributed corrections under concurrent ingestion.
- `applied` is now set on AP auto-post and inbox **approve** (corrections stay `corrected`-only), so eval cohorts can distinguish used vs ignored decisions.

### 4. Payments-cron heartbeat

`apps/order` `/api/cron/reconcile-pending` is wrapped in `Sentry.withMonitor` (crontab `* * * * *`, 5-min check-in margin; monitor auto-upserts on first production run). Config-error paths (`Stripe not configured`, DB query error) now **throw** inside the monitored callback so they register as failed runs instead of healthy ones; the handler still returns the same 500 JSON.

Also: `docs/ops-hardening-checklist.md` (the human dashboard items — Supabase IP allowlist, quarterly key rotation, BetterUptime, Vercel→Slack, PITR decision, the two approval-gated migrations) and STATE.md bookkeeping.

## Verification

- `npx tsc --noEmit` clean on `apps/backoffice` and `apps/order`
- `npx eslint` on all changed files: 0 errors (5 pre-existing warn-level warnings in backoffice)
- Behavior-preserving by construction: dashboard-stats route returns the exact shapes the page's `setLoyaltyStats`/`setInvStats` consumed; reconcile-pending's success/failure JSON is unchanged

## Notes

- No migrations in this PR — the proposal SQL is deliberately under `docs/proposals/`, not a migrations dir, so nothing auto-applies and the migration-guard is not implicated.
- After merge + deploy: follow `docs/ops-hardening-checklist.md` §5 to apply the loyalty policy fix, then §6 for the `hr_payroll_runs` one-liner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L3K554Hw6n4vaL9yvGbvtJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01L3K554Hw6n4vaL9yvGbvtJ)_