### PR TITLE
fix(finance): P&L Google ads counts campaign rows only, not the account rollup

### DIFF
--- a/apps/backoffice/src/lib/finance/reports/pnl-sourced-drill.ts
+++ b/apps/backoffice/src/lib/finance/reports/pnl-sourced-drill.ts
@@ -183,6 +183,7 @@ async function drillAds(companyId: string, start: string, end: string, outletId?
     SELECT m.date, c.outlet_id, COALESCE(SUM(m.cost_micros), 0)::float / 1e6 AS spend
     FROM ads_metric_daily m LEFT JOIN ads_campaign c ON c.id = m.campaign_id
     WHERE m.date >= ${dStart(start)} AND m.date <= ${dEnd(end)}
+      AND m.campaign_id IS NOT NULL
     GROUP BY m.date, c.outlet_id ORDER BY m.date ASC
   `);
   const byDay = new Map<string, number>();

--- a/apps/backoffice/src/lib/finance/reports/pnl-sourced.ts
+++ b/apps/backoffice/src/lib/finance/reports/pnl-sourced.ts
@@ -562,6 +562,7 @@ export async function buildSourcedPnl(input: {
       FROM ads_metric_daily m
       LEFT JOIN ads_campaign c ON c.id = m.campaign_id
       WHERE m.date >= ${dStart(start)} AND m.date <= ${dEnd(end)}
+        AND m.campaign_id IS NOT NULL
       GROUP BY c.outlet_id
     `);
     let adsSpend = 0;


### PR DESCRIPTION
The ads sync writes an account-level rollup row per day (campaign_id null)
alongside the per-campaign rows, and the two are equal by construction. The
P&L ads query summed BOTH: the campaign rows attributed per outlet, and the
rollup rows landing as untagged spend on the default company, so the group
and default-company ads figure came out at exactly double (RM120k vs the
real RM60k year to date). Both the P&L and its drill now filter to
campaign_id IS NOT NULL, so only real campaign spend counts; a genuine
brand campaign (a real campaign row with no outlet) still counts as untagged.
The duplicate historical rollup rows were also cleared from the table.
