### PR TITLE
finance: read-only channel settlement reconciliation

### DIFF
--- a/apps/backoffice/src/app/(admin)/finance/reports/page.tsx
+++ b/apps/backoffice/src/app/(admin)/finance/reports/page.tsx
@@ -2256,6 +2256,141 @@ type QrTender = {
 };
 type Recon = { start: string; end: string; channels: ReconChannel[]; qrTender: QrTender; totals: { salesRecognised: number; settledToBank: number; unreconciled: number } };
 
+// ─── Channel settlement reconciliation (per company + consolidated) ──
+type ChannelMonth = {
+  month: string; accrued: number; settled: number; residual: number;
+  commission: number; residualAfterCommission: number;
+};
+type ChannelRow = {
+  code: string; label: string; accrued: number; settled: number; residual: number;
+  commission: number; residualAfterCommission: number; months: ChannelMonth[];
+};
+type CompanyChannelSettlement = {
+  companyId: string; companyName: string; channels: ChannelRow[];
+  entityNet: number; totalCommission: number; entityNetAfterCommission: number;
+};
+type ChannelSettlement = {
+  start: string; end: string;
+  companies: CompanyChannelSettlement[];
+  consolidated: { channels: ChannelRow[]; entityNet: number; totalCommission: number; entityNetAfterCommission: number };
+};
+
+// One company (or the consolidated total) rendered as a channel table with an
+// expandable monthly drill per channel and a prominent entity-net summary row.
+function ChannelSettlementCard({ title, channels, entityNet, totalCommission, entityNetAfterCommission, idPrefix }: {
+  title: string;
+  channels: ChannelRow[];
+  entityNet: number;
+  totalCommission: number;
+  entityNetAfterCommission: number;
+  idPrefix: string;
+}) {
+  const [open, setOpen] = useState<string | null>(null);
+  const totAccrued = channels.reduce((s, c) => s + c.accrued, 0);
+  const totSettled = channels.reduce((s, c) => s + c.settled, 0);
+  const totResidual = channels.reduce((s, c) => s + c.residual, 0);
+  const totAfterComm = channels.reduce((s, c) => s + c.residualAfterCommission, 0);
+  return (
+    <div className="space-y-2">
+      <h4 className="text-sm font-semibold">{title}</h4>
+      <div className="overflow-x-auto rounded-lg border">
+        <table className="w-full min-w-[760px] text-sm">
+          <thead><tr className="border-b bg-muted/40 text-left text-muted-foreground">
+            <th className="px-3 py-2 font-medium">Channel</th>
+            <th className="px-3 py-2 text-right font-medium">Sales accrued</th>
+            <th className="px-3 py-2 text-right font-medium">Cash settled</th>
+            <th className="px-3 py-2 text-right font-medium">Net residual</th>
+            <th className="px-3 py-2 text-right font-medium">Commission booked</th>
+            <th className="px-3 py-2 text-right font-medium">Residual after commission</th>
+          </tr></thead>
+          <tbody className="divide-y">
+            {channels.map((c) => (
+              <Fragment key={c.code}>
+                <tr className="cursor-pointer hover:bg-muted/40" onClick={() => setOpen(open === c.code ? null : c.code)} title="Show monthly breakdown">
+                  <td className="px-3 py-1.5">
+                    <span className="font-medium">{c.label}</span>
+                    <span className="ml-2 text-xs text-muted-foreground tabular-nums">{c.code}</span>
+                  </td>
+                  <td className="px-3 py-1.5 text-right tabular-nums">{RM(c.accrued)}</td>
+                  <td className="px-3 py-1.5 text-right tabular-nums">{RM(c.settled)}</td>
+                  <td className={`px-3 py-1.5 text-right tabular-nums ${c.residual < 0 ? "text-rose-600 dark:text-rose-400" : ""}`}>{RM(c.residual)}</td>
+                  <td className="px-3 py-1.5 text-right tabular-nums text-muted-foreground">{RM(c.commission)}</td>
+                  <td className={`px-3 py-1.5 text-right tabular-nums ${c.residualAfterCommission < 0 ? "text-rose-600 dark:text-rose-400" : ""}`}>{RM(c.residualAfterCommission)}</td>
+                </tr>
+                {open === c.code && c.months.map((m) => (
+                  <tr key={`${idPrefix}-${c.code}-${m.month}`} className="bg-muted/20 text-xs">
+                    <td className="px-3 py-1 pl-8 text-muted-foreground tabular-nums">{m.month}</td>
+                    <td className="px-3 py-1 text-right tabular-nums">{RM(m.accrued)}</td>
+                    <td className="px-3 py-1 text-right tabular-nums">{RM(m.settled)}</td>
+                    <td className={`px-3 py-1 text-right tabular-nums ${m.residual < 0 ? "text-rose-600 dark:text-rose-400" : ""}`}>{RM(m.residual)}</td>
+                    <td className="px-3 py-1 text-right tabular-nums">{RM(m.commission)}</td>
+                    <td className={`px-3 py-1 text-right tabular-nums ${m.residualAfterCommission < 0 ? "text-rose-600 dark:text-rose-400" : ""}`}>{RM(m.residualAfterCommission)}</td>
+                  </tr>
+                ))}
+              </Fragment>
+            ))}
+          </tbody>
+          <tfoot>
+            <tr className="border-t font-medium">
+              <td className="px-3 py-1.5">All channels</td>
+              <td className="px-3 py-1.5 text-right tabular-nums">{RM(totAccrued)}</td>
+              <td className="px-3 py-1.5 text-right tabular-nums">{RM(totSettled)}</td>
+              <td className={`px-3 py-1.5 text-right tabular-nums ${totResidual < 0 ? "text-rose-600 dark:text-rose-400" : ""}`}>{RM(totResidual)}</td>
+              <td className="px-3 py-1.5 text-right tabular-nums text-muted-foreground">{RM(totalCommission)}</td>
+              <td className={`px-3 py-1.5 text-right tabular-nums ${totAfterComm < 0 ? "text-rose-600 dark:text-rose-400" : ""}`}>{RM(totAfterComm)}</td>
+            </tr>
+            <tr className="border-t-2 bg-muted/30 font-semibold">
+              <td className="px-3 py-2" title="Total across the three debtors of accrued minus settled. The true unreconciled figure, since per-channel splits are noisy.">Entity net (real unreconciled)</td>
+              <td className="px-3 py-2" colSpan={2} />
+              <td className={`px-3 py-2 text-right tabular-nums ${entityNet < 0 ? "text-rose-600 dark:text-rose-400" : ""}`}>{RM(entityNet)}</td>
+              <td className="px-3 py-2 text-right tabular-nums text-muted-foreground">{RM(totalCommission)}</td>
+              <td className={`px-3 py-2 text-right tabular-nums ${entityNetAfterCommission < 0 ? "text-rose-600 dark:text-rose-400" : ""}`}>{RM(entityNetAfterCommission)}</td>
+            </tr>
+          </tfoot>
+        </table>
+      </div>
+    </div>
+  );
+}
+
+function ChannelSettlementSection({ start, end }: { start: string; end: string }) {
+  const { data, isLoading } = useFetch<{ report: ChannelSettlement }>(`/api/finance/reports/channel-settlement?start=${start}&end=${end}`);
+  if (isLoading || !data?.report) {
+    return <div className="py-8 text-center text-sm text-muted-foreground">Loading channel settlement…</div>;
+  }
+  const r = data.report;
+  return (
+    <div className="mt-6 space-y-4">
+      <div className="flex items-baseline justify-between">
+        <h3 className="text-sm font-semibold">Channel settlement reconciliation</h3>
+        <span className="text-[11px] text-muted-foreground">accrued vs settled per channel debtor, by entity</span>
+      </div>
+      <ChannelSettlementCard
+        title="Consolidated (all entities)"
+        channels={r.consolidated.channels}
+        entityNet={r.consolidated.entityNet}
+        totalCommission={r.consolidated.totalCommission}
+        entityNetAfterCommission={r.consolidated.entityNetAfterCommission}
+        idPrefix="consolidated"
+      />
+      {r.companies.map((co) => (
+        <ChannelSettlementCard
+          key={co.companyId}
+          title={co.companyName}
+          channels={co.channels}
+          entityNet={co.entityNet}
+          totalCommission={co.totalCommission}
+          entityNetAfterCommission={co.entityNetAfterCommission}
+          idPrefix={co.companyId}
+        />
+      ))}
+      <p className="text-[11px] text-muted-foreground">
+        Sales are accrued as a debit to each channel debtor (Card 1006, GrabFood 1005, Cash &amp; QR 1000-02); bank settlements credit it. The residual splits into three causes. Per-channel gaps are inflated by settlement cash arriving under a different channel label than the sale was accrued under (for example a Grab payout crediting Card 1006 instead of 1005), so the per-channel columns are noisy and the <span className="font-medium">entity net</span> across all three debtors is the real unreconciled figure. Commission is the expected permanent portion, already expensed (GrabFood commission at the payout-derived rate applied to gross Grab accrual, card MDR as bank fees), so residual after commission is the misattribution-plus-timing part; whatever remains after that is timing (recent sales not yet settled). This view is strictly read-only. The clearing actions (retag misattributed settlements, post commission clearing) are a deliberate follow-up and are not done here.
+      </p>
+    </div>
+  );
+}
+
 function ReconTab() {
   // Default to the matched period: sales archive + bank feed both exist from
   // 2026-01, so the channels net to true fees/timing (before that the bank feed
@@ -2353,6 +2488,8 @@ function ReconTab() {
           <p className="text-[11px] text-muted-foreground">DuitNow QR settles same-day at full value (no commission), so QR sales rung should equal QR settled to the cent. Read from the tender source (StoreHub archive + POS-native QR vs the bank QR category) rather than the commingled Cash &amp; QR ledger account. Each month nets to a small settlement-timing gap; the first month also carries the prior-December QR that settled in January.</p>
         </div>
       )}
