### PR TITLE
fix(hr): correct EPF/SOCSO/EIS statutory math + first tests (H7/H8)

### DIFF
--- a/apps/backoffice/src/lib/hr/agents/payroll-calculator.ts
+++ b/apps/backoffice/src/lib/hr/agents/payroll-calculator.ts
@@ -431,8 +431,13 @@ export async function calculatePayroll(month: number, year: number): Promise<Pay
     const employeeReliefs = reliefsByUser.get(profile.user_id);
     const stat = await calcAllStatutory({
       wage: statutoryBasis,
+      // PERKESO SOCSO/EIS wages include overtime; EPF (statutoryBasis) excludes
+      // it. Pass the OT-inclusive figure so SOCSO/EIS aren't under-contributed.
+      socsoEisWage: statutoryBasis + totalOT,
       monthlyGross: gross,
       currentMonth: month,
+      periodYear: year,
+      periodMonth: month,
       ytdGross: ytd.gross,
       ytdTaxPaid: ytd.pcb,
       employmentType: profile.employment_type as string | undefined,

--- a/apps/backoffice/src/lib/hr/statutory/calculators.ts
+++ b/apps/backoffice/src/lib/hr/statutory/calculators.ts
@@ -3,6 +3,12 @@
 // updated via SQL when KWSP/PERKESO/LHDN publish new schedules.
 
 import { hrSupabaseAdmin } from "../supabase";
+import {
+  epfContribution,
+  socsoContribution,
+  eisContribution,
+  roundToCents,
+} from "./formulas";
 
 export type EpfInputs = {
   wage: number;              // OT + basic + fixed allowances (EPF-contributing items only)
@@ -38,17 +44,16 @@ export async function calcEPF(
 
   if (!rate) return { employee: 0, employer: 0, bracket: 0 };
 
-  const bracket = Math.ceil(inputs.wage / 20) * 20;
-  const employeeRate = inputs.employeeRateOverride ?? Number(rate.employee_rate);
-  const employerRate = inputs.employerRateOverride ?? Number(
-    inputs.wage <= 5000 ? rate.employer_rate_below_5000 : rate.employer_rate_above_5000,
-  );
-
-  // EPF Schedule A rounds up to nearest RM for contributions
-  const employee = Math.ceil((bracket * employeeRate) / 100);
-  const employer = Math.ceil((bracket * employerRate) / 100);
-
-  return { employee, employer, bracket };
+  // Band width is RM20 up to RM5,000 and RM100 above it (KWSP Third Schedule).
+  // Pure math lives in ./formulas so it can be unit-tested against the schedule.
+  return epfContribution({
+    wage: inputs.wage,
+    employeeRate: Number(rate.employee_rate),
+    employerRateBelow5000: Number(rate.employer_rate_below_5000),
+    employerRateAbove5000: Number(rate.employer_rate_above_5000),
+    employeeRateOverride: inputs.employeeRateOverride,
+    employerRateOverride: inputs.employerRateOverride,
+  });
 }
 
 // ─── SOCSO (Act 4) ──────────────────────────────────────────────
@@ -72,18 +77,18 @@ export async function calcSOCSO(
     .maybeSingle();
   if (!cfg) return { employee: 0, employer: 0, tier: 0 };
 
-  const cappedWage = Math.min(wage, Number(cfg.wage_ceiling));
-  const tier = Math.ceil(cappedWage / Number(cfg.round_to)) * Number(cfg.round_to);
-
-  if (category === 1) {
-    const employee = roundToCents(tier * (Number(cfg.cat1_employee_rate) / 100));
-    const employer = roundToCents(tier * (Number(cfg.cat1_employer_rate) / 100));
-    return { employee, employer, tier };
-  } else {
-    // Category 2: employer-only, injury-only scheme
-    const employer = roundToCents(tier * (Number(cfg.cat2_employer_rate) / 100));
-    return { employee: 0, employer, tier };
-  }
+  // Contribution is charged on the band's assumed wage (midpoint), not the
+  // ceiling — see ./formulas. `tier` now carries that assumed wage.
+  const { employee, employer, assumedWage } = socsoContribution({
+    wage,
+    category,
+    wageCeiling: Number(cfg.wage_ceiling),
+    roundTo: Number(cfg.round_to),
+    cat1EmployeeRate: Number(cfg.cat1_employee_rate),
+    cat1EmployerRate: Number(cfg.cat1_employer_rate),
+    cat2EmployerRate: Number(cfg.cat2_employer_rate),
+  });
+  return { employee, employer, tier: assumedWage };
 }
 
 // ─── EIS (Act 800) ──────────────────────────────────────────────
@@ -104,12 +109,16 @@ export async function calcEIS(
     .maybeSingle();
   if (!cfg) return { employee: 0, employer: 0, tier: 0 };
 
-  const cappedWage = Math.min(wage, Number(cfg.wage_ceiling));
-  const tier = Math.ceil(cappedWage / Number(cfg.round_to)) * Number(cfg.round_to);
-
-  const employee = roundToCents(tier * (Number(cfg.employee_rate) / 100));
-  const employer = roundToCents(tier * (Number(cfg.employer_rate) / 100));
-  return { employee, employer, tier };
+  // Charged on the band's assumed wage (midpoint), not the ceiling — see
+  // ./formulas. `tier` now carries that assumed wage.
+  const { employee, employer, assumedWage } = eisContribution({
+    wage,
+    wageCeiling: Number(cfg.wage_ceiling),
+    roundTo: Number(cfg.round_to),
+    employeeRate: Number(cfg.employee_rate),
+    employerRate: Number(cfg.employer_rate),
+  });
+  return { employee, employer, tier: assumedWage };
 }
 
 // ─── HRDF (PSMB) ────────────────────────────────────────────────
@@ -130,6 +139,8 @@ export async function calcHRDF(
   if (!cfg) return { employer: 0 };
   return { employer: roundToCents(wage * (Number(cfg.employer_rate) / 100)) };
 }
+
+// roundToCents lives in ./formulas (shared with the pure statutory math).
 
 // ─── PCB 2026 MTD Formula Method (LHDN PU(A) 354/2020) ─────────
 // Simplified for regular monthly remuneration (not TP3 mid-year):
@@ -264,9 +275,18 @@ export async function calcPCB(
 
 // ─── One-shot helper: compute all statutory contributions for an employee ──
 export type EmployeeStatutoryInputs = {
-  wage: number;
+  wage: number;                  // EPF basis (basic + fixed allowances, OT EXCLUDED)
+  // SOCSO/EIS basis. PERKESO "wages" INCLUDE overtime (EPF excludes it), so the
+  // caller passes wage + OT here. Defaults to `wage` when omitted so existing
+  // callers keep their prior behaviour.
+  socsoEisWage?: number;
   monthlyGross: number;
   currentMonth?: number;
+  // Payroll period, so statutory rates/PCB brackets are resolved as-of the month
+  // being paid rather than whenever the calc happens to run (a Dec run recomputed
+  // in Jan must use Dec's schedules). Falls back to "today" when omitted.
+  periodYear?: number;
+  periodMonth?: number;
   ytdGross?: number;
   ytdTaxPaid?: number;
   // Profile
@@ -307,20 +327,33 @@ export async function calcAllStatutory(inputs: EmployeeStatutoryInputs) {
   const socsoCat = inputs.socsoCategory === "injury_only" ? 2
     : inputs.socsoCategory === "exempt" ? null : 1;
 
+  // Resolve rate schedules as-of the payroll period (first of the paid month),
+  // not the wall-clock time the calc runs. Falls back to "now" when the caller
+  // doesn't supply a period.
+  const effectiveDate =
+    inputs.periodYear && inputs.periodMonth
+      ? new Date(Date.UTC(inputs.periodYear, inputs.periodMonth - 1, 1))
+      : new Date();
+  const pcbYear = inputs.periodYear ?? effectiveDate.getUTCFullYear();
+
+  // PERKESO wages include OT; EPF wages don't. Default to `wage` for callers
+  // that don't distinguish.
+  const socsoEisWage = inputs.socsoEisWage ?? inputs.wage;
+
   const epf = await calcEPF({
     wage: inputs.wage,
     epfCategory: epfCat,
     employeeRateOverride: inputs.epfEmployeeRateOverride,
     employerRateOverride: inputs.epfEmployerRateOverride,
-  });
+  }, effectiveDate);
 
   const socso = socsoCat
-    ? await calcSOCSO(inputs.wage, socsoCat as 1 | 2, true)
+    ? await calcSOCSO(socsoEisWage, socsoCat as 1 | 2, true, effectiveDate)
     : { employee: 0, employer: 0, tier: 0 };
 
-  const eis = await calcEIS(inputs.wage, inputs.eisEnabled ?? true);
+  const eis = await calcEIS(socsoEisWage, inputs.eisEnabled ?? true, effectiveDate);
 
-  const hrdf = await calcHRDF(inputs.wage, inputs.hrdfApplicable ?? true);
+  const hrdf = await calcHRDF(inputs.wage, inputs.hrdfApplicable ?? true, effectiveDate);
 
   const pcb = await calcPCB({
     monthlyGross: inputs.monthlyGross,
@@ -337,7 +370,7 @@ export async function calcAllStatutory(inputs: EmployeeStatutoryInputs) {
     disabledSpouse: inputs.disabledSpouse,
     taxResidentCategory: inputs.taxResidentCategory,
     reliefs: inputs.tp3Reliefs,
-  });
+  }, pcbYear);
 
   return {
     epf: { employee: epf.employee, employer: epf.employer },
@@ -350,6 +383,3 @@ export async function calcAllStatutory(inputs: EmployeeStatutoryInputs) {
   };
 }
 
-function roundToCents(amount: number): number {
-  return Math.round(amount * 20) / 20;  // round to RM 0.05
-}

--- a/apps/backoffice/src/lib/hr/statutory/formulas.test.ts
+++ b/apps/backoffice/src/lib/hr/statutory/formulas.test.ts
@@ -1,0 +1,118 @@
+import { describe, it, expect } from "vitest";
+import {
+  roundToCents,
+  epfBracket,
+  epfContribution,
+  perkesoAssumedWage,
+  socsoContribution,
+  eisContribution,
+} from "./formulas";
+
+// Rate config mirrors the live hr_stat_* reference rows (verified against the
+// DB): EPF cat A 11% / 13% (≤5k) / 12% (>5k); SOCSO 0.5% + 1.75% (cat1), 1.25%
+// (cat2), RM100 bands, RM6,000 ceiling; EIS 0.2% + 0.2%, same bands/ceiling.
+const EPF_A = { employeeRate: 11, employerRateBelow5000: 13, employerRateAbove5000: 12 };
+const SOCSO = {
+  wageCeiling: 6000, roundTo: 100,
+  cat1EmployeeRate: 0.5, cat1EmployerRate: 1.75, cat2EmployerRate: 1.25,
+};
+const EIS = { wageCeiling: 6000, roundTo: 100, employeeRate: 0.2, employerRate: 0.2 };
+
+describe("roundToCents (nearest RM0.05)", () => {
+  it("rounds half up to 5 sen", () => {
+    expect(roundToCents(51.625)).toBe(51.65);
+    expect(roundToCents(16.625)).toBe(16.65);
+    expect(roundToCents(36.875)).toBe(36.9);
+    expect(roundToCents(14.75)).toBe(14.75);
+  });
+});
+
+describe("epfBracket — RM20 bands ≤ RM5,000, RM100 bands above", () => {
+  it("uses RM20 steps up to and including RM5,000", () => {
+    expect(epfBracket(3000)).toBe(3000);
+    expect(epfBracket(4999)).toBe(5000);
+    expect(epfBracket(5000)).toBe(5000);
+  });
+  it("switches to RM100 steps above RM5,000 (the H7 fix)", () => {
+    expect(epfBracket(5001)).toBe(5100);
+    expect(epfBracket(5010)).toBe(5100);
+    expect(epfBracket(5100)).toBe(5100);
+    expect(epfBracket(5101)).toBe(5200);
+  });
+});
+
+describe("epfContribution (KWSP Third Schedule, category A)", () => {
+  it("RM3,000 → employee RM330, employer RM390", () => {
+    const r = epfContribution({ wage: 3000, ...EPF_A });
+    expect(r.bracket).toBe(3000);
+    expect(r.employee).toBe(330);
+    expect(r.employer).toBe(390);
+  });
+  it("RM5,000 boundary still uses the ≤5k employer rate (13%)", () => {
+    const r = epfContribution({ wage: 5000, ...EPF_A });
+    expect(r.employee).toBe(550);   // ceil(5000 × 11%)
+    expect(r.employer).toBe(650);   // ceil(5000 × 13%)
+  });
+  it("RM5,010 → RM100 band + above-5k employer rate: employee RM561, employer RM612 (was RM553 before the fix)", () => {
+    const r = epfContribution({ wage: 5010, ...EPF_A });
+    expect(r.bracket).toBe(5100);
+    expect(r.employee).toBe(561);   // ceil(5100 × 11%)
+    expect(r.employer).toBe(612);   // ceil(5100 × 12%)
+  });
+  it("honours voluntary rate overrides", () => {
+    const r = epfContribution({ wage: 3000, ...EPF_A, employeeRateOverride: 9 });
+    expect(r.employee).toBe(270);   // ceil(3000 × 9%)
+    expect(r.employer).toBe(390);   // employer unchanged
+  });
+  it("is nil for trivially small wages", () => {
+    expect(epfContribution({ wage: 10, ...EPF_A })).toEqual({ employee: 0, employer: 0, bracket: 0 });
+  });
+});
+
+describe("perkesoAssumedWage — band midpoint, not ceiling", () => {
+  it("returns ceiling − half a band", () => {
+    expect(perkesoAssumedWage(2950, 100)).toBe(2950); // band 2900.01–3000 → 2950
+    expect(perkesoAssumedWage(3000, 100)).toBe(2950); // same band
+    expect(perkesoAssumedWage(1000, 100)).toBe(950);
+    expect(perkesoAssumedWage(6000, 100)).toBe(5950); // top band
+  });
+});
+
+describe("socsoContribution (PERKESO published schedule)", () => {
+  it("Category 1, RM2,950 → employee RM14.75, employer RM51.65 (was RM15.00 on the ceiling before the fix)", () => {
+    const r = socsoContribution({ wage: 2950, category: 1, ...SOCSO });
+    expect(r.employee).toBe(14.75);
+    expect(r.employer).toBe(51.65);
+  });
+  it("Category 1 is band-stable across the band (RM3,000 same as RM2,950)", () => {
+    const r = socsoContribution({ wage: 3000, category: 1, ...SOCSO });
+    expect(r.employee).toBe(14.75);
+    expect(r.employer).toBe(51.65);
+  });
+  it("Category 1 caps at the RM6,000 ceiling (assumed wage RM5,950): employee RM29.75, employer RM104.15", () => {
+    const r = socsoContribution({ wage: 7000, category: 1, ...SOCSO });
+    expect(r.employee).toBe(29.75);
+    expect(r.employer).toBe(104.15);
+  });
+  it("Category 2 is employer-only (RM3,000 → RM36.90)", () => {
+    const r = socsoContribution({ wage: 3000, category: 2, ...SOCSO });
+    expect(r.employee).toBe(0);
+    expect(r.employer).toBe(36.9);
+  });
+  it("is nil at/below the RM30 floor", () => {
+    expect(socsoContribution({ wage: 30, category: 1, ...SOCSO })).toEqual({ employee: 0, employer: 0, assumedWage: 0 });
+  });
+});
+
+describe("eisContribution (0.2% + 0.2%)", () => {
+  it("RM2,950 → RM5.90 each side", () => {
+    const r = eisContribution({ wage: 2950, ...EIS });
+    expect(r.employee).toBe(5.9);
+    expect(r.employer).toBe(5.9);
+  });
+  it("caps at RM6,000 ceiling → RM11.90 each side", () => {
+    const r = eisContribution({ wage: 7000, ...EIS });
+    expect(r.employee).toBe(11.9);
+    expect(r.employer).toBe(11.9);
+  });
+});

--- a/apps/backoffice/src/lib/hr/statutory/formulas.ts
+++ b/apps/backoffice/src/lib/hr/statutory/formulas.ts
@@ -1,0 +1,107 @@
+// Pure Malaysian statutory contribution math — NO I/O, so it can be unit-tested
+// directly against the official KWSP / PERKESO published schedules. The async
+// wrappers in calculators.ts fetch the rate config from the hr_stat_* tables and
+// delegate here. Keep this file dependency-free.
+
+/** Round to the nearest RM0.05 (PERKESO/LHDN cents rounding). */
+export function roundToCents(amount: number): number {
+  return Math.round(amount * 20) / 20;
+}
+
+// ─── EPF (KWSP Act 452, Third Schedule) ─────────────────────────
+// Wage is rounded UP to the band CEILING, multiplied by the rate, and the
+// contribution rounded UP to the next ringgit. Band width is RM20 up to
+// RM5,000 and RM100 above RM5,000.
+//
+// FIX (H7): the previous code used RM20 bands for ALL wages, which understated
+// contributions above RM5,000 (e.g. wage 5010 → RM553 instead of the statutory
+// RM561, because ceil(5010/20)*20 = 5020 rather than ceil(5010/100)*100 = 5100).
+export function epfBracket(wage: number): number {
+  const step = wage <= 5000 ? 20 : 100;
+  return Math.ceil(wage / step) * step;
+}
+
+export function epfContribution(args: {
+  wage: number;
+  employeeRate: number;            // %
+  employerRateBelow5000: number;   // %
+  employerRateAbove5000: number;   // %
+  employeeRateOverride?: number;   // % (voluntary)
+  employerRateOverride?: number;   // %
+}): { employee: number; employer: number; bracket: number } {
+  if (args.wage <= 10) return { employee: 0, employer: 0, bracket: 0 };
+  const bracket = epfBracket(args.wage);
+  const employeeRate = args.employeeRateOverride ?? args.employeeRate;
+  const employerRate =
+    args.employerRateOverride ??
+    (args.wage <= 5000 ? args.employerRateBelow5000 : args.employerRateAbove5000);
+  return {
+    employee: Math.ceil((bracket * employeeRate) / 100),
+    employer: Math.ceil((bracket * employerRate) / 100),
+    bracket,
+  };
+}
+
+// ─── SOCSO / EIS (PERKESO — Act 4 / Act 800) ────────────────────
+// PERKESO's contribution schedule charges the rate on the band's ASSUMED WAGE,
+// which is the band MIDPOINT — not its ceiling. For RM100 bands the midpoint is
+// (ceiling − 50).
+//
+// FIX (H7): the previous code multiplied the rate by the band ceiling, which
+// over-deducted by ~half a band every month (e.g. wage 2950 → employee SOCSO
+// RM15.00 instead of the statutory RM14.75, which is 0.5% of the RM2,950
+// assumed wage). Verified against PERKESO's published table: the RM2,900.01–
+// 3,000.00 band is employee RM14.75 / employer RM51.65 for Category 1.
+//
+// NOTE: the very bottom of the PERKESO schedule has irregular sub-RM100 bands
+// (0–30 nil, 30.01–50, 50.01–70, 70.01–100). This midpoint rule is exact for
+// the RM100-band region (all real salaried staff); the handful of sub-RM100
+// bands are not modelled here because no employee falls in them.
+export function perkesoAssumedWage(cappedWage: number, roundTo: number): number {
+  const ceiling = Math.ceil(cappedWage / roundTo) * roundTo;
+  return ceiling - roundTo / 2;
+}
+
+export function socsoContribution(args: {
+  wage: number;
+  category: 1 | 2;
+  wageCeiling: number;
+  roundTo: number;
+  cat1EmployeeRate: number; // %
+  cat1EmployerRate: number; // %
+  cat2EmployerRate: number; // %
+}): { employee: number; employer: number; assumedWage: number } {
+  if (args.wage <= 30) return { employee: 0, employer: 0, assumedWage: 0 };
+  const capped = Math.min(args.wage, args.wageCeiling);
+  const assumedWage = perkesoAssumedWage(capped, args.roundTo);
+  if (args.category === 1) {
+    return {
+      employee: roundToCents(assumedWage * (args.cat1EmployeeRate / 100)),
+      employer: roundToCents(assumedWage * (args.cat1EmployerRate / 100)),
+      assumedWage,
+    };
+  }
+  // Category 2 (60+): employer-only, injury-only scheme.
+  return {
+    employee: 0,
+    employer: roundToCents(assumedWage * (args.cat2EmployerRate / 100)),
+    assumedWage,
+  };
+}
+
+export function eisContribution(args: {
+  wage: number;
+  wageCeiling: number;
+  roundTo: number;
+  employeeRate: number; // %
+  employerRate: number; // %
+}): { employee: number; employer: number; assumedWage: number } {
+  if (args.wage <= 30) return { employee: 0, employer: 0, assumedWage: 0 };
+  const capped = Math.min(args.wage, args.wageCeiling);
+  const assumedWage = perkesoAssumedWage(capped, args.roundTo);
+  return {
+    employee: roundToCents(assumedWage * (args.employeeRate / 100)),
+    employer: roundToCents(assumedWage * (args.employerRate / 100)),
+    assumedWage,
+  };
+}


### PR DESCRIPTION
## Summary

Fixes three verified Malaysian statutory-contribution errors from the codebase review (`docs/codebase-review-2026-07-01.md`, H7/H8) and adds the first unit tests for the statutory module. Pure math is extracted to `statutory/formulas.ts` (no I/O) and tested against the published KWSP/PERKESO schedules; `calculators.ts` fetches the `hr_stat_*` rate config and delegates.

> ⚠️ **Payroll math — please verify before merging** (CLAUDE.md hard rule 6). Every number below was cross-checked against the official schedules and the tests encode those figures, but statutory changes alter what's filed with LHDN/KWSP/PERKESO, so a human sign-off is warranted. I verified the rate config against the live `hr_stat_*` tables and confirmed **zero** duplicate payroll runs exist.

## The fixes

**1. SOCSO/EIS: band ceiling → assumed-wage midpoint.** PERKESO charges the rate on the band midpoint, not the ceiling. Wage RM2,950 gave employee SOCSO **RM15.00**; correct is **RM14.75** (0.5% of the RM2,950 midpoint). Verified against PERKESO's published RM2,900.01–3,000 band (employee 14.75 / employer 51.65).

**2. SOCSO/EIS wage basis excluded overtime.** PERKESO "wages" include OT (EPF correctly excludes it), so OT-earning staff were under-contributed. `calcAllStatutory` now takes a separate `socsoEisWage` (= EPF basis + OT); the payroll calculator passes it.

**3. EPF used RM20 bands for all wages.** KWSP widens to RM100 bands above RM5,000. Wage RM5,010 now yields employee **RM561** / employer **RM612** (was RM553), matching the KWSP Third Schedule.

**Also (H8): period-effective rates.** Statutory schedules + PCB brackets are now resolved as-of the payroll period (first of the paid month) rather than whenever the calc runs, so recomputing a prior month uses that month's schedules. `calcAllStatutory` threads `periodYear`/`periodMonth` through to every calc.

## Deliberately NOT changed
Finding #5 (PCB round-up to 5 sen + "nil below RM10"): I could **not** confirm that "nil below RM10" is a real LHDN formula-method rule, so PCB math is untouched pending your confirmation. If it is a rule, it's a one-line follow-up.

## Tests
`statutory/formulas.test.ts` — 20+ cases pinning EPF/SOCSO/EIS to the official published figures (independently re-verified: all pass). This is the first test coverage for the statutory module (previously zero).

## Test plan
- CI (vitest picks up the new test file; typecheck backoffice; lint).
- The tests are the acceptance gate; expected values are the official KWSP/PERKESO amounts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AVhg8aDKAV38geJYxQ9hwW

---
_Generated by [Claude Code](https://claude.ai/code/session_01AVhg8aDKAV38geJYxQ9hwW)_