### PR TITLE
security(rls): close the entire anon-reachable table surface (live audit + fixes)

### DIFF
--- a/docs/STATE.md
+++ b/docs/STATE.md
@@ -72,17 +72,32 @@ delete entries that have been promoted into `CLAUDE.md`, a skill, or a doc.
 
 ## Open failures
 
-- 2026-07-05 — **Loyalty tables anon-writable** — and wider than the access
-  map first said: the `USING (true)` "Service full access" policies in
-  `apps/order/supabase/migrations/001_initial_schema.sql:186-195` also
-  cover `staff_users` and `otp_codes`, and make the four public-read
-  tables anon-WRITABLE too. Code prerequisite is DONE (pickup page reads
-  moved behind `/api/pickup/dashboard-stats`); remaining step is applying
-  `docs/proposals/2026-07-05-loyalty-rls-policy-fix.sql` (human approval,
-  loyalty Supabase project) after that deploys. Checklist:
-  `docs/ops-hardening-checklist.md` §5.
+- 2026-07-05 — **14 public tables still anon-reachable with no RLS** (live
+  get_advisors, kqdcdhpnyuwrxqhbuyfl): `PendingPop` (POP `token`), grab_*
+  financial (webhook_events/reconcile_runs/campaigns/ads_spend/
+  modifier_links), ads_* , poster_events, pos_poster_perf,
+  challenge_nudge_assignment, product_*_seed. Need per-table check — some
+  server-written (safe deny-all), PendingPop/grab hit hard rule 6. Table +
+  grants in `docs/rls-access-map-2026-07-05.md` "Live advisor snapshot".
+  10 dated backup/snapshot tables from the same sweep already locked
+  (migration 074). Decision pending: rls-audit workflow vs hand-reviewed
+  batch.
+- 2026-07-05 — **`pos_*` + `orders`: 14 `USING(true)` policies are BY
+  DESIGN** (SUNMI tills write via the anon key). Do NOT lint-fix — needs a
+  data-layer plan (rls-strategy.md Path A).
 - 2026-07-05 — 13 of 14 Vercel crons still have no heartbeat monitoring
   (`reconcile-pending` wired 2026-07-05; the rest fail silently).
+- 2026-07-05 — Pickup dashboard **inventory tab reads tables that don't
+  exist** (`ingredients`, `stock_levels`, `ingredient_outlet_settings` —
+  absent from BOTH Supabase projects); it has been silently empty. Either
+  wire it to the real procurement stock tables (`StockBalance` etc.) or
+  remove the tab.
+
+_Resolved 2026-07-05 evening (see Lessons + access-map correction): the
+"loyalty tables anon-writable" finding was already fixed in production —
+live DB had drifted ahead of repo migration files. Actual live exposure
+was the `outlets` view (anon DML, RLS bypass); revoked same day
+(supabase/migrations/073, applied via Supabase MCP, verified)._
 
 _Fixed 2026-07-05 (see Lessons): categorizer correction mis-attribution +
 never-set `applied` flag — `related_id` now populated at decision time,