+
+      <ChannelSettlementSection start={start} end={end} />
     </div>
   );
 }

--- a/apps/backoffice/src/app/api/finance/reports/channel-settlement/route.ts
+++ b/apps/backoffice/src/app/api/finance/reports/channel-settlement/route.ts
@@ -1,0 +1,41 @@
+// GET /api/finance/reports/channel-settlement?start=YYYY-MM-DD&end=YYYY-MM-DD
+//
+// Read-only channel settlement reconciliation: per company and consolidated,
+// sales accrued vs cash settled vs the residual for each channel debtor, with
+// the commission (expected permanent) portion split out and the entity net
+// surfaced. Covers every active company (with a consolidated total), so it is
+// not scoped to the active company switcher.
+
+import { NextRequest, NextResponse } from "next/server";
+import { requireAuth } from "@/lib/auth";
+import { listCompanies } from "@/lib/finance/companies";
+import { buildChannelSettlement } from "@/lib/finance/reports/channel-settlement";
+
+export const dynamic = "force-dynamic";
+export const maxDuration = 60;
+
+export async function GET(req: NextRequest) {
+  const auth = await requireAuth(req);
+  if (auth.error) return auth.error;
+  if (!["OWNER", "ADMIN"].includes(auth.user.role)) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+
+  const params = new URL(req.url).searchParams;
+  const start = params.get("start");
+  const end = params.get("end");
+  const re = /^\d{4}-\d{2}-\d{2}$/;
+  if (!start || !end || !re.test(start) || !re.test(end)) {
+    return NextResponse.json({ error: "start and end (YYYY-MM-DD) required" }, { status: 400 });
+  }
+
+  try {
+    const companies = (await listCompanies())
+      .filter((c) => c.isActive)
+      .map((c) => ({ id: c.id, name: c.name }));
+    const report = await buildChannelSettlement({ start, end, companies });
+    return NextResponse.json({ report });
+  } catch (err) {
+    return NextResponse.json({ error: err instanceof Error ? err.message : String(err) }, { status: 500 });
+  }
+}

