### PR TITLE
Fix cold-send failures: invoice_request template, PDF fallback, 30d chase window

### DIFF
--- a/apps/backoffice/src/app/api/ops/workspace/templates/route.ts
+++ b/apps/backoffice/src/app/api/ops/workspace/templates/route.ts
@@ -70,6 +70,18 @@ const TEMPLATE_DEFS = [
     sample: ["Jiju Cakes To Share", "CC-CC002-0215"],
   },
   {
+    // Cold invoice chase (procurement). The invoice-requester cron falls back to
+    // this template when the supplier's 24h window is closed. {{1}} = supplier
+    // first name, {{2}} = PO number — must match sendWhatsAppTemplate in
+    // agents/invoice-requester.ts. Registered under the "en" language code (like
+    // every template here) even though the copy is Malay — the requester sends
+    // with "en" to match; Meta only requires the CODES to agree, not the language
+    // of the text. Until this is approved, every cold chase fails with #132001.
+    name: "invoice_request",
+    body: "Hi {{1}}, boleh keluarkan invois untuk order {{2}}? Terima kasih.",
+    sample: ["Faiz", "CC-CC002-0249"],
+  },
+  {
     // Multi-line LIST: a headline ({{1}}) + up to four item lines ({{2}}..{{5}}),
     // each on its OWN line — the only way to get real line breaks (a single param
     // can't contain newlines). Generous fixed text wraps the variables: Meta

--- a/apps/backoffice/src/lib/inventory/agents/invoice-requester.ts
+++ b/apps/backoffice/src/lib/inventory/agents/invoice-requester.ts
@@ -50,12 +50,18 @@ export interface InvoiceRequestSummary {
 export async function runInvoiceRequests(): Promise<InvoiceRequestSummary> {
   if (!enabled()) return { scanned: 0, requested: 0, skipped: 0 };
 
-  // POs confirmed/in-delivery with NO invoice attached yet.
+  // POs confirmed/in-delivery with NO invoice attached yet. RECENT only: old
+  // completed POs (pre-dating invoice tracking, or long settled outside the
+  // system) are noise to chase — a 12-week-old "boleh keluarkan invois?" reads
+  // as a mistake to the supplier and drowns the real asks.
+  const since = new Date();
+  since.setDate(since.getDate() - 30);
   const orders = await prisma.order.findMany({
     where: {
       orderType: "PURCHASE_ORDER",
       status: { in: INVOICE_DUE_STATUSES },
       invoices: { none: {} },
+      createdAt: { gte: since },
       // Per-supplier dial: OFF = the agent never contacts this supplier.
       supplier: { phone: { not: null }, status: "ACTIVE", automationMode: { not: "OFF" } },
     },
@@ -119,10 +125,13 @@ async function requestOne(
     const text = `Hi ${firstName(supplierName)} 🙏 boleh keluarkan invois untuk order ${orderNumber}? Terima kasih`;
 
     // Inside the window → free text. Outside → approved business-initiated template
-    // (fails gracefully until `invoice_request` is approved in WhatsApp Manager).
+    // (fails with #132001 until `invoice_request` is approved — submit it via
+    // /api/ops/workspace/templates?action=create). Language code "en" matches how
+    // the templates route registers ALL templates (the copy itself is Malay);
+    // sending "ms" against an en-registered template is itself a #132001.
     const res = windowOpen
       ? await sendWhatsAppText(dest, text)
-      : await sendWhatsAppTemplate(dest, TEMPLATE_NAME, "ms", [
+      : await sendWhatsAppTemplate(dest, TEMPLATE_NAME, "en", [
           {
             type: "body",
             parameters: [

--- a/apps/backoffice/src/lib/inventory/procurement-po-send.ts
+++ b/apps/backoffice/src/lib/inventory/procurement-po-send.ts
@@ -112,8 +112,8 @@ export async function sendPurchaseOrder(order: PoForSend): Promise<void> {
     if (!windowOpen) {
       // Preferred cold path: send the FULL order as a PDF on an approved DOCUMENT template — the
       // supplier gets the whole order in one message, no "reply for details" round-trip. Returns
-      // true when it handled the send (delivered OR a template failure recorded — don't also
-      // prompt); false to fall back to the prompt (PDF/upload error).
+      // true only when the PDF was DELIVERED; false (PDF/upload error, or Meta rejected the
+      // template send) falls through to the prompt flow so the PO still goes out.
       if (PO_DOC_TEMPLATE && (await sendPoAsDocument(order, supplier, dest))) return;
       // Fallback cold path: WhatsApp blocks free text, so ping with the approved prompt template
       // (if configured) so the supplier replies and opens the window; the full PO block then
@@ -233,9 +233,9 @@ export async function sendPurchaseOrder(order: PoForSend): Promise<void> {
 }
 
 // Cold-send a PO to the supplier as a PDF attached to an approved document template — the full
-// order in ONE message, no reply-prompt. Returns true when the send was handled (delivered OR a
-// template failure recorded — caller should NOT also prompt), false to fall back to the prompt
-// (PDF generation / upload failed). Deduped via poSentFor. Records the real caption + the PDF as
+// order in ONE message, no reply-prompt. Returns true only when the PDF send was DELIVERED;
+// false (PDF generation / upload failed, or Meta rejected the template send — recorded as a
+// failed row) tells the caller to fall back to the prompt flow. Deduped via poSentFor. Records the real caption + the PDF as
 // mediaUrl so the chat shows the actual message + attachment.
 async function sendPoAsDocument(
   order: PoForSend,
@@ -308,7 +308,11 @@ async function sendPoAsDocument(
       },
     });
     console.log(`[po-send] po=${order.orderNumber} cold → PDF document template (${PO_DOC_TEMPLATE}) ok=${t.ok}`);
-    return true;
+    // A rejected template send (#132000 param mismatch, #132001 missing template,
+    // bad env name) delivered NOTHING — fall back to the approved prompt flow so
+    // the PO still reaches the supplier instead of dead-ending as "failed" until
+    // someone fixes the template. Observed live: 365EAT FOOD's two POs on Jul 3.
+    return t.ok;
   } catch (e) {
     console.warn(`[po-send] po=${order.orderNumber} PDF send failed, falling back to prompt:`, e instanceof Error ? e.message : e);
     return false;


### PR DESCRIPTION
Root-caused from 365EAT FOOD's three failed sends (screenshot report).

## What was failing

1. **Cold PDF PO sends** (CC-CC001-0261, CC-CC002-0249, Jul 3) — Meta error **#132000** "Number of parameters does not match": whatever `PROCUREMENT_PO_DOC_TEMPLATE` points at doesn't have the shape the code sends (DOCUMENT header + 2 body variables). Worse, `sendPoAsDocument` returned `true` even on a rejected send, so the approved prompt flow never got a chance — the PO dead-ended as "failed".
2. **Cold invoice chase** (CC-CC002-0001, Jul 5) — Meta error **#132001** "Template name does not exist in the translation": `invoice_request` was never registered with Meta at all, and the code sent language `ms` while the templates route registers everything under `en`.
3. The chased PO was from **April 13** — the invoice cron had no recency limit, so it chases ancient completed POs that predate invoice tracking.

## Fixes

- `sendPoAsDocument` now returns `t.ok` — a rejected template send (which delivered nothing) falls back to the approved prompt flow, so the PO still reaches the supplier while the template gets fixed.
- `invoice_request` added to `TEMPLATE_DEFS` (body matches the requester's Malay copy; registered under `en` like every other template). Submit with `/api/ops/workspace/templates?action=create` as OWNER.
- Invoice requester sends language `en` to match, and only chases POs created in the last 30 days.

## Testing
- 187 backoffice tests pass; `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SrjfLzrbEAQdNUBgawNqE5

---
_Generated by [Claude Code](https://claude.ai/code/session_01SrjfLzrbEAQdNUBgawNqE5)_