### PR TITLE
Finance: expense-month accrual recognition + management-fee income line

### DIFF
--- a/apps/backoffice/src/app/(admin)/finance/recon/page.tsx
+++ b/apps/backoffice/src/app/(admin)/finance/recon/page.tsx
@@ -16,7 +16,7 @@ type CashIn = {
   salesByChannel: { channel: string; amount: number }[];
   grab: { gross: number; settled: number; deductionPct: number | null };
 };
-type UnmatchedLine = { bankLineId: string; desc: string; date: string; amount: number; category: string | null };
+type UnmatchedLine = { bankLineId: string; desc: string; date: string; amount: number; category: string | null; expenseMonth: string | null };
 type ReconData = {
   summary: {
     auto: number; review: number; doublePayments: number; unmatchedInvoices: number;
@@ -564,7 +564,14 @@ function LineRow({ row, direction, categories, accountNames, selected, onToggle,
         <td className="px-3 py-2 align-top">
           <input type="checkbox" checked={selected} onChange={onToggle} className="h-3.5 w-3.5 accent-terracotta" />
         </td>
-        <td className="px-3 py-2 text-xs text-gray-500 whitespace-nowrap align-top">{row.date}</td>
+        <td className="px-3 py-2 text-xs text-gray-500 whitespace-nowrap align-top">
+          {row.date}
+          {row.expenseMonth && (
+            <div className="text-[10px] text-amber-600" title="Expense month override: this line sits in this month on the P&L">
+              → {row.expenseMonth}
+            </div>
+          )}
+        </td>
         <td className="px-3 py-2 text-xs text-gray-700 align-top">
           {row.desc}
           {note && <div className="mt-0.5 text-[10px] text-red-600">{note}</div>}
@@ -608,6 +615,12 @@ function LineRow({ row, direction, categories, accountNames, selected, onToggle,
             >
               <History className="h-3 w-3" />
             </button>
+            <ExpenseMonthControl
+              bankLineId={row.bankLineId}
+              txnMonth={row.date.slice(0, 7)}
+              override={row.expenseMonth}
+              onDone={onDone}
+            />
           </div>
         </td>
       </tr>
@@ -694,7 +707,7 @@ function LineRow({ row, direction, categories, accountNames, selected, onToggle,
 
 // Per-line audit trail (fin_bank_line_events), rendered as compact sentences
 // like "31 May, categorised RENT to EQUIPMENTS by Ammar".
-type LineEventValue = { category?: string | null; invoiceId?: string; invoiceNumber?: string | null; payee?: string | null; linkOnly?: boolean } | null;
+type LineEventValue = { category?: string | null; invoiceId?: string; invoiceNumber?: string | null; payee?: string | null; linkOnly?: boolean; expenseMonth?: string | null } | null;
 type LineEvent = { id: string; event: string; old_value: LineEventValue; new_value: LineEventValue; actor: string | null; created_at: string };
 
 const fmtEventDay = (iso: string) =>
@@ -711,6 +724,8 @@ function eventLabel(e: LineEvent): string {
       return `unmatched from invoice ${invoiceRef(e.old_value)}`;
     case "reject_match":
       return `rejected proposed match with invoice ${invoiceRef(e.new_value)}`;
+    case "expense_month":
+      return `moved expense month from ${e.old_value?.expenseMonth ?? "auto"} to ${e.new_value?.expenseMonth ?? "auto"}`;
     default:
       return e.event.replace(/_/g, " ");
   }
@@ -793,6 +808,57 @@ function OpenInvoicesTable({ rows }: { rows: { invoiceId: string; invoiceNumber:
       </table>
       {filtered.length > pageSize && <p className="px-3 py-2 text-[11px] text-gray-400">Showing {pageSize} of {filtered.length}. Increase rows above to see more.</p>}
     </div>
+  );
+}
+
+// Per-line expense-month override: the month this payment's cost belongs to
+// on the P&L (cash flow and the bank recon stay on the payment date). The
+// input is prefilled with the effective month (override if set, else the
+// transaction month); picking a month saves it, the x clears the override.
+function ExpenseMonthControl({ bankLineId, txnMonth, override, onDone }: {
+  bankLineId: string;
+  txnMonth: string;          // YYYY-MM from the transaction date
+  override: string | null;   // YYYY-MM override, or null
+  onDone: () => void;
+}) {
+  const [busy, setBusy] = useState(false);
+  const [err, setErr] = useState<string | null>(null);
+
+  async function save(expenseMonth: string | null) {
+    setBusy(true); setErr(null);
+    try {
+      const res = await fetch("/api/finance/bank-lines/expense-month", {
+        method: "POST", headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ bankLineId, expenseMonth }),
+      });
+      const j = await res.json();
+      if (!res.ok) setErr(j.error ?? `Failed (${res.status})`);
+      else onDone();
+    } catch (e) { setErr(e instanceof Error ? e.message : String(e)); }
+    finally { setBusy(false); }
+  }
+
+  return (
+    <span className="flex items-center gap-1" title="Expense month: which month this payment's cost sits in on the P&L. Cash flow keeps the payment date.">
+      {override && <span className="h-1.5 w-1.5 shrink-0 rounded-full bg-amber-500" title="Expense month overridden" />}
+      <input
+        type="month"
+        key={override ?? "auto"}
+        defaultValue={override ?? txnMonth}
+        disabled={busy}
+        onChange={(e) => { if (e.target.value && e.target.value !== (override ?? txnMonth)) save(e.target.value); }}
+        className="h-6 rounded border border-gray-200 bg-white px-1 text-[11px] text-gray-700 disabled:opacity-50"
+      />
+      {override && (
+        <button onClick={() => save(null)} disabled={busy}
+          title="Clear the override (back to the automatic expense month)"
+          className="text-[11px] text-gray-400 hover:text-gray-600 disabled:opacity-50">
+          ×
+        </button>
+      )}
+      {busy && <Loader2 className="h-3 w-3 animate-spin text-gray-400" />}
+      {err && <span className="text-[10px] text-red-600">{err}</span>}
+    </span>
   );
 }
 

--- a/apps/backoffice/src/app/(admin)/finance/reports/page.tsx
+++ b/apps/backoffice/src/app/(admin)/finance/reports/page.tsx
@@ -228,6 +228,7 @@ type PnlReport = {
   expenses: PnlSection;
   netIncome: number;
   txnCount: number;
+  notes?: string[];
 };
 
 type MatchedInvoice = { invoiceNumber: string | null; vendor: string | null; amount: number };
@@ -252,6 +253,10 @@ type DrillLine = {
     direction?: "DR" | "CR";
     apInvoiceId?: string | null;
     matchedInvoice?: MatchedInvoice | null;
+    // Expense-month recognition: the month (YYYY-MM) the P&L recognised the
+    // line in, and whether a per-line override drove it.
+    expenseMonth?: string | null;
+    expenseMonthOverride?: boolean;
     // Journal-backed rows: the posting agent ("bank" journals expand into
     // their source bank lines).
     glAgent?: string | null;
@@ -742,6 +747,9 @@ function PnlTab() {
             </tbody>
           </table>
         </div>
+        {(report.notes ?? []).map((n) => (
+          <p key={n} className="text-[11px] text-muted-foreground">{n}</p>
+        ))}
         </>
       )}
 
@@ -877,6 +885,62 @@ function MatchedChip({ bankLineId, invoice, onSaved }: {
           {busy ? <Loader2 className="h-3 w-3 animate-spin" /> : <X className="h-3 w-3" />}
         </button>
       </span>
+      {err && <span className="text-[10px] text-rose-600">{err}</span>}
+    </span>
+  );
+}
+
+// Expense-month control for a bank line in the drill: which month the P&L
+// recognises this line in. Prefilled with the effective month (override if
+// set, else the automatic recognition month); picking a month saves an
+// override, the x clears it. Cash Flow and the GL stay on the payment date.
+function ExpenseMonthControl({ bankLineId, effectiveMonth, overridden, onSaved }: {
+  bankLineId: string;
+  effectiveMonth: string; // YYYY-MM
+  overridden: boolean;
+  onSaved: () => Promise<void> | void;
+}) {
+  const [busy, setBusy] = useState(false);
+  const [err, setErr] = useState<string | null>(null);
+
+  async function save(expenseMonth: string | null) {
+    setBusy(true); setErr(null);
+    try {
+      const res = await fetch("/api/finance/bank-lines/expense-month", {
+        method: "POST", headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ bankLineId, expenseMonth }),
+      });
+      const j = await res.json();
+      if (!res.ok) setErr(j.error ?? `Failed (${res.status})`);
+      else await onSaved();
+    } catch (e) { setErr(e instanceof Error ? e.message : String(e)); }
+    finally { setBusy(false); }
+  }
+
+  return (
+    <span className="inline-flex items-center gap-1" onClick={(e) => e.stopPropagation()}>
+      {overridden && <span className="h-1.5 w-1.5 shrink-0 rounded-full bg-amber-500" title="Expense month overridden" />}
+      <input
+        type="month"
+        key={`${overridden}-${effectiveMonth}`}
+        defaultValue={effectiveMonth}
+        disabled={busy}
+        onChange={(e) => { if (e.target.value && e.target.value !== effectiveMonth) save(e.target.value); }}
+        className="h-6 rounded border bg-background px-1 text-[11px] disabled:opacity-60"
+        title="Expense month: which month this payment's cost sits in on the P&L. Cash flow keeps the payment date."
+      />
+      {overridden && (
+        <button
+          type="button"
+          disabled={busy}
+          onClick={() => save(null)}
+          title="Clear the override (back to the automatic expense month)"
+          className="text-muted-foreground transition hover:text-foreground disabled:opacity-60"
+        >
+          <X className="h-3 w-3" />
+        </button>
+      )}
+      {busy && <Loader2 className="h-3 w-3 animate-spin" />}
       {err && <span className="text-[10px] text-rose-600">{err}</span>}
     </span>
   );
@@ -1044,6 +1108,18 @@ function DrillDown({ code, start, end, outletId, consolidated, onChanged }: { co
                           {l.meta.matchedInvoice && (
                             <MatchedChip bankLineId={l.meta.bankLineId} invoice={l.meta.matchedInvoice} onSaved={refresh} />
                           )}
+                          {l.meta.expenseMonth && l.meta.expenseMonth !== l.txnDate.slice(0, 7) && (
+                            <span
+                              title={`Recognised in ${monthLabel(l.meta.expenseMonth)}; paid ${l.txnDate}`}
+                              className="inline-flex items-center gap-1 rounded-full border px-2 py-0.5 text-[11px] text-muted-foreground"
+                            >
+                              {l.meta.expenseMonthOverride && <span className="h-1.5 w-1.5 rounded-full bg-amber-500" />}
+                              in {monthLabel(l.meta.expenseMonth)}
+                            </span>
+                          )}
+                          {l.meta.expenseMonthOverride && l.meta.expenseMonth === l.txnDate.slice(0, 7) && (
+                            <span className="h-1.5 w-1.5 rounded-full bg-amber-500" title="Expense month overridden" />
+                          )}
                         </span>
                       )}
                     </span>
@@ -1074,6 +1150,19 @@ function DrillDown({ code, start, end, outletId, consolidated, onChanged }: { co
                       {l.meta.matchedInvoice && (<><dt className="text-muted-foreground">Matched invoice</dt><dd>{l.meta.matchedInvoice.invoiceNumber ?? "(no number)"}{l.meta.matchedInvoice.vendor ? ` · ${l.meta.matchedInvoice.vendor}` : ""} · {RM(l.meta.matchedInvoice.amount)}</dd></>)}
                       <><dt className="text-muted-foreground">Inter-company</dt><dd>{l.meta.isInterCo ? "yes" : "no"}</dd></>
                       {(l.meta.classifiedBy || l.meta.ruleName) && (<><dt className="text-muted-foreground">Classified</dt><dd>{l.meta.classifiedBy ?? "rule"}{l.meta.ruleName ? ` · ${l.meta.ruleName}` : ""}</dd></>)}
+                      {l.meta.bankLineId && l.meta.expenseMonth && (
+                        <>
+                          <dt className="text-muted-foreground">Expense month</dt>
+                          <dd>
+                            <ExpenseMonthControl
+                              bankLineId={l.meta.bankLineId}
+                              effectiveMonth={l.meta.expenseMonth}
+                              overridden={!!l.meta.expenseMonthOverride}
+                              onSaved={refresh}
+                            />
+                          </dd>
+                        </>
+                      )}
                     </dl>
                   </td>
                 </tr>

--- a/apps/backoffice/src/app/api/finance/ap-match/route.ts
+++ b/apps/backoffice/src/app/api/finance/ap-match/route.ts
@@ -31,7 +31,7 @@ export async function GET(req: NextRequest) {
           txnDate: { gte: new Date(Date.now() - sinceDays * 86400_000) },
           OR: [{ category: null }, { category: "OTHER_INFLOW" }],
         },
-        select: { id: true, description: true, txnDate: true, amount: true, category: true },
+        select: { id: true, description: true, txnDate: true, amount: true, category: true, expenseMonth: true },
         orderBy: { amount: "desc" },
         take: 300,
       }),
@@ -42,6 +42,7 @@ export async function GET(req: NextRequest) {
       date: l.txnDate.toISOString().slice(0, 10),
       amount: Math.round(Number(l.amount) * 100) / 100,
       category: l.category as string | null,
+      expenseMonth: l.expenseMonth ? l.expenseMonth.toISOString().slice(0, 7) : null,
     }));
     const summary = {
       auto: result.auto.length,

--- a/apps/backoffice/src/app/api/finance/bank-lines/expense-month/route.ts
+++ b/apps/backoffice/src/app/api/finance/bank-lines/expense-month/route.ts
@@ -1,0 +1,67 @@
+// POST /api/finance/bank-lines/expense-month: set or clear the per-line
+// expense-month override for accrual P&L recognition.
+// Body: { bankLineId, expenseMonth } or bulk { bankLineIds: string[], expenseMonth }
+// where expenseMonth is 'YYYY-MM' or null (null clears the override, the line
+// falls back to matched invoice month > category shift map > cash month).
+//
+// The override only moves WHICH MONTH the sourced P&L recognises the expense
+// in. The GL journal, Cash Flow statement and bank recon stay cash-dated, so
+// no journal re-key is needed (classify re-keys because the category changes
+// the ACCOUNT; the expense month changes neither account nor posting date).
+// The feed-sync rebuild carries expenseMonth across, so overrides survive the
+// 6-hourly rebuild (see bukku-feed-sync.ts).
+
+import { NextRequest, NextResponse } from "next/server";
+import { requireAuth } from "@/lib/auth";
+import { prisma } from "@/lib/prisma";
+import { logBankLineEvents } from "@/lib/finance/bank-line-events";
+
+export const dynamic = "force-dynamic";
+export const maxDuration = 30;
+
+const ymd = (d: Date | null) => (d ? d.toISOString().slice(0, 7) : null);
+
+export async function POST(req: NextRequest) {
+  const auth = await requireAuth(req);
+  if (auth.error) return auth.error;
+  if (!["OWNER", "ADMIN"].includes(auth.user.role)) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+  let body: { bankLineId?: string; bankLineIds?: string[]; expenseMonth?: string | null } = {};
+  try { body = await req.json(); } catch { /* handled below */ }
+  const ids = body.bankLineIds ?? (body.bankLineId ? [body.bankLineId] : []);
+  const expenseMonth = body.expenseMonth ?? null;
+  if (!ids.length) return NextResponse.json({ error: "bankLineId(s) required" }, { status: 400 });
+  if (ids.length > 200) return NextResponse.json({ error: "Max 200 lines per bulk update" }, { status: 400 });
+  if (expenseMonth !== null && !/^\d{4}-(0[1-9]|1[0-2])$/.test(expenseMonth)) {
+    return NextResponse.json({ error: "expenseMonth must be 'YYYY-MM' or null" }, { status: 400 });
+  }
+  const value = expenseMonth ? new Date(`${expenseMonth}-01T00:00:00.000Z`) : null;
+
+  const lines = await prisma.bankStatementLine.findMany({
+    where: { id: { in: ids } },
+    select: { id: true, expenseMonth: true },
+  });
+  if (!lines.length) return NextResponse.json({ error: "Bank lines not found" }, { status: 404 });
+  const changed = lines.filter((l) => ymd(l.expenseMonth) !== expenseMonth);
+
+  if (changed.length) {
+    await prisma.bankStatementLine.updateMany({
+      where: { id: { in: changed.map((l) => l.id) } },
+      data: { expenseMonth: value },
+    });
+    // Audit trail: one event per line with old and new month. Best-effort,
+    // the helper never throws.
+    await logBankLineEvents(
+      changed.map((l) => ({
+        lineId: l.id,
+        event: "expense_month" as const,
+        oldValue: { expenseMonth: ymd(l.expenseMonth) },
+        newValue: { expenseMonth },
+      })),
+      auth.user.name,
+    );
+  }
+
+  return NextResponse.json({ ok: true, updated: changed.length, expenseMonth });
+}

--- a/apps/backoffice/src/lib/finance/ap-match.ts
+++ b/apps/backoffice/src/lib/finance/ap-match.ts
@@ -67,7 +67,7 @@ export type ApMatchResult = {
   review: ApMatch[];
   multi: ApMultiMatch[];
   unmatchedInvoices: { invoiceId: string; invoiceNumber: string | null; payee: string; amount: number; issueDate: string }[];
-  unmatchedOutflows: { bankLineId: string; desc: string; date: string; amount: number; category: string | null }[];
+  unmatchedOutflows: { bankLineId: string; desc: string; date: string; amount: number; category: string | null; expenseMonth: string | null }[];
   doublePayments: ApMatch[];
 };
 
@@ -139,7 +139,7 @@ export async function proposeApMatches(opts: { sinceDays?: number } = {}): Promi
       direction: "DR", isInterCo: false, txnDate: { gte: since }, apInvoiceId: null,
       OR: [{ category: null }, { category: { notIn: NON_SUPPLIER_CATEGORIES } }],
     },
-    select: { id: true, description: true, amount: true, txnDate: true, category: true },
+    select: { id: true, description: true, amount: true, txnDate: true, category: true, expenseMonth: true },
   });
 
   // Index bank lines by rounded amount for fast candidate lookup.
@@ -298,7 +298,7 @@ export async function proposeApMatches(opts: { sinceDays?: number } = {}): Promi
   // (the real "needs review" cash-out the user asked to see).
   const unmatchedOutflows = lines
     .filter((l) => !usedBankLineIds.has(l.id) && (l.category === null || l.category === "OTHER_OUTFLOW"))
-    .map((l) => ({ bankLineId: l.id, desc: (l.description ?? "").replace(/\s+/g, " ").slice(0, 60), date: ymd(l.txnDate), amount: round2(Number(l.amount)), category: l.category as string | null }))
+    .map((l) => ({ bankLineId: l.id, desc: (l.description ?? "").replace(/\s+/g, " ").slice(0, 60), date: ymd(l.txnDate), amount: round2(Number(l.amount)), category: l.category as string | null, expenseMonth: l.expenseMonth ? ymd(l.expenseMonth).slice(0, 7) : null }))
     .sort((a, b) => b.amount - a.amount);
 
   // Human verdicts are final: a pair the owner rejected (or unmatched) never

--- a/apps/backoffice/src/lib/finance/bank-line-events.ts
+++ b/apps/backoffice/src/lib/finance/bank-line-events.ts
@@ -9,7 +9,7 @@ import { getFinanceClient } from "./supabase";
 
 export type BankLineEventInput = {
   lineId: string;
-  event: "classify" | "match" | "unmatch" | "reject_match";
+  event: "classify" | "match" | "unmatch" | "reject_match" | "expense_month";
   oldValue?: Record<string, unknown> | null;
   newValue?: Record<string, unknown> | null;
 };

--- a/apps/backoffice/src/lib/finance/bukku-feed-sync.ts
+++ b/apps/backoffice/src/lib/finance/bukku-feed-sync.ts
@@ -179,6 +179,7 @@ async function syncAccount(
           txnDate: true, amount: true, direction: true, description: true,
           category: true, classifiedBy: true, ruleName: true, isInterCo: true, outletId: true,
           glTransactionId: true, glPostedAt: true, apInvoiceId: true, apMatchedAt: true,
+          expenseMonth: true,
         },
         orderBy: [{ txnDate: "asc" }, { id: "asc" }],
       });