--- a/apps/backoffice/src/lib/finance/reports/channel-settlement.ts
+++ b/apps/backoffice/src/lib/finance/reports/channel-settlement.ts
@@ -1,0 +1,255 @@
+// Channel settlement reconciliation. Strictly READ-ONLY: it reads the posted GL
+// (fin_journal_lines joined fin_transactions) for the three channel debtor
+// accounts, per company and per month, and separates the debtor residual into
+// its three known causes so the owner can see why the debtors do not clear to
+// zero before any clearing journals are posted.
+//
+// Sales are accrued as a DEBIT to a channel debtor (Card 1006, Grab 1005,
+// Cash & QR 1000-02); bank settlements CREDIT it. The residual (Dr minus Cr)
+// splits into:
+//   1) MISATTRIBUTION: the settlement cash arrives under a different channel
+//      label than the sale was accrued under, so per-channel gaps are noisy and
+//      the ENTITY NET across all three debtors is the meaningful figure.
+//   2) COMMISSION: Grab and card take commission BEFORE payout, so a debtor
+//      accrued at GROSS only ever receives NET cash. Already expensed
+//      (MKT-GRAB-COMM in the sourced P&L, card MDR as BANK_FEE 6514), this is
+//      the expected permanent portion. Surfaced per channel.
+//   3) TIMING: recent sales not yet settled. Whatever remains after 1 and 2.
+//
+// This report does NOT classify, retag or post any journal. The clearing
+// actions (retag misattributed settlements, post commission clearing) are a
+// deliberate follow-up, not built here.
+
+import { effectiveGrabRate } from "./pnl-sourced";
+import { pagedPostedTxns, pagedJournalLines } from "./paged";
+
+function round2(n: number): number { return Math.round(n * 100) / 100; }
+
+// The channel debtor accounts, in display order. Kept aligned with
+// CONTRA_ACCOUNT in gl-posting-map.ts.
+const DEBTORS: { code: string; label: string; commission: "grab" | "card" | "none" }[] = [
+  { code: "1006", label: "Card", commission: "card" },
+  { code: "1005", label: "GrabFood", commission: "grab" },
+  { code: "1000-02", label: "Cash & QR", commission: "none" },
+];
+
+// Card MDR / bank merchant fees account. Grab commission is netted before
+// payout (never in the bank feed) and is estimated via effectiveGrabRate.
+const BANK_FEE_ACCOUNT = "6514";
+
+const DEBTOR_CODES = DEBTORS.map((d) => d.code);
+
+export type ChannelMonth = {
+  month: string;
+  accrued: number;
+  settled: number;
+  residual: number;
+  commission: number;
+  residualAfterCommission: number;
+};
+
+export type ChannelRow = {
+  code: string;
+  label: string;
+  accrued: number;
+  settled: number;
+  residual: number;
+  commission: number;
+  residualAfterCommission: number;
+  months: ChannelMonth[];
+};
+
+export type CompanyChannelSettlement = {
+  companyId: string;
+  companyName: string;
+  channels: ChannelRow[];
+  // Entity net = total across the three debtors of (accrued minus settled).
+  // This is the true unreconciled figure since per-channel splits are noisy.
+  entityNet: number;
+  totalCommission: number;
+  entityNetAfterCommission: number;
+};
+
+export type ChannelSettlementReport = {
+  start: string;
+  end: string;
+  companies: CompanyChannelSettlement[];
+  consolidated: {
+    channels: ChannelRow[];
+    entityNet: number;
+    totalCommission: number;
+    entityNetAfterCommission: number;
+  };
+};
+
+type Company = { id: string; name: string };
+
+// Debit/credit per debtor account per month, for one company, read straight
+// from the posted GL and paged (Supabase caps unpaged selects at 1000 rows).
+async function debtorMovementsByCompany(
+  companyIds: string[],
+  end: string,
+  startMonth: string,
+): Promise<Map<string, Map<string, Map<string, { d: number; c: number }>>>> {
+  // company -> account -> month -> { debit, credit }
+  const out = new Map<string, Map<string, Map<string, { d: number; c: number }>>>();
+  for (const cid of companyIds) {
+    const { txnIds, txnDate } = await pagedPostedTxns([cid], end);
+    const byAcct = new Map<string, Map<string, { d: number; c: number }>>();
+    for (const code of DEBTOR_CODES) byAcct.set(code, new Map());
+    for await (const lines of pagedJournalLines(txnIds)) {
+      for (const l of lines) {
+        if (!DEBTOR_CODES.includes(l.account_code)) continue;
+        const date = txnDate.get(l.transaction_id);
+        if (!date) continue;
+        const month = date.slice(0, 7);
+        if (month < startMonth) continue;
+        const byMonth = byAcct.get(l.account_code);
+        if (!byMonth) continue;
+        const cur = byMonth.get(month) ?? { d: 0, c: 0 };
+        cur.d = round2(cur.d + Number(l.debit));
+        cur.c = round2(cur.c + Number(l.credit));
+        byMonth.set(month, cur);
+      }
+    }
+    out.set(cid, byAcct);
+  }
+  return out;
+}
+
+// Card MDR (BANK_FEE 6514) debited per company per month, from the posted GL.
+async function bankFeesByCompany(
+  companyIds: string[],
+  end: string,
+  startMonth: string,
+): Promise<Map<string, Map<string, number>>> {
+  const out = new Map<string, Map<string, number>>();
+  for (const cid of companyIds) {
+    const { txnIds, txnDate } = await pagedPostedTxns([cid], end);
+    const byMonth = new Map<string, number>();
+    for await (const lines of pagedJournalLines(txnIds)) {
+      for (const l of lines) {
+        if (l.account_code !== BANK_FEE_ACCOUNT) continue;
+        const date = txnDate.get(l.transaction_id);
+        if (!date) continue;
+        const month = date.slice(0, 7);
+        if (month < startMonth) continue;
+        byMonth.set(month, round2((byMonth.get(month) ?? 0) + Number(l.debit) - Number(l.credit)));
+      }
+    }
+    out.set(cid, byMonth);
+  }
+  return out;
+}
+
+// Build one company's channel rows. Commission is estimated per month:
+//   Grab: effectiveGrabRate (global, payout-derived) times that month's gross
+//         Grab accrual (the debits to 1005), the same gross the P&L commission
+//         line is applied to.
+//   Card: the card MDR (BANK_FEE 6514) booked for the company that month.
+//   Cash & QR: zero (no commission on QR or cash).
+function buildChannels(
+  byAcct: Map<string, Map<string, { d: number; c: number }>>,
+  bankFees: Map<string, number>,
+  grabRate: number,
+): ChannelRow[] {
+  return DEBTORS.map((debtor) => {
+    const byMonth = byAcct.get(debtor.code) ?? new Map();
+    const monthKeys = new Set<string>([...byMonth.keys()]);
+    if (debtor.commission === "card") for (const m of bankFees.keys()) monthKeys.add(m);
+    const months: ChannelMonth[] = [...monthKeys].sort((a, b) => a.localeCompare(b)).map((month) => {
+      const v = byMonth.get(month) ?? { d: 0, c: 0 };
+      const accrued = round2(v.d);
+      const settled = round2(v.c);
+      const residual = round2(accrued - settled);
+      let commission = 0;
+      if (debtor.commission === "grab") commission = round2(accrued * grabRate);
+      else if (debtor.commission === "card") commission = round2(bankFees.get(month) ?? 0);
+      return {
+        month, accrued, settled, residual, commission,
+        residualAfterCommission: round2(residual - commission),
+      };
+    });
+    const accrued = round2(months.reduce((s, m) => s + m.accrued, 0));
+    const settled = round2(months.reduce((s, m) => s + m.settled, 0));
+    const residual = round2(accrued - settled);
+    const commission = round2(months.reduce((s, m) => s + m.commission, 0));
+    return {
+      code: debtor.code, label: debtor.label,
+      accrued, settled, residual, commission,
+      residualAfterCommission: round2(residual - commission),
+      months,
+    };
+  });
+}
+
+function summarise(channels: ChannelRow[]) {
+  const entityNet = round2(channels.reduce((s, c) => s + c.residual, 0));
+  const totalCommission = round2(channels.reduce((s, c) => s + c.commission, 0));
+  return { entityNet, totalCommission, entityNetAfterCommission: round2(entityNet - totalCommission) };
+}
+
+// Consolidate per-channel rows across companies (sum accrued/settled/commission
+// per debtor and per month).
+function consolidateChannels(perCompany: CompanyChannelSettlement[]): ChannelRow[] {
+  return DEBTORS.map((debtor) => {
+    const monthAgg = new Map<string, { accrued: number; settled: number; commission: number }>();
+    for (const co of perCompany) {
+      const row = co.channels.find((c) => c.code === debtor.code);
+      if (!row) continue;
+      for (const m of row.months) {
+        const cur = monthAgg.get(m.month) ?? { accrued: 0, settled: 0, commission: 0 };
+        cur.accrued = round2(cur.accrued + m.accrued);
+        cur.settled = round2(cur.settled + m.settled);
+        cur.commission = round2(cur.commission + m.commission);
+        monthAgg.set(m.month, cur);
+      }
+    }
+    const months: ChannelMonth[] = [...monthAgg.entries()].sort((a, b) => a[0].localeCompare(b[0])).map(([month, v]) => {
+      const residual = round2(v.accrued - v.settled);
+      return {
+        month, accrued: v.accrued, settled: v.settled, residual, commission: v.commission,
+        residualAfterCommission: round2(residual - v.commission),
+      };
+    });
+    const accrued = round2(months.reduce((s, m) => s + m.accrued, 0));
+    const settled = round2(months.reduce((s, m) => s + m.settled, 0));
+    const residual = round2(accrued - settled);
+    const commission = round2(months.reduce((s, m) => s + m.commission, 0));
+    return {
+      code: debtor.code, label: debtor.label,
+      accrued, settled, residual, commission,
+      residualAfterCommission: round2(residual - commission),
+      months,
+    };
+  });
+}
+
+export async function buildChannelSettlement(input: {
+  start: string;
+  end: string;
+  companies: Company[];
+}): Promise<ChannelSettlementReport> {
+  const startMonth = input.start.slice(0, 7);
+  const companyIds = input.companies.map((c) => c.id);
+
+  // Global, payout-derived Grab commission rate (same source the sourced P&L
+  // uses). One rate for the whole period end.
+  const grabRate = (await effectiveGrabRate(input.end)).rate;
+
+  const movements = await debtorMovementsByCompany(companyIds, input.end, startMonth);
+  const bankFees = await bankFeesByCompany(companyIds, input.end, startMonth);
+
+  const companies: CompanyChannelSettlement[] = input.companies.map((co) => {
+    const byAcct = movements.get(co.id) ?? new Map();
+    const fees = bankFees.get(co.id) ?? new Map();
+    const channels = buildChannels(byAcct, fees, grabRate);
+    const s = summarise(channels);
+    return { companyId: co.id, companyName: co.name, channels, ...s };
+  });
+
+  const consolidatedChannels = consolidateChannels(companies);
+  const consolidated = { channels: consolidatedChannels, ...summarise(consolidatedChannels) };
+
+  return { start: input.start, end: input.end, companies, consolidated };
+}


