### PR TITLE
fix(reviews): gbp-relink — repair Tamarind's wrong GBP location by Places-id match

### DIFF
--- a/apps/backoffice/src/app/api/reviews/gbp-relink/route.ts
+++ b/apps/backoffice/src/app/api/reviews/gbp-relink/route.ts
@@ -1,0 +1,83 @@
+import { NextRequest, NextResponse } from "next/server";
+import { checkCronAuth } from "@celsius/shared";
+import { requireRole } from "@/lib/auth";
+import { prisma } from "@/lib/prisma";
+import { listAccountLocations } from "@/lib/reviews/gbp";
+
+export const dynamic = "force-dynamic";
+export const maxDuration = 60;
+
+// GET /api/reviews/gbp-relink[?apply=1] — audit (and with apply=1, repair) each
+// outlet's gbpLocationName against the GBP account's own location list, matched
+// by Places id. Exists because a location name can be mis-set by hand (found
+// live: Tamarind carried Shah Alam's locations/… id, so its review snapshots,
+// review feed and relevance audit all read the wrong shop). The Places id is
+// the outlet's verified public identity (matches its geogrid scans and review
+// QR), so the account listing whose metadata.placeId equals it IS this outlet.
+// Dry-run by default; nothing outside ReviewSettings.gbpLocationName is ever
+// touched, and only for outlets where the stored value provably mismatches.
+export async function GET(request: NextRequest) {
+  const cronAuth = checkCronAuth(request.headers);
+  if (!cronAuth.ok) {
+    try {
+      await requireRole(request.headers, "ADMIN");
+    } catch {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+  }
+  const apply = new URL(request.url).searchParams.get("apply") === "1";
+
+  const settings = await prisma.reviewSettings.findMany({
+    where: {
+      gbpAccountId: { not: null },
+      gbpPlaceId: { not: null },
+      outlet: { status: "ACTIVE" },
+    },
+    include: { outlet: { select: { name: true } } },
+  });
+  if (settings.length === 0) {
+    return NextResponse.json({ ok: true, checked: 0, note: "No outlets with gbpAccountId + gbpPlaceId" });
+  }
+
+  // One listing call per distinct account (they all share the MCC-style account).
+  const byAccount = new Map<string, Awaited<ReturnType<typeof listAccountLocations>>>();
+  const results: Array<Record<string, unknown>> = [];
+  let repaired = 0;
+
+  for (const s of settings) {
+    try {
+      let locations = byAccount.get(s.gbpAccountId!);
+      if (!locations) {
+        locations = await listAccountLocations(s.gbpAccountId!);
+        byAccount.set(s.gbpAccountId!, locations);
+      }
+      const match = locations.find((l) => l.placeId === s.gbpPlaceId);
+      if (!match) {
+        results.push({ outlet: s.outlet.name, status: "no_match", placeId: s.gbpPlaceId });
+        continue;
+      }
+      if (match.name === s.gbpLocationName) {
+        results.push({ outlet: s.outlet.name, status: "ok", location: match.name });
+        continue;
+      }
+      if (apply) {
+        await prisma.reviewSettings.update({
+          where: { outletId: s.outletId },
+          data: { gbpLocationName: match.name },
+        });
+        repaired++;
+      }
+      results.push({
+        outlet: s.outlet.name,
+        status: apply ? "repaired" : "mismatch",
+        stored: s.gbpLocationName,
+        correct: match.name,
+        gbpTitle: match.title,
+      });
+    } catch (e) {
+      results.push({ outlet: s.outlet.name, status: "error", error: (e as Error).message });
+    }
+  }
+
+  return NextResponse.json({ ok: true, mode: apply ? "apply" : "dry_run", checked: settings.length, repaired, results });
+}

--- a/apps/backoffice/src/lib/reviews/gbp.ts
+++ b/apps/backoffice/src/lib/reviews/gbp.ts
@@ -270,6 +270,35 @@ export async function getLocationGeo(
   };
 }
 
+// Every location in the GBP account, with the Places id Google holds for it.
+// This is the only way to map a public place id back to the internal
+// locations/NNN name — used to detect/repair outlets whose stored
+// gbpLocationName points at the wrong listing.
+export async function listAccountLocations(
+  accountId: string,
+): Promise<{ name: string; title: string | null; placeId: string | null }[]> {
+  const token = await getAccessToken();
+  const out: { name: string; title: string | null; placeId: string | null }[] = [];
+  let pageToken: string | undefined;
+  do {
+    const params = new URLSearchParams({ readMask: "name,title,metadata", pageSize: "100" });
+    if (pageToken) params.set("pageToken", pageToken);
+    const res = await fetch(`${GBP_INFO_BASE}/${accountId}/locations?${params}`, {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    if (!res.ok) {
+      const body = await res.text();
+      throw new Error(`GBP list locations error ${res.status}: ${body}`);
+    }
+    const data = await res.json();
+    for (const l of data.locations ?? []) {
+      out.push({ name: l.name, title: l.title ?? null, placeId: l.metadata?.placeId ?? null });
+    }
+    pageToken = data.nextPageToken;
+  } while (pageToken);
+  return out;
+}
+
 // The relevance-bearing profile fields — what Google reads to decide which
 // keywords this location is a match for. Input to the keyword relevance audit.
 export type GbpLocationProfile = {


### PR DESCRIPTION
## What & why

Tamarind's `ReviewSettings.gbpLocationName` carries **Shah Alam's** `locations/…` id, so its daily review snapshots, review feed and relevance audit all read the wrong shop (both outlets showed identical 1,486-review counts). The internal GBP location id can't be derived from any public identifier (it's not the CID or place id) — only the GBP account's own location list maps `placeId → locations/NNN`.

Each outlet's `gbpPlaceId` was verified against its geogrid scans and review-QR `g.page` tokens and set in prod, so a placeId match against the account listing is anchored to the outlet's real public identity.

## Changes

- **`lib/reviews/gbp.ts`** — `listAccountLocations(accountId)`: paginated Business Information API list (`name,title,metadata`).
- **`GET /api/reviews/gbp-relink`** (ADMIN session or cron secret) — audits every outlet that has `gbpAccountId` + `gbpPlaceId`, matching the account's listings by placeId. **Dry-run by default**; `?apply=1` repairs `gbpLocationName` where it provably mismatches. Touches nothing else, and reports `ok / mismatch / repaired / no_match / error` per outlet.

## After merge

1. Open (logged in as admin): `https://backoffice.celsiuscoffee.com/api/reviews/gbp-relink` → confirm the dry-run shows Tamarind as `mismatch` with the correct target.
2. Re-open with `?apply=1` → Tamarind repaired; tomorrow's 6:00 UTC snapshot cron starts reading the right listing.

## Verification

- Route follows the existing snapshot-cron auth pattern (cron secret OR admin session).
- `ReviewSettings.outletId` is `@unique` (checked) — the update targets exactly one row.
- No schema change; nothing runs automatically — the repair is an explicit click.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01KAg3qfmYoUCakrJNpQoMZJ)_