### PR TITLE
fix(reviews): nightly cron self-heals a wrong gbpLocationName (Tamarind → Shah Alam)

### DIFF
--- a/apps/backoffice/src/app/api/cron/reviews-daily-snapshot/route.ts
+++ b/apps/backoffice/src/app/api/cron/reviews-daily-snapshot/route.ts
@@ -3,6 +3,7 @@ import { checkCronAuth } from "@celsius/shared";
 import { getUserFromHeaders } from "@/lib/auth";
 import { prisma } from "@/lib/prisma";
 import { fetchGoogleReviews } from "@/lib/reviews/gbp";
+import { relinkGbpLocations } from "@/lib/reviews/relink";
 import { fetchNextAheadCompetitor } from "@/lib/reviews/competitors";
 import { buildScoreboard } from "@/lib/reviews/scoreboard";
 import { sendMessage } from "@/lib/telegram";
@@ -28,6 +29,18 @@ export async function GET(req: NextRequest) {
   today.setUTCHours(0, 0, 0, 0);
   const now = Date.now();
   const DAY = 86400000;
+
+  // Self-heal before snapshotting: if an outlet's gbpLocationName provably
+  // points at the wrong listing (placeId mismatch vs the account's own
+  // location list), repair it so tonight's snapshot — and everything
+  // downstream — reads the right shop. Idempotent; best-effort.
+  let relink: Record<string, unknown> | null = null;
+  try {
+    const r = await relinkGbpLocations(true);
+    relink = { repaired: r.repaired, results: r.results.filter((x) => x.status !== "ok") };
+  } catch (err) {
+    relink = { error: err instanceof Error ? err.message : String(err) };
+  }
 
   const outlets = await prisma.outlet.findMany({
     where: { status: "ACTIVE" },
@@ -108,5 +121,5 @@ export async function GET(req: NextRequest) {
     console.error("[reviews-daily-snapshot] nudge failed", err);
   }
 
-  return NextResponse.json({ snapshotDate: today.toISOString().slice(0, 10), outlets: results, nudged });
+  return NextResponse.json({ snapshotDate: today.toISOString().slice(0, 10), relink, outlets: results, nudged });
 }

--- a/apps/backoffice/src/app/api/reviews/gbp-relink/route.ts
+++ b/apps/backoffice/src/app/api/reviews/gbp-relink/route.ts
@@ -1,21 +1,18 @@
 import { NextRequest, NextResponse } from "next/server";
 import { checkCronAuth } from "@celsius/shared";
 import { requireRole } from "@/lib/auth";
-import { prisma } from "@/lib/prisma";
-import { listAccountLocations } from "@/lib/reviews/gbp";
+import { relinkGbpLocations } from "@/lib/reviews/relink";
 
 export const dynamic = "force-dynamic";
 export const maxDuration = 60;
 
 // GET /api/reviews/gbp-relink[?apply=1] — audit (and with apply=1, repair) each
 // outlet's gbpLocationName against the GBP account's own location list, matched
-// by Places id. Exists because a location name can be mis-set by hand (found
-// live: Tamarind carried Shah Alam's locations/… id, so its review snapshots,
-// review feed and relevance audit all read the wrong shop). The Places id is
-// the outlet's verified public identity (matches its geogrid scans and review
-// QR), so the account listing whose metadata.placeId equals it IS this outlet.
+// by Places id (see lib/reviews/relink.ts for why placeId is the anchor).
 // Dry-run by default; nothing outside ReviewSettings.gbpLocationName is ever
 // touched, and only for outlets where the stored value provably mismatches.
+// The nightly reviews-daily-snapshot cron also runs the repair, so this route
+// is for on-demand checks rather than the only fix path.
 export async function GET(request: NextRequest) {
   const cronAuth = checkCronAuth(request.headers);
   if (!cronAuth.ok) {
@@ -27,57 +24,9 @@ export async function GET(request: NextRequest) {
   }
   const apply = new URL(request.url).searchParams.get("apply") === "1";
 
-  const settings = await prisma.reviewSettings.findMany({
-    where: {
-      gbpAccountId: { not: null },
-      gbpPlaceId: { not: null },
-      outlet: { status: "ACTIVE" },
-    },
-    include: { outlet: { select: { name: true } } },
-  });
-  if (settings.length === 0) {
-    return NextResponse.json({ ok: true, checked: 0, note: "No outlets with gbpAccountId + gbpPlaceId" });
+  const { checked, repaired, results } = await relinkGbpLocations(apply);
+  if (checked === 0) {
+    return NextResponse.json({ ok: true, checked, note: "No outlets with gbpAccountId + gbpPlaceId" });
   }
-
-  // One listing call per distinct account (they all share the MCC-style account).
-  const byAccount = new Map<string, Awaited<ReturnType<typeof listAccountLocations>>>();
-  const results: Array<Record<string, unknown>> = [];
-  let repaired = 0;
-
-  for (const s of settings) {
-    try {
-      let locations = byAccount.get(s.gbpAccountId!);
-      if (!locations) {
-        locations = await listAccountLocations(s.gbpAccountId!);
-        byAccount.set(s.gbpAccountId!, locations);
-      }
-      const match = locations.find((l) => l.placeId === s.gbpPlaceId);
-      if (!match) {
-        results.push({ outlet: s.outlet.name, status: "no_match", placeId: s.gbpPlaceId });
-        continue;
-      }
-      if (match.name === s.gbpLocationName) {
-        results.push({ outlet: s.outlet.name, status: "ok", location: match.name });
-        continue;
-      }
-      if (apply) {
-        await prisma.reviewSettings.update({
-          where: { outletId: s.outletId },
-          data: { gbpLocationName: match.name },
-        });
-        repaired++;
-      }
-      results.push({
-        outlet: s.outlet.name,
-        status: apply ? "repaired" : "mismatch",
-        stored: s.gbpLocationName,
-        correct: match.name,
-        gbpTitle: match.title,
-      });
-    } catch (e) {
-      results.push({ outlet: s.outlet.name, status: "error", error: (e as Error).message });
-    }
-  }
-
-  return NextResponse.json({ ok: true, mode: apply ? "apply" : "dry_run", checked: settings.length, repaired, results });
+  return NextResponse.json({ ok: true, mode: apply ? "apply" : "dry_run", checked, repaired, results });
 }

--- a/apps/backoffice/src/lib/reviews/relink.ts
+++ b/apps/backoffice/src/lib/reviews/relink.ts
@@ -1,0 +1,85 @@
+/**
+ * GBP location relink — detect (and optionally repair) an outlet whose stored
+ * gbpLocationName points at the wrong listing, by matching the GBP account's
+ * own location list against the outlet's verified Places id.
+ *
+ * Why placeId is the anchor: it's the outlet's public identity, cross-checked
+ * against its geogrid scans and review-QR g.page token — while the internal
+ * locations/NNN id is invisible outside the GBP API and was mis-set by hand
+ * once (Tamarind carried Shah Alam's id, so its review snapshots, feed and
+ * relevance audit read the wrong shop, and its scoreboard velocity spiked
+ * when the wrong listing's count entered its history).
+ *
+ * Used by the admin/cron endpoint /api/reviews/gbp-relink and, in repair mode,
+ * by the nightly reviews-daily-snapshot cron so a mis-link self-heals instead
+ * of silently poisoning every downstream reviews feature.
+ */
+import { prisma } from "@/lib/prisma";
+import { listAccountLocations } from "@/lib/reviews/gbp";
+
+export type RelinkResult = {
+  outlet: string;
+  status: "ok" | "mismatch" | "repaired" | "no_match" | "error";
+  location?: string;
+  stored?: string | null;
+  correct?: string;
+  gbpTitle?: string | null;
+  placeId?: string | null;
+  error?: string;
+};
+
+export async function relinkGbpLocations(apply: boolean): Promise<{
+  checked: number;
+  repaired: number;
+  results: RelinkResult[];
+}> {
+  const settings = await prisma.reviewSettings.findMany({
+    where: {
+      gbpAccountId: { not: null },
+      gbpPlaceId: { not: null },
+      outlet: { status: "ACTIVE" },
+    },
+    include: { outlet: { select: { name: true } } },
+  });
+
+  const byAccount = new Map<string, Awaited<ReturnType<typeof listAccountLocations>>>();
+  const results: RelinkResult[] = [];
+  let repaired = 0;
+
+  for (const s of settings) {
+    try {
+      let locations = byAccount.get(s.gbpAccountId!);
+      if (!locations) {
+        locations = await listAccountLocations(s.gbpAccountId!);
+        byAccount.set(s.gbpAccountId!, locations);
+      }
+      const match = locations.find((l) => l.placeId === s.gbpPlaceId);
+      if (!match) {
+        results.push({ outlet: s.outlet.name, status: "no_match", placeId: s.gbpPlaceId });
+        continue;
+      }
+      if (match.name === s.gbpLocationName) {
+        results.push({ outlet: s.outlet.name, status: "ok", location: match.name });
+        continue;
+      }
+      if (apply) {
+        await prisma.reviewSettings.update({
+          where: { outletId: s.outletId },
+          data: { gbpLocationName: match.name },
+        });
+        repaired++;
+      }
+      results.push({
+        outlet: s.outlet.name,
+        status: apply ? "repaired" : "mismatch",
+        stored: s.gbpLocationName,
+        correct: match.name,
+        gbpTitle: match.title,
+      });
+    } catch (e) {
+      results.push({ outlet: s.outlet.name, status: "error", error: (e as Error).message });
+    }
+  }
+
+  return { checked: settings.length, repaired, results };
+}


### PR DESCRIPTION
## What & why

The Daily Rank Scoreboard showed **Tamarind with Shah Alam's 1,486 reviews and a fake 160.6/day velocity**. The snapshot history dates the poisoning precisely: Tamarind's rows were **correct** (353 → 370 reviews, ~17/30d — its real listing) through **Jul 2**; on **Jul 3** its count jumped to Shah Alam's 1,485 — the day the wrong `locations/…` id took effect. The "velocity" was that count-jump, not real reviews.

#783 added the `gbp-relink` audit/repair endpoint but left the repair as a manual click. This makes it self-healing.

## Changes

- **`lib/reviews/relink.ts`** — `relinkGbpLocations(apply)` extracted from the `/api/reviews/gbp-relink` route (the route is now a thin wrapper; same auth, same dry-run default).
- **`cron/reviews-daily-snapshot`** — runs the repair (apply mode) **before** snapshotting each night: a provable placeId mismatch heals the same night instead of silently poisoning snapshots, the review feed, auto-reply and the relevance audit. Best-effort — a relink failure never blocks the snapshot run; the result is included in the cron's response as `relink`.

## Prod data fix (already applied)

The three poisoned Tamarind snapshot rows (Jul 3–5, carrying the wrong listing's counts) were deleted. The scoreboard falls back to the last true row (Jul 2, 370 reviews) and rebuilds from the next snapshot.

## Safety

- Repair only fires on a **provable mismatch**: the stored `gbpLocationName` differs from the account listing whose `metadata.placeId` equals the outlet's verified `gbpPlaceId` (anchored to its geogrid scans + review-QR token).
- Touches only `ReviewSettings.gbpLocationName`. Idempotent — steady-state result is `ok` for every outlet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01KAg3qfmYoUCakrJNpQoMZJ)_