### PR TITLE
fix(hr): employee Performance tab crashed on the v2 allowance shape

### DIFF
--- a/apps/backoffice/src/app/(admin)/hr/employees/[id]/page.tsx
+++ b/apps/backoffice/src/app/(admin)/hr/employees/[id]/page.tsx
@@ -71,15 +71,33 @@ const MY_BANKS = [
   "MBSB Bank", "Touch 'n Go eWallet", "GXBank", "Aeon Bank",
 ];
 
+type AllowanceLever = {
+  key: string;
+  label: string;
+  applicable: boolean;
+  score: number;
+  tier: "perform" | "half" | "under";
+  slice: number;
+  earned: number;
+  detail: string;
+};
+
+// Mirrors computeAllowancesForUser() in lib/hr/allowances.ts (the v2 levers
+// model) — the tab previously rendered a pre-v2 shape and crashed on
+// undefined nesting for every employee.
 type AllowanceData = {
   breakdown: {
     isFullTime: boolean;
+    eligible: boolean;
     period: { year: number; month: number; daysElapsed: number; daysRemaining: number };
-    attendance: { base: number; earned: number; tip: string; metrics: { lateCount: number; absentCount: number; earlyOutCount: number; missedClockoutCount: number; exceededBreakCount: number }; penalties: { kind: string; label: string; amount: number; date?: string }[] };
-    performance: { base: number; earned: number; score: number; mode: string; eligible: boolean; breakdown: { checklists: number; reviews: number; audit: number }; tip: string };
+    pool: number;
+    levers: AllowanceLever[];
+    performanceEarned: number;
+    attendance: { deductions: { kind: string; label: string; amount: number; date?: string }[]; lateCount: number; absentCount: number; total: number };
     reviewPenalty: { total: number; entries: { id: string; reviewDate: string; rating: number; amount: number; reviewText?: string | null }[] };
     totalEarned: number;
     totalMax: number;
+    tip: string;
   };
 };
 