### PR DESCRIPTION
## What this reconciles

Adds a **Channel settlement reconciliation** section to the Finance Reconciliation report (`/finance/reports`, Reconciliation tab). It shows, per entity and channel and month, sales accrued vs cash settled vs the gap, so the owner can see why the channel sales debtors do not clear before any clearing journals are posted.

Per company (and a consolidated total), one row per channel debtor (Card 1006, GrabFood 1005, Cash and QR 1000-02) with columns:

- Sales accrued (debits to that debtor)
- Cash settled (credits)
- Net residual (accrued minus settled)
- Commission booked
- Residual after commission
- Expandable monthly drill so timing is visible
- A prominent **entity net** row: the total across the three debtors of accrued minus settled

## The three separated components

1. **Misattribution.** Settlement cash often arrives under a different channel label than the sale was accrued under (for example a Grab payout crediting Card 1006 instead of 1005). That makes per-channel gaps noisy, so the **entity net** across all three debtors is the meaningful figure and is surfaced prominently.
2. **Commission.** Grab and card take commission before payout, so a debtor accrued at gross only ever receives net cash. This is the expected permanent portion and is already expensed (GrabFood commission via the sourced P&L, card MDR as bank fees). GrabFood commission is the payout-derived `effectiveGrabRate` (reused from `pnl-sourced.ts`) applied to that entity's gross Grab accrual; card commission is the BANK_FEE (6514) bank lines for the entity; Cash and QR is zero.
3. **Timing.** Recent sales not yet settled: whatever remains after 1 and 2 (residual after commission).

## Numbers it produces (2026-01 onward, verified against production)

- Conezion: Grab accrued ~50,168 with ~0 settled, Card over-settled (residual ~ -50,055), entity net **+66,385**, Grab commission ~21,071 at the 42% effective rate.
- Consolidated entity net **~+85,006** (sum of the three entities' nets).

## Scope

Reads the posted GL (`fin_journal_lines` joined `fin_transactions`, status posted) for the debtor accounts by company and month, paged via the shared paging helper. Default 2026-01 onward, matching the existing reconciliation.

**Strictly read-only.** No classify, no journal, no writes. The clearing actions (retag misattributed settlements, post commission clearing) are a deliberate follow-up and are not built here.