### PR TITLE
fix(finance): never learn category hints from generic channel words

### DIFF
--- a/apps/backoffice/src/lib/finance/category-hints.ts
+++ b/apps/backoffice/src/lib/finance/category-hints.ts
@@ -26,7 +26,16 @@ const PREFIXES = [
 ];
 
 // Words that make a phrase too generic to be a counterparty signature.
-const STOPLIST = new Set(["CELSIUS", "COFFEE", "TRANSFER", "PAYMENT", "REMITTANCE", "DEPOSIT", "CREDIT", "DEBIT"]);
+// Generic transaction and channel words. A phrase made only of these is not a
+// distinctive counterparty, so it is never learned as a hint. Channel markers
+// (CARD, SALES, QR, GRAB, MN for the terminal merchant number) are owned by the
+// keyword rules, so a "CARD SALES MN" description must classify by rule, not by
+// an over-generic learned hint that outranks the rules (that once sent card
+// settlements to QR and broke the QR reconciliation).
+const STOPLIST = new Set([
+  "CELSIUS", "COFFEE", "TRANSFER", "PAYMENT", "REMITTANCE", "DEPOSIT", "CREDIT", "DEBIT",
+  "CARD", "SALES", "SALE", "QR", "GRAB", "MN", "POS", "TERMINAL", "SETTLEMENT",
+]);
 
 // Extract the counterparty signature from a bank description: strip the glued
 // 20-char sender prefix and transfer boilerplate, then take the longest run of


### PR DESCRIPTION
A learned hint 'SALES MN' -> QR was derived from a 'CR/CARD SALES MN ...'
bank description (the CARD token was glued to the CR/ prefix and dropped),
and since learned hints outrank the keyword rules it sent 67 card
settlements (RM76,977, Jun and Jul) to QR instead of CARD, doubling the June
QR reconciliation. The lines and the bad hint are already corrected; this
stops the class of bug at the source by adding the generic channel and
transaction words (CARD, SALES, QR, GRAB, MN, POS, TERMINAL, SETTLEMENT) to
the hint STOPLIST, so a phrase made only of them is never learned. Channel
identity stays owned by the keyword rules.
