### PR TITLE
feat(finance): read-only inter-company pairing reconciliation

### DIFF
--- a/apps/backoffice/src/app/(admin)/finance/reports/page.tsx
+++ b/apps/backoffice/src/app/(admin)/finance/reports/page.tsx
@@ -2391,6 +2391,210 @@ function ChannelSettlementSection({ start, end }: { start: string; end: string }
   );
 }
 
+// ─── Inter-company pairing reconciliation ───────────────────────────
+type IntercoBalanceRow = {
+  code: string; name: string; debits: number; credits: number; net: number; lines: number;
+  bareLines: number; bareAmount: number; selfLines: number; selfAmount: number;
+};
+type OutboundLeg = {
+  postingCompanyId: string; postingCompany: string;
+  counterpartyCode: string; counterpartyName: string;
+  debits: number; lines: number; hygiene: "self" | "bare" | null;
+};
+type InboundLeg = {
+  receivingCompanyId: string; receivingCompany: string; category: string;
+  amount: number; lines: number; shouldRouteTo3600: boolean;
+};
+type WouldNetRow = {
+  code: string; name: string; entity: string | null;
+  currentNet: number; inboundFundingCredit: number; wouldNet: number;
+};
+type IntercoReconciliation = {
+  start: string; end: string;
+  balances: IntercoBalanceRow[]; groupNet: number;
+  outbound: OutboundLeg[]; inbound: InboundLeg[];
+  managementFeeInbound: { amount: number; lines: number };
+  mislabelledInboundTotal: number;
+  wouldNet: WouldNetRow[]; groupWouldNet: number;
+  hygiene: { bareLines: number; bareAmount: number; selfLines: number; selfAmount: number };
+};
+
+function IntercoReconciliationSection({ start, end }: { start: string; end: string }) {
+  const { data, isLoading } = useFetch<{ report: IntercoReconciliation }>(`/api/finance/reports/interco-reconciliation?start=${start}&end=${end}`);
+  if (isLoading || !data?.report) {
+    return <div className="py-8 text-center text-sm text-muted-foreground">Loading inter-company reconciliation…</div>;
+  }
+  const r = data.report;
+  const inboundFundingTotal = r.mislabelledInboundTotal;
+  return (
+    <div className="mt-6 space-y-5">
+      <div className="flex items-baseline justify-between">
+        <h3 className="text-sm font-semibold">Inter-company pairing reconciliation</h3>
+        <span className="text-[11px] text-muted-foreground">why the 3600 due-to/from accounts do not net to zero</span>
+      </div>
+
+      {/* 1. 3600 balances */}
+      <div className="space-y-2">
+        <h4 className="text-sm font-semibold">3600 due-to/from control balances</h4>
+        <div className="overflow-x-auto rounded-lg border">
+          <table className="w-full min-w-[720px] text-sm">
+            <thead><tr className="border-b bg-muted/40 text-left text-muted-foreground">
+              <th className="px-3 py-2 font-medium">Account</th>
+              <th className="px-3 py-2 text-right font-medium">Debits</th>
+              <th className="px-3 py-2 text-right font-medium">Credits</th>
+              <th className="px-3 py-2 text-right font-medium">Net</th>
+              <th className="px-3 py-2 text-right font-medium">Lines</th>
+              <th className="px-3 py-2 text-left font-medium">Hygiene</th>
+            </tr></thead>
+            <tbody className="divide-y">
+              {r.balances.map((b) => {
+                const flags: string[] = [];
+                if (b.bareLines > 0) flags.push(`bare code (${b.bareLines})`);
+                if (b.selfLines > 0) flags.push(`self-posting (${b.selfLines})`);
+                return (
+                  <tr key={b.code} className="hover:bg-muted/40">
+                    <td className="px-3 py-1.5">
+                      <span className="font-medium">{b.name}</span>
+                      <span className="ml-2 text-xs text-muted-foreground tabular-nums">{b.code}</span>
+                    </td>
+                    <td className="px-3 py-1.5 text-right tabular-nums">{RM(b.debits)}</td>
+                    <td className="px-3 py-1.5 text-right tabular-nums">{RM(b.credits)}</td>
+                    <td className={`px-3 py-1.5 text-right tabular-nums ${b.net < 0 ? "text-rose-600 dark:text-rose-400" : ""}`}>{RM(b.net)}</td>
+                    <td className="px-3 py-1.5 text-right tabular-nums text-muted-foreground">{b.lines}</td>
+                    <td className="px-3 py-1.5 text-left text-[11px] text-amber-700 dark:text-amber-400">{flags.join(", ")}</td>
+                  </tr>
+                );
+              })}
+            </tbody>
+            <tfoot><tr className="border-t-2 font-semibold">
+              <td className="px-3 py-2">Group net</td>
+              <td className="px-3 py-2 text-right tabular-nums">{RM(r.balances.reduce((s, b) => s + b.debits, 0))}</td>
+              <td className="px-3 py-2 text-right tabular-nums">{RM(r.balances.reduce((s, b) => s + b.credits, 0))}</td>
+              <td className={`px-3 py-2 text-right tabular-nums ${r.groupNet < 0 ? "text-rose-600 dark:text-rose-400" : ""}`}>{RM(r.groupNet)}</td>
+              <td className="px-3 py-2" colSpan={2} />
+            </tr></tfoot>
+          </table>
+        </div>
+        {(r.hygiene.bareLines > 0 || r.hygiene.selfLines > 0) && (
+          <p className="text-[11px] text-amber-700 dark:text-amber-400">
+            Hygiene: {r.hygiene.bareLines} line(s) booked to the bare 3600 code ({RM(r.hygiene.bareAmount)}); {r.hygiene.selfLines} self-referential line(s) where an entity posted to its own due-to/from control ({RM(r.hygiene.selfAmount)}). These should be re-coded to the correct counterparty 3600-xx account.
+          </p>
+        )}
+      </div>
+
+      {/* 2. Transfer legs: outbound + inbound */}
+      <div className="grid gap-5 lg:grid-cols-2">
+        <div className="space-y-2">
+          <h4 className="text-sm font-semibold">Outbound legs (Dr 3600, payer side)</h4>
+          <div className="overflow-x-auto rounded-lg border">
+            <table className="w-full min-w-[420px] text-sm">
+              <thead><tr className="border-b bg-muted/40 text-left text-muted-foreground">
+                <th className="px-3 py-2 font-medium">Posting entity</th>
+                <th className="px-3 py-2 font-medium">Counterparty account</th>
+                <th className="px-3 py-2 text-right font-medium">Debits</th>
+                <th className="px-3 py-2 text-right font-medium">Lines</th>
+              </tr></thead>
+              <tbody className="divide-y">
+                {r.outbound.map((o) => (
+                  <tr key={`${o.postingCompanyId}-${o.counterpartyCode}`} className="hover:bg-muted/40">
+                    <td className="px-3 py-1.5">{o.postingCompany}</td>
+                    <td className="px-3 py-1.5">
+                      <span>{o.counterpartyName}</span>
+                      <span className="ml-2 text-xs text-muted-foreground tabular-nums">{o.counterpartyCode}</span>
+                      {o.hygiene && <span className="ml-2 text-[10px] text-amber-700 dark:text-amber-400">{o.hygiene}</span>}
+                    </td>
+                    <td className="px-3 py-1.5 text-right tabular-nums">{RM(o.debits)}</td>
+                    <td className="px-3 py-1.5 text-right tabular-nums text-muted-foreground">{o.lines}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+          <p className="text-[11px] text-muted-foreground">The payer records Dr 3600-xx (due from the counterparty) / Cr bank via resolveContra on the INTERCO_* categories. These legs are present, which is why every 3600 account is all debits.</p>
+        </div>
+
+        <div className="space-y-2">
+          <h4 className="text-sm font-semibold">Inbound legs (CR bank, receiver side)</h4>
+          <div className="overflow-x-auto rounded-lg border">
+            <table className="w-full min-w-[460px] text-sm">
+              <thead><tr className="border-b bg-muted/40 text-left text-muted-foreground">
+                <th className="px-3 py-2 font-medium">Receiving entity</th>
+                <th className="px-3 py-2 font-medium">Current category</th>
+                <th className="px-3 py-2 text-right font-medium">Amount</th>
+                <th className="px-3 py-2 text-right font-medium">Lines</th>
+                <th className="px-3 py-2 text-left font-medium">Should route to</th>
+              </tr></thead>
+              <tbody className="divide-y">
+                {r.inbound.map((i) => (
+                  <tr key={`${i.receivingCompanyId}-${i.category}`} className={`hover:bg-muted/40 ${i.shouldRouteTo3600 ? "bg-amber-50/60 dark:bg-amber-950/20" : ""}`}>
+                    <td className="px-3 py-1.5">{i.receivingCompany}</td>
+                    <td className="px-3 py-1.5 text-xs">{i.category}</td>
+                    <td className="px-3 py-1.5 text-right tabular-nums">{RM(i.amount)}</td>
+                    <td className="px-3 py-1.5 text-right tabular-nums text-muted-foreground">{i.lines}</td>
+                    <td className="px-3 py-1.5 text-left text-[11px]">{i.shouldRouteTo3600 ? <span className="text-amber-700 dark:text-amber-400">3600 (mislabelled)</span> : <span className="text-muted-foreground">{i.category === "MANAGEMENT_FEE" ? "6511 (real service fee)" : "stays"}</span>}</td>
+                  </tr>
+                ))}
+              </tbody>
+              <tfoot>
+                <tr className="border-t font-medium">
+                  <td className="px-3 py-1.5" colSpan={2}>Mislabelled funding (should route to 3600)</td>
+                  <td className="px-3 py-1.5 text-right tabular-nums">{RM(inboundFundingTotal)}</td>
+                  <td className="px-3 py-1.5" colSpan={2} />
+                </tr>
+                <tr className="font-medium">
+                  <td className="px-3 py-1.5" colSpan={2}>Management fee inbound (real HQ service fee, own row)</td>
+                  <td className="px-3 py-1.5 text-right tabular-nums">{RM(r.managementFeeInbound.amount)}</td>
+                  <td className="px-3 py-1.5 text-right tabular-nums text-muted-foreground">{r.managementFeeInbound.lines}</td>
+                  <td className="px-3 py-1.5" />
+                </tr>
+              </tfoot>
+            </table>
+          </div>
+          <p className="text-[11px] text-muted-foreground">The receiver leg (Dr bank / Cr 3600) is tagged with a purpose category instead of an INTERCO_* one, so it never credits 3600. Management fee inbound is a real HQ service fee (books 6511, eliminated in consolidation), kept as its own row and never counted as a 3600 leg.</p>
+        </div>
+      </div>
+
+      {/* 3. Would net to */}
+      <div className="space-y-2">
+        <h4 className="text-sm font-semibold">Would net to (after routing mislabelled inbound funding through 3600)</h4>
+        <div className="overflow-x-auto rounded-lg border">
+          <table className="w-full min-w-[640px] text-sm">
+            <thead><tr className="border-b bg-muted/40 text-left text-muted-foreground">
+              <th className="px-3 py-2 font-medium">Account</th>
+              <th className="px-3 py-2 text-right font-medium">Current net</th>
+              <th className="px-3 py-2 text-right font-medium">Inbound funding credit</th>
+              <th className="px-3 py-2 text-right font-medium">Would net to</th>
+            </tr></thead>
+            <tbody className="divide-y">
+              {r.wouldNet.map((w) => (
+                <tr key={w.code} className="hover:bg-muted/40">
+                  <td className="px-3 py-1.5">
+                    <span className="font-medium">{w.name}</span>
+                    <span className="ml-2 text-xs text-muted-foreground tabular-nums">{w.code}</span>
+                  </td>
+                  <td className={`px-3 py-1.5 text-right tabular-nums ${w.currentNet < 0 ? "text-rose-600 dark:text-rose-400" : ""}`}>{RM(w.currentNet)}</td>
+                  <td className="px-3 py-1.5 text-right tabular-nums text-muted-foreground">{RM(w.inboundFundingCredit)}</td>
+                  <td className={`px-3 py-1.5 text-right tabular-nums ${w.wouldNet < 0 ? "text-rose-600 dark:text-rose-400" : ""}`}>{RM(w.wouldNet)}</td>
+                </tr>
+              ))}
+            </tbody>
+            <tfoot><tr className="border-t-2 font-semibold">
+              <td className="px-3 py-2">Group</td>
+              <td className={`px-3 py-2 text-right tabular-nums ${r.groupNet < 0 ? "text-rose-600 dark:text-rose-400" : ""}`}>{RM(r.groupNet)}</td>
+              <td className="px-3 py-2 text-right tabular-nums text-muted-foreground">{RM(inboundFundingTotal)}</td>
+              <td className={`px-3 py-2 text-right tabular-nums ${r.groupWouldNet < 0 ? "text-rose-600 dark:text-rose-400" : ""}`}>{RM(r.groupWouldNet)}</td>
+            </tr></tfoot>
+          </table>
+        </div>
+      </div>
+
+      <p className="text-[11px] text-muted-foreground">
+        The 3600 due-to/from control accounts should net to zero across the group: every inter-entity transfer has a payer leg (Dr 3600) and a receiver leg (Cr 3600) that cancel. Today the group nets to {RM(r.groupNet)}, all debits, because the receiver leg is booked to a purpose category (salary, statutory, other inflow, loan, raw materials) instead of the 3600 control, so it never credits back. Routing that mislabelled inbound funding ({RM(inboundFundingTotal)}) through 3600 shows how much of the residual is pairable versus genuinely unmatched (group would net to {RM(r.groupWouldNet)}). Management fee inbound ({RM(r.managementFeeInbound.amount)}) is a real HQ service fee and is excluded. The clearing (retag the mislabelled inbound legs to INTERCO_*, post the 3600 clearing journals, re-code the bare 3600 and self-referential lines) is a deliberate follow-up and is not done here. This view is strictly read-only.
+      </p>
+    </div>
+  );
+}
+
 function ReconTab() {
   // Default to the matched period: sales archive + bank feed both exist from
   // 2026-01, so the channels net to true fees/timing (before that the bank feed
@@ -2490,6 +2694,8 @@ function ReconTab() {
       )}
 
       <ChannelSettlementSection start={start} end={end} />
+
+      <IntercoReconciliationSection start={start} end={end} />
     </div>
   );
 }

--- a/apps/backoffice/src/app/api/finance/reports/interco-reconciliation/route.ts
+++ b/apps/backoffice/src/app/api/finance/reports/interco-reconciliation/route.ts
@@ -1,0 +1,41 @@
+// GET /api/finance/reports/interco-reconciliation?start=YYYY-MM-DD&end=YYYY-MM-DD
+//
+// Read-only inter-company pairing reconciliation: the 3600 due-to/from control
+// balances (per account and group net), the outbound Dr 3600 legs and the
+// receiver-side inbound CR bank legs, with the mislabelled funding legs flagged
+// and a would-net-to figure. Covers every active company (there is no per-entity
+// view), so it is not scoped to the active company switcher.
+
+import { NextRequest, NextResponse } from "next/server";
+import { requireAuth } from "@/lib/auth";
+import { listCompanies } from "@/lib/finance/companies";
+import { buildIntercoReconciliation } from "@/lib/finance/reports/interco-reconciliation";
+
+export const dynamic = "force-dynamic";
+export const maxDuration = 60;
+
+export async function GET(req: NextRequest) {
+  const auth = await requireAuth(req);
+  if (auth.error) return auth.error;
+  if (!["OWNER", "ADMIN"].includes(auth.user.role)) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+
+  const params = new URL(req.url).searchParams;
+  const start = params.get("start");
+  const end = params.get("end");
+  const re = /^\d{4}-\d{2}-\d{2}$/;
+  if (!start || !end || !re.test(start) || !re.test(end)) {
+    return NextResponse.json({ error: "start and end (YYYY-MM-DD) required" }, { status: 400 });
+  }
+
+  try {
+    const companies = (await listCompanies())
+      .filter((c) => c.isActive)
+      .map((c) => ({ id: c.id, name: c.name }));
+    const report = await buildIntercoReconciliation({ start, end, companies });
+    return NextResponse.json({ report });
+  } catch (err) {
+    return NextResponse.json({ error: err instanceof Error ? err.message : String(err) }, { status: 500 });
+  }
+}

--- a/apps/backoffice/src/lib/finance/reports/interco-reconciliation.ts
+++ b/apps/backoffice/src/lib/finance/reports/interco-reconciliation.ts
@@ -1,0 +1,374 @@
+// Inter-company pairing reconciliation. Strictly READ-ONLY: it reads the posted
+// GL (fin_journal_lines joined fin_transactions) for the 3600 due-to/from control
+// accounts and the bank feed (BankStatementLine) for the receiver-side inbound
+// legs, so the owner can see WHY the 3600 accounts do not net to zero before any
+// clearing journals are posted.
+//
+// How inter-entity transfers are booked today:
+//   PAYER leg  (present):   Dr 3600-xx (due from the counterparty) / Cr bank.
+//                           resolveContra() routes INTERCO_* to 3600-xx.
+//   RECEIVER leg (missing):  should be Dr bank / Cr 3600-xx, but the inbound
+//                           bank line is tagged with a PURPOSE category
+//                           (EMPLOYEE_SALARY / STATUTORY_PAYMENT / OTHER_INFLOW /
+//                           LOAN / RAW_MATERIALS) instead of an INTERCO_* one, so
+//                           it never credits 3600. Every 3600 account is therefore
+//                           100% debits and the group nets to a large positive
+//                           residual (~RM69k) that never clears.
+//
+// MANAGEMENT_FEE inbound is the ONE real cross-charge (HQ service fee, books
+// 6511 + REV-MGMT, eliminated in the consolidated P&L), NOT a funding transfer,
+// so it is shown on its own row and never counted as a mislabelled 3600 leg.
+//
+// This report does NOT retag or post any journal. Routing the mislabelled
+// inbound legs through 3600 and posting clearing journals is a deliberate
+// follow-up, not built here.
+
+import { pagedPostedTxns, pagedJournalLines } from "./paged";
+import { prisma } from "@/lib/prisma";
+
+function round2(n: number): number { return Math.round(n * 100) / 100; }
+
+// The 3600 due-to/from control accounts, in display order, with the entity each
+// one represents (the counterparty the balance is due to/from). Kept aligned
+// with INTERCO_DUE_ACCOUNT in gl-posting-map.ts.
+const INTERCO_ACCOUNTS: { code: string; name: string; entity: string | null }[] = [
+  { code: "3600-00", name: "Due to/from Celsius Coffee Tamarind", entity: "celsiustamarind" },
+  { code: "3600-01", name: "Due to/from Celsius Coffee Conezion", entity: "celsiusconezion" },
+  { code: "3600-02", name: "Due to/from Celsius Coffee SB", entity: "celsius" },
+  { code: "3600", name: "Due to/from Related Companies (generic)", entity: null },
+];
+const INTERCO_CODES = INTERCO_ACCOUNTS.map((a) => a.code);
+
+// A company id -> its OWN due-to/from control code. A posting company crediting
+// or debiting its own control account is a hygiene issue (an entity should not
+// carry a balance due to/from itself).
+const OWN_ACCOUNT: Record<string, string> = {
+  celsiustamarind: "3600-00",
+  celsiusconezion: "3600-01",
+  celsius: "3600-02",
+};
+
+// The 4-digit Maybank account tail per company, embedded in
+// BankStatement.accountName (same mapping the sourced P&L uses).
+const BANK_ACCOUNT_SUFFIX: Record<string, string> = {
+  celsius: "4384",
+  celsiusconezion: "2644",
+  celsiustamarind: "9345",
+};
+
+// Inbound (CR) bank categories that are really inter-entity FUNDING and should
+// have credited a 3600 control account. MANAGEMENT_FEE is deliberately excluded
+// (it is a real service fee, shown on its own row).
+const MISLABELLED_INBOUND_CATS = new Set([
+  "EMPLOYEE_SALARY", "STATUTORY_PAYMENT", "OTHER_INFLOW", "LOAN", "RAW_MATERIALS",
+]);
+const MANAGEMENT_FEE_CAT = "MANAGEMENT_FEE";
+
+type Company = { id: string; name: string };
+
+// ─── 3600 balances ──────────────────────────────────────────────────────────
+
+export type IntercoBalanceRow = {
+  code: string;
+  name: string;
+  debits: number;
+  credits: number;
+  net: number;
+  lines: number;
+  // Hygiene: lines booked to the bare 3600 code, and lines an entity posted to
+  // its own due-to/from control (self-referential).
+  bareLines: number;
+  bareAmount: number;
+  selfLines: number;
+  selfAmount: number;
+};
+
+// ─── Transfer legs ───────────────────────────────────────────────────────────
+
+export type OutboundLeg = {
+  postingCompanyId: string;
+  postingCompany: string;
+  counterpartyCode: string;   // the 3600-xx the debit landed in
+  counterpartyName: string;
+  debits: number;
+  lines: number;
+  hygiene: "self" | "bare" | null; // self-referential or bare-3600 posting
+};
+
+export type InboundLeg = {
+  receivingCompanyId: string;
+  receivingCompany: string;
+  category: string;
+  amount: number;
+  lines: number;
+  // Mislabelled funding legs that should route to 3600. MANAGEMENT_FEE is a
+  // real service fee (own row) and is never flagged.
+  shouldRouteTo3600: boolean;
+};
+
+// ─── Would-net-to (pairing) ──────────────────────────────────────────────────
+
+export type WouldNetRow = {
+  code: string;
+  name: string;
+  entity: string | null;
+  currentNet: number;         // all-debit today
+  inboundFundingCredit: number; // mislabelled inbound funding, notionally credited here
+  wouldNet: number;           // currentNet minus inboundFundingCredit
+};
+
+export type IntercoReconciliationReport = {
+  start: string;
+  end: string;
+  balances: IntercoBalanceRow[];
+  groupNet: number;
+  outbound: OutboundLeg[];
+  inbound: InboundLeg[];
+  managementFeeInbound: { amount: number; lines: number };
+  mislabelledInboundTotal: number;
+  wouldNet: WouldNetRow[];
+  groupWouldNet: number;
+  hygiene: {
+    bareLines: number;
+    bareAmount: number;
+    selfLines: number;
+    selfAmount: number;
+  };
+};
+
+// Read every posted 3600 journal line for the companies, from startMonth.
+// Returns per-account totals and the outbound legs (grouped by posting company
+// and the 3600-xx account debited), plus hygiene tallies.
+async function readIntercoGl(
+  companies: Company[],
+  end: string,
+  startMonth: string,
+): Promise<{
+  balances: Map<string, { debits: number; credits: number; lines: number; bareLines: number; bareAmount: number; selfLines: number; selfAmount: number }>;
+  outbound: OutboundLeg[];
+}> {
+  const nameById = new Map(companies.map((c) => [c.id, c.name]));
+  const balances = new Map<string, { debits: number; credits: number; lines: number; bareLines: number; bareAmount: number; selfLines: number; selfAmount: number }>();
+  for (const code of INTERCO_CODES) balances.set(code, { debits: 0, credits: 0, lines: 0, bareLines: 0, bareAmount: 0, selfLines: 0, selfAmount: 0 });
+
+  // company -> counterpartyCode -> { debits, lines, hygiene }
+  const outMap = new Map<string, Map<string, { debits: number; lines: number; hygiene: "self" | "bare" | null }>>();
+
+  for (const co of companies) {
+    const { txnIds, txnDate } = await pagedPostedTxns([co.id], end);
+    for await (const lines of pagedJournalLines(txnIds)) {
+      for (const l of lines) {
+        if (!INTERCO_CODES.includes(l.account_code)) continue;
+        const date = txnDate.get(l.transaction_id);
+        if (!date || date.slice(0, 7) < startMonth) continue;
+        const debit = round2(Number(l.debit));
+        const credit = round2(Number(l.credit));
+
+        const bal = balances.get(l.account_code)!;
+        bal.debits = round2(bal.debits + debit);
+        bal.credits = round2(bal.credits + credit);
+        bal.lines += 1;
+
+        const isBare = l.account_code === "3600";
+        const isSelf = OWN_ACCOUNT[co.id] === l.account_code;
+        const net = round2(debit - credit);
+        if (isBare) { bal.bareLines += 1; bal.bareAmount = round2(bal.bareAmount + net); }
+        if (isSelf) { bal.selfLines += 1; bal.selfAmount = round2(bal.selfAmount + net); }
+
+        // Outbound leg = the Dr 3600 posting (the payer recording a due-from).
+        if (debit > 0) {
+          const byCode = outMap.get(co.id) ?? new Map();
+          const cur = byCode.get(l.account_code) ?? { debits: 0, lines: 0, hygiene: null as "self" | "bare" | null };
+          cur.debits = round2(cur.debits + debit);
+          cur.lines += 1;
+          cur.hygiene = isBare ? "bare" : isSelf ? "self" : cur.hygiene;
+          byCode.set(l.account_code, cur);
+          outMap.set(co.id, byCode);
+        }
+      }
+    }
+  }
+
+  const accountName = new Map(INTERCO_ACCOUNTS.map((a) => [a.code, a.name]));
+  const outbound: OutboundLeg[] = [];
+  for (const [companyId, byCode] of outMap) {
+    for (const [code, v] of byCode) {
+      outbound.push({
+        postingCompanyId: companyId,
+        postingCompany: nameById.get(companyId) ?? companyId,
+        counterpartyCode: code,
+        counterpartyName: accountName.get(code) ?? code,
+        debits: v.debits,
+        lines: v.lines,
+        hygiene: v.hygiene,
+      });
+    }
+  }
+  outbound.sort((a, b) => a.postingCompany.localeCompare(b.postingCompany) || a.counterpartyCode.localeCompare(b.counterpartyCode));
+  return { balances, outbound };
+}
+
+// Resolve a BankStatement.accountName to the receiving company id.
+function companyFromAccountName(accountName: string | null): string | null {
+  const a = (accountName ?? "").toUpperCase();
+  if (a.includes("4384") || a.includes("CELSIUS COFFEE SDN")) return "celsius";
+  if (a.includes("2644") || a.includes("CONEZION")) return "celsiusconezion";
+  if (a.includes("9345") || a.includes("TAMARIND")) return "celsiustamarind";
+  return null;
+}
+
+// Read the receiver-side inbound CR legs from the bank feed: interco credits
+// (description mentions CELSIUS COFFEE, or isInterCo) grouped by receiving
+// entity and current category. Paged via Prisma cursor (findMany batches).
+async function readInboundLegs(
+  companies: Company[],
+  start: string,
+  end: string,
+): Promise<{ inbound: InboundLeg[]; managementFee: { amount: number; lines: number }; byEntityFunding: Map<string, number> }> {
+  const nameById = new Map(companies.map((c) => [c.id, c.name]));
+  const dStart = new Date(`${start}T00:00:00.000Z`);
+  const dEnd = new Date(`${end}T23:59:59.999Z`);
+
+  // receivingCompany -> category -> { amount, lines }
+  const agg = new Map<string, Map<string, { amount: number; lines: number }>>();
+  let mgmtAmount = 0;
+  let mgmtLines = 0;
+
+  const PAGE = 1000;
+  for (let skip = 0; ; skip += PAGE) {
+    const rows = await prisma.bankStatementLine.findMany({
+      where: {
+        direction: "CR",
+        txnDate: { gte: dStart, lte: dEnd },
+        OR: [
+          { description: { contains: "CELSIUS COFFEE", mode: "insensitive" } },
+          { isInterCo: true },
+        ],
+      },
+      select: {
+        amount: true, category: true, description: true, isInterCo: true,
+        statement: { select: { accountName: true } },
+      },
+      orderBy: { id: "asc" },
+      skip,
+      take: PAGE,
+    });
+    for (const r of rows) {
+      const companyId = companyFromAccountName(r.statement?.accountName ?? null);
+      if (!companyId) continue;
+      const category = (r.category as string | null) ?? "UNCLASSIFIED";
+      const amount = round2(Number(r.amount));
+      if (category === MANAGEMENT_FEE_CAT) {
+        mgmtAmount = round2(mgmtAmount + amount);
+        mgmtLines += 1;
+        continue;
+      }
+      const byCat = agg.get(companyId) ?? new Map();
+      const cur = byCat.get(category) ?? { amount: 0, lines: 0 };
+      cur.amount = round2(cur.amount + amount);
+      cur.lines += 1;
+      byCat.set(category, cur);
+      agg.set(companyId, byCat);
+    }
+    if (rows.length < PAGE) break;
+  }
+
+  const inbound: InboundLeg[] = [];
+  const byEntityFunding = new Map<string, number>();
+  for (const [companyId, byCat] of agg) {
+    for (const [category, v] of byCat) {
+      const shouldRoute = MISLABELLED_INBOUND_CATS.has(category);
+      inbound.push({
+        receivingCompanyId: companyId,
+        receivingCompany: nameById.get(companyId) ?? companyId,
+        category,
+        amount: v.amount,
+        lines: v.lines,
+        shouldRouteTo3600: shouldRoute,
+      });
+      if (shouldRoute) byEntityFunding.set(companyId, round2((byEntityFunding.get(companyId) ?? 0) + v.amount));
+    }
+  }
+  inbound.sort((a, b) =>
+    a.receivingCompany.localeCompare(b.receivingCompany) ||
+    Number(b.shouldRouteTo3600) - Number(a.shouldRouteTo3600) ||
+    b.amount - a.amount);
+
+  return { inbound, managementFee: { amount: mgmtAmount, lines: mgmtLines }, byEntityFunding };
+}
+
+export async function buildIntercoReconciliation(input: {
+  start: string;
+  end: string;
+  companies: Company[];
+}): Promise<IntercoReconciliationReport> {
+  const startMonth = input.start.slice(0, 7);
+  // The report is written for the 3 companies that own a bank account and a
+  // 3600 control; keep to the ones we can map either way.
+  const companies = input.companies.filter((c) => BANK_ACCOUNT_SUFFIX[c.id] || OWN_ACCOUNT[c.id]);
+
+  const { balances, outbound } = await readIntercoGl(companies, input.end, startMonth);
+  const { inbound, managementFee, byEntityFunding } = await readInboundLegs(companies, input.start, input.end);
+
+  const balanceRows: IntercoBalanceRow[] = INTERCO_ACCOUNTS.map((a) => {
+    const b = balances.get(a.code) ?? { debits: 0, credits: 0, lines: 0, bareLines: 0, bareAmount: 0, selfLines: 0, selfAmount: 0 };
+    return {
+      code: a.code,
+      name: a.name,
+      debits: b.debits,
+      credits: b.credits,
+      net: round2(b.debits - b.credits),
+      lines: b.lines,
+      bareLines: b.bareLines,
+      bareAmount: b.bareAmount,
+      selfLines: b.selfLines,
+      selfAmount: b.selfAmount,
+    };
+  });
+  const groupNet = round2(balanceRows.reduce((s, r) => s + r.net, 0));
+
+  // Would-net-to: notionally credit each receiving entity's mislabelled inbound
+  // funding to its OWN due-to/from control, then re-net. Shows how much of the
+  // residual is pairable (funding that should have credited 3600) vs genuinely
+  // unmatched (whatever remains).
+  const wouldNet: WouldNetRow[] = INTERCO_ACCOUNTS.map((a) => {
+    const row = balanceRows.find((r) => r.code === a.code)!;
+    // The entity whose OWN control this code is receives the credit.
+    const owningEntity = a.entity;
+    const credit = owningEntity ? round2(byEntityFunding.get(owningEntity) ?? 0) : 0;
+    return {
+      code: a.code,
+      name: a.name,
+      entity: a.entity,
+      currentNet: row.net,
+      inboundFundingCredit: credit,
+      wouldNet: round2(row.net - credit),
+    };
+  });
+  const groupWouldNet = round2(wouldNet.reduce((s, r) => s + r.wouldNet, 0));
+
+  const mislabelledInboundTotal = round2(
+    inbound.filter((l) => l.shouldRouteTo3600).reduce((s, l) => s + l.amount, 0),
+  );
+
+  const hygiene = {
+    bareLines: balanceRows.reduce((s, r) => s + r.bareLines, 0),
+    bareAmount: round2(balanceRows.reduce((s, r) => s + r.bareAmount, 0)),
+    selfLines: balanceRows.reduce((s, r) => s + r.selfLines, 0),
+    selfAmount: round2(balanceRows.reduce((s, r) => s + r.selfAmount, 0)),
+  };
+
+  return {
+    start: input.start,
+    end: input.end,
+    balances: balanceRows,
+    groupNet,
+    outbound,
+    inbound,
+    managementFeeInbound: managementFee,
+    mislabelledInboundTotal,
+    wouldNet,
+    groupWouldNet,
+    hygiene,
+  };
+}


### PR DESCRIPTION
Adds an "Inter-company" section to the Reconciliation tab that shows why the 3600 due-to/from control accounts do not net to zero, before any clearing journals are posted.

## What it shows
1. **3600 balances** per control account (debits, credits, net) and the group net (~RM69k, all debits). Flags postings to the bare 3600 code and self-referential lines (an entity posting to its own due-to/from control) as hygiene issues.
2. **Transfer legs**: outbound Dr 3600 legs (payer side, grouped by posting entity and counterparty account) and inbound CR bank legs (receiver side, grouped by receiving entity and current category). The mislabelled inbound funding legs (EMPLOYEE_SALARY, STATUTORY_PAYMENT, OTHER_INFLOW, LOAN, RAW_MATERIALS) are flagged as "should route to 3600". MANAGEMENT_FEE inbound is kept as its own row (real HQ service fee, books 6511, eliminated in consolidation).
3. **Would net to**: notionally routes the mislabelled inbound funding through 3600 so the owner sees how much of the residual is pairable vs genuinely unmatched.

## Root cause
Inter-entity transfers post only the payer leg (Dr 3600 / Cr bank via resolveContra on INTERCO_* categories). The receiver inbound leg is tagged with a purpose category instead of INTERCO_*, so it never credits 3600. Every 3600 account is therefore 100% debits and the group never nets.

## Scope
Strictly **read-only**: no writes, no journals. New lib `interco-reconciliation.ts` + `/api/finance/reports/interco-reconciliation` route + a section component mirroring the channel-settlement section. Scoped 2026-01 onward.

Clearing (retag the inbound legs to INTERCO_*, post the 3600 clearing journals, re-code the bare/self-referential lines) is a deliberate follow-up and is **not** done here.

## Verification
- Group 3600 net ~RM69,226, all debit.
- Mislabelled inbound funding ~RM286k across salary/statutory/other/loan/raw.
- Management fee inbound ~RM80,854 shown separately.
- Typecheck, ESLint (0 errors), and tests (187 passed) green.