### PR TITLE
finance: accrue people cost from HR payroll (salary + employer statutory)

### DIFF
--- a/apps/backoffice/src/lib/finance/reports/people-cost.ts
+++ b/apps/backoffice/src/lib/finance/reports/people-cost.ts
@@ -1,0 +1,243 @@
+// People cost (salary + employer statutory) for the sourced P&L, on an ACCRUAL
+// basis sourced from the HR payroll module instead of the bank feed.
+//
+// Why: the bank EMPLOYEE_SALARY / STATUTORY_PAYMENT outflows are the CASH
+// settlement of payroll. They land when the transfer clears, which is usually
+// the following month and split awkwardly across the employer/employee legs, so
+// the P&L expense they produced was cash-timed and lagged a month. The cost of
+// employing people belongs to the month the work was done. That month is the
+// payroll RUN month, and the figure is the run's gross plus the employer-side
+// statutory contributions. This module reads exactly that.
+//
+// Scope:
+//   Salary    = SUM(hr_payroll_items.total_gross)         over the monthly runs
+//   Statutory = SUM(epf_employer + socso_employer + eis_employer)  (employer only;
+//               the employee-side epf/socso/eis/pcb are deductions already inside
+//               gross, so they are NOT added again, no double count).
+//
+// Attribution: item.user_id -> hr_employee_profiles.preferred_outlet_id ->
+// fin_outlet_companies.company_id. Per-outlet is the exact assigned-outlet split
+// from real staff, not a ratio. Employees with no assigned outlet cannot be
+// placed in a company, so their pay lands on a single visible "Unassigned"
+// line attributed to the default company (company + consolidated views only),
+// never silently dropped.
+//
+// Excludes the opening_balance run (a BrioHR YTD migration artifact).
+
+import { prisma } from "@/lib/prisma";
+import { Prisma } from "@prisma/client";
+
+const round2 = (n: number) => Math.round(n * 100) / 100;
+
+// P&L line codes emitted for the two HR-sourced people-cost lines.
+export const PEOPLE_SALARY_CODE = "PEOPLE-SALARY";
+export const PEOPLE_STAT_CODE = "PEOPLE-STAT";
+export const PEOPLE_SALARY_NAME = "Salaries and wages (accrued from payroll)";
+export const PEOPLE_STAT_NAME =
+  "Statutory contributions, employer EPF/SOCSO/EIS (accrued from payroll)";
+// The unassigned-payroll line, attributed to the default company only.
+export const PEOPLE_UNASSIGNED_SALARY_NAME = "Unassigned payroll (assign staff outlet in HR)";
+export const PEOPLE_UNASSIGNED_STAT_NAME = "Unassigned statutory (assign staff outlet in HR)";
+
+// The [start, end] YYYY-MM-DD window as an inclusive list of (year, month) the
+// monthly payroll runs are matched on. A payroll run recognises in its work
+// month regardless of the day-of-month the window starts/ends on.
+function monthsInWindow(start: string, end: string): { year: number; month: number }[] {
+  const [sy, sm] = start.slice(0, 7).split("-").map(Number);
+  const [ey, em] = end.slice(0, 7).split("-").map(Number);
+  const out: { year: number; month: number }[] = [];
+  let y = sy;
+  let m = sm;
+  // Guard against a malformed window producing an unbounded loop.
+  for (let i = 0; i < 240; i++) {
+    if (y > ey || (y === ey && m > em)) break;
+    out.push({ year: y, month: m });
+    m++;
+    if (m > 12) {
+      m = 1;
+      y++;
+    }
+  }
+  return out;
+}
+
+export type PeopleCostScope = {
+  companyId: string;        // the company the P&L is being built for
+  defaultCompanyId: string; // where unassigned pay is attributed
+  start: string;
+  end: string;
+  outletIds: string[];      // the company's outlets, or one when scoped to an outlet
+  outletScoped: boolean;    // true when the P&L is a single-outlet view
+  // consolidated: the group P&L builds one report PER company with
+  // excludeInterCo=true and sums them line-by-line. Each such per-company report
+  // must therefore still attribute only its OWN assigned staff (so the group
+  // total is each company summed once, not the whole group repeated per entity),
+  // and only the default company's report carries the unassigned pool. So
+  // consolidated does NOT change the per-company attribution here; it only
+  // affects whether the unassigned pool is a valid attribution target, which is
+  // already the default-company rule. Kept for signature symmetry / callers.
+  consolidated: boolean;
+};
+
+export type PeopleCostResult = {
+  salary: number;           // assigned salary for this scope
+  statutory: number;        // assigned employer statutory for this scope
+  unassignedSalary: number; // unassigned pool, only nonzero when it applies to this scope
+  unassignedStatutory: number;
+};
+
+// The month-window predicate as a raw SQL fragment matching monthly runs whose
+// (period_year, period_month) is in the window. Built from the JS month list so
+// the accrual boundary is identical to monthsInWindow above.
+function monthPredicate(start: string, end: string): Prisma.Sql {
+  const months = monthsInWindow(start, end);
+  if (!months.length) return Prisma.sql`FALSE`;
+  const tuples = months.map((mo) => Prisma.sql`(${mo.year}, ${mo.month})`);
+  return Prisma.sql`(r.period_year, r.period_month) IN (${Prisma.join(tuples)})`;
+}
+
+// Aggregate people cost for a P&L scope. Runs one grouped query over the monthly
+// payroll items in the window, bucketed by the employee's company (via assigned
+// outlet), and slices out the figures this scope should show:
+//   - outlet-scoped view: only the items whose preferred_outlet_id is in scope;
+//     the unassigned pool is excluded (it has no outlet).
+//   - company view (companyId set, not outlet-scoped): items mapping to that
+//     company; plus, when this is the default company, the whole unassigned pool.
+//   - consolidated: items summed across all companies plus the unassigned pool.
+export async function peopleCostForScope(scope: PeopleCostScope): Promise<PeopleCostResult> {
+  const { companyId, defaultCompanyId, start, end, outletIds, outletScoped } = scope;
+  const inWindow = monthPredicate(start, end);
+
+  // One grouped pass. bucket is the mapped company_id, 'UNASSIGNED' when the
+  // employee has no assigned outlet, keyed to the specific outlet too so an
+  // outlet-scoped view can slice exactly.
+  const rows = await prisma.$queryRaw<
+    { outlet_id: string | null; company_id: string | null; salary: number; statutory: number }[]
+  >(Prisma.sql`
+    SELECT p.preferred_outlet_id AS outlet_id,
+           fc.company_id AS company_id,
+           COALESCE(SUM(i.total_gross), 0)::float AS salary,
+           COALESCE(SUM(i.epf_employer + i.socso_employer + i.eis_employer), 0)::float AS statutory
+    FROM hr_payroll_items i
+    JOIN hr_payroll_runs r ON r.id = i.payroll_run_id AND r.cycle_type = 'monthly'
+    LEFT JOIN hr_employee_profiles p ON p.user_id = i.user_id
+    LEFT JOIN fin_outlet_companies fc ON fc.outlet_id = p.preferred_outlet_id
+    WHERE ${inWindow}
+    GROUP BY p.preferred_outlet_id, fc.company_id
+  `);
+
+  let salary = 0;
+  let statutory = 0;
+  let unassignedSalary = 0;
+  let unassignedStatutory = 0;
+
+  for (const r of rows) {
+    const isUnassigned = r.outlet_id == null; // no assigned outlet → no company
+    if (isUnassigned) {
+      // Attributed to the default company at company level, never in an
+      // outlet-scoped view (it has no outlet). The consolidated report is the
+      // sum of the per-company reports, so it inherits the pool from the
+      // default company's report exactly once.
+      if (!outletScoped && companyId === defaultCompanyId) {
+        unassignedSalary += Number(r.salary);
+        unassignedStatutory += Number(r.statutory);
+      }
+      continue;
+    }
+    if (outletScoped) {
+      // Exact per-outlet split: only this outlet's staff.
+      if (outletIds.includes(r.outlet_id!)) {
+        salary += Number(r.salary);
+        statutory += Number(r.statutory);
+      }
+      continue;
+    }
+    // Company view (and each per-company leg of the consolidated build): staff
+    // whose assigned outlet maps to this company. Summing the per-company
+    // reports gives the group total once, with no cross-entity double count.
+    if (r.company_id === companyId) {
+      salary += Number(r.salary);
+      statutory += Number(r.statutory);
+    }
+  }
+
+  return {
+    salary: round2(salary),
+    statutory: round2(statutory),
+    unassignedSalary: round2(unassignedSalary),
+    unassignedStatutory: round2(unassignedStatutory),
+  };
+}
+
+// Per-employee payroll rows for the drill, for the given scope and metric.
+// metric 'salary' → total_gross; 'statutory' → employer EPF+SOCSO+EIS.
+// scopeKind selects which employees are in scope, mirroring peopleCostForScope:
+//   'company'     → employees mapping to companyId (assigned outlet)
+//   'outlet'      → employees whose preferred_outlet_id is in outletIds
+//   'consolidated'→ all assigned employees
+//   'unassigned'  → employees with no assigned outlet (default company only)
+export type PeopleDrillRow = {
+  userId: string;
+  name: string | null;
+  outletId: string | null;
+  year: number;
+  month: number;
+  amount: number;
+};
+
+export async function peopleCostDrill(args: {
+  metric: "salary" | "statutory";
+  scopeKind: "company" | "outlet" | "consolidated" | "unassigned";
+  companyId: string;
+  outletIds: string[];
+  start: string;
+  end: string;
+}): Promise<PeopleDrillRow[]> {
+  const { metric, scopeKind, companyId, outletIds, start, end } = args;
+  const inWindow = monthPredicate(start, end);
+  const amountExpr =
+    metric === "salary"
+      ? Prisma.sql`i.total_gross`
+      : Prisma.sql`(i.epf_employer + i.socso_employer + i.eis_employer)`;
+
+  let scopeFilter: Prisma.Sql;
+  if (scopeKind === "unassigned") {
+    scopeFilter = Prisma.sql`p.preferred_outlet_id IS NULL`;
+  } else if (scopeKind === "outlet") {
+    if (!outletIds.length) return [];
+    scopeFilter = Prisma.sql`p.preferred_outlet_id IN (${Prisma.join(outletIds)})`;
+  } else if (scopeKind === "consolidated") {
+    scopeFilter = Prisma.sql`p.preferred_outlet_id IS NOT NULL AND fc.company_id IS NOT NULL`;
+  } else {
+    scopeFilter = Prisma.sql`fc.company_id = ${companyId}`;
+  }
+
+  const rows = await prisma.$queryRaw<
+    { user_id: string; name: string | null; outlet_id: string | null; year: number; month: number; amount: number }[]
+  >(Prisma.sql`
+    SELECT i.user_id,
+           u.name AS name,
+           p.preferred_outlet_id AS outlet_id,
+           r.period_year AS year,
+           r.period_month AS month,
+           ${amountExpr}::float AS amount
+    FROM hr_payroll_items i
+    JOIN hr_payroll_runs r ON r.id = i.payroll_run_id AND r.cycle_type = 'monthly'
+    LEFT JOIN hr_employee_profiles p ON p.user_id = i.user_id
+    LEFT JOIN fin_outlet_companies fc ON fc.outlet_id = p.preferred_outlet_id
+    LEFT JOIN "User" u ON u.id = i.user_id
+    WHERE ${inWindow} AND (${scopeFilter})
+    ORDER BY r.period_year ASC, r.period_month ASC, u.name ASC
+  `);
+
+  return rows
+    .map((r) => ({
+      userId: r.user_id,
+      name: r.name,
+      outletId: r.outlet_id,
+      year: Number(r.year),
+      month: Number(r.month),
+      amount: round2(Number(r.amount)),
+    }))
+    .filter((r) => r.amount !== 0);
+}

