### PR TITLE
obs(crons): cronRoute wrapper — 16 Sentry heartbeats + error capture on all ~59 scheduled crons

### DIFF
--- a/apps/backoffice/src/app/api/ai-agent/celsius-overview/route.ts
+++ b/apps/backoffice/src/app/api/ai-agent/celsius-overview/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
+import * as Sentry from "@sentry/nextjs";
 import { timingSafeEqual } from "node:crypto";
 import { getSession } from "@/lib/auth";
 import { runCelsiusOverviewAgent } from "@/lib/ai-agent/celsius-overview";
@@ -49,6 +50,9 @@ async function runHandler(req: NextRequest) {
       snapshot: result.snapshot,
     });
   } catch (err) {
+    // Scheduled 4×/day — a failure here previously died in Vercel logs.
+    Sentry.captureException(err, { tags: { cron: "celsius-overview" } });
+    await Sentry.flush(2000);
     console.error("[ai-agent] run failed:", err);
     const message = err instanceof Error ? err.message : "Unknown error";
     return NextResponse.json({ ok: false, error: message }, { status: 500 });

--- a/apps/backoffice/src/app/api/cron/ads-daily/route.ts
+++ b/apps/backoffice/src/app/api/cron/ads-daily/route.ts
@@ -1,4 +1,4 @@
-import { NextRequest, NextResponse } from "next/server";
+import { NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
 import { syncAccounts } from "@/lib/ads/sync-accounts";
 import { syncCampaigns } from "@/lib/ads/sync-campaigns";
@@ -6,7 +6,7 @@ import { syncMetrics } from "@/lib/ads/sync-metrics";
 import { syncSearchTerms } from "@/lib/ads/sync-search-terms";
 import { runSync } from "@/lib/ads/run-sync";
 import { buildAdsOptimizerReport } from "@/lib/ads/optimizer";
-import { checkCronAuth } from "@celsius/shared";
+import { cronRoute } from "@/lib/cron-monitor";
 
 export const dynamic = "force-dynamic";
 export const maxDuration = 300; // 5 min
@@ -14,10 +14,7 @@ export const maxDuration = 300; // 5 min
 // Runs daily @ 3 AM MYT via Vercel Cron.
 // - Refreshes account list
 // - For each non-manager account: refreshes campaigns, then pulls yesterday's metrics.
-export async function GET(req: NextRequest) {
-  const cronAuth = checkCronAuth(req.headers);
-  if (!cronAuth.ok) return NextResponse.json({ error: cronAuth.error }, { status: cronAuth.status });
-
+async function runAdsDaily() {
   const settings = await prisma.adsSettings.findUnique({ where: { id: "singleton" } });
   if (settings && !settings.dailySyncEnabled) {
     return NextResponse.json({ skipped: true, reason: "daily_sync_disabled" });
@@ -93,3 +90,10 @@ export async function GET(req: NextRequest) {
     optimizer,
   });
 }
+
+// Heartbeat tier: a silent no-run means live ad spend keeps burning with no
+// fresh metrics or optimizer input — money spent blind until someone notices.
+export const GET = cronRoute("ads-daily", runAdsDaily, {
+  schedule: "0 19 * * *",
+  maxRuntime: 8, // maxDuration 300s + margin
+});

--- a/apps/backoffice/src/app/api/cron/ads-monthly/route.ts
+++ b/apps/backoffice/src/app/api/cron/ads-monthly/route.ts
@@ -1,18 +1,15 @@
-import { NextRequest, NextResponse } from "next/server";
+import { NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
 import { syncInvoices } from "@/lib/ads/sync-invoices";
 import { runSync } from "@/lib/ads/run-sync";
-import { checkCronAuth } from "@celsius/shared";
+import { cronRoute } from "@/lib/cron-monitor";
 
 export const dynamic = "force-dynamic";
 export const maxDuration = 300;
 
 // Runs on the 2nd of each month @ 4 AM MYT via Vercel Cron.
 // Pulls the previous month's invoices for every active account.
-export async function GET(req: NextRequest) {
-  const cronAuth = checkCronAuth(req.headers);
-  if (!cronAuth.ok) return NextResponse.json({ error: cronAuth.error }, { status: cronAuth.status });
-
+async function runAdsMonthly() {
   const settings = await prisma.adsSettings.findUnique({ where: { id: "singleton" } });
   if (settings && !settings.invoiceSyncEnabled) {
     return NextResponse.json({ skipped: true, reason: "invoice_sync_disabled" });
@@ -38,3 +35,5 @@ export async function GET(req: NextRequest) {
 
   return NextResponse.json({ ok: true, yearMonth: ym, perAccount: results });
 }
+
+export const GET = cronRoute("ads-monthly", runAdsMonthly);

--- a/apps/backoffice/src/app/api/cron/attendance-auto-close/route.ts
+++ b/apps/backoffice/src/app/api/cron/attendance-auto-close/route.ts
@@ -1,8 +1,8 @@
-import { NextRequest, NextResponse } from "next/server";
+import { NextResponse } from "next/server";
 import { hrSupabaseAdmin } from "@/lib/hr/supabase";
 import { prisma } from "@/lib/prisma";
-import { checkCronAuth } from "@celsius/shared";
 import { deriveHours, mytDateString, mytDayOfWeek, mytInstant } from "@/lib/hr/hours";
+import { cronRoute } from "@/lib/cron-monitor";
 
 export const dynamic = "force-dynamic";
 
@@ -26,10 +26,7 @@ export const dynamic = "force-dynamic";
 // overtime request). Every auto-close AUTO-RESOLVES (approved + excused) — a
 // forgotten tap-out isn't a staff violation, so it must not flood the review
 // queue. Day-type (PH/rest-day) classification is preserved for the regular pay.
-export async function GET(req: NextRequest) {
-  const cronAuth = checkCronAuth(req.headers);
-  if (!cronAuth.ok) return NextResponse.json({ error: cronAuth.error }, { status: cronAuth.status });
-
+async function runAttendanceAutoClose() {
   const now = new Date();
 
   // Load thresholds
@@ -209,3 +206,9 @@ export async function GET(req: NextRequest) {
     thresholds: { staleMin, abandonedMin },
   });
 }
+
+// Heartbeat tier: a silent no-run leaves forgotten clock-outs open, so payroll
+// hours (money) go wrong for every affected shift.
+export const GET = cronRoute("attendance-auto-close", runAttendanceAutoClose, {
+  schedule: "*/15 * * * *",
+});

--- a/apps/backoffice/src/app/api/cron/bukku-feed-sync/route.ts
+++ b/apps/backoffice/src/app/api/cron/bukku-feed-sync/route.ts
@@ -12,24 +12,21 @@
 // Each is idempotent + bounded, so re-running every 6h is safe and drains the
 // backlog over a few runs.
 
-import { NextRequest, NextResponse } from "next/server";
+import { NextResponse } from "next/server";
 import { syncBukkuFeedLedger } from "@/lib/finance/bukku-feed-sync";
 import { applyApMatches } from "@/lib/finance/ap-match";
 import { applyVerifiedReview } from "@/lib/finance/agents/ap-verifier";
 import { createWagePaymentSlips } from "@/lib/finance/payment-slips";
 import { postBankLinesToGl } from "@/lib/finance/gl-posting";
 import { accrueSalaryControls } from "@/lib/finance/salary-accrual";
-import { checkCronAuth } from "@celsius/shared";
+import { cronRoute } from "@/lib/cron-monitor";
 
 export const dynamic = "force-dynamic";
 export const maxDuration = 300;
 
 const GL_LINES_PER_RUN = 3000; // bounded so the whole loop stays inside maxDuration
 
-export async function GET(req: NextRequest) {
-  const cronAuth = checkCronAuth(req.headers);
-  if (!cronAuth.ok) return NextResponse.json({ error: cronAuth.error }, { status: cronAuth.status });
-
+async function runBukkuFeedSync() {
   const out: Record<string, unknown> = {};
   const step = async (name: string, fn: () => Promise<unknown>) => {
     try { out[name] = await fn(); }
@@ -64,3 +61,10 @@ export async function GET(req: NextRequest) {
 
   return NextResponse.json(out);
 }
+
+// Heartbeat tier: the entire finance loop (bank ingest → AP match → GL post)
+// rides this single schedule — a silent no-run stalls the books.
+export const GET = cronRoute("bukku-feed-sync", runBukkuFeedSync, {
+  schedule: "0 */6 * * *",
+  maxRuntime: 8, // maxDuration 300s + margin
+});

--- a/apps/backoffice/src/app/api/cron/campaigns-auto/route.ts
+++ b/apps/backoffice/src/app/api/cron/campaigns-auto/route.ts
@@ -1,7 +1,7 @@
-import { NextRequest, NextResponse } from "next/server";
+import { NextResponse } from "next/server";
 import { supabaseAdmin } from "@/lib/loyalty/supabase";
 import { sendSMS, providerAutoPrependsSender, getActiveSmsProvider } from "@/lib/loyalty/sms";
-import { checkCronAuth } from "@celsius/shared";
+import { cronRoute } from "@/lib/cron-monitor";
 
 export const dynamic = "force-dynamic";
 export const maxDuration = 300;
@@ -170,10 +170,7 @@ async function findAlreadySentPhones(
   return new Set((data || []).map((r: { phone: string }) => r.phone));
 }
 
-export async function GET(req: NextRequest) {
-  const cronAuth = checkCronAuth(req.headers);
-  if (!cronAuth.ok) return NextResponse.json({ error: cronAuth.error }, { status: cronAuth.status });
-
+async function runCampaignsAuto() {
   const nowIso = new Date().toISOString();
 
   const { data: campaignRows, error: cErr } = await supabaseAdmin
@@ -395,3 +392,5 @@ export async function GET(req: NextRequest) {
     results,
   });
 }
+
+export const GET = cronRoute("campaigns-auto", runCampaignsAuto);

--- a/apps/backoffice/src/app/api/cron/cert-expiry-reminders/route.ts
+++ b/apps/backoffice/src/app/api/cron/cert-expiry-reminders/route.ts
@@ -1,6 +1,6 @@
-import { NextRequest, NextResponse } from "next/server";
+import { NextResponse } from "next/server";
 import { hrSupabaseAdmin } from "@/lib/hr/supabase";
-import { checkCronAuth } from "@celsius/shared";
+import { cronRoute } from "@/lib/cron-monitor";
 
 export const dynamic = "force-dynamic";
 export const maxDuration = 30;
@@ -12,10 +12,7 @@ export const maxDuration = 30;
 // Idempotent via hr_certification_reminders unique(certification_id, stage).
 //
 // Auth: Bearer CRON_SECRET.
-export async function GET(req: NextRequest) {
-  const cronAuth = checkCronAuth(req.headers);
-  if (!cronAuth.ok) return NextResponse.json({ error: cronAuth.error }, { status: cronAuth.status });
-
+async function runCertExpiryReminders() {
   const today = new Date();
   today.setUTCHours(0, 0, 0, 0);
   const isoToday = today.toISOString().slice(0, 10);
@@ -102,3 +99,5 @@ export async function GET(req: NextRequest) {
     }, {}),
   });
 }
+
+export const GET = cronRoute("cert-expiry-reminders", runCertExpiryReminders);

--- a/apps/backoffice/src/app/api/cron/checklist-assign/route.ts
+++ b/apps/backoffice/src/app/api/cron/checklist-assign/route.ts
@@ -1,5 +1,5 @@
-import { NextRequest, NextResponse } from "next/server";
-import { checkCronAuth } from "@celsius/shared";
+import { NextResponse } from "next/server";
+import { cronRoute } from "@/lib/cron-monitor";
 import { assignTodaysChecklists } from "@/lib/ops-nudges";
 
 export const dynamic = "force-dynamic";
@@ -18,9 +18,7 @@ export const maxDuration = 60;
  * everything is owned. OPS_NUDGES_MODE (off|shadow|armed, default armed).
  * Design: docs/design/verifier-agent.md.
  */
-export async function GET(req: NextRequest) {
-  const cronAuth = checkCronAuth(req.headers);
-  if (!cronAuth.ok) return NextResponse.json({ error: cronAuth.error }, { status: cronAuth.status });
+async function runChecklistAssign() {
   try {
     const result = await assignTodaysChecklists();
     console.log(
@@ -33,3 +31,5 @@ export async function GET(req: NextRequest) {
     return NextResponse.json({ error: msg }, { status: 500 });
   }
 }
+
+export const GET = cronRoute("checklist-assign", runChecklistAssign);

--- a/apps/backoffice/src/app/api/cron/consumption-post/route.ts
+++ b/apps/backoffice/src/app/api/cron/consumption-post/route.ts
@@ -1,9 +1,9 @@
 import { NextRequest, NextResponse } from "next/server";
-import { checkCronAuth } from "@celsius/shared";
 import { prisma } from "@/lib/prisma";
 import { getSession } from "@/lib/auth";
 import { mytDayWindow, type ConsumptionResult } from "@/lib/inventory/consumption";
 import { postOutletConsumption } from "@/lib/inventory/consumption-post";
+import { cronRoute } from "@/lib/cron-monitor";
 
 export const dynamic = "force-dynamic";
 export const maxDuration = 120;
@@ -20,15 +20,7 @@ export const maxDuration = 120;
 //
 // Auth: Vercel cron secret, or an OWNER/ADMIN may trigger on demand (and pass
 // ?date=YYYY-MM-DD to backfill a specific MYT day).
-export async function GET(req: NextRequest) {
-  const cronAuth = checkCronAuth(req.headers);
-  if (!cronAuth.ok) {
-    const user = await getSession();
-    if (!user || !["OWNER", "ADMIN"].includes(user.role)) {
-      return NextResponse.json({ error: cronAuth.error }, { status: cronAuth.status });
-    }
-  }
-
+async function runConsumptionPost(req: NextRequest) {
   try {
     const dateParam = req.nextUrl.searchParams.get("date");
     // Default to yesterday in MYT (sales for a full closed day).
@@ -80,4 +72,20 @@ export async function GET(req: NextRequest) {
     const msg = err instanceof Error ? err.message : "consumption-post failed";
     return NextResponse.json({ error: msg }, { status: 500 });
   }
+}
+
+// Heartbeat tier: a silent no-run means stock never depletes for sales, so
+// inventory (and everything ordered off it) drifts from reality unnoticed.
+const cronGET = cronRoute("consumption-post", runConsumptionPost, {
+  schedule: "25 19 * * *",
+  maxRuntime: 5, // maxDuration 120s + margin
+});
+
+// Preserved extra auth: an OWNER/ADMIN may trigger on demand without the cron
+// secret (cronRoute would reject them), so check the session first and only
+// then defer to the wrapped cron route.
+export async function GET(req: NextRequest) {
+  const user = await getSession();
+  if (user && ["OWNER", "ADMIN"].includes(user.role)) return runConsumptionPost(req);
+  return cronGET(req);
 }

--- a/apps/backoffice/src/app/api/cron/deactivate-resigned/route.ts
+++ b/apps/backoffice/src/app/api/cron/deactivate-resigned/route.ts
@@ -1,7 +1,7 @@
-import { NextRequest, NextResponse } from "next/server";
+import { NextResponse } from "next/server";
 import { hrSupabaseAdmin } from "@/lib/hr/supabase";
 import { prisma } from "@/lib/prisma";
-import { checkCronAuth } from "@celsius/shared";
+import { cronRoute } from "@/lib/cron-monitor";
 
 export const dynamic = "force-dynamic";
 export const maxDuration = 60;
@@ -11,10 +11,7 @@ export const maxDuration = 60;
 // (16:05 UTC previous day).
 //
 // Auth: Bearer token in CRON_SECRET env var (Vercel auto-sets).
-export async function GET(req: NextRequest) {
-  const cronAuth = checkCronAuth(req.headers);
-  if (!cronAuth.ok) return NextResponse.json({ error: cronAuth.error }, { status: cronAuth.status });
-
+async function runDeactivateResigned() {
   const today = new Date().toISOString().slice(0, 10);
 
   // Find profiles with end_date on/before today
@@ -47,3 +44,5 @@ export async function GET(req: NextRequest) {
     names: deactivated,
   });
 }
+
+export const GET = cronRoute("deactivate-resigned", runDeactivateResigned);

--- a/apps/backoffice/src/app/api/cron/finance-eod/route.ts
+++ b/apps/backoffice/src/app/api/cron/finance-eod/route.ts
@@ -6,9 +6,9 @@
 // Idempotent: re-running for a date that's already been posted skips the
 // outlet (shared outlet+date guard in the ingestors).
 
-import { NextRequest, NextResponse } from "next/server";
+import { NextResponse } from "next/server";
 import { ingestEodForDate } from "@/lib/finance/ingestors/pos-native-eod";
-import { checkCronAuth } from "@celsius/shared";
+import { cronRoute } from "@/lib/cron-monitor";
 
 export const dynamic = "force-dynamic";
 export const maxDuration = 300;
@@ -20,10 +20,7 @@ function yesterdayMyt(): string {
   return myt.toISOString().slice(0, 10);
 }
 
-export async function GET(req: NextRequest) {
-  const cronAuth = checkCronAuth(req.headers);
-  if (!cronAuth.ok) return NextResponse.json({ error: cronAuth.error }, { status: cronAuth.status });
-
+async function runFinanceEod() {
   const date = yesterdayMyt();
   const results = await ingestEodForDate(date);
 
@@ -38,3 +35,10 @@ export async function GET(req: NextRequest) {
 
   return NextResponse.json({ summary, results });
 }
+
+// Heartbeat tier: EOD ingestion is the finance book of record — a
+// silently skipped night must page, not wait to be noticed at month end.
+export const GET = cronRoute("finance-eod", runFinanceEod, {
+  schedule: "0 20 * * *",
+  maxRuntime: 8, // maxDuration 300s + margin
+});

--- a/apps/backoffice/src/app/api/cron/geogrid-keywords/route.ts
+++ b/apps/backoffice/src/app/api/cron/geogrid-keywords/route.ts
@@ -1,5 +1,5 @@
-import { NextRequest, NextResponse } from "next/server";
-import { checkCronAuth } from "@celsius/shared";
+import { NextResponse } from "next/server";
+import { cronRoute } from "@/lib/cron-monitor";
 import { prisma } from "@/lib/prisma";
 import { refreshKeywords, seedTargetKeywords } from "@/lib/geogrid/keywords";
 import { buildKeywordStrategy } from "@/lib/geogrid/keyword-selection";
@@ -14,10 +14,7 @@ export const maxDuration = 120;
 // Branded/navigational and competitor-brand terms are filtered out throughout.
 const TOP_N = Number(process.env.GEOGRID_KEYWORDS_PER_OUTLET || 4);
 
-export async function GET(req: NextRequest) {
-  const auth = checkCronAuth(req.headers);
-  if (!auth.ok) return NextResponse.json({ error: auth.error }, { status: auth.status });
-
+async function runGeogridKeywords() {
   const outlets = await prisma.outlet.findMany({
     where: { status: "ACTIVE" },
     include: { reviewSettings: true },
@@ -43,3 +40,5 @@ export async function GET(req: NextRequest) {
 
   return NextResponse.json({ ran_at: new Date().toISOString(), topN: TOP_N, results, strategy });
 }
+
+export const GET = cronRoute("geogrid-keywords", runGeogridKeywords);

--- a/apps/backoffice/src/app/api/cron/geogrid-scan/route.ts
+++ b/apps/backoffice/src/app/api/cron/geogrid-scan/route.ts
@@ -1,5 +1,5 @@
-import { NextRequest, NextResponse } from "next/server";
-import { checkCronAuth } from "@celsius/shared";
+import { NextResponse } from "next/server";
+import { cronRoute } from "@/lib/cron-monitor";
 import { prisma } from "@/lib/prisma";
 import { runScan, isDue, needScore } from "@/lib/geogrid/scan-runner";
 
@@ -17,10 +17,7 @@ const GRID_SIZE = Number(process.env.GEOGRID_GRID_SIZE || 9);
 // only ~±1.3km around the storefront, which trivially over-reports rank.
 const RANGE_MILES = Number(process.env.GEOGRID_RANGE_MILES || 1.5534);
 
-export async function GET(req: NextRequest) {
-  const auth = checkCronAuth(req.headers);
-  if (!auth.ok) return NextResponse.json({ error: auth.error }, { status: auth.status });
-
+async function runGeogridScan() {
   const apiKey = process.env.GOOGLE_PLACES_API_KEY;
   if (!apiKey) return NextResponse.json({ skipped: "GOOGLE_PLACES_API_KEY not set" });
 
@@ -79,3 +76,5 @@ export async function GET(req: NextRequest) {
     results,
   });
 }
+
+export const GET = cronRoute("geogrid-scan", runGeogridScan);

--- a/apps/backoffice/src/app/api/cron/grab-campaigns-sync/route.ts
+++ b/apps/backoffice/src/app/api/cron/grab-campaigns-sync/route.ts
@@ -1,5 +1,5 @@
-import { NextRequest, NextResponse } from "next/server";
-import { checkCronAuth } from "@celsius/shared";
+import { NextResponse } from "next/server";
+import { cronRoute } from "@/lib/cron-monitor";
 import { syncGrabCampaigns } from "@/lib/grab-campaigns";
 
 export const dynamic = "force-dynamic";
@@ -8,10 +8,9 @@ export const maxDuration = 120;
 // Daily refresh of the GrabFood campaign mirror (read-only) for every linked
 // outlet. Promo *cost* comes from order data, not here — this just keeps the
 // campaign list/status current.
-export async function GET(req: NextRequest) {
-  const cronAuth = checkCronAuth(req.headers);
-  if (!cronAuth.ok) return NextResponse.json({ error: cronAuth.error }, { status: cronAuth.status });
-
+async function runGrabCampaignsSync() {
   const result = await syncGrabCampaigns();
   return NextResponse.json({ ok: true, ...result });
 }
+
+export const GET = cronRoute("grab-campaigns-sync", runGrabCampaignsSync);

--- a/apps/backoffice/src/app/api/cron/grab-reconcile/route.ts
+++ b/apps/backoffice/src/app/api/cron/grab-reconcile/route.ts
@@ -1,6 +1,6 @@
-import { NextRequest, NextResponse } from "next/server";
-import { checkCronAuth } from "@celsius/shared";
+import { NextResponse } from "next/server";
 import { reconcileGrabOrders } from "@/lib/grab-reconcile";
+import { cronRoute } from "@/lib/cron-monitor";
 
 export const dynamic = "force-dynamic";
 export const maxDuration = 120;
@@ -9,10 +9,14 @@ export const maxDuration = 120;
 // pos_orders and backfill anything missing (so a missed/empty/out-of-order
 // webhook can't silently lose an order's docket AND its revenue). Runs frequently
 // — see vercel.json. Idempotent: only inserts orders we don't already have.
-export async function GET(req: NextRequest) {
-  const cronAuth = checkCronAuth(req.headers);
-  if (!cronAuth.ok) return NextResponse.json({ error: cronAuth.error }, { status: cronAuth.status });
-
+async function runGrabReconcile() {
   const summary = await reconcileGrabOrders();
   return NextResponse.json({ ok: true, ...summary });
 }
+
+// Heartbeat tier: a silent no-run means dropped GrabFood webhooks lose orders
+// (docket AND revenue) with nothing else to catch them.
+export const GET = cronRoute("grab-reconcile", runGrabReconcile, {
+  schedule: "*/15 * * * *",
+  maxRuntime: 5, // maxDuration 120s + margin
+});

--- a/apps/backoffice/src/app/api/cron/grant-birthday/route.ts
+++ b/apps/backoffice/src/app/api/cron/grant-birthday/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
-import { checkCronAuth } from "@celsius/shared";
+import { cronRoute } from "@/lib/cron-monitor";
 import { supabaseAdmin } from "@/lib/loyalty/supabase";
 import {
   birthdayPeriodKey,
@@ -17,12 +17,7 @@ export const maxDuration = 300;
 //
 // Re-homed from the loyalty app (was loyalty.celsiuscoffee.com
 // /api/loyalty/benefits/grant-birthday) as part of retiring that app.
-export async function GET(request: NextRequest) {
-  const cronAuth = checkCronAuth(request.headers);
-  if (!cronAuth.ok) {
-    return NextResponse.json({ error: cronAuth.error }, { status: cronAuth.status });
-  }
-
+async function runGrantBirthday(request: NextRequest) {
   const url = new URL(request.url);
   const brandId = url.searchParams.get("brand_id") || "brand-celsius";
   const dateParam = url.searchParams.get("date");
@@ -87,3 +82,5 @@ export async function GET(request: NextRequest) {
     results: summary.results,
   });
 }
+
+export const GET = cronRoute("grant-birthday", runGrantBirthday);

--- a/apps/backoffice/src/app/api/cron/grant-monthly/route.ts
+++ b/apps/backoffice/src/app/api/cron/grant-monthly/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
-import { checkCronAuth } from "@celsius/shared";
+import { cronRoute } from "@/lib/cron-monitor";
 import { supabaseAdmin } from "@/lib/loyalty/supabase";
 import {
   fetchTierRewardMap,
@@ -17,12 +17,7 @@ export const maxDuration = 300;
 //
 // Re-homed from the loyalty app (was loyalty.celsiuscoffee.com
 // /api/loyalty/benefits/grant-monthly) as part of retiring that app.
-export async function GET(request: NextRequest) {
-  const cronAuth = checkCronAuth(request.headers);
-  if (!cronAuth.ok) {
-    return NextResponse.json({ error: cronAuth.error }, { status: cronAuth.status });
-  }
-
+async function runGrantMonthly(request: NextRequest) {
   const url = new URL(request.url);
   const brandId = url.searchParams.get("brand_id") || "brand-celsius";
   const periodKey = monthlyPeriodKey(new Date());
@@ -62,3 +57,5 @@ export async function GET(request: NextRequest) {
     results: summary.results,
   });
 }
+
+export const GET = cronRoute("grant-monthly", runGrantMonthly);

--- a/apps/backoffice/src/app/api/cron/hr-compliance-reminder/route.ts
+++ b/apps/backoffice/src/app/api/cron/hr-compliance-reminder/route.ts
@@ -1,6 +1,6 @@
-import { NextRequest, NextResponse } from "next/server";
+import { NextResponse } from "next/server";
 import { hrSupabaseAdmin } from "@/lib/hr/supabase";
-import { checkCronAuth } from "@celsius/shared";
+import { cronRoute } from "@/lib/cron-monitor";
 
 export const dynamic = "force-dynamic";
 export const maxDuration = 30;
@@ -12,10 +12,7 @@ export const maxDuration = 30;
 // the HR dashboard widget renders the right colours.
 //
 // Auth: Bearer CRON_SECRET (Vercel auto-sets).
-export async function GET(req: NextRequest) {
-  const cronAuth = checkCronAuth(req.headers);
-  if (!cronAuth.ok) return NextResponse.json({ error: cronAuth.error }, { status: cronAuth.status });
-
+async function runHrComplianceReminder() {
   const today = new Date().toISOString().slice(0, 10);
 
   // 1. Mark overdue: due_date < today, status = pending → overdue
@@ -59,3 +56,5 @@ export async function GET(req: NextRequest) {
     },
   });
 }
+
+export const GET = cronRoute("hr-compliance-reminder", runHrComplianceReminder);

--- a/apps/backoffice/src/app/api/cron/labour-variance/route.ts
+++ b/apps/backoffice/src/app/api/cron/labour-variance/route.ts
@@ -1,5 +1,5 @@
-import { NextRequest, NextResponse } from "next/server";
-import { checkCronAuth } from "@celsius/shared";
+import { NextResponse } from "next/server";
+import { cronRoute } from "@/lib/cron-monitor";
 import { prisma } from "@/lib/prisma";
 import { hrSupabaseAdmin } from "@/lib/hr/supabase";
 import { actualWeekRevenue, gateSchedule } from "@/lib/hr/labour-gate";
@@ -36,10 +36,7 @@ function lastWeekMonday(now: Date): string {
   return myt.toISOString().slice(0, 10);
 }
 
-export async function GET(req: NextRequest) {
-  const cronAuth = checkCronAuth(req.headers);
-  if (!cronAuth.ok) return NextResponse.json({ error: cronAuth.error }, { status: cronAuth.status });
-
+async function runLabourVariance() {
   const runMode = mode();
   if (runMode === "off") return NextResponse.json({ ok: true, mode: runMode, lines: [] });
 
@@ -105,3 +102,5 @@ export async function GET(req: NextRequest) {
   }
   return NextResponse.json({ ok: true, mode: runMode, weekStart, lines, sent });
 }
+
+export const GET = cronRoute("labour-variance", runLabourVariance);

--- a/apps/backoffice/src/app/api/cron/loops-send/route.ts
+++ b/apps/backoffice/src/app/api/cron/loops-send/route.ts
@@ -1,5 +1,5 @@
-import { NextRequest, NextResponse } from "next/server";
-import { checkCronAuth } from "@celsius/shared";
+import { NextResponse } from "next/server";
+import { cronRoute } from "@/lib/cron-monitor";
 import { sendDueRounds, autoMeasureDueRounds } from "@/lib/loyalty/loop-engine";
 
 export const dynamic = "force-dynamic";
@@ -10,9 +10,7 @@ export const maxDuration = 300;
 // Runs every ~15 min (vercel.json), so the scorecard updates within minutes of a
 // window closing instead of waiting for the daily trigger cron. Approve-gated:
 // only sends rounds an operator scheduled via /api/loyalty/loops/schedule.
-export async function GET(req: NextRequest) {
-  const cronAuth = checkCronAuth(req.headers);
-  if (!cronAuth.ok) return NextResponse.json({ error: cronAuth.error }, { status: cronAuth.status });
+async function runLoopsSend() {
   try {
     const sent = await sendDueRounds();
     const measured = await autoMeasureDueRounds();
@@ -22,3 +20,5 @@ export async function GET(req: NextRequest) {
     return NextResponse.json({ error: msg }, { status: 500 });
   }
 }
+
+export const GET = cronRoute("loops-send", runLoopsSend);

--- a/apps/backoffice/src/app/api/cron/loops-trigger/route.ts
+++ b/apps/backoffice/src/app/api/cron/loops-trigger/route.ts
@@ -1,5 +1,5 @@
-import { NextRequest, NextResponse } from "next/server";
-import { checkCronAuth } from "@celsius/shared";
+import { NextResponse } from "next/server";
+import { cronRoute } from "@/lib/cron-monitor";
 import { runTriggeredLoops, autoMeasureDueRounds, runRoundGapDaily } from "@/lib/loyalty/loop-engine";
 
 export const dynamic = "force-dynamic";
@@ -10,9 +10,7 @@ export const maxDuration = 300;
 // voucher + sending the SMS to each newly-qualifying member. Also auto-measures
 // any sent round whose attribution window has closed so the leaderboard learns
 // without a manual click. No budget cap; cooldowns prevent double-targeting.
-export async function GET(req: NextRequest) {
-  const cronAuth = checkCronAuth(req.headers);
-  if (!cronAuth.ok) return NextResponse.json({ error: cronAuth.error }, { status: cronAuth.status });
+async function runLoopsTrigger() {
   try {
     const triggered = await runTriggeredLoops();
     const roundGap = await runRoundGapDaily(); // per-segment promo loop (its own mechanic)
@@ -23,3 +21,5 @@ export async function GET(req: NextRequest) {
     return NextResponse.json({ error: msg }, { status: 500 });
   }
 }
+
+export const GET = cronRoute("loops-trigger", runLoopsTrigger);

--- a/apps/backoffice/src/app/api/cron/ops-nudge-audit/route.ts
+++ b/apps/backoffice/src/app/api/cron/ops-nudge-audit/route.ts
@@ -1,5 +1,5 @@
-import { NextRequest, NextResponse } from "next/server";
-import { checkCronAuth } from "@celsius/shared";
+import { NextResponse } from "next/server";
+import { cronRoute } from "@/lib/cron-monitor";
 import { runAuditNudges } from "@/lib/ops-nudges";
 
 export const dynamic = "force-dynamic";
@@ -14,9 +14,7 @@ export const maxDuration = 60;
  * climb as they work through them. OPS_NUDGES_MODE (off|shadow|armed, default armed).
  * Design: docs/design/ops-performance-loop.md.
  */
-export async function GET(req: NextRequest) {
-  const cronAuth = checkCronAuth(req.headers);
-  if (!cronAuth.ok) return NextResponse.json({ error: cronAuth.error }, { status: cronAuth.status });
+async function runOpsNudgeAudit() {
   try {
     const result = await runAuditNudges();
     console.log(`[cron/ops-nudge-audit] mode=${result.mode} items=${result.items} leads=${result.staffSent}`);
@@ -27,3 +25,5 @@ export async function GET(req: NextRequest) {
     return NextResponse.json({ error: msg }, { status: 500 });
   }
 }
+
+export const GET = cronRoute("ops-nudge-audit", runOpsNudgeAudit);

--- a/apps/backoffice/src/app/api/cron/ops-nudge-checklist/route.ts
+++ b/apps/backoffice/src/app/api/cron/ops-nudge-checklist/route.ts
@@ -1,6 +1,6 @@
-import { NextRequest, NextResponse } from "next/server";
-import { checkCronAuth } from "@celsius/shared";
+import { NextResponse } from "next/server";
 import { runChecklistNudges } from "@/lib/ops-nudges";
+import { cronRoute } from "@/lib/cron-monitor";
 
 export const dynamic = "force-dynamic";
 export const maxDuration = 60;
@@ -17,9 +17,7 @@ export const maxDuration = 60;
  * Runs every 15 min. OPS_NUDGES_MODE (off|shadow|armed, default armed).
  * Design: docs/design/checklist-individual-accountability.md.
  */
-export async function GET(req: NextRequest) {
-  const cronAuth = checkCronAuth(req.headers);
-  if (!cronAuth.ok) return NextResponse.json({ error: cronAuth.error }, { status: cronAuth.status });
+async function runOpsNudgeChecklist() {
   try {
     const result = await runChecklistNudges();
     console.log(
@@ -32,3 +30,5 @@ export async function GET(req: NextRequest) {
     return NextResponse.json({ error: msg }, { status: 500 });
   }
 }
+
+export const GET = cronRoute("ops-nudge-checklist", runOpsNudgeChecklist);

--- a/apps/backoffice/src/app/api/cron/ops-nudge-clockin/route.ts
+++ b/apps/backoffice/src/app/api/cron/ops-nudge-clockin/route.ts
@@ -1,6 +1,6 @@
-import { NextRequest, NextResponse } from "next/server";
-import { checkCronAuth } from "@celsius/shared";
+import { NextResponse } from "next/server";
 import { runClockInNudges } from "@/lib/ops-nudges";
+import { cronRoute } from "@/lib/cron-monitor";
 
 export const dynamic = "force-dynamic";
 export const maxDuration = 60;
@@ -18,9 +18,7 @@ export const maxDuration = 60;
  * (off|shadow|armed), default armed.
  * Design: docs/design/ops-performance-loop.md.
  */
-export async function GET(req: NextRequest) {
-  const cronAuth = checkCronAuth(req.headers);
-  if (!cronAuth.ok) return NextResponse.json({ error: cronAuth.error }, { status: cronAuth.status });
+async function runOpsNudgeClockin() {
   try {
     const result = await runClockInNudges();
     console.log(`[cron/ops-nudge-clockin] mode=${result.mode} items=${result.items} staff=${result.staffSent} mgr=${result.managerSent}`);
@@ -31,3 +29,5 @@ export async function GET(req: NextRequest) {
     return NextResponse.json({ error: msg }, { status: 500 });
   }
 }
+
+export const GET = cronRoute("ops-nudge-clockin", runOpsNudgeClockin);

--- a/apps/backoffice/src/app/api/cron/ops-nudge-review/route.ts
+++ b/apps/backoffice/src/app/api/cron/ops-nudge-review/route.ts
@@ -1,7 +1,7 @@
-import { NextRequest, NextResponse } from "next/server";
-import { checkCronAuth } from "@celsius/shared";
+import { NextResponse } from "next/server";
 import { runReviewNudges } from "@/lib/ops-nudges";
 import { syncNegativeReviewDrafts } from "@/lib/reviews/sync-negatives";
+import { cronRoute } from "@/lib/cron-monitor";
 
 export const dynamic = "force-dynamic";
 export const maxDuration = 60;
@@ -19,9 +19,7 @@ export const maxDuration = 60;
  * OPS_NUDGES_MODE (off|shadow|armed, default armed).
  * Design: docs/design/ops-performance-loop.md.
  */
-export async function GET(req: NextRequest) {
-  const cronAuth = checkCronAuth(req.headers);
-  if (!cronAuth.ok) return NextResponse.json({ error: cronAuth.error }, { status: cronAuth.status });
+async function runOpsNudgeReview() {
   try {
     // 1) Ingest new negative Google reviews into ReviewReplyDraft (same path the
     // board uses) so there's something to nudge — they're no longer dependent on
@@ -44,3 +42,5 @@ export async function GET(req: NextRequest) {
     return NextResponse.json({ error: msg }, { status: 500 });
   }
 }
+
+export const GET = cronRoute("ops-nudge-review", runOpsNudgeReview);

--- a/apps/backoffice/src/app/api/cron/ops-nudge-roster/route.ts
+++ b/apps/backoffice/src/app/api/cron/ops-nudge-roster/route.ts
@@ -1,6 +1,6 @@
-import { NextRequest, NextResponse } from "next/server";
-import { checkCronAuth } from "@celsius/shared";
+import { NextResponse } from "next/server";
 import { runRosterPublishNudges } from "@/lib/ops-nudges";
+import { cronRoute } from "@/lib/cron-monitor";
 
 export const dynamic = "force-dynamic";
 export const maxDuration = 60;
@@ -19,9 +19,7 @@ export const maxDuration = 60;
  * OPS_NUDGES_MODE (off|shadow|armed), default armed.
  * Design: docs/design/ops-performance-loop.md.
  */
-export async function GET(req: NextRequest) {
-  const cronAuth = checkCronAuth(req.headers);
-  if (!cronAuth.ok) return NextResponse.json({ error: cronAuth.error }, { status: cronAuth.status });
+async function runOpsNudgeRoster() {
   try {
     const result = await runRosterPublishNudges();
     console.log(`[cron/ops-nudge-roster] mode=${result.mode} items=${result.items} mgr=${result.managerSent}`);
@@ -32,3 +30,5 @@ export async function GET(req: NextRequest) {
     return NextResponse.json({ error: msg }, { status: 500 });
   }
 }
+
+export const GET = cronRoute("ops-nudge-roster", runOpsNudgeRoster);

--- a/apps/backoffice/src/app/api/cron/ops-nudge-stockcount/route.ts
+++ b/apps/backoffice/src/app/api/cron/ops-nudge-stockcount/route.ts
@@ -1,6 +1,6 @@
-import { NextRequest, NextResponse } from "next/server";
-import { checkCronAuth } from "@celsius/shared";
+import { NextResponse } from "next/server";
 import { runStockCountNudges } from "@/lib/ops-nudges";
+import { cronRoute } from "@/lib/cron-monitor";
 
 export const dynamic = "force-dynamic";
 export const maxDuration = 60;
@@ -15,9 +15,7 @@ export const maxDuration = 60;
  * schedule gates whether it sends). OPS_NUDGES_MODE (off|shadow|armed), default armed.
  * Design: docs/design/ops-performance-loop.md.
  */
-export async function GET(req: NextRequest) {
-  const cronAuth = checkCronAuth(req.headers);
-  if (!cronAuth.ok) return NextResponse.json({ error: cronAuth.error }, { status: cronAuth.status });
+async function runOpsNudgeStockcount() {
   try {
     const result = await runStockCountNudges();
     console.log(`[cron/ops-nudge-stockcount] mode=${result.mode} items=${result.items} staff=${result.staffSent} mgr=${result.managerSent}`);
@@ -28,3 +26,5 @@ export async function GET(req: NextRequest) {
     return NextResponse.json({ error: msg }, { status: 500 });
   }
 }
+
+export const GET = cronRoute("ops-nudge-stockcount", runOpsNudgeStockcount);

--- a/apps/backoffice/src/app/api/cron/ops-nudge-store/route.ts
+++ b/apps/backoffice/src/app/api/cron/ops-nudge-store/route.ts
@@ -1,6 +1,6 @@
-import { NextRequest, NextResponse } from "next/server";
-import { checkCronAuth } from "@celsius/shared";
+import { NextResponse } from "next/server";
 import { runStoreStatusNudges } from "@/lib/ops-nudges";
+import { cronRoute } from "@/lib/cron-monitor";
 
 export const dynamic = "force-dynamic";
 export const maxDuration = 60;
@@ -20,9 +20,7 @@ export const maxDuration = 60;
  * open time. OPS_NUDGES_MODE (off|shadow|armed), default armed.
  * Design: docs/design/ops-performance-loop.md.
  */
-export async function GET(req: NextRequest) {
-  const cronAuth = checkCronAuth(req.headers);
-  if (!cronAuth.ok) return NextResponse.json({ error: cronAuth.error }, { status: cronAuth.status });
+async function runOpsNudgeStore() {
   try {
     const result = await runStoreStatusNudges();
     console.log(`[cron/ops-nudge-store] mode=${result.mode} items=${result.items} staff=${result.staffSent} mgr=${result.managerSent}`);
@@ -33,3 +31,5 @@ export async function GET(req: NextRequest) {
     return NextResponse.json({ error: msg }, { status: 500 });
   }
 }
+
+export const GET = cronRoute("ops-nudge-store", runOpsNudgeStore);

--- a/apps/backoffice/src/app/api/cron/ops-pulse-daily/route.ts
+++ b/apps/backoffice/src/app/api/cron/ops-pulse-daily/route.ts
@@ -1,6 +1,6 @@
-import { NextRequest, NextResponse } from "next/server";
-import { checkCronAuth } from "@celsius/shared";
+import { NextResponse } from "next/server";
 import { runDailyPulse } from "@/lib/ops-pulse";
+import { cronRoute } from "@/lib/cron-monitor";
 
 export const dynamic = "force-dynamic";
 export const maxDuration = 60;
@@ -15,10 +15,7 @@ export const maxDuration = 60;
  *
  * Design: docs/design/ops-kpi-pulse-loop.md.
  */
-export async function GET(req: NextRequest) {
-  const cronAuth = checkCronAuth(req.headers);
-  if (!cronAuth.ok) return NextResponse.json({ error: cronAuth.error }, { status: cronAuth.status });
-
+async function runOpsPulseDaily() {
   try {
     const result = await runDailyPulse();
     console.log(`[cron/ops-pulse-daily] mode=${result.mode} items=${result.breachCount} sent=${result.sent}`);
@@ -29,3 +26,5 @@ export async function GET(req: NextRequest) {
     return NextResponse.json({ error: msg }, { status: 500 });
   }
 }
+
+export const GET = cronRoute("ops-pulse-daily", runOpsPulseDaily);

--- a/apps/backoffice/src/app/api/cron/ops-pulse/route.ts
+++ b/apps/backoffice/src/app/api/cron/ops-pulse/route.ts
@@ -1,6 +1,6 @@
-import { NextRequest, NextResponse } from "next/server";
-import { checkCronAuth } from "@celsius/shared";
+import { NextResponse } from "next/server";
 import { runOpsPulse } from "@/lib/ops-pulse";
+import { cronRoute } from "@/lib/cron-monitor";
 
 export const dynamic = "force-dynamic";
 export const maxDuration = 60;
@@ -20,10 +20,7 @@ export const maxDuration = 60;
  *
  * Design: docs/design/ops-kpi-pulse-loop.md.
  */
-export async function GET(req: NextRequest) {
-  const cronAuth = checkCronAuth(req.headers);
-  if (!cronAuth.ok) return NextResponse.json({ error: cronAuth.error }, { status: cronAuth.status });
-
+async function runOpsPulseCron() {
   try {
     const result = await runOpsPulse();
     if (result.breachCount > 0) {
@@ -36,3 +33,5 @@ export async function GET(req: NextRequest) {
     return NextResponse.json({ error: msg }, { status: 500 });
   }
 }
+
+export const GET = cronRoute("ops-pulse", runOpsPulseCron);

--- a/apps/backoffice/src/app/api/cron/ops-reminders/route.ts
+++ b/apps/backoffice/src/app/api/cron/ops-reminders/route.ts
@@ -1,6 +1,6 @@
-import { NextRequest, NextResponse } from "next/server";
-import { checkCronAuth } from "@celsius/shared";
+import { NextResponse } from "next/server";
 import { runReminderDueNudges } from "@/lib/ops-reminders";
+import { cronRoute } from "@/lib/cron-monitor";
 
 export const dynamic = "force-dynamic";
 export const maxDuration = 60;
@@ -16,10 +16,7 @@ export const maxDuration = 60;
  *
  * Design: docs/design/ops-kpi-pulse-loop.md (workspace reminders extension).
  */
-export async function GET(req: NextRequest) {
-  const cronAuth = checkCronAuth(req.headers);
-  if (!cronAuth.ok) return NextResponse.json({ error: cronAuth.error }, { status: cronAuth.status });
-
+async function runOpsReminders() {
   try {
     const result = await runReminderDueNudges();
     console.log(`[cron/ops-reminders] considered=${result.considered} sent=${result.sent}`);
@@ -30,3 +27,5 @@ export async function GET(req: NextRequest) {
     return NextResponse.json({ error: msg }, { status: 500 });
   }
 }
+
+export const GET = cronRoute("ops-reminders", runOpsReminders);

--- a/apps/backoffice/src/app/api/cron/ops-scoreboard/route.ts
+++ b/apps/backoffice/src/app/api/cron/ops-scoreboard/route.ts
@@ -1,6 +1,6 @@
-import { NextRequest, NextResponse } from "next/server";
-import { checkCronAuth } from "@celsius/shared";
+import { NextResponse } from "next/server";
 import { runScoreboard } from "@/lib/ops-scoreboard";
+import { cronRoute } from "@/lib/cron-monitor";
 
 export const dynamic = "force-dynamic";
 export const maxDuration = 120;
@@ -16,10 +16,7 @@ export const maxDuration = 120;
  *
  * Design: docs/design/ops-performance-loop.md.
  */
-export async function GET(req: NextRequest) {
-  const cronAuth = checkCronAuth(req.headers);
-  if (!cronAuth.ok) return NextResponse.json({ error: cronAuth.error }, { status: cronAuth.status });
-
+async function runOpsScoreboard() {
   try {
     const result = await runScoreboard();
     console.log(
@@ -32,3 +29,5 @@ export async function GET(req: NextRequest) {
     return NextResponse.json({ error: msg }, { status: 500 });
   }
 }
+
+export const GET = cronRoute("ops-scoreboard", runOpsScoreboard);

--- a/apps/backoffice/src/app/api/cron/par-levels-recalc/route.ts
+++ b/apps/backoffice/src/app/api/cron/par-levels-recalc/route.ts
@@ -1,8 +1,8 @@
 import { NextRequest, NextResponse } from "next/server";
-import { checkCronAuth } from "@celsius/shared";
 import { getSession } from "@/lib/auth";
 import { prisma } from "@/lib/prisma";
 import { recalcOutletParLevels } from "@/lib/inventory/par-calc";
+import { cronRoute } from "@/lib/cron-monitor";
 
 export const dynamic = "force-dynamic";
 export const maxDuration = 120;
@@ -16,14 +16,7 @@ export const maxDuration = 120;
 // Pars are engine-managed: each run overwrites the outlet's rows. Outlets with
 // no POS sales in the window are skipped (their stale pars are left alone
 // rather than zeroed).
-export async function GET(req: NextRequest) {
-  const cronAuth = checkCronAuth(req.headers);
-  if (!cronAuth.ok) {
-    const user = await getSession();
-    if (!user || !["OWNER", "ADMIN"].includes(user.role)) {
-      return NextResponse.json({ error: cronAuth.error }, { status: cronAuth.status });
-    }
-  }
+async function runParLevelsRecalc() {
   try {
     const outlets = await prisma.outlet.findMany({
       where: { loyaltyOutletId: { not: null } },
@@ -57,4 +50,16 @@ export async function GET(req: NextRequest) {
     const msg = err instanceof Error ? err.message : "par-levels-recalc failed";
     return NextResponse.json({ error: msg }, { status: 500 });
   }
+}
+
+const cronHandler = cronRoute("par-levels-recalc", runParLevelsRecalc);
+
+// Cron secret (via cronRoute) OR an authenticated OWNER/ADMIN session, so the
+// recalc can be run on demand.
+export async function GET(req: NextRequest) {
+  const user = await getSession();
+  if (user && ["OWNER", "ADMIN"].includes(user.role)) {
+    return runParLevelsRecalc();
+  }
+  return cronHandler(req);
 }

--- a/apps/backoffice/src/app/api/cron/pos-loyalty-reconcile/route.ts
+++ b/apps/backoffice/src/app/api/cron/pos-loyalty-reconcile/route.ts
@@ -1,5 +1,6 @@
-import { NextRequest, NextResponse } from "next/server";
-import { checkCronAuth, createSupabaseAdmin } from "@celsius/shared";
+import { NextResponse } from "next/server";
+import { createSupabaseAdmin } from "@celsius/shared";
+import { cronRoute } from "@/lib/cron-monitor";
 
 export const dynamic = "force-dynamic";
 export const maxDuration = 60;
@@ -22,10 +23,7 @@ export const maxDuration = 60;
  * cron only heals fresh misses; a wider sweep can be run manually by calling
  * the DB function with a larger p_since_hours.
  */
-export async function GET(req: NextRequest) {
-  const cronAuth = checkCronAuth(req.headers);
-  if (!cronAuth.ok) return NextResponse.json({ error: cronAuth.error }, { status: cronAuth.status });
-
+async function runPosLoyaltyReconcile() {
   const supabase = createSupabaseAdmin(
     process.env.NEXT_PUBLIC_SUPABASE_URL!,
     process.env.SUPABASE_SERVICE_ROLE_KEY || process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
@@ -44,3 +42,10 @@ export async function GET(req: NextRequest) {
   }
   return NextResponse.json({ ok: true, ...(row ?? { orders_fixed: 0, points_awarded: 0, drops_created: 0 }) });
 }
+
+// Heartbeat tier: this IS the safety net — if it silently stops, offline-sale
+// members quietly lose their Beans and Mystery drops with no other backstop.
+export const GET = cronRoute("pos-loyalty-reconcile", runPosLoyaltyReconcile, {
+  schedule: "*/5 * * * *",
+  maxRuntime: 4, // maxDuration 60s + margin
+});

--- a/apps/backoffice/src/app/api/cron/pos-poster-autopilot/route.ts
+++ b/apps/backoffice/src/app/api/cron/pos-poster-autopilot/route.ts
@@ -1,7 +1,7 @@
-import { NextRequest, NextResponse } from "next/server";
-import { checkCronAuth } from "@celsius/shared";
+import { NextResponse } from "next/server";
 import { getSupabaseAdmin } from "@/lib/pickup/supabase";
 import { planPosterRotation } from "@/lib/pos/poster-autopilot";
+import { cronRoute } from "@/lib/cron-monitor";
 
 /**
  * GET /api/cron/pos-poster-autopilot  (daily ~07:00 MYT)
@@ -36,10 +36,7 @@ function isoDate(d: Date): string {
 }
 const modeFor = (d: Date): "autopilot" | "control" => (dayOfYear(d) % 2 === 0 ? "autopilot" : "control");
 
-export async function GET(req: NextRequest) {
-  const auth = checkCronAuth(req.headers);
-  if (!auth.ok) return NextResponse.json({ error: auth.error }, { status: auth.status });
-
+async function runPosPosterAutopilot() {
   const supabase = getSupabaseAdmin();
 
   const { data: flagRow } = await supabase
@@ -97,3 +94,5 @@ export async function GET(req: NextRequest) {
   console.warn(`[cron/pos-poster-autopilot] mode=${mode} applied=${applied} perf_logged=${logged}`);
   return NextResponse.json({ ok: true, mode, applied, perfLogged: logged, activeByPlacement });
 }
+
+export const GET = cronRoute("pos-poster-autopilot", runPosPosterAutopilot);

--- a/apps/backoffice/src/app/api/cron/procurement-exec/route.ts
+++ b/apps/backoffice/src/app/api/cron/procurement-exec/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
-import { checkCronAuth } from "@celsius/shared";
 import { getSession } from "@/lib/auth";
 import { runProcurementExec } from "@/lib/inventory/exec/exec-controller";
+import { cronRoute } from "@/lib/cron-monitor";
 
 export const dynamic = "force-dynamic";
 export const maxDuration = 120;
@@ -12,14 +12,7 @@ export const maxDuration = 120;
 //
 // Auth: the Vercel cron secret, or an authenticated OWNER/ADMIN (run on demand for
 // testing without the secret).
-export async function GET(req: NextRequest) {
-  const cronAuth = checkCronAuth(req.headers);
-  if (!cronAuth.ok) {
-    const user = await getSession();
-    if (!user || !["OWNER", "ADMIN"].includes(user.role)) {
-      return NextResponse.json({ error: cronAuth.error }, { status: cronAuth.status });
-    }
-  }
+async function runProcurementExecCron() {
   try {
     const result = await runProcurementExec();
     return NextResponse.json({ ok: true, ...result });
@@ -27,4 +20,20 @@ export async function GET(req: NextRequest) {
     const msg = err instanceof Error ? err.message : "procurement-exec failed";
     return NextResponse.json({ error: msg }, { status: 500 });
   }
+}
+
+// Heartbeat tier: a silent no-run means unsent re-source orders and overdue
+// POs go unchased — stockouts and supplier money slip by unnoticed.
+const cronGET = cronRoute("procurement-exec", runProcurementExecCron, {
+  schedule: "0 1 * * *",
+  maxRuntime: 5, // maxDuration 120s + margin
+});
+
+// Preserved extra auth: an OWNER/ADMIN may trigger on demand without the cron
+// secret (cronRoute would reject them), so check the session first and only
+// then defer to the wrapped cron route.
+export async function GET(req: NextRequest) {
+  const user = await getSession();
+  if (user && ["OWNER", "ADMIN"].includes(user.role)) return runProcurementExecCron();
+  return cronGET(req);
 }

--- a/apps/backoffice/src/app/api/cron/prune-poster-assets/route.ts
+++ b/apps/backoffice/src/app/api/cron/prune-poster-assets/route.ts
@@ -1,7 +1,7 @@
-import { NextRequest, NextResponse } from "next/server";
+import { NextResponse } from "next/server";
 import { v2 as cloudinary } from "cloudinary";
 import { getSupabaseAdmin } from "@/lib/pickup/supabase";
-import { checkCronAuth } from "@celsius/shared";
+import { cronRoute } from "@/lib/cron-monitor";
 import {
   listPosterAssets,
   loadReferencedUrls,
@@ -34,12 +34,7 @@ export const maxDuration = 60;
  */
 const GRACE_DAYS = 7;
 
-export async function GET(req: NextRequest) {
-  const cronAuth = checkCronAuth(req.headers);
-  if (!cronAuth.ok) {
-    return NextResponse.json({ error: cronAuth.error }, { status: cronAuth.status });
-  }
-
+async function runPrunePosterAssets() {
   // Fail-closed if Cloudinary isn't configured, rather than half-running.
   const cloudName = process.env.CLOUDINARY_CLOUD_NAME;
   const apiKey = process.env.CLOUDINARY_API_KEY;
@@ -111,3 +106,5 @@ export async function GET(req: NextRequest) {
   }
   return NextResponse.json({ ok: true, ...summary });
 }
+
+export const GET = cronRoute("prune-poster-assets", runPrunePosterAssets);

--- a/apps/backoffice/src/app/api/cron/request-invoices/route.ts
+++ b/apps/backoffice/src/app/api/cron/request-invoices/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
-import { checkCronAuth } from "@celsius/shared";
 import { getSession } from "@/lib/auth";
 import { runInvoiceRequests } from "@/lib/inventory/agents/invoice-requester";
+import { cronRoute } from "@/lib/cron-monitor";
 
 export const dynamic = "force-dynamic";
 export const maxDuration = 120;
@@ -10,17 +10,10 @@ export const maxDuration = 120;
 // supplier for an invoice on every confirmed/in-delivery PO that has none yet
 // (gated + allow-listed; de-duped per PO). Scheduled in vercel.json.
 //
-// Auth: the Vercel cron secret (checkCronAuth). As a convenience for testing, an
+// Auth: the Vercel cron secret (via cronRoute). As a convenience for testing, an
 // authenticated OWNER/ADMIN may also trigger it by hitting the URL while logged
 // in (so you can run it on demand without the secret).
-export async function GET(req: NextRequest) {
-  const cronAuth = checkCronAuth(req.headers);
-  if (!cronAuth.ok) {
-    const user = await getSession();
-    if (!user || !["OWNER", "ADMIN"].includes(user.role)) {
-      return NextResponse.json({ error: cronAuth.error }, { status: cronAuth.status });
-    }
-  }
+async function runRequestInvoices() {
   try {
     const result = await runInvoiceRequests();
     return NextResponse.json({ ok: true, ...result });
@@ -28,4 +21,20 @@ export async function GET(req: NextRequest) {
     const msg = err instanceof Error ? err.message : "request-invoices failed";
     return NextResponse.json({ error: msg }, { status: 500 });
   }
+}
+
+// Heartbeat tier: a silent no-run stops invoice chasing, so POs pile up with
+// no invoice and AP matching (and the books) quietly starve.
+const cronGET = cronRoute("request-invoices", runRequestInvoices, {
+  schedule: "0 */4 * * *",
+  maxRuntime: 5, // maxDuration 120s + margin
+});
+
+// Preserved extra auth: an OWNER/ADMIN may trigger on demand without the cron
+// secret (cronRoute would reject them), so check the session first and only
+// then defer to the wrapped cron route.
+export async function GET(req: NextRequest) {
+  const user = await getSession();
+  if (user && ["OWNER", "ADMIN"].includes(user.role)) return runRequestInvoices();
+  return cronGET(req);
 }

--- a/apps/backoffice/src/app/api/cron/request-receivings/route.ts
+++ b/apps/backoffice/src/app/api/cron/request-receivings/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
-import { checkCronAuth } from "@celsius/shared";
 import { getSession } from "@/lib/auth";
 import { runReceivingRequests } from "@/lib/inventory/agents/receiving-requester";
+import { cronRoute } from "@/lib/cron-monitor";
 
 export const dynamic = "force-dynamic";
 export const maxDuration = 120;
@@ -10,16 +10,9 @@ export const maxDuration = 120;
 // that should have arrived but have no Receiving yet (gated + allow-listed,
 // de-duped per PO). Scheduled in vercel.json.
 //
-// Auth: the Vercel cron secret (checkCronAuth), or an authenticated OWNER/ADMIN
+// Auth: the Vercel cron secret (via cronRoute), or an authenticated OWNER/ADMIN
 // (so it can be run on demand for testing without the secret).
-export async function GET(req: NextRequest) {
-  const cronAuth = checkCronAuth(req.headers);
-  if (!cronAuth.ok) {
-    const user = await getSession();
-    if (!user || !["OWNER", "ADMIN"].includes(user.role)) {
-      return NextResponse.json({ error: cronAuth.error }, { status: cronAuth.status });
-    }
-  }
+async function runRequestReceivings() {
   try {
     const result = await runReceivingRequests();
     return NextResponse.json({ ok: true, ...result });
@@ -27,4 +20,20 @@ export async function GET(req: NextRequest) {
     const msg = err instanceof Error ? err.message : "request-receivings failed";
     return NextResponse.json({ error: msg }, { status: 500 });
   }
+}
+
+// Heartbeat tier: a silent no-run means overdue POs are never chased into a
+// GRN, so stock and AP drift from what was actually delivered and paid.
+const cronGET = cronRoute("request-receivings", runRequestReceivings, {
+  schedule: "0 */6 * * *",
+  maxRuntime: 5, // maxDuration 120s + margin
+});
+
+// Preserved extra auth: an OWNER/ADMIN may trigger on demand without the cron
+// secret (cronRoute would reject them), so check the session first and only
+// then defer to the wrapped cron route.
+export async function GET(req: NextRequest) {
+  const user = await getSession();
+  if (user && ["OWNER", "ADMIN"].includes(user.role)) return runRequestReceivings();
+  return cronGET(req);
 }

--- a/apps/backoffice/src/app/api/cron/reviews-auto-reply/route.ts
+++ b/apps/backoffice/src/app/api/cron/reviews-auto-reply/route.ts
@@ -1,9 +1,9 @@
 import { NextRequest, NextResponse } from "next/server";
-import { checkCronAuth } from "@celsius/shared";
 import { getUserFromHeaders } from "@/lib/auth";
 import { prisma } from "@/lib/prisma";
 import { fetchGoogleReviews, replyToReview } from "@/lib/reviews/gbp";
 import { generateReply, extractImprovement, POSITIVE_THRESHOLD } from "@/lib/reviews/auto-reply";
+import { cronRoute } from "@/lib/cron-monitor";
 
 export const dynamic = "force-dynamic";
 export const maxDuration = 300;
@@ -40,14 +40,7 @@ type OutletResult = {
   error?: string;
 };
 
-export async function GET(req: NextRequest) {
-  // Cron secret OR an authenticated admin (so it can be triggered manually).
-  const cronAuth = checkCronAuth(req.headers);
-  if (!cronAuth.ok) {
-    const user = await getUserFromHeaders(req.headers);
-    if (!user) return NextResponse.json({ error: cronAuth.error }, { status: cronAuth.status });
-  }
-
+async function runReviewsAutoReply() {
   const outlets = await prisma.outlet.findMany({
     where: { status: "ACTIVE" },
     include: { reviewSettings: true },
@@ -182,4 +175,14 @@ export async function GET(req: NextRequest) {
     total_flagged: totalFlagged,
     results,
   });
+}
+
+const cronHandler = cronRoute("reviews-auto-reply", runReviewsAutoReply);
+
+// Cron secret (via cronRoute) OR an authenticated admin (so it can be
+// triggered manually).
+export async function GET(req: NextRequest) {
+  const user = await getUserFromHeaders(req.headers);
+  if (user) return runReviewsAutoReply();
+  return cronHandler(req);
 }

--- a/apps/backoffice/src/app/api/cron/reviews-daily-snapshot/route.ts
+++ b/apps/backoffice/src/app/api/cron/reviews-daily-snapshot/route.ts
@@ -1,5 +1,4 @@
 import { NextRequest, NextResponse } from "next/server";
-import { checkCronAuth } from "@celsius/shared";
 import { getUserFromHeaders } from "@/lib/auth";
 import { prisma } from "@/lib/prisma";
 import { fetchGoogleReviews } from "@/lib/reviews/gbp";
@@ -7,6 +6,7 @@ import { relinkGbpLocations } from "@/lib/reviews/relink";
 import { fetchNextAheadCompetitor } from "@/lib/reviews/competitors";
 import { buildScoreboard } from "@/lib/reviews/scoreboard";
 import { sendMessage } from "@/lib/telegram";
+import { cronRoute } from "@/lib/cron-monitor";
 
 export const dynamic = "force-dynamic";
 export const maxDuration = 300;
@@ -16,14 +16,7 @@ export const maxDuration = 300;
 // (reviews/day vs the rate needed to out-review the leader). Idempotent per
 // day via the (outletId, snapshotDate) unique key, so re-running just refreshes
 // today's row.
-export async function GET(req: NextRequest) {
-  // Cron secret OR an authenticated admin (so it can be triggered manually).
-  const cronAuth = checkCronAuth(req.headers);
-  if (!cronAuth.ok) {
-    const user = await getUserFromHeaders(req.headers);
-    if (!user) return NextResponse.json({ error: cronAuth.error }, { status: cronAuth.status });
-  }
-
+async function runReviewsDailySnapshot() {
   const apiKey = process.env.GOOGLE_PLACES_API_KEY;
   const today = new Date();
   today.setUTCHours(0, 0, 0, 0);
@@ -122,4 +115,14 @@ export async function GET(req: NextRequest) {
   }
 
   return NextResponse.json({ snapshotDate: today.toISOString().slice(0, 10), relink, outlets: results, nudged });
+}
+
+const cronHandler = cronRoute("reviews-daily-snapshot", runReviewsDailySnapshot);
+
+// Cron secret (via cronRoute) OR an authenticated admin (so it can be
+// triggered manually).
+export async function GET(req: NextRequest) {
+  const user = await getUserFromHeaders(req.headers);
+  if (user) return runReviewsDailySnapshot();
+  return cronHandler(req);
 }

--- a/apps/backoffice/src/app/api/cron/sweep-stale-orders/route.ts
+++ b/apps/backoffice/src/app/api/cron/sweep-stale-orders/route.ts
@@ -1,6 +1,6 @@
-import { NextRequest, NextResponse } from "next/server";
+import { NextResponse } from "next/server";
 import { getSupabaseAdmin } from "@/lib/pickup/supabase";
-import { checkCronAuth } from "@celsius/shared";
+import { cronRoute } from "@/lib/cron-monitor";
 
 export const dynamic = "force-dynamic";
 
@@ -26,10 +26,7 @@ export const dynamic = "force-dynamic";
  */
 const STALE_HOURS = 3;
 
-export async function GET(req: NextRequest) {
-  const cronAuth = checkCronAuth(req.headers);
-  if (!cronAuth.ok) return NextResponse.json({ error: cronAuth.error }, { status: cronAuth.status });
-
+async function runSweepStaleOrders() {
   const supabase = getSupabaseAdmin();
   const cutoff = new Date(Date.now() - STALE_HOURS * 3_600_000).toISOString();
   const nowIso = new Date().toISOString();
@@ -66,3 +63,5 @@ export async function GET(req: NextRequest) {
   }
   return NextResponse.json({ ok: true, ...summary });
 }
+
+export const GET = cronRoute("sweep-stale-orders", runSweepStaleOrders);

--- a/apps/backoffice/src/app/api/hr/overtime-requests/sync/route.ts
+++ b/apps/backoffice/src/app/api/hr/overtime-requests/sync/route.ts
@@ -1,6 +1,7 @@
-import { NextRequest, NextResponse } from "next/server";
+import { NextResponse } from "next/server";
 import { getSession } from "@/lib/auth";
 import { hrSupabaseAdmin } from "@/lib/hr/supabase";
+import { cronRoute } from "@/lib/cron-monitor";
 
 export const dynamic = "force-dynamic";
 
@@ -103,14 +104,9 @@ async function runSync(actorUserId: string) {
   return NextResponse.json({ ok: true, created: inserts.length });
 }
 
-// Vercel Cron — Bearer CRON_SECRET
-export async function GET(req: NextRequest) {
-  const auth = req.headers.get("authorization");
-  if (process.env.CRON_SECRET && auth !== `Bearer ${process.env.CRON_SECRET}`) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-  }
-  return runSync("system");
-}
+// Vercel Cron — cronRoute replaces the old inline check, which was
+// fail-open (a missing CRON_SECRET made this a public endpoint).
+export const GET = cronRoute("hr-overtime-requests-sync", () => runSync("system"));
 
 // Manual admin trigger from UI
 export async function POST() {

--- a/apps/backoffice/src/app/api/hr/review-penalties/sync/route.ts
+++ b/apps/backoffice/src/app/api/hr/review-penalties/sync/route.ts
@@ -1,8 +1,9 @@
-import { NextRequest, NextResponse } from "next/server";
+import { NextResponse } from "next/server";
 import { getSession } from "@/lib/auth";
 import { hrSupabaseAdmin } from "@/lib/hr/supabase";
 import { prisma } from "@/lib/prisma";
 import { fetchGoogleReviews } from "@/lib/reviews/gbp";
+import { cronRoute } from "@/lib/cron-monitor";
 
 export const dynamic = "force-dynamic";
 
@@ -94,14 +95,9 @@ async function runSync() {
   });
 }
 
-// Vercel Cron — Bearer CRON_SECRET
-export async function GET(req: NextRequest) {
-  const auth = req.headers.get("authorization");
-  if (process.env.CRON_SECRET && auth !== `Bearer ${process.env.CRON_SECRET}`) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-  }
-  return runSync();
-}
+// Vercel Cron — cronRoute replaces the old inline check, which was
+// fail-open (a missing CRON_SECRET made this a public endpoint).
+export const GET = cronRoute("hr-review-penalties-sync", () => runSync());
 
 // Manual admin trigger from UI
 export async function POST() {

--- a/apps/backoffice/src/lib/cron-monitor.ts
+++ b/apps/backoffice/src/lib/cron-monitor.ts
@@ -1,0 +1,63 @@
+// Cron observability wrapper — auth + Sentry in one call per route
+// (docs/monitoring-setup.md). Two tiers:
+//
+//  - heartbeat: pass `monitor` with the crontab from this app's
+//    vercel.json. Sentry upserts the Cron Monitor on first check-in and
+//    alerts on missed windows, overruns, and thrown errors. Reserved for
+//    crons where a silent no-run costs money — Sentry bills per monitor.
+//  - error-capture (default, no `monitor`): thrown errors reach Sentry
+//    tagged `cron:<slug>` instead of dying in Vercel logs. A cron that
+//    stops being invoked at all is NOT detected in this tier.
+//
+// Identical copies live in backoffice/order/staff: @celsius/shared is
+// deliberately free of @sentry/* imports (see sentry-scrub.ts) and the
+// pickup app has no Sentry dependency to satisfy a barrel re-export.
+
+import * as Sentry from "@sentry/nextjs";
+import { NextRequest, NextResponse } from "next/server";
+import { checkCronAuth } from "@celsius/shared";
+
+export type CronMonitorConfig = {
+  /** Crontab (UTC) — MUST match this cron's schedule in vercel.json. */
+  schedule: string;
+  /** Minutes past the scheduled time before the run counts as missed. */
+  checkinMargin?: number;
+  /** Minutes a run may take before it counts as failed. */
+  maxRuntime?: number;
+};
+
+export function cronRoute(
+  slug: string,
+  handler: (req: NextRequest) => Promise<Response>,
+  monitor?: CronMonitorConfig,
+): (req: NextRequest) => Promise<Response> {
+  return async (req) => {
+    const auth = checkCronAuth(req.headers);
+    if (!auth.ok) {
+      // No check-in on auth failure: scanners must not feed the monitor,
+      // and a misconfigured CRON_SECRET should surface as a missed
+      // window, not a healthy run.
+      return NextResponse.json({ error: auth.error }, { status: auth.status });
+    }
+    try {
+      if (monitor) {
+        return await Sentry.withMonitor(slug, () => handler(req), {
+          schedule: { type: "crontab", value: monitor.schedule },
+          checkinMargin: monitor.checkinMargin ?? 5,
+          maxRuntime: monitor.maxRuntime ?? 10,
+          timezone: "Etc/UTC", // vercel.json crontabs are UTC
+        });
+      }
+      return await handler(req);
+    } catch (err) {
+      Sentry.captureException(err, { tags: { cron: slug } });
+      // Flush before the serverless function freezes — without it the
+      // event can sit in the buffer and never send.
+      await Sentry.flush(2000);
+      return NextResponse.json(
+        { error: err instanceof Error ? err.message : `${slug} failed` },
+        { status: 500 },
+      );
+    }
+  };
+}

--- a/apps/backoffice/vercel.json
+++ b/apps/backoffice/vercel.json
@@ -69,10 +69,6 @@
       "schedule": "0 */6 * * *"
     },
     {
-      "path": "/api/cron/music-alerts",
-      "schedule": "*/5 * * * *"
-    },
-    {
       "path": "/api/cron/pos-loyalty-reconcile",
       "schedule": "*/5 * * * *"
     },

--- a/apps/order/src/app/api/cron/auto-hours/route.ts
+++ b/apps/order/src/app/api/cron/auto-hours/route.ts
@@ -1,8 +1,8 @@
 export const dynamic = "force-dynamic";
 
-import { NextRequest, NextResponse } from "next/server";
+import { NextResponse } from "next/server";
 import { getSupabaseAdmin } from "@/lib/supabase/server";
-import { checkCronAuth } from "@celsius/shared";
+import { cronRoute } from "@/lib/cron-monitor";
 
 interface StoreHours {
   open: string;
@@ -20,10 +20,7 @@ function timeToMinutes(time: string): number {
 // GET /api/cron/auto-hours
 // Reads outlet_hours from app_settings, checks current Malaysia time (UTC+8),
 // and updates outlet_settings.is_open accordingly.
-export async function GET(request: NextRequest) {
-  const cronAuth = checkCronAuth(request.headers);
-  if (!cronAuth.ok) return NextResponse.json({ error: cronAuth.error }, { status: cronAuth.status });
-
+async function runAutoHours() {
   try {
     const supabase = getSupabaseAdmin();
 
@@ -135,3 +132,9 @@ export async function GET(request: NextRequest) {
     return NextResponse.json({ error: "Internal server error" }, { status: 500 });
   }
 }
+
+// Heartbeat tier: if this stops silently, outlets stay marked closed past
+// opening (lost orders) or open past closing (orders nobody will make).
+export const GET = cronRoute("auto-hours", runAutoHours, {
+  schedule: "*/10 * * * *",
+});

--- a/apps/order/src/app/api/cron/birthday-treats/route.ts
+++ b/apps/order/src/app/api/cron/birthday-treats/route.ts
@@ -12,17 +12,14 @@ export const dynamic = "force-dynamic";
 // guarded by checking issued_rewards for source_type=birthday with
 // source_ref_id = `birthday-${year}`.
 
-import { NextRequest, NextResponse } from "next/server";
+import { NextResponse } from "next/server";
 import { getSupabaseAdmin } from "@/lib/supabase/server";
-import { checkCronAuth } from "@celsius/shared";
+import { cronRoute } from "@/lib/cron-monitor";
 import { issueVoucher } from "@/lib/loyalty/v2";
 
 const BRAND_ID = (process.env.LOYALTY_BRAND_ID ?? "brand-celsius").trim();
 
-export async function GET(req: NextRequest) {
-  const cronAuth = checkCronAuth(req.headers);
-  if (!cronAuth.ok) return NextResponse.json({ error: cronAuth.error }, { status: cronAuth.status });
-
+async function runBirthdayTreats() {
   const supabase = getSupabaseAdmin();
 
   // Birthday voucher template — admin-configured. Fail fast if missing.
@@ -93,3 +90,5 @@ export async function GET(req: NextRequest) {
 
   return NextResponse.json({ candidates: candidates.length, issued });
 }
+
+export const GET = cronRoute("birthday-treats", runBirthdayTreats);

--- a/apps/order/src/app/api/cron/expire-orders/route.ts
+++ b/apps/order/src/app/api/cron/expire-orders/route.ts
@@ -4,9 +4,9 @@ export const dynamic = "force-dynamic";
 // times out mid-sweep (leftovers re-qualify on the next run).
 export const maxDuration = 60;
 
-import { NextRequest, NextResponse } from "next/server";
+import { NextResponse } from "next/server";
 import { getSupabaseAdmin } from "@/lib/supabase/server";
-import { checkCronAuth } from "@celsius/shared";
+import { cronRoute } from "@/lib/cron-monitor";
 import { queryCheckoutStatus } from "@/lib/revenue-monster/client";
 import { markRmOrderPaid, markRmOrderFailed } from "@/lib/revenue-monster/order-status";
 
@@ -14,10 +14,7 @@ import { markRmOrderPaid, markRmOrderFailed } from "@/lib/revenue-monster/order-
 // This cleans up abandoned payments (user left FPX page, browser closed, etc.).
 // reconcile-pending runs every 5 min and resolves Stripe-known cases earlier.
 
-export async function GET(request: NextRequest) {
-  const cronAuth = checkCronAuth(request.headers);
-  if (!cronAuth.ok) return NextResponse.json({ error: cronAuth.error }, { status: cronAuth.status });
-
+async function runExpireOrders() {
   try {
     const supabase = getSupabaseAdmin();
     const cutoff   = new Date(Date.now() - 10 * 60 * 1000).toISOString(); // 10 minutes ago
@@ -92,3 +89,9 @@ export async function GET(request: NextRequest) {
     return NextResponse.json({ error: String(err) }, { status: 500 });
   }
 }
+
+// Heartbeat tier: if this sweep silently stops, abandoned pending orders
+// pile up and dropped RM successes never settle — that costs money/orders.
+export const GET = cronRoute("expire-orders", runExpireOrders, {
+  schedule: "*/15 * * * *",
+});

--- a/apps/order/src/app/api/cron/loyalty-pushes/route.ts
+++ b/apps/order/src/app/api/cron/loyalty-pushes/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
+import { cronRoute } from "@/lib/cron-monitor";
 import { getSupabaseAdmin } from "@/lib/supabase/server";
 import {
   notifyBirthdayReward,
@@ -35,48 +36,31 @@ import { evaluateAudience, reachableCandidateMemberIds, type RuleNode } from "@/
  *   "0  3 * * *"     /api/cron/loyalty-pushes?job=sitting-on-beans (11am MYT)
  *   "0  3 * * 1"     /api/cron/loyalty-pushes?job=miss-you        (11am MYT Mon)
  *
- * Auth: header `Authorization: Bearer ${CRON_SECRET}` OR Vercel-
- * native `x-vercel-cron` header. Local dev: pass ?secret= for
- * manual testing.
+ * Auth: header `Authorization: Bearer ${CRON_SECRET}` (checkCronAuth,
+ * enforced by cronRoute).
  */
 
 const BRAND_ID = "brand-celsius";
 
-function authorized(req: NextRequest): boolean {
-  if (req.headers.get("x-vercel-cron")) return true;
-  const expected = process.env.CRON_SECRET;
-  if (!expected) return false;
-  const header = req.headers.get("authorization");
-  const bearer = header?.startsWith("Bearer ") ? header.slice(7) : null;
-  const qs     = req.nextUrl.searchParams.get("secret");
-  return bearer === expected || qs === expected;
-}
-
-export async function GET(request: NextRequest) {
-  if (!authorized(request)) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-  }
+async function runLoyaltyPushes(request: NextRequest) {
   const job = request.nextUrl.searchParams.get("job") ?? "";
 
-  try {
-    switch (job) {
-      case "birthday":         return NextResponse.json(await runBirthday());
-      case "reward-expiring":  return NextResponse.json(await runRewardExpiring());
-      case "tier-at-risk":     return NextResponse.json(await runTierAtRisk());
-      case "miss-you":         return NextResponse.json(await runMissYou());
-      case "sitting-on-beans": return NextResponse.json(await runSittingOnBeans());
-      case "custom":           return NextResponse.json(await runCustomCampaigns());
-      default:
-        return NextResponse.json(
-          { error: "unknown job — expected birthday|reward-expiring|tier-at-risk|miss-you|sitting-on-beans|custom" },
-          { status: 400 },
-        );
-    }
-  } catch (err) {
-    console.error("[cron/loyalty-pushes]", err);
-    return NextResponse.json({ error: "Cron job failed" }, { status: 500 });
+  switch (job) {
+    case "birthday":         return NextResponse.json(await runBirthday());
+    case "reward-expiring":  return NextResponse.json(await runRewardExpiring());
+    case "tier-at-risk":     return NextResponse.json(await runTierAtRisk());
+    case "miss-you":         return NextResponse.json(await runMissYou());
+    case "sitting-on-beans": return NextResponse.json(await runSittingOnBeans());
+    case "custom":           return NextResponse.json(await runCustomCampaigns());
+    default:
+      return NextResponse.json(
+        { error: "unknown job — expected birthday|reward-expiring|tier-at-risk|miss-you|sitting-on-beans|custom" },
+        { status: 400 },
+      );
   }
 }
+
+export const GET = cronRoute("loyalty-pushes", runLoyaltyPushes);
 
 /* ────────────────────────────────────────────────────────────────────────── */
 /* Birthday                                                                   */

--- a/apps/order/src/app/api/cron/promote-scheduled/route.ts
+++ b/apps/order/src/app/api/cron/promote-scheduled/route.ts
@@ -1,9 +1,9 @@
 export const dynamic = "force-dynamic";
 
-import { NextRequest, NextResponse } from "next/server";
+import { NextResponse } from "next/server";
 import { getSupabaseAdmin } from "@/lib/supabase/server";
 import { notifyOrderPreparing } from "@/lib/push/templates";
-import { checkCronAuth } from "@celsius/shared";
+import { cronRoute } from "@/lib/cron-monitor";
 
 /**
  * Runs every 2 minutes. Finds scheduled orders sitting in "paid"
@@ -17,10 +17,7 @@ import { checkCronAuth } from "@celsius/shared";
  * outlet's prep time isn't set we default to 10 min (matches the
  * checkout-side default).
  */
-export async function GET(request: NextRequest) {
-  const cronAuth = checkCronAuth(request.headers);
-  if (!cronAuth.ok) return NextResponse.json({ error: cronAuth.error }, { status: cronAuth.status });
-
+async function runPromoteScheduled() {
   const supabase = getSupabaseAdmin();
 
   // Fetch held scheduled orders. Look at every "paid" row with a
@@ -95,3 +92,9 @@ export async function GET(request: NextRequest) {
 
   return NextResponse.json(result);
 }
+
+// Heartbeat tier: a silent stop leaves scheduled orders stuck in "paid" —
+// the kitchen never sees them, so customers wait on drinks nobody is making.
+export const GET = cronRoute("promote-scheduled", runPromoteScheduled, {
+  schedule: "*/2 * * * *",
+});

--- a/apps/order/src/app/api/cron/reconcile-pending/route.ts
+++ b/apps/order/src/app/api/cron/reconcile-pending/route.ts
@@ -1,11 +1,10 @@
 export const dynamic = "force-dynamic";
 
-import { NextRequest, NextResponse } from "next/server";
-import * as Sentry from "@sentry/nextjs";
+import { NextResponse } from "next/server";
 import Stripe from "stripe";
 import { getSupabaseAdmin } from "@/lib/supabase/server";
 import { earnLoyaltyPoints, deductLoyaltyPoints } from "@/lib/loyalty/points";
-import { checkCronAuth } from "@celsius/shared";
+import { cronRoute } from "@/lib/cron-monitor";
 import { queryCheckoutStatus } from "@/lib/revenue-monster/client";
 import { markRmOrderPaid, markRmOrderFailed } from "@/lib/revenue-monster/order-status";
 
@@ -37,29 +36,16 @@ type OrderLite = {
 
 const RM_METHODS = new Set(["fpx", "tng", "boost", "shopeepay", "grabpay", "duitnow", "card"]);
 
-export async function GET(request: NextRequest) {
-  const cronAuth = checkCronAuth(request.headers);
-  if (!cronAuth.ok) return NextResponse.json({ error: cronAuth.error }, { status: cronAuth.status });
-
-  // Heartbeat: this cron settles payments and fails silently into logs
-  // otherwise (docs/monitoring-setup.md). withMonitor upserts the Sentry
-  // Cron Monitor on first check-in and alerts on missed windows or thrown
-  // errors — config errors below throw (instead of returning 500 directly)
-  // so they register as failed runs, not healthy ones.
-  try {
-    return await Sentry.withMonitor("reconcile-pending", () => runReconcile(), {
-      schedule: { type: "crontab", value: "* * * * *" },
-      checkinMargin: 5,
-      maxRuntime: 10,
-      timezone: "Etc/UTC",
-    });
-  } catch (err) {
-    return NextResponse.json(
-      { error: err instanceof Error ? err.message : "reconcile-pending failed" },
-      { status: 500 },
-    );
-  }
-}
+// Heartbeat: this cron settles payments and fails silently into logs
+// otherwise (docs/monitoring-setup.md). cronRoute's withMonitor upserts the
+// Sentry Cron Monitor on first check-in and alerts on missed windows or
+// thrown errors — config errors below throw (instead of returning 500
+// directly) so they register as failed runs, not healthy ones.
+export const GET = cronRoute("reconcile-pending", runReconcile, {
+  schedule: "* * * * *",
+  checkinMargin: 5,
+  maxRuntime: 10,
+});
 
 async function runReconcile(): Promise<NextResponse> {
   const stripe = getStripe();

--- a/apps/order/src/app/api/cron/streak-update/route.ts
+++ b/apps/order/src/app/api/cron/streak-update/route.ts
@@ -7,9 +7,9 @@ export const dynamic = "force-dynamic";
 // push were removed when the streak-chest feature was retired — keep
 // the streak count maintenance so Wrapped continues to work.
 
-import { NextRequest, NextResponse } from "next/server";
+import { NextResponse } from "next/server";
 import { getSupabaseAdmin } from "@/lib/supabase/server";
-import { checkCronAuth } from "@celsius/shared";
+import { cronRoute } from "@/lib/cron-monitor";
 
 const MY_OFFSET_HOURS = 8;
 
@@ -24,10 +24,7 @@ function thisWeekStartIso(now = new Date()): string {
 
 const SAVER_REFILL_DAYS = 90;
 
-export async function GET(req: NextRequest) {
-  const cronAuth = checkCronAuth(req.headers);
-  if (!cronAuth.ok) return NextResponse.json({ error: cronAuth.error }, { status: cronAuth.status });
-
+async function runStreakUpdate() {
   const supabase = getSupabaseAdmin();
   const weekStart = thisWeekStartIso();
   const twoWeeksAgo = new Date(Date.now() - 14 * 24 * 60 * 60 * 1000).toISOString();
@@ -119,3 +116,5 @@ export async function GET(req: NextRequest) {
     refilled,
   });
 }
+
+export const GET = cronRoute("streak-update", runStreakUpdate);

--- a/apps/order/src/app/api/cron/sync-rm-payouts/route.ts
+++ b/apps/order/src/app/api/cron/sync-rm-payouts/route.ts
@@ -4,7 +4,7 @@ export const dynamic = "force-dynamic";
 export const maxDuration = 60;
 
 import { NextRequest, NextResponse } from "next/server";
-import { checkCronAuth } from "@celsius/shared";
+import { cronRoute } from "@/lib/cron-monitor";
 import { getSupabaseAdmin } from "@/lib/supabase/server";
 import {
   getDailySettlementReport,
@@ -46,10 +46,7 @@ function resolveStore(storeName: string | null, orderStore: string | null): { sl
   return { slug: orderStore || "unknown", entity: storeName || "Unknown" };
 }
 
-export async function GET(request: NextRequest) {
-  const cronAuth = checkCronAuth(request.headers);
-  if (!cronAuth.ok) return NextResponse.json({ error: cronAuth.error }, { status: cronAuth.status });
-
+async function runSyncRmPayouts(request: NextRequest) {
   const p = request.nextUrl.searchParams;
 
   // ── Probe: one call, raw + parsed, no DB writes. Fail-fast endpoint check. ──
@@ -176,3 +173,9 @@ export async function GET(request: NextRequest) {
 
   return NextResponse.json(result);
 }
+
+// Heartbeat tier: a silent stop means settlement batches never land in the
+// finance Payouts tab — money movement goes unreconciled until someone notices.
+export const GET = cronRoute("sync-rm-payouts", runSyncRmPayouts, {
+  schedule: "0 21 * * *",
+});

--- a/apps/order/src/app/api/cron/voucher-expiring/route.ts
+++ b/apps/order/src/app/api/cron/voucher-expiring/route.ts
@@ -9,15 +9,12 @@ export const dynamic = "force-dynamic";
 //      `status='active' AND expires_at < now()` rows accumulating
 //      forever — confusing customers + polluting analytics.
 
-import { NextRequest, NextResponse } from "next/server";
+import { NextResponse } from "next/server";
 import { getSupabaseAdmin } from "@/lib/supabase/server";
-import { checkCronAuth } from "@celsius/shared";
+import { cronRoute } from "@/lib/cron-monitor";
 import { notifyVoucherExpiringSoon } from "@/lib/push/templates";
 
-export async function GET(req: NextRequest) {
-  const cronAuth = checkCronAuth(req.headers);
-  if (!cronAuth.ok) return NextResponse.json({ error: cronAuth.error }, { status: cronAuth.status });
-
+async function runVoucherExpiring() {
   const supabase = getSupabaseAdmin();
 
   // ── 1) Sweep already-expired vouchers ─────────────────────────────
@@ -65,3 +62,5 @@ export async function GET(req: NextRequest) {
     sent,
   });
 }
+
+export const GET = cronRoute("voucher-expiring", runVoucherExpiring);

--- a/apps/order/src/lib/cron-monitor.ts
+++ b/apps/order/src/lib/cron-monitor.ts
@@ -1,0 +1,63 @@
+// Cron observability wrapper — auth + Sentry in one call per route
+// (docs/monitoring-setup.md). Two tiers:
+//
+//  - heartbeat: pass `monitor` with the crontab from this app's
+//    vercel.json. Sentry upserts the Cron Monitor on first check-in and
+//    alerts on missed windows, overruns, and thrown errors. Reserved for
+//    crons where a silent no-run costs money — Sentry bills per monitor.
+//  - error-capture (default, no `monitor`): thrown errors reach Sentry
+//    tagged `cron:<slug>` instead of dying in Vercel logs. A cron that
+//    stops being invoked at all is NOT detected in this tier.
+//
+// Identical copies live in backoffice/order/staff: @celsius/shared is
+// deliberately free of @sentry/* imports (see sentry-scrub.ts) and the
+// pickup app has no Sentry dependency to satisfy a barrel re-export.
+
+import * as Sentry from "@sentry/nextjs";
+import { NextRequest, NextResponse } from "next/server";
+import { checkCronAuth } from "@celsius/shared";
+
+export type CronMonitorConfig = {
+  /** Crontab (UTC) — MUST match this cron's schedule in vercel.json. */
+  schedule: string;
+  /** Minutes past the scheduled time before the run counts as missed. */
+  checkinMargin?: number;
+  /** Minutes a run may take before it counts as failed. */
+  maxRuntime?: number;
+};
+
+export function cronRoute(
+  slug: string,
+  handler: (req: NextRequest) => Promise<Response>,
+  monitor?: CronMonitorConfig,
+): (req: NextRequest) => Promise<Response> {
+  return async (req) => {
+    const auth = checkCronAuth(req.headers);
+    if (!auth.ok) {
+      // No check-in on auth failure: scanners must not feed the monitor,
+      // and a misconfigured CRON_SECRET should surface as a missed
+      // window, not a healthy run.
+      return NextResponse.json({ error: auth.error }, { status: auth.status });
+    }
+    try {
+      if (monitor) {
+        return await Sentry.withMonitor(slug, () => handler(req), {
+          schedule: { type: "crontab", value: monitor.schedule },
+          checkinMargin: monitor.checkinMargin ?? 5,
+          maxRuntime: monitor.maxRuntime ?? 10,
+          timezone: "Etc/UTC", // vercel.json crontabs are UTC
+        });
+      }
+      return await handler(req);
+    } catch (err) {
+      Sentry.captureException(err, { tags: { cron: slug } });
+      // Flush before the serverless function freezes — without it the
+      // event can sit in the buffer and never send.
+      await Sentry.flush(2000);
+      return NextResponse.json(
+        { error: err instanceof Error ? err.message : `${slug} failed` },
+        { status: 500 },
+      );
+    }
+  };
+}

--- a/apps/staff/src/app/api/cron/reset-checklists/route.ts
+++ b/apps/staff/src/app/api/cron/reset-checklists/route.ts
@@ -1,6 +1,6 @@
-import { NextResponse, NextRequest } from "next/server";
+import { NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
-import { checkCronAuth } from "@celsius/shared";
+import { cronRoute } from "@/lib/cron-monitor";
 
 /**
  * GET /api/cron/reset-checklists
@@ -13,10 +13,7 @@ import { checkCronAuth } from "@celsius/shared";
  *
  * Protected by CRON_SECRET to prevent unauthorized access.
  */
-export async function GET(req: NextRequest) {
-  const cronAuth = checkCronAuth(req.headers);
-  if (!cronAuth.ok) return NextResponse.json({ error: cronAuth.error }, { status: cronAuth.status });
-
+async function runResetChecklists() {
   // 12am MYT = the start of the new MYT day
   const mytDateStr = new Date(Date.now() + 8 * 60 * 60 * 1000)
     .toISOString()
@@ -48,3 +45,9 @@ export async function GET(req: NextRequest) {
     deletedItems: deletedItems.count,
   });
 }
+
+// Heartbeat tier: daily ops accountability breaks silently if this stops —
+// stale checklists never regenerate and outlets skip their opening checks.
+export const GET = cronRoute("reset-checklists", runResetChecklists, {
+  schedule: "0 16 * * *",
+});

--- a/apps/staff/src/lib/cron-monitor.ts
+++ b/apps/staff/src/lib/cron-monitor.ts
@@ -1,0 +1,63 @@
+// Cron observability wrapper — auth + Sentry in one call per route
+// (docs/monitoring-setup.md). Two tiers:
+//
+//  - heartbeat: pass `monitor` with the crontab from this app's
+//    vercel.json. Sentry upserts the Cron Monitor on first check-in and
+//    alerts on missed windows, overruns, and thrown errors. Reserved for
+//    crons where a silent no-run costs money — Sentry bills per monitor.
+//  - error-capture (default, no `monitor`): thrown errors reach Sentry
+//    tagged `cron:<slug>` instead of dying in Vercel logs. A cron that
+//    stops being invoked at all is NOT detected in this tier.
+//
+// Identical copies live in backoffice/order/staff: @celsius/shared is
+// deliberately free of @sentry/* imports (see sentry-scrub.ts) and the
+// pickup app has no Sentry dependency to satisfy a barrel re-export.
+
+import * as Sentry from "@sentry/nextjs";
+import { NextRequest, NextResponse } from "next/server";
+import { checkCronAuth } from "@celsius/shared";
+
+export type CronMonitorConfig = {
+  /** Crontab (UTC) — MUST match this cron's schedule in vercel.json. */
+  schedule: string;
+  /** Minutes past the scheduled time before the run counts as missed. */
+  checkinMargin?: number;
+  /** Minutes a run may take before it counts as failed. */
+  maxRuntime?: number;
+};
+
+export function cronRoute(
+  slug: string,
+  handler: (req: NextRequest) => Promise<Response>,
+  monitor?: CronMonitorConfig,
+): (req: NextRequest) => Promise<Response> {
+  return async (req) => {
+    const auth = checkCronAuth(req.headers);
+    if (!auth.ok) {
+      // No check-in on auth failure: scanners must not feed the monitor,
+      // and a misconfigured CRON_SECRET should surface as a missed
+      // window, not a healthy run.
+      return NextResponse.json({ error: auth.error }, { status: auth.status });
+    }
+    try {
+      if (monitor) {
+        return await Sentry.withMonitor(slug, () => handler(req), {
+          schedule: { type: "crontab", value: monitor.schedule },
+          checkinMargin: monitor.checkinMargin ?? 5,
+          maxRuntime: monitor.maxRuntime ?? 10,
+          timezone: "Etc/UTC", // vercel.json crontabs are UTC
+        });
+      }
+      return await handler(req);
+    } catch (err) {
+      Sentry.captureException(err, { tags: { cron: slug } });
+      // Flush before the serverless function freezes — without it the
+      // event can sit in the buffer and never send.
+      await Sentry.flush(2000);
+      return NextResponse.json(
+        { error: err instanceof Error ? err.message : `${slug} failed` },
+        { status: 500 },
+      );
+    }
+  };
+}

--- a/docs/STATE.md
+++ b/docs/STATE.md
@@ -76,8 +76,6 @@ delete entries that have been promoted into `CLAUDE.md`, a skill, or a doc.
   DESIGN** (SUNMI tills write via the anon key). Do NOT lint-fix — needs a
   data-layer plan (rls-strategy.md Path A). 4 `security_definer_view` +
   ~12 `function_search_path_mutable` remain as low-risk hardening.
-- 2026-07-05 — 13 of 14 Vercel crons still have no heartbeat monitoring
-  (`reconcile-pending` wired 2026-07-05; the rest fail silently).
 - 2026-07-05 — Pickup dashboard **inventory tab reads tables that don't
   exist** (`ingredients`, `stock_levels`, `ingredient_outlet_settings` —
   absent from BOTH Supabase projects); it has been silently empty. Either
@@ -93,6 +91,17 @@ get_advisors sweep then closed ALL remaining anon-reachable tables:
 10 backup snapshots (074) + 14 server-only tables incl. PendingPop/grab_*
 (075). Verified: rls_disabled_in_public 24→0, sensitive_columns_exposed
 2→0, security ERRORs 30→4 (the 4 left are SECURITY DEFINER views)._
+
+_Resolved 2026-07-05 evening: "13 of 14 Vercel crons unmonitored" — the
+real fleet was ~59 scheduled crons, not 14. All now route through
+`cronRoute()` (per-app `src/lib/cron-monitor.ts`): 16 money-critical
+crons carry Sentry Cron Monitor heartbeats, the rest get Sentry error
+capture (tag `cron:<slug>`). Also fixed en route: the 2 fail-open cron
+auths (`hr/{overtime-requests,review-penalties}/sync` GET),
+loyalty-pushes' spoofable `x-vercel-cron` + `?secret=` auth paths, and
+the phantom `music-alerts` vercel.json entry (404 every 5 min — route
+never existed). Human owes: Sentry → Crons alert rule after first prod
+run (monitors auto-create). Tier list: `docs/monitoring-setup.md`._
 
 _Fixed 2026-07-05 (see Lessons): categorizer correction mis-attribution +
 never-set `applied` flag — `related_id` now populated at decision time,
@@ -115,6 +124,18 @@ _Format: `YYYY-MM-DD — <symptom> — <evidence> — <hypothesis/fix> — <bloc
 
 ## Resume pointer
 
+- 2026-07-05 (evening) — **Security + observability batch.** Cron
+  observability wired repo-wide (see resolved Open-failure note above;
+  branch `claude/apps-fragmented-software-letsr7`, PR #805). Security
+  items §5/§6 of the hardening checklist turned out ALREADY CLOSED in
+  prod — live DB drifted ahead of repo migrations; verified independently
+  (`hr_payroll_runs`/`hr_payroll_items` relrowsecurity=true, 0 policies)
+  and cross-checked against PR #802. Checklist now has only true
+  human-dashboard items open: §1 IP allowlist, §3 BetterUptime +
+  Vercel→Slack + Sentry cron alert rule, §4 PITR decision. Next session:
+  watch Sentry → Crons after first prod runs (16 monitors auto-create;
+  schedules must stay in lockstep with vercel.json), and consider
+  promoting any error-tier cron that bites.
 - 2026-07-05 — **Staff access-control audit + hotfixes** (`docs/staff-access-
   audit-2026-07-05.md`). Application-layer RBAC audit across POS login, staff
   app, checklists, stock count, receiving, own audit/performance, backoffice,

--- a/docs/monitoring-setup.md
+++ b/docs/monitoring-setup.md
@@ -30,21 +30,34 @@ Expected response:
 
 ### Cron heartbeats (per-cron, alert if missing)
 
-The 14 Vercel crons silently fail into logs unless you wire heartbeat
-monitoring. **Recommended:** Sentry Cron Monitors (lives next to your
-existing Sentry setup, no new account).
-
-| Cron | Schedule | App |
-|------|----------|-----|
-| /api/cron/attendance-auto-close | Every 15 min | backoffice |
-| /api/cron/campaigns-auto | Hourly | backoffice |
-| /api/cron/ads-daily | 3 AM MYT | backoffice |
-| /api/cron/ads-monthly | 4 AM 2nd of month | backoffice |
-| /api/cron/deactivate-resigned | Nightly | backoffice |
-| /api/cron/expire-orders | Every 10 min | order |
-| /api/cron/reconcile-pending | Every 1 min | order |
-| /api/cron/auto-hours | Hourly | order |
-| /api/cron/reset-checklists | 12am MYT | staff |
+> **2026-07-05 — wired in code.** The real fleet is ~59 scheduled cron
+> entries (44 backoffice, 14 order, 1 staff — the old "14 crons" figure
+> here was stale). Every scheduled cron route now goes through
+> `cronRoute()` (`src/lib/cron-monitor.ts` in each app — identical
+> copies; `@celsius/shared` stays Sentry-free on purpose), which does
+> fail-closed cron auth + Sentry error capture, in two tiers:
+>
+> - **Heartbeat tier (16 monitors — Sentry bills per monitor):**
+>   Sentry Cron Monitor auto-created on first production run; alerts on
+>   missed windows, overruns, and errors. Chosen where a silent no-run
+>   costs money: backoffice `finance-eod`, `consumption-post`,
+>   `bukku-feed-sync`, `pos-loyalty-reconcile`, `grab-reconcile`,
+>   `attendance-auto-close`, `procurement-exec`, `request-invoices`,
+>   `request-receivings`, `ads-daily`; order `reconcile-pending`,
+>   `expire-orders`, `promote-scheduled`, `auto-hours`,
+>   `sync-rm-payouts`; staff `reset-checklists`.
+> - **Error-capture tier (everything else):** thrown errors reach
+>   Sentry tagged `cron:<slug>` instead of dying in Vercel logs. A cron
+>   that stops being *invoked* is not detected in this tier — promote it
+>   to heartbeat if it ever bites.
+>
+> The monitor's `schedule` config MUST match the crontab in that app's
+> `vercel.json` — update both together or Sentry will alert on phantom
+> missed runs.
+>
+> **Remaining human step:** Sentry → Crons → set the alert rule
+> (notify on missed check-in / error) once the monitors appear after
+> first production run.
 
 ## Recommended setup (free / low cost)
 
@@ -102,9 +115,9 @@ If you want the absolute minimum to not be flying blind:
 That covers "is the site up" and "did the last deploy fail" — 90% of
 "things are broken" alerts.
 
-The Sentry cron monitor wiring is more work (needs code change per
-cron) — leave for the next sprint unless a specific cron has been
-silently failing.
+The Sentry cron monitor wiring is DONE in code (2026-07-05, see the
+cron-heartbeats section above) — what's left of it is the Sentry alert
+rule, which is dashboard work.
 
 ## What to verify in Supabase dashboard
 

--- a/docs/ops-hardening-checklist.md
+++ b/docs/ops-hardening-checklist.md
@@ -40,10 +40,12 @@ points back at this section. Next one due: **2026-10-01**.
 - [ ] Verify: temporarily point one monitor at a bogus path and confirm the
       alert arrives, then fix it.
 
-Note: the `reconcile-pending` payments cron now carries a Sentry Cron
-Monitor heartbeat in code (auto-creates on first production run — check
-Sentry → Crons and set the alert rule to notify you). The other 13 crons
-remain unmonitored; wire them the same way if one bites.
+Note (updated 2026-07-05): ALL ~59 scheduled crons are now wired in code
+via `cronRoute()` — 16 money-critical ones carry Sentry Cron Monitor
+heartbeats (auto-create on first production run), the rest get Sentry
+error capture. See `docs/monitoring-setup.md` §cron-heartbeats for the
+tier list. Remaining dashboard step: Sentry → Crons → alert rule
+(notify on missed check-in / error) once the monitors appear.
 
 ## 4. Point-in-Time Recovery decision (~5 min to decide)
 
@@ -57,18 +59,17 @@ remain unmonitored; wire them the same way if one bites.
   stay on snapshots.
 - [ ] Record the decision (either way) in `docs/STATE.md`.
 
-## 5. Loyalty RLS policy fix (after this PR deploys)
+## 5. Loyalty RLS policy fix — ~~SUPERSEDED 2026-07-05~~
 
-- [ ] Confirm the pickup dashboard-stats API route is live in production.
-- [ ] Review + apply `docs/proposals/2026-07-05-loyalty-rls-policy-fix.sql`
-      (pre-apply verification steps are in the file header).
-- [ ] Smoke test: order checkout, OTP login, pickup dashboard loyalty tab,
-      POS loyalty lookup.
-- [ ] Move the SQL under the loyalty migrations dir + update the access map.
+The live DB had drifted ahead of the repo migration files: the
+`USING (true)` policies were already gone in production and anon DML on
+the sensitive tables already revoked. The proposal SQL is marked
+superseded in-file; the real live exposure (the `outlets` view) was
+fixed the same day. See PR #802 and the live-DB correction in
+`docs/rls-access-map-2026-07-05.md`. Nothing left to apply here.
 
-## 6. hr_payroll_runs deny-all RLS (quick follow-up migration)
+## 6. hr_payroll_runs deny-all RLS — ~~DONE (already live)~~
 
-- [ ] One-liner migration on the main project:
-      `ALTER TABLE hr_payroll_runs ENABLE ROW LEVEL SECURITY;`
-      (matches the 20260502 batch; no policies = service-role only).
-      Payroll table — review before applying per hard rule 6.
+Verified 2026-07-05 directly against production (`pg_class.relrowsecurity`):
+`hr_payroll_runs` and `hr_payroll_items` both have RLS enabled with zero
+policies (deny-all, service-role only). No migration needed.


### PR DESCRIPTION
## What

Closes the "crons fail silently into logs" open failure — for the real fleet, which turned out to be **~59 scheduled crons** (44 backoffice, 14 order, 1 staff), not the 14 the monitoring doc listed. Only `reconcile-pending` had any monitoring before this.

Every scheduled cron route now goes through **`cronRoute()`** (per-app `src/lib/cron-monitor.ts` — identical copies in backoffice/order/staff; `@celsius/shared` stays deliberately `@sentry`-free), which does fail-closed cron auth + Sentry error capture, in two owner-approved tiers:

- **Heartbeat tier (16 monitors — Sentry bills per monitor):** `Sentry.withMonitor` with the crontab from `vercel.json`; alerts on missed windows, overruns, and errors. Money/ops-critical only: `finance-eod`, `consumption-post`, `bukku-feed-sync`, `pos-loyalty-reconcile`, `grab-reconcile`, `attendance-auto-close`, `procurement-exec`, `request-invoices`, `request-receivings`, `ads-daily` (backoffice); `reconcile-pending` (refactored to the wrapper, same slug + monitor config), `expire-orders`, `promote-scheduled`, `auto-hours`, `sync-rm-payouts` (order); `reset-checklists` (staff).
- **Error-capture tier (everything else):** thrown errors reach Sentry tagged `cron:<slug>` instead of dying in Vercel logs. Missed runs are not detected in this tier — promote a cron if it bites.

### Security fixes picked up en route

- `hr/{overtime-requests,review-penalties}/sync` GET used the **fail-open** auth pattern `cron-auth.ts` explicitly warns about (missing `CRON_SECRET` ⇒ public endpoint). Now fail-closed via `cronRoute`; the session-authed POST (manual admin trigger) is untouched.
- `loyalty-pushes` accepted a **spoofable `x-vercel-cron` header** and a `?secret=` query param as auth — removed; Bearer `CRON_SECRET` only. Its error-swallowing catch is lifted so failures actually reach Sentry.
- `ai-agent/celsius-overview` keeps its dual session/cron auth (already fail-closed, timing-safe) but its catch now reports to Sentry before returning 500.
- Removed the phantom `/api/cron/music-alerts` entry from `vercel.json` — the route never existed; Vercel has been calling a 404 every 5 minutes.

Seven routes with a manual admin/session fallback (`consumption-post`, `procurement-exec`, `request-invoices`, `request-receivings`, `par-levels-recalc`, `reviews-auto-reply`, `reviews-daily-snapshot`) keep it: the session path runs the handler directly (manual runs don't feed the heartbeat), everything else goes through `cronRoute`.

### Checklist bookkeeping (security half of this session)

Hardening-checklist §5 (loyalty RLS proposal) and §6 (`hr_payroll_runs` RLS) are marked **closed** — verified directly against production (`relrowsecurity=true`, 0 policies on `hr_payroll_runs`/`hr_payroll_items`), consistent with the live-DB audit in #802. No SQL applied in this PR; a redundant migration draft was deleted before commit to avoid colliding with #802's 073–075 numbering.

**Note:** `docs/STATE.md` touches lines adjacent to #802's edits — whichever merges second may need a trivial conflict resolution.

### Remaining human (dashboard) steps

1. Sentry → Crons → alert rule after the first production runs (the 16 monitors auto-create).
2. Checklist §1 (Supabase IP allowlist), §3 (BetterUptime + Vercel→Slack), §4 (PITR decision) — unchanged, still open.

## Verification

- `npx tsc --noEmit` clean in backoffice, order, staff
- Root vitest: 318/318 passing
- eslint clean on all changed files
- Heartbeat `schedule` values cross-checked against each app's `vercel.json` (they must stay in lockstep — noted in `docs/monitoring-setup.md`)
- Order app is Next 16.2: bundled `dist/docs` route-handler conventions checked; no deprecated idioms introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0174mL9iVqrJJ2mVBReVTPBe

---
_Generated by [Claude Code](https://claude.ai/code/session_0174mL9iVqrJJ2mVBReVTPBe)_