### PR TITLE
fix(ui): prompt dialog types backwards — stop remounting on every keystroke

### DIFF
--- a/docs/STATE.md
+++ b/docs/STATE.md
@@ -107,6 +107,14 @@ _Format: `YYYY-MM-DD — <symptom> — <evidence> — <hypothesis/fix> — <bloc
   prompts ignore `--non-interactive`; set `CI=1` in the environment instead.
   Pass commit messages via env var, not inline in the shell command (backticks/
 
+- 2026-07-05 — A hook must never return a component whose identity changes per
+  render (`usePrompt`'s `PromptDialog` was a `useCallback` with state deps):
+  React sees a new element type each keystroke, remounts the subtree, and
+  `autoFocus` re-focuses with the caret at 0 — text comes out reversed. Fix
+  pattern: hoist the JSX to a module-level view component + return a
+  `useState`-created stable wrapper reading latest props from a ref
+  (`packages/ui/src/prompt-dialog.tsx`).
+
 - 2026-07-05 — The AI Fill week-wipe (60 shifts) was the old generator's
   DELETE-then-INSERT persist with no transaction; `hr_schedule_shift_audit`
   (migration 070) held every deleted row and `jsonb_populate_record` restored

--- a/packages/ui/src/prompt-dialog.tsx
+++ b/packages/ui/src/prompt-dialog.tsx
@@ -49,6 +49,72 @@ type State =
   | { open: false }
   | { open: true; opts: PromptOptions; resolve: (v: string | null) => void };
 
+type PromptDialogViewProps = {
+  state: State;
+  value: string;
+  error: string | null;
+  setValue: (v: string) => void;
+  setError: (e: string | null) => void;
+  close: (submitted: string | null) => void;
+  submit: () => void;
+};
+
+// Module-level so its identity never changes; the hook's returned component
+// must not be recreated per render, or React remounts the dialog subtree on
+// every keystroke (the input loses its caret and text comes out reversed).
+function PromptDialogView({ state, value, error, setValue, setError, close, submit }: PromptDialogViewProps) {
+  return (
+    <Dialog
+      open={state.open}
+      onOpenChange={(open) => {
+        if (!open) close(null);
+      }}
+    >
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>{state.open ? state.opts.title ?? "Enter value" : ""}</DialogTitle>
+          {state.open && state.opts.description ? (
+            <DialogDescription>{state.opts.description}</DialogDescription>
+          ) : null}
+        </DialogHeader>
+        <div className="py-2">
+          {state.open && state.opts.multiline ? (
+            <textarea
+              autoFocus
+              value={value}
+              onChange={(e) => { setValue(e.target.value); setError(null); }}
+              placeholder={state.opts.placeholder}
+              rows={4}
+              className="w-full rounded-md border bg-background px-3 py-2 text-sm focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+            />
+          ) : (
+            <input
+              autoFocus
+              type="text"
+              value={value}
+              onChange={(e) => { setValue(e.target.value); setError(null); }}
+              onKeyDown={(e) => {
+                if (e.key === "Enter" && !e.shiftKey) submit();
+              }}
+              placeholder={state.open ? state.opts.placeholder : undefined}
+              className="w-full rounded-md border bg-background px-3 py-2 text-sm focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+            />
+          )}
+          {error && <p className="mt-1 text-xs text-red-600">{error}</p>}
+        </div>
+        <DialogFooter>
+          <Button variant="outline" onClick={() => close(null)}>
+            {state.open ? state.opts.cancelLabel ?? "Cancel" : "Cancel"}
+          </Button>
+          <Button onClick={submit}>
+            {state.open ? state.opts.confirmLabel ?? "Submit" : "Submit"}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
 export function usePrompt() {
   const [state, setState] = React.useState<State>({ open: false });
   const [value, setValue] = React.useState("");
@@ -86,58 +152,20 @@ export function usePrompt() {
     close(trimmed);
   }, [state, value, close]);
 
-  const PromptDialog = React.useCallback(
-    () => (
-      <Dialog
-        open={state.open}
-        onOpenChange={(open) => {
-          if (!open) close(null);
-        }}
-      >
-        <DialogContent>
-          <DialogHeader>
-            <DialogTitle>{state.open ? state.opts.title ?? "Enter value" : ""}</DialogTitle>
-            {state.open && state.opts.description ? (
-              <DialogDescription>{state.opts.description}</DialogDescription>
-            ) : null}
-          </DialogHeader>
-          <div className="py-2">
-            {state.open && state.opts.multiline ? (
-              <textarea
-                autoFocus
-                value={value}
-                onChange={(e) => { setValue(e.target.value); setError(null); }}
-                placeholder={state.opts.placeholder}
-                rows={4}
-                className="w-full rounded-md border bg-background px-3 py-2 text-sm focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
-              />
-            ) : (
-              <input
-                autoFocus
-                type="text"
-                value={value}
-                onChange={(e) => { setValue(e.target.value); setError(null); }}
-                onKeyDown={(e) => {
-                  if (e.key === "Enter" && !e.shiftKey) submit();
-                }}
-                placeholder={state.open ? state.opts.placeholder : undefined}
-                className="w-full rounded-md border bg-background px-3 py-2 text-sm focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
-              />
-            )}
-            {error && <p className="mt-1 text-xs text-red-600">{error}</p>}
-          </div>
-          <DialogFooter>
-            <Button variant="outline" onClick={() => close(null)}>
-              {state.open ? state.opts.cancelLabel ?? "Cancel" : "Cancel"}
-            </Button>
-            <Button onClick={submit}>
-              {state.open ? state.opts.confirmLabel ?? "Submit" : "Submit"}
-            </Button>
-          </DialogFooter>
-        </DialogContent>
-      </Dialog>
-    ),
-    [state, value, error, close, submit],
+  // Latest-props ref: the stable PromptDialog below re-renders whenever the
+  // hook's owner re-renders, and reads current values from here.
+  const viewPropsRef = React.useRef<PromptDialogViewProps>({
+    state, value, error, setValue, setError, close, submit,
+  });
+  viewPropsRef.current = { state, value, error, setValue, setError, close, submit };
+
+  // Created exactly once per hook instance so `<PromptDialog />` keeps the
+  // same element type across renders (see PromptDialogView comment).
+  const [PromptDialog] = React.useState(
+    () =>
+      function PromptDialog() {
+        return <PromptDialogView {...viewPropsRef.current} />;
+      },
   );
 
   return { prompt, PromptDialog };


### PR DESCRIPTION
## Problem

Typing into any `usePrompt()` dialog (e.g. HR → Attendance → Excuse "Reason for excusing") came out reversed: typing `sadda` rendered `addas`.

## Root cause

`usePrompt` returned `PromptDialog` from a `useCallback` whose deps included the input `value`. Every keystroke therefore produced a **new component identity**; React saw `<PromptDialog />` as a different element type, unmounted and remounted the entire dialog subtree, and `autoFocus` re-focused the freshly-mounted textarea with the caret at position 0. Each character was inserted at the start of the text.

## Fix

`packages/ui/src/prompt-dialog.tsx`:
- Hoisted the dialog JSX into a module-level `PromptDialogView` component (stable type).
- The hook now returns a `PromptDialog` created exactly once per hook instance (via a `useState` initializer) that reads the latest state/handlers through a ref — so `<PromptDialog />` keeps the same element type across renders and the input keeps focus and caret.

Public API is unchanged; all six call sites (`hr/attendance`, `hr/employees/[id]`, `hr/memos`, `hr/shift-swaps`, `finance/fixed-assets`, staff `hr/memos`) work as before.

## Verification

- Behavioral check in headless Chromium (esbuild-bundled harness driving the real component with per-key typing):
  - **pre-fix**: typed `sadda` → textarea contained `addas` (bug reproduced)
  - **post-fix**: typed `sadda` → `sadda`, submit resolved the promise with `sadda`
- `npx vitest run`: 318 tests pass
- `tsc --noEmit` clean for `packages/ui`, `apps/backoffice`, `apps/staff`, `apps/order`, `apps/pickup`

Also appends the lesson to `docs/STATE.md` per the session protocol.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EYJjnzmo9fsfMz4Q5AMZnC

---
_Generated by [Claude Code](https://claude.ai/code/session_01EYJjnzmo9fsfMz4Q5AMZnC)_