--- a/apps/backoffice/src/lib/finance/reports/pnl-sourced-drill.ts
+++ b/apps/backoffice/src/lib/finance/reports/pnl-sourced-drill.ts
@@ -20,6 +20,12 @@ import { getDefaultCompanyId } from "../companies";
 import { depreciationByAsset } from "../fixed-assets";
 import { effectiveGrabRate, fetchRecognisedBankLines } from "./pnl-sourced";
 import { getUnifiedSalesForOutlet } from "@/app/api/sales/_lib/unified-sales";
+import {
+  peopleCostDrill,
+  PEOPLE_SALARY_CODE,
+  PEOPLE_STAT_CODE,
+  type PeopleDrillRow,
+} from "./people-cost";
 
 const round2 = (n: number) => Math.round(n * 100) / 100;
 const dStart = (s: string) => new Date(`${s}T00:00:00.000Z`);
@@ -94,7 +100,7 @@ function companyForAccount(accountName: string | null): string {
   return accountName ?? "—";
 }
 export function isSourcedPnlCode(code: string): boolean {
-  return /^(REV-|PROC$|INV-|MKT-|BANK:|DEP$)/.test(code);
+  return /^(REV-|PROC$|INV-|MKT-|BANK:|DEP$|PEOPLE-)/.test(code);
 }
 
 async function companyOutlets(companyId: string, outletId?: string | null): Promise<string[]> {
@@ -374,6 +380,58 @@ async function drillBank(cat: string, companyId: string, start: string, end: str
   }));
 }
 
