### PR TITLE
feat(finance): clickable invoice + payment detail in P&L drill

### DIFF
--- a/apps/backoffice/src/app/(admin)/finance/reports/page.tsx
+++ b/apps/backoffice/src/app/(admin)/finance/reports/page.tsx
@@ -1026,6 +1026,129 @@ function GlSourceLines({ transactionId, accountNames, onChanged }: {
   );
 }
 
+type InvoiceDetailResp = {
+  invoice: {
+    id: string;
+    invoiceNumber: string;
+    issueDate: string | null;
+    dueDate: string | null;
+    amount: number;
+    amountPaid: number;
+    status: string;
+    vendor: string | null;
+    outlet: string | null;
+    orderNumber: string | null;
+    deliveryCharge: number;
+    notes: string | null;
+    paidAt: string | null;
+    paidVia: string | null;
+    paymentRef: string | null;
+  };
+  lines: { id: string; description: string; quantity: number; unitPrice: number; lineTotal: number }[];
+  payments: { id: string; txnDate: string | null; description: string; reference: string | null; amount: number; account: string | null; matchedAt: string | null }[];
+};
+
+// Invoice detail sub-panel for a PROC (procurement invoice) drill row. Lazily
+// fetched on first expand (SWR caches per id, so re-opening is instant and the
+// URL is only requested when open). Shows the invoice header, its line items
+// (or an honest empty note for header-only imports) and the bank payment(s)
+// that settled it, or the out-of-band / unmatched paid state.
+function InvoiceDetail({ invoiceId, open }: { invoiceId: string; open: boolean }) {
+  const { data, isLoading, error } = useFetch<InvoiceDetailResp>(
+    open ? `/api/finance/invoices/${encodeURIComponent(invoiceId)}` : null
+  );
+  if (isLoading || !data) {
+    return (
+      <div className="flex items-center gap-2 px-3 py-2 text-[11px] text-muted-foreground">
+        {error ? "Could not load invoice detail." : <><Loader2 className="h-3.5 w-3.5 animate-spin" /> Loading invoice detail...</>}
+      </div>
+    );
+  }
+  const { invoice, lines, payments } = data;
+  const isPaid = invoice.status === "PAID";
+  return (
+    <div className="space-y-3 px-3 py-2.5">
+      <dl className="grid grid-cols-[7rem_1fr] gap-x-3 gap-y-1 text-[11px]">
+        <dt className="text-muted-foreground">Supplier</dt><dd>{invoice.vendor ?? "(no vendor)"}</dd>
+        <dt className="text-muted-foreground">Invoice no.</dt><dd>{invoice.invoiceNumber}{invoice.orderNumber ? <span className="text-muted-foreground"> · PO {invoice.orderNumber}</span> : null}</dd>
+        <dt className="text-muted-foreground">Issue date</dt><dd className="tabular-nums">{invoice.issueDate ?? "n/a"}{invoice.dueDate ? <span className="text-muted-foreground"> · due {invoice.dueDate}</span> : null}</dd>
+        {invoice.outlet && (<><dt className="text-muted-foreground">Outlet</dt><dd>{invoice.outlet}</dd></>)}
+        <dt className="text-muted-foreground">Total</dt><dd className="tabular-nums">{RM(invoice.amount)}{invoice.deliveryCharge ? <span className="text-muted-foreground"> (incl. {RM(invoice.deliveryCharge)} delivery)</span> : null}</dd>
+        <dt className="text-muted-foreground">Status</dt>
+        <dd>
+          <span className={`inline-flex items-center rounded-full px-2 py-0.5 text-[10px] font-medium ${isPaid ? "bg-emerald-500/15 text-emerald-700 dark:text-emerald-400" : "bg-amber-500/15 text-amber-700 dark:text-amber-400"}`}>
+            {invoice.status.toLowerCase().replace(/_/g, " ")}
+          </span>
+          {!isPaid && invoice.amountPaid > 0 && <span className="ml-2 text-muted-foreground tabular-nums">{RM(invoice.amountPaid)} paid so far</span>}
+        </dd>
+      </dl>
+
+      <div>
+        <div className="mb-1 text-[10px] uppercase tracking-wide text-muted-foreground">Line items</div>
+        {lines.length === 0 ? (
+          <div className="text-[11px] text-muted-foreground">No itemised lines recorded for this invoice.</div>
+        ) : (
+          <table className="w-full text-[11px]">
+            <thead className="text-left text-[10px] uppercase tracking-wide text-muted-foreground">
+              <tr className="border-b">
+                <th className="px-2 py-1 font-medium">Item</th>
+                <th className="whitespace-nowrap px-2 py-1 text-right font-medium">Qty</th>
+                <th className="whitespace-nowrap px-2 py-1 text-right font-medium">Unit price</th>
+                <th className="whitespace-nowrap px-2 py-1 text-right font-medium">Line total</th>
+              </tr>
+            </thead>
+            <tbody>
+              {lines.map((it) => (
+                <tr key={it.id} className="border-t">
+                  <td className="px-2 py-1">{it.description}</td>
+                  <td className="whitespace-nowrap px-2 py-1 text-right tabular-nums">{it.quantity}</td>
+                  <td className="whitespace-nowrap px-2 py-1 text-right tabular-nums">{RM(it.unitPrice)}</td>
+                  <td className="whitespace-nowrap px-2 py-1 text-right tabular-nums">{RM(it.lineTotal)}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        )}
+      </div>
+
+      <div>
+        <div className="mb-1 text-[10px] uppercase tracking-wide text-muted-foreground">Payment</div>
+        {payments.length > 0 ? (
+          <table className="w-full text-[11px]">
+            <thead className="text-left text-[10px] uppercase tracking-wide text-muted-foreground">
+              <tr className="border-b">
+                <th className="whitespace-nowrap px-2 py-1 font-medium">Date</th>
+                <th className="px-2 py-1 font-medium">Bank line</th>
+                <th className="whitespace-nowrap px-2 py-1 font-medium">Account</th>
+                <th className="whitespace-nowrap px-2 py-1 text-right font-medium">Amount</th>
+              </tr>
+            </thead>
+            <tbody>
+              {payments.map((p) => (
+                <tr key={p.id} className="border-t">
+                  <td className="whitespace-nowrap px-2 py-1 tabular-nums text-muted-foreground">{p.txnDate ?? "n/a"}</td>
+                  <td className="px-2 py-1">
+                    <span className="break-words">{p.description}</span>
+                    {p.reference && <span className="block text-[10px] text-muted-foreground">ref {p.reference}</span>}
+                  </td>
+                  <td className="whitespace-nowrap px-2 py-1 text-muted-foreground">{p.account ?? "n/a"}</td>
+                  <td className="whitespace-nowrap px-2 py-1 text-right tabular-nums">{RM(p.amount)}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        ) : invoice.paidAt ? (
+          <div className="text-[11px] text-muted-foreground">
+            Marked paid {invoice.paidAt}{invoice.paidVia ? ` via ${invoice.paidVia}` : ""}{invoice.paymentRef ? ` (ref ${invoice.paymentRef})` : ""}, but not matched to a bank line.
+          </div>
+        ) : (
+          <div className="text-[11px] text-muted-foreground">Not yet matched to a bank payment.</div>
+        )}
+      </div>
+    </div>
+  );
+}
+
 // Inline drill panel: the source rows behind one P&L line, rendered
 // full-width directly beneath the clicked report row (the same accordion
 // pattern as the General Ledger workbench). One transaction per line with
@@ -1109,13 +1232,17 @@ function DrillDown({ code, name, start, end, outletId, consolidated, onChanged, 
               const isBankRow = !!l.meta?.bankLineId;
               const isBankJournal = !isBankRow && l.meta?.glAgent === "bank";
               const hasDetail = !!l.meta && !l.meta.glAgent;
-              const expandable = hasDetail || isBankJournal;
+              // PROC rows are procurement invoices: transactionId is the
+              // Invoice id, and they carry no meta. Expanding lazy-loads the
+              // invoice + payment detail.
+              const isProcRow = code === "PROC";
+              const expandable = hasDetail || isBankJournal || isProcRow;
               const open = openRow === key;
               return (
                 <Fragment key={key}>
                 <tr className={`border-t ${i % 2 === 1 ? "bg-muted/20" : ""} ${expandable ? "cursor-pointer hover:bg-muted/30" : ""}`}
                     onClick={expandable ? () => setOpenRow(open ? null : key) : undefined}
-                    title={expandable ? (isBankJournal ? "Click to see the source bank lines" : "Click to see the transaction detail") : undefined}>
+                    title={expandable ? (isBankJournal ? "Click to see the source bank lines" : isProcRow ? "Click to see the invoice and payment detail" : "Click to see the transaction detail") : undefined}>
                   <td className="whitespace-nowrap px-3 py-1.5 text-xs tabular-nums text-muted-foreground">
                     <span className="flex items-center gap-1.5">
                       <span className="w-2.5 text-[10px]">{expandable ? (open ? "▾" : "▸") : ""}</span>
@@ -1172,6 +1299,13 @@ function DrillDown({ code, name, start, end, outletId, consolidated, onChanged, 
                   <tr className="border-t bg-muted/20">
                     <td colSpan={cols} className="p-0" onClick={(e) => e.stopPropagation()}>
                       <GlSourceLines transactionId={l.transactionId} accountNames={accountNames} onChanged={refresh} />
+                    </td>
+                  </tr>
+                )}
+                {open && isProcRow && (
+                  <tr className="border-t bg-muted/20">
+                    <td colSpan={cols} className="p-0" onClick={(e) => e.stopPropagation()}>
+                      <InvoiceDetail invoiceId={l.transactionId} open={open} />
                     </td>
                   </tr>
                 )}

--- a/apps/backoffice/src/app/api/finance/invoices/[id]/route.ts
+++ b/apps/backoffice/src/app/api/finance/invoices/[id]/route.ts
@@ -1,0 +1,128 @@
+// GET /api/finance/invoices/[id]
+//
+// Invoice detail for the finance P&L drill. A PROC drill row is a procurement
+// invoice; clicking it lazy-loads this endpoint to show the invoice header,
+// its line items (from the linked purchase order) and the payment(s) that
+// settled it. Read-only, Owner/Admin only.
+//
+// Payment resolution: an invoice is paid from the bank side via
+// BankStatementLine.apInvoiceId = invoice.id (one or more DR lines, stamped
+// apMatchedAt when matched). Some invoices were marked paid out of band (a POP
+// upload or the pre-bank-feed migration) with paidAt/paidVia/paymentRef set but
+// no bank line; we surface that honestly rather than pretending it is unpaid.
+
+import { NextRequest, NextResponse } from "next/server";
+import { requireAuth } from "@/lib/auth";
+import { prisma } from "@/lib/prisma";
+
+export const dynamic = "force-dynamic";
+
+const round2 = (n: number) => Math.round(n * 100) / 100;
+const dayOf = (d: Date | null | undefined) => (d ? d.toISOString().slice(0, 10) : null);
+
+export async function GET(req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  const auth = await requireAuth(req);
+  if (auth.error) return auth.error;
+  if (!["OWNER", "ADMIN"].includes(auth.user.role)) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+
+  const { id } = await params;
+
+  const invoice = await prisma.invoice.findUnique({
+    where: { id },
+    select: {
+      id: true,
+      invoiceNumber: true,
+      issueDate: true,
+      dueDate: true,
+      amount: true,
+      amountPaid: true,
+      status: true,
+      vendorName: true,
+      notes: true,
+      paidAt: true,
+      paidVia: true,
+      paymentRef: true,
+      supplier: { select: { name: true } },
+      outlet: { select: { name: true } },
+      // Line items live on the linked purchase order (OrderItem). Stock-transfer
+      // invoices and header-only imports have no order, so lines can be empty.
+      order: {
+        select: {
+          orderNumber: true,
+          deliveryCharge: true,
+          items: {
+            select: {
+              id: true,
+              quantity: true,
+              unitPrice: true,
+              totalPrice: true,
+              product: { select: { name: true } },
+            },
+          },
+        },
+      },
+    },
+  });
+  if (!invoice) return NextResponse.json({ error: "Not found" }, { status: 404 });
+
+  // Bank payment side: DR bank lines matched to this invoice via apInvoiceId.
+  const bankLines = await prisma.bankStatementLine.findMany({
+    where: { apInvoiceId: id },
+    select: {
+      id: true,
+      txnDate: true,
+      description: true,
+      reference: true,
+      amount: true,
+      apMatchedAt: true,
+      statement: { select: { accountName: true } },
+    },
+    orderBy: { txnDate: "asc" },
+  });
+
+  const lines = (invoice.order?.items ?? []).map((it) => ({
+    id: it.id,
+    description: it.product?.name ?? "(unnamed product)",
+    quantity: round2(Number(it.quantity)),
+    unitPrice: round2(Number(it.unitPrice)),
+    lineTotal: round2(Number(it.totalPrice)),
+  }));
+
+  const payments = bankLines.map((l) => ({
+    id: l.id,
+    txnDate: dayOf(l.txnDate),
+    description: l.description || "(no description)",
+    reference: l.reference,
+    amount: round2(Number(l.amount)),
+    account: l.statement?.accountName ?? null,
+    matchedAt: dayOf(l.apMatchedAt),
+  }));
+
+  const amount = round2(Number(invoice.amount));
+  const amountPaid = round2(Number(invoice.amountPaid ?? 0));
+
+  return NextResponse.json({
+    invoice: {
+      id: invoice.id,
+      invoiceNumber: invoice.invoiceNumber,
+      issueDate: dayOf(invoice.issueDate),
+      dueDate: dayOf(invoice.dueDate),
+      amount,
+      amountPaid,
+      status: invoice.status,
+      vendor: invoice.supplier?.name ?? invoice.vendorName ?? null,
+      outlet: invoice.outlet?.name ?? null,
+      orderNumber: invoice.order?.orderNumber ?? null,
+      deliveryCharge: invoice.order ? round2(Number(invoice.order.deliveryCharge)) : 0,
+      notes: invoice.notes ?? null,
+      // Out-of-band paid state (POP / migration) when there is no bank line.
+      paidAt: dayOf(invoice.paidAt),
+      paidVia: invoice.paidVia ?? null,
+      paymentRef: invoice.paymentRef ?? null,
+    },
+    lines,
+    payments,
+  });
+}


### PR DESCRIPTION
## What

The finance Reports P&L drill's procurement rows (code `PROC`) are supplier invoices, but they were flat, non-clickable lines. This makes each one expandable: clicking a `PROC` row opens a full-width inline sub-panel (same accordion style as the existing bank-line expansion) showing the invoice detail and the payment detail.

## Which rows are clickable

- `PROC` (Cost of Sales procurement invoices) rows: newly expandable. Each row's `transactionId` is the `Invoice.id`, so the panel loads that invoice.
- `BANK:*` bank-line rows: unchanged, their existing expansion (GL legs, category chips, matched-invoice chip, expense-month control) keeps working.
- `REV-*` sales days: out of scope (no invoice / payment concept).

## Invoice-detail API

New `GET /api/finance/invoices/[id]` (Owner/Admin gated via `requireAuth`, read-only). Response shape:

```
{
  invoice: { id, invoiceNumber, issueDate, dueDate, amount, amountPaid, status,
             vendor, outlet, orderNumber, deliveryCharge, notes,
             paidAt, paidVia, paymentRef },
  lines:   [{ id, description, quantity, unitPrice, lineTotal }],
  payments:[{ id, txnDate, description, reference, amount, account, matchedAt }]
}
```

- **Lines** come from the invoice's linked purchase order (`Order.items` / `OrderItem`): product name, quantity, unit price, line total. Header-only imports (no order) return an empty `lines`, and the UI shows "No itemised lines recorded for this invoice."
- **Payments** are the `BankStatementLine` DR legs matched to the invoice.

## How payment is resolved

An invoice's bank payment is every `BankStatementLine` whose `apInvoiceId = invoice.id` (stamped `apMatchedAt` on match). One invoice can have one or more such lines. When there are none:

- if the invoice carries an out-of-band paid state (`paidAt` set, e.g. a POP upload or the pre-bank-feed migration, with `paidVia` / `paymentRef`), the panel says so honestly ("Marked paid ... but not matched to a bank line");
- otherwise it shows "Not yet matched to a bank payment."

## UX

Lazy-loaded on first expand (SWR keyed on the invoice id, so re-opening is instant and the request only fires when open), with a subtle loading row. Styling matches the drill: `tabular-nums`, `RM()` with parenthesised negatives, muted uppercase headers, dark-mode-safe. No new dependencies.

## Verification

- Typecheck (`tsc --noEmit` on backoffice) and ESLint on both touched files: clean (the two pre-existing `set-state-in-effect` warnings are untouched, unrelated lines).
- Read-only SQL against production: confirmed a PAID invoice resolves its 33 line items (product, qty, unit price, total) and its single `apInvoiceId`-matched bank line (date, description, ref, amount matching the invoice total); confirmed a PENDING invoice resolves its line items with zero bank payments (renders the unmatched state).