@@ -96,7 +111,6 @@ _Format: `YYYY-MM-DD — <symptom> — <evidence> — <hypothesis/fix> — <bloc
 - 2026-07-04 — `eas update` shells out to `expo export`, whose interactive
   prompts ignore `--non-interactive`; set `CI=1` in the environment instead.
   Pass commit messages via env var, not inline in the shell command (backticks/
-  `*`/newlines get shell-expanded). (Source: `.github/workflows/pos-native-ota.yml`.)
 
 - 2026-07-05 — The AI Fill week-wipe (60 shifts) was the old generator's
   DELETE-then-INSERT persist with no transaction; `hr_schedule_shift_audit`

--- a/docs/STATE.md
+++ b/docs/STATE.md
@@ -72,19 +72,10 @@ delete entries that have been promoted into `CLAUDE.md`, a skill, or a doc.
 
 ## Open failures
 
-- 2026-07-05 — **14 public tables still anon-reachable with no RLS** (live
-  get_advisors, kqdcdhpnyuwrxqhbuyfl): `PendingPop` (POP `token`), grab_*
-  financial (webhook_events/reconcile_runs/campaigns/ads_spend/
-  modifier_links), ads_* , poster_events, pos_poster_perf,
-  challenge_nudge_assignment, product_*_seed. Need per-table check — some
-  server-written (safe deny-all), PendingPop/grab hit hard rule 6. Table +
-  grants in `docs/rls-access-map-2026-07-05.md` "Live advisor snapshot".
-  10 dated backup/snapshot tables from the same sweep already locked
-  (migration 074). Decision pending: rls-audit workflow vs hand-reviewed
-  batch.
 - 2026-07-05 — **`pos_*` + `orders`: 14 `USING(true)` policies are BY
   DESIGN** (SUNMI tills write via the anon key). Do NOT lint-fix — needs a
-  data-layer plan (rls-strategy.md Path A).
+  data-layer plan (rls-strategy.md Path A). 4 `security_definer_view` +
+  ~12 `function_search_path_mutable` remain as low-risk hardening.
 - 2026-07-05 — 13 of 14 Vercel crons still have no heartbeat monitoring
   (`reconcile-pending` wired 2026-07-05; the rest fail silently).
 - 2026-07-05 — Pickup dashboard **inventory tab reads tables that don't
@@ -97,7 +88,11 @@ _Resolved 2026-07-05 evening (see Lessons + access-map correction): the
 "loyalty tables anon-writable" finding was already fixed in production —
 live DB had drifted ahead of repo migration files. Actual live exposure
 was the `outlets` view (anon DML, RLS bypass); revoked same day
-(supabase/migrations/073, applied via Supabase MCP, verified)._
+(supabase/migrations/073, applied via Supabase MCP, verified). Full
+get_advisors sweep then closed ALL remaining anon-reachable tables:
+10 backup snapshots (074) + 14 server-only tables incl. PendingPop/grab_*
+(075). Verified: rls_disabled_in_public 24→0, sensitive_columns_exposed
+2→0, security ERRORs 30→4 (the 4 left are SECURITY DEFINER views)._
 
 _Fixed 2026-07-05 (see Lessons): categorizer correction mis-attribution +
 never-set `applied` flag — `related_id` now populated at decision time,

--- a/docs/proposals/2026-07-05-loyalty-rls-policy-fix.sql
+++ b/docs/proposals/2026-07-05-loyalty-rls-policy-fix.sql
@@ -1,3 +1,16 @@
+-- ⚠️ SUPERSEDED 2026-07-05 — NOT NEEDED. Live-DB verification (pg_policies,
+-- role_table_grants on project kqdcdhpnyuwrxqhbuyfl) showed production had
+-- already drifted AHEAD of the repo migrations: the USING(true) "Service
+-- full access" policies no longer exist, anon's DML grants on the sensitive
+-- tables were already revoked (permission denied before RLS even applies),
+-- and staff_users was dropped entirely. The real live exposure was the
+-- `outlets` VIEW instead — fixed in
+-- supabase/migrations/073_revoke_anon_writes_outlets_view.sql.
+-- Kept for the record of what the repo's migration files (wrongly) implied.
+-- Lesson: audit the live DB, not migration files (STATE.md 2026-07-05).
+--
+-- Original header follows.
+--
 -- PROPOSAL — NOT APPLIED. Requires human approval (CLAUDE.md hard rule 6)
 -- and must ship AFTER the pickup dashboard-stats API route is deployed
 -- (the page's browser reads move server-side in the same PR as this file).

--- a/docs/rls-access-map-2026-07-05.md
+++ b/docs/rls-access-map-2026-07-05.md
@@ -5,6 +5,31 @@ and what RLS actually covers today. Supersedes that doc's "where we stand"
 section, which is stale (see corrections below). Evidence gathered by
 code/migration sweep on this date.
 
+> **⚠️ Live-DB correction (same day, evening):** this map was built from the
+> repo's migration files, and the live database (kqdcdhpnyuwrxqhbuyfl) had
+> drifted **ahead** of them. Verified against `pg_policies` +
+> `role_table_grants` directly:
+> - **Exposure 1 below was already fixed in production** — the `USING (true)`
+>   policies are gone, anon's DML grants on members / member_brands /
+>   point_transactions / redemptions / otp_codes are revoked (permission
+>   denied before RLS applies), and `staff_users` no longer exists. The
+>   proposal SQL is superseded (marked in-file).
+> - **`hr_payroll_runs` already has RLS enabled** (deny-all) — exposure 3 is
+>   closed too.
+> - The **real live exposure was `public.outlets`**: a postgres-owned VIEW
+>   over `"Outlet"` without `security_invoker` (writes bypass RLS), with
+>   full anon/authenticated DML grants — an anon-key write path into outlet
+>   master config. **Fixed 2026-07-05**:
+>   `supabase/migrations/073_revoke_anon_writes_outlets_view.sql`.
+> - Exposure 2 (pickup page browser reads) was real but manifested as the
+>   loyalty/inventory tabs silently returning nothing (deny-all), not as a
+>   data leak; the server-side route shipped in #782 fixes the loyalty tab.
+>   The inventory tab reads tables (`ingredients`, `stock_levels`) that
+>   exist in NEITHER Supabase project — pre-existing dead feature, still
+>   returning empty via the new route.
+> - Lesson: **audit the live database, not migration files.** The weekly
+>   rls-audit routine now includes a live `pg_policies`/grants/views check.
+
 ## Corrections to `rls-strategy.md`
 
 1. **"Only `orders`/`order_items` have RLS" is outdated.** Three later
@@ -75,6 +100,35 @@ Fold into the next deny-all batch.
 
 Native apps (`pos-native`, `pickup-native`, `staff-native`) touch none of
 these tables — their anon clients read POS/catalog tables only.
+
+## Live advisor snapshot — 2026-07-05 (get_advisors, project kqdcdhpnyuwrxqhbuyfl)
+
+Running Supabase's own security linter surfaced a wider surface than the
+code sweep. Totals: 30 ERROR, 44 WARN, 187 INFO.
+
+**Fixed this session (verified live):**
+- `outlets` view — anon/authenticated DML revoked
+  (`073_revoke_anon_writes_outlets_view.sql`).
+- 10 dated snapshot/soft-delete tables — deny-all RLS enabled
+  (`074_enable_rls_backup_snapshot_tables.sql`).
+
+**Still open — need per-table decision (NOT changed; several hit hard rule 6):**
+
+| Table(s) | Why sensitive | anon grants | Note |
+| --- | --- | --- | --- |
+| `PendingPop` | POP `token` column (payments-adjacent) | full DML, no RLS | verify who writes it before locking |
+| `grab_webhook_events`, `grab_reconcile_runs`, `grab_campaigns`, `grab_ads_spend`, `grab_modifier_links` | Grab financial/ops | full DML, no RLS | webhooks land via server route (service-role) — likely safe to deny-all, verify |
+| `ads_budget_change`, `ads_search_term_daily`, `ads_term_exclusion` | ad spend | no RLS | server-written; verify |
+| `poster_events`, `pos_poster_perf` | `session_id` | no RLS | telemetry |
+| `challenge_nudge_assignment` | loyalty experiment assignment | full DML, no RLS | |
+| `product_co_purchase_seed`, `product_round_seed` | loop seed data | no RLS | check no anon-client read before deny-all |
+| 14× `rls_policy_always_true` on `pos_*` + `orders` | **the SUNMI till architecture** — registers write via the anon key by design | intentional | do NOT revoke without a data-layer plan (rls-strategy.md Path A); this is the POS hot path |
+| 4× `security_definer_view`, 12× `function_search_path_mutable`, `pg_net` in public, exposed materialized view | hardening | — | lower priority |
+
+The `pos_*` always-true policies are load-bearing: the tills authenticate
+with the anon key and INSERT/UPDATE orders/payments/shifts directly.
+Tightening them means moving those writes behind a server API (Path A's real
+cost) — a project, not a migration. Flag, don't touch.
 
 ## Proposed order of work
 

--- a/docs/rls-access-map-2026-07-05.md
+++ b/docs/rls-access-map-2026-07-05.md
@@ -112,18 +112,24 @@ code sweep. Totals: 30 ERROR, 44 WARN, 187 INFO.
 - 10 dated snapshot/soft-delete tables — deny-all RLS enabled
   (`074_enable_rls_backup_snapshot_tables.sql`).
 
-**Still open — need per-table decision (NOT changed; several hit hard rule 6):**
+**Fixed 2026-07-05 (batch 2, migration 075) — all 14 remaining
+anon-reachable tables locked:** `PendingPop` (POP `token`; Prisma-only
+writer, RLS-exempt), grab_* (webhook_events/reconcile_runs/campaigns/
+ads_spend/modifier_links), ads_* (budget_change/search_term_daily/
+term_exclusion), poster_events + pos_poster_perf, challenge_nudge_assignment,
+product_*_seed. All verified server-only (no native/browser/client-component
+anon access). Deny-all, zero app impact.
 
-| Table(s) | Why sensitive | anon grants | Note |
-| --- | --- | --- | --- |
-| `PendingPop` | POP `token` column (payments-adjacent) | full DML, no RLS | verify who writes it before locking |
-| `grab_webhook_events`, `grab_reconcile_runs`, `grab_campaigns`, `grab_ads_spend`, `grab_modifier_links` | Grab financial/ops | full DML, no RLS | webhooks land via server route (service-role) — likely safe to deny-all, verify |
-| `ads_budget_change`, `ads_search_term_daily`, `ads_term_exclusion` | ad spend | no RLS | server-written; verify |
-| `poster_events`, `pos_poster_perf` | `session_id` | no RLS | telemetry |
-| `challenge_nudge_assignment` | loyalty experiment assignment | full DML, no RLS | |
-| `product_co_purchase_seed`, `product_round_seed` | loop seed data | no RLS | check no anon-client read before deny-all |
-| 14× `rls_policy_always_true` on `pos_*` + `orders` | **the SUNMI till architecture** — registers write via the anon key by design | intentional | do NOT revoke without a data-layer plan (rls-strategy.md Path A); this is the POS hot path |
-| 4× `security_definer_view`, 12× `function_search_path_mutable`, `pg_net` in public, exposed materialized view | hardening | — | lower priority |
+**Post-batch advisor state (verified):** `rls_disabled_in_public` 24 → **0**;
+`sensitive_columns_exposed` 2 → **0**; security ERRORs 30 → **4**.
+
+**Still open — deliberately not touched:**
+
+| Finding | Why left | Note |
+| --- | --- | --- |
+| 14× `rls_policy_always_true` on `pos_*` + `orders` | **the SUNMI till architecture** — registers write via the anon key by design | do NOT revoke without a data-layer plan (rls-strategy.md Path A); this is the POS hot path |
+| 4× `security_definer_view` (`unified_sales`, `unified_sale_items`, `pos_pair_upsell_report`, `outlets`) | hardening; `outlets` write path already revoked (073) | convert to `security_invoker` when convenient |
+| ~12× `function_search_path_mutable`, `pg_net` in public, exposed materialized view | low-risk hardening | next pass |
 
 The `pos_*` always-true policies are load-bearing: the tills authenticate
 with the anon key and INSERT/UPDATE orders/payments/shifts directly.

--- a/supabase/migrations/073_revoke_anon_writes_outlets_view.sql
+++ b/supabase/migrations/073_revoke_anon_writes_outlets_view.sql
@@ -1,0 +1,15 @@
+-- Applied 2026-07-05 via Supabase MCP (apply_migration:
+-- revoke_anon_writes_outlets_view). Saved here for the audit trail per
+-- docs/database-migrations.md — do not re-run.
+--
+-- Finding (2026-07-05 live-DB audit): public.outlets is a postgres-owned
+-- VIEW over "Outlet" (outlet master config — names, addresses, Grab
+-- merchant ids, company reg) WITHOUT security_invoker, so DML through it
+-- runs with the owner's privileges and bypasses RLS on "Outlet". anon and
+-- authenticated held INSERT/UPDATE/DELETE grants — a live write path into
+-- outlet config using the published anon key via PostgREST.
+--
+-- SELECT is retained: the order app's public store list reads this view.
+-- Verified after apply: anon/authenticated = REFERENCES,SELECT,TRIGGER only.
+
+REVOKE INSERT, UPDATE, DELETE, TRUNCATE ON public.outlets FROM anon, authenticated;

--- a/supabase/migrations/074_enable_rls_backup_snapshot_tables.sql
+++ b/supabase/migrations/074_enable_rls_backup_snapshot_tables.sql
@@ -1,0 +1,26 @@
+-- Applied 2026-07-05 via Supabase MCP (apply_migration:
+-- enable_rls_on_backup_snapshot_tables). Saved for the audit trail per
+-- docs/database-migrations.md — do not re-run.
+--
+-- From the 2026-07-05 get_advisors security sweep: 24 public tables had RLS
+-- disabled (anon-reachable via PostgREST). This migration closes the 10
+-- unambiguously-safe ones — dated snapshot / soft-delete copies nothing
+-- reads through the anon key. Deny-all (RLS on, no policy); service-role
+-- bypasses so ops/exports are unaffected. Drop candidates once retention
+-- passes (separate human-run cleanup).
+--
+-- The remaining 14 (PendingPop, grab_*, ads_*, poster_events, pos_poster_perf,
+-- challenge_nudge_assignment, product_*_seed) touch payments/POS/grab and
+-- need per-table verification — see docs/rls-access-map-2026-07-05.md
+-- "Live advisor snapshot"; NOT changed here (hard rule 6).
+
+alter table public.pos_orders_backup_20260606 enable row level security;
+alter table public.pos_order_items_backup_20260606 enable row level security;
+alter table public.pos_order_payments_backup_20260606 enable row level security;
+alter table public.pos_shifts_backup_20260606 enable row level security;
+alter table public.pos_pair_events_backup_20260606 enable row level security;
+alter table public.point_txn_deleted_20260606 enable row level security;
+alter table public.point_txn_deleted_20260615 enable row level security;
+alter table public.member_brands_adj_20260606 enable row level security;
+alter table public.member_brands_adj_20260615 enable row level security;
+alter table public.loop_assignments_quarantine_20260624 enable row level security;

--- a/supabase/migrations/075_enable_rls_server_only_public_tables.sql
+++ b/supabase/migrations/075_enable_rls_server_only_public_tables.sql
@@ -1,0 +1,29 @@
+-- Applied 2026-07-05 via Supabase MCP (apply_migration:
+-- enable_rls_server_only_public_tables), human in session. Audit trail per
+-- docs/database-migrations.md — do not re-run.
+--
+-- Batch 2 of the 2026-07-05 get_advisors sweep: the 14 remaining
+-- RLS-disabled public tables, all verified server-only (no native/browser/
+-- client-component anon access — grep of apps/ + packages/; "PendingPop" is
+-- Prisma-only, direct connection, RLS-exempt). Deny-all closes the public
+-- PostgREST exposure with zero app impact (service-role bypasses RLS).
+--
+-- Result (re-ran get_advisors after): rls_disabled_in_public 24 -> 0,
+-- sensitive_columns_exposed 2 -> 0, security ERRORs 30 -> 4 (the 4 left are
+-- SECURITY DEFINER views — separate hardening; the outlets view's write
+-- path is already revoked in migration 073).
+
+alter table public."PendingPop" enable row level security;             -- POP token; Prisma-only writer
+alter table public.grab_webhook_events enable row level security;
+alter table public.grab_reconcile_runs enable row level security;
+alter table public.grab_campaigns enable row level security;
+alter table public.grab_ads_spend enable row level security;
+alter table public.grab_modifier_links enable row level security;
+alter table public.ads_budget_change enable row level security;
+alter table public.ads_search_term_daily enable row level security;
+alter table public.ads_term_exclusion enable row level security;
+alter table public.poster_events enable row level security;            -- session_id
+alter table public.pos_poster_perf enable row level security;
+alter table public.challenge_nudge_assignment enable row level security;
+alter table public.product_co_purchase_seed enable row level security;
+alter table public.product_round_seed enable row level security;


### PR DESCRIPTION
## What

Applying the ops-hardening RLS items surfaced that **the live database had drifted ahead of the repo migration files**, so I audited production directly with Supabase `get_advisors` (+ `pg_policies`/grants) rather than trusting the files. Result: the entire anon-reachable-without-RLS surface is now closed. Three migrations, all applied to prod with a human in the session (hard rule 6) and saved for the audit trail.

### Applied to prod + saved

- **`073_revoke_anon_writes_outlets_view.sql`** — `public.outlets` is a postgres-owned `SECURITY DEFINER` view over `"Outlet"` (outlet master config: names, addresses, Grab merchant IDs, company reg). `anon`/`authenticated` held full `INSERT/UPDATE/DELETE`, and since the view isn't `security_invoker`, writes bypassed RLS on the base table — a live anon-key write path into outlet config. Revoked DML, kept `SELECT`. Verified.
- **`074_enable_rls_backup_snapshot_tables.sql`** — deny-all RLS on 10 dated snapshot / soft-delete tables (public, RLS off).
- **`075_enable_rls_server_only_public_tables.sql`** — deny-all on the 14 remaining anon-reachable tables (`PendingPop` POP-token, grab_* financial, ads_*, poster_events, pos_poster_perf, challenge_nudge_assignment, product_*_seed). Each verified server-only — no native/browser/client-component reads or writes any of them via the anon key (grep of `apps/` + `packages/`); `PendingPop` is Prisma-only (direct connection, RLS-exempt). Zero app impact; service-role bypasses RLS.

### Verified outcome (re-ran get_advisors after)

- `rls_disabled_in_public`: **24 → 0**
- `sensitive_columns_exposed`: **2 → 0**
- security ERRORs: **30 → 4**

### Items 1 & 2 from the checklist were already done in prod

The loyalty `USING(true)` policies and the `hr_payroll_runs` RLS gap from the access map were already fixed on the live DB — the repo migrations just didn't reflect it. `docs/proposals/2026-07-05-loyalty-rls-policy-fix.sql` is marked **superseded**.

### Deliberately left (documented in the access map)

- **14 `USING(true)` policies on `pos_*` + `orders` are intentional** — SUNMI tills write orders/payments/shifts via the anon key by design. Tightening them is the Path-A data-layer project (rls-strategy.md), not a lint fix.
- **4 `SECURITY DEFINER` views** (`unified_sales`, `unified_sale_items`, `pos_pair_upsell_report`, `outlets`) + ~12 `function_search_path_mutable` + `pg_net` in public — low-risk hardening for a later pass. (`outlets`' write path is already revoked here.)

Also: `docs/STATE.md` bookkeeping, and the weekly RLS-audit routine now runs the live `get_advisors` each Monday and diffs against the access map's "Live advisor snapshot".

## Verification

Every migration re-queried post-apply (`relrowsecurity` / grants), and the advisor re-run confirms the ERROR/exposed-column drop. Repo diff is SQL-record + docs only; the SQL was applied in-session via the Supabase MCP, so no `schema.prisma` change and the migration-guard is not implicated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L3K554Hw6n4vaL9yvGbvtJ