### PR TITLE
fix(finance): gl-posting imports prisma relatively so root vitest resolves it

### DIFF
--- a/apps/backoffice/src/lib/finance/gl-posting.ts
+++ b/apps/backoffice/src/lib/finance/gl-posting.ts
@@ -38,7 +38,7 @@
 // resolveGrabSettlementRouting, upsertMirrorJournal, and the mirror-aware GC.
 
 import { createHash } from "crypto";
-import { prisma } from "@/lib/prisma";
+import { prisma } from "../prisma";
 import { postJournal } from "./ledger";
 import { getFinanceClient } from "./supabase";
 import type { JournalLineInput } from "./types";


### PR DESCRIPTION
The root CI vitest run has no @ path alias (only apps/backoffice's own
vitest config does), so the @/lib/prisma import added with the cutover
broke the test job. Relative import matches what root vitest can resolve.
