### PR TITLE
fix(hr): guard payroll-run state machine on confirm + weekly item edits (C6/H10)

### DIFF
--- a/apps/backoffice/src/app/api/hr/payroll/route.ts
+++ b/apps/backoffice/src/app/api/hr/payroll/route.ts
@@ -115,6 +115,12 @@ export async function POST(req: NextRequest) {
   if (action === "confirm") {
     if (!run_id) return NextResponse.json({ error: "run_id required" }, { status: 400 });
 
+    // Only a not-yet-confirmed run can be confirmed. The status filter makes
+    // this atomic: a concurrent double-confirm — or confirming an already-paid
+    // run, which would otherwise silently DOWNGRADE it back to "confirmed" and
+    // desync the bank files already generated from it — matches zero rows on
+    // the losing call instead of racing. maybeSingle() then returns null, and
+    // we read the current status to return a clear 409.
     const { data, error } = await hrSupabaseAdmin
       .from("hr_payroll_runs")
       .update({
@@ -123,10 +129,23 @@ export async function POST(req: NextRequest) {
         confirmed_at: new Date().toISOString(),
       })
       .eq("id", run_id)
+      .in("status", ["ai_computed", "draft"])
       .select()
-      .single();
+      .maybeSingle();
 
     if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+    if (!data) {
+      const { data: cur } = await hrSupabaseAdmin
+        .from("hr_payroll_runs")
+        .select("status")
+        .eq("id", run_id)
+        .maybeSingle();
+      if (!cur) return NextResponse.json({ error: "Payroll run not found" }, { status: 404 });
+      return NextResponse.json(
+        { error: `Payroll run is already ${cur.status}; only a computed or draft run can be confirmed.` },
+        { status: 409 },
+      );
+    }
 
     await logActivity({
       actorId: session.id,

--- a/apps/backoffice/src/app/api/hr/payroll/weekly/route.ts
+++ b/apps/backoffice/src/app/api/hr/payroll/weekly/route.ts
@@ -178,6 +178,29 @@ export async function PATCH(req: NextRequest) {
     .single();
   if (!existing) return NextResponse.json({ error: "Item not found" }, { status: 404 });
 
+  // Guard the parent run before mutating an item:
+  //  • confirmed/paid runs are locked (bank files already generated) — mirror
+  //    the monthly items/[item_id] and adjustments routes, which both refuse.
+  //  • this endpoint applies part-time semantics below (net_pay = gross, no
+  //    statutory deductions), so it must only ever touch a WEEKLY run. Pointed
+  //    at a monthly item it would wipe that item's EPF/SOCSO/EIS/PCB by
+  //    overwriting net_pay with gross.
+  const { data: parentRun } = await hrSupabaseAdmin
+    .from("hr_payroll_runs")
+    .select("status, cycle_type")
+    .eq("id", existing.payroll_run_id)
+    .maybeSingle();
+  if (!parentRun) return NextResponse.json({ error: "Run not found" }, { status: 404 });
+  if (["confirmed", "paid"].includes(parentRun.status)) {
+    return NextResponse.json({ error: `Cannot edit a ${parentRun.status} run` }, { status: 400 });
+  }
+  if (parentRun.cycle_type !== "weekly") {
+    return NextResponse.json(
+      { error: "This endpoint only edits weekly (part-time) runs; use the monthly item route." },
+      { status: 400 },
+    );
+  }
+
   const newHours = hours !== undefined ? Number(hours) : Number(existing.total_regular_hours || 0);
   const newRate = hourly_rate !== undefined
     ? Number(hourly_rate)


### PR DESCRIPTION
## Summary

Fixes two payroll-run integrity findings from the codebase review (`docs/codebase-review-2026-07-01.md`).

**Important reassessment of C6.** The review's headline C6 claim — concurrent `compute` creating duplicate monthly runs that double YTD PCB — is **already blocked by the database**. There is a live `UNIQUE INDEX hr_payroll_runs(period_month, period_year)`, and monthly runs always set both columns, so a second concurrent insert fails rather than duplicating. Verified against production: **zero duplicate periods exist**. So C6-as-written is not a live risk.

What *was* genuinely unguarded is the run **state machine**:

### 1. `confirm` — no status precondition (real)
`api/hr/payroll` `POST action=confirm` updated `status → confirmed` keyed only on `id`. Confirming an already-**paid** run silently downgraded it back to `confirmed` (desyncing the bank files already generated from it), and a concurrent double-confirm raced. Now an **atomic conditional update** restricted to `status in (ai_computed, draft)`; the losing/invalid call matches zero rows and returns a clear **409** (or 404 if the run is gone) instead of racing.

### 2. weekly item `PATCH` — no run guard, can erase statutory deductions (H10, real)
`api/hr/payroll/weekly` `PATCH` edited `hr_payroll_items` with no parent-run status check (confirmed/paid runs were editable after bank files generated), and — because it writes `net_pay = gross` under part-time semantics — pointed at a **monthly** item it would wipe that item's EPF/SOCSO/EIS/PCB. Now guards the parent run: refuses `confirmed`/`paid` (mirroring the monthly `items/[item_id]` and `adjustments` routes) and refuses any run whose `cycle_type` is not `weekly`.

Both are **additive guards** — the happy path (confirm a computed run; edit an open weekly item) is unchanged.

## Test plan
- CI (typecheck backoffice + lint + vitest).
- Manual: confirm a computed run → succeeds; re-confirm or confirm a paid run → 409, status unchanged. Weekly PATCH on an open weekly item → succeeds; on a confirmed/paid run → 400; on a monthly item id → 400 (statutory deductions preserved).

## Not included (separate follow-ups)
The higher-value statutory **math** errors (H7/H8 — SOCSO/EIS band basis, EPF bands, period-effective rates, PCB rounding) and the finance GL findings (C5) are untouched; those warrant their own PR with unit tests against the `hr_stat_*` tables.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AVhg8aDKAV38geJYxQ9hwW

---
_Generated by [Claude Code](https://claude.ai/code/session_01AVhg8aDKAV38geJYxQ9hwW)_