### PR TITLE
fix(hr): harden clock flow — selfie-gated clock-out + re-clock-in guard

### DIFF
--- a/apps/staff/src/app/(ops)/hr/clock/page.tsx
+++ b/apps/staff/src/app/(ops)/hr/clock/page.tsx
@@ -32,6 +32,10 @@ export default function ClockPage() {
   const [gpsLoading, setGpsLoading] = useState(true);
   const [result, setResult] = useState<{ success: boolean; message: string; withinGeofence?: boolean } | null>(null);
   const [elapsed, setElapsed] = useState("");
+  // Clock-OUT is a two-step, selfie-gated action: the first tap arms the camera,
+  // and the deliberate selfie capture (shutter) is what actually clocks out — so a
+  // reflexive double-tap can't close a shift. Clock-IN stays one tap (frictionless).
+  const [clockOutArmed, setClockOutArmed] = useState(false);
 
   // Camera state
   const videoRef = useRef<HTMLVideoElement>(null);
@@ -164,6 +168,11 @@ export default function ClockPage() {
     return () => clearInterval(interval);
   }, [status?.activeLog]);
 
+  // Once the shift is closed (no longer clocked in), disarm the clock-out camera.
+  useEffect(() => {
+    if (!isClockedIn) setClockOutArmed(false);
+  }, [isClockedIn]);
+
   const handleClock = useCallback(async () => {
     // Capture photo first
     const photo = capturePhoto();
@@ -205,6 +214,15 @@ export default function ClockPage() {
   }, [isClockedIn, gps, mutate, capturePhoto]);
 
   const retakePhoto = () => setCapturedPhoto(null);
+
+  // Clock-IN is a single tap. Clock-OUT is selfie-gated: the first tap only arms
+  // the camera; the shutter tap (which captures the selfie) is what submits — so a
+  // reflexive double-tap opens the camera but can't close the shift.
+  const primaryAction = useCallback(() => {
+    if (!isClockedIn) { handleClock(); return; }            // clock-in
+    if (!clockOutArmed) { setClockOutArmed(true); return; } // clock-out step 1: arm camera
+    handleClock();                                          // clock-out step 2: selfie = clock out
+  }, [isClockedIn, clockOutArmed, handleClock]);
 
   // Distance to geofence
   let distanceInfo = "";
@@ -321,7 +339,7 @@ export default function ClockPage() {
           through and the server tags them for review. Clock-out still needs GPS
           to satisfy the same-outlet gate; if it's missing the server explains why. */}
       <button
-        onClick={handleClock}
+        onClick={primaryAction}
         disabled={
           loading ||
           gpsLoading ||
@@ -336,6 +354,11 @@ export default function ClockPage() {
       >
         {loading ? (
           <Loader2 className="h-8 w-8 animate-spin" />
+        ) : isClockedIn && clockOutArmed ? (
+          <>
+            <Camera className="mb-1 h-8 w-8" />
+            <span className="text-sm font-bold">Take selfie</span>
+          </>
         ) : isClockedIn ? (
           <>
             <LogOut className="mb-1 h-8 w-8" />
@@ -348,6 +371,22 @@ export default function ClockPage() {
           </>
         )}
       </button>
+
+      {/* Selfie-gated clock-out: once armed, the shutter above is the only way to
+          clock out. Prompt the deliberate selfie, and offer a way to back out. */}
+      {isClockedIn && clockOutArmed && !loading && (
+        <>
+          <p className="mt-3 text-center text-xs font-medium text-gray-600">
+            Frame your face and tap <span className="font-bold">Take selfie</span> to clock out.
+          </p>
+          <button
+            onClick={() => setClockOutArmed(false)}
+            className="mt-1 text-xs font-medium text-gray-400 underline active:text-gray-600"
+          >
+            Cancel
+          </button>
+        </>
+      )}
 
       {/* GPS warning — soft for clock-in, required for clock-out (server gate) */}
       {gpsError && (

--- a/apps/staff/src/app/api/hr/clock/route.ts
+++ b/apps/staff/src/app/api/hr/clock/route.ts
@@ -220,6 +220,31 @@ export async function POST(req: NextRequest) {
       return NextResponse.json({ error: "Already clocked in" }, { status: 400 });
     }
 
+    // Guard against an ACCIDENTAL immediate RE-clock-in. The clock button flips
+    // "Clock Out" → "Clock In" the instant you clock out, so a reflexive double-tap
+    // at end-of-shift re-opened a phantom session seconds later (26 seen historically,
+    // 13 of them 0h junk). Reject a clock-in within 30s of this user's last clock-out.
+    // 30s: every observed double-tap was ≤20s apart; deliberate re-clock-ins are 30s+.
+    // Mirror of the MIN_SHIFT_MINUTES clock-out guard below.
+    const { data: lastOut } = await supabase
+      .from("hr_attendance_logs")
+      .select("clock_out")
+      .eq("user_id", session.id)
+      .not("clock_out", "is", null)
+      .order("clock_out", { ascending: false })
+      .limit(1)
+      .maybeSingle();
+    const RECLOCK_COOLDOWN_SECONDS = 30;
+    if (lastOut?.clock_out) {
+      const secsSinceOut = (Date.now() - new Date(lastOut.clock_out).getTime()) / 1000;
+      if (secsSinceOut >= 0 && secsSinceOut < RECLOCK_COOLDOWN_SECONDS) {
+        return NextResponse.json({
+          error: "You just clocked out — you're all set. (If you meant to clock back in, wait a moment and tap again.)",
+          justClockedOut: true,
+        }, { status: 400 });
+      }
+    }
+
     const photoUrl = photo ? await uploadPhoto(photo, "in") : null;
     const clockInAt = new Date();
     const roster = await findRosterShift(session.id, clockInAt);


### PR DESCRIPTION
## Why

A reflexive **double-tap** on the clock button was silently corrupting attendance in two directions, because the button flips state instantly with no friction:

- **End-of-shift:** the staff PWA auto-captured a selfie and **submitted in the same tap**, so a double-tap on the red button instantly closed the shift.
- **After clock-out:** the button flips back to *Clock In*, so a reflexive tap **re-opened a phantom session 1–2s later** — the staffer shows as "clocked in 0h" when they were actually done, and it closes to a 0h junk log at the 1am sweep.

This is the exact case we just saw live (Hafifie: clocked out cleanly at 8:07 PM after a full 7.48h shift, then a tap 1.5s later re-clocked them in). Across history: **26** accidental re-clock-ins, **13** of them 0-hour junk logs.

## Changes

**1. Selfie-gated clock-out** — `apps/staff/src/app/(ops)/hr/clock/page.tsx`

Clock-out is now two-step: the **first tap arms the camera**, and the **deliberate selfie capture (the shutter) is what submits** the clock-out. The selfie *is* the confirmation — no separate confirm tap. A **Cancel** backs out. So a reflexive double-tap just opens the camera; it can't close a shift.

Clock-**in** stays a single tap (company soft-control policy — never make a barista fight to *start* a shift). This also brings the PWA in line with the **native app, which already does deliberate capture + biometric before submit**, so no native change was needed.

**2. Re-clock-in cooldown** — `apps/staff/src/app/api/hr/clock/route.ts`

Server-side: reject a clock-in within **30s** of the same user's last clock-out (friendly "you're all set — wait a moment if you meant to clock back in"). Mirror of the existing `MIN_SHIFT_MINUTES` clock-out guard, so one place covers both PWA and native. 30s threshold: every observed accidental double-tap was ≤20s apart, while deliberate re-clock-ins are 30s+, so genuine re-entries are preserved.

## Notes

- No schema change. No migration.
- The phantom session that prompted this was already cleaned up out-of-band; this PR stops new ones forming.

## Testing

`tsc` on the changed files shows only the repo's standard env noise (missing `@types/node` → a pre-existing `Buffer` flag in the unchanged `uploadPhoto`, and the usual JSX implicit-any). No new real type errors from either change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01B7WiKCn4NpWzaka6ZtjB6z)_