### PR TITLE
finance: allocate central salary and statutory per outlet by staff payroll weight

### DIFF
--- a/apps/backoffice/src/app/(admin)/finance/reports/page.tsx
+++ b/apps/backoffice/src/app/(admin)/finance/reports/page.tsx
@@ -671,7 +671,7 @@ function PnlTab() {
       )}
       {!consolidated && outletId && (
         <p className="text-[11px] text-amber-600">
-          Per-outlet view: revenue + COGS + outlet-tagged costs only (contribution margin). Shared/HQ opex is paid from the entity account and can&apos;t be split per outlet.
+          Per-outlet view: revenue + COGS + outlet-tagged costs. Salary and statutory are allocated across the entity&apos;s outlets by staff payroll weight; other shared/HQ opex stays entity level and isn&apos;t split per outlet, so this reads as a contribution margin.
         </p>
       )}
 

--- a/apps/backoffice/src/lib/finance/reports/pnl-sourced-drill.ts
+++ b/apps/backoffice/src/lib/finance/reports/pnl-sourced-drill.ts
@@ -18,7 +18,7 @@ import { Prisma, type CashCategory } from "@prisma/client";
 import { getFinanceClient } from "../supabase";
 import { getDefaultCompanyId } from "../companies";
 import { depreciationByAsset } from "../fixed-assets";
-import { effectiveGrabRate, fetchRecognisedBankLines } from "./pnl-sourced";
+import { effectiveGrabRate, fetchRecognisedBankLines, outletPayrollWeights } from "./pnl-sourced";
 import { getUnifiedSalesForOutlet } from "@/app/api/sales/_lib/unified-sales";
 
 const round2 = (n: number) => Math.round(n * 100) / 100;
@@ -373,6 +373,38 @@ async function drillBank(cat: string, companyId: string, start: string, end: str
   }));
 }
 
