### PR TITLE
finance: GL posting cutover (2026-01-01) + cross-entity Grab settlement routing

### DIFF
--- a/apps/backoffice/src/app/api/cron/bukku-feed-sync/route.ts
+++ b/apps/backoffice/src/app/api/cron/bukku-feed-sync/route.ts
@@ -52,7 +52,7 @@ export async function GET(req: NextRequest) {
   // 4. post the classified bank lines into the GL (bounded; drains over runs)
   await step("glPost", async () => {
     const r = await postBankLinesToGl({ commit: true, limit: GL_LINES_PER_RUN });
-    return { journals: r.journals, reusedJournals: r.reusedJournals, gcJournals: r.gcJournals, postedLines: r.postedLines, suspenseLines: r.suspenseLines, errors: r.errors.length };
+    return { journals: r.journals, reusedJournals: r.reusedJournals, mirrorJournals: r.mirrorJournals, gcJournals: r.gcJournals, postedLines: r.postedLines, suspenseLines: r.suspenseLines, errors: r.errors.length };
   });
   // 5. clear the payroll control accounts — cash-basis salary expense for what
   //    the bank paid (self-reconciling; a no-op once real HR payroll accruals

--- a/apps/backoffice/src/lib/finance/gl-posting-map.ts
+++ b/apps/backoffice/src/lib/finance/gl-posting-map.ts
@@ -5,6 +5,14 @@
 export const BANK_CASH = "1000-01"; // Bank Account (per company via fin_transactions.company_id)
 export const SUSPENSE = "1999";     // Suspense / Unclassified — keeps the bank tied out
 
+// GL posting cutover. 2025 books live in Bukku (reconciled through Dec 2025);
+// this GL owns 2026 onward with opening balances posted as at the cutover.
+// No automated path may post before this date: the bank bridge hard filters
+// its candidate lines, the EOD ingestors refuse pre-cutover dates, and the
+// salary accrual skips pre-cutover months. This keeps backfill and cron reruns
+// from recreating 2025 journals after the balance sheet surgery deletes them.
+export const GL_POSTING_CUTOVER = "2026-01-01";
+
 // CashCategory → contra GL account code. The bank line's direction (CR in / DR
 // out) decides which side BANK_CASH sits on; the contra always takes the other.
 export const CONTRA_ACCOUNT: Record<string, string> = {
@@ -13,7 +21,7 @@ export const CONTRA_ACCOUNT: Record<string, string> = {
   STOREHUB: "1006",        // legacy POS card-style settlement
   QR: "1000-02",           // DuitNow QR / cash banked out of Cash on Hand
   GRAB: "1005",            // Grabfood debtors
-  GRAB_PUTRAJAYA: "1999",  // settles into HQ bank but debtor sits in Conezion — cross-entity, park in suspense
+  GRAB_PUTRAJAYA: "1999",  // settles into HQ bank but debtor sits in Conezion; CR lines route via resolveGrabSettlementRouting, this fallback only parks odd cases (DR side, or the outlet company's own bank)
   FOODPANDA: "1005",       // marketplace debtor (no separate FP account yet)
   REVENUE_MONSTER: "1000-02", // RM terminal settling pickup/table QR+e-wallet sales already accrued by EOD → clears the Cash & QR debtor (crediting income here double-counted revenue)
   // ── inflows NOT in EOD (B2B / online) → recognise income directly ──
@@ -88,6 +96,71 @@ function intercoAccount(descUpper: string): string {
   if (/CONEZION|\bCONE\b/.test(descUpper)) return "3600-01";
   if (/CELSIUS\s*COFFEE\s*SDN|\bCCSB\b/.test(descUpper)) return "3600-02";
   return "3600"; // generic inter-company current account
+}
+
+// "Due to/from <entity>" inter-company account keyed by the COUNTERPARTY
+// company id. Same accounts intercoAccount() resolves from bank narratives,
+// but addressable by fin_companies.id for programmatic routing.
+export const INTERCO_DUE_ACCOUNT: Record<string, string> = {
+  celsiustamarind: "3600-00",
+  celsiusconezion: "3600-01",
+  celsius: "3600-02",
+};
+
+export const GRAB_DEBTOR = "1005"; // Grabfood debtors (keep aligned with CONTRA_ACCOUNT.GRAB)
+
+// Categories that represent a Grab payout settling into a bank account.
+// GRAB_PUTRAJAYA is the legacy hand-applied label for Grab money earned by the
+// Putrajaya (Conezion) outlet that settles into the SB account.
+export const GRAB_SETTLEMENT_CATS = new Set(["GRAB", "GRAB_PUTRAJAYA"]);
+
+export type GrabSettlementRouting = {
+  // Contra credited in the RECEIVING company's journal: due to the outlet's company.
+  contra: string;
+  // Second journal posted in the OUTLET's company.
+  mirror: {
+    company: string;       // the outlet's legal entity
+    debitAccount: string;  // 3600-xx due from the receiving company
+    creditAccount: string; // 1005 Grabfood debtors, cleared where EOD accrued them
+  };
+};
+
+// Cross-entity Grab settlement routing.
+//
+// ALL Grab payouts land in Celsius Coffee SB's bank account (4384), including
+// money earned by the Putrajaya (Conezion) and Tamarind outlets, while the EOD
+// AR agent accrues those sales as Dr 1005 in the OUTLET's company. Crediting
+// the receiving company's own 1005 (or parking in suspense) leaves the outlet
+// company's 1005 debits uncleared forever and piles phantom credits on SB.
+// Instead the settlement posts as TWO balanced journals:
+//   receiving company: Dr 1000-01 bank, Cr 3600-xx (due to the outlet's company)
+//   outlet's company:  Dr 3600-yy (due from the receiver), Cr 1005 Grabfood debtors
+//
+// Returns null when the line is not a Grab settlement, when the outlet's
+// company cannot be resolved, or when the outlet belongs to the receiving
+// company itself. Own-outlet settlements (Shah Alam, Nilai in SB's account)
+// keep the plain single-journal behavior: Dr bank, Cr 1005.
+export function resolveGrabSettlementRouting(
+  category: string,
+  bankCompany: string,
+  outletCompanyId: string | null,
+): GrabSettlementRouting | null {
+  if (!GRAB_SETTLEMENT_CATS.has(category)) return null;
+  // The GRAB_PUTRAJAYA category itself carries the outlet identity, so lines
+  // without a resolved outlet still route to Conezion.
+  const outletCompany = outletCompanyId ?? (category === "GRAB_PUTRAJAYA" ? "celsiusconezion" : null);
+  if (!outletCompany || outletCompany === bankCompany) return null;
+  const dueToOutletCompany = INTERCO_DUE_ACCOUNT[outletCompany];
+  const dueFromBankCompany = INTERCO_DUE_ACCOUNT[bankCompany];
+  if (!dueToOutletCompany || !dueFromBankCompany) return null;
+  return {
+    contra: dueToOutletCompany,
+    mirror: {
+      company: outletCompany,
+      debitAccount: dueFromBankCompany,
+      creditAccount: GRAB_DEBTOR,
+    },
+  };
 }
 
 // Resolve the contra account for a bank line — the accurate version that mirrors

--- a/apps/backoffice/src/lib/finance/gl-posting.test.ts
+++ b/apps/backoffice/src/lib/finance/gl-posting.test.ts
@@ -1,5 +1,12 @@
 import { describe, it, expect } from "vitest";
-import { contraFor, companyFromAccountName, CONTRA_ACCOUNT, resolveContra } from "./gl-posting-map";
+import {
+  contraFor, companyFromAccountName, CONTRA_ACCOUNT, resolveContra,
+  GL_POSTING_CUTOVER, INTERCO_DUE_ACCOUNT, resolveGrabSettlementRouting,
+} from "./gl-posting-map";
+import {
+  bankCrossEntityJournalKey, bankJournalKey, bankMirrorJournalKey,
+  buildBankGroups, type GroupableBankLine,
+} from "./gl-posting";
 
 describe("resolveContra — Bukku-accurate control / inter-co routing", () => {
   it("routes full-time salary to the Salary Control liability (cleared by payroll accrual)", () => {
@@ -70,5 +77,158 @@ describe("contraFor", () => {
   });
   it("never throws on an unknown category — routes to suspense", () => {
     expect(contraFor("SOME_FUTURE_CATEGORY")).toEqual({ code: "1999", suspense: true });
+  });
+});
+
+// ── posting cutover + cross-entity Grab settlement routing ──
+
+const SB_ACCT = "CELSIUS COFFEE SDN. BHD. (4384)";
+const OUTLET_COMPANY = new Map([
+  ["outlet-sa", "celsius"],
+  ["outlet-nilai", "celsius"],
+  ["outlet-conezion", "celsiusconezion"],
+  ["outlet-tamarind", "celsiustamarind"],
+]);
+
+function line(over: Partial<GroupableBankLine> = {}): GroupableBankLine {
+  return {
+    id: "l1",
+    txnDate: new Date("2026-06-01T00:00:00Z"),
+    amount: 100,
+    direction: "CR",
+    category: "GRAB",
+    description: "1575371GPAY NETWORK (M) SDN",
+    outletId: null,
+    accountName: SB_ACCT,
+    ...over,
+  };
+}
+
+describe("GL_POSTING_CUTOVER filtering", () => {
+  it("is the agreed 2026 opening date", () => {
+    expect(GL_POSTING_CUTOVER).toBe("2026-01-01");
+  });
+  it("drops pre-cutover lines from grouping regardless of classification", () => {
+    const { groups, skippedLines } = buildBankGroups(
+      [line({ id: "old", txnDate: new Date("2025-12-31T00:00:00Z"), category: "RENT", direction: "DR" })],
+      OUTLET_COMPANY,
+    );
+    expect(groups.size).toBe(0);
+    expect(skippedLines).toBe(1);
+  });
+  it("keeps lines dated exactly on the cutover", () => {
+    const { groups, skippedLines } = buildBankGroups(
+      [line({ txnDate: new Date("2026-01-01T00:00:00Z") })],
+      OUTLET_COMPANY,
+    );
+    expect(groups.size).toBe(1);
+    expect(skippedLines).toBe(0);
+  });
+});
+
+describe("resolveGrabSettlementRouting", () => {
+  it("routes a Grab payout for another company's outlet through the inter-co accounts", () => {
+    const r = resolveGrabSettlementRouting("GRAB", "celsius", "celsiusconezion");
+    expect(r).toEqual({
+      contra: "3600-01",
+      mirror: { company: "celsiusconezion", debitAccount: "3600-02", creditAccount: "1005" },
+    });
+    const t = resolveGrabSettlementRouting("GRAB", "celsius", "celsiustamarind");
+    expect(t?.contra).toBe("3600-00");
+    expect(t?.mirror).toEqual({ company: "celsiustamarind", debitAccount: "3600-02", creditAccount: "1005" });
+  });
+  it("keeps own-outlet settlements on the plain single-journal path", () => {
+    expect(resolveGrabSettlementRouting("GRAB", "celsius", "celsius")).toBeNull();
+    expect(resolveGrabSettlementRouting("GRAB", "celsius", null)).toBeNull();
+  });
+  it("resolves the legacy GRAB_PUTRAJAYA label to Conezion when no outlet is stamped", () => {
+    const r = resolveGrabSettlementRouting("GRAB_PUTRAJAYA", "celsius", null);
+    expect(r?.contra).toBe("3600-01");
+    expect(r?.mirror.company).toBe("celsiusconezion");
+  });
+  it("ignores non-Grab categories and unknown companies", () => {
+    expect(resolveGrabSettlementRouting("CARD", "celsius", "celsiusconezion")).toBeNull();
+    expect(resolveGrabSettlementRouting("GRAB", "celsius", "somebody-else")).toBeNull();
+  });
+  it("keeps the inter-co account map aligned with the narrative resolver", () => {
+    expect(resolveContra("INTERCO_PEOPLE", "TRANSFER FR A/C CONEZION").code).toBe(INTERCO_DUE_ACCOUNT.celsiusconezion);
+    expect(resolveContra("INTERCO_PEOPLE", "TRANSFER TO A/C CELSIUS COFFEE TAMARIND").code).toBe(INTERCO_DUE_ACCOUNT.celsiustamarind);
+    expect(resolveContra("INTERCO_PEOPLE", "to celsius coffee sdn bhd").code).toBe(INTERCO_DUE_ACCOUNT.celsius);
+  });
+});
+
+describe("buildBankGroups Grab settlement grouping", () => {
+  it("keeps own-outlet Grab as a single journal clearing SB's 1005", () => {
+    const { groups } = buildBankGroups([line({ outletId: "outlet-sa" })], OUTLET_COMPANY);
+    expect(groups.size).toBe(1);
+    const g = [...groups.values()][0];
+    expect(g.company).toBe("celsius");
+    expect(g.contra).toBe("1005");
+    expect(g.mirror).toBeUndefined();
+  });
+  it("routes cross-entity Grab to the inter-co contra with a mirror in the outlet's company", () => {
+    const { groups } = buildBankGroups(
+      [
+        line({ id: "a", outletId: "outlet-conezion", amount: 100 }),
+        line({ id: "b", outletId: "outlet-conezion", amount: 150.5 }),
+      ],
+      OUTLET_COMPANY,
+    );
+    expect(groups.size).toBe(1);
+    const g = [...groups.values()][0];
+    expect(g.company).toBe("celsius");
+    expect(g.contra).toBe("3600-01");
+    expect(g.amount).toBe(250.5);
+    expect(g.lineIds).toEqual(["a", "b"]);
+    expect(g.mirror).toEqual({ company: "celsiusconezion", debitAccount: "3600-02", creditAccount: "1005" });
+  });
+  it("never folds a cross-entity Grab group into a plain inter-co group on the same contra and day", () => {
+    const { groups } = buildBankGroups(
+      [
+        line({ id: "grab", outletId: "outlet-conezion", amount: 100 }),
+        line({
+          id: "interco", outletId: "outlet-conezion", amount: 500,
+          category: "INTERCO_PEOPLE", description: "TRANSFER FR A/C CONEZION",
+        }),
+      ],
+      OUTLET_COMPANY,
+    );
+    expect(groups.size).toBe(2);
+    const grab = [...groups.values()].find((g) => g.category === "GRAB");
+    const interco = [...groups.values()].find((g) => g.category === "INTERCO_PEOPLE");
+    expect(grab?.contra).toBe("3600-01");
+    expect(interco?.contra).toBe("3600-01");
+    expect(grab?.mirror).toBeDefined();
+    expect(interco?.mirror).toBeUndefined();
+  });
+});
+
+describe("cross-entity journal keys", () => {
+  const args = ["celsius", "outlet-conezion", "3600-01", "2026-06-01", "CR"] as const;
+  it("are stable across runs and distinct from the plain and mirror keys", () => {
+    const primary1 = bankCrossEntityJournalKey(...args);
+    const primary2 = bankCrossEntityJournalKey(...args);
+    expect(primary1).toBe(primary2);
+    expect(primary1).not.toBe(bankJournalKey(...args));
+    const mirror1 = bankMirrorJournalKey(primary1);
+    const mirror2 = bankMirrorJournalKey(primary2);
+    expect(mirror1).toBe(mirror2);
+    expect(mirror1).not.toBe(primary1);
+  });
+  it("format as UUIDs so they fit fin_transactions.posting_key", () => {
+    const uuid = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/;
+    const primary = bankCrossEntityJournalKey(...args);
+    expect(primary).toMatch(uuid);
+    expect(bankMirrorJournalKey(primary)).toMatch(uuid);
+    expect(bankJournalKey(...args)).toMatch(uuid);
+  });
+  it("produce the same pair for identical group aggregations across two runs", () => {
+    const input = [line({ id: "a", outletId: "outlet-conezion" })];
+    const run1 = [...buildBankGroups(input, OUTLET_COMPANY).groups.values()][0];
+    const run2 = [...buildBankGroups(input, OUTLET_COMPANY).groups.values()][0];
+    const key1 = bankCrossEntityJournalKey(run1.company, run1.outletId, run1.contra, run1.date, run1.direction);
+    const key2 = bankCrossEntityJournalKey(run2.company, run2.outletId, run2.contra, run2.date, run2.direction);
+    expect(key1).toBe(key2);
+    expect(bankMirrorJournalKey(key1)).toBe(bankMirrorJournalKey(key2));
   });
 });

--- a/apps/backoffice/src/lib/finance/gl-posting.ts
+++ b/apps/backoffice/src/lib/finance/gl-posting.ts
@@ -31,25 +31,58 @@
 // A GC pass then deletes bank journals no line references (orphans left by
 // rebuilds under older rules) — run only when the backlog fully drained, so a
 // bounded run never deletes journals whose lines it hasn't reached yet.
+//
+// CUTOVER: only lines dated on/after GL_POSTING_CUTOVER are ever candidates;
+// 2025 stays in Bukku. Cross-entity Grab settlements (payout in one company's
+// bank, sale accrued in another company's 1005) post a PAIR of journals; see
+// resolveGrabSettlementRouting, upsertMirrorJournal, and the mirror-aware GC.
 
 import { createHash } from "crypto";
 import { prisma } from "@/lib/prisma";
 import { postJournal } from "./ledger";
 import { getFinanceClient } from "./supabase";
 import type { JournalLineInput } from "./types";
-import { BANK_CASH, companyFromAccountName, resolveContra, round2, SKIP_CATS } from "./gl-posting-map";
+import {
+  BANK_CASH, companyFromAccountName, GL_POSTING_CUTOVER, resolveContra,
+  resolveGrabSettlementRouting, round2, SKIP_CATS,
+} from "./gl-posting-map";
+import type { GrabSettlementRouting } from "./gl-posting-map";
 
-// Deterministic journal identity for a (company, outlet, contra, day, direction)
-// aggregate. Formatted as a UUID so it fits fin_transactions.posting_key and
+// md5 digest formatted as a UUID so it fits fin_transactions.posting_key and
 // matches postgres md5(text)::uuid — SQL backfills can reproduce it exactly.
-export function bankJournalKey(company: string, outletId: string | null, contra: string, date: string, direction: string): string {
-  const h = createHash("md5").update(`bank-gl|${company}|${outletId ?? ""}|${contra}|${date}|${direction}`).digest("hex");
+function md5Uuid(input: string): string {
+  const h = createHash("md5").update(input).digest("hex");
   return `${h.slice(0, 8)}-${h.slice(8, 12)}-${h.slice(12, 16)}-${h.slice(16, 20)}-${h.slice(20)}`;
 }
 
-export { CONTRA_ACCOUNT, companyFromAccountName, contraFor, resolveContra } from "./gl-posting-map";
+// Deterministic journal identity for a (company, outlet, contra, day, direction)
+// aggregate.
+export function bankJournalKey(company: string, outletId: string | null, contra: string, date: string, direction: string): string {
+  return md5Uuid(`bank-gl|${company}|${outletId ?? ""}|${contra}|${date}|${direction}`);
+}
 
-type Group = {
+// Cross-entity Grab settlement aggregates get their own key namespace so they
+// can never collide with a plain inter-company journal that resolves to the
+// same 3600-xx contra on the same day (both would otherwise hash the same
+// components and fold into one journal, corrupting the mirror amount).
+export function bankCrossEntityJournalKey(company: string, outletId: string | null, contra: string, date: string, direction: string): string {
+  return md5Uuid(`bank-gl-x|${company}|${outletId ?? ""}|${contra}|${date}|${direction}`);
+}
+
+// The mirror journal's identity derives from the PRIMARY journal's posting key
+// string itself, so anything holding a bank journal's posting_key (the poster,
+// the GC) can locate its mirror deterministically without knowing the original
+// aggregation parameters. Re-runs always land on the same pair of keys.
+export function bankMirrorJournalKey(primaryKey: string): string {
+  return md5Uuid(`bank-gl-mirror|${primaryKey}`);
+}
+
+export {
+  CONTRA_ACCOUNT, companyFromAccountName, contraFor, GL_POSTING_CUTOVER,
+  INTERCO_DUE_ACCOUNT, resolveContra, resolveGrabSettlementRouting,
+} from "./gl-posting-map";
+
+export type Group = {
   company: string;
   outletId: string | null;
   contra: string;        // resolved contra account (control/inter-co/expense/…)
@@ -59,16 +92,73 @@ type Group = {
   direction: "CR" | "DR";
   amount: number;
   lineIds: string[];
+  // Set for cross-entity Grab settlements: the second journal to post in the
+  // outlet's company (Dr due-from-receiver, Cr 1005), mirroring this group's
+  // amount. See resolveGrabSettlementRouting in gl-posting-map.ts.
+  mirror?: GrabSettlementRouting["mirror"];
 };
+
+// Minimal line shape the grouping logic needs. Kept structural so unit tests
+// can feed synthetic lines without Prisma.
+export type GroupableBankLine = {
+  id: string;
+  txnDate: Date;
+  amount: number;
+  direction: "CR" | "DR";
+  category: string;
+  description: string;
+  outletId: string | null;
+  accountName: string | null;
+};
+
+// Aggregate classified bank lines into posting groups. Pure: company comes
+// from the statement account name, the outlet's company from the supplied
+// fin_outlet_companies map. Lines dated before GL_POSTING_CUTOVER are dropped
+// here as well as in the query, so every caller gets the same hard floor.
+export function buildBankGroups(
+  lines: GroupableBankLine[],
+  outletCompanyById: Map<string, string>,
+): { groups: Map<string, Group>; skippedLines: number } {
+  const groups = new Map<string, Group>();
+  let skippedLines = 0;
+  for (const l of lines) {
+    const category = l.category;
+    if (SKIP_CATS.has(category)) { skippedLines++; continue; }
+    const date = l.txnDate.toISOString().slice(0, 10);
+    if (date < GL_POSTING_CUTOVER) { skippedLines++; continue; } // pre-cutover: Bukku's books
+    const company = companyFromAccountName(l.accountName);
+    const direction = l.direction;
+    // Cross-entity Grab settlement? Route through the inter-company accounts
+    // and remember the mirror journal; otherwise resolve the contra as usual.
+    const routing = direction === "CR"
+      ? resolveGrabSettlementRouting(category, company, (l.outletId && outletCompanyById.get(l.outletId)) || null)
+      : null;
+    const { code: contra, suspense } = routing
+      ? { code: routing.contra, suspense: false }
+      : resolveContra(category, l.description);
+    const key = [company, l.outletId ?? "", contra, date, direction, routing ? `x:${routing.mirror.company}` : ""].join("|");
+    const g = groups.get(key);
+    if (g) { g.amount = round2(g.amount + l.amount); g.lineIds.push(l.id); }
+    else {
+      groups.set(key, {
+        company, outletId: l.outletId, contra, suspense, category, date, direction,
+        amount: round2(l.amount), lineIds: [l.id],
+        ...(routing ? { mirror: routing.mirror } : {}),
+      });
+    }
+  }
+  return { groups, skippedLines };
+}
 
 export type GlPostResult = {
   committed: boolean;
   scannedLines: number;
-  journals: number;        // journals posted (or that would post)
+  journals: number;        // journals posted (or that would post); a cross-entity group counts once here
   reusedJournals: number;  // groups folded into an existing deterministic journal
+  mirrorJournals: number;  // cross-entity Grab mirror journals posted alongside their primaries
   gcJournals: number;      // orphaned bank journals deleted (no line references)
   postedLines: number;     // bank lines that landed in a journal
-  skippedLines: number;    // TRANSFER_NOT_SUCCESSFUL
+  skippedLines: number;    // TRANSFER_NOT_SUCCESSFUL, plus any pre-cutover stragglers
   suspenseLines: number;   // parked in 1999
   totalDebit: number;
   totalCredit: number;
@@ -84,11 +174,18 @@ export async function postBankLinesToGl(
 ): Promise<GlPostResult> {
   const commit = opts.commit ?? false;
 
+  // Hard cutover floor: lines dated before GL_POSTING_CUTOVER are Bukku's and
+  // are never posted, previewed, or counted as backlog, regardless of their
+  // classification state. sinceDays can only NARROW the window further.
+  const cutoverFloor = new Date(`${GL_POSTING_CUTOVER}T00:00:00Z`);
+  const sinceFloor = opts.sinceDays ? new Date(Date.now() - opts.sinceDays * 86_400_000) : cutoverFloor;
+  const txnDateFloor = sinceFloor > cutoverFloor ? sinceFloor : cutoverFloor;
+
   const lines = await prisma.bankStatementLine.findMany({
     where: {
       category: { not: null },
       glTransactionId: null,
-      ...(opts.sinceDays ? { txnDate: { gte: new Date(Date.now() - opts.sinceDays * 86_400_000) } } : {}),
+      txnDate: { gte: txnDateFloor },
     },
     select: {
       id: true, txnDate: true, amount: true, direction: true, category: true, description: true, outletId: true,
@@ -98,28 +195,38 @@ export async function postBankLinesToGl(
     take: opts.limit,
   });
 
-  // Resolve the contra account per line (so statutory splits by type and inter-co
-  // routes by counterparty), then aggregate into one journal per
+  // Outlet to legal-entity map, needed to spot Grab settlements that landed in
+  // another company's bank account (fetched once; small table).
+  const fin = getFinanceClient();
+  const { data: outletCompanies, error: ocErr } = await fin
+    .from("fin_outlet_companies")
+    .select("outlet_id, company_id");
+  if (ocErr) throw new Error(ocErr.message);
+  const outletCompanyById = new Map(
+    (outletCompanies ?? []).map((r) => [r.outlet_id as string, r.company_id as string]),
+  );
+
+  // Resolve the contra account per line (so statutory splits by type, inter-co
+  // routes by counterparty, and cross-entity Grab settlements route through the
+  // 3600-xx accounts), then aggregate into one journal per
   // (company, outlet, CONTRA account, day, direction).
-  const groups = new Map<string, Group>();
-  let skippedLines = 0;
-  for (const l of lines) {
-    const category = l.category as string;
-    if (SKIP_CATS.has(category)) { skippedLines++; continue; }
-    const company = companyFromAccountName(l.statement.accountName);
-    const date = l.txnDate.toISOString().slice(0, 10);
-    const direction = l.direction as "CR" | "DR";
-    const { code: contra, suspense } = resolveContra(category, l.description ?? "");
-    const key = [company, l.outletId ?? "", contra, date, direction].join("|");
-    const g = groups.get(key);
-    if (g) { g.amount = round2(g.amount + Number(l.amount)); g.lineIds.push(l.id); }
-    else groups.set(key, { company, outletId: l.outletId, contra, suspense, category, date, direction, amount: round2(Number(l.amount)), lineIds: [l.id] });
-  }
+  const { groups, skippedLines } = buildBankGroups(
+    lines.map((l) => ({
+      id: l.id,
+      txnDate: l.txnDate,
+      amount: Number(l.amount),
+      direction: l.direction as "CR" | "DR",
+      category: l.category as string,
+      description: l.description ?? "",
+      outletId: l.outletId,
+      accountName: l.statement.accountName,
+    })),
+    outletCompanyById,
+  );
 
   const byCat = new Map<string, { account: string; direction: string; journals: number; lines: number; amount: number; suspense: boolean }>();
   const errors: GlPostResult["errors"] = [];
-  const fin = getFinanceClient();
-  let journals = 0, reusedJournals = 0, postedLines = 0, suspenseLines = 0, totalDebit = 0, totalCredit = 0;
+  let journals = 0, reusedJournals = 0, mirrorJournals = 0, postedLines = 0, suspenseLines = 0, totalDebit = 0, totalCredit = 0;
 
   for (const g of groups.values()) {
     if (g.amount <= 0) continue;
@@ -135,6 +242,7 @@ export async function postBankLinesToGl(
     byCat.set(ck, agg);
 
     journals++;
+    if (g.mirror) mirrorJournals++;
     postedLines += g.lineIds.length;
     if (g.suspense) suspenseLines += g.lineIds.length;
     totalDebit = round2(totalDebit + g.amount);
@@ -142,7 +250,12 @@ export async function postBankLinesToGl(
 
     if (!commit) continue;
     try {
-      const key = bankJournalKey(g.company, g.outletId, contra, g.date, g.direction);
+      // Cross-entity Grab aggregates key in their own namespace (see
+      // bankCrossEntityJournalKey) so they never fold into a plain inter-co
+      // journal that shares the same 3600-xx contra and day.
+      const key = g.mirror
+        ? bankCrossEntityJournalKey(g.company, g.outletId, contra, g.date, g.direction)
+        : bankJournalKey(g.company, g.outletId, contra, g.date, g.direction);
       const { data: existingRows, error: exErr } = await fin
         .from("fin_transactions")
         .select("id, amount")
@@ -154,6 +267,9 @@ export async function postBankLinesToGl(
       const existing = existingRows?.[0];
 
       let txnId: string;
+      // The journal amount this group settles on. The mirror (if any) is kept
+      // identical to it below.
+      let finalTotal = g.amount;
       if (!existing) {
         const desc = `Bank ${g.direction === "CR" ? "receipts" : "payments"} — ${g.category}→${contra} ${g.date} (${g.lineIds.length} line${g.lineIds.length > 1 ? "s" : ""})`;
         const res = await postJournal({
@@ -188,8 +304,14 @@ export async function postBankLinesToGl(
         }
         const { error: tErr } = await fin.from("fin_transactions").update({ amount: newTotal }).eq("id", txnId);
         if (tErr) throw new Error(tErr.message);
+        finalTotal = newTotal;
         reusedJournals++;
       }
+      // Cross-entity Grab: upsert the mirror journal in the outlet's company
+      // BEFORE stamping the lines. If the mirror fails, the lines stay
+      // unstamped, the group re-forms next run, the primary is found and
+      // reused, and the mirror upsert retries. Self-healing.
+      if (g.mirror) await upsertMirrorJournal(fin, g, key, finalTotal);
       await prisma.bankStatementLine.updateMany({
         where: { id: { in: g.lineIds } },
         data: { glTransactionId: txnId, glPostedAt: new Date() },
@@ -197,6 +319,7 @@ export async function postBankLinesToGl(
     } catch (err) {
       errors.push({ company: g.company, category: g.category, date: g.date, error: err instanceof Error ? err.message : String(err) });
       journals--; postedLines -= g.lineIds.length;
+      if (g.mirror) mirrorJournals--;
       totalDebit = round2(totalDebit - g.amount); totalCredit = round2(totalCredit - g.amount);
     }
   }
@@ -222,27 +345,94 @@ export async function postBankLinesToGl(
   return {
     committed: commit,
     scannedLines: lines.length,
-    journals, reusedJournals, gcJournals, postedLines, skippedLines, suspenseLines,
+    journals, reusedJournals, mirrorJournals, gcJournals, postedLines, skippedLines, suspenseLines,
     totalDebit, totalCredit, byCategory, errors,
   };
+}
+
+// Post or update the mirror journal for a cross-entity Grab settlement group:
+// in the OUTLET's company, Dr 3600-yy due from the receiving company, Cr 1005
+// Grabfood debtors. Idempotent via bankMirrorJournalKey(primaryKey); on reuse
+// the amounts are REPLACED with the primary's settled total so the pair can
+// never drift apart across re-runs and fold-ins.
+async function upsertMirrorJournal(
+  fin: ReturnType<typeof getFinanceClient>,
+  g: Group,
+  primaryKey: string,
+  total: number,
+): Promise<void> {
+  const mirror = g.mirror;
+  if (!mirror) return;
+  const mirrorKey = bankMirrorJournalKey(primaryKey);
+  const { data: rows, error: exErr } = await fin
+    .from("fin_transactions")
+    .select("id")
+    .eq("posting_key", mirrorKey)
+    .eq("posted_by_agent", "bank")
+    .eq("status", "posted")
+    .limit(1);
+  if (exErr) throw new Error(exErr.message);
+  const existing = rows?.[0];
+
+  if (!existing) {
+    await postJournal({
+      companyId: mirror.company,
+      txnDate: g.date,
+      description: `Grab settlement received by ${g.company} on behalf of ${mirror.company} ${g.date} (${g.lineIds.length} line${g.lineIds.length > 1 ? "s" : ""}); clears ${mirror.creditAccount} via inter-co ${mirror.debitAccount}`,
+      txnType: "payment",
+      outletId: g.outletId,
+      agent: "bank",
+      agentVersion: "bank-gl-v1",
+      confidence: 1,
+      postingKey: mirrorKey,
+      lines: [
+        { accountCode: mirror.debitAccount, debit: total, outletId: g.outletId },
+        { accountCode: mirror.creditAccount, credit: total, outletId: g.outletId },
+      ],
+    });
+    return;
+  }
+
+  const txnId = existing.id as string;
+  const { data: jls, error: jlErr } = await fin
+    .from("fin_journal_lines").select("id, debit, credit").eq("transaction_id", txnId);
+  if (jlErr) throw new Error(jlErr.message);
+  if (!jls || jls.length !== 2) throw new Error(`mirror journal ${txnId} has ${jls?.length ?? 0} lines; expected 2`);
+  for (const jl of jls) {
+    const upd = Number(jl.debit) > 0 ? { debit: total } : { credit: total };
+    const { error } = await fin.from("fin_journal_lines").update(upd).eq("id", jl.id);
+    if (error) throw new Error(error.message);
+  }
+  const { error: tErr } = await fin.from("fin_transactions").update({ amount: total }).eq("id", txnId);
+  if (tErr) throw new Error(tErr.message);
 }
 
 // Delete posted bank-agent journals that no bank line references. These are
 // derived rows whose source lines were rebuilt away; keeping them is exactly
 // the double-count. Scoped to the given window and to posted_by_agent='bank' —
 // AR/manual journals are never touched.
+//
+// Mirror journals (cross-entity Grab) NEVER carry line stamps: their lines are
+// stamped onto the primary. Plain zero-ref logic would wrongly delete every
+// live mirror, so mirrors are identified by key derivation. A journal whose
+// posting_key equals bankMirrorJournalKey(k) for some present posting_key k is
+// k's mirror, and it lives and dies with that primary: kept while the primary
+// has line refs, deleted alongside it when the primary is an orphan. A mirror
+// whose primary is GONE entirely is not identified (nothing derives its key)
+// and falls through to plain zero-ref deletion, which is the correct outcome.
 async function gcOrphanBankJournals(sinceDate: string): Promise<number> {
   const fin = getFinanceClient();
   const { data: txns, error } = await fin
     .from("fin_transactions")
-    .select("id")
+    .select("id, posting_key")
     .eq("posted_by_agent", "bank")
     .eq("status", "posted")
     .gte("txn_date", sinceDate);
   if (error) throw new Error(error.message);
-  const ids = (txns ?? []).map((t) => t.id as string);
+  const rows = (txns ?? []).map((t) => ({ id: t.id as string, key: (t.posting_key as string | null) ?? null }));
+  const ids = rows.map((r) => r.id);
 
-  const orphans: string[] = [];
+  const unlinked = new Set<string>();
   for (let i = 0; i < ids.length; i += 500) {
     const chunk = ids.slice(i, i + 500);
     const linked = await prisma.bankStatementLine.groupBy({
@@ -250,7 +440,25 @@ async function gcOrphanBankJournals(sinceDate: string): Promise<number> {
       where: { glTransactionId: { in: chunk } },
     });
     const linkedSet = new Set(linked.map((r) => r.glTransactionId));
-    for (const id of chunk) if (!linkedSet.has(id)) orphans.push(id);
+    for (const id of chunk) if (!linkedSet.has(id)) unlinked.add(id);
+  }
+
+  // mirror journal id -> its primary journal id, via key derivation.
+  const idByKey = new Map<string, string>();
+  for (const r of rows) if (r.key) idByKey.set(r.key, r.id);
+  const mirrorToPrimary = new Map<string, string>();
+  for (const r of rows) {
+    if (!r.key) continue;
+    const mirrorId = idByKey.get(bankMirrorJournalKey(r.key));
+    if (mirrorId && mirrorId !== r.id) mirrorToPrimary.set(mirrorId, r.id);
+  }
+
+  const orphans: string[] = [];
+  for (const r of rows) {
+    if (!unlinked.has(r.id)) continue;
+    const primaryId = mirrorToPrimary.get(r.id);
+    if (primaryId && !unlinked.has(primaryId)) continue; // live primary keeps its mirror
+    orphans.push(r.id);
   }
 
   for (let i = 0; i < orphans.length; i += 200) {

--- a/apps/backoffice/src/lib/finance/ingestors/pos-native-eod.ts
+++ b/apps/backoffice/src/lib/finance/ingestors/pos-native-eod.ts
@@ -31,6 +31,7 @@ import { Prisma } from "@prisma/client";
 import { getFinanceClient } from "../supabase";
 import { postDailyAr, type EodSummary, type EodChannelSplit } from "../agents/ar";
 import { resolveCompanyFromOutlet, getDefaultCompanyId } from "../companies";
+import { GL_POSTING_CUTOVER } from "../gl-posting-map";
 import type { IngestEodResult } from "./storehub-eod";
 import { ingestOutletEod } from "./storehub-eod";
 
@@ -211,6 +212,13 @@ export async function ingestOutletNativeEod(
   opts: { includeStorehubDelivery?: boolean } = {},
 ): Promise<IngestEodResult> {
   const { id: outletId, name: outletName } = outlet;
+
+  // GL posting cutover: 2025 books live in Bukku. Refusing pre-cutover dates
+  // here (not just in the cron router) keeps backfills and manual replays from
+  // recreating 2025 AR journals after the balance sheet surgery deletes them.
+  if (date < GL_POSTING_CUTOVER) {
+    return { outletId, outletName, date, transactionsFetched: 0, skipped: `pre-cutover date (GL starts ${GL_POSTING_CUTOVER})` };
+  }
 
   // Already posted for this outlet/day? (matches storehub-eod's guard.) A
   // REVERSED journal doesn't count — that's how the cutover backfill re-posts a

--- a/apps/backoffice/src/lib/finance/ingestors/storehub-eod.ts
+++ b/apps/backoffice/src/lib/finance/ingestors/storehub-eod.ts
@@ -27,6 +27,7 @@ import { prisma } from "@/lib/prisma";
 import { getFinanceClient } from "../supabase";
 import { postDailyAr, type EodSummary, type EodChannelSplit } from "../agents/ar";
 import { resolveCompanyFromOutlet, getDefaultCompanyId } from "../companies";
+import { GL_POSTING_CUTOVER } from "../gl-posting-map";
 import type { StoreHubTransaction } from "@/lib/storehub";
 
 type ChannelKey = keyof EodChannelSplit;
@@ -228,6 +229,11 @@ export async function ingestOutletEod(
   outletId: string,
   date: string                     // YYYY-MM-DD (MYT)
 ): Promise<IngestEodResult> {
+  // GL posting cutover: 2025 books live in Bukku. Never post pre-cutover AR
+  // journals from here, even on manual replays or backfills.
+  if (date < GL_POSTING_CUTOVER) {
+    return { outletId, outletName: "?", date, transactionsFetched: 0, skipped: `pre-cutover date (GL starts ${GL_POSTING_CUTOVER})` };
+  }
   const outlet = await prisma.outlet.findUnique({
     where: { id: outletId },
     select: { id: true, name: true, storehubId: true },

--- a/apps/backoffice/src/lib/finance/salary-accrual.ts
+++ b/apps/backoffice/src/lib/finance/salary-accrual.ts
@@ -28,6 +28,7 @@
 
 import { getFinanceClient } from "./supabase";
 import { postJournal } from "./ledger";
+import { GL_POSTING_CUTOVER } from "./gl-posting-map";
 import type { JournalLineInput } from "./types";
 
 const round2 = (n: number) => Math.round(n * 100) / 100;
@@ -85,12 +86,15 @@ export async function accrueSalaryControls(opts: { commit?: boolean } = {}): Pro
   // Positive deltas per company|month.
   const today = new Date(Date.now() + 8 * 3600_000).toISOString().slice(0, 10); // MYT
   const currentMonth = today.slice(0, 7);
+  const cutoverMonth = GL_POSTING_CUTOVER.slice(0, 7);
   const byMonth = new Map<string, Record<string, number>>();
   for (const [key, v] of agg) {
     const delta = round2(v.d - v.c);
     if (delta <= 0.005) continue;
     const [company, month, account] = key.split("|");
     if (month > currentMonth) continue;
+    if (month < cutoverMonth) continue; // pre-cutover months belong to Bukku; never accrue into them
+
     const mk = `${company}|${month}`;
     const rec = byMonth.get(mk) ?? {};
     rec[account] = delta;


### PR DESCRIPTION
## What this is

Code half of the authorized balance sheet repair: (1) a hard GL posting cutover at 2026-01-01, and (2) cross-entity routing for Grab settlements that land in SB's bank but belong to Conezion or Tamarind outlets. The data surgery (deleting pre-cutover journals, re-keying the parked Grab suspense, posting opening balances) runs separately through existing APIs and SQL AFTER this deploys.

> **WARNING: deploy this BEFORE running the data surgery.** The surgery deletes 2025 journals and un-stamps the mis-routed Grab lines; without this code deployed, the very next 6-hourly cron would re-post the 2025 backlog and re-park the Grab lines in suspense.

## 1. Posting cutover

`GL_POSTING_CUTOVER = '2026-01-01'` (defined in `gl-posting-map.ts`, re-exported from `gl-posting.ts`). 2025 books live in Bukku (reconciled through Dec 2025); this GL owns 2026 onward with opening balances posted as at the cutover.

**Exact filter added** to `postBankLinesToGl` (used by the cron, the manual POST commit, and the GET dry-run preview, so scanned/backlog counts all share it):

```ts
const cutoverFloor = new Date(`${GL_POSTING_CUTOVER}T00:00:00Z`);
const sinceFloor = opts.sinceDays ? new Date(Date.now() - opts.sinceDays * 86_400_000) : cutoverFloor;
const txnDateFloor = sinceFloor > cutoverFloor ? sinceFloor : cutoverFloor;
...
where: { category: { not: null }, glTransactionId: null, txnDate: { gte: txnDateFloor } }
```

`sinceDays` can only narrow the window, never widen it past the cutover. The grouping function (`buildBankGroups`) ALSO drops any `date < GL_POSTING_CUTOVER` line as a belt-and-braces guard, so every caller gets the same floor even if handed stale lines.

**Other clamped paths** (so EOD backfills cannot recreate 2025 journals after the surgery):
- `ingestOutletNativeEod` (pos-native-eod.ts) refuses pre-cutover dates, returns `skipped: "pre-cutover date"`. Covers the finance-eod cron, the finance-eod-backfill route, and manual replays.
- `ingestOutletEod` (storehub-eod.ts) same guard. Covers the cron router's StoreHub leg and the manual `/api/finance/ingest/storehub-eod` route.
- `accrueSalaryControls` (salary-accrual.ts) skips months before 2026-01.
- GC is naturally windowed at `lines[0].txnDate`, which is now always >= cutover, so it can never touch pre-cutover journals either.

## 2. Cross-entity Grab settlement routing

All Grab payouts settle into SB's (4384) account, while EOD AR accrues Grab sales as Dr 1005 in the OUTLET's company. Previously cross-entity payouts parked in suspense (`GRAB_PUTRAJAYA -> 1999`) or credited SB's own 1005, so Conezion/Tamarind 1005 debits were never cleared.

Now (see `resolveGrabSettlementRouting` in gl-posting-map.ts): when a CR line with category `GRAB` or `GRAB_PUTRAJAYA` resolves (via `fin_outlet_companies`, or via the `GRAB_PUTRAJAYA` label itself when no outlet is stamped) to an outlet owned by a different company, the group posts TWO journals:

- **Primary, in the receiving company (SB):** Dr 1000-01 bank / Cr 3600-xx due to the outlet's company (3600-00 Tamarind, 3600-01 Conezion).
- **Mirror, in the outlet's company:** Dr 3600-02 due from SB / Cr 1005 Grabfood debtors.

Own-outlet Grab (Shah Alam, Nilai) keeps the existing single journal (Dr bank / Cr SB 1005). Both directions of the mapping are generic, so a Tamarind-account payout for another company's outlet would route correctly too.

**Key scheme (idempotency):**
- Primary: `bankCrossEntityJournalKey = md5uuid("bank-gl-x|company|outlet|contra|date|direction")`. Own namespace (`bank-gl-x|` vs the plain `bank-gl|`) so a cross-entity Grab aggregate can never hash-collide and fold into a plain inter-co journal that resolves to the same 3600-xx contra on the same day.
- Mirror: `bankMirrorJournalKey(primaryKey) = md5uuid("bank-gl-mirror|" + primaryKey)`. Derived from the primary's posting_key STRING, so anything holding a bank journal's key (poster, GC, SQL) can locate its mirror deterministically without the aggregation parameters. Re-runs always land on the same pair; fold-ins REPLACE the mirror's amounts with the primary's settled total, so the pair cannot drift.

**Stamping approach:** bank lines are stamped with the PRIMARY journal's id only (`glTransactionId` is a single column; the primary is the journal in the line's own company, which is what recon and re-key flows expect). The mirror is discoverable via key derivation. Ordering makes it self-healing: the mirror is upserted BEFORE stamping, so if the mirror write fails the lines stay unstamped, the group re-forms next run, the primary is found and reused, and the mirror upsert retries.

**GC safety:** mirrors never carry line stamps, so the old zero-line-refs rule would have deleted every live mirror. The GC now identifies mirrors by key derivation: a journal whose posting_key equals `bankMirrorJournalKey(k)` for some present key k is k's mirror and lives and dies with that primary (kept while the primary has refs, deleted alongside an orphaned primary). A mirror whose primary is gone entirely is not identified as one and falls through to plain orphan deletion, which is the correct outcome. Re-key flows (reclassify, manual classify, AP match/unmatch) only un-stamp lines; the GC then removes the orphaned primary and its mirror together, and the next posting run rebuilds both under the same keys.

## Tests

`gl-posting.test.ts` (14 new, all pure, no DB):
- cutover: constant value, pre-cutover lines dropped from grouping, on-cutover kept
- routing: cross-entity Conezion/Tamarind account pairs, own-outlet and unknown-company null, legacy `GRAB_PUTRAJAYA` label resolves to Conezion, inter-co account map stays aligned with the narrative resolver
- grouping: own-outlet Grab single journal to 1005 with no mirror; cross-entity aggregates into one group with the mirror spec; cross-entity never folds into a plain inter-co group on the same contra/day
- keys: stable across runs, distinct across namespaces (plain vs cross-entity vs mirror), UUID formatted, identical pair from identical aggregations on two runs

Full suite: 182 passed. Typecheck clean. ESLint clean on touched files.

## Notes for the surgery

- Already-stamped `GRAB_PUTRAJAYA` suspense lines will NOT re-route on their own (stamped lines are never re-posted). The surgery must un-stamp them (and delete or let GC collect their 1999 journals); the next cron run then posts the correct pairs.
- No schema changes. No data touched by this PR.
