### PR TITLE
fix(staff): close unauthenticated + unscoped access holes (audit hotfixes)

### DIFF
--- a/apps/staff/src/app/api/audits/[id]/items/[itemId]/route.ts
+++ b/apps/staff/src/app/api/audits/[id]/items/[itemId]/route.ts
@@ -22,6 +22,35 @@ export async function PATCH(
     return NextResponse.json({ error: "Item not found" }, { status: 404 });
   }
 
+  // Only the auditor / managers-in-outlet / admins may write item ratings —
+  // not the staff member being audited. Mirrors PATCH /api/audits/[id]; without
+  // it any staffer could rewrite ratings/notes/photos on any audit by id.
+  const report = await prisma.auditReport.findUnique({
+    where: { id },
+    select: { auditorId: true, outletId: true },
+  });
+  if (!report) {
+    return NextResponse.json({ error: "Not found" }, { status: 404 });
+  }
+  const isAdmin = session.role === "OWNER" || session.role === "ADMIN";
+  let allowed = isAdmin || report.auditorId === session.id;
+  if (!allowed) {
+    const me = await prisma.user.findUnique({
+      where: { id: session.id },
+      select: { moduleAccess: true, outletId: true, outletIds: true },
+    });
+    const ops = (me?.moduleAccess as Record<string, unknown> | null)?.["ops"];
+    const hasAuditModule = ops === true || (Array.isArray(ops) && ops.includes("audit"));
+    const myOutlets = new Set<string>([
+      ...(me?.outletId ? [me.outletId] : []),
+      ...(me?.outletIds ?? []),
+    ]);
+    allowed = hasAuditModule && myOutlets.has(report.outletId);
+  }
+  if (!allowed) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+
   const data: Record<string, unknown> = {};
   if (rating !== undefined) data.rating = rating;
   if (notes !== undefined) data.notes = notes;

--- a/apps/staff/src/app/api/audits/[id]/route.ts
+++ b/apps/staff/src/app/api/audits/[id]/route.ts
@@ -2,6 +2,37 @@ import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
 import { getSession } from "@/lib/auth";
 