+// PEOPLE-SALARY / PEOPLE-STAT (and their -UNASSIGNED variants): the per-employee
+// payroll items behind the accrued people-cost line, from the SAME aggregation
+// as buildSourcedPnl (people-cost.ts) so the drill total ties to the line. Each
+// row is one employee in one payroll-run month; the unassigned variant lists the
+// employees with no assigned outlet.
+async function drillPeople(
+  code: string,
+  companyId: string,
+  start: string,
+  end: string,
+  outletId?: string | null,
+): Promise<DrillLine[]> {
+  const isUnassigned = code.endsWith("-UNASSIGNED");
+  const metric: "salary" | "statutory" = code.startsWith(PEOPLE_STAT_CODE) ? "statutory" : "salary";
+  const outletIds = await companyOutlets(companyId, outletId);
+  let scopeKind: "company" | "outlet" | "consolidated" | "unassigned";
+  if (isUnassigned) scopeKind = "unassigned";
+  else if (outletId) scopeKind = "outlet";
+  else if (companyId === CONSOLIDATED) scopeKind = "consolidated";
+  else scopeKind = "company";
+
+  const rows: PeopleDrillRow[] = await peopleCostDrill({
+    metric,
+    scopeKind,
+    companyId,
+    outletIds,
+    start,
+    end,
+  });
+
+  // Resolve outlet names once for the row descriptions (assigned staff only).
+  const oids = [...new Set(rows.map((r) => r.outletId).filter((x): x is string => !!x))];
+  const outletNames = new Map<string, string>();
+  if (oids.length) {
+    const outlets = await prisma.outlet.findMany({ where: { id: { in: oids } }, select: { id: true, name: true } });
+    for (const o of outlets) outletNames.set(o.id, o.name);
+  }
+
+  const monthLabel = (y: number, m: number) => `${y}-${String(m).padStart(2, "0")}`;
+  return rows.map((r) => {
+    const where = r.outletId ? outletNames.get(r.outletId) ?? "(outlet)" : "no assigned outlet";
+    return {
+      transactionId: `people-${metric}-${r.userId}-${r.year}-${r.month}`,
+      txnDate: `${monthLabel(r.year, r.month)}-01`,
+      description: `${r.name ?? r.userId} · ${where} · payroll ${monthLabel(r.year, r.month)}`,
+      amount: r.amount,
+      debit: r.amount,
+      credit: 0,
+    };
+  });
+}
+
 export async function sourcedPnlDrillDown(args: {
   companyId: string;
   code: string;
@@ -395,6 +453,10 @@ export async function sourcedPnlDrillDown(args: {
   if (code === "MKT-GRAB-PROMO") return drillGrabPromo(companyId, start, end, outletId);
   if (code === "MKT-GRAB-ADS") return drillGrabAds(companyId, start, end, outletId);
   if (code === "DEP") return drillDepreciation(companyId, start, end, outletId);
+  // People cost (accrued from HR payroll): drill into the per-employee items.
+  if (code.startsWith(PEOPLE_SALARY_CODE) || code.startsWith(PEOPLE_STAT_CODE)) {
+    return drillPeople(code, companyId, start, end, outletId);
+  }
   // Every opex bank line drills through the shared expense-month recognition
   // (override > matched invoice month > category shift > cash), so shifted
   // categories like management fee, salary, utilities and statutory tie to

--- a/apps/backoffice/src/lib/finance/reports/pnl-sourced.ts
+++ b/apps/backoffice/src/lib/finance/reports/pnl-sourced.ts
@@ -22,6 +22,15 @@ import { getDefaultCompanyId } from "../companies";
 import { depreciationTotal } from "../fixed-assets";
 import type { PnlReport, PnlLine } from "./pnl";
 import { getUnifiedSalesForOutlet } from "@/app/api/sales/_lib/unified-sales";
+import {
+  peopleCostForScope,
+  PEOPLE_SALARY_CODE,
+  PEOPLE_STAT_CODE,
+  PEOPLE_SALARY_NAME,
+  PEOPLE_STAT_NAME,
+  PEOPLE_UNASSIGNED_SALARY_NAME,
+  PEOPLE_UNASSIGNED_STAT_NAME,
+} from "./people-cost";
 
 const round2 = (n: number) => Math.round(n * 100) / 100;
 
@@ -37,6 +46,12 @@ const BANK_ACCOUNT_SUFFIX: Record<string, string> = {
 const BANK_COGS = new Set(["RAW_MATERIALS", "DELIVERY", "INTERCO_RAW_MATERIAL"]); // COGS comes from procurement
 const BANK_DIGITAL_ADS = new Set(["DIGITAL_ADS"]);                                // = ads module (dedup)
 const BANK_MARKETING = new Set(["MARKETPLACE_FEE", "KOL", "OTHER_MARKETING"]);     // non-digital marketing
+// Salary + employer statutory now come from the HR payroll module on an accrual
+// basis (see people-cost.ts), so their bank outflows are the cash settlement
+// only and must NOT feed the P&L expense, so dropping them here avoids double
+// counting the people cost. The bank lines still exist for the cash ledger,
+// recon and GL. PARTIMER is intentionally NOT here: it stays outlet-tagged cash.
+const BANK_PEOPLE_ACCRUED = new Set(["EMPLOYEE_SALARY", "STATUTORY_PAYMENT"]);
 const BANK_NONOPEX = new Set([                                                    // internal / financing / capex / distributions — not operating
   "CAPITAL", "LOAN", "INTERCO_PEOPLE", "INTERCO_INVESTMENTS",
   "INTERCO_EXPENSES", "INVESTMENTS", "EQUIPMENTS", "ADTD", "TRANSFER_NOT_SUCCESSFUL",
@@ -85,7 +100,7 @@ const ACCRUED_SUFFIX = " (accrued, paid the following month)";
 // procurement invoice already counted in COGS purchases and stay excluded.
 function isOpexFeedCategory(cat: string | null): boolean {
   if (!cat) return false;
-  return !BANK_COGS.has(cat) && !BANK_NONOPEX.has(cat) && !BANK_DIGITAL_ADS.has(cat) && !BANK_REVIEW.has(cat);
+  return !BANK_COGS.has(cat) && !BANK_NONOPEX.has(cat) && !BANK_DIGITAL_ADS.has(cat) && !BANK_REVIEW.has(cat) && !BANK_PEOPLE_ACCRUED.has(cat);
 }
 
 export type RecognisedBankLine = {
@@ -466,6 +481,8 @@ export async function buildSourcedPnl(input: {
   let saleCount = 0;
   // Any accrual-shifted line in the period adds a short note to the report.
   let shiftedPresent = false;
+  // HR-sourced people cost present in the period adds its own accrual note.
+  let peoplePresent = false;
   const perOutlet = await Promise.all(
     outletRows.map((o) =>
       getUnifiedSalesForOutlet(
@@ -676,7 +693,7 @@ export async function buildSourcedPnl(input: {
     const byCat = new Map<string, number>();
     for (const l of opexLines) {
       const cat = l.category;
-      if (cat && (BANK_COGS.has(cat) || BANK_NONOPEX.has(cat) || BANK_DIGITAL_ADS.has(cat))) continue;
+      if (cat && (BANK_COGS.has(cat) || BANK_NONOPEX.has(cat) || BANK_DIGITAL_ADS.has(cat) || BANK_PEOPLE_ACCRUED.has(cat))) continue;
       byCat.set(cat ?? "NULL", (byCat.get(cat ?? "NULL") ?? 0) + l.amount);
     }
     for (const [key, sum] of byCat) {
@@ -696,6 +713,44 @@ export async function buildSourcedPnl(input: {
         parentCode: null,
       });
       totalExpenses += amt;
+    }
+  }
+
+  // People cost: salary + employer statutory, ACCRUED from the HR payroll runs
+  // for the period (people-cost.ts), replacing the bank EMPLOYEE_SALARY /
+  // STATUTORY_PAYMENT outflows dropped above. The cost lands in the work month
+  // of the run, independent of when the bank paid it, so the latest month is
+  // always populated once its run exists. Per outlet uses each employee's
+  // assigned outlet exactly; staff with no assigned outlet fall into a single
+  // visible unassigned line (default company + consolidated only).
+  {
+    const pc = await peopleCostForScope({
+      companyId,
+      defaultCompanyId: defaultCompany,
+      start,
+      end,
+      outletIds,
+      outletScoped: !!outletId,
+      consolidated: !!excludeInterCo,
+    });
+    if (pc.salary) {
+      expenseLines.push({ code: PEOPLE_SALARY_CODE, name: PEOPLE_SALARY_NAME, amount: pc.salary, parentCode: null });
+      totalExpenses += pc.salary;
+    }
+    if (pc.statutory) {
+      expenseLines.push({ code: PEOPLE_STAT_CODE, name: PEOPLE_STAT_NAME, amount: pc.statutory, parentCode: null });
+      totalExpenses += pc.statutory;
+    }
+    if (pc.unassignedSalary) {
+      expenseLines.push({ code: `${PEOPLE_SALARY_CODE}-UNASSIGNED`, name: PEOPLE_UNASSIGNED_SALARY_NAME, amount: pc.unassignedSalary, parentCode: null });
+      totalExpenses += pc.unassignedSalary;
+    }
+    if (pc.unassignedStatutory) {
+      expenseLines.push({ code: `${PEOPLE_STAT_CODE}-UNASSIGNED`, name: PEOPLE_UNASSIGNED_STAT_NAME, amount: pc.unassignedStatutory, parentCode: null });
+      totalExpenses += pc.unassignedStatutory;
+    }
+    if (pc.salary || pc.statutory || pc.unassignedSalary || pc.unassignedStatutory) {
+      peoplePresent = true;
     }
   }
 
@@ -732,10 +787,17 @@ export async function buildSourcedPnl(input: {
     netIncome,
     txnCount: saleCount,
     // Boundary honesty: with a one-month-arrears shift, the newest month of a
-    // report only fills once the following month's payments are recorded.
-    ...(shiftedPresent ? { notes: [ACCRUAL_NOTE] } : {}),
+    // report only fills once the following month's payments are recorded. The
+    // people-cost note flags the HR-accrual semantics separately.
+    ...((shiftedPresent || peoplePresent)
+      ? { notes: [...(shiftedPresent ? [ACCRUAL_NOTE] : []), ...(peoplePresent ? [PEOPLE_ACCRUAL_NOTE] : [])] }
+      : {}),
   };
 }
+
+// Shown under the P&L whenever an HR-sourced people-cost line is present.
+const PEOPLE_ACCRUAL_NOTE =
+  "Salary and statutory are accrued from the HR payroll runs for the period, so they land in the month worked, not when paid. Per outlet uses each employee's assigned outlet. A month shows people cost once its payroll run exists.";
 
 // Shown under the P&L whenever a shift-recognised line is present.
 const ACCRUAL_NOTE =


### PR DESCRIPTION
## What

Source the sourced-P&L salary and statutory expense from the **HR payroll module** on an **accrual** basis, instead of the bank feed.

## Accrual semantics

- **Salary** = `SUM(hr_payroll_items.total_gross)` over the **monthly** `hr_payroll_runs` whose `(period_year, period_month)` fall in the P&L window. Cost lands in the month worked, not when the transfer clears.
- **Statutory** = `SUM(epf_employer + socso_employer + eis_employer)`, **employer side only**. The employee legs (epf/socso/eis/pcb) are deductions already inside gross, so they are not added again (no double count).
- The `opening_balance` run (a BrioHR YTD migration artifact) is **excluded**.

## Per-outlet split (exact, not a ratio)

`item.user_id` -> `hr_employee_profiles.preferred_outlet_id` -> `fin_outlet_companies.company_id`. Each per-company report attributes only its **own** assigned staff, so the consolidated total is each company summed **once** with no cross-entity double count.

Staff with **no assigned outlet** land on a single visible **"Unassigned payroll (assign staff outlet in HR)"** line on the **default company** (company and consolidated views only), never silently dropped and never shown in a per-outlet view.

## Bank lines removed from the P&L expense

`EMPLOYEE_SALARY` and `STATUTORY_PAYMENT` are removed from the sourced-P&L opex loop. They are the **cash settlement** now, not the expense, so keeping them would double count. The bank lines still exist for the cash ledger, recon and GL. **PARTIMER is untouched** and stays outlet-tagged bank cash.

## UI

Two P&L expense lines, `PEOPLE-SALARY` and `PEOPLE-STAT`, shown only when nonzero, each **drillable** into per-employee payroll-run rows (employee name via the User table, amount, run month). The Unassigned variants drill the null-outlet employees. A short muted note explains the accrual semantics.

## Verified ties (all monthly runs, salary leg)

- Nilai 8,245.40 + Shah Alam 80,566.36 = **88,811.76** (celsius entity)
- Putrajaya **105,083.78** (conezion)
- Tamarind **86,288.08** (tamarind)
- IOI Mall: zero staff
- **Consolidated salary 425,827.63 = whole monthly gross** (excl. opening_balance); statutory **53,168.10 = whole employer EPF+SOCSO+EIS**. Every payroll item counted exactly once.

## Caveats

- Only **posted** monthly runs feed the accrual; draft runs are excluded.
- Staff without an assigned outlet currently pool into the Unassigned line (assign outlets in HR to split them per entity).

Typecheck clean, ESLint clean on touched files, `npm test` green (187 tests).