+// Allocated people-cost drill (EMPLOYEE_SALARY, STATUTORY_PAYMENT) in a
+// per-outlet view. These P&L lines are an ALLOCATION of the entity total by
+// staff payroll weight, not per-outlet transactions, so the honest drill shows
+// the entity's actual salary/statutory bank lines for the period with a header
+// row stating this outlet's weight percent and the entity total. The
+// transactions are entity-level; only the P&L line is the outlet's share.
+async function drillAllocatedPeopleCost(
+  cat: string,
+  companyId: string,
+  start: string,
+  end: string,
+  outletId: string,
+): Promise<DrillLine[]> {
+  // Entity-level lines: no outletId filter, so the whole entity's salary or
+  // statutory shows (matches the entity total the P&L allocated from).
+  const lines = await drillBankRecognised(cat, companyId, start, end, null, "DR");
+  const total = round2(lines.reduce((s, l) => s + l.amount, 0));
+  const weights = await outletPayrollWeights(companyId);
+  const share = weights.get(outletId) ?? 0;
+  const sharePct = Math.round(share * 1000) / 10;
+  const allocated = round2(total * share);
+  const header: DrillLine = {
+    transactionId: `alloc-${cat}`,
+    txnDate: end,
+    description: `Allocation basis: this outlet's P&L figure is ${sharePct}% of the entity total RM${total.toFixed(2)}, which is RM${allocated.toFixed(2)}, split by staff payroll weight. The rows below are the entity's actual salary and statutory bank lines for the period (entity-level, not per outlet).`,
+    amount: 0,
+    debit: 0,
+    credit: 0,
+  };
+  return [header, ...lines];
+}
+
 export async function sourcedPnlDrillDown(args: {
   companyId: string;
   code: string;
@@ -398,7 +430,15 @@ export async function sourcedPnlDrillDown(args: {
   // (override > matched invoice month > category shift > cash), so shifted
   // categories like management fee, salary, utilities and statutory tie to
   // their accrual-recognised P&L lines.
-  if (code.startsWith("BANK:")) return drillBankRecognised(code.slice(5), companyId, start, end, outletId);
+  if (code.startsWith("BANK:")) {
+    const cat = code.slice(5);
+    // Per-outlet salary/statutory are an allocation of the entity total, so drill
+    // the entity's lines with a header note about this outlet's share.
+    if (outletId && (cat === "EMPLOYEE_SALARY" || cat === "STATUTORY_PAYMENT")) {
+      return drillAllocatedPeopleCost(cat, companyId, start, end, outletId);
+    }
+    return drillBankRecognised(cat, companyId, start, end, outletId);
+  }
   if (code === "MKT-GRAB-COMM") {
     // A derived line, not transactions — the drawer explains the calculation.
     const [rev, gr] = await Promise.all([

--- a/apps/backoffice/src/lib/finance/reports/pnl-sourced.ts
+++ b/apps/backoffice/src/lib/finance/reports/pnl-sourced.ts
@@ -289,6 +289,69 @@ export async function effectiveGrabRate(end: string): Promise<GrabRate> {
   }
 }
 
+// ─── Per-outlet payroll weights, for allocating centrally-paid people cost ───
+// Centrally-paid EMPLOYEE_SALARY and STATUTORY_PAYMENT bank lines are mostly
+// UNtagged (paid from the entity account, no outletId), so they vanish from the
+// per-outlet view. The owner allocates them across the entity's outlets by each
+// outlet's share of active full-time and contract staff basic salary.
+//
+// Weight source (owner-confirmed): hr_employee_profiles.basic_salary for ACTIVE
+// FT/contract staff, mapped to an outlet via preferred_outlet_id and to the
+// entity via fin_outlet_companies. "Active" = end_date IS NULL AND resigned_at
+// IS NULL AND COALESCE(basic_salary,0) > 0 AND employment_type IN
+// ('full_time','contract'). hr_employee_profiles is an hr_ table managed outside
+// Prisma, so it is queried with $queryRaw, not a Prisma model.
+//
+// Returns a Map<outletId, share 0..1> covering EVERY outlet of the entity (an
+// outlet with no salaried staff mapped gets share 0). A single-outlet entity
+// gives that outlet 1.0. If the entity's total weight is 0 (no salaried staff
+// mapped at all), it falls back to an equal split across the entity's outlets
+// so a real salary/statutory cost is never silently dropped from every outlet.
+export async function outletPayrollWeights(companyId: string): Promise<Map<string, number>> {
+  const client = getFinanceClient();
+  const { data: oc } = await client
+    .from("fin_outlet_companies").select("outlet_id").eq("company_id", companyId);
+  const outletIds = (oc ?? []).map((r) => r.outlet_id as string);
+  const weights = new Map<string, number>();
+  if (!outletIds.length) return weights;
+  if (outletIds.length === 1) {
+    weights.set(outletIds[0], 1);
+    return weights;
+  }
+
+  const rows = await prisma.$queryRaw<{ outlet_id: string; weight: number }[]>(Prisma.sql`
+    SELECT p.preferred_outlet_id AS outlet_id, SUM(p.basic_salary)::float AS weight
+    FROM hr_employee_profiles p
+    WHERE p.preferred_outlet_id IN (${Prisma.join(outletIds)})
+      AND p.end_date IS NULL AND p.resigned_at IS NULL
+      AND COALESCE(p.basic_salary, 0) > 0
+      AND p.employment_type IN ('full_time', 'contract')
+    GROUP BY p.preferred_outlet_id
+  `);
+  const byOutlet = new Map<string, number>();
+  let total = 0;
+  for (const r of rows) {
+    const w = Number(r.weight) || 0;
+    byOutlet.set(r.outlet_id, w);
+    total += w;
+  }
+
+  if (total <= 0) {
+    // No salaried staff mapped to any of the entity's outlets: split equally so
+    // the entity's real people cost still shows per outlet instead of vanishing.
+    const equal = 1 / outletIds.length;
+    for (const id of outletIds) weights.set(id, equal);
+    return weights;
+  }
+  for (const id of outletIds) weights.set(id, (byOutlet.get(id) ?? 0) / total);
+  return weights;
+}
+
+// The two centrally-paid people-cost categories allocated per outlet by payroll
+// weight in the per-outlet view. Everything else keeps its outlet-tagged
+// behaviour (PARTIMER is already tagged, utilities stay entity-level).
+const ALLOCATED_PEOPLE_CATEGORIES = new Set(["EMPLOYEE_SALARY", "STATUTORY_PAYMENT"]);
+
 function humanCat(c: string | null): string {
   if (!c) return "Unclassified";
   return c.toLowerCase().replace(/_/g, " ").replace(/\b\w/g, (m) => m.toUpperCase());
@@ -648,6 +711,11 @@ export async function buildSourcedPnl(input: {
     for (const l of opexLines) {
       const cat = l.category;
       if (cat && (BANK_COGS.has(cat) || BANK_NONOPEX.has(cat) || BANK_DIGITAL_ADS.has(cat))) continue;
+      // Per-outlet view: EMPLOYEE_SALARY and STATUTORY_PAYMENT are centrally paid
+      // and mostly untagged, so the tagged filter here would understate them. They
+      // are allocated from the ENTITY total by payroll weight below instead, so
+      // skip them in this outlet-tagged loop to avoid counting them twice.
+      if (outletId && cat && ALLOCATED_PEOPLE_CATEGORIES.has(cat)) continue;
       byCat.set(cat ?? "NULL", (byCat.get(cat ?? "NULL") ?? 0) + l.amount);
     }
     for (const [key, sum] of byCat) {
@@ -667,6 +735,44 @@ export async function buildSourcedPnl(input: {
         parentCode: null,
       });
       totalExpenses += amt;
+    }
+
+    // Per-outlet allocation of centrally-paid people cost. EMPLOYEE_SALARY and
+    // STATUTORY_PAYMENT are paid from the entity account and mostly untagged, so
+    // the tagged filter above understates them. Take the ENTITY TOTAL for each
+    // category over the same recognition window and rules the company-level view
+    // uses (fetchRecognisedBankLines for the whole entity, no outletId filter),
+    // then multiply by this outlet's payroll-weight share. The line keeps the
+    // stable BANK:<CAT> code so drill-down still routes, and its name states the
+    // entity total and the allocation basis. The company-level and consolidated
+    // views never enter this branch, so their salary/statutory totals are
+    // unchanged (no allocation).
+    if (outletId) {
+      const [entityLines, weights] = await Promise.all([
+        fetchRecognisedBankLines({ direction: "DR", start, end, suffix, excludeInterCo }),
+        outletPayrollWeights(companyId),
+      ]);
+      const share = weights.get(outletId) ?? 0;
+      const entityTotal = new Map<string, number>();
+      for (const l of entityLines) {
+        const cat = l.category;
+        if (cat && ALLOCATED_PEOPLE_CATEGORIES.has(cat)) {
+          entityTotal.set(cat, (entityTotal.get(cat) ?? 0) + l.amount);
+        }
+      }
+      const sharePct = Math.round(share * 1000) / 10; // one decimal place
+      for (const cat of ["EMPLOYEE_SALARY", "STATUTORY_PAYMENT"]) {
+        const total = round2(entityTotal.get(cat) ?? 0);
+        if (!total) continue;
+        const allocated = round2(total * share);
+        if (!allocated) continue;
+        const name =
+          cat === "EMPLOYEE_SALARY"
+            ? `Employee salary (this outlet's ${sharePct}% share of RM${total.toFixed(2)}, by staff payroll)`
+            : `Statutory EPF/SOCSO/EIS/PCB (this outlet's ${sharePct}% share of RM${total.toFixed(2)}, by staff payroll)`;
+        expenseLines.push({ code: `BANK:${cat}`, name, amount: allocated, parentCode: null });
+        totalExpenses += allocated;
+      }
     }
   }
 


### PR DESCRIPTION
## What

Per-outlet allocation of centrally-paid salary and statutory cost in the sourced P&L.

The sourced P&L per-outlet view scopes bank opex to outlet-TAGGED lines only. `EMPLOYEE_SALARY` and `STATUTORY_PAYMENT` are paid centrally from the entity account and are mostly untagged, so they dropped out of the per-outlet view and understated its cost. The owner asked to allocate them across an entity's outlets by staff payroll weight.

## Weight source and formula

New helper `outletPayrollWeights(companyId)` in `pnl-sourced.ts`. Per-outlet weight = SUM(`basic_salary`) for ACTIVE full_time and contract staff at that outlet, where active = `end_date IS NULL AND resigned_at IS NULL AND COALESCE(basic_salary,0) > 0 AND employment_type IN ('full_time','contract')`. Source table `hr_employee_profiles` is an hr_ table managed outside Prisma, so it is read with `$queryRaw`; outlets map to the entity via `fin_outlet_companies`. The helper returns a `Map<outletId, share 0..1>` where each outlet's share = its weight over the entity total. An outlet with no salaried staff mapped gets share 0.

- Single-outlet entity: that outlet gets 1.0 (100%).
- Zero total weight (no salaried staff mapped at all): fall back to an equal split across the entity's outlets, so real people cost is never silently dropped.

## Which categories are allocated

Only `EMPLOYEE_SALARY` and `STATUTORY_PAYMENT`, and only in the per-outlet path. For each, the code computes the ENTITY TOTAL over the period (same recognition window and rules the company-level view uses, `fetchRecognisedBankLines` for the whole entity with no outletId filter) and multiplies by this outlet's weight share. Lines keep the stable `BANK:EMPLOYEE_SALARY` and `BANK:STATUTORY_PAYMENT` codes so drill-down still routes, with names that state the entity total and the allocation basis.

## What is left unchanged

- Utilities: not allocated, unchanged. They show per outlet only where already tagged (owner handles utilities via per-line tagging separately).
- PARTIMER: already outlet-tagged, unchanged.
- Company-level view (no outletId) and consolidated view: never enter the allocation branch and salary/statutory are not skipped from their opex loop, so their totals are identical to before.

## Double count avoided

The two categories are excluded from the outlet-tagged opex loop when `outletId` is set, then added exactly once as the weighted entity-total allocation. They are not added once tagged and once allocated.

## Drill

Drilling `BANK:EMPLOYEE_SALARY` or `BANK:STATUTORY_PAYMENT` in a per-outlet view shows the entity's actual salary and statutory bank lines for the period, with a header row stating this outlet's weight percent and the entity total. The transactions are entity-level; only the P&L line is the outlet's allocated share. No per-outlet transactions are fabricated.

## Verified split (May 2026, celsius entity)

Weights: Shah Alam 10400 (83.2%), Nilai 2100 (16.8%), IOI Mall 0 (0%). Entity `EMPLOYEE_SALARY` RM64,294.45, `STATUTORY_PAYMENT` RM19,195.28.

- Shah Alam: salary RM53,492.98, statutory RM15,970.47
- Nilai: salary RM10,801.47, statutory RM3,224.81
- Shah Alam + Nilai reconstitute the entity total (IOI Mall carries 0 weight).
- Single-outlet entities Putrajaya and Tamarind get weight 1.0, so their per-outlet salary and statutory equal the entity total.

Typecheck clean, ESLint clean on touched files (only pre-existing warnings elsewhere), diff free of em and en dashes.
