### PR TITLE
fix(inventory): make par-calc prisma import lazy so its unit test loads

### DIFF
--- a/apps/backoffice/src/lib/inventory/par-calc.ts
+++ b/apps/backoffice/src/lib/inventory/par-calc.ts
@@ -1,5 +1,3 @@
-import { prisma } from "@/lib/prisma";
-
 // ─── Par-level calculation (shared by the manual route + weekly cron) ────
 //
 // Formula (base UOM):
@@ -119,6 +117,13 @@ export interface ParCalcResult {
 }
 
 export async function recalcOutletParLevels(outletId: string, opts: ParCalcOptions = {}): Promise<ParCalcResult> {
+  // Lazy import so the pure exports above (classifyByDailyValue,
+  // VALUE_CLASS_PARAMS) can be unit-tested without the test runner having to
+  // resolve the `@/lib/prisma` alias — importing prisma at module top level
+  // made par-calc.test.ts fail with ERR_MODULE_NOT_FOUND. Runtime behaviour is
+  // unchanged: the module cache resolves this once on first recalc.
+  const { prisma } = await import("@/lib/prisma");
+
   const lookbackDays = opts.lookbackDays ?? PAR_DEFAULTS.lookbackDays;
   const safetyDays = opts.safetyDays ?? PAR_DEFAULTS.safetyDays;
   // null ⇒ class-based coverage (the default); a number ⇒ manual override for all classes.


### PR DESCRIPTION
## Problem

The `test` CI job is **failing on every open PR**. `apps/backoffice/src/lib/inventory/par-calc.test.ts` imports the pure helpers (`classifyByDailyValue`, `VALUE_CLASS_PARAMS`) from `par-calc.ts`, but that module imports `@/lib/prisma` at the **top level**. The vitest runner doesn't resolve the `@` alias for that path, so loading the module throws:

```
Error: Cannot find package '@/lib/prisma' imported from .../par-calc.ts
  ❯ apps/backoffice/src/lib/inventory/par-calc.ts:1:1
```

The file landed in #714; the broken test has been red on `main` since, taking down the shared `test` job for all branches.

## Fix

Move the prisma import **inside** `recalcOutletParLevels` as a lazy `await import("@/lib/prisma")`:
- The function is already `async`, so this is a one-line change.
- Mirrors an existing pattern in the repo (`api/pos/auth/verify-manager` lazy-imports prisma the same way).
- The tested functions are pure and no longer drag prisma into module load.
- **Runtime behaviour unchanged** — the module cache resolves the import once on first recalc; the two route callers (`cron/par-levels-recalc`, `inventory/par-levels/calculate`) are untouched.

## Verification
- `apps/backoffice/src/lib/inventory/par-calc.test.ts` → 5 passed.
- Full root `vitest run` → **31 files, 318 tests, all passing**.
- `apps/backoffice` `tsc --noEmit` clean.

## Context
Surfaced while working through the staff-access audit (PR #794); this unblocks CI green on that PR and its follow-ups. Unrelated to the audit changes themselves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rv7HYks3KA5qN5V86m8jFq

---
_Generated by [Claude Code](https://claude.ai/code/session_01Rv7HYks3KA5qN5V86m8jFq)_