### PR TITLE
feat(hr): daily schedule view, whole-week rest-day spread, FT sunk-cost labour %

### DIFF
--- a/apps/backoffice/src/app/(admin)/hr/schedules/page.tsx
+++ b/apps/backoffice/src/app/(admin)/hr/schedules/page.tsx
@@ -169,6 +169,8 @@ export default function SchedulesPage() {
   }>(null);
   const [publishing, setPublishing] = useState(false);
   const [gate, setGate] = useState<LabourGateInfo | null>(null);
+  const [view, setView] = useState<"week" | "day">("week");
+  const [dayIdx, setDayIdx] = useState(0);
   const [generating, setGenerating] = useState(false);
   const [clearing, setClearing] = useState(false);
   const [swapAction, setSwapAction] = useState<string | null>(null);
@@ -632,6 +634,18 @@ export default function SchedulesPage() {
           Week of <strong>{weekStart}</strong> → {grid?.week_end || "..."}
         </div>
 
+        <div className="flex overflow-hidden rounded-lg border text-sm">
+          {(["week", "day"] as const).map((v) => (
+            <button
+              key={v}
+              onClick={() => setView(v)}
+              className={`px-3 py-1.5 font-medium capitalize ${view === v ? "bg-terracotta text-white" : "hover:bg-muted"}`}
+            >
+              {v}
+            </button>
+          ))}
+        </div>
+
         {gate && (
           <div
             className={`flex items-center gap-2 rounded-lg border px-3 py-1.5 text-sm font-medium ${
@@ -745,7 +759,9 @@ export default function SchedulesPage() {
       )}
 
       {/* Grid */}
-      {grid && grid.users.length > 0 ? (
+      {grid && grid.users.length > 0 && view === "day" ? (
+        <DayView grid={grid} dayIdx={dayIdx} setDayIdx={setDayIdx} gate={gate} />
+      ) : grid && grid.users.length > 0 ? (
         <div className="flex-1 min-h-0 overflow-auto rounded-xl border bg-card shadow-sm overflow-x-auto">
           <table className="w-full text-sm min-w-[720px]">
             <thead className="sticky top-0 z-20">
@@ -1129,4 +1145,121 @@ function guessColor(shift: Shift): string {
   if (label.includes("middle")) return "blue";
   if (label.includes("nilai")) return "purple";
   return "gray";
+}
+
+// Day view — one date at a time: who opens, who's on each middle, who
+// closes, who's resting or on leave, and that day's coverage. Read-only;
+// editing stays in the week grid.
+function DayView({
+  grid,
+  dayIdx,
+  setDayIdx,
+  gate,
+}: {
+  grid: GridData;
+  dayIdx: number;
+  setDayIdx: (i: number) => void;
+  gate: LabourGateInfo | null;
+}) {
+  const date = grid.days[Math.min(dayIdx, grid.days.length - 1)];
+  const nameOf = new Map(grid.users.map((u) => [u.id, u.fullName || u.name]));
+  const positionOf = new Map(grid.users.map((u) => [u.id, u.profile?.position ?? ""]));
+
+  const dayShifts = grid.shifts.filter((s) => s.shift_date === date);
+  const resting = dayShifts.filter((s) => s.notes === "rest_day");
+  const working = dayShifts.filter((s) => s.notes !== "rest_day");
+  const onLeave = grid.leaves.filter((l) => date >= l.start_date && date <= l.end_date);
+
+  // Group by identical shift (label + span), ordered by start time.
+  const groups = new Map<string, { label: string; start: string; end: string; shifts: Shift[] }>();
+  for (const s of [...working].sort((a, b) => a.start_time.localeCompare(b.start_time))) {
+    const key = `${s.start_time}-${s.end_time}-${s.role_type ?? ""}`;
+    const g = groups.get(key) ?? { label: s.role_type || "Shift", start: s.start_time, end: s.end_time, shifts: [] };
+    g.shifts.push(s);
+    groups.set(key, g);
+  }
+  const cov = gate?.coverage?.find((c) => c.date === date);
+
+  return (
+    <div className="flex-1 min-h-0 space-y-3 overflow-auto">
+      <div className="flex flex-wrap items-center gap-1">
+        {grid.days.map((d, i) => (
+          <button
+            key={d}
+            onClick={() => setDayIdx(i)}
+            className={`rounded-lg border px-3 py-1.5 text-sm font-medium ${
+              d === date ? "border-terracotta bg-terracotta text-white" : "hover:bg-muted"
+            }`}
+          >
+            {DAY_NAMES[i]} {formatDay(d)}
+          </button>
+        ))}
+        {cov && cov.neededHours > 0 && (
+          <span
+            className={`ml-auto rounded-lg border px-3 py-1.5 text-sm font-medium ${
+              cov.shortHours === 0
+                ? "border-green-200 bg-green-50 text-green-700"
+                : "border-amber-300 bg-amber-50 text-amber-700"
+            }`}
+          >
+            Coverage {cov.scheduledHours}/{cov.neededHours} staff-hours
+            {cov.shortHours > 0 ? ` — ${cov.shortHours}h short` : " ✓"}
+          </span>
+        )}
+      </div>
+
+      {groups.size === 0 && (
+        <div className="rounded-xl border bg-card py-12 text-center text-sm text-muted-foreground">
+          No shifts on {date} — use the week view to assign.
+        </div>
+      )}
+
+      {[...groups.values()].map((g) => (
+        <div key={`${g.start}-${g.end}-${g.label}`} className="rounded-xl border bg-card p-4">
+          <div className="mb-2 flex items-center justify-between">
+            <h3 className="font-semibold">{g.label}</h3>
+            <span className="text-sm text-muted-foreground">
+              {g.start.slice(0, 5)} – {g.end.slice(0, 5)} · {g.shifts.length} pax
+            </span>
+          </div>
+          <ul className="grid gap-1 sm:grid-cols-2 lg:grid-cols-3">
+            {g.shifts.map((s) => (
+              <li
+                key={s.id}
+                className={`rounded-lg border px-3 py-2 text-sm ${
+                  s.notes === "pt_suggestion" ? "border-dashed border-amber-400 bg-amber-50" : "bg-muted/30"
+                }`}
+              >
+                <span className="font-medium">
+                  {s.notes === "pt_suggestion" ? "PT? " : ""}
+                  {nameOf.get(s.user_id) ?? s.user_id.slice(0, 8)}
+                </span>
+                {positionOf.get(s.user_id) && (
+                  <span className="ml-1 text-xs text-muted-foreground">· {positionOf.get(s.user_id)}</span>
+                )}
+              </li>
+            ))}
+          </ul>
+        </div>
+      ))}
+
+      {(resting.length > 0 || onLeave.length > 0) && (
+        <div className="rounded-xl border bg-card p-4">
+          <h3 className="mb-2 font-semibold">Off today</h3>
+          <div className="flex flex-wrap gap-1.5 text-sm">
+            {resting.map((s) => (
+              <span key={s.id} className="rounded-lg border border-red-200 bg-red-50 px-2.5 py-1 text-red-700">
+                {nameOf.get(s.user_id) ?? "?"} · rest day
+              </span>
+            ))}
+            {onLeave.map((l, i) => (
+              <span key={i} className="rounded-lg border border-purple-200 bg-purple-50 px-2.5 py-1 text-purple-700">
+                {nameOf.get(l.user_id) ?? "?"} · {l.leave_type}
+              </span>
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  );
 }

--- a/apps/backoffice/src/lib/hr/agents/schedule-generator.ts
+++ b/apps/backoffice/src/lib/hr/agents/schedule-generator.ts
@@ -34,11 +34,10 @@ import { prisma } from "@/lib/prisma";
 import { hrSupabaseAdmin } from "../supabase";
 import { templatesForOutlet, workingHours, type ShiftTemplate } from "../shift-templates";
 import {
-  costRoster,
+  weeklySalaryShare,
   OUTLET_BUDGETS,
   DEFAULT_BUDGET,
   ROVER_SHARE_WEEKLY,
-  type ShiftCostRow,
 } from "../labour-gate-lib";
 import { forecastWeekRevenue } from "../labour-gate";
 
@@ -282,7 +281,11 @@ export async function generateSchedule(outletId: string, weekStart: string): Pro
   // day loses more than its share of crew — one rest per day first, and when
   // there are more FT than rest slots, the doubles land on the quietest
   // weekdays instead of stacking on Monday/Tuesday.
-  const restSlots = [1, 2, 3, 4]
+  // Spread across ALL open days (not just Mon–Thu): one rest per day before
+  // any day takes a second, extras landing quietest-day-first — so a large
+  // crew no longer stacks 3–4 rests onto the early week, and the busiest
+  // day (usually Saturday) is the last to lose anyone.
+  const restSlots = [0, 1, 2, 3, 4, 5, 6]
     .filter((d) => daysOpen.has(d))
     .sort((a, b) => (dowLoad.get(a) ?? 0) - (dowLoad.get(b) ?? 0));
   const restCount = new Map<number, number>(restSlots.map((d) => [d, 0]));
@@ -415,23 +418,11 @@ export async function generateSchedule(outletId: string, weekStart: string): Pro
 
   // ── Stage 2: PT budget envelope — the only spend that moves labour % ─
   const forecast = Math.round(await forecastWeekRevenue(outlet, weekStart));
-  const ftCostRows: ShiftCostRow[] = rows
-    .filter((r) => r.notes !== "rest_day")
-    .map((r) => {
-      const s = staff.find((x) => x.id === r.user_id);
-      const rover = roverUsers.find((x) => x.id === r.user_id);
-      return {
-        user_id: r.user_id, shift_date: r.shift_date, start_time: r.start_time, end_time: r.end_time,
-        userName: s?.name ?? rover?.name ?? r.user_id.slice(0, 8),
-        // Rovers carry their rover position so costRoster prices them at RM0.
-        position: s?.position ?? roverPositionOf.get(r.user_id) ?? null,
-        employment_type: s?.employment_type ?? "full_time",
-        hourly_rate: s?.hourly_rate ?? null,
-        basic_salary: s?.basic_salary ?? 0,
-        epf_employer_rate: null,
-      };
-    });
-  const ftCost = Math.round(costRoster(ftCostRows).cost);
+  // FT salaries are sunk — the envelope charges every schedulable FT their
+  // full weekly share whether the roster fills them to 45h or not.
+  const ftCost = Math.round(
+    fullTimers.reduce((sum, s) => sum + weeklySalaryShare(s.basic_salary, null), 0),
+  );
   const ptBudget = Math.max(0, Math.round(budget.target * forecast - ftCost - ROVER_SHARE_WEEKLY));
   notes.push(
     `Budget: forecast RM${forecast.toLocaleString()} × ${(budget.target * 100).toFixed(0)}% = RM${Math.round(budget.target * forecast).toLocaleString()}; ` +

--- a/apps/backoffice/src/lib/hr/labour-gate-lib.ts
+++ b/apps/backoffice/src/lib/hr/labour-gate-lib.ts
@@ -153,6 +153,16 @@ export function costRoster(rows: ShiftCostRow[]): {
   return { cost, hours, blockers, warnings };
 }
 
+// A salaried FT's cost to the outlet per roster week: the full monthly
+// gross + employer statutory, prorated to a week — REGARDLESS of hours
+// rostered. Salaries are sunk: an FT rostered 30h costs the same as one
+// rostered 45h, so pricing FT by rostered hours understates labour %.
+export function weeklySalaryShare(basicSalary: number, epfEmployerRate: number | null): number {
+  const stat = normalizeRate(epfEmployerRate);
+  const load = stat != null && stat > 0 ? stat + 0.0175 + 0.002 : DEFAULT_EMPLOYER_STATUTORY;
+  return (basicSalary * (1 + load) * 12) / 52;
+}
+
 export function verdictFor(
   pct: number | null,
   budget: { target: number; ceiling: number },

--- a/apps/backoffice/src/lib/hr/labour-gate.ts
+++ b/apps/backoffice/src/lib/hr/labour-gate.ts
@@ -5,7 +5,9 @@ import { prisma } from "@/lib/prisma";
 import { hrSupabaseAdmin } from "@/lib/hr/supabase";
 import {
   costRoster,
+  shiftHours,
   verdictFor,
+  weeklySalaryShare,
   OUTLET_BUDGETS,
   DEFAULT_BUDGET,
   ROVER_SHARE_WEEKLY,
@@ -152,8 +154,44 @@ export async function gateSchedule(outletId: string, weekStart: string): Promise
     });
   }
 
-  const { cost, hours, blockers, warnings } = costRoster(rows);
-  const rosterCost = Math.round(cost + ROVER_SHARE_WEEKLY);
+  // costRoster still validates the roster (blockers, quota warnings,
+  // hours), but the COST side splits: FT salaries are sunk, so every
+  // schedulable FT assigned to this outlet is charged their full weekly
+  // share whether the roster uses them for 30h or 45h. Only PT hours move
+  // with the roster — the owner's rule: PT is the spend that moves %.
+  const { hours, blockers, warnings } = costRoster(rows);
+  const { data: ftProfiles } = await hrSupabaseAdmin
+    .from("hr_employee_profiles")
+    .select("user_id, position, employment_type, basic_salary, epf_employer_rate, schedule_required")
+    .is("end_date", null)
+    .in("employment_type", ["full_time", "contract"]);
+  type FtRow = {
+    user_id: string; position: string | null; employment_type: string;
+    basic_salary: number | null; epf_employer_rate: number | null; schedule_required: boolean | null;
+  };
+  const ftCandidates = ((ftProfiles ?? []) as FtRow[]).filter(
+    (p) =>
+      p.schedule_required !== false &&
+      !["manager", "area manager", "head of department", "barista lead"].includes(
+        (p.position ?? "").trim().toLowerCase(),
+      ),
+  );
+  const outletFtUsers = ftCandidates.length
+    ? await prisma.user.findMany({
+        where: { id: { in: ftCandidates.map((p) => p.user_id) }, status: "ACTIVE", outletId },
+        select: { id: true },
+      })
+    : [];
+  const outletFtIds = new Set(outletFtUsers.map((u) => u.id));
+  const ftWeekly = ftCandidates
+    .filter((p) => outletFtIds.has(p.user_id))
+    .reduce((sum, p) => sum + weeklySalaryShare(Number(p.basic_salary) || 0, p.epf_employer_rate == null ? null : Number(p.epf_employer_rate)), 0);
+  const ptCost = rows.reduce((sum, r) => {
+    if (r.employment_type !== "part_time" && r.employment_type !== "intern") return sum;
+    if (!r.hourly_rate || r.hourly_rate <= 0) return sum;
+    return sum + shiftHours(r.start_time, r.end_time) * r.hourly_rate;
+  }, 0);
+  const rosterCost = Math.round(ftWeekly + ptCost + ROVER_SHARE_WEEKLY);
   const forecastRevenue = Math.round(await forecastWeekRevenue(outlet, weekStart));
   const pct = forecastRevenue > 0 ? rosterCost / forecastRevenue : null;
 

--- a/apps/backoffice/src/lib/inventory/par-calc.ts
+++ b/apps/backoffice/src/lib/inventory/par-calc.ts
@@ -1,4 +1,4 @@
-import { prisma } from "@/lib/prisma";
+import { prisma } from "../prisma";
 
 // ─── Par-level calculation (shared by the manual route + weekly cron) ────
 //


### PR DESCRIPTION
## What

Three follow-ups to the AI Fill / labour-gate loop, from the owner's review of the Putrajaya week grid:

### 1. Daily view on the schedules page
Week/Day toggle above the grid. The day view shows each shift group (Opening / Middle / Closing) as a card with the crew and pax count, an "Off today" strip (rest days + leave), and that day's coverage badge — so a manager can eyeball whether a single day is properly covered without decoding the week grid.

### 2. Rest days spread across the whole week
AI Fill previously placed FT rest days only on Mon–Thu, so they bunched at the start of the week. Rest slots now rotate through **all** open days of the week, quietest days (by trailing-4-week sales) first, busiest day last.

### 3. Labour % priced with FT as sunk cost
The gate previously priced full-timers by rostered hours, so an under-rostered week looked cheaper than it really is. FT salaries are fixed — the outlet pays them regardless of the roster — so the gate now charges **every schedulable full-timer assigned to the outlet** their full weekly salary share (`basic × (1 + statutory) × 12 / 52`), and only PT hours move the percentage. Rovers stay at the fixed weekly share (RM309). The AI Fill budget envelope uses the same pricing, so the PT suggestions it sizes match what the gate will charge.

Also carries the `par-calc.ts` relative-import fix so root vitest resolves the prisma module (pre-existing on main).

## Explicitly left out
The demand-led "cap FT at what sales need" change was dropped per the owner — total-hours behaviour stays as on main (fill FT to 45h/week).

## Verification
- `npx tsc --noEmit` clean (backoffice)
- `npx eslint` clean on touched files (one pre-existing warning on main remains)
- Root `npx vitest run`: 31 files, 318 tests passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R2Kv8uNdKdCSqfUFR7vkWM