@@ -589,103 +607,99 @@ export default function EmployeeDetailPage() {
             </div>
           </div>
 
-          <div className="grid gap-3 md:grid-cols-2">
-            {/* Attendance */}
-            <div className="rounded-lg bg-white/70 p-3">
-              <div className="mb-1 flex items-center justify-between text-sm">
-                <div className="flex items-center gap-1.5">
-                  <Clock className="h-4 w-4 text-blue-600" />
-                  <span className="font-medium">Attendance</span>
-                </div>
-                <span className="font-semibold">RM {allowance.attendance.earned} / {allowance.attendance.base}</span>
-              </div>
-              <div className="mb-2 h-1.5 overflow-hidden rounded-full bg-gray-200">
-                <div
-                  className="h-full rounded-full bg-blue-500"
-                  style={{ width: allowance.attendance.base > 0 ? `${(allowance.attendance.earned / allowance.attendance.base) * 100}%` : "0%" }}
-                />
-              </div>
-              <div className="flex flex-wrap gap-3 text-[11px] text-gray-600">
-                <span>Late {allowance.attendance.metrics.lateCount}</span>
-                <span>Absent {allowance.attendance.metrics.absentCount}</span>
-                <span>Early-out {allowance.attendance.metrics.earlyOutCount}</span>
-                <span>Missed clockout {allowance.attendance.metrics.missedClockoutCount}</span>
-              </div>
-              {allowance.attendance.penalties.length > 0 && (
-                <details className="mt-2 text-xs">
-                  <summary className="cursor-pointer text-gray-600 hover:text-gray-800">
-                    {allowance.attendance.penalties.length} penalt{allowance.attendance.penalties.length === 1 ? "y" : "ies"} — tap to view
-                  </summary>
-                  <ul className="mt-1 space-y-0.5 text-gray-600">
-                    {allowance.attendance.penalties.slice(0, 10).map((p, i) => (
-                      <li key={i}>
-                        {p.date ? <span className="font-mono text-[10px]">{p.date}</span> : null} · {p.label} (−RM {p.amount})
+          {!allowance.eligible ? (
+            <p className="rounded-lg bg-white/70 p-3 text-xs text-gray-600">{allowance.tip}</p>
+          ) : (
+            <>
+              <div className="grid gap-3 md:grid-cols-2">
+                {/* Performance levers */}
+                <div className="rounded-lg bg-white/70 p-3">
+                  <div className="mb-2 flex items-center justify-between text-sm">
+                    <div className="flex items-center gap-1.5">
+                      <Sparkles className="h-4 w-4 text-amber-600" />
+                      <span className="font-medium">Performance levers</span>
+                    </div>
+                    <span className="font-semibold">RM {allowance.performanceEarned} / {allowance.pool}</span>
+                  </div>
+                  <ul className="space-y-1.5">
+                    {allowance.levers.filter((l) => l.applicable).map((l) => (
+                      <li key={l.key} className="flex items-center justify-between gap-2 text-xs">
+                        <span
+                          className={`h-2 w-2 shrink-0 rounded-full ${
+                            l.tier === "perform" ? "bg-emerald-500" : l.tier === "half" ? "bg-amber-400" : "bg-gray-300"
+                          }`}
+                        />
+                        <span className="flex-1 truncate" title={l.detail}>
+                          {l.label} <span className="text-gray-400">· {l.detail}</span>
+                        </span>
+                        <span className="font-mono">RM {l.earned}/{l.slice}</span>
                       </li>
                     ))}
-                    {allowance.attendance.penalties.length > 10 && <li>… and {allowance.attendance.penalties.length - 10} more</li>}
                   </ul>
-                </details>
-              )}
-            </div>
-
-            {/* Performance */}
-            <div className="rounded-lg bg-white/70 p-3">
-              <div className="mb-1 flex items-center justify-between text-sm">
-                <div className="flex items-center gap-1.5">
-                  <Sparkles className="h-4 w-4 text-amber-600" />
-                  <span className="font-medium">Performance</span>
-                  {allowance.performance.eligible && <span className="text-xs text-gray-400">· score {allowance.performance.score}/100</span>}
                 </div>
-                <span className="font-semibold">
-                  {allowance.performance.eligible ? `RM ${allowance.performance.earned} / ${allowance.performance.base}` : "FT only"}
-                </span>
-              </div>
-              {allowance.performance.eligible ? (
-                <>
-                  <div className="mb-2 h-1.5 overflow-hidden rounded-full bg-gray-200">
-                    <div
-                      className="h-full rounded-full bg-amber-500"
-                      style={{ width: allowance.performance.base > 0 ? `${(allowance.performance.earned / allowance.performance.base) * 100}%` : "0%" }}
-                    />
+
+                {/* Attendance deductions */}
+                <div className="rounded-lg bg-white/70 p-3">
+                  <div className="mb-1 flex items-center justify-between text-sm">
+                    <div className="flex items-center gap-1.5">
+                      <Clock className="h-4 w-4 text-blue-600" />
+                      <span className="font-medium">Attendance</span>
+                    </div>
+                    <span className={`font-semibold ${allowance.attendance.total > 0 ? "text-red-600" : ""}`}>
+                      {allowance.attendance.total > 0 ? `−RM ${allowance.attendance.total}` : "No deductions"}
+                    </span>
                   </div>
                   <div className="flex flex-wrap gap-3 text-[11px] text-gray-600">
-                    <span>Checklists {allowance.performance.breakdown.checklists}</span>
-                    <span>Reviews {allowance.performance.breakdown.reviews}</span>
-                    <span>Audit {allowance.performance.breakdown.audit}</span>
+                    <span>Late {allowance.attendance.lateCount}</span>
+                    <span>No-show {allowance.attendance.absentCount}</span>
                   </div>
-                  <p className="mt-1 text-xs text-gray-600">{allowance.performance.tip}</p>
-                </>
-              ) : (
-                <p className="text-xs text-gray-500">Performance allowance is for full-time staff only.</p>
-              )}
-            </div>
-          </div>
-
-          {/* Review penalty */}
-          {allowance.reviewPenalty.total > 0 && (
-            <div className="mt-3 rounded-lg border border-red-200 bg-red-50 p-3">
-              <div className="mb-1 flex items-center justify-between text-sm">
-                <div className="flex items-center gap-1.5">
-                  <AlertTriangle className="h-4 w-4 text-red-600" />
-                  <span className="font-medium text-red-700">Review penalty</span>
+                  {allowance.attendance.deductions.length > 0 && (
+                    <details className="mt-2 text-xs">
+                      <summary className="cursor-pointer text-gray-600 hover:text-gray-800">
+                        {allowance.attendance.deductions.length} deduction{allowance.attendance.deductions.length === 1 ? "" : "s"} — tap to view
+                      </summary>
+                      <ul className="mt-1 space-y-0.5 text-gray-600">
+                        {allowance.attendance.deductions.slice(0, 10).map((d, i) => (
+                          <li key={i}>
+                            {d.date ? <span className="font-mono text-[10px]">{d.date}</span> : null} · {d.label} (−RM {d.amount})
+                          </li>
+                        ))}
+                        {allowance.attendance.deductions.length > 10 && <li>… and {allowance.attendance.deductions.length - 10} more</li>}
+                      </ul>
+                    </details>
+                  )}
                 </div>
-                <span className="font-semibold text-red-700">−RM {allowance.reviewPenalty.total}</span>
               </div>
-              <ul className="space-y-0.5 text-xs text-red-700">
-                {allowance.reviewPenalty.entries.map((e) => (
-                  <li key={e.id} className="flex items-start gap-1.5">
-                    <span className="flex shrink-0 items-center">
-                      {Array.from({ length: 5 }).map((_, i) => (
-                        <Star key={i} className={`h-3 w-3 ${i < e.rating ? "fill-red-500 text-red-500" : "text-red-200"}`} />
-                      ))}
-                    </span>
-                    <span className="font-mono text-[10px]">{e.reviewDate}</span>
-                    <span>· −RM {e.amount}</span>
-                    {e.reviewText && <span className="text-red-600 italic truncate">&ldquo;{e.reviewText}&rdquo;</span>}
-                  </li>
-                ))}
-              </ul>
-            </div>
+
+              {/* Review penalty */}
+              {allowance.reviewPenalty.total > 0 && (
+                <div className="mt-3 rounded-lg border border-red-200 bg-red-50 p-3">
+                  <div className="mb-1 flex items-center justify-between text-sm">
+                    <div className="flex items-center gap-1.5">
+                      <AlertTriangle className="h-4 w-4 text-red-600" />
+                      <span className="font-medium text-red-700">Review penalty</span>
+                    </div>
+                    <span className="font-semibold text-red-700">−RM {allowance.reviewPenalty.total}</span>
+                  </div>
+                  <ul className="space-y-0.5 text-xs text-red-700">
+                    {allowance.reviewPenalty.entries.map((e) => (
+                      <li key={e.id} className="flex items-start gap-1.5">
+                        <span className="flex shrink-0 items-center">
+                          {Array.from({ length: 5 }).map((_, i) => (
+                            <Star key={i} className={`h-3 w-3 ${i < e.rating ? "fill-red-500 text-red-500" : "text-red-200"}`} />
+                          ))}
+                        </span>
+                        <span className="font-mono text-[10px]">{e.reviewDate}</span>
+                        <span>· −RM {e.amount}</span>
+                        {e.reviewText && <span className="text-red-600 italic truncate">&ldquo;{e.reviewText}&rdquo;</span>}
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+              )}
+
+              <p className="mt-3 text-xs text-gray-600">{allowance.tip}</p>
+            </>
           )}
 
           <div className="mt-3 flex justify-end">


### PR DESCRIPTION
## What

Fixes the "Something went wrong" crash on `/hr/employees/[id]` (reported on Aina's page, but it hit **every** employee).

## Root cause

The allowances engine moved to the v2 levers model (`perf_allowance_v2`, migration 060), changing `computeAllowancesForUser()`'s response: `attendance.metrics`, `attendance.penalties`, and the whole `performance` object no longer exist. The employee detail page's Performance tab still rendered the pre-v2 shape, so `allowance.attendance.metrics.lateCount` threw a client-side TypeError and Next's error boundary swallowed the whole page. (No server error — which is why Vercel runtime logs were clean.)

## Fix

The tab now renders the real v2 response:
- **Performance levers** — checklist / phone capture / serving / audit, each with a tier dot (green = full, amber = half, gray = under), detail, and earned/slice RM.
- **Attendance** — total deduction, late + no-show counts, expandable per-deduction list with dates.
- **Review penalty** — unchanged (its shape survived v2).
- Coaching tip line, and a clean not-eligible state (PT/contract or schedule-not-required roles) instead of a crash.
- `AllowanceData` type now mirrors `lib/hr/allowances.ts`.

## Verification

`tsc --noEmit` clean, 299 root tests pass, eslint clean (two pre-existing warnings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R2Kv8uNdKdCSqfUFR7vkWM

---
_Generated by [Claude Code](https://claude.ai/code/session_01R2Kv8uNdKdCSqfUFR7vkWM)_