### PR TITLE
fix(finance): Balance Sheet and Cash Flow page past Supabase's 1000-row cap

### DIFF
--- a/apps/backoffice/src/lib/finance/reports/balance-sheet.ts
+++ b/apps/backoffice/src/lib/finance/reports/balance-sheet.ts
@@ -21,6 +21,7 @@
 // booked to 3600 (INTERCO_PEOPLE), so they are not cross-company mirrors.
 
 import { getFinanceClient } from "../supabase";
+import { pagedJournalLines, pagedPostedTxns } from "./paged";
 
 export const CONSOLIDATED_COMPANY_ID = "consolidated";
 
@@ -83,23 +84,19 @@ export async function buildBalanceSheet(input: BsInput): Promise<BsReport> {
 
   // Posted txns through asOf. Consolidated = every active company's ledger;
   // summing all their journal lines per account IS the group balance.
-  let txnQuery = client
-    .from("fin_transactions")
-    .select("id, txn_date")
-    .eq("status", "posted")
-    .lte("txn_date", input.asOf);
+  // Paged reads: the ledger outgrew Supabase's 1000-row cap, which silently
+  // truncated this walk and made the BS disagree with the TB and GL.
+  let companyIds: string[];
   if (consolidated) {
     const { data: cos } = await client
       .from("fin_companies")
       .select("id")
       .eq("is_active", true);
-    txnQuery = txnQuery.in("company_id", (cos ?? []).map((c) => c.id as string));
+    companyIds = (cos ?? []).map((c) => c.id as string);
   } else {
-    txnQuery = txnQuery.eq("company_id", input.companyId);
+    companyIds = [input.companyId];
   }
-  const { data: txns } = await txnQuery;
-  const txnIds = (txns ?? []).map((t) => t.id as string);
-  const txnDate = new Map((txns ?? []).map((t) => [t.id as string, t.txn_date as string]));
+  const { txnIds, txnDate } = await pagedPostedTxns(companyIds, input.asOf);
 
   const byCode = new Map<string, number>();
   let pnlYtd = 0;     // current fiscal year earnings → synthetic equity line
@@ -110,14 +107,8 @@ export async function buildBalanceSheet(input: BsInput): Promise<BsReport> {
   let intercoNet = 0;
 
   if (txnIds.length > 0) {
-    const chunkSize = 200;
-    for (let i = 0; i < txnIds.length; i += chunkSize) {
-      const chunk = txnIds.slice(i, i + chunkSize);
-      const { data: lines } = await client
-        .from("fin_journal_lines")
-        .select("transaction_id, account_code, debit, credit")
-        .in("transaction_id", chunk);
-      for (const l of lines ?? []) {
+    for await (const lines of pagedJournalLines(txnIds)) {
+      for (const l of lines) {
         const code = l.account_code as string;
         const meta = accountMeta.get(code);
         if (!meta) continue;

--- a/apps/backoffice/src/lib/finance/reports/cash-flow.ts
+++ b/apps/backoffice/src/lib/finance/reports/cash-flow.ts
@@ -27,6 +27,7 @@
 
 import { getFinanceClient } from "../supabase";
 import { CONSOLIDATED_COMPANY_ID } from "./balance-sheet";
+import { pagedJournalLines, pagedPostedTxns } from "./paged";
 
 export type CfSection = {
   title: string;
@@ -88,35 +89,26 @@ export async function buildCashFlow(input: CfInput): Promise<CfReport> {
 
   // One ledger walk: every posted txn through the period end. Consolidated
   // spans all active companies, so cash and every bucket sum across the group.
-  let txnQuery = client
-    .from("fin_transactions")
-    .select("id, txn_date")
-    .eq("status", "posted")
-    .lte("txn_date", input.end);
+  // Paged reads: the ledger outgrew Supabase's 1000-row cap, which silently
+  // truncated this walk and made the CF disagree with the TB and GL.
+  let companyIds: string[];
   if (consolidated) {
     const { data: cos } = await client
       .from("fin_companies")
       .select("id")
       .eq("is_active", true);
-    txnQuery = txnQuery.in("company_id", (cos ?? []).map((c) => c.id as string));
+    companyIds = (cos ?? []).map((c) => c.id as string);
   } else {
-    txnQuery = txnQuery.eq("company_id", input.companyId);
+    companyIds = [input.companyId];
   }
-  const { data: txns } = await txnQuery;
-  const txnDate = new Map((txns ?? []).map((t) => [t.id as string, t.txn_date as string]));
-  const txnIds = [...txnDate.keys()];
+  const { txnIds, txnDate } = await pagedPostedTxns(companyIds, input.end);
 
   let cashAtStart = 0;
   let cashAtEnd = 0;
   const flows = new Map<BucketKey, number>(); // (credit − debit) per bucket, in-range only
 
-  for (let i = 0; i < txnIds.length; i += 200) {
-    const chunk = txnIds.slice(i, i + 200);
-    const { data: lines } = await client
-      .from("fin_journal_lines")
-      .select("transaction_id, account_code, debit, credit")
-      .in("transaction_id", chunk);
-    for (const l of lines ?? []) {
+  for await (const lines of pagedJournalLines(txnIds)) {
+    for (const l of lines) {
       const date = txnDate.get(l.transaction_id as string) ?? "";
       const code = l.account_code as string;
       const debit = Number(l.debit);

--- a/apps/backoffice/src/lib/finance/reports/paged.ts
+++ b/apps/backoffice/src/lib/finance/reports/paged.ts
@@ -1,0 +1,64 @@
+// Paged ledger reads. Supabase caps unpaged selects at 1000 rows, which
+// silently truncated whole-ledger walks once the journal count grew past
+// that: the Balance Sheet and Cash Flow disagreed with the Trial Balance
+// and General Ledger (which already page) on high-volume accounts.
+import { getFinanceClient } from "../supabase";
+
+const PAGE = 1000;
+
+// Every posted transaction id (with its date) for the companies through `to`.
+export async function pagedPostedTxns(
+  companyIds: string[],
+  to: string
+): Promise<{ txnIds: string[]; txnDate: Map<string, string> }> {
+  const client = getFinanceClient();
+  const txnIds: string[] = [];
+  const txnDate = new Map<string, string>();
+  for (let offset = 0; ; offset += PAGE) {
+    const { data } = await client
+      .from("fin_transactions")
+      .select("id, txn_date")
+      .eq("status", "posted")
+      .lte("txn_date", to)
+      .in("company_id", companyIds)
+      .order("txn_date", { ascending: true })
+      .order("id", { ascending: true })
+      .range(offset, offset + PAGE - 1);
+    for (const t of data ?? []) {
+      txnIds.push(t.id as string);
+      txnDate.set(t.id as string, t.txn_date as string);
+    }
+    if (!data || data.length < PAGE) break;
+  }
+  return { txnIds, txnDate };
+}
+
+export type PagedJournalLine = {
+  transaction_id: string;
+  account_code: string;
+  debit: number;
+  credit: number;
+};
+
+// Journal lines for the given transactions, chunked and paged within each
+// chunk: 200 txns can carry more than 1000 lines (EOD sales journals post
+// many legs), so the chunk read pages too.
+export async function* pagedJournalLines(
+  txnIds: string[]
+): AsyncGenerator<PagedJournalLine[]> {
+  const client = getFinanceClient();
+  for (let i = 0; i < txnIds.length; i += 200) {
+    const chunk = txnIds.slice(i, i + 200);
+    for (let offset = 0; ; offset += PAGE) {
+      const { data } = await client
+        .from("fin_journal_lines")
+        .select("transaction_id, account_code, debit, credit")
+        .in("transaction_id", chunk)
+        .order("transaction_id", { ascending: true })
+        .order("line_order", { ascending: true })
+        .range(offset, offset + PAGE - 1);
+      yield (data ?? []) as PagedJournalLine[];
+      if (!data || data.length < PAGE) break;
+    }
+  }
+}


### PR DESCRIPTION
The BS and CF builders walked the ledger with unpaged selects. Supabase
returns at most 1000 rows per select, and the journal count outgrew that,
so both statements silently dropped most of the ledger on high-volume
accounts: live, 1000-01 showed RM 129,348.48 on the BS while the Trial
Balance and General Ledger (which already page) showed -18,141.63 for the
same scope. The per-chunk journal line reads could also exceed 1000 rows.

New shared paged.ts (pagedPostedTxns + pagedJournalLines, following the
gl-reports pattern) and both builders now walk the full ledger.