@@ -233,6 +234,9 @@ async function syncAccount(
           const data: CarryData = {};
           if (old.glTransactionId) { data.glTransactionId = old.glTransactionId; data.glPostedAt = old.glPostedAt; }
           if (old.apInvoiceId) { data.apInvoiceId = old.apInvoiceId; data.apMatchedAt = old.apMatchedAt; }
+          // Expense-month overrides are user state, they must survive the
+          // rebuild or the accrual P&L silently reverts within 6 hours.
+          if (old.expenseMonth) { data.expenseMonth = old.expenseMonth; }
           if (old.classifiedBy && old.classifiedBy !== "rule") {
             data.category = old.category; data.classifiedBy = old.classifiedBy; data.ruleName = old.ruleName;
             data.isInterCo = old.isInterCo; data.outletId = old.outletId;

--- a/apps/backoffice/src/lib/finance/reports/pnl-sourced-drill.ts
+++ b/apps/backoffice/src/lib/finance/reports/pnl-sourced-drill.ts
@@ -18,7 +18,7 @@ import { Prisma, type CashCategory } from "@prisma/client";
 import { getFinanceClient } from "../supabase";
 import { getDefaultCompanyId } from "../companies";
 import { depreciationByAsset } from "../fixed-assets";
-import { effectiveGrabRate } from "./pnl-sourced";
+import { effectiveGrabRate, fetchRecognisedBankLines } from "./pnl-sourced";
 import { getUnifiedSalesForOutlet } from "@/app/api/sales/_lib/unified-sales";
 
 const round2 = (n: number) => Math.round(n * 100) / 100;
@@ -47,6 +47,11 @@ export type DrillLine = {
     direction?: "DR" | "CR";
     apInvoiceId?: string | null;
     matchedInvoice?: MatchedInvoiceSummary | null;
+    // Expense-month recognition: the month (YYYY-MM) the P&L recognised this
+    // line in, and whether a per-line override drove it. Lets the UI flag
+    // lines whose expense month differs from their cash date.
+    expenseMonth?: string | null;
+    expenseMonthOverride?: boolean;
     // Journal-backed rows (ledger drill): the agent that posted the journal.
     // "bank" journals can expand into their source bank lines.
     glAgent?: string | null;
@@ -88,13 +93,6 @@ function companyForAccount(accountName: string | null): string {
   if (a.includes("4384") || a.includes("CELSIUS COFFEE SDN")) return "Celsius Coffee SB";
   return accountName ?? "—";
 }
-function addMonths(s: string, n: number): string {
-  const [y, m, d] = s.split("-").map(Number);
-  const t = new Date(Date.UTC(y, m - 1 + n, 1));
-  const lastDay = new Date(Date.UTC(t.getUTCFullYear(), t.getUTCMonth() + 1, 0)).getUTCDate();
-  return `${t.getUTCFullYear()}-${String(t.getUTCMonth() + 1).padStart(2, "0")}-${String(Math.min(d, lastDay)).padStart(2, "0")}`;
-}
-
 export function isSourcedPnlCode(code: string): boolean {
   return /^(REV-|PROC$|INV-|MKT-|BANK:|DEP$)/.test(code);
 }
@@ -274,8 +272,59 @@ async function drillDepreciation(companyId: string, start: string, end: string, 
   }));
 }
 
