### PR TITLE
feat(hr): Putrajaya budget 18/20; red gate publishes with a typed reason

### DIFF
--- a/apps/backoffice/src/app/(admin)/hr/schedules/page.tsx
+++ b/apps/backoffice/src/app/(admin)/hr/schedules/page.tsx
@@ -480,7 +480,7 @@ export default function SchedulesPage() {
           if (!reason) return;
           res = await publishOnce({ reason });
         } else if (verdict === "red") {
-          const override = prompt(`${data.error}\n\nOwner override reason (owner only):`);
+          const override = prompt(`${data.error}\n\nOverride reason:`);
           if (!override) return;
           res = await publishOnce({ override_reason: override });
         }

--- a/apps/backoffice/src/app/api/hr/schedules/publish/route.ts
+++ b/apps/backoffice/src/app/api/hr/schedules/publish/route.ts
@@ -87,23 +87,20 @@ export async function POST(req: NextRequest) {
       }
       gateNote = `${gate.verdict} ${pctLabel} reason: ${reason.trim()}`;
     } else {
-      // red — over ceiling
-      if (session.role !== "OWNER") {
+      // red — over ceiling. Interim policy (owner, 2026-07-05): a typed
+      // reason publishes, from any role allowed here — still logged loudly
+      // as an override so the weekly variance digest surfaces it.
+      const redReason = (override_reason ?? reason ?? "").trim();
+      if (redReason.length < 5) {
         return NextResponse.json(
           {
-            error: `Roster is ${pctLabel} of forecast — over the ${(gate.ceilingPct * 100).toFixed(0)}% ceiling. Owner override required.`,
+            error: `Roster is ${pctLabel} of forecast — over the ${(gate.ceilingPct * 100).toFixed(0)}% ceiling. A reason is required to publish.`,
             gate,
           },
-          { status: 403 },
-        );
-      }
-      if (!override_reason || override_reason.trim().length < 5) {
-        return NextResponse.json(
-          { error: "Over-ceiling publish requires an override reason", gate },
           { status: 422 },
         );
       }
-      gateNote = `RED OVERRIDE ${pctLabel} by owner: ${override_reason.trim()}`;
+      gateNote = `RED OVERRIDE ${pctLabel} by ${session.role.toLowerCase()}: ${redReason}`;
     }
     for (const w of gate.warnings) gateNote += ` | ${w}`;
 

--- a/apps/backoffice/src/lib/hr/labour-gate-lib.ts
+++ b/apps/backoffice/src/lib/hr/labour-gate-lib.ts
@@ -24,10 +24,9 @@ import {
 // Outlet.code. Tamarind's interim budget is deliberately above the company
 // 18% target: its 3-pax service floor can't reach 18% at current weekday
 // revenue — the fix there is sales growth, reviewed monthly, not a gate
-// that cries wolf every week. Blended still lands ≤18% because Conezion
-// runs under.
+// that cries wolf every week.
 export const OUTLET_BUDGETS: Record<string, { target: number; ceiling: number }> = {
-  CC001: { target: 0.16, ceiling: 0.18 }, // Conezion (Putrajaya)
+  CC001: { target: 0.18, ceiling: 0.2 }, // Conezion (Putrajaya) — owner set 18/20, 2026-07-05
   CC002: { target: 0.18, ceiling: 0.2 }, // Shah Alam
   CC003: { target: 0.22, ceiling: 0.25 }, // Tamarind — interim, revenue plan attached
 };


### PR DESCRIPTION
## What

Two owner-requested gate adjustments so this week's Putrajaya roster can publish:

1. **Putrajaya (CC001) budget raised to the company standard 18% target / 20% ceiling** (was 16/18). All three outlets now sit at 18/20 except Tamarind's interim 22/25.

2. **Red (over-ceiling) publish now needs just a typed reason** — the OWNER-only refusal is dropped. Any role allowed to publish (OWNER/ADMIN/MANAGER with outlet access) can publish a red week with a reason of ≥5 characters. It's still logged loudly as `RED OVERRIDE <pct> by <role>: <reason>` in the schedule's ai_notes, so the Monday variance digest surfaces every red publish. Interim policy per the owner (2026-07-05); tightening back to owner-only is a one-line revert.

The publish prompt text drops "(owner only)" to match.

## Verification
- `npx tsc --noEmit` clean (backoffice)
- `npx eslint` on touched files: only the pre-existing warning from main
- Root `npx vitest run`: 31 files, 318 tests passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R2Kv8uNdKdCSqfUFR7vkWM

---
_Generated by [Claude Code](https://claude.ai/code/session_01R2Kv8uNdKdCSqfUFR7vkWM)_