+// Authorization for a single audit report. Mirrors the list/DELETE routes:
+//   - OWNER/ADMIN: any report.
+//   - The auditor who created it: always.
+//   - The auditee (staff being audited): read-only, their own report — this is
+//     the "see your own performance" path (allowAuditee).
+//   - A manager with ops:audit: reports at an outlet in their scope.
+// Everyone else: forbidden. Without this, any authenticated staffer could read
+// or rewrite any audit by id (their own or a colleague's scores/notes).
+async function canAccessReport(
+  session: { id: string; role: string },
+  report: { auditorId: string; auditeeId: string | null; outletId: string },
+  opts: { allowAuditee: boolean },
+): Promise<boolean> {
+  if (session.role === "OWNER" || session.role === "ADMIN") return true;
+  if (report.auditorId === session.id) return true;
+  if (opts.allowAuditee && report.auditeeId === session.id) return true;
+
+  const me = await prisma.user.findUnique({
+    where: { id: session.id },
+    select: { moduleAccess: true, outletId: true, outletIds: true },
+  });
+  const moduleAccess = (me?.moduleAccess ?? null) as Record<string, unknown> | null;
+  if (!hasModule(session.role, moduleAccess, "ops:audit")) return false;
+
+  const myOutlets = new Set<string>([
+    ...(me?.outletId ? [me.outletId] : []),
+    ...(me?.outletIds ?? []),
+  ]);
+  return myOutlets.has(report.outletId);
+}
+
 // GET /api/audits/[id] — full audit report detail
 export async function GET(
   _req: NextRequest,
@@ -24,6 +55,10 @@ export async function GET(
 
   if (!report) {
     return NextResponse.json({ error: "Not found" }, { status: 404 });
+  }
+
+  if (!(await canAccessReport(session, report, { allowAuditee: true }))) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
   }
 
   return NextResponse.json({
@@ -59,6 +94,18 @@ export async function PATCH(
   if (!session) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
 
   const { id } = await params;
+
+  // Only the auditor / managers-in-outlet / admins may finalize or edit an
+  // audit — the auditee cannot score their own report.
+  const existing = await prisma.auditReport.findUnique({
+    where: { id },
+    select: { auditorId: true, auditeeId: true, outletId: true },
+  });
+  if (!existing) return NextResponse.json({ error: "Not found" }, { status: 404 });
+  if (!(await canAccessReport(session, existing, { allowAuditee: false }))) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+
   const body = await req.json();
   const { overallNotes, complete } = body;
 

--- a/apps/staff/src/app/api/auth/switch-outlet/route.ts
+++ b/apps/staff/src/app/api/auth/switch-outlet/route.ts
@@ -28,6 +28,24 @@ export async function POST(req: NextRequest) {
     return NextResponse.json({ error: "Outlet not found" }, { status: 404 });
   }
 
+  // A manager may only switch to an outlet within their own scope. OWNER/ADMIN
+  // are unscoped. Without this, a manager assigned to outlet A could mint a
+  // session for any outlet (existence was the only check) and reach outlet-B
+  // data on every outlet-scoped route downstream.
+  if (session.role === "MANAGER") {
+    const me = await prisma.user.findUnique({
+      where: { id: session.id },
+      select: { outletId: true, outletIds: true },
+    });
+    const myOutlets = new Set<string>([
+      ...(me?.outletId ? [me.outletId] : []),
+      ...(me?.outletIds ?? []),
+    ]);
+    if (!myOutlets.has(outlet.id)) {
+      return NextResponse.json({ error: "Outlet not in your scope" }, { status: 403 });
+    }
+  }
+
   // Create new session with updated outlet
   await createSession({
     id: session.id,

--- a/apps/staff/src/app/api/dashboard/route.ts
+++ b/apps/staff/src/app/api/dashboard/route.ts
@@ -6,7 +6,13 @@ export async function GET(req: NextRequest) {
   const session = await getSession();
   if (!session) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
 
-  const outletId = new URL(req.url).searchParams.get("outletId") || undefined;
+  // Non-admins only ever see their own outlet's figures — the client
+  // ?outletId= is ignored for them (was a cross-outlet leak of
+  // spend/approvals/wastage). OWNER/ADMIN may scope to any outlet, or omit
+  // for the all-outlets view.
+  const isAdmin = session.role === "OWNER" || session.role === "ADMIN";
+  const requestedOutletId = new URL(req.url).searchParams.get("outletId") || undefined;
+  const outletId = isAdmin ? requestedOutletId : (session.outletId ?? undefined);
   const outletFilter = outletId ? { outletId } : undefined;
   const now = new Date();
   const weekAgo = new Date(now.getTime() - 7 * 24 * 60 * 60 * 1000);

--- a/apps/staff/src/app/api/transfers/[id]/route.ts
+++ b/apps/staff/src/app/api/transfers/[id]/route.ts
@@ -10,6 +10,25 @@ export async function PATCH(req: NextRequest, { params }: { params: Promise<{ id
   const body = await req.json();
   const { status } = body;
 
+  // Outlet scope: a non-admin may only act on a transfer they're an endpoint
+  // of (source or destination outlet). Without this, any staffer could
+  // complete any transfer by id and inject stock into an arbitrary outlet
+  // (adjustStockBalance(toOutletId, …) below).
+  const existing = await prisma.stockTransfer.findUnique({
+    where: { id },
+    select: { fromOutletId: true, toOutletId: true },
+  });
+  if (!existing) return NextResponse.json({ error: "Not found" }, { status: 404 });
+
+  const isAdmin = session.role === "OWNER" || session.role === "ADMIN";
+  if (
+    !isAdmin &&
+    session.outletId !== existing.fromOutletId &&
+    session.outletId !== existing.toOutletId
+  ) {
+    return NextResponse.json({ error: "Transfer not in your outlet" }, { status: 403 });
+  }
+
   const data: Record<string, unknown> = { status };
 
   if (status === "COMPLETED") {


### PR DESCRIPTION
## What

Web-only hotfixes for the **staff app** findings in `docs/staff-access-audit-2026-07-05.md` (PR #794). Each fix copies the outlet/self scoping the sibling routes already use. No schema, no OTA, no payroll/payment paths.

## Fixes

| Route | Was | Now | Finding |
|---|---|---|---|
| `GET /api/dashboard` | **fully unauthenticated** — any outlet's spend/approvals/wastage via `?outletId=` | require session; non-admins pinned to their own `session.outletId`, admins may scope or view all | C-3 |
| `GET /api/products/options` | unauthenticated; exposes supplier names + **cost prices** | require session | H-2 |
| `GET /api/settings/stock-count` | unauthenticated | require session | H-2 |
| `GET /api/audits/[id]` | any staff could read **any** audit | admin / auditor / **auditee-self** (own performance) / manager-in-outlet | F-3 |
| `PATCH /api/audits/[id]` + `PATCH .../items/[itemId]` | any staff could rewrite **any** audit's scores | admin / auditor / manager-in-outlet; auditee can't score their own | F-3 |
| `PATCH /api/transfers/[id]` | any staff could complete any transfer → stock injection into an arbitrary outlet | caller must be a from/to endpoint outlet, or admin | F-4 |
| `POST /api/auth/switch-outlet` | a MANAGER could mint a session for **any** outlet (existence was the only check) | target must be in their `outletIds` | F-8 |

## Deliberately left alone
`GET /api/outlets` stays public — it's called **pre-login** by the outlet picker (`login/page.tsx` and `staff-native/lib/outlets.ts` with `auth: false`). Gating it would break login.

## Scope boundary
This PR is the **staff app** only (the modules originally flagged: checklists, stock count, receiving, own audit/performance). The POS `verify-manager` oracle (C-2) and the backoffice cross-app `ops/audit-*` hole (H-1) are separate follow-ups — POS is OTA-coupled, and H-1 needs the audience-import fix.

## Verification
- `apps/staff` `tsc --noEmit` clean.
- `eslint` on all changed routes clean.

## CI note
This branch is based on `main`, which currently has a broken `test` job (unrelated `par-calc.test.ts`, fixed in **#801**). The `test` check here will go green once #801 merges and this branch is updated onto it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rv7HYks3KA5qN5V86m8jFq

---
_Generated by [Claude Code](https://claude.ai/code/session_01Rv7HYks3KA5qN5V86m8jFq)_