-// BANK:<CAT> — the classified bank lines behind the opex line. Also serves the
-// bank-sourced income lines (GastroHub, Meetings & Events) on the CR side.
+// BANK:<CAT> opex drill: the classified bank lines behind the line, using the
+// SAME expense-month recognition as buildSourcedPnl (per-line override >
+// matched invoice issue month > category shift map > cash month), so the
+// drill total ties to the line for shifted categories too. Also serves the
+// REV-MGMT income drill on the CR side.
+async function drillBankRecognised(
+  cat: string,
+  companyId: string,
+  start: string,
+  end: string,
+  outletId?: string | null,
+  direction: "DR" | "CR" = "DR",
+): Promise<DrillLine[]> {
+  const consolidated = companyId === CONSOLIDATED;
+  const suffix = BANK_ACCOUNT_SUFFIX[companyId];
+  if (!consolidated && !suffix) return [];
+  const all = await fetchRecognisedBankLines({
+    direction,
+    start,
+    end,
+    suffix: consolidated ? undefined : suffix,
+    consolidated,
+    outletId,
+  });
+  const lines = all.filter((l) => (cat === "NULL" ? l.category === null : l.category === cat));
+  const invById = await matchedInvoiceSummaries(lines.map((l) => l.apInvoiceId));
+  return lines.map((l) => ({
+    transactionId: l.id,
+    txnDate: l.txnDate,
+    description: l.description || "(no description)",
+    amount: l.amount,
+    debit: direction === "DR" ? l.amount : 0,
+    credit: direction === "CR" ? l.amount : 0,
+    meta: {
+      reference: l.reference,
+      category: l.category,
+      company: companyForAccount(l.accountName),
+      account: l.accountName,
+      isInterCo: l.isInterCo,
+      classifiedBy: l.classifiedBy,
+      ruleName: l.ruleName,
+      bankLineId: l.id,
+      direction,
+      apInvoiceId: l.apInvoiceId,
+      matchedInvoice: l.apInvoiceId ? invById.get(l.apInvoiceId) ?? null : null,
+      expenseMonth: l.recognisedMonth,
+      expenseMonthOverride: l.hasOverride,
+    },
+  }));
+}
+
+// Cash-dated CR drill for the bank-sourced income lines (GastroHub,
+// Meetings & Events), those P&L lines aggregate at the transaction date.
 async function drillBank(cat: string, companyId: string, start: string, end: string, outletId?: string | null, direction: "DR" | "CR" = "DR"): Promise<DrillLine[]> {
   const consolidated = companyId === CONSOLIDATED;
   const suffix = BANK_ACCOUNT_SUFFIX[companyId];
@@ -336,17 +385,20 @@ export async function sourcedPnlDrillDown(args: {
   // no POS orders behind them) — must route before the generic REV-* branch.
   if (code === "REV-GASTRO") return drillBank("GASTROHUB", companyId, start, end, outletId, "CR");
   if (code === "REV-EVENTS") return drillBank("MEETINGS_EVENTS", companyId, start, end, outletId, "CR");
+  // Management fee income (HQ side): the MANAGEMENT_FEE inflow lines, with the
+  // same one-month-arrears recognition as the P&L line.
+  if (code === "REV-MGMT") return drillBankRecognised("MANAGEMENT_FEE", companyId, start, end, outletId, "CR");
   if (code.startsWith("REV-")) return drillRevenue(code, companyId, start, end, outletId);
   if (code === "PROC") return drillPurchases(companyId, start, end, outletId);
   if (code === "MKT-ADS") return drillAds(companyId, start, end, outletId);
   if (code === "MKT-GRAB-PROMO") return drillGrabPromo(companyId, start, end, outletId);
   if (code === "MKT-GRAB-ADS") return drillGrabAds(companyId, start, end, outletId);
   if (code === "DEP") return drillDepreciation(companyId, start, end, outletId);
-  // Management fee is recognised on accrual (paid a month in arrears), so its
-  // drill uses the same shifted window as the P&L line — payments in the
-  // following month, which are this period's fee.
-  if (code === "BANK:MANAGEMENT_FEE") return drillBank("MANAGEMENT_FEE", companyId, addMonths(start, 1), addMonths(end, 1), outletId);
-  if (code.startsWith("BANK:")) return drillBank(code.slice(5), companyId, start, end, outletId);
+  // Every opex bank line drills through the shared expense-month recognition
+  // (override > matched invoice month > category shift > cash), so shifted
+  // categories like management fee, salary, utilities and statutory tie to
+  // their accrual-recognised P&L lines.
+  if (code.startsWith("BANK:")) return drillBankRecognised(code.slice(5), companyId, start, end, outletId);
   if (code === "MKT-GRAB-COMM") {
     // A derived line, not transactions — the drawer explains the calculation.
     const [rev, gr] = await Promise.all([

--- a/apps/backoffice/src/lib/finance/reports/pnl-sourced.ts
+++ b/apps/backoffice/src/lib/finance/reports/pnl-sourced.ts
@@ -53,6 +53,154 @@ const BANK_NONOPEX = new Set([                                                  
 // auto-match re-tags them. Visible so it can't silently inflate the P&L.
 const BANK_REVIEW = new Set(["OTHER_OUTFLOW"]);
 
+// ─── Expense-month accrual: the category shift map ──────────────────────────
+// "A payment in month N belongs to month N + shift." The P&L recognises a
+// shifted category's expense for [start, end] from the payments dated in
+// [start - shift, end - shift] (for shift -1 that is the following month),
+// the same window arithmetic the bespoke management-fee block used before it
+// was generalised here. A per-line expenseMonth override (set from the recon
+// page or the P&L drill) always outranks this map, and an AP-matched opex
+// line outranks it with its invoice issue month. Cash Flow, the cashflow
+// projections and the bank recon tie stay strictly cash-dated.
+export const EXPENSE_MONTH_SHIFT: Record<string, number> = {
+  MANAGEMENT_FEE: -1,   // HQ bills one month in arrears
+  EMPLOYEE_SALARY: -1,  // salary paid early in month N pays for month N-1 work
+  UTILITIES: -1,        // TNB and water bill the prior month's usage
+  STATUTORY_PAYMENT: -1, // EPF/SOCSO/EIS/PCB due by the 15th for the prior month
+};
+// PARTIMER is deliberately NOT shifted: the owner wants part timer wages
+// matched to HR payroll runs in a later phase, so they stay on a cash basis
+// until then. RENT is unshifted too, it is paid in the month, for the month.
+
+// P&L line-name suffix for shift-recognised categories.
+const ACCRUED_SUFFIX = " (accrued, paid the following month)";
+
+// Categories that feed the P&L as their own opex line (not COGS, not
+// non-operating, not the digital-ads dedup, not the flagged review pile).
+// Only these keep an AP-matched bank line in opex, recognised at the matched
+// invoice's issue month; AP-matched lines outside this set settle a
+// procurement invoice already counted in COGS purchases and stay excluded.
+function isOpexFeedCategory(cat: string | null): boolean {
+  if (!cat) return false;
+  return !BANK_COGS.has(cat) && !BANK_NONOPEX.has(cat) && !BANK_DIGITAL_ADS.has(cat) && !BANK_REVIEW.has(cat);
+}
+
+export type RecognisedBankLine = {
+  id: string;
+  txnDate: string;         // cash date, YYYY-MM-DD
+  description: string;
+  reference: string | null;
+  amount: number;
+  category: string | null;
+  isInterCo: boolean;
+  classifiedBy: string | null;
+  ruleName: string | null;
+  apInvoiceId: string | null;
+  accountName: string | null;
+  outletId: string | null;
+  recognisedDate: string;  // the date the P&L recognises the line at
+  recognisedMonth: string; // YYYY-MM of recognisedDate
+  recognisedBy: "override" | "invoice" | "shift" | "cash";
+  hasOverride: boolean;
+};
+
+// Bank lines with their effective expense-month recognition applied, for a
+// P&L period [start, end]. Shared by buildSourcedPnl and the drill so the
+// drill total always ties to the line amount. Precedence per line:
+//   expenseMonth override > matched invoice issue month (DR opex only)
+//   > category shift map > cash month.
+// Inclusion is by recognisedDate within [start, end]; the fetch window covers
+// the following month (shift -1 pulls payments from there) plus any line
+// whose override drags it into the period from further away.
+export async function fetchRecognisedBankLines(args: {
+  direction: "DR" | "CR";
+  start: string;
+  end: string;
+  suffix?: string;          // company bank-account tail (per-company view)
+  consolidated?: boolean;   // all accounts, inter-company legs dropped
+  outletId?: string | null;
+  excludeInterCo?: boolean;
+}): Promise<RecognisedBankLine[]> {
+  const { direction, start, end, suffix, consolidated, outletId, excludeInterCo } = args;
+  if (!consolidated && !suffix) return [];
+  const monthFirst = (s: string) => `${s.slice(0, 7)}-01`;
+  const rows = await prisma.bankStatementLine.findMany({
+    where: {
+      direction,
+      ...(consolidated ? { isInterCo: false } : { statement: { accountName: { contains: suffix ?? "" } } }),
+      ...(outletId ? { outletId } : {}),
+      ...(excludeInterCo ? { isInterCo: false } : {}),
+      OR: [
+        { txnDate: { gte: dStart(start), lte: dEnd(addMonths(end, 1)) } },
+        { expenseMonth: { gte: dStart(monthFirst(start)), lte: dEnd(monthFirst(end)) } },
+      ],
+    },
+    select: {
+      id: true, txnDate: true, description: true, reference: true, amount: true,
+      category: true, isInterCo: true, classifiedBy: true, ruleName: true,
+      apInvoiceId: true, expenseMonth: true, outletId: true,
+      statement: { select: { accountName: true } },
+    },
+    orderBy: { txnDate: "asc" },
+  });
+
+  // AP-matched DR lines: settled procurement invoices (COGS) drop out of opex
+  // entirely; matched OPEX lines stay and recognise at the invoice issue
+  // month. One batched lookup, no per-line queries.
+  const kept = rows.filter((l) => {
+    if (direction === "CR" || !l.apInvoiceId) return true;
+    return isOpexFeedCategory((l.category as string | null) ?? null);
+  });
+  const invoiceIds = [...new Set(kept.filter((l) => direction === "DR" && l.apInvoiceId).map((l) => l.apInvoiceId as string))];
+  const issueById = new Map<string, string>();
+  if (invoiceIds.length) {
+    const invoices = await prisma.invoice.findMany({
+      where: { id: { in: invoiceIds } },
+      select: { id: true, issueDate: true },
+    });
+    for (const inv of invoices) issueById.set(inv.id, ymd(inv.issueDate));
+  }
+
+  const out: RecognisedBankLine[] = [];
+  for (const l of kept) {
+    const cat = (l.category as string | null) ?? null;
+    const txn = ymd(l.txnDate);
+    let recognisedDate = txn;
+    let recognisedBy: RecognisedBankLine["recognisedBy"] = "cash";
+    if (l.expenseMonth) {
+      recognisedDate = ymd(l.expenseMonth);
+      recognisedBy = "override";
+    } else if (direction === "DR" && l.apInvoiceId && issueById.has(l.apInvoiceId)) {
+      recognisedDate = issueById.get(l.apInvoiceId)!;
+      recognisedBy = "invoice";
+    } else if (cat && EXPENSE_MONTH_SHIFT[cat]) {
+      recognisedDate = addMonths(txn, EXPENSE_MONTH_SHIFT[cat]);
+      recognisedBy = "shift";
+    }
+    if (recognisedDate < start || recognisedDate > end) continue;
+    out.push({
+      id: l.id,
+      txnDate: txn,
+      description: l.description,
+      reference: l.reference,
+      amount: round2(Number(l.amount)),
+      category: cat,
+      isInterCo: l.isInterCo,
+      classifiedBy: l.classifiedBy,
+      ruleName: l.ruleName,
+      apInvoiceId: l.apInvoiceId,
+      accountName: l.statement?.accountName ?? null,
+      outletId: l.outletId,
+      recognisedDate,
+      recognisedMonth: recognisedDate.slice(0, 7),
+      recognisedBy,
+      hasOverride: !!l.expenseMonth,
+    });
+  }
+  out.sort((a, b) => a.recognisedDate.localeCompare(b.recognisedDate) || a.txnDate.localeCompare(b.txnDate));
+  return out;
+}
+
 // GrabFood revenue is booked GROSS in income, but Grab deducts a commission
 // (marketplace fee) at source before paying out — so it never appears in the
 // bank feed and must be recognised as a cost here, else Grab margin is wildly
@@ -254,6 +402,8 @@ export async function buildSourcedPnl(input: {
     : [];
   const rev = { instore: 0, online: 0, grab: 0, foodpanda: 0 };
   let saleCount = 0;
+  // Any accrual-shifted line in the period adds a short note to the report.
+  let shiftedPresent = false;
   const perOutlet = await Promise.all(
     outletRows.map((o) =>
       getUnifiedSalesForOutlet(
@@ -309,6 +459,25 @@ export async function buildSourcedPnl(input: {
           : { code: "REV-EVENTS", name: "Meetings and events sales", amount: amt, parentCode: null },
       );
       totalIncome = round2(totalIncome + amt);
+    }
+
+    // Management fee INCOME (HQ side): the fee the group outlets pay lands as
+    // a MANAGEMENT_FEE inflow in this company's account. Bukku's books carried
+    // these receipts on account 5007 Management fees, so they keep their own
+    // revenue line here rather than folding into sales. Recognised with the
+    // same one-month-arrears shift as the expense side, and the lines are
+    // flagged isInterCo so the consolidated view (excludeInterCo) eliminates
+    // them against the outlets' management-fee expense.
+    const feeInflows = await fetchRecognisedBankLines({
+      direction: "CR", start, end, suffix: incomeSuffix, outletId, excludeInterCo,
+    });
+    const mgmtFeeIncome = round2(
+      feeInflows.filter((l) => l.category === "MANAGEMENT_FEE").reduce((s, l) => s + l.amount, 0),
+    );
+    if (mgmtFeeIncome) {
+      incomeLines.push({ code: "REV-MGMT", name: "Management fees (from group outlets)", amount: mgmtFeeIncome, parentCode: null });
+      totalIncome = round2(totalIncome + mgmtFeeIncome);
+      shiftedPresent = true;
     }
   }
 
@@ -434,59 +603,36 @@ export async function buildSourcedPnl(input: {
     totalExpenses += grabComm;
   }
 
-  // Bank-classified outflows for this company's account.
+  // Bank-classified outflows for this company's account, each line recognised
+  // in its expense month (per-line override > matched invoice issue month >
+  // category shift map > cash month). The shift map replaced the bespoke
+  // management-fee accrual block; the window arithmetic is unchanged.
   const suffix = BANK_ACCOUNT_SUFFIX[companyId];
   if (suffix) {
-    const grouped = await prisma.bankStatementLine.groupBy({
-      by: ["category"],
-      where: {
-        direction: "DR",
-        txnDate: { gte: dStart(start), lte: dEnd(end) },
-        statement: { accountName: { contains: suffix } },
-        apInvoiceId: null, // AP-matched lines settle a procurement invoice (COGS) — not opex
-        ...(outletId ? { outletId } : {}), // per-outlet: only outlet-tagged costs
-        ...(excludeInterCo ? { isInterCo: false } : {}),
-      },
-      _sum: { amount: true },
-    });
-    for (const g of grouped) {
-      const cat = (g.category as string | null) ?? null;
-      const amt = round2(Number(g._sum?.amount ?? 0));
+    const opexLines = await fetchRecognisedBankLines({ direction: "DR", start, end, suffix, outletId, excludeInterCo });
+    const byCat = new Map<string, number>();
+    for (const l of opexLines) {
+      const cat = l.category;
+      if (cat && (BANK_COGS.has(cat) || BANK_NONOPEX.has(cat) || BANK_DIGITAL_ADS.has(cat))) continue;
+      byCat.set(cat ?? "NULL", (byCat.get(cat ?? "NULL") ?? 0) + l.amount);
+    }
+    for (const [key, sum] of byCat) {
+      const cat = key === "NULL" ? null : key;
+      const amt = round2(sum);
       if (!amt) continue;
-      // MANAGEMENT_FEE is recognised on an ACCRUAL basis below (paid in arrears
-      // for the previous month), not at the cash date — skip it here.
-      if (cat && (BANK_COGS.has(cat) || BANK_NONOPEX.has(cat) || BANK_DIGITAL_ADS.has(cat) || cat === "MANAGEMENT_FEE")) continue;
       const isReview = !cat || BANK_REVIEW.has(cat);
       const isMkt = !!cat && BANK_MARKETING.has(cat);
+      const isShifted = !!cat && !!EXPENSE_MONTH_SHIFT[cat];
+      if (isShifted) shiftedPresent = true;
       expenseLines.push({
         code: `BANK:${cat ?? "NULL"}`,
-        name: isReview ? "Unclassified (pending AP match review)" : humanCat(cat) + (isMkt ? " (marketing)" : ""),
+        name: isReview
+          ? "Unclassified (pending AP match review)"
+          : humanCat(cat) + (isMkt ? " (marketing)" : "") + (isShifted ? ACCRUED_SUFFIX : ""),
         amount: amt,
         parentCode: null,
       });
       totalExpenses += amt;
-    }
-
-    // Management fee accrual: HQ bills a month in arrears, so the fee that
-    // BELONGS to this period [start,end] is the one PAID the following month.
-    // Recognise payments in [start+1mo, end+1mo] as this period's expense — so
-    // a month's P&L carries its own fee, not the prior month's cash payment.
-    const mfAgg = await prisma.bankStatementLine.aggregate({
-      _sum: { amount: true },
-      where: {
-        direction: "DR",
-        category: "MANAGEMENT_FEE",
-        txnDate: { gte: dStart(addMonths(start, 1)), lte: dEnd(addMonths(end, 1)) },
-        statement: { accountName: { contains: suffix } },
-        apInvoiceId: null,
-        ...(outletId ? { outletId } : {}),
-        ...(excludeInterCo ? { isInterCo: false } : {}),
-      },
-    });
-    const mfAmt = round2(Number(mfAgg._sum?.amount ?? 0));
-    if (mfAmt) {
-      expenseLines.push({ code: "BANK:MANAGEMENT_FEE", name: "Management fee (accrued, paid the following month)", amount: mfAmt, parentCode: null });
-      totalExpenses += mfAmt;
     }
   }
 
@@ -522,8 +668,15 @@ export async function buildSourcedPnl(input: {
     expenses: { type: "expense", total: totalExpenses, lines: expenseLines },
     netIncome,
     txnCount: saleCount,
+    // Boundary honesty: with a one-month-arrears shift, the newest month of a
+    // report only fills once the following month's payments are recorded.
+    ...(shiftedPresent ? { notes: [ACCRUAL_NOTE] } : {}),
   };
 }
+
+// Shown under the P&L whenever a shift-recognised line is present.
+const ACCRUAL_NOTE =
+  "Accrued lines are shown in the month the cost belongs to, not the payment month. The latest month completes once the following month's payments land.";
 
 // ─── Consolidated P&L — the GROUP statement ─────────────────────────────────
 // Per-company P&Ls distort where the group pays centrally: HQ carries all
@@ -557,6 +710,7 @@ export async function buildConsolidatedPnl(input: { start: string; end: string }
   const income = mergeLines(reports.map((r) => r.income.lines));
   const cogs = mergeLines(reports.map((r) => r.cogs.lines));
   const expenses = mergeLines(reports.map((r) => r.expenses.lines));
+  const notes = [...new Set(reports.flatMap((r) => r.notes ?? []))];
   const totalIncome = round2(reports.reduce((s, r) => s + r.income.total, 0));
   const cogsTotal = round2(reports.reduce((s, r) => s + r.cogs.total, 0));
   const totalExpenses = round2(reports.reduce((s, r) => s + r.expenses.total, 0));
@@ -572,5 +726,6 @@ export async function buildConsolidatedPnl(input: { start: string; end: string }
     expenses: { type: "expense", total: totalExpenses, lines: expenses },
     netIncome: round2(grossProfit - totalExpenses),
     txnCount: reports.reduce((s, r) => s + r.txnCount, 0),
+    ...(notes.length ? { notes } : {}),
   };
 }

--- a/apps/backoffice/src/lib/finance/reports/pnl.ts
+++ b/apps/backoffice/src/lib/finance/reports/pnl.ts
@@ -35,6 +35,8 @@ export type PnlReport = {
   expenses: PnlSection;
   netIncome: number;
   txnCount: number;
+  // Optional reader notes (e.g. the sourced P&L's accrual boundary note).
+  notes?: string[];
 };
 
 export type PnlInput = {

--- a/packages/db/prisma/migrations/20260705_bankline_expense_month/migration.sql
+++ b/packages/db/prisma/migrations/20260705_bankline_expense_month/migration.sql
@@ -1,0 +1,4 @@
+-- Per-line expense-month override for accrual P&L recognition: first day of
+-- the month the payment's expense belongs to. Null = derive from the category
+-- shift map / matched invoice / cash date. Cash Flow and GL stay cash-dated.
+ALTER TABLE "BankStatementLine" ADD COLUMN IF NOT EXISTS "expenseMonth" DATE;

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -2058,6 +2058,10 @@ model BankStatementLine {
   // posted; null = not yet in the ledger. Idempotency key for the poster.
   glTransactionId String?
   glPostedAt      DateTime?
+  // Per-line expense-month override for the accrual P&L: first day of the
+  // month this payment's expense belongs to. Null = derive from the category
+  // shift map / matched invoice / cash date. Cash Flow and GL stay cash-dated.
+  expenseMonth    DateTime? @db.Date
   notes           String?
   createdAt       DateTime @default(now())
   updatedAt       DateTime @updatedAt


### PR DESCRIPTION
Puts opex under its month of expense instead of the cash-out date, and adds the HQ management-fee income line.

## Category shift map
`EXPENSE_MONTH_SHIFT` in `apps/backoffice/src/lib/finance/reports/pnl-sourced.ts`: a payment in month N belongs to month N + shift.
- `MANAGEMENT_FEE: -1` (replaces the bespoke accrual block, identical output)
- `EMPLOYEE_SALARY: -1` (paid early month N for month N-1 work)
- `UTILITIES: -1` (TNB and water bill the prior month)
- `STATUTORY_PAYMENT: -1` (EPF/SOCSO/EIS/PCB paid by the 15th for the prior month)
- `PARTIMER` and `RENT` deliberately unshifted (part timer wages will match HR payroll runs in a later phase)

Shifted P&L lines get the "(accrued, paid the following month)" suffix, and the P&L shows a short note that the latest month completes once the following month's payments land.

## Precedence chain (per line)
per-line `expenseMonth` override > matched invoice issue month (AP-matched opex lines, batched lookup) > category shift map > cash month. Implemented once in `fetchRecognisedBankLines` and shared by the P&L build and the drill, so drill totals always tie.

## Per-line override
- `BankStatementLine.expenseMonth` (nullable DATE), migration at `packages/db/prisma/migrations/20260705_bankline_expense_month/migration.sql` (not applied to any DB; additive column, applies on deploy).
- New route `POST /api/finance/bank-lines/expense-month` accepting `{ bankLineIds, expenseMonth: 'YYYY-MM' | null }`, Owner/Admin only, writes an `expense_month` audit event per line. GL journals untouched: posting keys on the cash txnDate and the account, neither changes.
- **Carry-over**: wired into the feed-rebuild snapshot in `apps/backoffice/src/lib/finance/bukku-feed-sync.ts` (old-line select + restore batch, next to glTransactionId/apInvoiceId/user classifications), so overrides survive the 6-hourly rebuild.
- UI: month input in the recon categorise tab per-line controls and in the P&L drill expanded row, prefilled with the effective month, clear button and amber dot when overridden; drilled lines show the recognised month when it differs from the cash date.

## Management-fee income (HQ)
`REV-MGMT` "Management fees (from group outlets)" on the receiving company's P&L, built from MANAGEMENT_FEE bank inflows with the same -1 shift (Bukku booked these to account 5007). Lines are isInterCo, so the consolidated P&L eliminates income and expense together. Drill lists the inflow lines.

## Verified against production data (read-only)
- Conezion Apr-Jun MANAGEMENT_FEE expense: RM26,505.18 before and after (generalised shift reproduces the bespoke block exactly).
- SB standalone Apr-Jun shows REV-MGMT RM43,339.02; drill lists the Conezion and Tamarind transfers and ties to the line.
- June accrual shapes: SB salary June = RM59,681.90 (July payment) vs RM63,587.20 cash; utilities and statutory June empty until July bills land (covered by the P&L note); PARTIMER and RENT unchanged on cash.
- Consolidated Apr-Jun: no REV-MGMT and no BANK:MANAGEMENT_FEE (both eliminated).
- byMonth cross-foot: Apr+May+Jun sums equal the full-period figure for every bank-sourced code.
- Cash Flow, cashflow projections and the bank recon tie are untouched (cash-dated by definition).

Typecheck and eslint clean on touched files.