### PR TITLE
fix(test): root vitest resolves the backoffice @/ alias (main broken by #714) + session STATE

### DIFF
--- a/docs/STATE.md
+++ b/docs/STATE.md
@@ -106,6 +106,28 @@ _Format: `YYYY-MM-DD — <symptom> — <evidence> — <hypothesis/fix> — <bloc
 
 ## Resume pointer
 
+- 2026-07-05 — **Ads + local-rank loop hardened** (PRs #732/#751/#781/#783/#797
+  all merged): budget-cut optimizer live at `/ads/optimizer` (waste tier +
+  efficiency trims vs fleet-best cost/conv, `ads_budget_change` ledger applied
+  to prod, approval-gated, weekly shadow inside `ads-daily` Mondays); keyword
+  strategy board at `/reviews/geogrid/keywords` (own/focus/prominence/retire,
+  opportunity-sorted). **Measurement bugs fixed:** `ads_campaign.status` stores
+  Google's numeric enum ("2"=ENABLED) — filter with `ENABLED_STATUSES`; the
+  geogrid auto-scan defaulted to 0.2mi (storefront) — now 1.5534mi = the ±10km
+  catchment; keyword buckets only trust complete catchment-scale scans (Nilai's
+  "owned" verdicts were 0.1mi artifacts). **Tamarind was wired to Shah Alam's
+  GBP location** (poisoned snapshots Jul 3–5, deleted from prod; the fake
+  160.6/day velocity was the count-jump): `reviews-daily-snapshot` now
+  self-heals `gbpLocationName` nightly by matching `gbpPlaceId` (set for all 4
+  outlets from verified scan/QR evidence) against `listAccountLocations`;
+  on-demand check at `/api/reviews/gbp-relink[?apply=1]`. **Lever validation:**
+  categories = strongest rank lever; review velocity ≈20% and the binding
+  constraint (Nilai 2/30d, SA ~11, Tam ~17, Putrajaya 34); GBP description is
+  NOT a rank factor — stop treating geo-in-description as a rank play.
+  **Next:** after the first true-10km scan (Mon Jul 6, 1pm MYT) read fresh
+  baselines and propose per-outlet GBP category adds; owner still owes the ads
+  search-term backfill curl (CRON_SECRET) and the review-velocity ops push.
+
 - 2026-07-05 — **People-cost gating loop shipped** (PRs #765/#780/#785 all
   merged): labour gate + publish enforcement (green/amber/red, per-outlet
   budgets Con 16/18, SA 18/20, Tam 22/25 interim), editor badge + per-day

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,20 @@
+import { defineConfig } from "vitest/config";
+import { fileURLToPath } from "node:url";
+import path from "node:path";
+
+const dir = path.dirname(fileURLToPath(import.meta.url));
+
+// Root config for the repo-wide `npx vitest run` that CI's `test` job uses.
+// Backoffice modules import via the `@/` tsconfig alias; without it resolved
+// here, any backoffice test whose import chain touches `@/…` fails to even
+// load (first hit: par-calc.test.ts → par-calc.ts → `@/lib/prisma`, #714).
+// apps/backoffice/vitest.config.ts declares the same alias but only applies
+// when vitest runs from inside that app — vitest does not auto-apply nested
+// configs to a root run. `@/` is only used by backoffice code today; if
+// another app adopts the alias for root-run tests, this needs a per-project
+// split instead of a single mapping.
+export default defineConfig({
+  resolve: {
+    alias: { "@": path.resolve(dir, "apps/backoffice/src") },
+  },
+});


### PR DESCRIPTION
## 1. Fix: `test` job broken on main by #714

#714 (merged 09:38 UTC today) added `par-calc.test.ts`, whose module chain imports `@/lib/prisma`. CI's `test` job runs `npx vitest run` **from the repo root**, which had no `@` alias — `apps/backoffice/vitest.config.ts` declares it, but a nested config doesn't apply to a root run. The suite fails at import (`ERR_MODULE_NOT_FOUND`), so **every PR's `test` job now fails on main**; this docs PR was just the first to sample it (313/313 individual tests still pass).

Fix: root `vitest.config.ts` mapping `@` → `apps/backoffice/src` (the only app using the alias in root-run tests). Safe: `npm ci` already generates the Prisma client (backoffice `postinstall`) and the prisma singleton is lazy — no DB connection in tests.

## 2. Session STATE update (docs)

`docs/STATE.md` resume pointer for today's merged work (#732/#751/#781/#783/#797): budget optimizer + keyword strategy live, status-enum and scan-radius measurement fixes, Tamarind GBP self-heal + prod cleanup, lever validation, and next steps (true-10km baselines Mon Jul 6 → category adds; owner owes backfill curl + review-velocity push).

🤖 Generated with [Claude Code](https://claude.com/claude-code)